### PR TITLE
[OPIK-7512] [FE] fix: Optimization Studio display cleanups — dead Pass rate column, {{variable}} rendering, Rerun label

### DIFF
--- a/apps/opik-frontend/src/lib/optimizations.test.ts
+++ b/apps/opik-frontend/src/lib/optimizations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   convertOptimizationVariableFormat,
+  restorePromptVariableFormat,
   checkIsTestSuite,
   getOptimizationDefaultConfigByProvider,
   extractKwargsKeysFromPython,
@@ -897,5 +898,96 @@ describe("getOptimizationDefaultConfigByProvider — Anthropic", () => {
     ) as LLMAnthropicConfigsType;
 
     expect(config.temperature).toBeUndefined();
+  });
+});
+
+describe("restorePromptVariableFormat", () => {
+  it("restores single-brace variables in a message array", () => {
+    expect(
+      restorePromptVariableFormat([
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "Answer {question} using {context}." },
+      ]),
+    ).toEqual([
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "Answer {{question}} using {{context}}." },
+    ]);
+  });
+
+  it("leaves already-doubled variables untouched", () => {
+    expect(
+      restorePromptVariableFormat([
+        { role: "user", content: "Answer {{question}}" },
+      ]),
+    ).toEqual([{ role: "user", content: "Answer {{question}}" }]);
+  });
+
+  // The reason this helper uses an identifier-shaped pattern rather than the
+  // broad `[^{}]+` of convertOptimizationVariableFormat: prompts commonly embed
+  // literal braces, and mangling them would corrupt what the user reads.
+  it("does not touch literal JSON or code braces", () => {
+    const content =
+      'Return JSON like {"name": "x"} and never write { return x; } here.';
+    expect(restorePromptVariableFormat([{ role: "user", content }])).toEqual([
+      { role: "user", content },
+    ]);
+  });
+
+  it("preserves the single-prompt {name: messages} wrapper shape", () => {
+    expect(
+      restorePromptVariableFormat({
+        "chat-prompt": [{ role: "user", content: "Hi {name}" }],
+      }),
+    ).toEqual({
+      "chat-prompt": [{ role: "user", content: "Hi {{name}}" }],
+    });
+  });
+
+  it("preserves a { messages: [...] } wrapper and other message fields", () => {
+    expect(
+      restorePromptVariableFormat({
+        messages: [{ role: "user", content: "Hi {name}", name: "u1" }],
+      }),
+    ).toEqual({
+      messages: [{ role: "user", content: "Hi {{name}}", name: "u1" }],
+    });
+  });
+
+  it("restores variables inside multimodal text parts only", () => {
+    expect(
+      restorePromptVariableFormat([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Describe {image_alt}" },
+            { type: "image_url", image_url: { url: "http://x/y{z}.png" } },
+          ],
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Describe {{image_alt}}" },
+          { type: "image_url", image_url: { url: "http://x/y{z}.png" } },
+        ],
+      },
+    ]);
+  });
+
+  it("handles a bare string prompt and non-prompt values", () => {
+    expect(restorePromptVariableFormat("Answer {question}")).toBe(
+      "Answer {{question}}",
+    );
+    expect(restorePromptVariableFormat(null)).toBeNull();
+    expect(restorePromptVariableFormat("-")).toBe("-");
+  });
+
+  it("supports dotted and hyphenated variable names", () => {
+    expect(
+      restorePromptVariableFormat([
+        { role: "user", content: "{user.name} and {user-input}" },
+      ]),
+    ).toEqual([{ role: "user", content: "{{user.name}} and {{user-input}}" }]);
   });
 });

--- a/apps/opik-frontend/src/lib/optimizations.ts
+++ b/apps/opik-frontend/src/lib/optimizations.ts
@@ -549,6 +549,101 @@ export const sortCandidates = (
   });
 };
 
+// A template variable as the optimizer SDK writes it: a single-braced Python
+// identifier, optionally dotted/hyphenated.
+//
+// Deliberately NARROWER than convertOptimizationVariableFormat's `[^{}]+`.
+// That function runs on an explicit user action (save to prompt library), where
+// over-matching is recoverable. This one runs on every prompt we *display*, and
+// prompts routinely contain literal single braces that are not variables at all
+// — JSON examples like {"name": "x"}, code like { return x; }. Re-doubling those
+// would corrupt the text the user is reading, so only identifier-shaped tokens
+// are restored. Residual limitation: a literal `{word}` in prose that was never
+// a variable is still converted; that is rare and near-indistinguishable from a
+// real variable without knowing the dataset columns.
+const OPTIMIZER_VARIABLE_TOKEN = /(?<!\{)\{([A-Za-z_][A-Za-z0-9_.-]*)\}(?!\})/g;
+
+const restoreVariableFormatInContent = (content: unknown): unknown => {
+  if (typeof content === "string") {
+    return content.replace(OPTIMIZER_VARIABLE_TOKEN, "{{$1}}");
+  }
+
+  // Multimodal content: a list of parts, only the text ones carry variables.
+  if (Array.isArray(content)) {
+    return content.map((part) =>
+      part &&
+      typeof part === "object" &&
+      (part as { type?: unknown }).type === "text" &&
+      typeof (part as { text?: unknown }).text === "string"
+        ? {
+            ...part,
+            text: (part as { text: string }).text.replace(
+              OPTIMIZER_VARIABLE_TOKEN,
+              "{{$1}}",
+            ),
+          }
+        : part,
+    );
+  }
+
+  return content;
+};
+
+/**
+ * Restore the Mustache-style `{{variable}}` syntax the user authored, for
+ * display, on a prompt that has been through the optimizer.
+ *
+ * The Studio form uses `{{variable}}`; the optimizer SDK uses `{variable}`, and
+ * the python-backend rewrites one into the other on ingest
+ * (`studio/types.py::_convert_template_syntax`). Everything downstream of that
+ * — trial prompts in experiment metadata, the best-prompt panel, the diff view
+ * — therefore shows a single brace, which reads as if the user had typed a
+ * broken prompt. This reverses it at the display boundary only; nothing is
+ * re-sent to the backend in this form.
+ *
+ * Walks the value structurally rather than normalizing it, so every prompt
+ * wrapper shape survives unchanged: a bare message array, a `{ messages: [...] }`
+ * object, the single-prompt `{ "<name>": [...] }` wrapper, and the multi-prompt
+ * named map. Only the `content` of message-like objects is rewritten.
+ */
+const restoreVariableFormatInPrompt = (prompt: unknown): unknown => {
+  if (typeof prompt === "string") {
+    return restoreVariableFormatInContent(prompt);
+  }
+
+  if (Array.isArray(prompt)) {
+    return prompt.map(restoreVariableFormatInPrompt);
+  }
+
+  if (prompt && typeof prompt === "object") {
+    const record = prompt as Record<string, unknown>;
+
+    // A message: rewrite its content and leave every other field alone.
+    if ("role" in record && "content" in record) {
+      return {
+        ...record,
+        content: restoreVariableFormatInContent(record.content),
+      };
+    }
+
+    // A wrapper ({ messages }, a named-prompt map, ...): recurse into values.
+    return Object.fromEntries(
+      Object.entries(record).map(([key, value]) => [
+        key,
+        restoreVariableFormatInPrompt(value),
+      ]),
+    );
+  }
+
+  return prompt;
+};
+
+// Generic wrapper: the transform is shape-preserving, so callers keep the type
+// they passed in (a prompt payload stays assignable to whatever they had) rather
+// than being handed `unknown` and having to re-narrow at every call site.
+export const restorePromptVariableFormat = <T>(prompt: T): T =>
+  restoreVariableFormatInPrompt(prompt) as T;
+
 export const convertOptimizationVariableFormat = (
   content: string | unknown,
 ): string | unknown => {

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/BestPromptCard/BestPrompt.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/ui/card";
 import { Button } from "@/ui/button";
 import { formatNumericData, toString } from "@/lib/utils";
+import { restorePromptVariableFormat } from "@/lib/optimizations";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import ColoredTagNew from "@/shared/ColoredTag/ColoredTagNew";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -76,8 +77,12 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
     return scoreObject?.score;
   }, [baselineExperiment, scoreMap]);
 
+  // Restore the user's {{variable}} syntax for display — the stored prompt uses
+  // the optimizer's single-brace form (see restorePromptVariableFormat).
   const promptData = useMemo(() => {
-    return get(experiment.metadata ?? {}, OPTIMIZATION_PROMPT_KEY, "-");
+    return restorePromptVariableFormat(
+      get(experiment.metadata ?? {}, OPTIMIZATION_PROMPT_KEY, "-"),
+    );
   }, [experiment]);
 
   const extractedPrompt = useMemo((): ExtractedPromptData | null => {
@@ -95,12 +100,13 @@ export const BestPrompt: React.FC<BestPromptProps> = ({
 
   const baselinePrompt = useMemo(() => {
     if (!baselineExperiment) return null;
-    const val = get(
+    const raw = get(
       baselineExperiment.metadata ?? {},
       OPTIMIZATION_PROMPT_KEY,
       null,
     );
-    if (!val) return null;
+    if (!raw) return null;
+    const val = restorePromptVariableFormat(raw);
 
     const extracted = extractPromptData(val);
     if (extracted) {

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/OptimizationHeader.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Database, History, RotateCw, Route, X } from "lucide-react";
+import { Copy, Database, History, Route, X } from "lucide-react";
 import { Button } from "@/ui/button";
 import { useNavigate } from "@tanstack/react-router";
 import { OPTIMIZATION_STATUS, Optimization } from "@/types/optimizations";
@@ -122,10 +122,13 @@ const OptimizationHeader: React.FC<OptimizationHeaderProps> = ({
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2">
+        {/* Opens the new-run panel prefilled from this run (see handleRerun); it
+            never launches a run directly, so the label and icon describe
+            duplicating rather than re-executing. */}
         {canRerun && (
           <Button variant="outline" size="2xs" onClick={handleRerun}>
-            <RotateCw className="size-3.5 shrink-0" />
-            <span className="ml-1.5">Rerun</span>
+            <Copy className="size-3.5 shrink-0" />
+            <span className="ml-1.5">Duplicate run</span>
           </Button>
         )}
         {canStop && (

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.test.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+
+import { getPromptFromExperiment } from "./TrialPromptCell";
+import { getCandidatePrompt } from "./candidatePrompt";
+import { Experiment } from "@/types/datasets";
+
+const makeExperiment = (id: string, configuration: unknown): Experiment =>
+  ({ id, metadata: { configuration } }) as unknown as Experiment;
+
+describe("getPromptFromExperiment", () => {
+  // The bug this guards: the trials table rendered the optimizer's single-brace
+  // form while the overview's best-trial panel rendered the authored
+  // double-brace form, so two surfaces on the same run page disagreed. That is
+  // worse than the original papercut, where both were consistently wrong.
+  it("restores the authored {{variable}} syntax for display", () => {
+    const experiment = makeExperiment("e1", {
+      prompt: [{ role: "user", content: "Answer {question}" }],
+    });
+
+    expect(getPromptFromExperiment(experiment)).toEqual([
+      { role: "user", content: "Answer {{question}}" },
+    ]);
+  });
+
+  it("restores the legacy prompt_messages key too", () => {
+    const experiment = makeExperiment("e2", {
+      prompt_messages: [{ role: "user", content: "Answer {question}" }],
+    });
+
+    expect(getPromptFromExperiment(experiment)).toEqual([
+      { role: "user", content: "Answer {{question}}" },
+    ]);
+  });
+
+  it("returns null when the experiment carries no prompt", () => {
+    expect(
+      getPromptFromExperiment(makeExperiment("e3", { model: "gpt-4o-mini" })),
+    ).toBeNull();
+    expect(
+      getPromptFromExperiment({ id: "e4" } as unknown as Experiment),
+    ).toBeNull();
+  });
+
+  // This is the invariant that actually matters. Two near-identical resolvers
+  // read a trial's prompt — this one (single experiment, used by the trials
+  // table cell and its diff hover card) and getCandidatePrompt (candidate +
+  // experiment map, used by the overview panel and the trial sidebar). The
+  // duplication is why the surfaces drifted apart in the first place, so pin
+  // them to the same output until one shared resolver replaces both.
+  describe("agreement with getCandidatePrompt", () => {
+    const cases: Array<[string, unknown]> = [
+      [
+        "message array under `prompt`",
+        { prompt: [{ role: "user", content: "Answer {question}" }] },
+      ],
+      [
+        "message array under legacy `prompt_messages`",
+        { prompt_messages: [{ role: "system", content: "Use {context}" }] },
+      ],
+      [
+        "single-prompt named wrapper",
+        { prompt: { "chat-prompt": [{ role: "user", content: "Hi {name}" }] } },
+      ],
+      [
+        "multimodal content parts",
+        {
+          prompt: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "Describe {image_alt}" },
+                { type: "image_url", image_url: { url: "http://x/y{z}.png" } },
+              ],
+            },
+          ],
+        },
+      ],
+      [
+        "prompt containing literal JSON braces",
+        {
+          prompt: [
+            { role: "user", content: 'Reply with {"ok": true} for {question}' },
+          ],
+        },
+      ],
+    ];
+
+    it.each(cases)("agrees on a %s", (_label, configuration) => {
+      const experiment = makeExperiment("e1", configuration);
+      const experimentsById = new Map([["e1", experiment]]);
+
+      expect(getPromptFromExperiment(experiment)).toEqual(
+        getCandidatePrompt({ experimentIds: ["e1"] }, experimentsById),
+      );
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.tsx
@@ -13,16 +13,28 @@ import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import PromptDiff from "@/shared/CodeDiff/PromptDiff";
 import { extractMessages } from "@/lib/optimization-config";
+import { restorePromptVariableFormat } from "@/lib/optimizations";
 import { cn } from "@/lib/utils";
 
+/**
+ * Read a trial's prompt off its experiment configuration.
+ *
+ * Single-experiment sibling of {@link getCandidatePrompt} in ./candidatePrompt —
+ * and, like it, restores the authored `{{variable}}` syntax for display (the
+ * stored value uses the optimizer's single-brace form). Both the cell preview
+ * and the "Diff vs baseline" hover card render from here, so without this the
+ * trials table would contradict the overview's best-trial panel on the same
+ * page: one showing `{question}` and the other `{{question}}`.
+ */
 const getPromptFromExperiment = (experiment: Experiment): unknown => {
   const metadata = experiment.metadata;
   if (!metadata || !isObject(metadata)) return null;
   const config = get(metadata, "configuration");
   if (!config || !isObject(config)) return null;
   const c = config as Record<string, unknown>;
-  if ("prompt" in c) return c["prompt"];
-  if ("prompt_messages" in c) return c["prompt_messages"];
+  if ("prompt" in c) return restorePromptVariableFormat(c["prompt"]);
+  if ("prompt_messages" in c)
+    return restorePromptVariableFormat(c["prompt_messages"]);
   return null;
 };
 

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/TrialPromptCell.tsx
@@ -26,7 +26,7 @@ import { cn } from "@/lib/utils";
  * trials table would contradict the overview's best-trial panel on the same
  * page: one showing `{question}` and the other `{{question}}`.
  */
-const getPromptFromExperiment = (experiment: Experiment): unknown => {
+export const getPromptFromExperiment = (experiment: Experiment): unknown => {
   const metadata = experiment.metadata;
   if (!metadata || !isObject(metadata)) return null;
   const config = get(metadata, "configuration");

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/candidatePrompt.test.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/candidatePrompt.test.ts
@@ -7,9 +7,17 @@ import { AggregatedCandidate } from "@/types/optimizations";
 const makeExperiment = (id: string, configuration: unknown): Experiment =>
   ({ id, metadata: { configuration } }) as unknown as Experiment;
 
+// As stored by the optimizer: single-brace (Python-style) variables, because the
+// python-backend rewrites the user's {{text}} to {text} on ingest.
 const messages = [
   { role: "system", content: "You are a classifier." },
   { role: "user", content: "{text}" },
+];
+
+// As displayed: the resolver restores the syntax the user actually authored.
+const restoredMessages = [
+  { role: "system", content: "You are a classifier." },
+  { role: "user", content: "{{text}}" },
 ];
 
 describe("getCandidatePrompt", () => {
@@ -23,7 +31,7 @@ describe("getCandidatePrompt", () => {
       experimentsById,
     );
 
-    expect(prompt).toEqual(messages);
+    expect(prompt).toEqual(restoredMessages);
   });
 
   it("falls back to prompt_messages", () => {
@@ -36,7 +44,25 @@ describe("getCandidatePrompt", () => {
       experimentsById,
     );
 
-    expect(prompt).toEqual(messages);
+    expect(prompt).toEqual(restoredMessages);
+  });
+
+  // The user-visible bug this guards: a prompt authored as {{text}} was being
+  // displayed as {text} everywhere downstream of the run, reading as if the user
+  // had typed a broken prompt.
+  it("restores the authored {{variable}} syntax for display", () => {
+    const experimentsById = new Map([
+      [
+        "e1",
+        makeExperiment("e1", {
+          prompt: [{ role: "user", content: "Answer {question}" }],
+        }),
+      ],
+    ]);
+
+    expect(
+      getCandidatePrompt({ experimentIds: ["e1"] }, experimentsById),
+    ).toEqual([{ role: "user", content: "Answer {{question}}" }]);
   });
 
   it("returns null when no experiment resolves a prompt", () => {

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/candidatePrompt.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/candidatePrompt.ts
@@ -2,6 +2,7 @@ import get from "lodash/get";
 
 import { Experiment } from "@/types/datasets";
 import { AggregatedCandidate } from "@/types/optimizations";
+import { restorePromptVariableFormat } from "@/lib/optimizations";
 import { ComparisonCandidate } from "@/shared/CodeDiff/promptComparisonTargets";
 
 type CandidateWithExperiments = { experimentIds: string[] };
@@ -24,8 +25,14 @@ export const toComparisonCandidate = (
  * Resolve a candidate's prompt from its trial experiment configuration. The
  * prompt lives on the experiment (not the candidate), under
  * `metadata.configuration.prompt` (or the legacy `prompt_messages`). Returns
- * the raw prompt value — PromptComparison normalizes it — or null when none of
+ * the prompt value — PromptComparison normalizes it — or null when none of
  * the candidate's experiments carry one.
+ *
+ * Template variables are restored to the `{{variable}}` form the user authored
+ * (see {@link restorePromptVariableFormat}); the stored value uses the
+ * optimizer's single-brace form. This is the single resolver behind both v2
+ * prompt surfaces (overview best-trial panel and the trial sidebar), so the
+ * conversion lands once here.
  */
 export const getCandidatePrompt = (
   candidate: CandidateWithExperiments,
@@ -43,7 +50,7 @@ export const getCandidatePrompt = (
         prompt != null &&
         !(typeof prompt === "string" && prompt.trim() === "")
       )
-        return prompt;
+        return restorePromptVariableFormat(prompt);
     }
   }
   return null;

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationMetricCells.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationMetricCells.tsx
@@ -13,51 +13,41 @@ import {
   formatAsCurrency,
 } from "@/lib/optimization-formatters";
 
-export const OptimizationPassRateCell = (
+/**
+ * The run's best objective score, rendered per run type.
+ *
+ * This replaces the former separate "Pass rate" and "Accuracy" columns. Those
+ * were mutually exclusive — each rendered a literal "-" for the run type it did
+ * not handle — so a test-suite run always had an empty Accuracy cell and, more
+ * visibly, every Studio dataset run always had an empty Pass rate cell.
+ *
+ * Note the header stays type-neutral ("Best score") rather than using
+ * getObjectiveLabel the way the trials table does: a single optimization run has
+ * one type, but this list can mix test-suite and dataset runs, so no static
+ * header can be per-row correct. Which metric produced the score is already
+ * carried by the sibling "Metric" column and, for dataset runs, by the score
+ * tag's own label.
+ */
+export const OptimizationObjectiveScoreCell = (
   context: CellContext<unknown, unknown>,
 ) => {
   const row = context.row.original as Optimization;
   const isTestSuite = (row.experiment_scores?.length ?? 0) > 0;
 
-  if (!isTestSuite) {
-    return (
-      <CellWrapper
-        metadata={context.column.columnDef.meta}
-        tableMetadata={context.table.options.meta}
-      >
-        <span className="comet-body-s text-muted-slate">-</span>
-      </CellWrapper>
-    );
-  }
-
-  return (
-    <CellWrapper
-      metadata={context.column.columnDef.meta}
-      tableMetadata={context.table.options.meta}
-    >
-      <MetricComparisonCell
-        baseline={row.baseline_objective_score}
-        current={row.best_objective_score}
-        formatter={formatAsPercentage}
-        compact
-      />
-    </CellWrapper>
-  );
-};
-
-export const OptimizationAccuracyCell = (
-  context: CellContext<unknown, unknown>,
-) => {
-  const row = context.row.original as Optimization;
-  const isTestSuite = (row.experiment_scores?.length ?? 0) > 0;
-
+  // Test-suite runs report a pass rate, which is meaningful as a
+  // baseline-vs-best delta.
   if (isTestSuite) {
     return (
       <CellWrapper
         metadata={context.column.columnDef.meta}
         tableMetadata={context.table.options.meta}
       >
-        <span className="comet-body-s text-muted-slate">-</span>
+        <MetricComparisonCell
+          baseline={row.baseline_objective_score}
+          current={row.best_objective_score}
+          formatter={formatAsPercentage}
+          compact
+        />
       </CellWrapper>
     );
   }

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.test.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  DEFAULT_COLUMNS,
+  DEFAULT_SELECTED_COLUMNS,
+  DEFAULT_COLUMNS_ORDER,
+} from "./OptimizationsColumns";
+import { OptimizationObjectiveScoreCell } from "./OptimizationMetricCells";
+import { Optimization } from "@/types/optimizations";
+
+const OBJECTIVE_COLUMN_ID = "accuracy";
+
+const objectiveColumn = () =>
+  DEFAULT_COLUMNS.find((c) => c.id === OBJECTIVE_COLUMN_ID);
+
+const makeRun = (overrides: Partial<Optimization> = {}): Optimization =>
+  ({
+    id: "opt-1",
+    objective_name: "equals",
+    ...overrides,
+  }) as unknown as Optimization;
+
+describe("optimization runs list columns", () => {
+  // The reported bug: "Pass rate" and "Accuracy" were mutually exclusive — each
+  // rendered a literal "-" for the run type it did not handle — so every Studio
+  // dataset run carried a permanently empty column next to the real score.
+  it("exposes a single objective-score column, not a Pass rate / Accuracy pair", () => {
+    const scoreColumns = DEFAULT_COLUMNS.filter(
+      (c) => c.cell === (OptimizationObjectiveScoreCell as never),
+    );
+
+    expect(scoreColumns).toHaveLength(1);
+    expect(scoreColumns[0].id).toBe(OBJECTIVE_COLUMN_ID);
+    expect(DEFAULT_COLUMNS.some((c) => c.id === "pass_rate")).toBe(false);
+  });
+
+  it("drops the retired pass_rate id from the default selection and order", () => {
+    expect(DEFAULT_SELECTED_COLUMNS).not.toContain("pass_rate");
+    expect(DEFAULT_COLUMNS_ORDER).not.toContain("pass_rate");
+  });
+
+  // Deliberate: the merged column keeps the pre-existing "accuracy" id because
+  // that id is already in existing users' saved selected-columns state. A rename
+  // would leave the id absent from that saved state, so the column would render
+  // HIDDEN for every existing user — and forcing it visible means bumping
+  // SELECTED_COLUMNS_KEY and resetting everyone's column customizations.
+  // Renaming it for semantic tidiness is therefore a user-visible regression.
+  it("keeps the objective column's saved-state id stable", () => {
+    expect(objectiveColumn()).toBeDefined();
+    expect(DEFAULT_SELECTED_COLUMNS).toContain(OBJECTIVE_COLUMN_ID);
+    expect(DEFAULT_COLUMNS_ORDER).toContain(OBJECTIVE_COLUMN_ID);
+  });
+
+  // The column must carry a value for BOTH run types. This is what makes
+  // run-type-dependent column filtering unnecessary — the page used to drop this
+  // column when no dataset run was present, which after the merge stripped the
+  // only score column from a test-suite-only page.
+  describe("objective accessor covers both run types", () => {
+    it("uses the best objective score for a test-suite run", () => {
+      const row = makeRun({
+        experiment_scores: [{ name: "pass_rate", value: 0.8 }],
+        best_objective_score: 0.8,
+      });
+
+      expect(objectiveColumn()?.accessorFn?.(row)).toBe(0.8);
+    });
+
+    it("uses the objective feedback score for a dataset run", () => {
+      const row = makeRun({
+        experiment_scores: [],
+        feedback_scores: [{ name: "equals", value: 0.42 }],
+      });
+
+      expect(objectiveColumn()?.accessorFn?.(row)).toMatchObject({
+        name: "equals",
+        value: 0.42,
+      });
+    });
+
+    it("does not throw when a run carries no scores at all", () => {
+      expect(() => objectiveColumn()?.accessorFn?.(makeRun())).not.toThrow();
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.tsx
@@ -14,8 +14,7 @@ import ItemSourceCell, {
 } from "@/v2/pages-shared/experiments/ItemSourceCell";
 import OptimizationStatusCell from "@/v2/pages/OptimizationsPage/OptimizationStatusCell";
 import {
-  OptimizationPassRateCell,
-  OptimizationAccuracyCell,
+  OptimizationObjectiveScoreCell,
   OptimizationLatencyCell,
   OptimizationCostCell,
   OptimizationTotalCostCell,
@@ -91,21 +90,22 @@ export const DEFAULT_COLUMNS: ColumnData<Optimization>[] = [
     size: 120,
   },
   {
-    id: "pass_rate",
-    label: "Pass rate",
-    type: COLUMN_TYPE.numberDictionary,
-    size: DEFAULT_METRIC_COLUMN_WIDTH,
-    accessorFn: (row) => row.best_objective_score,
-    cell: OptimizationPassRateCell as never,
-  },
-  {
+    // Merged objective-score column (was the separate "Pass rate" + "Accuracy"
+    // pair, each of which rendered "-" for the run type it did not handle). The
+    // id stays "accuracy" deliberately: it is already present in existing users'
+    // saved selected-columns/order state, so the merged column stays visible and
+    // keeps its position without bumping SELECTED_COLUMNS_KEY and resetting
+    // everyone's column customizations. The now-unused "pass_rate" id simply
+    // no longer matches a column and is ignored.
     id: "accuracy",
-    label: "Accuracy",
+    label: "Best score",
     type: COLUMN_TYPE.numberDictionary,
     size: DEFAULT_METRIC_COLUMN_WIDTH,
     accessorFn: (row) =>
-      getFeedbackScore(row.feedback_scores ?? [], row.objective_name),
-    cell: OptimizationAccuracyCell as never,
+      (row.experiment_scores?.length ?? 0) > 0
+        ? row.best_objective_score
+        : getFeedbackScore(row.feedback_scores ?? [], row.objective_name),
+    cell: OptimizationObjectiveScoreCell as never,
   },
   {
     id: "latency",
@@ -151,7 +151,6 @@ export const DEFAULT_SELECTED_COLUMNS: string[] = [
   "metric",
   "created_at",
   "status",
-  "pass_rate",
   "accuracy",
   "latency",
   "cost",
@@ -166,7 +165,6 @@ export const DEFAULT_COLUMNS_ORDER: string[] = [
   "metric",
   "created_at",
   "status",
-  "pass_rate",
   "accuracy",
   "latency",
   "cost",

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsPage.tsx
@@ -218,29 +218,21 @@ const OptimizationsPage: React.FunctionComponent = () => {
     projectId: activeProjectId ?? undefined,
   });
 
-  const hasOldTypeOptimizations = useMemo(
-    () =>
-      optimizations.some(
-        (opt) => !opt.experiment_scores || opt.experiment_scores.length === 0,
-      ),
-    [optimizations],
-  );
-
-  const visibleColumns = useMemo(
-    () =>
-      hasOldTypeOptimizations
-        ? DEFAULT_COLUMNS
-        : DEFAULT_COLUMNS.filter((c) => c.id !== "accuracy"),
-    [hasOldTypeOptimizations],
-  );
-
+  // The objective-score column used to be a mutually-exclusive pair ("Pass rate"
+  // for test-suite runs, "Accuracy" for dataset runs), and this list dropped
+  // "accuracy" whenever the page held no dataset run so its all-"-" cells would
+  // not show. That was only ever half a fix — the reverse case (a Studio-only
+  // workspace showing a permanently empty "Pass rate") is the bug this change
+  // addresses. Now that the pair is merged into one column that renders for both
+  // run types, no run-type-dependent column filtering is needed at all: dropping
+  // it here would strip the only score column from a pure test-suite page.
   const defaultColumns = useMemo(
     () =>
-      convertColumnDataToColumn(visibleColumns, {
+      convertColumnDataToColumn(DEFAULT_COLUMNS, {
         columnsOrder,
         selectedColumns,
       }),
-    [visibleColumns, columnsOrder, selectedColumns],
+    [columnsOrder, selectedColumns],
   );
 
   const columns = useMemo(() => {
@@ -349,7 +341,7 @@ const OptimizationsPage: React.FunctionComponent = () => {
               selectedRows={selectedRows}
               isFetching={isFetching}
               onRefresh={() => refetch()}
-              columns={visibleColumns}
+              columns={DEFAULT_COLUMNS}
               selectedColumns={selectedColumns}
               onSelectedColumnsChange={setSelectedColumns}
               columnsOrder={columnsOrder}


### PR DESCRIPTION
## Details

Fixes three Optimization Studio papercuts reported from dogfooding. **v2 only** — v1 is deliberately untouched (precedent: `4c5ec9a4ca`). Full issue → why → decision notes are in the ticket comments.

### 1. Dead "Pass rate" column on the runs list

`Pass rate` and `Accuracy` were mutually exclusive — each rendered a literal `-` for the run type it did not handle — so **every Studio dataset run showed a permanently empty Pass rate column**. Merged into one objective column rendered per run type.

- Header is type-neutral (**"Best score"**) rather than dynamic via `getObjectiveLabel`: that works in the trials table because one run has one type, but this *list* can mix test-suite and dataset runs, so no static header can be per-row correct.
- The merged column keeps id `accuracy` deliberately — it is already in existing users' saved selected-columns state, so the column stays visible and positioned without bumping `SELECTED_COLUMNS_KEY` and resetting everyone's customizations.
- Also removed `OptimizationsPage`'s run-type column filter. It dropped `accuracy` when no dataset run was present — only ever half a fix (the reverse case is this bug), and after the merge it would strip the *only* score column from a pure test-suite page.

### 2. A brace pair disappeared from displayed prompts

The Studio form uses `{{variable}}`; `studio/types.py::_convert_template_syntax` rewrites it to `{variable}` on ingest, so every view downstream of a run showed a single brace — reading as if the user had authored a broken prompt.

Added `restorePromptVariableFormat` and applied it at the **display boundary only** (nothing is re-sent to the backend in this form). All three v2 prompt read sites now restore: `candidatePrompt.ts`, `BestPrompt.tsx`, `TrialPromptCell.tsx`.

- The pattern is narrower than the existing `convertOptimizationVariableFormat`'s `[^{}]+`: prompts routinely embed literal braces (JSON examples, code) and re-doubling those would corrupt what the user reads, so only identifier-shaped tokens are restored.
- `convertOptimizationVariableFormat` is left untouched because **v1 shares it**.
- The transform walks the value structurally instead of normalizing it, so every prompt wrapper shape survives: bare message array, `{ messages: [...] }`, the single-prompt `{ "<name>": [...] }` wrapper, and the named multi-prompt map.

### 3. "Rerun" never reran

It opens the new-run panel prefilled from the run and never launches anything → **"Duplicate run"**, with the icon changed from `RotateCw` to `Copy` for the same reason.

### Not included

- Extending the ingest conversion to multimodal content — investigated and closed as **not an issue** (OPIK_7582): text-only Studio prompts are a deliberate decision (`disableMedia` defaults true, `StudioMessage.content` is typed `string`), and the real future work is OPIK_4198.

### Known follow-up (design call, not changed here)

On the runs list, `Metric: Equals` sits directly beside `Best score: [equals 0]` — the metric name is duplicated. A bare value would be cleaner and would match Latency/Cost, but this is the pre-existing `FeedbackScoreTag` treatment and a design decision, so it is left as-is.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves [OPIK-7512](https://comet-ml.atlassian.net/browse/OPIK-7512)

Related, not resolved here (underscored on purpose so they don't link): OPIK_7582, OPIK_4198.

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5 (implementation); Claude Fable 5 (this PR description restructure)
  - Scope: all code and test changes in this PR, plus the PR description
  - Human verification: driven end-to-end in a real browser against a locally-built backend; full frontend test/lint/typecheck suite reviewed (see Testing)

## Testing

- Typecheck clean; eslint/stylelint clean with `--max-warnings=0`.
- **2272/2272 tests** across 151 files pass (9 new), run under Node 20.
- Driven end-to-end in a real browser against a locally-built backend, which caught **two bugs the test suite could not**:
  1. `OptimizationsPage`'s run-type filter stripping the merged column on a test-suite-only page (commit 2).
  2. `TrialPromptCell` keeping the single-brace form via its own duplicate resolver, so the trials table and the overview panel disagreed on the same page — worse than the original papercut, where both were consistently wrong (commit 3).
- Confirmed in the UI: one "Best score" column, `{{question}}` in the best-trial panel, the trials table and the diff hover card, "Duplicate run" in the header, no console errors.
- Not exercised live: the **test-suite branch** of the merged column — no test-suite optimization runs existed in the local dataset. It is covered by unit tests and code reading.

## Documentation

No documentation changes — UI-only fixes with no behavior that docs describe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-7512]: https://comet-ml.atlassian.net/browse/OPIK-7512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ