### PR TITLE
[NA] increase timeout for waiting page to be ready

### DIFF
--- a/tests_end_to_end/visual-tests/page-objects/logs.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/logs.page.ts
@@ -13,7 +13,7 @@ export class LogsPage extends BasePage {
   }
 
   async waitForTracesReady(expectedCellText: string): Promise<void> {
-    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 30000 });
     await Promise.race([
       this.page.locator('tbody tr td').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 20000 }),
       this.page.getByRole('heading', { name: /no traces yet/i }).waitFor({ state: 'visible', timeout: 20000 }),
@@ -38,7 +38,7 @@ export class LogsPage extends BasePage {
   }
 
   async waitForEmptyTraces(): Promise<void> {
-    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.getByRole('radio', { name: 'Traces' }).waitFor({ state: 'visible', timeout: 30000 });
     await this.page.getByRole('heading', { name: /no traces yet/i }).waitFor({ state: 'visible', timeout: 20000 });
   }
 


### PR DESCRIPTION
## Details
Increases the timeout for waiting on the Traces radio button to become visible in the Logs page object, from 10s to 30s. This addresses flakiness in the visual regression tests where the page wasn't ready in time under slower CI conditions.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA


## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation
- Human verification: code review

## Testing
This is a single-line timeout increase in a Playwright page object, aimed at reducing flakiness observed in CI runs of the visual regression suite (`tests_end_to_end/visual-tests`). Not re-run locally as part of this change; validation will come from subsequent CI runs of the visual-tests suite.

## Documentation
N/A
