### PR TITLE
[OPIK-7542] [QA] fix: retarget Optimization Studio POM at the new-run side panel

### DIFF
--- a/tests_end_to_end/e2e/core/local-runner/connect.ts
+++ b/tests_end_to_end/e2e/core/local-runner/connect.ts
@@ -30,6 +30,13 @@ export interface StartConnectOpts {
   projectName: string;
   workspace: string;
   apiKey: string;
+  /**
+   * Opik API base URL the daemon talks to. Required: without it the SDK falls
+   * back to `~/.opik.config`, which on a machine that also runs a local stack
+   * points at localhost and makes the daemon miss the target deployment
+   * entirely ("Workspace not found").
+   */
+  apiUrl: string;
   /** Agent working directory the daemon watches (Ollie reads/edits code here). */
   cwd: string;
   /** How long to wait for the pairing URL to appear. */
@@ -67,6 +74,7 @@ export async function startConnectRunner(opts: StartConnectOpts): Promise<Connec
         ...process.env,
         OPIK_API_KEY: opts.apiKey,
         OPIK_WORKSPACE: opts.workspace,
+        OPIK_URL_OVERRIDE: opts.apiUrl,
         // `uv run` resolves the bridge venv from this project dir, so the
         // command uses the same pinned opik the suite seeds with.
         UV_PROJECT: BRIDGE_DIR,
@@ -169,6 +177,7 @@ export async function startEndpointRunner(opts: StartEndpointOpts): Promise<Endp
         ...process.env,
         OPIK_API_KEY: opts.apiKey,
         OPIK_WORKSPACE: opts.workspace,
+        OPIK_URL_OVERRIDE: opts.apiUrl,
         UV_PROJECT: BRIDGE_DIR,
       },
     },

--- a/tests_end_to_end/e2e/pom/ollie.page.ts
+++ b/tests_end_to_end/e2e/pom/ollie.page.ts
@@ -259,18 +259,23 @@ export class OlliePage {
   }
 
   /** Reset to a fresh conversation (clears history back to the greeting). */
-  async startNewChat(): Promise<void> {
+  async startNewChat(timeoutMs = 60_000): Promise<void> {
     return test.step('start a new Ollie chat', async () => {
       await this.frame().getByRole('button', { name: 'New chat' }).click();
-      await expect(this.greeting()).toBeVisible();
+      await expect(this.greeting()).toBeVisible({ timeout: timeoutMs });
     });
   }
 
   greeting(): Locator {
-    // "Hi there!" opens both greetings — the empty-project onboarding state
-    // ("I'm Ollie, your AI coding assistant…") and the chat state on a project
-    // that already has traces ("How can I help you today?").
-    return this.frame().getByText('Hi there!');
+    // Three greeting variants are in play: the two "Hi there!" states (the
+    // empty-project onboarding copy and the has-traces chat copy) and the
+    // post-"New chat" panel, which renders only the action strapline
+    // ("Investigate traces, analyze performance, or run actions.") with no
+    // "Hi there!" anywhere. Match any of them — keying on "Hi there!" alone
+    // failed ~1 run in 3 against production after a New chat.
+    return this.frame()
+      .getByText(/Hi there!|Investigate traces, analyze performance/)
+      .first();
   }
 
   inputTextbox(): Locator {

--- a/tests_end_to_end/e2e/pom/optimization-studio.page.ts
+++ b/tests_end_to_end/e2e/pom/optimization-studio.page.ts
@@ -36,12 +36,15 @@ export class OptimizationStudioPage {
   ) {}
 
   async gotoNew(): Promise<void> {
-    return test.step('Open the Optimization Studio new-run page', async () => {
+    return test.step('Open the Optimization Studio new-run panel', async () => {
       const env = loadEnvConfig();
+      // The new-run flow is a side panel over the runs list
+      // (`/optimizations?new=true`). `/optimizations/new` is kept as a redirect
+      // to it, so navigating the legacy path also covers that back-compat route.
       await this.page.goto(
         `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/optimizations/new`,
       );
-      await this.page.getByRole('heading', { name: 'Optimize a prompt' }).waitFor();
+      await this.newRunPanel().waitFor();
     });
   }
 
@@ -64,8 +67,11 @@ export class OptimizationStudioPage {
   async selectDataset(name: string): Promise<void> {
     return test.step(`Select dataset "${name}"`, async () => {
       await this.datasetPickerButton().click();
-      await this.page.getByTestId('search-input').fill(name);
-      await this.page.getByRole('dialog').getByText(name, { exact: true }).click();
+      const dialog = this.page.getByRole('dialog');
+      // Scope to the dialog: the run panel behind it also renders a
+      // `search-input`, so an unscoped testid matches two elements.
+      await dialog.getByTestId('search-input').fill(name);
+      await dialog.getByText(name, { exact: true }).click();
       await expect(this.page.getByRole('button', { name })).toBeVisible();
     });
   }
@@ -193,6 +199,15 @@ export class OptimizationStudioPage {
     });
   }
 
+  /**
+   * The new-run side panel. `ResizableSidePanel` renders its `panelId` as a
+   * data-testid, so this is the one purpose-built hook on the panel — the
+   * header is a plain span ("New optimization run"), not a heading.
+   */
+  private newRunPanel(): Locator {
+    return this.page.locator('[data-testid="new-optimization-run-sidebar"]');
+  }
+
   private promptEditor(): Locator {
     return this.page.locator('[data-testid="playground-message-editor"] .cm-content');
   }
@@ -212,10 +227,15 @@ export class OptimizationStudioPage {
 
   private modelCombobox(): Locator {
     // The model picker is the only combobox on the form that renders a provider
-    // name; the others show "GEPA optimizer" / "Equals".
+    // name; the others show "GEPA optimizer" / "Equals". With no provider key
+    // configured it renders its "Select an LLM model" placeholder instead, so
+    // match that too — the form must still be assertable in that state.
     return this.page
       .locator('[role="combobox"]')
-      .filter({ hasText: /Anthropic|OpenAI|Gemini|openrouter|free|gpt-|claude|GPT|Claude/i });
+      .filter({
+        hasText:
+          /Anthropic|OpenAI|Gemini|openrouter|free|gpt-|claude|GPT|Claude|Select an LLM model/i,
+      });
   }
 
   private trialsTable(): Locator {

--- a/tests_end_to_end/e2e/pom/optimization-studio.page.ts
+++ b/tests_end_to_end/e2e/pom/optimization-studio.page.ts
@@ -190,12 +190,16 @@ export class OptimizationStudioPage {
     });
   }
 
-  /** Assert the Best-trial-configuration panel shows the given algorithm + metric. */
+  /**
+   * Assert the run's configuration shows the given algorithm + metric. These
+   * render as pills in the detail page's header, which sits outside the tab
+   * structure — so scope to `main`, not to the Overview tabpanel.
+   */
   async expectBestTrialConfig(opts: { algorithm: string; metric: string }): Promise<void> {
-    return test.step('Assert Best-trial configuration panel', async () => {
-      const overview = this.page.getByRole('tabpanel');
-      await expect(overview).toContainText(opts.algorithm);
-      await expect(overview).toContainText(opts.metric);
+    return test.step('Assert the run configuration pills', async () => {
+      const header = this.page.locator('main');
+      await expect(header).toContainText(opts.algorithm);
+      await expect(header).toContainText(opts.metric);
     });
   }
 

--- a/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
+++ b/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
@@ -33,6 +33,7 @@ test.describe('Agent Playground — Local Runner', { tag: ['@t3-nightly', '@agen
           apiKey,
           cwd: scratchDir.path,
           command: ['python', path.join(scratchDir.path, 'agent.py')],
+          apiUrl: envConfig.apiBaseUrl,
           apiBaseUrl: envConfig.apiBaseUrl,
         }));
 

--- a/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
@@ -58,6 +58,7 @@ test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@ollie'] }, () =
           projectName: project.name,
           workspace: envConfig.workspace,
           apiKey: envConfig.apiKey!,
+          apiUrl: envConfig.apiBaseUrl,
           cwd: scratchDir.path,
         }));
 
@@ -135,6 +136,7 @@ test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@ollie'] }, () =
           projectName: project.name,
           workspace: envConfig.workspace,
           apiKey: envConfig.apiKey!,
+          apiUrl: envConfig.apiBaseUrl,
           cwd: scratchDir.path,
         }));
 

--- a/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
+++ b/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
@@ -37,6 +37,15 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
     testNamespace,
     page,
   }) => {
+    // Pin the model the same way the run tests do, rather than relying on the
+    // form's default: the default is whatever the deployment offers (the free
+    // gpt-5-nano on Comet), and on a deployment with no provider key it is
+    // empty, which keeps Optimize disabled and fails the assertion below.
+    const modelDisplayName = await test.step(
+      'Ensure an LLM provider is available',
+      async () => ensureModelAvailable(page),
+    );
+
     // A form-only test still needs a project-associated dataset for the picker.
     const dataset = await test.step('Seed a dataset for the picker', async () =>
       seedSentimentDataset(sdkClient, project.name, `${testNamespace}-form-ds`));
@@ -48,7 +57,8 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
       await studio.assertFormRenders();
     });
 
-    await test.step('Optimize enables once dataset + prompt + reference key are set', async () => {
+    await test.step('Optimize enables once model + dataset + prompt + reference key are set', async () => {
+      await studio.selectModel(modelDisplayName);
       await studio.selectDataset(dataset.name);
       await studio.setUserPrompt(PROMPT);
       await studio.setReferenceKey('label');


### PR DESCRIPTION
## Details

Fixes the test-side causes behind the nightly `Opik v2 production t3` failures. The three Optimization Studio specs had failed **every** run since 2026-07-17 — 39/39 attempts with a byte-identical stack, Allure per-test success rate **0.0** across four weeks. Not flaky: deterministic. Four distinct defects, all in test code.

**1. Route + selector drift.** PR #7291 (OPIK_7042) moved the new-run flow out of the `/optimizations/new` full page into a side panel (`/optimizations?new=true`) and deleted the `Optimize a prompt` heading the POM waited on. All three specs died in the shared `gotoNew()` helper, so none ever reached Studio logic.

- `gotoNew()` waits on the panel's own `data-testid` instead of the deleted heading, and still navigates the legacy `/new` path so the back-compat redirect stays covered.
- `selectDataset()` scopes `search-input` to the dialog — the panel behind it renders a second one (verified: 2 on page, 1 in dialog), so the unscoped testid hit a strict-mode violation.
- `modelCombobox()` also matches the `Select an LLM model` placeholder, so the form stays assertable when no provider key is configured.
- The form spec pins its model via `ensureModelAvailable` (Claude Haiku 4.5) instead of trusting the deployment default — that default is the free gpt-5-nano on Comet and empty without a provider key, which left `Optimize prompt` disabled.

**2. `expectBestTrialConfig` queried the wrong container.** It scoped to `getByRole('tabpanel')`, but the algorithm and metric render as pills in the page header: `OptimizationHeader` mounts at `OptimizationPage.tsx:198`, outside the `<Tabs>` that starts at `:207`. The Overview panel provably cannot contain `"GEPA optimizer"`. Now scoped to `main`. The expected label strings were already correct — `OPTIMIZER_CLASS_LABELS` maps `GepaOptimizer → "GEPA optimizer"` and `HierarchicalReflectiveOptimizer → "Hierarchical Reflective"`.

### 3. Local-runner daemons never received the Opik URL

`startConnectRunner` / `startEndpointRunner` spawned `opik connect` / `opik endpoint` with `OPIK_API_KEY` and `OPIK_WORKSPACE` but **no `OPIK_URL_OVERRIDE`**, so the SDK fell back to `~/.opik.config`. On any machine that also runs a local stack that config points at localhost, and the daemon reported `Workspace not found` / `URL http://localhost:5173/api` while aimed at a cloud target — failing before the pairing URL was ever scraped.

The two other places the suite spawns the SDK (`playwright.config.ts:62`, `agents/known-failing/harness.ts:65`) already pass the override; this brings the local-runner spawns in line. `apiUrl` is **required** on `StartConnectOpts` so a missing URL is a compile error rather than a silent fall-through to whatever the host happens to have configured — which immediately surfaced a third affected call site in `agent-playground-local-runner.spec.ts`.

This is the `startConnectRunner` / "Project not found" failure mode previously seen on self-hosted-eks nightlies (noted as environment/seeding on OPIK_7604 — it was a harness bug).

### 4. Ollie `startNewChat()` matched a greeting that isn't rendered

`startNewChat()` waited on `"Hi there!"`, but after clicking **New chat** the production panel renders only the action strapline (`"Investigate traces, analyze performance, or run actions."`) — no `"Hi there!"` anywhere — so the wait failed with `element(s) not found`, not a slow render. Now matches either variant, with an explicit budget since the greeting is re-rendered by the assistant pod rather than the host page.

Measured against production (`WORKERS=1`, `ollie-smoke` "completion"): **3/6 runs failed → 1/8 runs failed**.

**Residual, deliberately not fixed here:** the remaining ~1/8 is a *different* failure — the `Send message` button is absent within the 15s `actionTimeout` after the input is filled (`pom/ollie.page.ts:68`), looking conditionally rendered rather than always mounted. It needs its own investigation and is documented in the commit rather than folded in.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7530

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigation of the nightly failures (Allure history, local/staging/production reproduction, product-source tracing) and authoring of the four test-side fixes in this PR.
- Human verification: Author ran the suite locally against a provisioned stack, reviewed each diff, and confirmed the repeated-run results below.

## Testing

Local stack (Docker compose, OSS deployment) with an Anthropic provider key configured, from `tests_end_to_end/e2e`:

```
npx playwright test optimization-studio --reporter=line
npx tsc --noEmit -p tsconfig.json
```

**Optimization Studio specs, isolated:** 15/15 passed over 5 consecutive runs (18/18 including the first verification run). Before the fix: 0 passes in 13 consecutive nightly runs.

**Whole suite at CI's concurrency (`WORKERS=2`), 3 consecutive runs:** 46/0/10, 45/1/10, 45/1/10 (passed/failed/skipped). The single repeated failure is `playground/playground-smoke.spec.ts:13` (`expect(experiments).toBeGreaterThanOrEqual(1)` → received 0), which **also fails on a clean worktree at this branch's merge-base (`0a6c0feeb5`)** — pre-existing and unrelated to these changes. This PR touches 5 files, none of them that spec.

**Ollie suite against production** (`opik-testing`, the workspace the nightly targets), authenticated via `global-setup`'s canonical login path:

| Stage | Result |
| --- | --- |
| Before (stale auth state) | 9 failed — every test stranded on the login page |
| After real login, `WORKERS=1` | **8 passed, 1 failed** |
| After the greeting fix, `WORKERS=2` | 7 passed, 2 failed |

`/improve` — the end-to-end agentic spec that had never passed in the Allure window (0/51 attempts) — **passes on production**. `ollie-agentic.spec.ts:53` failed at `WORKERS=2` but passed at `WORKERS=1`; single data point, not diagnosed.

`tsc --noEmit` clean.

Scenarios validated:
- Happy path: both run specs execute **real** optimizer runs end-to-end (GEPA and Hierarchical Reflective) — trials produced, costs recorded, backend polled to `completed`, detail page + trials tab + downloadable logs all asserted.
- Edge case, no provider key: the form spec previously failed here; it now selects a model explicitly rather than depending on the deployment default.
- Regression, legacy route: `gotoNew()` still navigates `/optimizations/new`, so the back-compat redirect to the sidebar remains covered rather than silently dropped.

Deployment verification beyond local:
- **Staging**: redirect fires to `?new="true"`, panel `data-testid` resolves, old heading absent, `Optimize prompt` transitions disabled → enabled after selecting a dataset.
- **Production** (`opik-testing`, the workspace the failing suite targets): redirect fires, panel `data-testid` resolves, old heading absent.

Not run: the specs were not executed as a full suite against prod — they seed datasets and launch billed optimizer runs, so end-to-end execution was kept to local and the deployed checks above were read-only DOM verification.

## Documentation

No documentation changes. This PR touches only E2E test code under `tests_end_to_end/e2e/` — no user-facing behaviour, API, or configuration changes.

Two **product** issues were found while fixing these tests and are deliberately **not** addressed here, since this PR is test-only:

- The run detail page shows a "No usable scores" banner alongside a correctly scored baseline (`equals 100%`) whenever the optimizer finds no improvement. `computeEmptyRunWarning` returns `nonBaselineCandidates.every(c => c.score == null)`, and `.every()` is `true` for an empty array, so a baseline-only run trips the warning. This is OPIK_7458's remaining scope; the tests do not assert on it.
- The Best-trial prompt display renders `{{text}}` as `{text}`. Display-only — the run scored 100%, so variable substitution worked. Consistent with the brace-rendering scope in OPIK_7460.
