### PR TITLE
[issue-7658] [FE] fix: use provider hint for message format detection

### DIFF
--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.test.ts
@@ -40,4 +40,14 @@ describe("detectLLMMessages", () => {
       confidence: "low",
     });
   });
+
+  it("safely falls back for a prototype property hint", () => {
+    expect(
+      detectLLMMessages(AMBIGUOUS_INPUT, { fieldType: "input" }, "__proto__"),
+    ).toEqual({
+      supported: true,
+      format: "openai",
+      confidence: "low",
+    });
+  });
 });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { detectLLMMessages } from "./detectLLMMessages";
+
+const AMBIGUOUS_INPUT = {
+  messages: [
+    {
+      role: "user",
+      type: "human",
+      content: "Hello",
+    },
+  ],
+};
+
+describe("detectLLMMessages", () => {
+  it("uses registry order when no format hint is provided", () => {
+    expect(detectLLMMessages(AMBIGUOUS_INPUT, { fieldType: "input" })).toEqual({
+      supported: true,
+      format: "openai",
+      confidence: "medium",
+    });
+  });
+
+  it("tries the hinted format before registry order", () => {
+    expect(
+      detectLLMMessages(AMBIGUOUS_INPUT, { fieldType: "input" }, "langchain"),
+    ).toEqual({
+      supported: true,
+      format: "langchain",
+      confidence: "high",
+    });
+  });
+
+  it("falls back to registry order when the hint is unsupported", () => {
+    expect(
+      detectLLMMessages(AMBIGUOUS_INPUT, { fieldType: "input" }, "anthropic"),
+    ).toEqual({
+      supported: true,
+      format: "openai",
+      confidence: "low",
+    });
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
@@ -1,5 +1,9 @@
 export { detectLLMMessages } from "./detectLLMMessages";
 export { mapAndCombineMessages } from "./mapAndCombineMessages";
+export {
+  canShowLLMMessages,
+  resolveLLMMessageFormatHint,
+} from "./messageRendering";
 
 export type {
   LLMMessageFormat,

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { mapAndCombineMessages } from "./mapAndCombineMessages";
+
+const AMBIGUOUS_MESSAGES = {
+  messages: [
+    {
+      role: "assistant",
+      type: "ai",
+      content: "Hello",
+    },
+  ],
+};
+
+describe("mapAndCombineMessages", () => {
+  it("uses the format hint for both input and output mapping", () => {
+    const result = mapAndCombineMessages(
+      AMBIGUOUS_MESSAGES,
+      AMBIGUOUS_MESSAGES,
+      "langchain",
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].role).toBe("ai");
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -9,9 +9,18 @@ import {
 export function mapAndCombineMessages(
   input: unknown,
   output: unknown,
+  formatHint?: string,
 ): LLMMapperResult {
-  const inputDetection = detectLLMMessages(input, { fieldType: "input" });
-  const outputDetection = detectLLMMessages(output, { fieldType: "output" });
+  const inputDetection = detectLLMMessages(
+    input,
+    { fieldType: "input" },
+    formatHint,
+  );
+  const outputDetection = detectLLMMessages(
+    output,
+    { fieldType: "output" },
+    formatHint,
+  );
 
   const inputResult = mapForDetection(input, inputDetection, "input");
   const outputResult = mapForDetection(output, outputDetection, "output");

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canShowLLMMessages,
+  resolveLLMMessageFormatHint,
+} from "./messageRendering";
+
+const OPENAI_INPUT = {
+  messages: [{ role: "user", content: "Hello" }],
+};
+
+describe("resolveLLMMessageFormatHint", () => {
+  it("keeps an explicit span provider", () => {
+    expect(resolveLLMMessageFormatHint("langchain", ["openai"])).toBe(
+      "langchain",
+    );
+  });
+
+  it("uses a single registered trace provider", () => {
+    expect(resolveLLMMessageFormatHint(undefined, ["openai"])).toBe("openai");
+  });
+
+  it.each([
+    [undefined, undefined],
+    [[], undefined],
+    [["openai", "anthropic"], undefined],
+    [["anthropic"], undefined],
+  ])(
+    "falls back for ambiguous or unsupported trace providers",
+    (providers, expected) => {
+      expect(resolveLLMMessageFormatHint(undefined, providers)).toBe(expected);
+    },
+  );
+});
+
+describe("canShowLLMMessages", () => {
+  it("allows one supported field when the other is empty", () => {
+    expect(canShowLLMMessages(OPENAI_INPUT, {}, "openai")).toBe(true);
+  });
+
+  it("rejects mixed supported and invalid fields", () => {
+    expect(
+      canShowLLMMessages(OPENAI_INPUT, { unexpected: true }, "openai"),
+    ).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.test.ts
@@ -16,6 +16,13 @@ describe("resolveLLMMessageFormatHint", () => {
     );
   });
 
+  it.each(["unsupported", "__proto__", "constructor"])(
+    "falls back for an unregistered span provider: %s",
+    (provider) => {
+      expect(resolveLLMMessageFormatHint(provider, ["openai"])).toBeUndefined();
+    },
+  );
+
   it("uses a single registered trace provider", () => {
     expect(resolveLLMMessageFormatHint(undefined, ["openai"])).toBe("openai");
   });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.ts
@@ -1,18 +1,17 @@
 import { detectLLMMessages } from "./detectLLMMessages";
 import { getFormat } from "./providers/registry";
-import { LLMMessageFormat } from "./types";
 
 export const resolveLLMMessageFormatHint = (
   provider?: string,
   traceProviders?: string[],
 ): string | undefined => {
   // Span providers may include integration formats such as "langchain".
-  if (provider) return provider;
+  if (provider) return getFormat(provider)?.name;
 
   if (traceProviders?.length !== 1) return undefined;
 
   const [traceProvider] = traceProviders;
-  return getFormat(traceProvider as LLMMessageFormat)?.name;
+  return getFormat(traceProvider)?.name;
 };
 
 export const canShowLLMMessages = (

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/messageRendering.ts
@@ -1,0 +1,39 @@
+import { detectLLMMessages } from "./detectLLMMessages";
+import { getFormat } from "./providers/registry";
+import { LLMMessageFormat } from "./types";
+
+export const resolveLLMMessageFormatHint = (
+  provider?: string,
+  traceProviders?: string[],
+): string | undefined => {
+  // Span providers may include integration formats such as "langchain".
+  if (provider) return provider;
+
+  if (traceProviders?.length !== 1) return undefined;
+
+  const [traceProvider] = traceProviders;
+  return getFormat(traceProvider as LLMMessageFormat)?.name;
+};
+
+export const canShowLLMMessages = (
+  inputData: unknown,
+  outputData: unknown,
+  formatHint?: string,
+): boolean => {
+  const input = detectLLMMessages(
+    inputData,
+    { fieldType: "input" },
+    formatHint,
+  );
+  const output = detectLLMMessages(
+    outputData,
+    { fieldType: "output" },
+    formatHint,
+  );
+
+  const hasValid = input.supported || output.supported;
+  const hasInvalid =
+    (!input.supported && !input.empty) || (!output.supported && !output.empty);
+
+  return hasValid && !hasInvalid;
+};

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/registry.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/registry.ts
@@ -13,9 +13,13 @@ const FORMAT_REGISTRY: Record<
 };
 
 export const getFormat = (
-  format: LLMMessageFormat,
+  format: string,
 ): LLMMessageFormatImplementation | null => {
-  return FORMAT_REGISTRY[format] || null;
+  if (!Object.prototype.hasOwnProperty.call(FORMAT_REGISTRY, format)) {
+    return null;
+  }
+
+  return FORMAT_REGISTRY[format as LLMMessageFormat];
 };
 
 export const getAllFormats = (): LLMMessageFormatImplementation[] => {

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -33,6 +33,7 @@ type MessagesTabProps = {
   media: UnifiedMediaItem[];
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
+  formatHint?: string;
 };
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
@@ -54,10 +55,12 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   media,
   isLoading,
   scrollContainerRef,
+  formatHint,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
-    () => mapAndCombineMessages(transformedInput, transformedOutput),
-    [transformedInput, transformedOutput],
+    () =>
+      mapAndCombineMessages(transformedInput, transformedOutput, formatHint),
+    [formatHint, transformedInput, transformedOutput],
   );
 
   const allMessageIds = useMemo(

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -41,7 +41,10 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v1/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
-import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
+import {
+  canShowLLMMessages,
+  resolveLLMMessageFormatHint,
+} from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 
 type TraceDataViewerProps = {
@@ -75,6 +78,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const type = get(data, "type", TRACE_TYPE_FOR_TREE);
   const tokens = data.usage?.total_tokens;
   const provider = get(data, "provider", undefined);
+  const formatHint = resolveLLMMessageFormatHint(
+    provider,
+    get(data, "providers", undefined),
+  );
 
   const agentGraphData = get(
     data,
@@ -90,26 +97,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
-  // Show Messages tab when at least one field is supported and neither is invalid
-  const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(
-      transformedInput,
-      { fieldType: "input" },
-      provider,
-    );
-    const output = detectLLMMessages(
-      transformedOutput,
-      { fieldType: "output" },
-      provider,
-    );
-
-    const hasValid = input.supported || output.supported;
-    const hasInvalid =
-      (!input.supported && !input.empty) ||
-      (!output.supported && !output.empty);
-
-    return hasValid && !hasInvalid;
-  }, [provider, transformedInput, transformedOutput]);
+  const canShowMessagesTab = useMemo(
+    () => canShowLLMMessages(transformedInput, transformedOutput, formatHint),
+    [formatHint, transformedInput, transformedOutput],
+  );
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -363,7 +354,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
-                formatHint={provider}
+                formatHint={formatHint}
               />
             </TabsContent>
           )}

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -97,9 +97,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
-  const canShowMessagesTab = useMemo(
-    () => canShowLLMMessages(transformedInput, transformedOutput, formatHint),
-    [formatHint, transformedInput, transformedOutput],
+  const canShowMessagesTab = canShowLLMMessages(
+    transformedInput,
+    transformedOutput,
+    formatHint,
   );
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -74,6 +74,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const rootScrollRef = useRef<HTMLDivElement>(null);
   const type = get(data, "type", TRACE_TYPE_FOR_TREE);
   const tokens = data.usage?.total_tokens;
+  const provider = get(data, "provider", undefined);
 
   const agentGraphData = get(
     data,
@@ -91,10 +92,16 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(transformedInput, { fieldType: "input" });
-    const output = detectLLMMessages(transformedOutput, {
-      fieldType: "output",
-    });
+    const input = detectLLMMessages(
+      transformedInput,
+      { fieldType: "input" },
+      provider,
+    );
+    const output = detectLLMMessages(
+      transformedOutput,
+      { fieldType: "output" },
+      provider,
+    );
 
     const hasValid = input.supported || output.supported;
     const hasInvalid =
@@ -102,7 +109,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
       (!output.supported && !output.empty);
 
     return hasValid && !hasInvalid;
-  }, [transformedInput, transformedOutput]);
+  }, [provider, transformedInput, transformedOutput]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -166,7 +173,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const created_at = data.created_at ? formatDate(data.created_at) : "";
   const estimatedCost = data.total_estimated_cost;
   const model = get(data, "model", null);
-  const provider = get(data, "provider", null);
 
   const durationTooltip = (
     <div>
@@ -357,6 +363,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
+                formatHint={provider}
               />
             </TabsContent>
           )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -34,6 +34,7 @@ type MessagesTabProps = {
   media: UnifiedMediaItem[];
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
+  formatHint?: string;
 };
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
@@ -55,10 +56,12 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   media,
   isLoading,
   scrollContainerRef,
+  formatHint,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
-    () => mapAndCombineMessages(transformedInput, transformedOutput),
-    [transformedInput, transformedOutput],
+    () =>
+      mapAndCombineMessages(transformedInput, transformedOutput, formatHint),
+    [formatHint, transformedInput, transformedOutput],
   );
 
   const allMessageIds = useMemo(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -67,6 +67,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const rootScrollRef = useRef<HTMLDivElement>(null);
   const type = get(data, "type", TRACE_TYPE_FOR_TREE);
   const tokens = data.usage?.total_tokens;
+  const provider = get(data, "provider", undefined);
 
   const agentGraphData = get(
     data,
@@ -82,10 +83,18 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(transformedInput, { fieldType: "input" });
-    const output = detectLLMMessages(transformedOutput, {
-      fieldType: "output",
-    });
+    const input = detectLLMMessages(
+      transformedInput,
+      { fieldType: "input" },
+      provider,
+    );
+    const output = detectLLMMessages(
+      transformedOutput,
+      {
+        fieldType: "output",
+      },
+      provider,
+    );
 
     const hasValid = input.supported || output.supported;
     const hasInvalid =
@@ -93,7 +102,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
       (!output.supported && !output.empty);
 
     return hasValid && !hasInvalid;
-  }, [transformedInput, transformedOutput]);
+  }, [provider, transformedInput, transformedOutput]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -155,7 +164,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const created_at = data.created_at ? formatDate(data.created_at) : "";
   const model = get(data, "model", null);
-  const provider = get(data, "provider", null);
 
   return (
     <div ref={rootScrollRef} className="size-full max-w-full overflow-auto">
@@ -313,6 +321,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
+                formatHint={provider}
               />
             </TabsContent>
           )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -88,9 +88,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
-  const canShowMessagesTab = useMemo(
-    () => canShowLLMMessages(transformedInput, transformedOutput, formatHint),
-    [formatHint, transformedInput, transformedOutput],
+  const canShowMessagesTab = canShowLLMMessages(
+    transformedInput,
+    transformedOutput,
+    formatHint,
   );
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -36,7 +36,10 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
-import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
+import {
+  canShowLLMMessages,
+  resolveLLMMessageFormatHint,
+} from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 
 type TraceDataViewerProps = {
@@ -68,6 +71,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const type = get(data, "type", TRACE_TYPE_FOR_TREE);
   const tokens = data.usage?.total_tokens;
   const provider = get(data, "provider", undefined);
+  const formatHint = resolveLLMMessageFormatHint(
+    provider,
+    get(data, "providers", undefined),
+  );
 
   const agentGraphData = get(
     data,
@@ -81,28 +88,10 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
-  // Show Messages tab when at least one field is supported and neither is invalid
-  const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(
-      transformedInput,
-      { fieldType: "input" },
-      provider,
-    );
-    const output = detectLLMMessages(
-      transformedOutput,
-      {
-        fieldType: "output",
-      },
-      provider,
-    );
-
-    const hasValid = input.supported || output.supported;
-    const hasInvalid =
-      (!input.supported && !input.empty) ||
-      (!output.supported && !output.empty);
-
-    return hasValid && !hasInvalid;
-  }, [provider, transformedInput, transformedOutput]);
+  const canShowMessagesTab = useMemo(
+    () => canShowLLMMessages(transformedInput, transformedOutput, formatHint),
+    [formatHint, transformedInput, transformedOutput],
+  );
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -321,7 +310,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
-                formatHint={provider}
+                formatHint={formatHint}
               />
             </TabsContent>
           )}


### PR DESCRIPTION
## Details
The span provider was already stored and `detectLLMMessages` already accepted a format hint, but neither trace details implementation forwarded that provider into format detection. Ambiguous payloads therefore always used fixed registry order.

- Forward the provider hint through Messages-tab eligibility and message mapping in both v1 and v2 trace viewers.
- Preserve registry fallback when a provider is unknown or has no registered implementation.
- Cover default ordering, hinted ordering, unsupported-hint fallback, and mapping with ambiguous payloads.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7658

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: OpenAI Codex
- Model(s): GPT-5
- Scope: repository analysis, implementation, regression tests, local validation, and PR drafting
- Human verification: No manual UI interaction was performed; the deterministic dispatch behavior was validated with focused and full automated tests.

## Testing
- `npx --yes node@20 ./node_modules/vitest/vitest.mjs run src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.test.ts src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts` — 2 files, 4 tests passed.
- `env TZ=UTC npx --yes --package=node@20 -- npm test -- --run` — 153 files, 2267 tests passed.
- `npx --yes --package=node@20 -- npm run lint` — passed.
- `npx --yes --package=node@20 -- npm run typecheck` — passed.
- `env TZ=UTC npx --yes --package=node@20 -- npm run build` — passed.
- `make precommit` — frontend ESLint and typecheck hooks passed.
- `npm run deps:validate` — reports the pre-existing `IntegrationDetailsDialog.tsx` to `AgentOnboardingContext.tsx` boundary violation; reproduced unchanged in a clean `origin/main@572170e26` worktree. This PR adds no imports.

No screenshot or recording is included because the change adds no visual surface; it only changes deterministic format selection for ambiguous trace payloads.

## Documentation
No documentation update is needed because this is internal rendering dispatch with no public API or configuration change.