### PR TITLE
[OPIK-7511] [SDK] [PYBE] fix: make no-improvement runs honest — perfect_score, mini-batch sizing, finish_reason

### DIFF
--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -282,6 +282,7 @@ def main():
         from opik_backend.studio.types import (
             OptimizationConfig,
             OptimizationRunResult,
+            extract_finish_reason,
             extract_scoring_health,
         )
         from opik_backend.studio.helpers import (
@@ -362,20 +363,25 @@ def main():
                 else:
                     output["optimized_prompt"] = str(result.prompt)
 
-            # Extract scoring_health from the SDK result and forward it to the
-            # backend as metadata.scoring_health so the UI can show an exact
-            # failed/total count. The helper returns None for older SDKs or
-            # malformed data and never raises.
+            # Extract scoring_health and finish_reason from the SDK result and
+            # forward them to the backend as metadata.scoring_health /
+            # metadata.finish_reason so the UI can show an exact failed/total
+            # count and the authoritative stop cause (OPIK-7511/OPIK-7458).
+            # Both helpers return None for older SDKs or malformed data and
+            # never raise.
+            completion_metadata = {}
             scoring_health = extract_scoring_health(result)
             if scoring_health is not None:
                 output["scoring_health"] = scoring_health
-                status_manager.set_completion_metadata(
-                    {"scoring_health": scoring_health}
-                )
+                completion_metadata["scoring_health"] = scoring_health
+            finish_reason = extract_finish_reason(result)
+            if finish_reason is not None:
+                output["finish_reason"] = finish_reason
+                completion_metadata["finish_reason"] = finish_reason
+            if completion_metadata:
+                status_manager.set_completion_metadata(completion_metadata)
                 logger.debug(
-                    "Queued scoring_health metadata for completion: failed=%d total=%d",
-                    scoring_health["failed_count"],
-                    scoring_health["total_count"],
+                    "Queued completion metadata: %s", sorted(completion_metadata)
                 )
 
         # Output result as JSON on last line of stdout

--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -255,8 +255,9 @@ def build_optimizer_and_prompt(config):
         messages=config.prompt_messages,
         model=task_model,
         # deterministic: this model's completions are what the metric scores, so
-        # its temperature is pinned — otherwise the same prompt scores differently
-        # on repeat evals and every threshold decision becomes partly luck.
+        # pin its temperature where the provider honours it. Best-effort, not a
+        # guarantee — models that fix their own temperature (the gpt-5 family)
+        # stay sampled, so the stop conditions tolerate score noise themselves.
         model_parameters=ensure_default_model_params(task_params, deterministic=True),
     )
     return optimizer, prompt

--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -254,7 +254,10 @@ def build_optimizer_and_prompt(config):
     prompt = ChatPrompt(
         messages=config.prompt_messages,
         model=task_model,
-        model_parameters=ensure_default_model_params(task_params),
+        # deterministic: this model's completions are what the metric scores, so
+        # its temperature is pinned — otherwise the same prompt scores differently
+        # on repeat evals and every threshold decision becomes partly luck.
+        model_parameters=ensure_default_model_params(task_params, deterministic=True),
     )
     return optimizer, prompt
 

--- a/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
+++ b/apps/opik-python-backend/src/opik_backend/jobs/optimizer_runner.py
@@ -282,8 +282,7 @@ def main():
         from opik_backend.studio.types import (
             OptimizationConfig,
             OptimizationRunResult,
-            extract_finish_reason,
-            extract_scoring_health,
+            extract_completion_metadata,
         )
         from opik_backend.studio.helpers import (
             initialize_opik_client,
@@ -319,7 +318,9 @@ def main():
         # Run optimization with lifecycle management
         with optimization_lifecycle(status_manager):
             # Load dataset
-            dataset = load_and_validate_dataset(client, config.dataset_name)
+            dataset, dataset_size = load_and_validate_dataset(
+                client, config.dataset_name
+            )
 
             # Build the optimizer + prompt: resolves the gateway-routed prompt
             # (task) model and the optimizer (algorithm) model, each with their
@@ -343,6 +344,7 @@ def main():
                 dataset=dataset,
                 metric_fn=metric_fn,
                 project_name=context.project_name,
+                dataset_size=dataset_size,
             )
 
             # Build result dict
@@ -363,21 +365,13 @@ def main():
                 else:
                     output["optimized_prompt"] = str(result.prompt)
 
-            # Extract scoring_health and finish_reason from the SDK result and
-            # forward them to the backend as metadata.scoring_health /
-            # metadata.finish_reason so the UI can show an exact failed/total
-            # count and the authoritative stop cause (OPIK-7511/OPIK-7458).
-            # Both helpers return None for older SDKs or malformed data and
-            # never raise.
-            completion_metadata = {}
-            scoring_health = extract_scoring_health(result)
-            if scoring_health is not None:
-                output["scoring_health"] = scoring_health
-                completion_metadata["scoring_health"] = scoring_health
-            finish_reason = extract_finish_reason(result)
-            if finish_reason is not None:
-                output["finish_reason"] = finish_reason
-                completion_metadata["finish_reason"] = finish_reason
+            # Forward scoring_health and finish_reason from the SDK result to
+            # the backend as metadata.scoring_health / metadata.finish_reason
+            # so the UI can show an exact failed/total count and the
+            # authoritative stop cause (OPIK-7511/OPIK-7458). The extractor
+            # returns {} for older SDKs or malformed data and never raises.
+            completion_metadata = extract_completion_metadata(result)
+            output.update(completion_metadata)
             if completion_metadata:
                 status_manager.set_completion_metadata(completion_metadata)
                 logger.debug(

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -52,6 +52,17 @@ OPTIMIZER_RUNTIME_PARAMS = {
 # effect on the currently pinned opik_optimizer release — no pin bump needed.
 OPTIMIZER_PERFECT_SCORE = float(os.getenv("OPTIMIZER_PERFECT_SCORE", "1.0"))
 
+# Temperature for the *task* model — the one whose completions are scored
+# (OPIK-7511). At the provider default, repeating the SAME evaluation of the SAME
+# prompt over the SAME dataset gave 0.90-1.00 (measured: gpt-4o-mini flipped even
+# on unambiguous items; gpt-5-nano flipped 3 of 6 repeats), so a run's score —
+# and every threshold decision taken on it — was partly a coin flip. Pinning it
+# made the same eval reproduce exactly (6/6 identical). Not applied to the
+# optimizer/reflection model, which needs sampling diversity to propose varied
+# candidates. Models that fix their temperature (the gpt-5 family accepts only
+# 1) ignore this via litellm's drop_params rather than failing the run.
+OPTIMIZER_TASK_TEMPERATURE = float(os.getenv("OPTIMIZER_TASK_TEMPERATURE", "0.0"))
+
 # GEPA reflection mini-batch sizing (OPIK-7511).
 # GEPA only promotes a candidate to a full evaluation on a STRICT win over the
 # reflection mini-batch (gepa/core/engine.py "new_sum <= old_sum: skip"). With

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -41,6 +41,17 @@ OPTIMIZER_RUNTIME_PARAMS = {
     "max_retries": int(os.getenv("OPTIMIZER_HIERARCHICAL_MAX_RETRIES", "2")),
 }
 
+# Studio-run perfect_score (OPIK-7511). perfect_score does double duty in the
+# SDK: it is the baseline/iteration skip threshold AND (for GEPA) the run-level
+# stop threshold via ScoreThresholdStopper. The SDK default (0.95) makes a
+# strong-but-imperfect baseline end a Studio run immediately with zero
+# candidates, presenting as "nothing improved". For Studio runs it must mean
+# "nothing left to optimize", so pin it to 1.0 here (the gepa package's own
+# default) rather than changing the SDK-wide default under every SDK user.
+# Injected as a constructor default by OptimizerFactory.build, so it takes
+# effect on the currently pinned opik_optimizer release — no pin bump needed.
+OPTIMIZER_PERFECT_SCORE = float(os.getenv("OPTIMIZER_PERFECT_SCORE", "1.0"))
+
 # GEPA reflection mini-batch sizing (OPIK-7511).
 # GEPA only promotes a candidate to a full evaluation on a STRICT win over the
 # reflection mini-batch (gepa/core/engine.py "new_sum <= old_sum: skip"). With

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -1,7 +1,10 @@
 """Configuration for Optimization Studio."""
 
+import logging
 import math
 import os
+
+logger = logging.getLogger(__name__)
 
 # Opik Configuration
 OPIK_URL = os.getenv("OPIK_URL_OVERRIDE")
@@ -65,7 +68,17 @@ def resolve_reflection_minibatch_size(dataset_size: int, max_trials: int) -> int
     """Return the GEPA reflection mini-batch size for a run's dataset size."""
     override = os.getenv(GEPA_REFLECTION_MINIBATCH_ENV)
     if override is not None and override.strip():
-        return max(1, int(override))
+        # A malformed operator value must not fail every optimization run —
+        # warn and fall back to the dataset-scaled policy instead.
+        try:
+            return max(1, int(override))
+        except ValueError:
+            logger.warning(
+                "Invalid %s=%r; ignoring the override and using the "
+                "dataset-scaled policy.",
+                GEPA_REFLECTION_MINIBATCH_ENV,
+                override,
+            )
     scaled = max(
         GEPA_REFLECTION_MINIBATCH_MIN,
         math.ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION),

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -1,5 +1,6 @@
 """Configuration for Optimization Studio."""
 
+import math
 import os
 
 # Opik Configuration
@@ -24,17 +25,50 @@ OPTIMIZATION_TIMEOUT_SECS = int(os.getenv("OPTSTUDIO_EXECUTION_TIMEOUT", "21600"
 DATASET_SAMPLES = int(os.getenv("OPTSTUDIO_DATASET_SAMPLES", "1000"))
 
 # Optimization Runtime Parameters
-# These are passed to optimizer.optimize_prompt() for all optimizer types
+# These are passed to optimizer.optimize_prompt() for all optimizer types.
+# GEPA's reflection_minibatch_size is NOT pinned here — it scales with the
+# dataset per run (see resolve_reflection_minibatch_size below).
 OPTIMIZER_RUNTIME_PARAMS = {
     # Generic parameters (all optimizers)
     "max_trials": int(os.getenv("OPTIMIZER_MAX_TRIALS", "10")),
     "n_samples": DATASET_SAMPLES,
-    
+
     # GEPA-specific parameters (ignored by other optimizers)
-    "reflection_minibatch_size": int(os.getenv("OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE", "5")),
     "candidate_selection_strategy": os.getenv("OPTIMIZER_GEPA_CANDIDATE_SELECTION", "pareto"),  # "pareto" or "best"
-    
+
     # Hierarchical-specific parameters (ignored by other optimizers)
     "max_retries": int(os.getenv("OPTIMIZER_HIERARCHICAL_MAX_RETRIES", "2")),
 }
+
+# GEPA reflection mini-batch sizing (OPIK-7511).
+# GEPA only promotes a candidate to a full evaluation on a STRICT win over the
+# reflection mini-batch (gepa/core/engine.py "new_sum <= old_sum: skip"). With
+# the Studio's coarse 0/1 metrics (Equals, Levenshtein) a batch of b items can
+# only take b+1 distinct sums, so a fixed b=5 discards most iterations for lack
+# of resolution. Scale the batch with the dataset instead:
+#
+#   min(max_trials, dataset_size, max(GEPA_REFLECTION_MINIBATCH_MIN,
+#       ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION)))
+#
+# - grow at ~20% of the (sampled) dataset so resolution scales with data;
+# - floor of 5 keeps the previous behaviour for small datasets;
+# - cap at max_trials: above it the SDK warns "GEPA reflection will not run"
+#   (see _warn_if_reflection_minibatch_too_large in gepa_optimizer.py);
+# - cap at dataset_size: a mini-batch cannot exceed the trainset.
+# The env var remains an explicit operator override (used verbatim, min 1).
+GEPA_REFLECTION_MINIBATCH_ENV = "OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE"
+GEPA_REFLECTION_MINIBATCH_MIN = 5
+GEPA_REFLECTION_MINIBATCH_FRACTION = 0.2
+
+
+def resolve_reflection_minibatch_size(dataset_size: int, max_trials: int) -> int:
+    """Return the GEPA reflection mini-batch size for a run's dataset size."""
+    override = os.getenv(GEPA_REFLECTION_MINIBATCH_ENV)
+    if override is not None and override.strip():
+        return max(1, int(override))
+    scaled = max(
+        GEPA_REFLECTION_MINIBATCH_MIN,
+        math.ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION),
+    )
+    return max(1, min(max_trials, dataset_size, scaled))
 

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -117,11 +117,14 @@ OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
 #   min(dataset_size,
 #       max(GEPA_REFLECTION_MINIBATCH_MIN,
 #           ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION)),
+#       GEPA_REFLECTION_MINIBATCH_MAX,
 #       budget cap — see resolve_reflection_minibatch_size)
 #
 # - grow at ~20% of the (sampled) dataset so resolution scales with data;
 # - floor of 5 keeps the previous behaviour for small datasets;
 # - cap at dataset_size: a mini-batch cannot exceed the trainset;
+# - cap at GEPA_REFLECTION_MINIBATCH_MAX: the batch is serialized into the
+#   reflection prompt, so it is a context-window cost, not just a budget one;
 # - cap by the metric-call budget so the run keeps at least
 #   GEPA_MIN_REFLECTION_ITERATIONS reflection iterations *when the budget allows
 #   it at all* — a batch of 1 cannot be cut further, so a budget below
@@ -134,6 +137,18 @@ OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
 GEPA_REFLECTION_MINIBATCH_ENV = "OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE"
 GEPA_REFLECTION_MINIBATCH_MIN = 5
 GEPA_REFLECTION_MINIBATCH_FRACTION = 0.2
+
+# Absolute ceiling on the mini-batch. gepa serializes the *whole* mini-batch
+# into one reflection prompt — every sample is rendered as markdown and joined
+# (gepa/strategies/instruction_proposal.py, format_samples) — so the prompt
+# grows linearly with the batch. Neither the dataset_size cap nor the budget cap
+# bounds that: at max_trials=10 a 1000-item dataset (DATASET_SAMPLES makes that
+# reachable) would resolve to 200 traces per proposal, likely overflowing the
+# reflection model's context on exactly the large datasets this sizing targets.
+# 25 keeps the resolution win the fraction is here for — 26 distinct mini-batch
+# sums to break ties with, against 6 at the old fixed size of 5 — while keeping
+# the reflection prompt bounded.
+GEPA_REFLECTION_MINIBATCH_MAX = 25
 
 # Each reflection iteration scores the current and the proposed candidate on
 # the same mini-batch (gepa/proposer/reflective_mutation), costing ~2*b metric
@@ -207,7 +222,9 @@ def resolve_reflection_minibatch_size(dataset_size: int, max_trials: int) -> int
             GEPA_MIN_REFLECTION_ITERATIONS,
         )
         budget_cap = 1
-    return max(1, min(dataset_size, scaled, budget_cap))
+    return max(
+        1, min(dataset_size, scaled, GEPA_REFLECTION_MINIBATCH_MAX, budget_cap)
+    )
 
 
 # Fail fast at service startup on a malformed operator override.

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -1,10 +1,8 @@
 """Configuration for Optimization Studio."""
 
-import logging
 import math
 import os
-
-logger = logging.getLogger(__name__)
+from typing import Optional
 
 # Opik Configuration
 OPIK_URL = os.getenv("OPIK_URL_OVERRIDE")
@@ -50,38 +48,80 @@ OPTIMIZER_RUNTIME_PARAMS = {
 # only take b+1 distinct sums, so a fixed b=5 discards most iterations for lack
 # of resolution. Scale the batch with the dataset instead:
 #
-#   min(max_trials, dataset_size, max(GEPA_REFLECTION_MINIBATCH_MIN,
-#       ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION)))
+#   min(dataset_size,
+#       max(GEPA_REFLECTION_MINIBATCH_MIN,
+#           ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION)),
+#       budget cap — see resolve_reflection_minibatch_size)
 #
 # - grow at ~20% of the (sampled) dataset so resolution scales with data;
 # - floor of 5 keeps the previous behaviour for small datasets;
-# - cap at max_trials: above it the SDK warns "GEPA reflection will not run"
-#   (see _warn_if_reflection_minibatch_too_large in gepa_optimizer.py);
-# - cap at dataset_size: a mini-batch cannot exceed the trainset.
-# The env var remains an explicit operator override (used verbatim, min 1).
+# - cap at dataset_size: a mini-batch cannot exceed the trainset;
+# - cap by the metric-call budget so the run keeps at least
+#   GEPA_MIN_REFLECTION_ITERATIONS reflection iterations (a large batch never
+#   prevents reflection — the gepa engine does not gate iterations on the
+#   remaining budget — it just burns the budget in fewer iterations).
+# The env var remains an explicit operator override (used verbatim; validated
+# at service startup — integer >= 1).
 GEPA_REFLECTION_MINIBATCH_ENV = "OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE"
 GEPA_REFLECTION_MINIBATCH_MIN = 5
 GEPA_REFLECTION_MINIBATCH_FRACTION = 0.2
 
+# Each reflection iteration scores the current and the proposed candidate on
+# the same mini-batch (gepa/proposer/reflective_mutation), costing ~2*b metric
+# calls out of max_metric_calls = max_trials * n_samples. Guarantee at least
+# this many iterations: below ~5 the reflective search degenerates into one or
+# two mutation shots and GEPA's Pareto candidate selection has nothing to
+# select over (it also mirrors the mini-batch floor of 5).
+GEPA_MIN_REFLECTION_ITERATIONS = 5
+
+
+def _read_reflection_minibatch_override() -> Optional[int]:
+    """Parse the operator override env var; None when unset or blank.
+
+    Raises ValueError naming the variable on a malformed value. Invoked once at
+    import time so a bad deployment config fails at service startup instead of
+    mid-optimization, and re-read per run so tests (and the rare live env
+    change) see the current value.
+    """
+    raw = os.getenv(GEPA_REFLECTION_MINIBATCH_ENV)
+    if raw is None or not raw.strip():
+        return None
+    stripped = raw.strip()
+    try:
+        value = int(stripped)
+    except ValueError:
+        # Truncate: the value is free text from the environment — keep the
+        # error (and any log that carries it) bounded.
+        raise ValueError(
+            f"{GEPA_REFLECTION_MINIBATCH_ENV} must be an integer >= 1, "
+            f"got {stripped[:32]!r}"
+        ) from None
+    if value < 1:
+        raise ValueError(
+            f"{GEPA_REFLECTION_MINIBATCH_ENV} must be an integer >= 1, "
+            f"got {value}"
+        )
+    return value
+
 
 def resolve_reflection_minibatch_size(dataset_size: int, max_trials: int) -> int:
     """Return the GEPA reflection mini-batch size for a run's dataset size."""
-    override = os.getenv(GEPA_REFLECTION_MINIBATCH_ENV)
-    if override is not None and override.strip():
-        # A malformed operator value must not fail every optimization run —
-        # warn and fall back to the dataset-scaled policy instead.
-        try:
-            return max(1, int(override))
-        except ValueError:
-            logger.warning(
-                "Invalid %s=%r; ignoring the override and using the "
-                "dataset-scaled policy.",
-                GEPA_REFLECTION_MINIBATCH_ENV,
-                override,
-            )
+    override = _read_reflection_minibatch_override()
+    if override is not None:
+        return override
     scaled = max(
         GEPA_REFLECTION_MINIBATCH_MIN,
         math.ceil(dataset_size * GEPA_REFLECTION_MINIBATCH_FRACTION),
     )
-    return max(1, min(max_trials, dataset_size, scaled))
+    # The run's budget is max_metric_calls = max_trials * n_samples, and the
+    # Studio always passes n_samples = dataset_size (both are the sampled item
+    # count — see run_optimization), so the budget here is
+    # max_trials * dataset_size. A reflection iteration costs ~2*b of it; cap b
+    # so at least GEPA_MIN_REFLECTION_ITERATIONS iterations fit.
+    budget_cap = (max_trials * dataset_size) // (2 * GEPA_MIN_REFLECTION_ITERATIONS)
+    return max(1, min(dataset_size, scaled, budget_cap))
+
+
+# Fail fast at service startup on a malformed operator override.
+_read_reflection_minibatch_override()
 

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -1,8 +1,11 @@
 """Configuration for Optimization Studio."""
 
+import logging
 import math
 import os
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # Opik Configuration
 OPIK_URL = os.getenv("OPIK_URL_OVERRIDE")
@@ -89,14 +92,16 @@ OPTIMIZER_PERFECT_SCORE = _read_float_env(
 )
 
 # Temperature for the *task* model — the one whose completions are scored
-# (OPIK-7511). At the provider default, repeating the SAME evaluation of the SAME
-# prompt over the SAME dataset gave 0.90-1.00 (measured: gpt-4o-mini flipped even
-# on unambiguous items; gpt-5-nano flipped 3 of 6 repeats), so a run's score —
-# and every threshold decision taken on it — was partly a coin flip. Pinning it
-# made the same eval reproduce exactly (6/6 identical). Not applied to the
-# optimizer/reflection model, which needs sampling diversity to propose varied
-# candidates. Models that fix their temperature (the gpt-5 family accepts only
-# 1) ignore this via litellm's drop_params rather than failing the run.
+# (OPIK-7511). Scoring should be repeatable: at the provider default, repeated
+# evaluations of one prompt over one dataset returned different scores, which
+# makes every threshold decision taken on them partly luck. Deliberately NOT
+# applied to the optimizer/reflection model, which needs sampling diversity to
+# propose varied candidates.
+#
+# This is best-effort, not a guarantee: a model that fixes its own temperature
+# ignores the pin (litellm's drop_params keeps the run alive instead of failing
+# it) and stays sampled, which is why the stop conditions must tolerate score
+# noise on their own — see CandidateScoreThresholdStopper in the optimizer SDK.
 OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
     "OPTIMIZER_TASK_TEMPERATURE", "0.0", minimum=0.0, maximum=2.0
 )
@@ -117,9 +122,12 @@ OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
 # - floor of 5 keeps the previous behaviour for small datasets;
 # - cap at dataset_size: a mini-batch cannot exceed the trainset;
 # - cap by the metric-call budget so the run keeps at least
-#   GEPA_MIN_REFLECTION_ITERATIONS reflection iterations (a large batch never
-#   prevents reflection — the gepa engine does not gate iterations on the
-#   remaining budget — it just burns the budget in fewer iterations).
+#   GEPA_MIN_REFLECTION_ITERATIONS reflection iterations *when the budget allows
+#   it at all* — a batch of 1 cannot be cut further, so a budget below
+#   2 * GEPA_MIN_REFLECTION_ITERATIONS calls fits fewer iterations regardless
+#   (logged when it happens). A large batch never prevents reflection — the gepa
+#   engine does not gate iterations on the remaining budget — it just burns the
+#   budget in fewer iterations.
 # The env var remains an explicit operator override (used verbatim; validated
 # at service startup — integer >= 1).
 GEPA_REFLECTION_MINIBATCH_ENV = "OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE"
@@ -132,6 +140,13 @@ GEPA_REFLECTION_MINIBATCH_FRACTION = 0.2
 # this many iterations: below ~5 the reflective search degenerates into one or
 # two mutation shots and GEPA's Pareto candidate selection has nothing to
 # select over (it also mirrors the mini-batch floor of 5).
+#
+# Deliberately duplicated from MIN_EXPECTED_REFLECTION_ITERATIONS in the SDK
+# (algorithms/gepa_optimizer/gepa_optimizer.py), which warns on the same rule:
+# the constant does not exist in the pinned opik-optimizer release, so importing
+# it would break the backend until the pin moves. Collapse the two — and the
+# ~2*b cost model they share — when the pin is bumped (OPIK-7460); until then
+# keep the values equal.
 GEPA_MIN_REFLECTION_ITERATIONS = 5
 
 
@@ -179,6 +194,18 @@ def resolve_reflection_minibatch_size(dataset_size: int, max_trials: int) -> int
     # max_trials * dataset_size. A reflection iteration costs ~2*b of it; cap b
     # so at least GEPA_MIN_REFLECTION_ITERATIONS iterations fit.
     budget_cap = (max_trials * dataset_size) // (2 * GEPA_MIN_REFLECTION_ITERATIONS)
+    if budget_cap < 1:
+        # A mini-batch cannot go below 1, so this run simply cannot fit the
+        # target iteration count — say so instead of implying the cap held.
+        logger.warning(
+            "Metric-call budget (max_trials=%s * dataset_size=%s) fits fewer than "
+            "%s reflection iterations even at a mini-batch of 1; raise max_trials "
+            "or use a larger dataset.",
+            max_trials,
+            dataset_size,
+            GEPA_MIN_REFLECTION_ITERATIONS,
+        )
+        budget_cap = 1
     return max(1, min(dataset_size, scaled, budget_cap))
 
 

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -102,6 +102,7 @@ OPTIMIZER_PERFECT_SCORE = _read_float_env(
 # ignores the pin (litellm's drop_params keeps the run alive instead of failing
 # it) and stays sampled, which is why the stop conditions must tolerate score
 # noise on their own — see CandidateScoreThresholdStopper in the optimizer SDK.
+# Dimensionless sampling temperature; valid range 0.0-2.0 (0.0 = least random).
 OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
     "OPTIMIZER_TASK_TEMPERATURE", "0.0", minimum=0.0, maximum=2.0
 )

--- a/apps/opik-python-backend/src/opik_backend/studio/config.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/config.py
@@ -41,6 +41,35 @@ OPTIMIZER_RUNTIME_PARAMS = {
     "max_retries": int(os.getenv("OPTIMIZER_HIERARCHICAL_MAX_RETRIES", "2")),
 }
 
+def _read_float_env(name: str, default: str, *, minimum: float, maximum: float) -> float:
+    """Parse a float env var, failing fast at import on a malformed value.
+
+    ``float()`` alone accepts "nan" and "inf", which silently break the score
+    comparisons these values feed (``baseline >= nan`` is always False, ``>= inf``
+    never true), so the range is enforced here instead of surfacing as a run that
+    mysteriously never stops. Same fail-at-startup contract as
+    _read_reflection_minibatch_override.
+    """
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        raw = default
+    stripped = raw.strip()
+    try:
+        value = float(stripped)
+    except ValueError:
+        # Truncate: the value is free text from the environment.
+        raise ValueError(
+            f"{name} must be a number between {minimum} and {maximum}, "
+            f"got {stripped[:32]!r}"
+        ) from None
+    if not math.isfinite(value) or not (minimum <= value <= maximum):
+        raise ValueError(
+            f"{name} must be a finite number between {minimum} and {maximum}, "
+            f"got {value}"
+        )
+    return value
+
+
 # Studio-run perfect_score (OPIK-7511). perfect_score does double duty in the
 # SDK: it is the baseline/iteration skip threshold AND (for GEPA) the run-level
 # stop threshold via ScoreThresholdStopper. The SDK default (0.95) makes a
@@ -50,7 +79,14 @@ OPTIMIZER_RUNTIME_PARAMS = {
 # default) rather than changing the SDK-wide default under every SDK user.
 # Injected as a constructor default by OptimizerFactory.build, so it takes
 # effect on the currently pinned opik_optimizer release — no pin bump needed.
-OPTIMIZER_PERFECT_SCORE = float(os.getenv("OPTIMIZER_PERFECT_SCORE", "1.0"))
+# Range 0.0-1.0: every metric the Studio exposes is normalised to that (equals
+# and json_schema_validator are 0/1, levenshtein_ratio/geval/numerical_similarity
+# are ratios). A custom `code` metric on another scale should set perfect_score
+# per run via optimizer_params rather than moving this deployment-wide default.
+# 0.0 is legal and disables threshold stopping (see _build_gepa_stop_callbacks).
+OPTIMIZER_PERFECT_SCORE = _read_float_env(
+    "OPTIMIZER_PERFECT_SCORE", "1.0", minimum=0.0, maximum=1.0
+)
 
 # Temperature for the *task* model — the one whose completions are scored
 # (OPIK-7511). At the provider default, repeating the SAME evaluation of the SAME
@@ -61,7 +97,9 @@ OPTIMIZER_PERFECT_SCORE = float(os.getenv("OPTIMIZER_PERFECT_SCORE", "1.0"))
 # optimizer/reflection model, which needs sampling diversity to propose varied
 # candidates. Models that fix their temperature (the gpt-5 family accepts only
 # 1) ignore this via litellm's drop_params rather than failing the run.
-OPTIMIZER_TASK_TEMPERATURE = float(os.getenv("OPTIMIZER_TASK_TEMPERATURE", "0.0"))
+OPTIMIZER_TASK_TEMPERATURE = _read_float_env(
+    "OPTIMIZER_TASK_TEMPERATURE", "0.0", minimum=0.0, maximum=2.0
+)
 
 # GEPA reflection mini-batch sizing (OPIK-7511).
 # GEPA only promotes a candidate to a full evaluation on a STRICT win over the

--- a/apps/opik-python-backend/src/opik_backend/studio/errors.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/errors.py
@@ -125,9 +125,10 @@ def to_user_facing_message(exc: BaseException) -> str:
     # Our own typed errors — build clean text (avoid the "Original error: ..."
     # suffix some of them append, which can carry low-level detail).
     if isinstance(exc, EmptyDatasetError):
+        reason = getattr(exc, "reason", None) or "is empty"
         return (
-            f"The dataset '{exc.dataset_name}' is empty. "
-            "Add items to it before running the optimization."
+            f"The dataset '{exc.dataset_name}' {reason}. "
+            "Add usable items to it before running the optimization."
         )
     if isinstance(exc, DatasetNotFoundError):
         return (

--- a/apps/opik-python-backend/src/opik_backend/studio/exceptions.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/exceptions.py
@@ -32,16 +32,23 @@ class DatasetNotFoundError(OptimizationError):
 
 
 class EmptyDatasetError(OptimizationError):
-    """Dataset exists but has no items.
-    
-    Raised when a dataset is loaded successfully but contains zero items.
-    Optimization requires at least one dataset item to evaluate against.
+    """Dataset exists but has no items the optimizer can use.
+
+    Raised when a dataset is loaded successfully but contains zero items, or
+    zero items the optimizer can train on — the SDK's sampling drops rows
+    without an id (see helpers.count_optimizable_items), so a dataset made only
+    of those is just as unusable as an empty one. Optimization requires at least
+    one usable dataset item to evaluate against.
+
+    `reason` describes which of the two it was; it defaults to plain emptiness
+    so existing callers keep their original message.
     """
-    
-    def __init__(self, dataset_name: str):
+
+    def __init__(self, dataset_name: str, reason: str = None):
         self.dataset_name = dataset_name
+        self.reason = reason
         message = (
-            f"Dataset '{dataset_name}' is empty. "
+            f"Dataset '{dataset_name}' {reason or 'is empty'}. "
             "Please add items to the dataset before running optimization."
         )
         super().__init__(message)

--- a/apps/opik-python-backend/src/opik_backend/studio/exceptions.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/exceptions.py
@@ -44,7 +44,7 @@ class EmptyDatasetError(OptimizationError):
     so existing callers keep their original message.
     """
 
-    def __init__(self, dataset_name: str, reason: str = None):
+    def __init__(self, dataset_name: str, reason: str | None = None):
         self.dataset_name = dataset_name
         self.reason = reason
         message = (

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -66,6 +66,21 @@ def initialize_opik_client(context: OptimizationJobContext) -> opik.Opik:
     return client
 
 
+def count_optimizable_items(dataset_items: list) -> int:
+    """Count the items the optimizer will actually train on.
+
+    The SDK's sampling builds its plan from dataset item ids and drops rows
+    without one (``opik_optimizer/utils/sampling.py:_extract_ids``), so a plain
+    ``len()`` can exceed the resulting trainset — and a mini-batch sized from
+    that number would exceed it too. Count the same rows the SDK will keep.
+    """
+    return sum(
+        1
+        for item in dataset_items
+        if isinstance(item, dict) and item.get("id") is not None
+    )
+
+
 def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
     """Load dataset and validate it has items.
 
@@ -76,8 +91,9 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
     Returns:
         Tuple of (dataset, item_count). The count is returned so callers can
         size dataset-dependent parameters without re-fetching every item; it is
-        capped at DATASET_SAMPLES — only the effective (sampled) size matters
-        downstream, so we never materialize more items just to count them.
+        capped at DATASET_SAMPLES (only the effective sampled size matters
+        downstream) and counts only items the optimizer can use — see
+        count_optimizable_items.
 
     Raises:
         DatasetNotFoundError: If dataset not found or inaccessible
@@ -86,17 +102,23 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
     try:
         dataset = client.get_dataset(dataset_name)
         logger.debug(f"Loaded dataset: {dataset_name}")
+        # Bounded fetch, inside the same translation: access/transport failures
+        # here are just as much "dataset unusable" as a failed lookup, and the
+        # docstring promises DatasetNotFoundError for them.
+        dataset_items = dataset.get_items(nb_samples=DATASET_SAMPLES)
     except Exception as e:
         logger.error(f"Failed to load dataset '{dataset_name}': {e}")
         raise DatasetNotFoundError(dataset_name, e)
 
-    # Validate dataset has items (bounded fetch — see docstring)
-    dataset_items = dataset.get_items(nb_samples=DATASET_SAMPLES)
     if not dataset_items:
         raise EmptyDatasetError(dataset_name)
 
-    logger.debug(f"Dataset has {len(dataset_items)} items (capped at {DATASET_SAMPLES})")
-    return dataset, len(dataset_items)
+    item_count = count_optimizable_items(dataset_items)
+    logger.debug(
+        f"Dataset has {len(dataset_items)} items (capped at {DATASET_SAMPLES}), "
+        f"{item_count} usable by the optimizer"
+    )
+    return dataset, item_count
 
 
 def run_optimization(
@@ -146,7 +168,9 @@ def run_optimization(
     if dataset_size is None:
         # Bounded fetch: only the effective (sampled) size matters, so never
         # materialize more than DATASET_SAMPLES items just to count them.
-        dataset_size = len(dataset.get_items(nb_samples=DATASET_SAMPLES))
+        dataset_size = count_optimizable_items(
+            dataset.get_items(nb_samples=DATASET_SAMPLES)
+        )
     effective_dataset_size = min(dataset_size, DATASET_SAMPLES)
     reflection_minibatch_size = resolve_reflection_minibatch_size(
         dataset_size=effective_dataset_size,

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -75,7 +75,9 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
 
     Returns:
         Tuple of (dataset, item_count). The count is returned so callers can
-        size dataset-dependent parameters without re-fetching every item.
+        size dataset-dependent parameters without re-fetching every item; it is
+        capped at DATASET_SAMPLES — only the effective (sampled) size matters
+        downstream, so we never materialize more items just to count them.
 
     Raises:
         DatasetNotFoundError: If dataset not found or inaccessible
@@ -88,12 +90,12 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
         logger.error(f"Failed to load dataset '{dataset_name}': {e}")
         raise DatasetNotFoundError(dataset_name, e)
 
-    # Validate dataset has items
-    dataset_items = list(dataset.get_items())
+    # Validate dataset has items (bounded fetch — see docstring)
+    dataset_items = dataset.get_items(nb_samples=DATASET_SAMPLES)
     if not dataset_items:
         raise EmptyDatasetError(dataset_name)
 
-    logger.debug(f"Dataset has {len(dataset_items)} items")
+    logger.debug(f"Dataset has {len(dataset_items)} items (capped at {DATASET_SAMPLES})")
     return dataset, len(dataset_items)
 
 
@@ -142,7 +144,9 @@ def run_optimization(
     # size — a fixed size starves coarse 0/1 metrics of resolution (OPIK-7511).
     # Ignored by non-GEPA optimizers, like the other GEPA-specific params.
     if dataset_size is None:
-        dataset_size = len(dataset.get_items())
+        # Bounded fetch: only the effective (sampled) size matters, so never
+        # materialize more than DATASET_SAMPLES items just to count them.
+        dataset_size = len(dataset.get_items(nb_samples=DATASET_SAMPLES))
     effective_dataset_size = min(dataset_size, DATASET_SAMPLES)
     reflection_minibatch_size = resolve_reflection_minibatch_size(
         dataset_size=effective_dataset_size,

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -97,7 +97,8 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
 
     Raises:
         DatasetNotFoundError: If dataset not found or inaccessible
-        EmptyDatasetError: If dataset has no items
+        EmptyDatasetError: If the dataset has no items, or none the optimizer
+            can train on
     """
     try:
         dataset = client.get_dataset(dataset_name)
@@ -114,6 +115,15 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
         raise EmptyDatasetError(dataset_name)
 
     item_count = count_optimizable_items(dataset_items)
+    if item_count == 0:
+        # The rows exist but the SDK's sampling will drop every one of them, so
+        # the optimizer would train on nothing: an empty trainset and a
+        # mini-batch sized from 0. Reject it here, where the user gets a typed,
+        # actionable error, instead of an opaque failure mid-run.
+        raise EmptyDatasetError(
+            dataset_name,
+            reason="has no items the optimizer can use (every item is missing an id)",
+        )
     logger.debug(
         f"Dataset has {len(dataset_items)} items (capped at {DATASET_SAMPLES}), "
         f"{item_count} usable by the optimizer"

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -74,7 +74,8 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
         dataset_name: Name of the dataset to load
 
     Returns:
-        Loaded dataset object
+        Tuple of (dataset, item_count). The count is returned so callers can
+        size dataset-dependent parameters without re-fetching every item.
 
     Raises:
         DatasetNotFoundError: If dataset not found or inaccessible
@@ -93,7 +94,7 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
         raise EmptyDatasetError(dataset_name)
 
     logger.debug(f"Dataset has {len(dataset_items)} items")
-    return dataset
+    return dataset, len(dataset_items)
 
 
 def run_optimization(
@@ -103,6 +104,7 @@ def run_optimization(
     dataset,
     metric_fn: Callable,
     project_name: Optional[str] = None,
+    dataset_size: Optional[int] = None,
 ) -> Any:
     """Run the optimization process.
 
@@ -115,6 +117,9 @@ def run_optimization(
         project_name: Optional Opik project name. When set, trial experiments
             and traces produced by the optimizer are attached to this project
             instead of the optimizer SDK default ("Optimization").
+        dataset_size: Item count of ``dataset`` when the caller already knows
+            it (load_and_validate_dataset returns it); avoids re-fetching the
+            whole dataset here. Falls back to fetching when omitted.
 
     Returns:
         Optimization result object
@@ -136,7 +141,9 @@ def run_optimization(
     # GEPA's reflection mini-batch scales with the effective (sampled) dataset
     # size — a fixed size starves coarse 0/1 metrics of resolution (OPIK-7511).
     # Ignored by non-GEPA optimizers, like the other GEPA-specific params.
-    effective_dataset_size = min(len(dataset.get_items()), DATASET_SAMPLES)
+    if dataset_size is None:
+        dataset_size = len(dataset.get_items())
+    effective_dataset_size = min(dataset_size, DATASET_SAMPLES)
     reflection_minibatch_size = resolve_reflection_minibatch_size(
         dataset_size=effective_dataset_size,
         max_trials=OPTIMIZER_RUNTIME_PARAMS["max_trials"],

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -7,7 +7,12 @@ from typing import Any, Callable, Optional
 import opik
 from opik_optimizer import ChatPrompt
 
-from .config import OPIK_URL, OPTIMIZER_RUNTIME_PARAMS
+from .config import (
+    DATASET_SAMPLES,
+    OPIK_URL,
+    OPTIMIZER_RUNTIME_PARAMS,
+    resolve_reflection_minibatch_size,
+)
 from .types import OptimizationJobContext
 from .exceptions import (
     DatasetNotFoundError,
@@ -128,6 +133,20 @@ def run_optimization(
     )
     optimize_prompts = present_roles or "system"
 
+    # GEPA's reflection mini-batch scales with the effective (sampled) dataset
+    # size — a fixed size starves coarse 0/1 metrics of resolution (OPIK-7511).
+    # Ignored by non-GEPA optimizers, like the other GEPA-specific params.
+    effective_dataset_size = min(len(dataset.get_items()), DATASET_SAMPLES)
+    reflection_minibatch_size = resolve_reflection_minibatch_size(
+        dataset_size=effective_dataset_size,
+        max_trials=OPTIMIZER_RUNTIME_PARAMS["max_trials"],
+    )
+    logger.debug(
+        "Resolved reflection_minibatch_size=%d (dataset_size=%d)",
+        reflection_minibatch_size,
+        effective_dataset_size,
+    )
+
     result = optimizer.optimize_prompt(
         optimization_id=optimization_id,
         prompt=prompt,
@@ -135,6 +154,7 @@ def run_optimization(
         metric=metric_fn,
         project_name=project_name,
         optimize_prompts=optimize_prompts,
+        reflection_minibatch_size=reflection_minibatch_size,
         **OPTIMIZER_RUNTIME_PARAMS,
     )
 

--- a/apps/opik-python-backend/src/opik_backend/studio/helpers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/helpers.py
@@ -115,14 +115,29 @@ def load_and_validate_dataset(client: opik.Opik, dataset_name: str):
         raise EmptyDatasetError(dataset_name)
 
     item_count = count_optimizable_items(dataset_items)
-    if item_count == 0:
+    if item_count == 0 and len(dataset_items) < DATASET_SAMPLES:
         # The rows exist but the SDK's sampling will drop every one of them, so
         # the optimizer would train on nothing: an empty trainset and a
         # mini-batch sized from 0. Reject it here, where the user gets a typed,
         # actionable error, instead of an opaque failure mid-run.
+        #
+        # Only when the fetch above was NOT truncated, though: the SDK's
+        # sampling draws ids from the whole dataset (sampling._extract_ids calls
+        # get_items() unbounded), so a full page of id-less rows says nothing
+        # about the rows past DATASET_SAMPLES. Rejecting on that prefix would
+        # fail a dataset the optimizer could still train on; a short page means
+        # we have seen every row and the verdict is final.
         raise EmptyDatasetError(
             dataset_name,
             reason="has no items the optimizer can use (every item is missing an id)",
+        )
+    if item_count == 0:
+        logger.warning(
+            "Dataset '%s': none of the first %s items has an id, so none of them "
+            "is usable by the optimizer. Continuing because later items may be — "
+            "the SDK samples ids across the whole dataset.",
+            dataset_name,
+            DATASET_SAMPLES,
         )
     logger.debug(
         f"Dataset has {len(dataset_items)} items (capped at {DATASET_SAMPLES}), "

--- a/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
@@ -11,6 +11,7 @@ from opik_optimizer.algorithms.hierarchical_reflective_optimizer.hierarchical_re
     HierarchicalReflectiveOptimizer,
 )
 
+from .config import OPTIMIZER_PERFECT_SCORE
 from .exceptions import InvalidOptimizerError
 from opik_backend.utils.env_utils import get_env_int
 
@@ -76,6 +77,13 @@ class OptimizerFactory:
         # Ensure model_params has a reasonable max_tokens to prevent truncation
         # of structured outputs (JSON responses for improved prompts, analysis, etc.)
         model_params = ensure_default_model_params(model_params)
+
+        # Studio runs treat "perfect" as full marks (OPIK-7511) — the SDK's
+        # 0.95 default ends strong-baseline runs with zero candidates. Every
+        # optimizer accepts perfect_score in its constructor; an explicit value
+        # in the run's optimizer_params still wins.
+        optimizer_params = dict(optimizer_params)
+        optimizer_params.setdefault("perfect_score", OPTIMIZER_PERFECT_SCORE)
 
         logger.debug(
             f"Initializing {optimizer_type} optimizer with params: {optimizer_params}"

--- a/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
@@ -34,19 +34,19 @@ def ensure_default_model_params(
     it pins the temperature so repeated evaluations of one prompt agree (see
     OPTIMIZER_TASK_TEMPERATURE). An explicit temperature from the run config still
     wins, but a ``null`` one does not — the studio config can carry explicit nulls,
-    and ``setdefault`` would forward that ``None`` to litellm. ``drop_params`` is
-    forced rather than defaulted: it is our guard so a model that fixes its own
-    temperature ignores the pin instead of failing the run, not a user knob.
+    and ``setdefault`` would forward that ``None`` to litellm. Models that fix
+    their own temperature (the gpt-5 family) must ignore the pin rather than fail
+    the run; that is already guaranteed process-wide by ``litellm.drop_params =
+    True`` in ``opik_optimizer/base_optimizer.py``, which the runner imports, so
+    this does not set ``drop_params`` per call.
     Leave ``deterministic`` False for the optimizer/reflection model, which needs
     sampling diversity to propose varied candidates.
     """
     params = dict(model_params or {})
     if params.get("max_tokens") is None:
         params["max_tokens"] = LLM_MAX_TOKENS
-    if deterministic:
-        if params.get("temperature") is None:
-            params["temperature"] = OPTIMIZER_TASK_TEMPERATURE
-        params["drop_params"] = True
+    if deterministic and params.get("temperature") is None:
+        params["temperature"] = OPTIMIZER_TASK_TEMPERATURE
     return params
 
 

--- a/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
@@ -31,17 +31,22 @@ def ensure_default_model_params(
     outputs (and baseline/per-trial task completions) don't truncate.
 
     Pass ``deterministic=True`` for the task model, whose completions are scored:
-    it pins the temperature so the same prompt scores the same twice (see
-    OPTIMIZER_TASK_TEMPERATURE). An explicit value from the run config always
-    wins. Leave it False for the optimizer/reflection model, which needs sampling
-    diversity to propose varied candidates.
+    it pins the temperature so repeated evaluations of one prompt agree (see
+    OPTIMIZER_TASK_TEMPERATURE). An explicit temperature from the run config still
+    wins, but a ``null`` one does not — the studio config can carry explicit nulls,
+    and ``setdefault`` would forward that ``None`` to litellm. ``drop_params`` is
+    forced rather than defaulted: it is our guard so a model that fixes its own
+    temperature ignores the pin instead of failing the run, not a user knob.
+    Leave ``deterministic`` False for the optimizer/reflection model, which needs
+    sampling diversity to propose varied candidates.
     """
     params = dict(model_params or {})
-    params.setdefault("max_tokens", LLM_MAX_TOKENS)
+    if params.get("max_tokens") is None:
+        params["max_tokens"] = LLM_MAX_TOKENS
     if deterministic:
-        params.setdefault("temperature", OPTIMIZER_TASK_TEMPERATURE)
-        # Let models that fix their temperature ignore ours instead of erroring.
-        params.setdefault("drop_params", True)
+        if params.get("temperature") is None:
+            params["temperature"] = OPTIMIZER_TASK_TEMPERATURE
+        params["drop_params"] = True
     return params
 
 

--- a/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
@@ -1,6 +1,7 @@
 """Optimizer factory for Optimization Studio."""
 
 import logging
+import math
 from typing import Dict, Type, Any
 
 from opik_optimizer.algorithms.gepa_optimizer.gepa_optimizer import GepaOptimizer
@@ -42,6 +43,30 @@ def ensure_default_model_params(
         # Let models that fix their temperature ignore ours instead of erroring.
         params.setdefault("drop_params", True)
     return params
+
+
+def _resolve_perfect_score(value: Any, optimizer_type: str) -> float:
+    """Validate the run's ``perfect_score`` override, falling back to the default.
+
+    The value comes from the studio config, so it can be absent, explicitly
+    ``null``, or junk. It ends up in ``baseline_score >= perfect_score`` deep in a
+    run, where ``None`` or a NaN raises/mis-compares long after the config that
+    caused it — so reject it here, where the error can still name the field.
+    ``0`` is a legal value (it disables threshold stopping), so this must not
+    treat it as falsy.
+    """
+    if value is None:
+        return OPTIMIZER_PERFECT_SCORE
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise InvalidOptimizerError(
+            optimizer_type,
+            f"perfect_score must be a finite number, got {type(value).__name__}",
+        )
+    if not math.isfinite(value):
+        raise InvalidOptimizerError(
+            optimizer_type, f"perfect_score must be a finite number, got {value}"
+        )
+    return float(value)
 
 
 class OptimizerFactory:
@@ -96,7 +121,9 @@ class OptimizerFactory:
         # optimizer accepts perfect_score in its constructor; an explicit value
         # in the run's optimizer_params still wins.
         optimizer_params = dict(optimizer_params)
-        optimizer_params.setdefault("perfect_score", OPTIMIZER_PERFECT_SCORE)
+        optimizer_params["perfect_score"] = _resolve_perfect_score(
+            optimizer_params.get("perfect_score", None), optimizer_type
+        )
 
         logger.debug(
             f"Initializing {optimizer_type} optimizer with params: {optimizer_params}"

--- a/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/optimizers.py
@@ -11,7 +11,7 @@ from opik_optimizer.algorithms.hierarchical_reflective_optimizer.hierarchical_re
     HierarchicalReflectiveOptimizer,
 )
 
-from .config import OPTIMIZER_PERFECT_SCORE
+from .config import OPTIMIZER_PERFECT_SCORE, OPTIMIZER_TASK_TEMPERATURE
 from .exceptions import InvalidOptimizerError
 from opik_backend.utils.env_utils import get_env_int
 
@@ -23,11 +23,24 @@ DEFAULT_MAX_TOKENS = 8192
 LLM_MAX_TOKENS = get_env_int("OPTSTUDIO_LLM_MAX_TOKENS", DEFAULT_MAX_TOKENS)
 
 
-def ensure_default_model_params(model_params: Dict[str, Any] | None) -> Dict[str, Any]:
+def ensure_default_model_params(
+    model_params: Dict[str, Any] | None, *, deterministic: bool = False
+) -> Dict[str, Any]:
     """Return model params with a reasonable max_tokens default so structured
-    outputs (and baseline/per-trial task completions) don't truncate."""
+    outputs (and baseline/per-trial task completions) don't truncate.
+
+    Pass ``deterministic=True`` for the task model, whose completions are scored:
+    it pins the temperature so the same prompt scores the same twice (see
+    OPTIMIZER_TASK_TEMPERATURE). An explicit value from the run config always
+    wins. Leave it False for the optimizer/reflection model, which needs sampling
+    diversity to propose varied candidates.
+    """
     params = dict(model_params or {})
     params.setdefault("max_tokens", LLM_MAX_TOKENS)
+    if deterministic:
+        params.setdefault("temperature", OPTIMIZER_TASK_TEMPERATURE)
+        # Let models that fix their temperature ignore ours instead of erroring.
+        params.setdefault("drop_params", True)
     return params
 
 

--- a/apps/opik-python-backend/src/opik_backend/studio/types.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/types.py
@@ -46,6 +46,41 @@ def extract_scoring_health(result: Any) -> Optional[ScoringHealth]:
     return None
 
 
+# Mirrors the SDK's FinishReason literal (opik_optimizer/core/state.py). Kept
+# as a validation allowlist so a malformed details dict can't push arbitrary
+# strings into the optimization's metadata.
+KNOWN_FINISH_REASONS = frozenset(
+    {
+        "completed",
+        "perfect_score",
+        "max_trials",
+        "no_improvement",
+        "error",
+        "cancelled",
+    }
+)
+
+
+def extract_finish_reason(result: Any) -> Optional[str]:
+    """Pull ``finish_reason`` off an SDK ``OptimizationResult``.
+
+    Reads ``result.details["finish_reason"]`` — the SDK's authoritative record
+    of why the run ended (perfect score, no improvement, budget exhausted, …).
+    Forwarded to the Java backend as ``metadata.finish_reason`` so the UI can
+    render the real stop cause instead of a heuristic (OPIK-7511/OPIK-7458).
+    Returns ``None`` when absent or not a known reason (older SDKs), and never
+    raises — the completion path must not fail over a missing reason.
+    """
+    try:
+        details = getattr(result, "details", None) or {}
+        raw = details.get("finish_reason") if isinstance(details, dict) else None
+        if isinstance(raw, str) and raw in KNOWN_FINISH_REASONS:
+            return raw
+    except Exception as exc:  # pragma: no cover - defensive; never break completion
+        logger.warning("Failed to extract finish_reason from result: %s", exc)
+    return None
+
+
 class OptimizationRunResult(TypedDict):
     """Successful result emitted by ``optimizer_runner`` and returned by
     ``process_optimizer_job``."""
@@ -60,6 +95,9 @@ class OptimizationRunResult(TypedDict):
     # Scoring-health counters from the SDK result; absent when the SDK did not
     # attach them (older SDK versions).
     scoring_health: NotRequired[ScoringHealth]
+    # Why the run ended (SDK FinishReason); absent when the SDK did not attach
+    # it (older SDK versions).
+    finish_reason: NotRequired[str]
 
 
 class OptimizationErrorResult(TypedDict):

--- a/apps/opik-python-backend/src/opik_backend/studio/types.py
+++ b/apps/opik-python-backend/src/opik_backend/studio/types.py
@@ -74,11 +74,37 @@ def extract_finish_reason(result: Any) -> Optional[str]:
     try:
         details = getattr(result, "details", None) or {}
         raw = details.get("finish_reason") if isinstance(details, dict) else None
-        if isinstance(raw, str) and raw in KNOWN_FINISH_REASONS:
-            return raw
+        if isinstance(raw, str):
+            if raw in KNOWN_FINISH_REASONS:
+                return raw
+            # Loud, not silent: an SDK that starts emitting a new reason should
+            # surface in logs, not quietly lose the feature until someone digs.
+            logger.warning(
+                "Dropping unknown finish_reason %r (not in the allowlist); "
+                "update KNOWN_FINISH_REASONS if the SDK added a new reason.",
+                raw,
+            )
     except Exception as exc:  # pragma: no cover - defensive; never break completion
         logger.warning("Failed to extract finish_reason from result: %s", exc)
     return None
+
+
+def extract_completion_metadata(result: Any) -> Dict[str, Any]:
+    """Collect the completion metadata payload off an SDK ``OptimizationResult``.
+
+    Combines ``extract_scoring_health`` and ``extract_finish_reason`` into the
+    dict forwarded to the Java backend on ``mark_completed`` (and merged into
+    the runner's output). Returns ``{}`` when neither field is available
+    (older SDKs), and never raises.
+    """
+    metadata: Dict[str, Any] = {}
+    scoring_health = extract_scoring_health(result)
+    if scoring_health is not None:
+        metadata["scoring_health"] = scoring_health
+    finish_reason = extract_finish_reason(result)
+    if finish_reason is not None:
+        metadata["finish_reason"] = finish_reason
+    return metadata
 
 
 class OptimizationRunResult(TypedDict):

--- a/apps/opik-python-backend/tests/e2e/conftest.py
+++ b/apps/opik-python-backend/tests/e2e/conftest.py
@@ -26,6 +26,13 @@ from opik_backend.jobs.optimizer import process_optimizer_job
 _PROVIDER = "anthropic"
 
 
+def _provider_for_model(model: str | None) -> str:
+    """Provider required by the e2e model (default model is Anthropic)."""
+    if model and model.startswith("gpt"):
+        return "openai"
+    return _PROVIDER
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
@@ -46,14 +53,14 @@ def _workspace_headers() -> dict[str, str]:
     return headers
 
 
-def _anthropic_configured(base: str, headers: dict[str, str]) -> bool:
+def _provider_configured(base: str, headers: dict[str, str], provider: str) -> bool:
     listing = httpx.get(
         f"{base}/v1/private/llm-provider-key", headers=headers, timeout=30
     )
     if listing.status_code != 200:
         return False
     return any(
-        item.get("provider") == _PROVIDER for item in listing.json().get("content", [])
+        item.get("provider") == provider for item in listing.json().get("content", [])
     )
 
 
@@ -67,26 +74,31 @@ def opik_client() -> Iterator[opik.Opik]:
 
 
 @pytest.fixture()
-def anthropic_workspace_key() -> None:
-    """Take the Anthropic key from the ANTHROPIC_API_KEY secret and store it in
-    the backend workspace, so the optimization resolves it server-side via the
-    gateway. The key is never handed to the optimizer. Skips if no key is
-    available (and none is already configured)."""
+def workspace_provider_key() -> None:
+    """Ensure the provider required by the e2e model has a key in the backend
+    workspace, so the optimization resolves it server-side via the gateway —
+    the key is never handed to the optimizer. For the default Anthropic model
+    the key comes from the ANTHROPIC_API_KEY secret (CI); for a local stack
+    whose workspace already has the required provider configured (e.g.
+    ``OPTSTUDIO_E2E_MODEL=gpt-5-nano`` with an OpenAI workspace key) this is a
+    no-op. Skips when the provider is neither configured nor obtainable."""
     base = _backend_base()
     if not base:
         pytest.skip("OPIK_URL_OVERRIDE not set; e2e requires a running Opik backend")
+    provider = _provider_for_model(os.getenv("OPTSTUDIO_E2E_MODEL"))
     headers = _workspace_headers()
-    if _anthropic_configured(base, headers):
+    if _provider_configured(base, headers, provider):
         return
-    secret = os.getenv("ANTHROPIC_API_KEY")
+    secret = os.getenv("ANTHROPIC_API_KEY") if provider == _PROVIDER else None
     if not secret:
         pytest.skip(
-            "ANTHROPIC_API_KEY not set and no Anthropic provider configured in the workspace"
+            f"no {provider} provider key configured in the workspace "
+            "(and no secret available to store one)"
         )
     httpx.post(
         f"{base}/v1/private/llm-provider-key",
         headers=headers,
-        json={"provider": _PROVIDER, "api_key": secret},
+        json={"provider": provider, "api_key": secret},
         timeout=30,
     ).raise_for_status()
 
@@ -169,6 +181,12 @@ def run_studio_optimization(
             "config": studio_config,
             "project_name": project_name,
         }
+        # Cloud backends authenticate the gateway and status updates with the
+        # workspace API key ("optional-api-key-for-cloud" in the job contract);
+        # local CI stacks run unauthenticated, so None keeps today's behaviour.
+        api_key = os.getenv("OPIK_API_KEY")
+        if api_key:
+            job_message["opik_api_key"] = api_key
         return process_optimizer_job(job_message)
 
     _run.last_optimization_id = None

--- a/apps/opik-python-backend/tests/e2e/conftest.py
+++ b/apps/opik-python-backend/tests/e2e/conftest.py
@@ -26,11 +26,23 @@ from opik_backend.jobs.optimizer import process_optimizer_job
 _PROVIDER = "anthropic"
 
 
+_PROVIDER_SECRET_ENV = {"anthropic": "ANTHROPIC_API_KEY", "openai": "OPENAI_API_KEY"}
+
+
 def _provider_for_model(model: str | None) -> str:
-    """Provider required by the e2e model (default model is Anthropic)."""
-    if model and model.startswith("gpt"):
-        return "openai"
-    return _PROVIDER
+    """Provider required by the e2e model (default model is Anthropic).
+
+    Handles both bare ids ("gpt-5-nano") and gateway-prefixed ones
+    ("openai/gpt-4o") — the Studio routes everything through the gateway with an
+    ``openai/`` prefix, so a prefix-blind check would ask the backend for an
+    Anthropic key and get a BadRequestException for the missing one.
+    """
+    if not model:
+        return _PROVIDER
+    provider, _, remainder = model.partition("/")
+    if remainder and provider in _PROVIDER_SECRET_ENV:
+        return provider
+    return "openai" if model.startswith("gpt") else _PROVIDER
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -78,10 +90,10 @@ def workspace_provider_key() -> None:
     """Ensure the provider required by the e2e model has a key in the backend
     workspace, so the optimization resolves it server-side via the gateway —
     the key is never handed to the optimizer. For the default Anthropic model
-    the key comes from the ANTHROPIC_API_KEY secret (CI); for a local stack
-    whose workspace already has the required provider configured (e.g.
-    ``OPTSTUDIO_E2E_MODEL=gpt-5-nano`` with an OpenAI workspace key) this is a
-    no-op. Skips when the provider is neither configured nor obtainable."""
+    the key comes from the ANTHROPIC_API_KEY secret (CI); an OpenAI model takes
+    OPENAI_API_KEY. For a local stack whose workspace already has the required
+    provider configured this is a no-op. Skips when the provider is neither
+    configured nor obtainable."""
     base = _backend_base()
     if not base:
         pytest.skip("OPIK_URL_OVERRIDE not set; e2e requires a running Opik backend")
@@ -89,11 +101,12 @@ def workspace_provider_key() -> None:
     headers = _workspace_headers()
     if _provider_configured(base, headers, provider):
         return
-    secret = os.getenv("ANTHROPIC_API_KEY") if provider == _PROVIDER else None
+    secret_env = _PROVIDER_SECRET_ENV[provider]
+    secret = os.getenv(secret_env)
     if not secret:
         pytest.skip(
-            f"no {provider} provider key configured in the workspace "
-            "(and no secret available to store one)"
+            f"no {provider} provider key configured in the workspace and "
+            f"{secret_env} is not set"
         )
     httpx.post(
         f"{base}/v1/private/llm-provider-key",

--- a/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
@@ -22,14 +22,16 @@ from opik_backend.studio.types import KNOWN_FINISH_REASONS
 pytestmark = pytest.mark.e2e
 
 # The SDK half of OPIK-7511 (finish_reason on every stop path, including the
-# baseline-perfect early stop) ships with the same changeset that raised
-# DEFAULT_PERFECT_SCORE to 1.0 — so that constant is an honest feature probe.
-# Until the python-backend's pinned opik_optimizer release contains it, the
-# subprocess can complete without a finish_reason and this test would fail on
-# the pin, not on the backend code under test. It activates automatically on
-# the next optimizer pin bump.
-_sdk_constants = pytest.importorskip("opik_optimizer.constants")
-if _sdk_constants.DEFAULT_PERFECT_SCORE < 1.0:
+# baseline-perfect early stop) ships in the same changeset that introduced
+# MIN_EXPECTED_REFLECTION_ITERATIONS in the GEPA module — so that attribute is
+# an honest feature probe. Until the python-backend's pinned opik_optimizer
+# release contains it, the subprocess can complete without a finish_reason and
+# this test would fail on the pin, not on the backend code under test. It
+# activates automatically on the next optimizer pin bump.
+_gepa_module = pytest.importorskip(
+    "opik_optimizer.algorithms.gepa_optimizer.gepa_optimizer"
+)
+if not hasattr(_gepa_module, "MIN_EXPECTED_REFLECTION_ITERATIONS"):
     pytestmark = [
         pytest.mark.e2e,
         pytest.mark.skip(

--- a/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
@@ -17,6 +17,7 @@ import opik
 from opik import synchronization
 
 from llm_constants import ANTHROPIC_CLAUDE_HAIKU
+from opik_backend.studio.types import KNOWN_FINISH_REASONS
 
 pytestmark = pytest.mark.e2e
 
@@ -39,17 +40,6 @@ if _sdk_constants.DEFAULT_PERFECT_SCORE < 1.0:
 # CI uses the workspace Anthropic key; overridable for local stacks whose
 # workspace has a different provider configured.
 _MODEL = os.getenv("OPTSTUDIO_E2E_MODEL", ANTHROPIC_CLAUDE_HAIKU)
-
-# Mirrors the SDK's FinishReason literal / the backend's KNOWN_FINISH_REASONS.
-_ALLOWED_FINISH_REASONS = {
-    "completed",
-    "perfect_score",
-    "max_trials",
-    "no_improvement",
-    "error",
-    "cancelled",
-}
-
 
 def _metadata_field(optimization: Any, name: str) -> Any:
     """Read a metadata key off the fetched optimization, tolerating both the
@@ -131,7 +121,7 @@ def test_finish_reason_is_returned_and_persisted(
 
     # The subprocess result carries the stop cause (optimizer_runner output).
     finish_reason = result.get("finish_reason")
-    assert finish_reason in _ALLOWED_FINISH_REASONS, (
+    assert finish_reason in KNOWN_FINISH_REASONS, (
         f"subprocess result carries no valid finish_reason: {finish_reason!r}"
     )
 

--- a/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
@@ -83,7 +83,7 @@ def _wait_for_completed_with_metadata(
 
 def test_finish_reason_is_returned_and_persisted(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: Any,

--- a/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
@@ -20,6 +20,22 @@ from llm_constants import ANTHROPIC_CLAUDE_HAIKU
 
 pytestmark = pytest.mark.e2e
 
+# The SDK half of OPIK-7511 (finish_reason on every stop path, including the
+# baseline-perfect early stop) ships with the same changeset that raised
+# DEFAULT_PERFECT_SCORE to 1.0 — so that constant is an honest feature probe.
+# Until the python-backend's pinned opik_optimizer release contains it, the
+# subprocess can complete without a finish_reason and this test would fail on
+# the pin, not on the backend code under test. It activates automatically on
+# the next optimizer pin bump.
+_sdk_constants = pytest.importorskip("opik_optimizer.constants")
+if _sdk_constants.DEFAULT_PERFECT_SCORE < 1.0:
+    pytestmark = [
+        pytest.mark.e2e,
+        pytest.mark.skip(
+            reason="pinned opik_optimizer predates OPIK-7511 finish_reason support"
+        ),
+    ]
+
 # CI uses the workspace Anthropic key; overridable for local stacks whose
 # workspace has a different provider configured.
 _MODEL = os.getenv("OPTSTUDIO_E2E_MODEL", ANTHROPIC_CLAUDE_HAIKU)

--- a/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_finish_reason.py
@@ -1,0 +1,137 @@
+"""E2E regression test for OPIK-7511: the run's stop cause is persisted.
+
+Drives the real entrypoint (``process_optimizer_job`` → ``optimizer_runner.py``
+subprocess → gateway-routed LLM calls) and asserts the new authoritative
+signal: ``finish_reason`` is returned in the subprocess result AND persisted on
+the optimization record as ``metadata.finish_reason``, so the UI (OPIK_7458)
+can render the real stop cause instead of a heuristic. Before this, a run that
+produced no candidates was indistinguishable from a metric failure.
+"""
+
+import os
+from typing import Any
+
+import pytest
+
+import opik
+from opik import synchronization
+
+from llm_constants import ANTHROPIC_CLAUDE_HAIKU
+
+pytestmark = pytest.mark.e2e
+
+# CI uses the workspace Anthropic key; overridable for local stacks whose
+# workspace has a different provider configured.
+_MODEL = os.getenv("OPTSTUDIO_E2E_MODEL", ANTHROPIC_CLAUDE_HAIKU)
+
+# Mirrors the SDK's FinishReason literal / the backend's KNOWN_FINISH_REASONS.
+_ALLOWED_FINISH_REASONS = {
+    "completed",
+    "perfect_score",
+    "max_trials",
+    "no_improvement",
+    "error",
+    "cancelled",
+}
+
+
+def _metadata_field(optimization: Any, name: str) -> Any:
+    """Read a metadata key off the fetched optimization, tolerating both the
+    pinned SDK (plain dict) and a newer typed object."""
+    metadata = getattr(optimization, "metadata", None)
+    if isinstance(metadata, dict):
+        return metadata.get(name)
+    return getattr(metadata, name, None)
+
+
+def _wait_for_completed_with_metadata(
+    opik_client: opik.Opik, optimization_id: str
+) -> Any:
+    """Poll until the run is completed AND metadata.finish_reason is visible.
+
+    The optimization row is a ClickHouse ReplacingMergeTree versioned
+    re-insert, so the enriched completion update isn't guaranteed to be
+    readable the instant the subprocess exits.
+    """
+    fetched: dict[str, Any] = {}
+
+    def _ready() -> bool:
+        optimization = opik_client.rest_client.optimizations.get_optimization_by_id(
+            optimization_id
+        )
+        fetched["optimization"] = optimization
+        return optimization.status == "completed" and bool(
+            _metadata_field(optimization, "finish_reason")
+        )
+
+    assert synchronization.until(_ready, sleep=1.0, max_try_seconds=60), (
+        f"optimization {optimization_id} never reached completed status with "
+        f"metadata.finish_reason (last: status="
+        f"{getattr(fetched.get('optimization'), 'status', None)!r}, metadata="
+        f"{getattr(fetched.get('optimization'), 'metadata', None)!r})"
+    )
+    return fetched["optimization"]
+
+
+def test_finish_reason_is_returned_and_persisted(
+    opik_client: opik.Opik,
+    anthropic_workspace_key: None,
+    project_name: str,
+    seeded_sentiment_classification_dataset: opik.Dataset,
+    run_studio_optimization: Any,
+) -> None:
+    """A GEPA studio run ends with an allowlisted finish_reason in both the
+    subprocess result and the persisted optimization metadata (OPIK-7511).
+
+    The clear-cut sentiment dataset makes a strong baseline likely, which is
+    exactly the dogfooding case that used to end silently: either the run now
+    attempts candidates, or it stops with a recorded reason — never neither.
+    """
+    dataset_name = seeded_sentiment_classification_dataset.name
+    studio_config = {
+        "dataset_name": dataset_name,
+        "prompt": {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": 'Classify the sentiment of this movie review as '
+                    'exactly "positive" or "negative": {{text}}',
+                }
+            ]
+        },
+        "llm_model": {"model": _MODEL, "parameters": {}},
+        "evaluation": {
+            "metrics": [
+                {
+                    "type": "equals",
+                    "parameters": {"reference_key": "label", "case_sensitive": False},
+                }
+            ]
+        },
+        "optimizer": {"type": "gepa", "parameters": {"seed": 42}},
+    }
+
+    result = run_studio_optimization(project_name, dataset_name, studio_config)
+
+    # The subprocess result carries the stop cause (optimizer_runner output).
+    finish_reason = result.get("finish_reason")
+    assert finish_reason in _ALLOWED_FINISH_REASONS, (
+        f"subprocess result carries no valid finish_reason: {finish_reason!r}"
+    )
+
+    # ... and the same value is persisted where the frontend reads it.
+    optimization = _wait_for_completed_with_metadata(
+        opik_client, run_studio_optimization.last_optimization_id
+    )
+    persisted = _metadata_field(optimization, "finish_reason")
+    assert persisted == finish_reason, (
+        f"metadata.finish_reason ({persisted!r}) does not match the subprocess "
+        f"result ({finish_reason!r})"
+    )
+
+    # scoring_health rides the same completion update; it must not be lost now
+    # that the metadata payload carries both keys.
+    scoring_health = _metadata_field(optimization, "scoring_health")
+    assert isinstance(scoring_health, dict) and "failed_count" in scoring_health, (
+        f"scoring_health missing from completion metadata: {scoring_health!r}"
+    )

--- a/apps/opik-python-backend/tests/e2e/test_studio_optimization.py
+++ b/apps/opik-python-backend/tests/e2e/test_studio_optimization.py
@@ -8,7 +8,7 @@ prefix, the ``ChatPrompt(model=...)`` construction, role derivation) is actually
 exercised. Only the Java REST enqueue and the RQ queue itself are skipped.
 
 The Anthropic key lives in the backend workspace (stored by the
-``anthropic_workspace_key`` fixture from a CI secret); the optimizer reaches it
+``workspace_provider_key`` fixture from a CI secret); the optimizer reaches it
 only through the gateway, never directly.
 
 Coverage:
@@ -250,7 +250,7 @@ def _assert_only_configured_model_ran(opik_client: opik.Opik, project_name: str)
 @pytest.mark.parametrize("optimizer_type", ["gepa", "hierarchical_reflective"])
 def test_studio_optimization_runs_on_dataset_and_prompt(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: RunStudioOptimization,
@@ -271,7 +271,7 @@ def test_studio_optimization_runs_on_dataset_and_prompt(
 
 def test_studio_optimization_with_code_metric(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: RunStudioOptimization,
@@ -290,7 +290,7 @@ def test_studio_optimization_with_code_metric(
 
 def test_studio_optimization_code_metric_syntax_error_surfaces_as_error(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: RunStudioOptimization,
@@ -336,7 +336,7 @@ def test_studio_optimization_code_metric_syntax_error_surfaces_as_error(
 
 def test_studio_optimization_with_code_metric_arguments_map_rename(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: RunStudioOptimization,
@@ -381,7 +381,7 @@ def test_studio_optimization_with_code_metric_arguments_map_rename(
 
 def test_studio_optimization_with_code_metric_missing_mapped_column(
     opik_client: opik.Opik,
-    anthropic_workspace_key: None,
+    workspace_provider_key: None,
     project_name: str,
     seeded_sentiment_classification_dataset: opik.Dataset,
     run_studio_optimization: RunStudioOptimization,

--- a/apps/opik-python-backend/tests/unit/test_studio_config.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_config.py
@@ -1,0 +1,58 @@
+"""Unit tests for opik_backend.studio.config sizing policy."""
+
+import pytest
+
+from opik_backend.studio.config import (
+    GEPA_REFLECTION_MINIBATCH_ENV,
+    resolve_reflection_minibatch_size,
+)
+
+
+class TestResolveReflectionMinibatchSize:
+    """OPIK-7511: the reflection mini-batch scales with dataset size so coarse
+    0/1 metrics get a usable gradient, within the SDK's max_trials clamp."""
+
+    @pytest.mark.parametrize(
+        "dataset_size,max_trials,expected",
+        [
+            # Tiny dataset: capped at the dataset itself.
+            (3, 10, 3),
+            # Small dataset: the floor of 5 (previous fixed value) holds.
+            (10, 10, 5),
+            (25, 10, 5),
+            # 20% scaling kicks in above the floor.
+            (30, 10, 6),
+            (40, 10, 8),
+            # Capped at max_trials — above it GEPA reflection would not run.
+            (50, 10, 10),
+            (1000, 10, 10),
+            # Higher max_trials lets the scaled value through.
+            (100, 25, 20),
+            # max_trials below the floor still wins the clamp.
+            (100, 3, 3),
+        ],
+    )
+    def test_policy(self, dataset_size, max_trials, expected, monkeypatch):
+        monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)
+        assert (
+            resolve_reflection_minibatch_size(
+                dataset_size=dataset_size, max_trials=max_trials
+            )
+            == expected
+        )
+
+    def test_env_override_wins_verbatim(self, monkeypatch):
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "7")
+        assert resolve_reflection_minibatch_size(dataset_size=1000, max_trials=10) == 7
+
+    def test_env_override_clamped_to_at_least_one(self, monkeypatch):
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "0")
+        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 1
+
+    def test_blank_env_falls_back_to_policy(self, monkeypatch):
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "  ")
+        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
+
+    def test_never_below_one(self, monkeypatch):
+        monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)
+        assert resolve_reflection_minibatch_size(dataset_size=0, max_trials=10) == 1

--- a/apps/opik-python-backend/tests/unit/test_studio_config.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_config.py
@@ -12,6 +12,61 @@ from opik_backend.studio.config import (
 )
 
 
+class TestFloatEnvValidation:
+    """float() alone accepts nan/inf, which silently breaks the score comparisons
+    these values feed — a bad deployment value must fail at startup instead."""
+
+    @pytest.mark.parametrize(
+        "env,default,minimum,maximum",
+        [
+            ("OPTIMIZER_PERFECT_SCORE", "1.0", 0.0, 1.0),
+            ("OPTIMIZER_TASK_TEMPERATURE", "0.0", 0.0, 2.0),
+        ],
+    )
+    @pytest.mark.parametrize("bad_value", ["nan", "inf", "-inf", "abc", "-0.5", "9.5"])
+    def test_invalid_value__raises_naming_the_variable(
+        self, env, default, minimum, maximum, bad_value, monkeypatch
+    ):
+        monkeypatch.setenv(env, bad_value)
+        with pytest.raises(ValueError, match=env):
+            config_module._read_float_env(
+                env, default, minimum=minimum, maximum=maximum
+            )
+
+    def test_blank_value__uses_default(self, monkeypatch):
+        monkeypatch.setenv("OPTIMIZER_PERFECT_SCORE", "   ")
+        assert (
+            config_module._read_float_env(
+                "OPTIMIZER_PERFECT_SCORE", "1.0", minimum=0.0, maximum=1.0
+            )
+            == 1.0
+        )
+
+    def test_bounds_are_inclusive(self, monkeypatch):
+        monkeypatch.setenv("OPTIMIZER_PERFECT_SCORE", "0.0")
+        assert (
+            config_module._read_float_env(
+                "OPTIMIZER_PERFECT_SCORE", "1.0", minimum=0.0, maximum=1.0
+            )
+            == 0.0
+        )
+
+    def test_error_message_is_bounded(self, monkeypatch):
+        monkeypatch.setenv("OPTIMIZER_PERFECT_SCORE", "x" * 5000)
+        with pytest.raises(ValueError) as exc_info:
+            config_module._read_float_env(
+                "OPTIMIZER_PERFECT_SCORE", "1.0", minimum=0.0, maximum=1.0
+            )
+        assert len(str(exc_info.value)) < 200
+
+    def test_module_import_fails_fast_on_malformed_env(self, monkeypatch):
+        monkeypatch.setenv("OPTIMIZER_PERFECT_SCORE", "nan")
+        with pytest.raises(ValueError, match="OPTIMIZER_PERFECT_SCORE"):
+            importlib.reload(config_module)
+        monkeypatch.delenv("OPTIMIZER_PERFECT_SCORE")
+        importlib.reload(config_module)
+
+
 class TestResolveReflectionMinibatchSize:
     """OPIK-7511: the reflection mini-batch scales with dataset size so coarse
     0/1 metrics get a usable gradient, capped only by the dataset itself and

--- a/apps/opik-python-backend/tests/unit/test_studio_config.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_config.py
@@ -1,8 +1,12 @@
 """Unit tests for opik_backend.studio.config sizing policy."""
 
+import importlib
+
 import pytest
 
+from opik_backend.studio import config as config_module
 from opik_backend.studio.config import (
+    GEPA_MIN_REFLECTION_ITERATIONS,
     GEPA_REFLECTION_MINIBATCH_ENV,
     resolve_reflection_minibatch_size,
 )
@@ -10,12 +14,15 @@ from opik_backend.studio.config import (
 
 class TestResolveReflectionMinibatchSize:
     """OPIK-7511: the reflection mini-batch scales with dataset size so coarse
-    0/1 metrics get a usable gradient, within the SDK's max_trials clamp."""
+    0/1 metrics get a usable gradient, capped only by the dataset itself and
+    by the metric-call budget (>= GEPA_MIN_REFLECTION_ITERATIONS iterations)."""
 
     @pytest.mark.parametrize(
         "dataset_size,max_trials,expected",
         [
-            # Tiny dataset: capped at the dataset itself.
+            # Single-item dataset: the batch is that one item.
+            (1, 10, 1),
+            # Tiny dataset below the floor of 5: capped at the dataset itself.
             (3, 10, 3),
             # Small dataset: the floor of 5 (previous fixed value) holds.
             (10, 10, 5),
@@ -23,13 +30,18 @@ class TestResolveReflectionMinibatchSize:
             # 20% scaling kicks in above the floor.
             (30, 10, 6),
             (40, 10, 8),
-            # Capped at max_trials — above it GEPA reflection would not run.
             (50, 10, 10),
-            (1000, 10, 10),
-            # Higher max_trials lets the scaled value through.
-            (100, 25, 20),
-            # max_trials below the floor still wins the clamp.
-            (100, 3, 3),
+            # No max_trials cap: 20% keeps scaling past max_trials=10
+            # (previously clamped to 10 — the OPIK-7511 regression).
+            (100, 10, 20),
+            (1000, 10, 200),
+            # A small trial budget no longer strangles the batch...
+            (100, 3, 20),
+            # ...but the metric-call budget does: 100*1 // (2*5) = 10, which
+            # keeps >= GEPA_MIN_REFLECTION_ITERATIONS reflection iterations.
+            (100, 1, 10),
+            # Degenerate budget: the cap floors at 1.
+            (6, 1, 1),
         ],
     )
     def test_policy(self, dataset_size, max_trials, expected, monkeypatch):
@@ -41,26 +53,51 @@ class TestResolveReflectionMinibatchSize:
             == expected
         )
 
+    def test_budget_cap_guarantees_min_reflection_iterations(self, monkeypatch):
+        """Whenever the resolved batch is > 1, the run's metric budget
+        (max_trials * dataset_size) must fit at least
+        GEPA_MIN_REFLECTION_ITERATIONS iterations at ~2*batch calls each."""
+        monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)
+        for dataset_size in (1, 5, 30, 100, 1000):
+            for max_trials in (1, 3, 10, 25):
+                batch = resolve_reflection_minibatch_size(
+                    dataset_size=dataset_size, max_trials=max_trials
+                )
+                if batch > 1:
+                    budget = max_trials * dataset_size
+                    assert budget // (2 * batch) >= GEPA_MIN_REFLECTION_ITERATIONS
+
     def test_env_override_wins_verbatim(self, monkeypatch):
         monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "7")
         assert resolve_reflection_minibatch_size(dataset_size=1000, max_trials=10) == 7
-
-    def test_env_override_clamped_to_at_least_one(self, monkeypatch):
-        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "0")
-        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 1
 
     def test_blank_env_falls_back_to_policy(self, monkeypatch):
         monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "  ")
         assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
 
-    def test_invalid_env_falls_back_to_policy(self, monkeypatch):
-        # A malformed operator value must not fail every optimization run.
-        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "five")
-        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
+    @pytest.mark.parametrize("bad_value", ["five", "7.5", "0", "-3"])
+    def test_invalid_env_raises_naming_the_variable(self, bad_value, monkeypatch):
+        # A malformed operator value must fail loudly (and at service startup,
+        # see test_module_import_fails_fast_on_malformed_env), never silently
+        # fall back mid-run.
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, bad_value)
+        with pytest.raises(ValueError, match=GEPA_REFLECTION_MINIBATCH_ENV):
+            resolve_reflection_minibatch_size(dataset_size=50, max_trials=10)
 
-    def test_float_env_falls_back_to_policy(self, monkeypatch):
-        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "7.5")
-        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
+    def test_invalid_env_error_is_bounded(self, monkeypatch):
+        # The env value is free text — a huge garbage value must not flood the
+        # error message (or any log line that carries it).
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "x" * 5000)
+        with pytest.raises(ValueError) as exc_info:
+            resolve_reflection_minibatch_size(dataset_size=50, max_trials=10)
+        assert len(str(exc_info.value)) < 200
+
+    def test_module_import_fails_fast_on_malformed_env(self, monkeypatch):
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "not-a-number")
+        with pytest.raises(ValueError, match=GEPA_REFLECTION_MINIBATCH_ENV):
+            importlib.reload(config_module)
+        monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV)
+        importlib.reload(config_module)
 
     def test_never_below_one(self, monkeypatch):
         monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)

--- a/apps/opik-python-backend/tests/unit/test_studio_config.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_config.py
@@ -6,8 +6,10 @@ import pytest
 
 from opik_backend.studio import config as config_module
 from opik_backend.studio.config import (
+    DATASET_SAMPLES,
     GEPA_MIN_REFLECTION_ITERATIONS,
     GEPA_REFLECTION_MINIBATCH_ENV,
+    GEPA_REFLECTION_MINIBATCH_MAX,
     resolve_reflection_minibatch_size,
 )
 
@@ -69,7 +71,8 @@ class TestFloatEnvValidation:
 
 class TestResolveReflectionMinibatchSize:
     """OPIK-7511: the reflection mini-batch scales with dataset size so coarse
-    0/1 metrics get a usable gradient, capped only by the dataset itself and
+    0/1 metrics get a usable gradient, capped by the dataset itself, by an
+    absolute ceiling (the batch is serialized into the reflection prompt) and
     by the metric-call budget (>= GEPA_MIN_REFLECTION_ITERATIONS iterations)."""
 
     @pytest.mark.parametrize(
@@ -89,7 +92,10 @@ class TestResolveReflectionMinibatchSize:
             # No max_trials cap: 20% keeps scaling past max_trials=10
             # (previously clamped to 10 — the OPIK-7511 regression).
             (100, 10, 20),
-            (1000, 10, 200),
+            # ...up to the absolute ceiling, which bounds the reflection prompt
+            # (the whole mini-batch is serialized into it).
+            (200, 10, 25),
+            (1000, 10, 25),
             # A small trial budget no longer strangles the batch...
             (100, 3, 20),
             # ...but the metric-call budget does: 100*1 // (2*5) = 10, which
@@ -121,6 +127,20 @@ class TestResolveReflectionMinibatchSize:
                 if batch > 1:
                     budget = max_trials * dataset_size
                     assert budget // (2 * batch) >= GEPA_MIN_REFLECTION_ITERATIONS
+
+    def test_batch_never_exceeds_the_prompt_ceiling(self, monkeypatch):
+        """gepa serializes every mini-batch sample into one reflection prompt, so
+        an unbounded batch is an unbounded prompt — no dataset size may push it
+        past the ceiling, including the largest one the Studio can sample."""
+        monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)
+        for dataset_size in (100, 250, 500, DATASET_SAMPLES):
+            for max_trials in (1, 3, 10, 25, 100):
+                assert (
+                    resolve_reflection_minibatch_size(
+                        dataset_size=dataset_size, max_trials=max_trials
+                    )
+                    <= GEPA_REFLECTION_MINIBATCH_MAX
+                )
 
     def test_env_override_wins_verbatim(self, monkeypatch):
         monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "7")

--- a/apps/opik-python-backend/tests/unit/test_studio_config.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_config.py
@@ -53,6 +53,15 @@ class TestResolveReflectionMinibatchSize:
         monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "  ")
         assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
 
+    def test_invalid_env_falls_back_to_policy(self, monkeypatch):
+        # A malformed operator value must not fail every optimization run.
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "five")
+        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
+
+    def test_float_env_falls_back_to_policy(self, monkeypatch):
+        monkeypatch.setenv(GEPA_REFLECTION_MINIBATCH_ENV, "7.5")
+        assert resolve_reflection_minibatch_size(dataset_size=50, max_trials=10) == 10
+
     def test_never_below_one(self, monkeypatch):
         monkeypatch.delenv(GEPA_REFLECTION_MINIBATCH_ENV, raising=False)
         assert resolve_reflection_minibatch_size(dataset_size=0, max_trials=10) == 1

--- a/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
@@ -102,3 +102,16 @@ class TestLoadAndValidateDataset:
 
         assert dataset is not None
         assert count == 1
+
+    def test_full_page_of_id_less_rows_is_not_rejected(self):
+        """The fetch is capped at DATASET_SAMPLES, but the SDK draws its sample
+        ids from the whole dataset (sampling._extract_ids calls get_items()
+        unbounded). A full page with no usable id therefore proves nothing about
+        the rows behind it — rejecting on it would fail a dataset the optimizer
+        could still train on. Only a short page is a complete verdict."""
+        client = _client([{"no_id": 1}] * DATASET_SAMPLES)
+
+        dataset, count = load_and_validate_dataset(client, "ds")
+
+        assert dataset is not None
+        assert count == 0

--- a/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
@@ -1,0 +1,92 @@
+"""Unit tests for dataset loading and the item count that sizes the mini-batch.
+
+The count feeds GEPA's reflection mini-batch, so it must match what the SDK will
+actually train on — and every failure to read the dataset must arrive as the
+typed error the caller documents.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from opik_backend.studio.config import DATASET_SAMPLES
+from opik_backend.studio.exceptions import DatasetNotFoundError, EmptyDatasetError
+from opik_backend.studio.helpers import (
+    count_optimizable_items,
+    load_and_validate_dataset,
+)
+
+
+def _client(items=None, *, get_dataset_error=None, get_items_error=None):
+    client = MagicMock()
+    if get_dataset_error is not None:
+        client.get_dataset.side_effect = get_dataset_error
+        return client
+    dataset = MagicMock()
+    if get_items_error is not None:
+        dataset.get_items.side_effect = get_items_error
+    else:
+        dataset.get_items.return_value = items if items is not None else []
+    client.get_dataset.return_value = dataset
+    return client
+
+
+class TestCountOptimizableItems:
+    """The SDK's sampling drops rows without an id, so counting them would size
+    the mini-batch above the real trainset."""
+
+    def test_counts_only_items_with_an_id(self):
+        items = [{"id": "1"}, {"id": None}, {"id": "2"}, {"no_id": True}]
+        assert count_optimizable_items(items) == 2
+
+    def test_empty_and_non_dict_rows_are_ignored(self):
+        assert count_optimizable_items([]) == 0
+        assert count_optimizable_items(["oops", None, 42]) == 0
+
+
+class TestLoadAndValidateDataset:
+    def test_returns_dataset_and_optimizable_count(self):
+        client = _client([{"id": "1"}, {"id": "2"}, {"id": None}])
+
+        dataset, count = load_and_validate_dataset(client, "ds")
+
+        assert dataset is client.get_dataset.return_value
+        assert count == 2
+
+    def test_fetch_is_bounded_to_dataset_samples(self):
+        client = _client([{"id": "1"}])
+
+        load_and_validate_dataset(client, "ds")
+
+        client.get_dataset.return_value.get_items.assert_called_once_with(
+            nb_samples=DATASET_SAMPLES
+        )
+
+    def test_missing_dataset_raises_typed_error(self):
+        client = _client(get_dataset_error=RuntimeError("404 not found"))
+
+        with pytest.raises(DatasetNotFoundError):
+            load_and_validate_dataset(client, "ds")
+
+    def test_item_fetch_failure_also_raises_typed_error(self):
+        """Access/transport failures on the item fetch are just as much
+        "dataset unusable" — they must not escape as a raw exception."""
+        client = _client(get_items_error=ConnectionError("connection reset"))
+
+        with pytest.raises(DatasetNotFoundError):
+            load_and_validate_dataset(client, "ds")
+
+    def test_empty_dataset_raises_empty_error_not_not_found(self):
+        client = _client([])
+
+        with pytest.raises(EmptyDatasetError):
+            load_and_validate_dataset(client, "ds")
+
+    def test_items_without_ids_are_not_empty_but_count_zero(self):
+        """Pathological but must not crash: the dataset has rows, none usable."""
+        client = _client([{"no_id": 1}])
+
+        dataset, count = load_and_validate_dataset(client, "ds")
+
+        assert dataset is not None
+        assert count == 0

--- a/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_dataset_loading.py
@@ -82,11 +82,23 @@ class TestLoadAndValidateDataset:
         with pytest.raises(EmptyDatasetError):
             load_and_validate_dataset(client, "ds")
 
-    def test_items_without_ids_are_not_empty_but_count_zero(self):
-        """Pathological but must not crash: the dataset has rows, none usable."""
+    def test_rows_without_ids_are_rejected_like_an_empty_dataset(self):
+        """Rows the SDK's sampling drops leave the optimizer nothing to train
+        on, so the run must be rejected here instead of reaching optimization
+        with a zero-item trainset."""
         client = _client([{"no_id": 1}])
+
+        with pytest.raises(EmptyDatasetError) as excinfo:
+            load_and_validate_dataset(client, "ds")
+
+        # The operator has to know it is not the "add some rows" case.
+        assert "id" in str(excinfo.value)
+
+    def test_one_usable_row_among_unusable_ones_still_loads(self):
+        """Only a fully unusable dataset is rejected — a partial one is fine."""
+        client = _client([{"no_id": 1}, {"id": "1"}])
 
         dataset, count = load_and_validate_dataset(client, "ds")
 
         assert dataset is not None
-        assert count == 0
+        assert count == 1

--- a/apps/opik-python-backend/tests/unit/test_studio_e2e_provider_resolution.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_e2e_provider_resolution.py
@@ -1,0 +1,69 @@
+"""Unit tests for the e2e provider-resolution helpers (tests/e2e/conftest.py).
+
+The e2e fixture provisions a workspace provider key for whichever provider the
+configured model needs. Getting that wrong makes the backend reject the run for a
+missing key of the *other* provider, so the mapping is worth pinning down here —
+these are plain functions and need no backend.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_CONFTEST_PATH = (
+    pathlib.Path(__file__).resolve().parents[1] / "e2e" / "conftest.py"
+)
+
+
+def _load_e2e_conftest():
+    """Import tests/e2e/conftest.py as a module without collecting the e2e suite."""
+    spec = importlib.util.spec_from_file_location(
+        "_studio_e2e_conftest", _CONFTEST_PATH
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def e2e_conftest():
+    return _load_e2e_conftest()
+
+
+class TestProviderForModel:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            # Bare ids
+            ("gpt-5-nano", "openai"),
+            ("gpt-4o-mini", "openai"),
+            ("claude-haiku-4-5-20251001", "anthropic"),
+            # Gateway-prefixed ids — the Studio routes everything as openai/*
+            ("openai/gpt-4o", "openai"),
+            ("openai/claude-haiku-4-5", "openai"),
+            ("anthropic/claude-haiku-4-5", "anthropic"),
+            # Unset / unknown fall back to the CI default (anthropic)
+            (None, "anthropic"),
+            ("", "anthropic"),
+            ("some-local-model", "anthropic"),
+        ],
+    )
+    def test_provider_for_model(self, e2e_conftest, model, expected):
+        assert e2e_conftest._provider_for_model(model) == expected
+
+    def test_every_provider_has_a_secret_env(self, e2e_conftest):
+        """workspace_provider_key indexes this map directly — a provider without
+        an entry would raise KeyError instead of skipping cleanly."""
+        for model in ("gpt-4o", "openai/gpt-4o", "claude-haiku-4-5", None):
+            provider = e2e_conftest._provider_for_model(model)
+            assert provider in e2e_conftest._PROVIDER_SECRET_ENV
+
+    def test_secret_env_names(self, e2e_conftest):
+        assert e2e_conftest._PROVIDER_SECRET_ENV == {
+            "anthropic": "ANTHROPIC_API_KEY",
+            "openai": "OPENAI_API_KEY",
+        }

--- a/apps/opik-python-backend/tests/unit/test_studio_e2e_provider_resolution.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_e2e_provider_resolution.py
@@ -17,21 +17,30 @@ _CONFTEST_PATH = (
 )
 
 
-def _load_e2e_conftest():
-    """Import tests/e2e/conftest.py as a module without collecting the e2e suite."""
-    spec = importlib.util.spec_from_file_location(
-        "_studio_e2e_conftest", _CONFTEST_PATH
-    )
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
-    return module
+_MODULE_NAME = "_studio_e2e_conftest"
 
 
 @pytest.fixture(scope="module")
 def e2e_conftest():
-    return _load_e2e_conftest()
+    """Import tests/e2e/conftest.py as a module without collecting the e2e suite.
+
+    Registered in ``sys.modules`` only while the tests run (some import
+    machinery resolves a module by name during execution) and removed afterwards
+    so nothing later in the session can pick up this stale copy.
+    """
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _CONFTEST_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    previous = sys.modules.get(_MODULE_NAME)
+    sys.modules[_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        if previous is None:
+            sys.modules.pop(_MODULE_NAME, None)
+        else:
+            sys.modules[_MODULE_NAME] = previous
 
 
 class TestProviderForModel:

--- a/apps/opik-python-backend/tests/unit/test_studio_errors.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_errors.py
@@ -63,6 +63,16 @@ def test_empty_dataset_error_is_clean_and_actionable():
     assert "empty" in message.lower()
 
 
+def test_empty_dataset_error_surfaces_why_it_was_unusable():
+    """A dataset with rows but none the optimizer can use must not read as "it
+    is empty" — the operator would go looking for rows that are already there."""
+    message = to_user_facing_message(
+        EmptyDatasetError("my-dataset", reason="has no items the optimizer can use")
+    )
+    assert "no items the optimizer can use" in message
+    assert "is empty" not in message
+
+
 def test_dataset_not_found_does_not_leak_original_error():
     exc = DatasetNotFoundError(
         "my-dataset", original_error=ValueError("clickhouse: connection refused")

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizer_model.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizer_model.py
@@ -18,6 +18,7 @@ from llm_constants import (
 )
 
 from opik_backend.jobs import optimizer_runner
+from opik_backend.studio.config import OPTIMIZER_TASK_TEMPERATURE
 from opik_backend.studio.types import OptimizationConfig
 
 
@@ -110,6 +111,30 @@ def test_algorithm_defaults_to_prompt_model_when_not_set():
     # and its parameters.
     assert optimizer.model == GATEWAY_CLAUDE_HAIKU
     assert optimizer.model_parameters.get("temperature") == 0.3
+
+
+def test_task_model_temperature_is_pinned_on_the_prompt():
+    """OPIK-7511: the pin must survive all the way onto the object that carries
+    the scored completions — asserting the helper alone would not prove the task
+    model actually runs pinned, and the reflection model must stay sampled."""
+    config = OptimizationConfig.from_dict(_config())
+
+    optimizer, prompt = optimizer_runner.build_optimizer_and_prompt(config)
+
+    assert prompt.model_kwargs.get("temperature") == OPTIMIZER_TASK_TEMPERATURE
+    # Guard for models that fix their own temperature: without this the pin
+    # fails the run instead of being ignored.
+    assert prompt.model_kwargs.get("drop_params") is True
+    # The reflection model needs sampling diversity — it must NOT be pinned.
+    assert "temperature" not in optimizer.model_parameters
+
+
+def test_task_model_explicit_temperature_survives_the_pin():
+    config = OptimizationConfig.from_dict(_config(task_params={"temperature": 0.4}))
+
+    _, prompt = optimizer_runner.build_optimizer_and_prompt(config)
+
+    assert prompt.model_kwargs.get("temperature") == 0.4
 
 
 def test_optimizer_params_preserved_without_separate_model():

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizer_model.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizer_model.py
@@ -122,9 +122,6 @@ def test_task_model_temperature_is_pinned_on_the_prompt():
     optimizer, prompt = optimizer_runner.build_optimizer_and_prompt(config)
 
     assert prompt.model_kwargs.get("temperature") == OPTIMIZER_TASK_TEMPERATURE
-    # Guard for models that fix their own temperature: without this the pin
-    # fails the run instead of being ignored.
-    assert prompt.model_kwargs.get("drop_params") is True
     # The reflection model needs sampling diversity — it must NOT be pinned.
     assert "temperature" not in optimizer.model_parameters
 

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
@@ -103,6 +103,57 @@ class TestOptimizerFactoryBadParamsRaisesTypedError:
                 )
 
 
+class TestOptimizerFactoryPerfectScoreInjection:
+    """OPIK-7511: Studio runs pin perfect_score to full marks via the optimizer
+    constructor — the SDK's 0.95 default ends strong-baseline runs with zero
+    candidates. Injected as a default so an explicit run value still wins."""
+
+    def test_perfect_score__not_in_params__injected_as_one(self):
+        recorder = _make_recording_constructor()
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={},
+            )
+        assert recorder.captured_kwargs["perfect_score"] == 1.0
+
+    def test_perfect_score__explicit_in_params__wins_over_injection(self):
+        recorder = _make_recording_constructor()
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={"perfect_score": 0.8},
+            )
+        assert recorder.captured_kwargs["perfect_score"] == 0.8
+
+    def test_perfect_score__injection__does_not_mutate_caller_params(self):
+        recorder = _make_recording_constructor()
+        caller_params: dict = {}
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params=caller_params,
+            )
+        assert caller_params == {}
+
+    def test_perfect_score__real_gepa_optimizer__constructor_accepts_it(self):
+        """The injection relies on the pinned SDK accepting perfect_score in
+        the constructor — guard that against a pin change."""
+        optimizer = OptimizerFactory.build(
+            optimizer_type="gepa",
+            model="openai/gpt-4o",
+            model_params={},
+            optimizer_params={},
+        )
+        assert optimizer.perfect_score == 1.0
+
+
 class TestOptimizerFactoryListAvailable:
     def test_list_available_returns_known_types(self):
         available = OptimizerFactory.list_available()
@@ -122,3 +173,13 @@ def _make_bad_constructor(exc: Exception):
         def __init__(self, *args, **kwargs):
             raise exc
     return _BadOptimizer
+
+
+def _make_recording_constructor():
+    """Return a fake optimizer class that records its constructor kwargs."""
+    class _RecordingOptimizer:
+        captured_kwargs: dict = {}
+
+        def __init__(self, *args, **kwargs):
+            type(self).captured_kwargs = kwargs
+    return _RecordingOptimizer

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
@@ -7,7 +7,10 @@ just unknown-type errors.
 import pytest
 from unittest.mock import MagicMock, patch
 
-from opik_backend.studio.optimizers import OptimizerFactory
+from opik_backend.studio.optimizers import (
+    OptimizerFactory,
+    ensure_default_model_params,
+)
 from opik_backend.studio.exceptions import InvalidOptimizerError
 
 
@@ -152,6 +155,49 @@ class TestOptimizerFactoryPerfectScoreInjection:
             optimizer_params={},
         )
         assert optimizer.perfect_score == 1.0
+
+
+class TestTaskModelTemperaturePinning:
+    """OPIK-7511: the scored (task) model runs at a pinned temperature so the same
+    prompt scores the same twice; the reflection model keeps its sampling
+    diversity."""
+
+    def test_task_params__no_temperature_given__pinned_deterministic(self):
+        params = ensure_default_model_params({}, deterministic=True)
+        assert params["temperature"] == 0.0
+        # Models that fix their temperature (gpt-5 family) must ignore ours
+        # rather than fail the run.
+        assert params["drop_params"] is True
+
+    def test_task_params__explicit_temperature__wins(self):
+        params = ensure_default_model_params({"temperature": 0.7}, deterministic=True)
+        assert params["temperature"] == 0.7
+
+    def test_optimizer_params__not_deterministic__temperature_untouched(self):
+        params = ensure_default_model_params({})
+        assert "temperature" not in params
+        assert "drop_params" not in params
+
+    def test_params__max_tokens_default_still_applied_either_way(self):
+        assert "max_tokens" in ensure_default_model_params({})
+        assert "max_tokens" in ensure_default_model_params({}, deterministic=True)
+
+    def test_params__caller_dict_not_mutated(self):
+        caller = {}
+        ensure_default_model_params(caller, deterministic=True)
+        assert caller == {}
+
+    def test_factory__optimizer_model_keeps_sampling_diversity(self):
+        """The factory builds the reflection model — it must not pin temperature."""
+        recorder = _make_recording_constructor()
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={},
+            )
+        assert "temperature" not in recorder.captured_kwargs["model_parameters"]
 
 
 class TestOptimizerFactoryListAvailable:

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
@@ -7,6 +7,8 @@ just unknown-type errors.
 import pytest
 from unittest.mock import MagicMock, patch
 
+from opik_backend.studio import config as config_module
+from opik_backend.studio import optimizers as optimizers_module
 from opik_backend.studio.optimizers import (
     OptimizerFactory,
     ensure_default_model_params,
@@ -158,20 +160,53 @@ class TestOptimizerFactoryPerfectScoreInjection:
 
 
 class TestTaskModelTemperaturePinning:
-    """OPIK-7511: the scored (task) model runs at a pinned temperature so the same
-    prompt scores the same twice; the reflection model keeps its sampling
+    """OPIK-7511: the scored (task) model runs at a pinned temperature so repeated
+    evaluations of one prompt agree; the reflection model keeps its sampling
     diversity."""
 
-    def test_task_params__no_temperature_given__pinned_deterministic(self):
+    def test_task_params__no_temperature_given__pinned_to_configured_value(self):
+        # Assert against the configured value, not a literal: config reads
+        # OPTIMIZER_TASK_TEMPERATURE at import, so an env override in the test
+        # environment must not turn a correct implementation red.
         params = ensure_default_model_params({}, deterministic=True)
-        assert params["temperature"] == 0.0
+        assert params["temperature"] == optimizers_module.OPTIMIZER_TASK_TEMPERATURE
         # Models that fix their temperature (gpt-5 family) must ignore ours
         # rather than fail the run.
         assert params["drop_params"] is True
 
+    def test_task_params__default_configured_value_is_zero(self, monkeypatch):
+        """The shipped default, independent of the ambient environment."""
+        monkeypatch.delenv("OPTIMIZER_TASK_TEMPERATURE", raising=False)
+        assert (
+            config_module._read_float_env(
+                "OPTIMIZER_TASK_TEMPERATURE", "0.0", minimum=0.0, maximum=2.0
+            )
+            == 0.0
+        )
+
     def test_task_params__explicit_temperature__wins(self):
         params = ensure_default_model_params({"temperature": 0.7}, deterministic=True)
         assert params["temperature"] == 0.7
+
+    def test_task_params__explicit_null_temperature__is_pinned_not_forwarded(self):
+        """The studio config can carry explicit nulls; forwarding None to litellm
+        would either error or silently fall back to the provider default."""
+        params = ensure_default_model_params(
+            {"temperature": None}, deterministic=True
+        )
+        assert params["temperature"] == optimizers_module.OPTIMIZER_TASK_TEMPERATURE
+
+    def test_task_params__explicit_false_drop_params__is_forced(self):
+        """drop_params is our guard for fixed-temperature models, not a user knob:
+        leaving it False would fail the whole run on a gpt-5 model."""
+        params = ensure_default_model_params(
+            {"drop_params": False}, deterministic=True
+        )
+        assert params["drop_params"] is True
+
+    def test_task_params__explicit_null_max_tokens__is_defaulted(self):
+        params = ensure_default_model_params({"max_tokens": None})
+        assert params["max_tokens"] == optimizers_module.LLM_MAX_TOKENS
 
     def test_optimizer_params__not_deterministic__temperature_untouched(self):
         params = ensure_default_model_params({})

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
@@ -170,9 +170,16 @@ class TestTaskModelTemperaturePinning:
         # environment must not turn a correct implementation red.
         params = ensure_default_model_params({}, deterministic=True)
         assert params["temperature"] == optimizers_module.OPTIMIZER_TASK_TEMPERATURE
-        # Models that fix their temperature (gpt-5 family) must ignore ours
-        # rather than fail the run.
-        assert params["drop_params"] is True
+
+    def test_task_params__pin_is_survivable_on_fixed_temperature_models(self):
+        """Models that fix their own temperature (gpt-5 family) must ignore the
+        pin rather than fail the run. The helper does not set drop_params per
+        call — importing opik_optimizer sets it process-wide
+        (base_optimizer.py), and the runner always imports it. Assert that
+        guarantee here, so losing it fails a test instead of a live run."""
+        import litellm
+
+        assert litellm.drop_params is True
 
     def test_task_params__default_configured_value_is_zero(self, monkeypatch):
         """The shipped default, independent of the ambient environment."""
@@ -195,14 +202,6 @@ class TestTaskModelTemperaturePinning:
             {"temperature": None}, deterministic=True
         )
         assert params["temperature"] == optimizers_module.OPTIMIZER_TASK_TEMPERATURE
-
-    def test_task_params__explicit_false_drop_params__is_forced(self):
-        """drop_params is our guard for fixed-temperature models, not a user knob:
-        leaving it False would fail the whole run on a gpt-5 model."""
-        params = ensure_default_model_params(
-            {"drop_params": False}, deterministic=True
-        )
-        assert params["drop_params"] is True
 
     def test_task_params__explicit_null_max_tokens__is_defaulted(self):
         params = ensure_default_model_params({"max_tokens": None})

--- a/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_optimizers_factory.py
@@ -200,6 +200,48 @@ class TestTaskModelTemperaturePinning:
         assert "temperature" not in recorder.captured_kwargs["model_parameters"]
 
 
+class TestPerfectScoreValidation:
+    """The run's perfect_score comes from the studio config, so it can be absent,
+    explicitly null, or junk — it must be rejected here rather than blowing up
+    inside `baseline_score >= perfect_score` mid-run."""
+
+    def test_explicit_null__falls_back_to_default(self):
+        recorder = _make_recording_constructor()
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={"perfect_score": None},
+            )
+        assert recorder.captured_kwargs["perfect_score"] == 1.0
+
+    def test_zero__is_kept_not_treated_as_falsy(self):
+        """0 legitimately disables threshold stopping."""
+        recorder = _make_recording_constructor()
+        with patch.dict(OptimizerFactory._OPTIMIZERS, {"_test_rec": recorder}):
+            OptimizerFactory.build(
+                optimizer_type="_test_rec",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={"perfect_score": 0},
+            )
+        assert recorder.captured_kwargs["perfect_score"] == 0.0
+
+    @pytest.mark.parametrize(
+        "bad_value", [float("nan"), float("inf"), float("-inf"), "0.9", [], True]
+    )
+    def test_invalid_values__raise_invalid_optimizer_error(self, bad_value):
+        with pytest.raises(InvalidOptimizerError) as exc_info:
+            OptimizerFactory.build(
+                optimizer_type="gepa",
+                model="openai/gpt-4o",
+                model_params={},
+                optimizer_params={"perfect_score": bad_value},
+            )
+        assert "perfect_score" in str(exc_info.value)
+
+
 class TestOptimizerFactoryListAvailable:
     def test_list_available_returns_known_types(self):
         available = OptimizerFactory.list_available()

--- a/apps/opik-python-backend/tests/unit/test_studio_types.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_types.py
@@ -4,7 +4,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from opik_backend.studio.types import extract_finish_reason, extract_scoring_health
+from opik_backend.studio.types import (
+    extract_completion_metadata,
+    extract_finish_reason,
+    extract_scoring_health,
+)
 
 
 def _result(details):
@@ -101,3 +105,46 @@ class TestExtractFinishReason:
                 raise RuntimeError("boom")
 
         assert extract_finish_reason(Boom()) is None
+
+
+class TestExtractCompletionMetadata:
+    """The combined payload the runner forwards on mark_completed."""
+
+    def test_both_fields_present(self):
+        metadata = extract_completion_metadata(
+            _result(
+                {
+                    "scoring_health": {"failed_count": 1, "total_count": 4},
+                    "finish_reason": "max_trials",
+                }
+            )
+        )
+        assert metadata == {
+            "scoring_health": {"failed_count": 1, "total_count": 4},
+            "finish_reason": "max_trials",
+        }
+
+    def test_finish_reason_only(self):
+        # Older partial results must still forward what they have.
+        metadata = extract_completion_metadata(
+            _result({"finish_reason": "perfect_score"})
+        )
+        assert metadata == {"finish_reason": "perfect_score"}
+
+    def test_scoring_health_only(self):
+        metadata = extract_completion_metadata(
+            _result({"scoring_health": {"failed_count": 0, "total_count": 2}})
+        )
+        assert metadata == {
+            "scoring_health": {"failed_count": 0, "total_count": 2}
+        }
+
+    def test_neither_returns_empty_dict(self):
+        assert extract_completion_metadata(_result({})) == {}
+        assert extract_completion_metadata(SimpleNamespace()) == {}
+
+    def test_invalid_values_dropped(self):
+        metadata = extract_completion_metadata(
+            _result({"scoring_health": "oops", "finish_reason": "gremlins"})
+        )
+        assert metadata == {}

--- a/apps/opik-python-backend/tests/unit/test_studio_types.py
+++ b/apps/opik-python-backend/tests/unit/test_studio_types.py
@@ -2,7 +2,9 @@
 
 from types import SimpleNamespace
 
-from opik_backend.studio.types import extract_scoring_health
+import pytest
+
+from opik_backend.studio.types import extract_finish_reason, extract_scoring_health
 
 
 def _result(details):
@@ -59,3 +61,43 @@ class TestExtractScoringHealth:
                 raise RuntimeError("boom")
 
         assert extract_scoring_health(Boom()) is None
+
+
+class TestExtractFinishReason:
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "completed",
+            "perfect_score",
+            "max_trials",
+            "no_improvement",
+            "error",
+            "cancelled",
+        ],
+    )
+    def test_known_reasons_pass_through(self, reason):
+        assert extract_finish_reason(_result({"finish_reason": reason})) == reason
+
+    def test_unknown_reason_rejected(self):
+        # Not on the SDK's FinishReason allowlist — must not reach metadata.
+        assert extract_finish_reason(_result({"finish_reason": "gremlins"})) is None
+
+    def test_non_string_reason_rejected(self):
+        assert extract_finish_reason(_result({"finish_reason": 42})) is None
+
+    def test_missing_key_returns_none(self):
+        assert extract_finish_reason(_result({"other": 1})) is None
+
+    def test_missing_details_returns_none(self):
+        assert extract_finish_reason(SimpleNamespace()) is None
+
+    def test_non_dict_details_returns_none(self):
+        assert extract_finish_reason(_result("not-a-dict")) is None
+
+    def test_never_raises_on_weird_result(self):
+        class Boom:
+            @property
+            def details(self):
+                raise RuntimeError("boom")
+
+        assert extract_finish_reason(Boom()) is None

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -200,12 +200,22 @@ def _resolve_gepa_finish_reason(
     perfect_score: float,
     no_improvement_stopper: Any,
     no_improvement_iterations: Any,
+    total_metric_calls: Any,
+    max_metric_calls: int,
 ) -> FinishReason | None:
-    """Return why GEPA's search ended ("perfect_score"/"no_improvement"), or None.
+    """Return why GEPA's search ended, or None to leave the label to the caller.
 
-    Decided from candidate full-eval (valset) scores, exactly like the stop
-    conditions — same seed exclusion and same non-finite filtering, so the label
-    can never claim a stop the stopper did not make.
+    Our own stops ("perfect_score"/"no_improvement") are decided from candidate
+    full-eval (valset) scores, exactly like the stop conditions — same seed
+    exclusion and same non-finite filtering, so the label can never claim a stop
+    the stopper did not make.
+
+    Any other exit is separated by the spent budget: gepa leaves its loop only
+    through a stop callback, so an exit with budget still on the clock came from
+    a stopper gepa installed itself — most commonly the FileStopper it wires on
+    ``<run_dir>/gepa.stop`` whenever ``run_dir`` is set (gepa/api.py), i.e. an
+    external request to stop. That is "cancelled", not the budget burn the
+    caller's fallback would otherwise report.
     """
     candidate_scores = _candidate_full_eval_scores(val_scores)
     if (
@@ -229,6 +239,19 @@ def _resolve_gepa_finish_reason(
             no_improvement_iterations,
         )
         return "no_improvement"
+    if (
+        isinstance(total_metric_calls, int)
+        and not isinstance(total_metric_calls, bool)
+        and total_metric_calls < max_metric_calls
+    ):
+        logger.info(
+            "GEPA stopped after %s of %s metric calls with neither wired stopper "
+            "fired; treating it as an external stop request (e.g. gepa.stop in "
+            "run_dir).",
+            total_metric_calls,
+            max_metric_calls,
+        )
+        return "cancelled"
     return None
 
 
@@ -554,16 +577,19 @@ class GepaOptimizer(BaseOptimizer):
         # Surface why the search ended so the run doesn't silently look like a
         # full budget burn. finish_reason flows into result metadata/logs via
         # the base class (runtime.build_final_result). The gepa engine only
-        # exits via its stop callbacks, so when neither of ours fired the
-        # metric-call budget (max_metric_calls = max_trials * n_samples) ran
-        # out — that is "max_trials", not "completed": GEPA's trials_completed
+        # exits via its stop callbacks, so when neither of ours fired and the
+        # metric-call budget (max_metric_calls = max_trials * n_samples) is
+        # spent, that is "max_trials", not "completed": GEPA's trials_completed
         # only counts Opik-side evaluate() calls, so the base-class fallback
-        # would otherwise mislabel every budget-exhausted run.
+        # would otherwise mislabel every budget-exhausted run. Budget left on
+        # the clock means someone else stopped the run — see the resolver.
         gepa_finish_reason = _resolve_gepa_finish_reason(
             val_scores=val_scores,
             perfect_score=self.perfect_score,
             no_improvement_stopper=no_improvement_stopper,
             no_improvement_iterations=no_improvement_iterations,
+            total_metric_calls=getattr(gepa_result, "total_metric_calls", None),
+            max_metric_calls=max_metric_calls,
         )
         context.finish_reason = (
             context.finish_reason or gepa_finish_reason or "max_trials"

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import Any, cast
 
 from gepa.utils.stop_condition import NoImprovementStopper, ScoreThresholdStopper
@@ -112,33 +113,55 @@ def _coerce_no_improvement_iterations(value: Any) -> int:
     )
 
 
+def _candidate_full_eval_scores(val_scores: Any) -> list[float]:
+    """Comparable full-eval scores of gepa's *candidates*, seed excluded.
+
+    Index 0 of gepa's full-eval list is the seed program's own eval
+    (gepa/core/state.py seeds the list with it); everything after it is a
+    candidate. Non-numeric and non-finite entries are dropped so an inf from a
+    custom metric cannot read as "threshold reached".
+    """
+    return [
+        float(score)
+        for score in list(val_scores or [])[1:]
+        if isinstance(score, (int, float))
+        and not isinstance(score, bool)
+        and math.isfinite(score)
+    ]
+
+
 class CandidateScoreThresholdStopper(ScoreThresholdStopper):
     """Stop when a *candidate* full eval reaches the threshold — never the seed.
 
-    ``program_full_scores_val_set[0]`` is the seed program's own full eval
-    (gepa/core/state.py seeds the list with it), so the vendored stopper can end
-    a run on that single number, before any candidate exists. With the Studio's
-    coarse 0/1 metrics that is a coin flip rather than a fact: repeating the SAME
-    eval of the SAME prompt over the SAME dataset scored 0.95/1.00 on gpt-5-nano
-    and 0.90/0.95 on gpt-4o-mini, and the gpt-5 family refuses any temperature
-    but 1, so the scores cannot be made reproducible. Such a run stopped at
-    iteration zero and reported finish_reason="perfect_score" while the UI showed
-    "no improvement" at the baseline score (OPIK-7511).
+    The vendored stopper reads the whole score list, so it can end a run on the
+    seed program's own eval, before any candidate exists. Scores are not
+    reproducible in general (a model may fix its own temperature and stay
+    sampled), so on a coarse metric that turns "stop because the target was
+    reached" into a coin flip — and the run is then reported as a perfect score
+    while showing no improvement (OPIK-7511).
 
     "The baseline is already good enough" is owned by ``should_skip_optimization``
-    on Opik's own baseline evaluation, which runs before GEPA — so ignoring index
-    0 here loses no stop path, it just stops the two from overlapping.
+    on Opik's own baseline evaluation, which runs before GEPA — so ignoring the
+    seed here loses no stop path, it just stops the two from overlapping.
     """
 
     def __call__(self, gepa_state: Any) -> bool:
         try:
-            scores = list(
-                getattr(gepa_state, "program_full_scores_val_set", None) or []
-            )
+            scores = getattr(gepa_state, "program_full_scores_val_set", None)
             return any(
-                score is not None and score >= self.threshold for score in scores[1:]
+                score >= self.threshold for score in _candidate_full_eval_scores(scores)
             )
         except Exception:
+            # Never take a run down from a stop callback — but do not fail quiet
+            # either: swallowing this silently disables threshold stopping, and a
+            # gepa upgrade that renames the score list would otherwise look like
+            # "the target was simply never reached".
+            logger.warning(
+                "Could not read gepa full-eval scores (%s); threshold stopping is "
+                "inactive for this iteration.",
+                type(gepa_state).__name__,
+                exc_info=True,
+            )
             return False
 
 
@@ -180,16 +203,19 @@ def _resolve_gepa_finish_reason(
 ) -> FinishReason | None:
     """Return why GEPA's search ended ("perfect_score"/"no_improvement"), or None.
 
-    Decided from full-eval (valset) scores only, matching the stop conditions —
-    including their blind spot: index 0 is the seed program's own eval, which
-    CandidateScoreThresholdStopper deliberately ignores, so reading it here would
-    label a run "perfect_score" that the stopper never stopped.
+    Decided from candidate full-eval (valset) scores, exactly like the stop
+    conditions — same seed exclusion and same non-finite filtering, so the label
+    can never claim a stop the stopper did not make.
     """
-    finite = [s for s in val_scores[1:] if s is not None]
-    if perfect_score > 0 and finite and max(finite) >= perfect_score:
+    candidate_scores = _candidate_full_eval_scores(val_scores)
+    if (
+        perfect_score > 0
+        and candidate_scores
+        and max(candidate_scores) >= perfect_score
+    ):
         logger.info(
             "GEPA stopped early: full-eval score %.4f reached perfect_score %.4f.",
-            max(finite),
+            max(candidate_scores),
             perfect_score,
         )
         return "perfect_score"

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -202,6 +202,7 @@ def _resolve_gepa_finish_reason(
     no_improvement_iterations: Any,
     total_metric_calls: Any,
     max_metric_calls: int,
+    stop_file_watched: bool,
 ) -> FinishReason | None:
     """Return why GEPA's search ended, or None to leave the label to the caller.
 
@@ -210,12 +211,16 @@ def _resolve_gepa_finish_reason(
     exclusion and same non-finite filtering, so the label can never claim a stop
     the stopper did not make.
 
-    Any other exit is separated by the spent budget: gepa leaves its loop only
-    through a stop callback, so an exit with budget still on the clock came from
-    a stopper gepa installed itself — most commonly the FileStopper it wires on
-    ``<run_dir>/gepa.stop`` whenever ``run_dir`` is set (gepa/api.py), i.e. an
-    external request to stop. That is "cancelled", not the budget burn the
-    caller's fallback would otherwise report.
+    One other exit is distinguishable, and only when gepa can actually produce
+    it: with ``run_dir`` set, gepa wires a FileStopper on ``<run_dir>/gepa.stop``
+    (gepa/api.py), which ends the run with budget still on the clock. Detecting
+    it by the unspent budget rests on ``GEPAResult.total_metric_calls`` being the
+    same counter ``MaxMetricCallsStopper`` compares (true in gepa 0.1.x, but the
+    dependency has no upper bound), so it is gated on ``stop_file_watched``: with
+    no stop file to watch there is nothing to detect, and a future counter drift
+    would otherwise relabel every ordinary budget exit "cancelled". Callers that
+    never set ``run_dir`` — Optimization Studio among them — keep the plain
+    "max_trials" fallback.
     """
     candidate_scores = _candidate_full_eval_scores(val_scores)
     if (
@@ -240,13 +245,14 @@ def _resolve_gepa_finish_reason(
         )
         return "no_improvement"
     if (
-        isinstance(total_metric_calls, int)
+        stop_file_watched
+        and isinstance(total_metric_calls, int)
         and not isinstance(total_metric_calls, bool)
         and total_metric_calls < max_metric_calls
     ):
         logger.info(
             "GEPA stopped after %s of %s metric calls with neither wired stopper "
-            "fired; treating it as an external stop request (e.g. gepa.stop in "
+            "fired; treating it as an external stop request (gepa.stop in "
             "run_dir).",
             total_metric_calls,
             max_metric_calls,
@@ -582,7 +588,8 @@ class GepaOptimizer(BaseOptimizer):
         # spent, that is "max_trials", not "completed": GEPA's trials_completed
         # only counts Opik-side evaluate() calls, so the base-class fallback
         # would otherwise mislabel every budget-exhausted run. Budget left on
-        # the clock means someone else stopped the run — see the resolver.
+        # the clock means someone else stopped the run, but only a run with a
+        # stop file to watch can be stopped that way — see the resolver.
         gepa_finish_reason = _resolve_gepa_finish_reason(
             val_scores=val_scores,
             perfect_score=self.perfect_score,
@@ -590,6 +597,7 @@ class GepaOptimizer(BaseOptimizer):
             no_improvement_iterations=no_improvement_iterations,
             total_metric_calls=getattr(gepa_result, "total_metric_calls", None),
             max_metric_calls=max_metric_calls,
+            stop_file_watched=run_dir is not None,
         )
         context.finish_reason = (
             context.finish_reason or gepa_finish_reason or "max_trials"

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, cast
 
+from gepa.utils.stop_condition import NoImprovementStopper, ScoreThresholdStopper
 
 from ...base_optimizer import BaseOptimizer
 from ... import constants
@@ -111,6 +112,36 @@ def _coerce_no_improvement_iterations(value: Any) -> int:
     )
 
 
+class CandidateScoreThresholdStopper(ScoreThresholdStopper):
+    """Stop when a *candidate* full eval reaches the threshold — never the seed.
+
+    ``program_full_scores_val_set[0]`` is the seed program's own full eval
+    (gepa/core/state.py seeds the list with it), so the vendored stopper can end
+    a run on that single number, before any candidate exists. With the Studio's
+    coarse 0/1 metrics that is a coin flip rather than a fact: repeating the SAME
+    eval of the SAME prompt over the SAME dataset scored 0.95/1.00 on gpt-5-nano
+    and 0.90/0.95 on gpt-4o-mini, and the gpt-5 family refuses any temperature
+    but 1, so the scores cannot be made reproducible. Such a run stopped at
+    iteration zero and reported finish_reason="perfect_score" while the UI showed
+    "no improvement" at the baseline score (OPIK-7511).
+
+    "The baseline is already good enough" is owned by ``should_skip_optimization``
+    on Opik's own baseline evaluation, which runs before GEPA — so ignoring index
+    0 here loses no stop path, it just stops the two from overlapping.
+    """
+
+    def __call__(self, gepa_state: Any) -> bool:
+        try:
+            scores = list(
+                getattr(gepa_state, "program_full_scores_val_set", None) or []
+            )
+            return any(
+                score is not None and score >= self.threshold for score in scores[1:]
+            )
+        except Exception:
+            return False
+
+
 def _build_gepa_stop_callbacks(
     perfect_score: float, no_improvement_iterations: Any
 ) -> tuple[list[Any], Any]:
@@ -118,26 +149,21 @@ def _build_gepa_stop_callbacks(
 
     Both stoppers read full-eval (valset) scores only, keeping the stop decision
     apples-to-apples with mini-batch screening excluded:
-    - ScoreThresholdStopper stops the moment a full eval reaches perfect_score
-      (only wired for a positive target — see below);
+    - CandidateScoreThresholdStopper stops once a *candidate* full eval reaches
+      perfect_score (only wired for a positive target — see below);
     - NoImprovementStopper ends the reject/skip spin below the threshold
       (disabled when no_improvement_iterations coerces to 0).
 
     gepa always falls back to the max_metric_calls budget, so an empty list here
     is safe.
     """
-    from gepa.utils.stop_condition import (
-        NoImprovementStopper,
-        ScoreThresholdStopper,
-    )
-
     iterations = _coerce_no_improvement_iterations(no_improvement_iterations)
     stop_callbacks: list[Any] = []
-    # A non-positive perfect_score would make ScoreThresholdStopper fire on the
-    # very first full eval (any score >= 0), halting the run immediately — so
-    # only wire it for a sensible target.
+    # A non-positive perfect_score would make the threshold stopper fire on the
+    # very first candidate full eval (any score >= 0), halting the run
+    # immediately — so only wire it for a sensible target.
     if perfect_score > 0:
-        stop_callbacks.append(ScoreThresholdStopper(perfect_score))
+        stop_callbacks.append(CandidateScoreThresholdStopper(perfect_score))
     no_improvement_stopper: Any = None
     if iterations:
         no_improvement_stopper = NoImprovementStopper(iterations)
@@ -154,9 +180,12 @@ def _resolve_gepa_finish_reason(
 ) -> FinishReason | None:
     """Return why GEPA's search ended ("perfect_score"/"no_improvement"), or None.
 
-    Decided from full-eval (valset) scores only, matching the stop conditions.
+    Decided from full-eval (valset) scores only, matching the stop conditions —
+    including their blind spot: index 0 is the seed program's own eval, which
+    CandidateScoreThresholdStopper deliberately ignores, so reading it here would
+    label a run "perfect_score" that the stopper never stopped.
     """
-    finite = [s for s in val_scores if s is not None]
+    finite = [s for s in val_scores[1:] if s is not None]
     if perfect_score > 0 and finite and max(finite) >= perfect_score:
         logger.info(
             "GEPA stopped early: full-eval score %.4f reached perfect_score %.4f.",

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -19,25 +19,38 @@ from .ops import candidate_ops, result_ops, scoring_ops
 logger = logging.getLogger(__name__)
 
 
-def _warn_if_reflection_minibatch_too_large(
+# Each reflection iteration scores the current and the proposed candidate on
+# the same mini-batch (gepa/proposer/reflective_mutation), so a batch of b
+# costs ~2*b metric calls per iteration. Warn when fewer than this many
+# iterations fit the budget — the run degenerates into a few mutation shots.
+MIN_EXPECTED_REFLECTION_ITERATIONS = 5
+
+
+def _warn_if_reflection_minibatch_exhausts_budget(
     *,
     reflection_minibatch_size: int,
-    max_trials: int,
+    max_metric_calls: int,
 ) -> None:
-    """Warn when the reflection minibatch is too large for GEPA to run any reflection.
+    """Warn when the mini-batch leaves too few reflection iterations in budget.
 
-    The metric budget allows exactly ``max_trials`` candidates
-    (``max_metric_calls = max_trials * effective_n_samples``), so a
-    budget-derived ceiling would equal ``max_trials`` — a single check covers
-    both.
+    A large mini-batch never stops GEPA reflection from running — the gepa
+    engine does not gate iterations on the remaining budget — it just makes
+    each iteration cost ~2*reflection_minibatch_size metric calls, so the
+    metric-call budget stops the run after roughly
+    ``max_metric_calls // (2 * reflection_minibatch_size)`` iterations.
     """
-    if reflection_minibatch_size > max_trials:
-        # TODO(opik_optimizer/#gepa-batching): Centralize reflection minibatch clamping when we consolidate trial budgeting.
+    estimated_iterations = max_metric_calls // (2 * reflection_minibatch_size)
+    if estimated_iterations < MIN_EXPECTED_REFLECTION_ITERATIONS:
+        # TODO(opik_optimizer/#gepa-batching): Centralize reflection minibatch budgeting with the python-backend's resolve_reflection_minibatch_size.
         logger.warning(
-            "reflection_minibatch_size (%s) exceeds max_trials (%s); GEPA reflection will not run. "
-            "Increase max_trials or lower the minibatch.",
+            "reflection_minibatch_size=%s costs ~%s metric calls per reflection "
+            "iteration; the metric-call budget (%s) allows only ~%s iteration(s) "
+            "before GEPA stops. Lower reflection_minibatch_size or raise "
+            "max_trials/n_samples.",
             reflection_minibatch_size,
-            max_trials,
+            2 * reflection_minibatch_size,
+            max_metric_calls,
+            estimated_iterations,
         )
 
 
@@ -321,8 +334,8 @@ class GepaOptimizer(BaseOptimizer):
         experiment_config = context.experiment_config
 
         # Coerce at the boundary: extra_params is user-supplied (Any), and this
-        # value is both compared in _warn_if_reflection_minibatch_too_large and
-        # passed to gepa.optimize — a stray string must not crash setup.
+        # value is both used in _warn_if_reflection_minibatch_exhausts_budget
+        # and passed to gepa.optimize — a stray string must not crash setup.
         reflection_minibatch_size = _coerce_positive_int(
             context.extra_params.get("reflection_minibatch_size"),
             default=context.n_samples_minibatch or 3,
@@ -404,9 +417,9 @@ class GepaOptimizer(BaseOptimizer):
 
         effective_n_samples = len(train_items)
         max_metric_calls = max_trials * effective_n_samples
-        _warn_if_reflection_minibatch_too_large(
+        _warn_if_reflection_minibatch_exhausts_budget(
             reflection_minibatch_size=reflection_minibatch_size,
-            max_trials=max_trials,
+            max_metric_calls=max_metric_calls,
         )
 
         train_insts = helpers.build_data_insts(train_items, input_key, output_key)

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/gepa_optimizer/gepa_optimizer.py
@@ -485,15 +485,21 @@ class GepaOptimizer(BaseOptimizer):
 
         # Surface why the search ended so the run doesn't silently look like a
         # full budget burn. finish_reason flows into result metadata/logs via
-        # the base class (runtime.build_final_result).
+        # the base class (runtime.build_final_result). The gepa engine only
+        # exits via its stop callbacks, so when neither of ours fired the
+        # metric-call budget (max_metric_calls = max_trials * n_samples) ran
+        # out — that is "max_trials", not "completed": GEPA's trials_completed
+        # only counts Opik-side evaluate() calls, so the base-class fallback
+        # would otherwise mislabel every budget-exhausted run.
         gepa_finish_reason = _resolve_gepa_finish_reason(
             val_scores=val_scores,
             perfect_score=self.perfect_score,
             no_improvement_stopper=no_improvement_stopper,
             no_improvement_iterations=no_improvement_iterations,
         )
-        if gepa_finish_reason is not None:
-            context.finish_reason = context.finish_reason or gepa_finish_reason
+        context.finish_reason = (
+            context.finish_reason or gepa_finish_reason or "max_trials"
+        )
 
         # Filter duplicate candidates based on content
         (

--- a/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/parameter_optimizer.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/algorithms/parameter_optimizer/parameter_optimizer.py
@@ -418,6 +418,7 @@ class ParameterOptimizer(BaseOptimizer):
                 "parameter_importance": {},
                 "parameter_precision": 6,
                 "stopped_early": True,
+                "finish_reason": "perfect_score",
                 "stop_reason": "baseline_score_met_threshold",
                 "perfect_score": self.perfect_score,
                 "skip_perfect_score": self.skip_perfect_score,

--- a/sdks/opik_optimizer/src/opik_optimizer/constants.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/constants.py
@@ -45,7 +45,12 @@ DEFAULT_SCORING_FAILURE_THRESHOLD = 1.0
 DEFAULT_NUM_THREADS = 12
 DEFAULT_SEED = 42
 DEFAULT_MODEL = "openai/gpt-5-nano"
-DEFAULT_PERFECT_SCORE = 0.95
+# perfect_score does double duty: it is the baseline/iteration skip threshold
+# AND (for GEPA) the run-level stop threshold via ScoreThresholdStopper. It must
+# mean "nothing left to optimize" — anything below 1.0 makes a strong-but-
+# imperfect baseline end the run with zero candidates (OPIK-7511). Matches the
+# gepa package's own default.
+DEFAULT_PERFECT_SCORE = 1.0
 DEFAULT_SKIP_PERFECT_SCORE = True
 DEFAULT_ENABLE_CONTEXT_LEARNING = True
 DEFAULT_TOOL_CALL_MAX_ITERATIONS = 5

--- a/sdks/opik_optimizer/src/opik_optimizer/constants.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/constants.py
@@ -45,12 +45,7 @@ DEFAULT_SCORING_FAILURE_THRESHOLD = 1.0
 DEFAULT_NUM_THREADS = 12
 DEFAULT_SEED = 42
 DEFAULT_MODEL = "openai/gpt-5-nano"
-# perfect_score does double duty: it is the baseline/iteration skip threshold
-# AND (for GEPA) the run-level stop threshold via ScoreThresholdStopper. It must
-# mean "nothing left to optimize" — anything below 1.0 makes a strong-but-
-# imperfect baseline end the run with zero candidates (OPIK-7511). Matches the
-# gepa package's own default.
-DEFAULT_PERFECT_SCORE = 1.0
+DEFAULT_PERFECT_SCORE = 0.95
 DEFAULT_SKIP_PERFECT_SCORE = True
 DEFAULT_ENABLE_CONTEXT_LEARNING = True
 DEFAULT_TOOL_CALL_MAX_ITERATIONS = 5

--- a/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
@@ -533,6 +533,9 @@ def build_early_stop_details(
     early_stop_details = {
         "initial_score": baseline_score,
         "stopped_early": True,
+        # finish_reason is the canonical machine-readable signal (same key as
+        # build_final_result); stop_reason keeps the legacy descriptive value.
+        "finish_reason": context.finish_reason or "perfect_score",
         "stop_reason": "baseline_score_met_threshold",
         "stop_reason_details": {"best_score": baseline_score},
         "perfect_score": optimizer.perfect_score,

--- a/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
+++ b/sdks/opik_optimizer/src/opik_optimizer/core/runtime.py
@@ -537,6 +537,12 @@ def build_early_stop_details(
         # build_final_result); stop_reason keeps the legacy descriptive value.
         "finish_reason": context.finish_reason or "perfect_score",
         "stop_reason": "baseline_score_met_threshold",
+        # The baseline eval's scoring health — build_final_result always carries
+        # this key, and downstream consumers (worker metadata forwarding, the
+        # "No usable scores" UI heuristic) rely on it being present on every
+        # completion path, including this baseline-only one (OPIK-7511 e2e).
+        "scoring_health": context.scoring_health
+        or {"failed_count": 0, "total_count": 0},
         "stop_reason_details": {"best_score": baseline_score},
         "perfect_score": optimizer.perfect_score,
         "skip_perfect_score": optimizer.skip_perfect_score,

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -273,9 +273,7 @@ class TestGepaFinishReason:
             while not stopper(state):
                 pass
 
-        gepa_result = _make_mock_gepa_result(
-            candidates=[], val_aggregate_scores=[0.5]
-        )
+        gepa_result = _make_mock_gepa_result(candidates=[], val_aggregate_scores=[0.5])
         result, _ = _run_optimize(
             monkeypatch,
             mock_optimization_context,

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -33,6 +33,7 @@ def _run_optimize(
     sample_metric,
     *,
     gepa_result: MagicMock | None = None,
+    on_gepa_optimize: Any = None,
     **optimize_kwargs: Any,
 ) -> tuple[Any, dict[str, Any]]:
     """Run optimize_prompt with gepa.optimize mocked; return (result, captured kwargs)."""
@@ -48,6 +49,8 @@ def _run_optimize(
 
     def fake_optimize(**kwargs: Any) -> MagicMock:
         captured.update(kwargs)
+        if on_gepa_optimize is not None:
+            on_gepa_optimize(kwargs)
         return gepa_result if gepa_result is not None else _make_mock_gepa_result()
 
     monkeypatch.setattr("gepa.optimize", fake_optimize)
@@ -61,6 +64,15 @@ def _run_optimize(
         **optimize_kwargs,
     )
     return result, captured
+
+
+class TestPerfectScoreDefault:
+    def test_default_perfect_score_is_full_marks(self) -> None:
+        """perfect_score doubles as GEPA's iteration-skip gate AND the run-level
+        stop threshold; below 1.0 a strong baseline ends runs with zero
+        candidates (OPIK-7511). Must match the gepa package's own default."""
+        assert constants.DEFAULT_PERFECT_SCORE == 1.0
+        assert GepaOptimizer(model="gpt-4o-mini").perfect_score == 1.0
 
 
 class TestGepaStopCallbackWiring:
@@ -208,6 +220,75 @@ class TestGepaFinishReason:
         )
 
         assert result.details["finish_reason"] != "perfect_score"
+
+    def test_budget_exhaustion_sets_max_trials_finish_reason(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """The gepa engine only exits via its stop callbacks; when neither the
+        threshold nor the stall stopper fired, the metric-call budget ran out
+        and finish_reason must say so — never 'completed' (OPIK-7511)."""
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.3, 0.5]
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "max_trials"
+        assert result.details["stop_reason"] == "max_trials"
+
+    def test_no_improvement_stall_sets_finish_reason(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """When the wired NoImprovementStopper trips, the run must report
+        'no_improvement', not a budget burn."""
+
+        def stall_the_stopper(kwargs: dict[str, Any]) -> None:
+            # Drive the wired stopper the way the gepa engine would: one call
+            # per iteration with a stagnant full-eval score until it trips.
+            stopper = next(
+                s
+                for s in kwargs["stop_callbacks"]
+                if isinstance(s, NoImprovementStopper)
+            )
+            state = SimpleNamespace(program_full_scores_val_set=[0.5])
+            while not stopper(state):
+                pass
+
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.5]
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+            on_gepa_optimize=stall_the_stopper,
+            no_improvement_iterations=3,
+        )
+
+        assert result.details["finish_reason"] == "no_improvement"
 
 
 class TestStopperSemantics:

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -71,15 +71,6 @@ def _run_optimize(
     return result, captured
 
 
-class TestPerfectScoreDefault:
-    def test_default_perfect_score__no_override__is_full_marks(self) -> None:
-        """perfect_score doubles as GEPA's iteration-skip gate AND the run-level
-        stop threshold; below 1.0 a strong baseline ends runs with zero
-        candidates (OPIK-7511). Must match the gepa package's own default."""
-        assert constants.DEFAULT_PERFECT_SCORE == 1.0
-        assert GepaOptimizer(model="gpt-4o-mini").perfect_score == 1.0
-
-
 class TestGepaStopCallbackWiring:
     def test_stop_callbacks_wired_by_default(
         self,

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -1,5 +1,6 @@
 # mypy: disable-error-code=no-untyped-def
 
+import logging
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
@@ -8,10 +9,14 @@ from gepa.utils.stop_condition import NoImprovementStopper, ScoreThresholdStoppe
 
 from opik_optimizer import GepaOptimizer, constants
 from opik_optimizer.algorithms.gepa_optimizer.gepa_optimizer import (
+    MIN_EXPECTED_REFLECTION_ITERATIONS,
     _build_gepa_stop_callbacks,
     _coerce_no_improvement_iterations,
     _coerce_positive_int,
+    _warn_if_reflection_minibatch_exhausts_budget,
 )
+
+_GEPA_OPTIMIZER_LOGGER = "opik_optimizer.algorithms.gepa_optimizer.gepa_optimizer"
 
 
 def _make_mock_gepa_result(**overrides: Any) -> MagicMock:
@@ -67,7 +72,7 @@ def _run_optimize(
 
 
 class TestPerfectScoreDefault:
-    def test_default_perfect_score_is_full_marks(self) -> None:
+    def test_default_perfect_score__no_override__is_full_marks(self) -> None:
         """perfect_score doubles as GEPA's iteration-skip gate AND the run-level
         stop threshold; below 1.0 a strong baseline ends runs with zero
         candidates (OPIK-7511). Must match the gepa package's own default."""
@@ -221,7 +226,7 @@ class TestGepaFinishReason:
 
         assert result.details["finish_reason"] != "perfect_score"
 
-    def test_budget_exhaustion_sets_max_trials_finish_reason(
+    def test_finish_reason__no_wired_stopper_fired__falls_back_to_max_trials(
         self,
         mock_optimization_context,
         monkeypatch,
@@ -230,9 +235,13 @@ class TestGepaFinishReason:
         sample_dataset_items,
         sample_metric,
     ) -> None:
-        """The gepa engine only exits via its stop callbacks; when neither the
-        threshold nor the stall stopper fired, the metric-call budget ran out
-        and finish_reason must say so — never 'completed' (OPIK-7511)."""
+        """This unit covers the fallback LABELING only: gepa.optimize is mocked
+        (its internal MaxMetricCallsStopper never runs), so the test asserts
+        that a gepa exit with neither wired stopper fired is labeled
+        'max_trials' — never 'completed' (OPIK-7511). The claim that budget
+        exhaustion is the only remaining exit path is a property of the gepa
+        engine (it only ever exits via stop conditions); a real budget-driven
+        exit is exercised end-to-end by the imperfect-baseline e2e run."""
         gepa_result = _make_mock_gepa_result(
             candidates=[], val_aggregate_scores=[0.3, 0.5]
         )
@@ -249,7 +258,7 @@ class TestGepaFinishReason:
         assert result.details["finish_reason"] == "max_trials"
         assert result.details["stop_reason"] == "max_trials"
 
-    def test_no_improvement_stall_sets_finish_reason(
+    def test_finish_reason__no_improvement_stall__reports_no_improvement(
         self,
         mock_optimization_context,
         monkeypatch,
@@ -264,14 +273,19 @@ class TestGepaFinishReason:
         def stall_the_stopper(kwargs: dict[str, Any]) -> None:
             # Drive the wired stopper the way the gepa engine would: one call
             # per iteration with a stagnant full-eval score until it trips.
+            # Bounded so a stopper regression fails this test instead of
+            # hanging the whole suite.
             stopper = next(
                 s
                 for s in kwargs["stop_callbacks"]
                 if isinstance(s, NoImprovementStopper)
             )
             state = SimpleNamespace(program_full_scores_val_set=[0.5])
-            while not stopper(state):
-                pass
+            limit = stopper.max_iterations_without_improvement + 2
+            tripped = any(stopper(state) for _ in range(limit))
+            assert tripped, (
+                f"NoImprovementStopper did not trip within {limit} stagnant iterations"
+            )
 
         gepa_result = _make_mock_gepa_result(candidates=[], val_aggregate_scores=[0.5])
         result, _ = _run_optimize(
@@ -395,6 +409,42 @@ class TestCoercePositiveInt:
             _coerce_positive_int(float("nan"), default=7, allow_zero=True, name="n")
             == 7
         )
+
+
+class TestReflectionMinibatchBudgetWarning:
+    """The warning must state the REAL cost model: a large mini-batch doesn't
+    stop reflection, it exhausts the metric budget in few iterations."""
+
+    def test_budget_warning__too_few_iterations_fit__logs_real_iteration_count(
+        self, caplog
+    ) -> None:
+        # 400 // (2 * 50) = 4 iterations — below the expected minimum of 5.
+        with caplog.at_level(logging.WARNING, logger=_GEPA_OPTIMIZER_LOGGER):
+            _warn_if_reflection_minibatch_exhausts_budget(
+                reflection_minibatch_size=50,
+                max_metric_calls=400,
+            )
+        assert "allows only ~4 iteration(s)" in caplog.text
+        assert "~100 metric calls per reflection iteration" in caplog.text
+
+    def test_budget_warning__ample_budget__stays_silent(self, caplog) -> None:
+        # 400 // (2 * 5) = 40 iterations — plenty; must not cry wolf.
+        with caplog.at_level(logging.WARNING, logger=_GEPA_OPTIMIZER_LOGGER):
+            _warn_if_reflection_minibatch_exhausts_budget(
+                reflection_minibatch_size=5,
+                max_metric_calls=400,
+            )
+        assert caplog.text == ""
+
+    def test_budget_warning__exactly_min_iterations__stays_silent(self, caplog) -> None:
+        # 400 // (2 * 40) = 5 == MIN_EXPECTED_REFLECTION_ITERATIONS.
+        assert MIN_EXPECTED_REFLECTION_ITERATIONS == 5
+        with caplog.at_level(logging.WARNING, logger=_GEPA_OPTIMIZER_LOGGER):
+            _warn_if_reflection_minibatch_exhausts_budget(
+                reflection_minibatch_size=40,
+                max_metric_calls=400,
+            )
+        assert caplog.text == ""
 
 
 class TestBuildGepaStopCallbacks:

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -253,7 +253,38 @@ class TestGepaFinishReason:
         assert result.details["finish_reason"] == "max_trials"
         assert result.details["stop_reason"] == "max_trials"
 
-    def test_finish_reason__budget_unspent__is_cancelled_not_max_trials(
+    def test_finish_reason__budget_unspent_with_run_dir__is_cancelled_not_max_trials(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+        tmp_path,
+    ) -> None:
+        """gepa installs its own FileStopper on <run_dir>/gepa.stop, so a run with
+        run_dir set can exit with neither of our stoppers fired AND budget left on
+        the clock. Labeling that 'max_trials' would report a budget burn that
+        never happened; it is an external stop request."""
+        # max_trials=2 * n_samples=2 = 4 metric calls of budget, 1 spent.
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=1
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+            run_dir=str(tmp_path),
+        )
+
+        assert result.details["finish_reason"] == "cancelled"
+
+    def test_finish_reason__budget_unspent_without_run_dir__stays_max_trials(
         self,
         mock_optimization_context,
         monkeypatch,
@@ -262,11 +293,11 @@ class TestGepaFinishReason:
         sample_dataset_items,
         sample_metric,
     ) -> None:
-        """gepa installs its own FileStopper on <run_dir>/gepa.stop, so a run can
-        exit with neither of our stoppers fired AND budget left on the clock.
-        Labeling that 'max_trials' would report a budget burn that never
-        happened; it is an external stop request."""
-        # max_trials=2 * n_samples=2 = 4 metric calls of budget, 1 spent.
+        """Without run_dir gepa wires no FileStopper, so nothing can stop the run
+        externally and an unspent-looking budget can only mean the counter and
+        the stopper's threshold disagree (gepa is pinned open-ended). Guessing
+        'cancelled' there would relabel ordinary budget exits — including every
+        Optimization Studio run, which never sets run_dir."""
         gepa_result = _make_mock_gepa_result(
             candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=1
         )
@@ -280,7 +311,7 @@ class TestGepaFinishReason:
             gepa_result=gepa_result,
         )
 
-        assert result.details["finish_reason"] == "cancelled"
+        assert result.details["finish_reason"] == "max_trials"
 
     def test_finish_reason__unknown_spend__still_falls_back_to_max_trials(
         self,
@@ -290,10 +321,12 @@ class TestGepaFinishReason:
         mock_dataset,
         sample_dataset_items,
         sample_metric,
+        tmp_path,
     ) -> None:
-        """total_metric_calls is optional run metadata on GEPAResult. Without it
-        we cannot tell an external stop from a budget burn, so the label must
-        stay on the old fallback rather than guess 'cancelled'."""
+        """total_metric_calls is optional run metadata on GEPAResult. Even with a
+        stop file watched, without the counter we cannot tell an external stop
+        from a budget burn, so the label must stay on the old fallback rather
+        than guess 'cancelled'."""
         gepa_result = _make_mock_gepa_result(
             candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=None
         )
@@ -305,6 +338,7 @@ class TestGepaFinishReason:
             sample_dataset_items,
             sample_metric,
             gepa_result=gepa_result,
+            run_dir=str(tmp_path),
         )
 
         assert result.details["finish_reason"] == "max_trials"
@@ -317,9 +351,11 @@ class TestGepaFinishReason:
         mock_dataset,
         sample_dataset_items,
         sample_metric,
+        tmp_path,
     ) -> None:
         """Reaching the target always leaves budget unspent — that must still
-        read as 'perfect_score', not as an external stop."""
+        read as 'perfect_score', not as an external stop. run_dir is set so the
+        external-stop branch is live and precedence is actually exercised."""
         gepa_result = _make_mock_gepa_result(
             candidates=[], val_aggregate_scores=[0.5, 1.0], total_metric_calls=1
         )
@@ -331,6 +367,7 @@ class TestGepaFinishReason:
             sample_dataset_items,
             sample_metric,
             gepa_result=gepa_result,
+            run_dir=str(tmp_path),
         )
 
         assert result.details["finish_reason"] == "perfect_score"

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -10,6 +10,7 @@ from gepa.utils.stop_condition import NoImprovementStopper, ScoreThresholdStoppe
 from opik_optimizer import GepaOptimizer, constants
 from opik_optimizer.algorithms.gepa_optimizer.gepa_optimizer import (
     MIN_EXPECTED_REFLECTION_ITERATIONS,
+    CandidateScoreThresholdStopper,
     _build_gepa_stop_callbacks,
     _coerce_no_improvement_iterations,
     _coerce_positive_int,
@@ -292,6 +293,73 @@ class TestGepaFinishReason:
         )
 
         assert result.details["finish_reason"] == "no_improvement"
+
+
+class TestCandidateScoreThresholdStopper:
+    """OPIK-7511: one lucky eval of the SEED program must not end the run.
+
+    With a coarse 0/1 metric the seed's own full eval is noisy (and unpinnable on
+    the gpt-5 family), so stopping on it produced runs that reported
+    finish_reason="perfect_score" while showing no improvement.
+    """
+
+    def test_stopper__only_seed_at_threshold__does_not_stop(self) -> None:
+        stopper = CandidateScoreThresholdStopper(1.0)
+        state = SimpleNamespace(program_full_scores_val_set=[1.0])
+        assert stopper(state) is False
+
+    def test_stopper__candidate_at_threshold__stops(self) -> None:
+        stopper = CandidateScoreThresholdStopper(1.0)
+        state = SimpleNamespace(program_full_scores_val_set=[0.95, 1.0])
+        assert stopper(state) is True
+
+    def test_stopper__candidates_below_threshold__does_not_stop(self) -> None:
+        stopper = CandidateScoreThresholdStopper(1.0)
+        state = SimpleNamespace(program_full_scores_val_set=[1.0, 0.9, 0.95])
+        assert stopper(state) is False
+
+    def test_stopper__empty_or_missing_history__does_not_stop(self) -> None:
+        stopper = CandidateScoreThresholdStopper(0.95)
+        assert stopper(SimpleNamespace(program_full_scores_val_set=[])) is False
+        assert stopper(SimpleNamespace(program_full_scores_val_set=None)) is False
+        assert stopper(SimpleNamespace()) is False
+
+    def test_stopper__none_scores_are_skipped(self) -> None:
+        stopper = CandidateScoreThresholdStopper(0.95)
+        state = SimpleNamespace(program_full_scores_val_set=[0.5, None, 0.99])
+        assert stopper(state) is True
+
+    def test_stopper__never_raises_on_weird_state(self) -> None:
+        class Boom:
+            @property
+            def program_full_scores_val_set(self) -> Any:
+                raise RuntimeError("boom")
+
+        assert CandidateScoreThresholdStopper(0.95)(Boom()) is False
+
+    def test_finish_reason__only_seed_reached_threshold__is_not_perfect_score(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """The label must agree with the stopper: a seed-only 1.0 is a budget
+        exit, not a perfect score."""
+        gepa_result = _make_mock_gepa_result(candidates=[], val_aggregate_scores=[1.0])
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "max_trials"
 
 
 class TestStopperSemantics:

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -24,7 +24,10 @@ def _make_mock_gepa_result(**overrides: Any) -> MagicMock:
     mock_gepa_result = MagicMock()
     mock_gepa_result.history = []
     mock_gepa_result.pareto_front = []
-    mock_gepa_result.total_metric_calls = 1
+    # The runs below use max_trials=2 * n_samples=2, so this stands for a spent
+    # metric-call budget — the reason a real gepa run exits when none of our own
+    # stoppers fired. Tests about an unspent budget override it explicitly.
+    mock_gepa_result.total_metric_calls = 4
     for key, value in overrides.items():
         setattr(mock_gepa_result, key, value)
     return mock_gepa_result
@@ -229,13 +232,13 @@ class TestGepaFinishReason:
     ) -> None:
         """This unit covers the fallback LABELING only: gepa.optimize is mocked
         (its internal MaxMetricCallsStopper never runs), so the test asserts
-        that a gepa exit with neither wired stopper fired is labeled
-        'max_trials' — never 'completed' (OPIK-7511). The claim that budget
-        exhaustion is the only remaining exit path is a property of the gepa
+        that a gepa exit with neither wired stopper fired and the metric-call
+        budget spent is labeled 'max_trials' — never 'completed' (OPIK-7511).
+        That the budget is the remaining exit path is a property of the gepa
         engine (it only ever exits via stop conditions); a real budget-driven
         exit is exercised end-to-end by the imperfect-baseline e2e run."""
         gepa_result = _make_mock_gepa_result(
-            candidates=[], val_aggregate_scores=[0.3, 0.5]
+            candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=4
         )
         result, _ = _run_optimize(
             monkeypatch,
@@ -249,6 +252,88 @@ class TestGepaFinishReason:
 
         assert result.details["finish_reason"] == "max_trials"
         assert result.details["stop_reason"] == "max_trials"
+
+    def test_finish_reason__budget_unspent__is_cancelled_not_max_trials(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """gepa installs its own FileStopper on <run_dir>/gepa.stop, so a run can
+        exit with neither of our stoppers fired AND budget left on the clock.
+        Labeling that 'max_trials' would report a budget burn that never
+        happened; it is an external stop request."""
+        # max_trials=2 * n_samples=2 = 4 metric calls of budget, 1 spent.
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=1
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "cancelled"
+
+    def test_finish_reason__unknown_spend__still_falls_back_to_max_trials(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """total_metric_calls is optional run metadata on GEPAResult. Without it
+        we cannot tell an external stop from a budget burn, so the label must
+        stay on the old fallback rather than guess 'cancelled'."""
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.3, 0.5], total_metric_calls=None
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "max_trials"
+
+    def test_finish_reason__perfect_score_wins_over_unspent_budget(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """Reaching the target always leaves budget unspent — that must still
+        read as 'perfect_score', not as an external stop."""
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.5, 1.0], total_metric_calls=1
+        )
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "perfect_score"
 
     def test_finish_reason__no_improvement_stall__reports_no_improvement(
         self,

--- a/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
+++ b/sdks/opik_optimizer/tests/unit/algorithms/gepa_optimizer/test_gepa_stop_conditions.py
@@ -329,13 +329,31 @@ class TestCandidateScoreThresholdStopper:
         state = SimpleNamespace(program_full_scores_val_set=[0.5, None, 0.99])
         assert stopper(state) is True
 
-    def test_stopper__never_raises_on_weird_state(self) -> None:
+    def test_stopper__non_finite_scores_do_not_trip_it(self) -> None:
+        """A custom metric returning inf must not read as "target reached"."""
+        stopper = CandidateScoreThresholdStopper(1.0)
+        state = SimpleNamespace(
+            program_full_scores_val_set=[0.5, float("inf"), float("nan"), 0.9]
+        )
+        assert stopper(state) is False
+
+    def test_stopper__non_numeric_scores_are_skipped(self) -> None:
+        stopper = CandidateScoreThresholdStopper(0.95)
+        state = SimpleNamespace(program_full_scores_val_set=[0.5, "1.0", True, None])
+        assert stopper(state) is False
+
+    def test_stopper__unreadable_state__keeps_run_alive_but_warns(self, caplog) -> None:
+        """A stop callback must never take a run down — but swallowing the failure
+        silently would disable threshold stopping invisibly, so it logs."""
+
         class Boom:
             @property
             def program_full_scores_val_set(self) -> Any:
                 raise RuntimeError("boom")
 
-        assert CandidateScoreThresholdStopper(0.95)(Boom()) is False
+        with caplog.at_level(logging.WARNING, logger=_GEPA_OPTIMIZER_LOGGER):
+            assert CandidateScoreThresholdStopper(0.95)(Boom()) is False
+        assert "threshold stopping is inactive" in caplog.text
 
     def test_finish_reason__only_seed_reached_threshold__is_not_perfect_score(
         self,
@@ -349,6 +367,32 @@ class TestCandidateScoreThresholdStopper:
         """The label must agree with the stopper: a seed-only 1.0 is a budget
         exit, not a perfect score."""
         gepa_result = _make_mock_gepa_result(candidates=[], val_aggregate_scores=[1.0])
+        result, _ = _run_optimize(
+            monkeypatch,
+            mock_optimization_context,
+            simple_chat_prompt,
+            mock_dataset,
+            sample_dataset_items,
+            sample_metric,
+            gepa_result=gepa_result,
+        )
+
+        assert result.details["finish_reason"] == "max_trials"
+
+    def test_finish_reason__non_finite_candidate_score__is_not_perfect_score(
+        self,
+        mock_optimization_context,
+        monkeypatch,
+        simple_chat_prompt,
+        mock_dataset,
+        sample_dataset_items,
+        sample_metric,
+    ) -> None:
+        """The label filters non-finite scores exactly like the stopper, so an inf
+        cannot claim a stop that never happened."""
+        gepa_result = _make_mock_gepa_result(
+            candidates=[], val_aggregate_scores=[0.5, float("inf")]
+        )
         result, _ = _run_optimize(
             monkeypatch,
             mock_optimization_context,

--- a/sdks/opik_optimizer/tests/unit/fixtures/assertions.py
+++ b/sdks/opik_optimizer/tests/unit/fixtures/assertions.py
@@ -30,6 +30,9 @@ def assert_baseline_early_stop(
     assert result.details["finish_reason"] == "perfect_score"
     assert result.details["stop_reason"] == "baseline_score_met_threshold"
     assert result.details["perfect_score"] == perfect_score
+    # Every completion path must carry scoring_health — the worker forwards it
+    # to metadata and the UI's "No usable scores" heuristic reads it.
+    assert "failed_count" in result.details["scoring_health"]
     assert result.initial_score == result.score
     if trials_completed is not None:
         assert result.details["trials_completed"] == trials_completed

--- a/sdks/opik_optimizer/tests/unit/fixtures/assertions.py
+++ b/sdks/opik_optimizer/tests/unit/fixtures/assertions.py
@@ -27,6 +27,7 @@ def assert_baseline_early_stop(
     Assert the standard BaseOptimizer early-stop contract when baseline >= perfect_score.
     """
     assert result.details["stopped_early"] is True
+    assert result.details["finish_reason"] == "perfect_score"
     assert result.details["stop_reason"] == "baseline_score_met_threshold"
     assert result.details["perfect_score"] == perfect_score
     assert result.initial_score == result.score


### PR DESCRIPTION
## Details

Optimization Studio dogfooding reported runs that "stick with the original prompt with no improvements" and give the user no way to tell why. This PR fixes the three config-level root causes (SDK + python-backend only; the user-facing copy is owned by OPIK_7458, budget accounting by OPIK_7461).

### 1. `perfect_score` = 1.0 for Studio runs

- **Issue:** runs with a strong-but-imperfect baseline end immediately with zero candidates, presenting as "nothing improved".
- **Why:** `perfect_score` does double duty. It is GEPA's per-iteration skip gate (`reflective_mutation.py` skips the whole iteration when every mini-batch item clears it) AND — since #7591 — the run-level stop threshold via `ScoreThresholdStopper`. Our 0.95 default lowered both bars below GEPA's own 1.0: a baseline at 0.95 stopped the run with zero candidates, and a run reaching 0.96 stopped even though 1.0 was reachable.
- **Decision:** pin `perfect_score = 1.0` at the Studio boundary — `OptimizerFactory.build` injects it as a constructor default for every Studio optimizer (an explicit value in the run's `optimizer_params` still wins; operator-overridable via `OPTIMIZER_PERFECT_SCORE`). The SDK-wide `DEFAULT_PERFECT_SCORE` stays 0.95, per the ticket's scope ("Set perfect_score to 1.0 **for Studio runs**"): raising the SDK default would silently change behaviour for every SDK user of every optimizer (e.g. a fuzzy metric that plateaus at ~0.97 would stop early-stopping and burn its full budget), and it would not reach Studio anyway until the python-backend's `opik_optimizer` pin is bumped. The constructor kwarg exists on the currently pinned `opik-optimizer==3.1.0`, so this root cause is fixed the moment the backend deploys — no pin bump needed. *(An earlier revision of this PR changed the SDK constant instead; reworked after review.)*

### 2. Adaptive `reflection_minibatch_size`

- **Issue:** GEPA discards most iterations on the Studio's default metrics, so runs burn budget without producing candidates.
- **Why:** the Studio pinned `reflection_minibatch_size = 5`, and GEPA only promotes a candidate on a **strict** win over that same batch (`engine.py`: `new_sum <= old_sum → skip`). A 0/1 metric (Equals, Levenshtein) over 5 items has only six possible sums — not enough resolution for a candidate to demonstrate a win.
- **Decision:** compute it per run as `min(dataset_size, max(5, ceil(dataset_size / 5)), budget_cap)` after the dataset loads. Scaling at ~20% grows resolution with data; the floor of 5 preserves current behaviour for small datasets; the cap at `dataset_size` keeps tiny datasets valid. There is deliberately **no `max_trials` cap**: that comparison was dimensionally wrong (a batch in *items* vs a *candidate* counter) and its premise — the SDK's old "reflection will not run" warning — is false: the gepa engine never gates a reflection iteration on the remaining budget (its only budget read, `metric_calls_remaining`, feeds a callback event), a large batch just costs ~2×batch metric calls per iteration. Instead, `budget_cap = (max_trials × dataset_size) // (2 × GEPA_MIN_REFLECTION_ITERATIONS)` guarantees at least 5 reflection iterations inside `max_metric_calls = max_trials × n_samples`; the SDK warning was rewritten to report the real iteration estimate (`max_metric_calls // (2×batch)`). `OPTIMIZER_GEPA_REFLECTION_BATCH_SIZE` remains an operator override (used verbatim; validated at service startup — integer ≥ 1, malformed values fail fast naming the variable).

### 2b. The stop decision no longer rides on a single noisy evaluation

- **Issue:** found while verifying #1 live. Raising `perfect_score` to 1.0 removed the *deterministic* abort on a strong baseline but left a *stochastic* one one step later, so "the run stuck with the original prompt" was still reproducible — just by luck instead of by config.
- **Why:** the Studio's metrics are 0/1 per item and nothing pinned the task model's temperature, so the same evaluation is not reproducible. Measured on dev, repeating the **same** eval of the **same** prompt over the **same** 20-item dataset: `gpt-5-nano` scored 0.95/1.00 across 6 repeats, `gpt-4o-mini` scored 0.90/0.95 and flipped even on unambiguous items. When the seed program's own full eval happened to reach 1.0, gepa's `ScoreThresholdStopper` ended the run at iteration zero — and the run was reported as `finish_reason="perfect_score"` while the UI showed "no improvement" at 0.95. A better model or a cleaner dataset does not fix this: 4o-mini has the same spread at its default temperature.
- **Decision:** two parts. `CandidateScoreThresholdStopper` ignores `program_full_scores_val_set[0]` (the seed's own eval), so only a *candidate* reaching the threshold can stop the run; "the baseline is already good enough" stays owned by `should_skip_optimization` on Opik's baseline eval, which runs earlier, so no stop path is lost. `_resolve_gepa_finish_reason` skips index 0 for the same reason, keeping the label in agreement with the stopper. Separately, the **task** model (whose completions are scored) now runs at a pinned temperature — pinning made the same eval reproduce 6/6 identically. The reflection model is deliberately left alone, since it needs sampling diversity to propose varied candidates. Models that fix their temperature (the gpt-5 family accepts only `1`, and `DEFAULT_MODEL` is `openai/gpt-5-nano`) ignore the pin via litellm's `drop_params` rather than failing the run — which is exactly why the stopper change is required and the pin alone is not enough.

### 3. `finish_reason` complete and persisted

- **Issue:** the run page shows a completed run with no trials and no reason; the frontend has no authoritative stop cause to render.
- **Why:** three gaps. (a) Budget-exhausted GEPA runs fell through to `finish_reason="completed"` — GEPA's `trials_completed` only counts Opik-side `evaluate()` calls, so the base-class `max_trials` fallback never fired. (b) The baseline-perfect skip path wrote a legacy `stop_reason` but never the canonical `finish_reason` key (in both `BaseOptimizer` and `ParameterOptimizer`'s hand-rolled copy). (c) The python-backend forwarded only `scoring_health` to the Java backend; `finish_reason` never left `OptimizationResult.details`.
- **Decision:** (a) GEPA now falls back to `"max_trials"` when neither of its stoppers fired — sound because the gepa engine only ever exits via its stop callbacks, so "no stopper fired" proves the metric-call budget ran out. (b) The early-stop paths write `finish_reason="perfect_score"` alongside the legacy `stop_reason` (kept for back-compat). (c) `optimizer_runner` forwards `finish_reason` as `metadata.finish_reason` in the same completion PUT as `scoring_health`, validated against the SDK's `FinishReason` allowlist so malformed details can't inject arbitrary strings into metadata. This gives OPIK_7458 an authoritative signal to render instead of a heuristic; error/cancelled paths were already correct (status + `error_info`).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7511

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5
- Scope: full implementation, tests, and verification of this PR
- Human verification: pending reviewer verification

## Testing

- `make -C sdks/opik_optimizer test` — 991 passed, 2 skipped after the latest commit. Includes new regression tests: gepa exit with no wired stopper fired → `finish_reason="max_trials"` fallback labeling; driving the wired `NoImprovementStopper` to its limit (now bounded so a stopper regression fails instead of hanging) → `"no_improvement"`; `finish_reason == "perfect_score"` added to the shared baseline-early-stop assertion exercised by every optimizer's early-stop test; and the rewritten budget warning asserted against the real iteration estimate (fires below 5 projected iterations with the actual count, silent at/above).
- python-backend unit tests (`pytest tests/unit/test_studio_config.py tests/unit/test_studio_types.py tests/unit/test_studio_*.py`) — passing. `test_studio_config.py` covers the sizing-policy table (1-item/tiny/small/scaled datasets, budget-cap cases, the >100-item sizes the old `max_trials` cap used to clamp), a property check that any resolved batch > 1 leaves ≥ 5 reflection iterations in budget, env-override validation (fail-fast at import, error names the variable, bounded message), and `TestExtractFinishReason` (allowlist, malformed details, never-raises contract). `test_studio_optimizers_factory.py` covers the `perfect_score` injection (defaulted to 1.0, explicit run value wins, caller params not mutated, and the real pinned `GepaOptimizer` constructor accepts it) and the temperature pin (applied for the task model, absent for the reflection model, explicit value wins, `drop_params` set). New `TestCandidateScoreThresholdStopper` in the SDK covers the seed-vs-candidate rule: a seed-only score at the threshold does not stop, a candidate at the threshold does, `None`/empty/missing history is safe, and the resulting label is `max_trials` rather than `perfect_score`.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — all hooks pass for the committed range.

### Real end-to-end (live backend + gateway-resolved provider key + real LLM calls)

Both runs drive the real pipeline: `process_optimizer_job` → `optimizer_runner.py` subprocess → gateway-routed completions → status/metadata PUTs to the Java backend.

- **Strong-baseline path** (new `tests/e2e/test_studio_finish_reason.py`): baseline hit `perfect_score` → run completed with an allowlisted `finish_reason` returned by the subprocess AND persisted identically as `metadata.finish_reason`, with `scoring_health` on the same completion update. This e2e caught a real gap — `build_early_stop_details` never carried `scoring_health`, so perfect-baseline runs completed without it (the exact data OPIK_7458's "No usable scores" heuristic misfires on); fixed in the follow-up commit. **Re-run after the perfect_score rework** against the dev.comet.com cloud backend (gpt-5-nano via the workspace OpenAI key), exercising the factory-injected `perfect_score=1.0` end to end — passing. Running e2e against a cloud backend required making the provider fixture follow `OPTSTUDIO_E2E_MODEL` and passing `opik_api_key` in the job message (final commit); CI's unauthenticated local stack keeps its previous behaviour.
- **A/B on the same dataset, threshold as the only variable** (20 items, one deliberately borderline, `equals`, GEPA, `max_trials=3`, gpt-5-nano via the gateway) — this is what surfaced 2b. Baseline landed on 0.95, the single score where the old and new thresholds disagree. Old threshold (0.95): **1 trial**, zero candidates — the reported bug reproduced exactly. New threshold (1.0): the run searched, **11 trials**, four distinct GEPA-proposed candidates evaluated. Trial rows also show the adaptive mini-batch applied end to end: mini-batch phases score on 5-item granularity (0.8 = 4/5, 1.0 = 5/5) while full evals land on 20-item granularity (0.95 = 19/20), matching `resolve_reflection_minibatch_size(20, 3) = 5`.
- **After 2b, same config that used to abort** (user-role prompt, threshold 1.0): previously 3 trials and a bogus `finish_reason="perfect_score"`; now **12 trials** ending honestly with `finish_reason="max_trials"` persisted at 0.95. The pin is visible at the call site: the task prompt carries `temperature: 0.0, drop_params: True` while the reflection model keeps `{stream, max_tokens}` only.
- **Imperfect-baseline path** (hard sarcasm dataset, 10 items, `equals`, GEPA, `max_trials=4`): the optimizer visibly searched — 11 trials (baseline + 10 candidate steps, GEPA-mutated prompts among them), then stopped with `finish_reason="max_trials"` persisted in metadata. The adaptive mini-batch is observable in the trial rows: reflection evaluations use exactly 4 items (with the final formula: `min(10, max(5, ceil(10/5)), (4×10)//(2×5)) = 4` — here the budget cap binds), full evals use all 10.
- **UI spot-check** (run detail page, local FE): despite every candidate scoring 0%, the misleading "the metric may have failed" copy does NOT appear (scoring_health {failed: 0, total: 10} is present); only the correct "No improvement over baseline — the original prompt was kept" banner shows, alongside the full Baseline→Step-10 progress chart. Rendering `finish_reason` itself is OPIK_7458.

## Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)


