### PR TITLE
[NA] test: add retry/recovery for flaky Ollie explain pod availability

### DIFF
--- a/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
@@ -1,5 +1,6 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from '@e2e/fixtures';
-import { LogsPage } from '@e2e/pom/logs.page';
+import { LogsPage, type ExplainKind } from '@e2e/pom/logs.page';
 import { OlliePage } from '@e2e/pom/ollie.page';
 
 /**
@@ -23,6 +24,71 @@ const KEYWORD_PATTERN: Record<'cost' | 'duration', RegExp> = {
   cost: /cost/i,
   duration: /duration|second|end time|running|\bms\b|millisecond/i,
 };
+
+// The assistant pod occasionally flips ready → down moments after coming up
+// (see explainStore.ts's pod lifecycle), which kills an in-flight explain call
+// instantly with this exact copy — a transient infra hiccup, not a rendering
+// bug, so retry the whole open-and-read a few times before failing on it.
+const UNAVAILABLE_PATTERN = /Ollie is unavailable/i;
+
+// Mirrors AssistantErrorState.tsx's two error-state button labels
+// ("retry now" pre-escalation, "retry" once retryCount > 0).
+const ASSISTANT_RETRY_BUTTON = /^retry( now)?$/i;
+
+// Nudges the host to reconnect after a pod blip. First pass: click the
+// error state's own retry action, like a real user would. If that already
+// happened and Ollie is still unavailable next time round, a soft in-app
+// retry clearly isn't enough — escalate to a full reload.
+async function recoverAssistant(
+  page: Page,
+  logs: LogsPage,
+  ollie: OlliePage,
+  escalate: boolean,
+): Promise<void> {
+  const retryButton = page.getByRole('button', { name: ASSISTANT_RETRY_BUTTON });
+  if (!escalate && (await retryButton.isVisible({ timeout: 2_000 }).catch(() => false))) {
+    console.log('[recoverAssistant] clicking the assistant\'s own retry button');
+    await retryButton.click();
+  } else {
+    console.log(
+      escalate
+        ? '[recoverAssistant] retry button already tried, escalating to a full reload'
+        : '[recoverAssistant] no retry button found, reloading the page',
+    );
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await logs.waitForReady();
+  }
+  await ollie.waitForSidebarReady();
+}
+
+async function openExplainWithRetry(
+  page: Page,
+  logs: LogsPage,
+  ollie: OlliePage,
+  traceId: string,
+  kind: ExplainKind,
+  attempts = 3,
+): Promise<string> {
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    await logs.openExplain(traceId, kind);
+    const text = await logs.readExplanation();
+    if (!UNAVAILABLE_PATTERN.test(text)) {
+      // Kept permanently: surfaces pod-flapping frequency in CI output.
+      if (attempt > 1) console.log(`[openExplainWithRetry] recovered on attempt ${attempt} (${kind})`);
+      return text;
+    }
+    if (attempt === attempts) {
+      console.log(`[openExplainWithRetry] gave up after ${attempts} attempts (${kind})`);
+      return text;
+    }
+    console.log(`[openExplainWithRetry] hit "unavailable" on attempt ${attempt} (${kind}), retrying`);
+    await logs.closeExplain();
+    // First recovery tries the in-app retry button; if it's still
+    // unavailable next time round, that button already didn't work.
+    await recoverAssistant(page, logs, ollie, attempt > 1);
+  }
+  throw new Error('unreachable');
+}
 
 // The popover and the sidebar chat bubble render the same markdown through
 // two independent components (the popover per ExplainPopover.tsx; the
@@ -56,8 +122,7 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
 
     for (const trace of explainTraces) {
       await test.step(`Explain the Errors cell for "${trace.name}"`, async () => {
-        await logs.openExplain(trace.id, 'error');
-        const text = await logs.readExplanation();
+        const text = await openExplainWithRetry(page, logs, ollie, trace.id, 'error');
         expect(text.length).toBeGreaterThan(0);
         expect(text).toMatch(new RegExp(trace.errorKeywordSource, 'i'));
         await logs.closeExplain();
@@ -66,8 +131,7 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
 
     for (const trace of explainTraces) {
       await test.step(`Explain the Estimated cost cell for "${trace.name}" (cost=${trace.cost ?? 'NA'})`, async () => {
-        await logs.openExplain(trace.id, 'cost');
-        const text = await logs.readExplanation();
+        const text = await openExplainWithRetry(page, logs, ollie, trace.id, 'cost');
         expect(text.length).toBeGreaterThan(0);
         expect(text).toMatch(KEYWORD_PATTERN.cost);
         await logs.closeExplain();
@@ -76,8 +140,7 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
 
     for (const trace of explainTraces) {
       await test.step(`Explain the Duration cell for "${trace.name}" (duration=${trace.durationSeconds ?? 'NA'})`, async () => {
-        await logs.openExplain(trace.id, 'duration');
-        const text = await logs.readExplanation();
+        const text = await openExplainWithRetry(page, logs, ollie, trace.id, 'duration');
         expect(text.length).toBeGreaterThan(0);
         expect(text).toMatch(KEYWORD_PATTERN.duration);
         await logs.closeExplain();
@@ -101,11 +164,10 @@ test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () 
       await ollie.waitForSidebarReady();
     });
 
-    await test.step('Open Explain on the Errors cell and read its settled text', async () => {
-      await logs.openExplain(trace.id, 'error');
-    });
-
-    const explanation = await logs.readExplanation();
+    const explanation = await test.step(
+      'Open Explain on the Errors cell and read its settled text',
+      async () => openExplainWithRetry(page, logs, ollie, trace.id, 'error'),
+    );
 
     await test.step('Continue the conversation and confirm the sidebar shows the same answer', async () => {
       const beforeCount = await ollie.messages().count();


### PR DESCRIPTION
## Details

Ollie's assistant pod occasionally flips ready → down right after coming up, killing an in-flight "explain" call with an "Ollie is unavailable" message — a transient infra hiccup rather than a UI bug. This adds a retry wrapper (`openExplainWithRetry`) around the Errors/Estimated cost/Duration explain checks in `ollie-explain.spec.ts`: it retries the open-and-read a few times, first clicking the assistant's own retry button and escalating to a full page reload if that doesn't recover it, with logging so pod-flapping frequency is visible in CI output.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

N/A — no-ticket branch (`[NA]`), test-only reliability fix.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Sonnet 5
- Scope: full implementation
- Human verification: code review

## Testing

- `npx tsc --noEmit` in `tests_end_to_end/e2e` passes with no errors.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — no hooks apply to this file (E2E TS not covered by configured hooks); nothing failed.
- Not run: the actual Playwright spec against a live environment (requires a running Ollie assistant pod and CI credentials) — this is a nightly (`@t3-nightly`, `@ollie`) tagged test intended to run in CI.

## Documentation

N/A
