### PR TITLE
[OPIK-7265] [CI] feat(release): publish opik-optimizer via PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/opik-optimizer-publish.yml
+++ b/.github/workflows/opik-optimizer-publish.yml
@@ -1,9 +1,11 @@
 name: "Opik Optimizer - Publish SDK"
 run-name: "Opik Optimizer Publish SDK ${{ github.ref_name }} by @${{ github.actor }}"
 
+# PyPI Trusted Publishing (OIDC): no long-lived API token needed.
+# id-token: write lets the runner mint the short-lived OIDC token PyPI trusts.
 permissions:
     contents: read
-    packages: write
+    id-token: write
 
 on:
     workflow_dispatch:
@@ -24,12 +26,6 @@ jobs:
           with:
                 python-version: 3.9
 
-        - name: PyPI token preflight
-          uses: ./.github/actions/pypi-token-preflight
-          with:
-            pypi_token: ${{ secrets.PYPI_API_TOKEN }}
-            package_name: opik-optimizer
-
         - name: Build pip package
           run: |
                 cd sdks/opik_optimizer
@@ -39,7 +35,6 @@ jobs:
         - name: Publish package distributions to PyPI
           uses: pypa/gh-action-pypi-publish@v1.12.4
           with:
-            password: ${{ secrets.PYPI_API_TOKEN }}
             packages-dir: sdks/opik_optimizer/dist
             # Symmetric to OPIK-6624's npm publish 403-skip: replays / races where
             # the version is already on PyPI should not fail the release.


### PR DESCRIPTION
## Details

Switches the `opik-optimizer` publish off the long-lived `PYPI_API_TOKEN` and onto PyPI Trusted Publishing (OIDC), matching what `comet-python-mpm-sdk` already does. Uploads had been failing with `403 Forbidden` since February because the token is scoped to the `opik` project and not `opik-optimizer` — the same secret published `opik` 2.2.8 successfully on the morning of 28 Jul and 403'd for the optimizer hours later.

- `permissions`: add `id-token: write` so the runner can mint the short-lived OIDC token PyPI trusts; drop `packages: write` (GitHub Packages, unused here).
- Remove the explicit `password:` input — an explicit password disables Trusted Publishing outright, which the failing run logged verbatim along with a warning that it also voids `attestations`.
- Remove the PyPI token preflight step — it exists only to validate a stored token, and there no longer is one. It was also a no-op: PyPI answers its bodyless `POST` probe with `405`, which falls through to the action's "continue anyway" branch, so it passed on every release regardless of token validity and green-lit run `30353241153`'s sibling `30353461156` seconds before that run 403'd.

The Trusted Publisher for `comet-ml/opik` + `opik-optimizer-publish.yml` (Environment: Any) is registered on the PyPI project, so OIDC works with no stored credential.

## Change checklist
- [x] User facing
- [ ] Documentation update

Marked user facing because it is what allows `opik-optimizer` releases to reach PyPI again; 3.1.1 carries five months of unreleased Optimization Studio fixes.

## Issues

- OPIK-7265

Related but not resolved here: OPIK_7460 and OPIK_7461 are unblocked by the resulting 3.1.1 release but are closed by the pin bump plus a staging verification run, not by this workflow change. OPIK_7265 itself stays open after this merge — it covers every comet-ml repo that publishes to PyPI, and this PR migrates one workflow. The `opik` package in `build_and_publish_sdk.yaml` still uses the token and the same no-op preflight.

## AI-WATERMARK

AI-WATERMARK: [yes]

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5
  - Scope: Diagnosed the 403 (compared token behaviour across the two publish workflows, established the scope mismatch, and identified the 405 fall-through that made the preflight vacuous), authored the three workflow edits and this description.
  - Human verification: Trusted Publisher registration on PyPI was performed by a human with owner rights. The change is verified by an actual successful publish (see Testing) rather than by inspection.

## Testing

Validated by running the real workflow from this branch before opening the PR, which is the path OPIK-7265 documents (configure publisher, add `id-token: write`, drop the token, dispatch from a branch).

- Command: `gh workflow run opik-optimizer-publish.yml --repo comet-ml/opik --ref awkoy/OPIK-7265/optimizer-trusted-publishing`
- Result: run 30364058956 — every step green, including `Publish package distributions to PyPI`.
- Confirmed on the registry, not just in CI: `opik-optimizer` 3.1.1 is live on PyPI, both artifacts, uploaded 2026-07-28T13:34:31Z (`opik_optimizer-3.1.1-py3-none-any.whl`, `opik_optimizer-3.1.1.tar.gz`).
- Confirmed OIDC was actually the mechanism: the run log reports "Generating and uploading digital attestations" and no longer emits the "explicit password ... disabling Trusted Publishing" warning that the previous token-based run did.

Not run: nothing else in this repo exercises this workflow, and it is `workflow_dispatch`-only, so there is no local or PR-triggered path to test. Note that the publish already happened from this branch, so a post-merge dispatch will hit `skip-existing: true` for 3.1.1 rather than re-uploading.

## Documentation

No documentation change. The mechanism swap is invisible to users of the package, and the release procedure itself is unchanged (still a manual `workflow_dispatch`). Making that procedure easier to run and adding a version-drift guard is tracked separately in OPIK_7514.
