### PR TITLE
[OPIK-7584] [BE] Narrow the experiment aggregation-branch counts to the requested project

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentDAO.java
@@ -2294,6 +2294,7 @@ public class ExperimentDAO {
             var aggregationCriteria = AggregationBranchCountsCriteria.builder()
                     .experimentIds(experimentSearchCriteria.experimentIds())
                     .datasetId(experimentSearchCriteria.datasetId())
+                    .projectId(experimentSearchCriteria.projectId())
                     .build();
 
             var targetProjectIdsMono = getTargetProjectIdsForExperiments(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCounts.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCounts.java
@@ -1,7 +1,13 @@
 package com.comet.opik.domain.experiments.aggregations;
 
+import lombok.Builder;
+
+@Builder(toBuilder = true)
 public record AggregatedExperimentCounts(long aggregated, long notAggregated) {
-    public static final AggregatedExperimentCounts BOTH_BRANCHES = new AggregatedExperimentCounts(1, 1);
+    public static final AggregatedExperimentCounts BOTH_BRANCHES = AggregatedExperimentCounts.builder()
+            .aggregated(1)
+            .notAggregated(1)
+            .build();
 
     public boolean hasAggregated() {
         return aggregated == 0 && notAggregated == 0 || aggregated > 0;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/AggregationBranchCountsCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/AggregationBranchCountsCriteria.java
@@ -5,12 +5,28 @@ import lombok.Builder;
 import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Criteria narrowing the aggregated/non-aggregated experiment counts that decide which branches of the
+ * experiment queries are rendered.
+ * <p>
+ * {@code projectId} narrows only the non-aggregated (raw fallback) count. Without it the count is
+ * workspace-wide, so a single non-aggregated experiment anywhere in the workspace keeps the raw branch for
+ * every request in that workspace, even when no experiment in the requested project needs it.
+ * <p>
+ * An experiment belongs to a project either through its own {@code project_id} or through the projects of the
+ * traces its items reference - the raw branch matches on the concatenation of both. Most experiments carry no
+ * {@code project_id}, so the trace-derived side cannot be dropped; and a substantial minority carry a
+ * {@code project_id} that none of their traces point at, so the {@code project_id} side cannot be dropped
+ * either. Both are therefore required for the count to be correct: under-counting would drop the raw branch
+ * and silently omit matching experiments from the response.
+ */
 @Builder(toBuilder = true)
 public record AggregationBranchCountsCriteria(
         Set<UUID> experimentIds,
         UUID datasetId,
         UUID id,
-        Set<UUID> idsList) {
+        Set<UUID> idsList,
+        UUID projectId) {
 
     public static AggregationBranchCountsCriteria empty() {
         return AggregationBranchCountsCriteria.builder().build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -123,6 +123,20 @@ public interface ExperimentAggregatesDAO {
     Mono<ProjectStats> getExperimentItemsStatsFromAggregates(UUID datasetId, UUID versionId, Set<UUID> experimentIds,
             List<ExperimentsComparisonFilter> filters);
 
+    /**
+     * Counts aggregated and non-aggregated experiments so callers can drop query branches that cannot contribute
+     * rows.
+     * <p>
+     * When {@link AggregationBranchCountsCriteria#projectId()} is set, the non-aggregated count is restricted to
+     * experiments reachable from that project. Reachability follows the project of the experiment itself and the
+     * projects of the traces its items reference.
+     * <p>
+     * The trace lookup is deliberately restricted to trace ids that appear in {@code experiment_items}. A project
+     * can hold tens of millions of traces while a workspace holds under a million experiment items, so driving the
+     * lookup from the project alone builds an enormous set: measured against a seven-million-trace project it read
+     * 7.19M rows using 1.4 GiB, versus 197K rows and 12 MiB with the restriction, for an identical result. Without
+     * it this count can cost more than the branch it is meant to eliminate.
+     */
     Mono<AggregatedExperimentCounts> getAggregationBranchCounts(AggregationBranchCountsCriteria criteria);
 
     Mono<Long> deleteByExperimentIds(Set<UUID> experimentIds);
@@ -1436,11 +1450,41 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             SELECT
                 count() AS total,
                 countIf(has_aggregated) AS aggregated,
-                countIf(NOT has_aggregated) AS not_aggregated
+                countIf(NOT has_aggregated AND in_project_scope) AS not_aggregated
             FROM (
                 SELECT
                     e.id,
-                    notEmpty(agg.id) AS has_aggregated
+                    notEmpty(agg.id) AS has_aggregated,
+                    <if(project_id)>
+                    (e.project_id = :project_id
+                        OR e.id IN (
+                            SELECT experiment_id
+                            FROM experiment_items
+                            WHERE workspace_id = :workspace_id
+                              AND trace_id IN (
+                                  SELECT id
+                                  FROM traces
+                                  WHERE workspace_id = :workspace_id
+                                    AND project_id = :project_id
+                                    AND id IN (
+                                        SELECT trace_id
+                                        FROM experiment_items
+                                        WHERE workspace_id = :workspace_id
+                                          AND experiment_id NOT IN (
+                                              SELECT id
+                                              FROM experiment_aggregates
+                                              WHERE workspace_id = :workspace_id
+                                              <if(experiment_ids)> AND id IN :experiment_ids <endif>
+                                              <if(dataset_id)> AND dataset_id = :dataset_id <endif>
+                                              <if(id)> AND id = :id <endif>
+                                              <if(ids_list)> AND id IN :ids_list <endif>
+                                          )
+                                    )
+                              )
+                        )) AS in_project_scope
+                    <else>
+                    true AS in_project_scope
+                    <endif>
                 FROM experiments e FINAL
                 LEFT JOIN (
                     SELECT DISTINCT
@@ -2803,6 +2847,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             Optional.ofNullable(criteria.idsList())
                     .filter(CollectionUtils::isNotEmpty)
                     .ifPresent(idsList -> template.add("ids_list", idsList));
+            Optional.ofNullable(criteria.projectId())
+                    .ifPresent(projectId -> template.add("project_id", projectId));
 
             var statement = connection.createStatement(template.render());
 
@@ -2817,6 +2863,8 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
             Optional.ofNullable(criteria.idsList())
                     .filter(CollectionUtils::isNotEmpty)
                     .ifPresent(idsList -> statement.bind("ids_list", idsList.toArray(UUID[]::new)));
+            Optional.ofNullable(criteria.projectId())
+                    .ifPresent(projectId -> statement.bind("project_id", projectId));
 
             return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
                     .flatMap(result -> result

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -2874,9 +2874,10 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
             return makeFluxContextAware(bindWorkspaceIdToFlux(statement))
                     .flatMap(result -> result
-                            .map((row, metadata) -> new AggregatedExperimentCounts(
-                                    row.get("aggregated", Long.class),
-                                    row.get("not_aggregated", Long.class))))
+                            .map((row, metadata) -> AggregatedExperimentCounts.builder()
+                                    .aggregated(row.get("aggregated", Long.class))
+                                    .notAggregated(row.get("not_aggregated", Long.class))
+                                    .build()))
                     .next()
                     .defaultIfEmpty(AggregatedExperimentCounts.BOTH_BRANCHES);
         }));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/experiments/aggregations/ExperimentAggregatesDAO.java
@@ -131,6 +131,13 @@ public interface ExperimentAggregatesDAO {
      * experiments reachable from that project. Reachability follows the project of the experiment itself and the
      * projects of the traces its items reference.
      * <p>
+     * The restriction applies to the non-aggregated count only, and must not be hoisted into the outer filter. The
+     * two branches decide project membership differently: the raw branch from traces and {@code project_id}, the
+     * aggregated branch from {@code experiment_aggregates.project_id}. Aggregated experiments exist whose stored
+     * project is no longer reachable from their traces, because those traces were deleted after aggregation.
+     * Filtering every row by the raw branch's notion of reachability would drop such experiments from the
+     * aggregated count, and with it the aggregated branch that returns them.
+     * <p>
      * The trace lookup is deliberately restricted to trace ids that appear in {@code experiment_items}. A project
      * can hold tens of millions of traces while a workspace holds under a million experiment items, so driving the
      * lookup from the project alone builds an enormous set: measured against a seven-million-trace project it read
@@ -1448,7 +1455,6 @@ class ExperimentAggregatesDAOImpl implements ExperimentAggregatesDAO {
 
     private static final String SELECT_EXPERIMENT_AGGREGATION_COUNTS = """
             SELECT
-                count() AS total,
                 countIf(has_aggregated) AS aggregated,
                 countIf(NOT has_aggregated AND in_project_scope) AS not_aggregated
             FROM (

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -82,6 +82,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -132,6 +133,14 @@ class ExperimentAggregatesIntegrationTest {
 
     public static final String[] IGNORED_FIELDS_EXPERIMENT_ITEM = {"createdAt", "lastUpdatedAt", "createdBy",
             "lastUpdatedBy", "comments", "projectName", "executionPolicy"};
+
+    public static final String[] UNORDERED_FIELDS_SCORES = {"experimentScores", "feedbackScores"};
+
+    public static final String[] UNORDERED_FIELDS_SCORES_IN_CONTENT = Arrays.stream(UNORDERED_FIELDS_SCORES)
+            .map("content."::concat)
+            .toArray(String[]::new);
+
+    public static final String[] UNORDERED_FIELDS_ASSERTIONS = {"feedbackScores", "assertionResults"};
 
     @RegisterApp
     private final TestDropwizardAppExtension app;
@@ -607,12 +616,12 @@ class ExperimentAggregatesIntegrationTest {
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
 
-        var page = findByProject(project.id(), workspaceId);
+        var scoped = findByProject(project.id(), workspaceId);
+        var reference = findByIds(Set.of(aggregatedExperiment.id(), nonAggregatedExperiment.id()), workspaceId);
 
-        assertThat(page).isNotNull();
-        assertThat(page.content().stream().map(Experiment::id).toList())
-                .as("both the aggregated and the non-aggregated experiment of the requested project must be returned")
-                .contains(aggregatedExperiment.id(), nonAggregatedExperiment.id());
+        assertSameExperiments(scoped, reference,
+                "a project-scoped find must return the same experiments, field for field, as a find that cannot "
+                        + "drop the raw branch - including the non-aggregated experiment of that project");
     }
 
     /**
@@ -649,29 +658,56 @@ class ExperimentAggregatesIntegrationTest {
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
 
-        var page = findByProject(requestedProject.id(), workspaceId);
+        var scoped = findByProject(requestedProject.id(), workspaceId);
+        var reference = findByIds(Set.of(aggregatedExperiment.id()), workspaceId);
 
-        assertThat(page).isNotNull();
-        assertThat(page.content().stream().map(Experiment::id).toList())
-                .as("the experiment of the requested project must be returned")
-                .contains(aggregatedExperiment.id());
-        assertThat(page.content().stream().map(Experiment::id).toList())
-                .as("an experiment reachable only from another project must not leak into this listing")
-                .doesNotContain(unrelatedNonAggregated.id());
+        assertSameExperiments(scoped, reference,
+                "dropping the raw branch must not change the returned experiments, and an experiment reachable "
+                        + "only from another project must not appear at all");
     }
 
-    private Experiment.ExperimentPage findByProject(UUID projectId, String workspaceId) {
-        var searchCriteria = ExperimentSearchCriteria.builder()
+    private List<Experiment> findByProject(UUID projectId, String workspaceId) {
+        return findExperiments(ExperimentSearchCriteria.builder()
                 .projectId(projectId)
                 .entityType(EntityType.TRACE)
                 .sortingFields(List.of())
-                .build();
+                .build(), workspaceId);
+    }
 
-        return experimentService.find(1, 100, searchCriteria)
+    private List<Experiment> findByIds(Set<UUID> experimentIds, String workspaceId) {
+        return findExperiments(ExperimentSearchCriteria.builder()
+                .experimentIds(experimentIds)
+                .entityType(EntityType.TRACE)
+                .sortingFields(List.of())
+                .build(), workspaceId);
+    }
+
+    private List<Experiment> findExperiments(ExperimentSearchCriteria searchCriteria, String workspaceId) {
+        var page = experimentService.find(1, 100, searchCriteria)
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.USER_NAME, USER)
                         .put(RequestContext.WORKSPACE_ID, workspaceId))
                 .block();
+
+        assertThat(page).isNotNull();
+
+        return page.content().stream()
+                .sorted(Comparator.comparing(Experiment::id))
+                .toList();
+    }
+
+    private void assertSameExperiments(List<Experiment> actual, List<Experiment> expected, String description) {
+        assertThat(expected)
+                .as("the reference find must return experiments, otherwise the comparison is vacuous")
+                .isNotEmpty();
+
+        assertThat(actual)
+                .as(description)
+                .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
+                        .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                        .build())
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES)
+                .isEqualTo(expected);
     }
 
     @ParameterizedTest(name = "Group by {0}")
@@ -821,7 +857,7 @@ class ExperimentAggregatesIntegrationTest {
                         RecursiveComparisonConfiguration.builder()
                                 .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                                 .build())
-                .ignoringCollectionOrderInFields("feedbackScores", "experimentScores")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES)
                 .isEqualTo(aggregationsFromRaw);
     }
 
@@ -1050,7 +1086,7 @@ class ExperimentAggregatesIntegrationTest {
                 .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
                         .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                         .build())
-                .ignoringCollectionOrderInFields("feedbackScores", "experimentScores")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES)
                 .isEqualTo(fromRaw);
     }
 
@@ -1479,7 +1515,7 @@ class ExperimentAggregatesIntegrationTest {
                     .usingRecursiveComparison()
                     .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                     .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "duration")
-                    .ignoringCollectionOrderInFields("feedbackScores", "assertionResults")
+                    .ignoringCollectionOrderInFields(UNORDERED_FIELDS_ASSERTIONS)
                     .ignoringFields(IGNORED_FIELDS_EXPERIMENT_ITEM)
                     .isEqualTo(expectedExperiments);
         }
@@ -1515,7 +1551,7 @@ class ExperimentAggregatesIntegrationTest {
                 .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
                         .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                         .build())
-                .ignoringCollectionOrderInFields("content.feedbackScores", "content.experimentScores")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES_IN_CONTENT)
                 .isEqualTo(expected);
     }
 
@@ -1536,7 +1572,7 @@ class ExperimentAggregatesIntegrationTest {
                 .usingRecursiveComparison(RecursiveComparisonConfiguration.builder()
                         .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                         .build())
-                .ignoringCollectionOrderInFields("feedbackScores", "experimentScores")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES)
                 .isEqualTo(expected);
     }
 
@@ -2440,7 +2476,7 @@ class ExperimentAggregatesIntegrationTest {
                 .as("experiment item must be identical before and after aggregation")
                 .usingRecursiveComparison()
                 .ignoringFields(IGNORED_FIELDS_EXPERIMENT_ITEM)
-                .ignoringCollectionOrderInFields("feedbackScores", "assertionResults")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_ASSERTIONS)
                 .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                 .isEqualTo(beforeItem);
     }
@@ -3200,7 +3236,7 @@ class ExperimentAggregatesIntegrationTest {
                                 .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
                                 .build())
                 .ignoringFields(EXPERIMENT_AGGREGATED_FIELDS_TO_IGNORE)
-                .ignoringCollectionOrderInFields("experimentScores", "feedbackScores")
+                .ignoringCollectionOrderInFields(UNORDERED_FIELDS_SCORES)
                 .isEqualTo(rawExperiment);
 
         assertThat(aggregatedExperiment.id())

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -82,7 +82,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -691,11 +690,14 @@ class ExperimentAggregatesIntegrationTest {
 
         assertThat(page).isNotNull();
 
-        return page.content().stream()
-                .sorted(Comparator.comparing(Experiment::id))
-                .toList();
+        return page.content();
     }
 
+    /**
+     * Compares two result lists field for field, in the order the API returned them. Both finds render the same
+     * {@code ORDER BY id DESC}, so the order is deterministic and identical - do not sort the lists before
+     * comparing, or a change in result ordering stops being caught.
+     */
     private void assertSameExperiments(List<Experiment> actual, List<Experiment> expected, String description) {
         assertThat(expected)
                 .as("the reference find must return experiments, otherwise the comparison is vacuous")

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -574,6 +574,106 @@ class ExperimentAggregatesIntegrationTest {
         assertExperimentMatches(rawExperiment, experimentFromAggregates, projectA.id(), projectB.id());
     }
 
+    /**
+     * The aggregated/non-aggregated counts decide which branches of FIND are rendered, and they are narrowed by
+     * the requested project. A non-aggregated experiment reachable from that project must keep the raw branch
+     * alive, otherwise it disappears from the response. This is the data-loss case, and it exercises the
+     * trace-derived binding: the experiment reaches the project through the traces its items point at, which is
+     * how most experiments are bound to a project.
+     */
+    @Test
+    @DisplayName("A project-scoped find returns non-aggregated experiments belonging to that project")
+    void projectScopedFindReturnsNonAggregatedExperimentsOfThatProject() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var project = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        List<String> feedbackScores = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+
+        var aggregatedExperiment = createExperiment(dataset, apiKey, workspaceName);
+        createExperimentItemWithData(
+                aggregatedExperiment.id(), dataset.id(), project.name(), feedbackScores, apiKey, workspaceName);
+
+        var nonAggregatedExperiment = createExperiment(dataset, apiKey, workspaceName);
+        createExperimentItemWithData(
+                nonAggregatedExperiment.id(), dataset.id(), project.name(), feedbackScores, apiKey, workspaceName);
+
+        experimentAggregatesService.populateAggregations(aggregatedExperiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        var page = findByProject(project.id(), workspaceId);
+
+        assertThat(page).isNotNull();
+        assertThat(page.content().stream().map(Experiment::id).toList())
+                .as("both the aggregated and the non-aggregated experiment of the requested project must be returned")
+                .contains(aggregatedExperiment.id(), nonAggregatedExperiment.id());
+    }
+
+    /**
+     * The mirror case: an experiment reachable only from another project must not appear in this project's
+     * listing. Before the counts were narrowed by project such an experiment also forced the raw branch to be
+     * rendered for every request in the workspace, which is the cost this narrowing removes.
+     */
+    @Test
+    @DisplayName("A project-scoped find excludes non-aggregated experiments of other projects")
+    void projectScopedFindExcludesNonAggregatedExperimentsOfOtherProjects() {
+        var workspaceName = UUID.randomUUID().toString();
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var requestedProject = createProject(apiKey, workspaceName);
+        var otherProject = createProject(apiKey, workspaceName);
+        var dataset = createDataset(apiKey, workspaceName);
+        List<String> feedbackScores = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+
+        var aggregatedExperiment = createExperiment(dataset, apiKey, workspaceName);
+        createExperimentItemWithData(
+                aggregatedExperiment.id(), dataset.id(), requestedProject.name(), feedbackScores, apiKey,
+                workspaceName);
+
+        var unrelatedNonAggregated = createExperiment(dataset, apiKey, workspaceName);
+        createExperimentItemWithData(
+                unrelatedNonAggregated.id(), dataset.id(), otherProject.name(), feedbackScores, apiKey,
+                workspaceName);
+
+        experimentAggregatesService.populateAggregations(aggregatedExperiment.id())
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+
+        var page = findByProject(requestedProject.id(), workspaceId);
+
+        assertThat(page).isNotNull();
+        assertThat(page.content().stream().map(Experiment::id).toList())
+                .as("the experiment of the requested project must be returned")
+                .contains(aggregatedExperiment.id());
+        assertThat(page.content().stream().map(Experiment::id).toList())
+                .as("an experiment reachable only from another project must not leak into this listing")
+                .doesNotContain(unrelatedNonAggregated.id());
+    }
+
+    private Experiment.ExperimentPage findByProject(UUID projectId, String workspaceId) {
+        var searchCriteria = ExperimentSearchCriteria.builder()
+                .projectId(projectId)
+                .entityType(EntityType.TRACE)
+                .sortingFields(List.of())
+                .build();
+
+        return experimentService.find(1, 100, searchCriteria)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.USER_NAME, USER)
+                        .put(RequestContext.WORKSPACE_ID, workspaceId))
+                .block();
+    }
+
     @ParameterizedTest(name = "Group by {0}")
     @MethodSource("groupingTestCases")
     @DisplayName("ExperimentAggregatesService.findGroups matches ExperimentService.findGroups (raw)")

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ExperimentAggregatesIntegrationTest.java
@@ -694,9 +694,11 @@ class ExperimentAggregatesIntegrationTest {
     }
 
     /**
-     * Compares two result lists field for field, in the order the API returned them. Both finds render the same
-     * {@code ORDER BY id DESC}, so the order is deterministic and identical - do not sort the lists before
-     * comparing, or a change in result ordering stops being caught.
+     * Compares two result lists field for field, in the order the API returned them.
+     * {@link #findByProject(UUID, String)} and {@link #findByIds(Set, String)} both render the same
+     * {@code ORDER BY id DESC}, so their ordering is deterministic and identical. Do not sort the lists before
+     * comparing: the recursive comparison is order-sensitive at the top level, which is what makes a change in
+     * result ordering fail the test.
      */
     private void assertSameExperiments(List<Experiment> actual, List<Experiment> expected, String description) {
         assertThat(expected)

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCountsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCountsTest.java
@@ -11,7 +11,10 @@ class AggregatedExperimentCountsTest {
     @Test
     @DisplayName("a zero non-aggregated count drops the raw branch while keeping the aggregated one")
     void zeroNonAggregatedDropsRawBranch() {
-        var counts = new AggregatedExperimentCounts(7546, 0);
+        var counts = AggregatedExperimentCounts.builder()
+                .aggregated(7546)
+                .notAggregated(0)
+                .build();
 
         assertThat(counts.hasRaw())
                 .as("no experiment needs the raw fallback, so its branch must not be rendered")
@@ -22,7 +25,10 @@ class AggregatedExperimentCountsTest {
     @Test
     @DisplayName("a single non-aggregated experiment keeps the raw branch")
     void anyNonAggregatedKeepsRawBranch() {
-        var counts = new AggregatedExperimentCounts(56, 3);
+        var counts = AggregatedExperimentCounts.builder()
+                .aggregated(56)
+                .notAggregated(3)
+                .build();
 
         assertThat(counts.hasRaw())
                 .as("dropping the branch here would omit the three non-aggregated experiments")
@@ -33,7 +39,10 @@ class AggregatedExperimentCountsTest {
     @Test
     @DisplayName("a zero aggregated count drops the aggregated branch while keeping the raw one")
     void zeroAggregatedDropsAggregatedBranch() {
-        var counts = new AggregatedExperimentCounts(0, 12);
+        var counts = AggregatedExperimentCounts.builder()
+                .aggregated(0)
+                .notAggregated(12)
+                .build();
 
         assertThat(counts.hasAggregated()).isFalse();
         assertThat(counts.hasRaw()).isTrue();
@@ -42,7 +51,10 @@ class AggregatedExperimentCountsTest {
     @Test
     @DisplayName("both counts zero keeps both branches rather than rendering an empty query")
     void bothCountsZeroKeepsBothBranches() {
-        var counts = new AggregatedExperimentCounts(0, 0);
+        var counts = AggregatedExperimentCounts.builder()
+                .aggregated(0)
+                .notAggregated(0)
+                .build();
 
         assertThat(counts.hasAggregated()).isTrue();
         assertThat(counts.hasRaw()).isTrue();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCountsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/experiments/aggregations/AggregatedExperimentCountsTest.java
@@ -1,0 +1,57 @@
+package com.comet.opik.domain.experiments.aggregations;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Aggregated Experiment Counts")
+class AggregatedExperimentCountsTest {
+
+    @Test
+    @DisplayName("a zero non-aggregated count drops the raw branch while keeping the aggregated one")
+    void zeroNonAggregatedDropsRawBranch() {
+        var counts = new AggregatedExperimentCounts(7546, 0);
+
+        assertThat(counts.hasRaw())
+                .as("no experiment needs the raw fallback, so its branch must not be rendered")
+                .isFalse();
+        assertThat(counts.hasAggregated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a single non-aggregated experiment keeps the raw branch")
+    void anyNonAggregatedKeepsRawBranch() {
+        var counts = new AggregatedExperimentCounts(56, 3);
+
+        assertThat(counts.hasRaw())
+                .as("dropping the branch here would omit the three non-aggregated experiments")
+                .isTrue();
+        assertThat(counts.hasAggregated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("a zero aggregated count drops the aggregated branch while keeping the raw one")
+    void zeroAggregatedDropsAggregatedBranch() {
+        var counts = new AggregatedExperimentCounts(0, 12);
+
+        assertThat(counts.hasAggregated()).isFalse();
+        assertThat(counts.hasRaw()).isTrue();
+    }
+
+    @Test
+    @DisplayName("both counts zero keeps both branches rather than rendering an empty query")
+    void bothCountsZeroKeepsBothBranches() {
+        var counts = new AggregatedExperimentCounts(0, 0);
+
+        assertThat(counts.hasAggregated()).isTrue();
+        assertThat(counts.hasRaw()).isTrue();
+    }
+
+    @Test
+    @DisplayName("the both-branches fallback keeps both branches")
+    void bothBranchesFallbackKeepsBothBranches() {
+        assertThat(AggregatedExperimentCounts.BOTH_BRANCHES.hasAggregated()).isTrue();
+        assertThat(AggregatedExperimentCounts.BOTH_BRANCHES.hasRaw()).isTrue();
+    }
+}


### PR DESCRIPTION
## Details

The aggregated/non-aggregated experiment counts decide which branches of the experiment `FIND` query are rendered, but they were computed workspace-wide. A single non-aggregated experiment anywhere in a workspace therefore kept the expensive raw fallback branch alive for every request in that workspace, including projects whose experiments are all aggregated. This passes the requested project into `AggregationBranchCountsCriteria` and restricts the non-aggregated count to experiments reachable from that project, so the branch is dropped when it provably cannot contribute rows.

- Reachability follows both the experiment's own `project_id` **and** the projects of the traces its items reference, because either can bind an experiment to a project in the raw branch. Counting only one side would drop the branch and silently omit rows: in a production sample 74.6% of experiments carry no `project_id` at all, while 27.1% of non-aggregated experiments that do carry one are not reachable through their traces.
- The trace lookup is bounded to trace ids present in `experiment_items`. A project can hold tens of millions of traces while a workspace holds under a million experiment items, so driving it from the project alone builds an enormous set and can cost more than the branch it removes.
- `total` is removed from the counts query. Scoping the non-aggregated count left it counting the whole workspace, so it no longer equalled `aggregated + not_aggregated`. Nothing read it.
- Other callers leave `projectId` unset and render an unconditional scope, so their behaviour is unchanged.

### Before / after — the `FIND` query

Same query text and parameters against a production replica, raw branch dropped, n=4 per variant, medians. Output was **byte-identical** between the two (checksum over the sorted result set matched), which is expected by construction: when every matching experiment is aggregated the raw branch contributes no rows.

| Metric | Before (both branches) | After (aggregated-only) | Change |
|---|---:|---:|---:|
| Wall duration | 440 ms | 110 ms | −75% (4.0x) |
| Query CPU | 1,707 ms | 168 ms | **−90% (10.2x)** |
| Rows read | 1,641,000 | 103,000 | −94% (15.9x) |
| Bytes read | 178 MiB | 54 MiB | −70% (3.3x) |
| Marks scanned | 384 | 24 | −94% (16x) |
| Parts scanned | 336 | 21 | −94% (16x) |
| Ranges scanned | 336 | 21 | −94% (16x) |
| Peak memory | 2,795 MiB | 130 MiB | **−95% (21.5x)** |
| Query-plan optimization | 292 ms | 7 ms | −98% (42x) |

Dropping the branch removes roughly 9 of the 15 CTEs and all reads of `traces`, `spans`, `feedback_scores`, `authored_feedback_scores`, `assertion_results` and `comments`. The plan-optimization collapse matters on ClickHouse 26.3, whose new planning phase scales with plan size.

Independent production evidence for the same effect: requests that already render aggregated-only cost a median **95 ms CPU against 1,379 ms** for both-branches.

### Before / after — the counts pre-query it adds to

| Scope | Wall | CPU | Rows read | Marks | Memory |
|---|---:|---:|---:|---:|---:|
| Before (workspace-wide) | 12 ms | 25 ms | 106 K | 24 | 17 MiB |
| After — large fully-aggregated workspace (~19k experiments) | 128 ms | 243 ms | 1,105 K | 206 | 127 MiB |
| After — scope that must keep the branch | 25 ms | 90 ms | 272 K | 117 | 13 MiB |
| After — project holding ~7M traces | 23 ms | 70 ms | 184 K | 90 | 20 MiB |

So the check costs roughly 45–220 ms CPU more than before, against ~1,500 ms saved whenever it lets the branch go.

### Expected reach

Evaluating every distinct (workspace, project) scope in a production sample of raw-branch traffic — 179 scopes, not a sample of them — 163 are droppable, covering 92.8% of the CPU currently spent on raw-branch requests. The remaining 16 correctly keep the branch. Net effect is a projection rather than a measurement and should be re-measured after rollout.

## Design notes

Three shapes were considered and rejected on measurements. Recording them so they are not re-litigated or "fixed" back.

**1. Why the project restriction is a separate `in_project_scope` term and not an outer `WHERE` filter.** The two branches decide project membership differently — the raw branch from traces plus `project_id`, the aggregated branch from `experiment_aggregates.project_id`. Those disagree in practice. Of 29,449 aggregated experiments in a production sample, 399 have no traces remaining at all and 109 have a stored project that is not among their current trace projects: 508 (1.7%) whose association the raw branch's notion of reachability cannot see, because the traces were deleted after aggregation. Filtering every row by that condition would drop them from the **aggregated** count, and where they are the only aggregated experiments in a project scope `hasAggregated()` would flip false and drop the branch that returns them.

**2. Evaluating reachability only over non-aggregated rows is not cheaper.** The cost is building the reachability sets once, not evaluating the boolean per row:

| Form | Wall | CPU | Rows read | Memory |
|---|---:|---:|---:|---:|
| Current (`in_project_scope` term) | 128 ms | **243 ms** | 1,104,975 | 127 MiB |
| Two scalar subqueries, scope on non-aggregated rows only | 132 ms | 248 ms | 1,211,767 | 130 MiB |

Identical counts from both.

**3. The duplicated reads are deliberate — they buy index-time granule pruning.** `experiment_aggregates` is read twice (the `agg` join and the inner bound) and `experiment_items` twice (the outer projection and the inner trace-id bound), and ClickHouse does not materialize those subqueries. Folding them into a single joined scope relation does remove the duplication, and is faster on a large workspace, but it converts a set known at index-analysis time into a runtime join filter. Measured on a project holding ~7M traces, both join orders:

| Form | CPU | Rows read | Marks scanned | Memory |
|---|---:|---:|---:|---:|
| Current (nested `IN` set) | **55 ms** | **134,506** | **77** | 11 MiB |
| Folded, `experiment_items` left-most | 688 ms | 7,173,826 | 26,845 | 14 MiB |
| Folded, `traces` left-most | 628 ms | 7,166,300 | 26,843 | 12 MiB |

Both folded forms return identical counts, and 26.3's join runtime filters *do* engage — `RuntimeFiltersCreated = 2` with ~6.83M rows skipped. But they filter at join time, after granule selection has already happened, so the scan is not avoided: **26,843 marks read versus 77**, a 348x difference. The nested `IN` set is available during index analysis, which is what prunes the granules.

On a large workspace the fold is the faster shape (157–190 ms CPU versus 243), so the trade-off is not universal. It is chosen for the tail: the duplicated tables are small — `experiment_items` peaks at 821 K rows per workspace and the aggregates read touches 7 of 121 granules — whereas the pruning they buy is worth 11–12x CPU and 348x marks on a large project. If the aggregate backfill ever completes and non-aggregated experiments disappear, the folded form becomes the better choice.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7584

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigation, query analysis against a production replica, the implementation and its tests, and this description.
- Human verification: Author directed the investigation and rejected several earlier iterations — an unbounded trace lookup that would have cost more than the branch it removed, a workspace-wide item bound that scaled poorly, and id-only test assertions that would not have caught wrong field values. Each was re-measured and corrected; the rejected shapes are recorded under Design notes. Reviewer should focus on the reachability condition in `SELECT_EXPERIMENT_AGGREGATION_COUNTS`: under-counting non-aggregated experiments there drops the raw branch and silently omits rows.

## Testing

Commands run:

- `mvn -o test-compile` — BUILD SUCCESS
- `mvn -o surefire:test -Dtest=AggregatedExperimentCountsTest` — **5/5 passing**

Scenarios validated:

- `AggregatedExperimentCountsTest` covers the `hasRaw`/`hasAggregated` truth table, including the both-counts-zero fallback that keeps both branches, which is the behaviour this change relies on.
- `ExperimentAggregatesIntegrationTest` adds two cases that compare whole `Experiment` objects field for field against a find by experiment ids, a path whose branch decision the project narrowing cannot affect:
  - a non-aggregated experiment in the requested project is still returned, with identical data (the data-loss guard, exercising the trace-derived binding);
  - an experiment reachable only from another project does not appear.
- The rendered query was executed against a production replica and its counts cross-checked against independently computed values, for a fully-aggregated scope, a scope that must keep the branch, and a project holding ~7M traces.

Not run locally: the two integration tests need the ClickHouse test harness, which does not bootstrap in this environment. CI is the gate for those.

## Documentation

No documentation change. The reachability rules, the reason the trace lookup is bounded, and the reason the restriction is not hoisted into the outer filter are documented in javadoc on `AggregationBranchCountsCriteria` and `ExperimentAggregatesDAO#getAggregationBranchCounts`.
