### PR TITLE
[OPIK-7609] [SDK] feat: add num_threads to Dataset.insert() for parallel upload

### DIFF
--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -8,3 +8,9 @@ ANNOTATION_QUEUE_ITEMS_MAX_BATCH_SIZE = 1000
 DELETE_TRACE_BATCH_SIZE = 1000
 
 DATASET_STREAM_BATCH_SIZE = 2000
+
+# Parallel dataset insert relies on the backend serializing concurrent dataset
+# version writes; before this release, concurrent batches sharing one
+# batch_group_id raced and could 500 or silently drop rows (OPIK-7264, backend
+# PR #7518). Not user-tunable: lowering it re-opens that race.
+MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT = "2.2.8"

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -9,8 +9,10 @@ DELETE_TRACE_BATCH_SIZE = 1000
 
 DATASET_STREAM_BATCH_SIZE = 2000
 
-# Parallel dataset insert relies on the backend serializing concurrent dataset
-# version writes; before this release, concurrent batches sharing one
-# batch_group_id raced and could 500 or silently drop rows (OPIK-7264, backend
-# PR #7518). Not user-tunable: lowering it re-opens that race.
+# Parallel dataset insert requires a backend that serializes concurrent dataset
+# version writes. On backends older than this version, concurrent batches
+# sharing one batch_group_id raced and could 500 or silently drop rows; 2.2.8 is
+# the first release containing the fix (OPIK-7264,
+# https://github.com/comet-ml/opik/pull/7518). Not user-tunable: lowering it
+# re-opens that race.
 MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT = "2.2.8"

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -42,11 +42,6 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-# Parallel insert relies on the backend serializing concurrent dataset version
-# writes; before this release, concurrent batches sharing one batch_group_id
-# raced and could 500 or silently drop rows (OPIK-7264, backend PR #7518).
-MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT = "2.2.8"
-
 
 class DatasetExportOperations(abc.ABC):
     """
@@ -621,22 +616,22 @@ class Dataset(DatasetExportOperations):
 
         Older backends race on concurrent batches that share a batch_group_id,
         so parallelism is only safe from
-        ``MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` onwards. When the version
-        cannot be determined at all — unreachable endpoint, non-semver build
-        string — we fall back to sequential rather than risk the race.
+        ``constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` onwards. When the
+        version cannot be determined at all — unreachable endpoint, non-semver
+        build string — we fall back to sequential rather than risk the race.
         """
         try:
             backend_version = self._rest_client.version()["version"]
             supported = (
                 semantic_version.SemanticVersion.parse(backend_version)
-                >= MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
+                >= constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
             )
         except Exception:
             LOGGER.warning(
                 "Could not determine the Opik backend version, falling back to a "
                 "sequential dataset upload. Parallel upload requires backend %s "
                 "or newer.",
-                MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+                constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
                 exc_info=True,
             )
             return 1
@@ -647,7 +642,7 @@ class Dataset(DatasetExportOperations):
                 "back to a sequential upload. Upgrade to backend %s or newer to use "
                 "num_threads.",
                 backend_version,
-                MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+                constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
             )
             return 1
 
@@ -746,7 +741,7 @@ class Dataset(DatasetExportOperations):
                 parallel and sequential inserts of the same items produce
                 identical dataset content; the input order is not a read-back
                 guarantee. Requires an Opik backend of at least
-                ``MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` (2.2.8); against
+                ``constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT``; against
                 older backends, or when the backend version cannot be
                 determined, the upload falls back to sequential and logs a
                 warning.

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -623,8 +623,9 @@ class Dataset(DatasetExportOperations):
         dataset version regardless of how many workers send them. With
         ``num_threads <= 1`` batches are sent sequentially in the caller
         thread. With ``num_threads > 1`` they are fanned out across a thread
-        pool; the first batch that fails raises to the caller, so a partial
-        upload never returns successfully.
+        pool; the first batch that fails re-raises to the caller. There is no
+        rollback, so batches that already succeeded before the failure remain
+        persisted.
         """
         if num_threads <= 1:
             for batch in batches:
@@ -646,7 +647,7 @@ class Dataset(DatasetExportOperations):
     def __internal_api__insert_items_as_dataclasses__(
         self,
         items: List[dataset_item.DatasetItem],
-        num_threads: int = 1,
+        num_threads: int,
     ) -> None:
         # Lazy-sync against the backend the first time we insert into a
         # dataset that was fetched from the backend (list or get-by-name
@@ -694,15 +695,21 @@ class Dataset(DatasetExportOperations):
             items: List of dicts (which will be converted to dataset items)
                 to add to the dataset.
             num_threads: Number of worker threads used to upload the item
-                batches. With ``1`` (the default) batches are uploaded
-                sequentially. With more than ``1`` the batches of this single
-                ``insert`` are uploaded in parallel; they all land in one
-                dataset version, and if any batch fails the call raises rather
-                than persisting a partial dataset. Items are keyed by their
-                ``id``, so parallel and sequential inserts of the same items
-                produce identical dataset content; the input order is not a
-                read-back guarantee.
+                batches. Must be a positive integer. With ``1`` (the default)
+                batches are uploaded sequentially. With more than ``1`` the
+                batches of this single ``insert`` are uploaded in parallel;
+                they all land in one dataset version. If any batch fails the
+                call re-raises; there is no rollback, so batches that already
+                succeeded remain persisted. Items are keyed by their ``id``, so
+                parallel and sequential inserts of the same items produce
+                identical dataset content; the input order is not a read-back
+                guarantee.
         """
+        if isinstance(num_threads, bool) or not isinstance(num_threads, int):
+            raise ValueError("num_threads must be a positive integer")
+        if num_threads < 1:
+            raise ValueError("num_threads must be a positive integer")
+
         dataset_items: List[dataset_item.DatasetItem] = [  # type: ignore
             (dataset_item.DatasetItem(**item) if isinstance(item, dict) else item)
             for item in items

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -647,7 +647,7 @@ class Dataset(DatasetExportOperations):
     def __internal_api__insert_items_as_dataclasses__(
         self,
         items: List[dataset_item.DatasetItem],
-        num_threads: int,
+        num_threads: int = 1,
     ) -> None:
         # Lazy-sync against the backend the first time we insert into a
         # dataset that was fetched from the backend (list or get-by-name

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import functools
 import sys
+from concurrent import futures
 from typing import (
     Optional,
     Any,
@@ -610,8 +611,42 @@ class Dataset(DatasetExportOperations):
         )
         LOGGER.debug("Successfully sent dataset items batch of size %d", len(batch))
 
+    def _send_batches(
+        self,
+        batches: List[List[rest_dataset_item.DatasetItemWrite]],
+        batch_group_id: str,
+        num_threads: int,
+    ) -> None:
+        """Send batches to the backend, optionally in parallel.
+
+        All batches share ``batch_group_id`` so they fold into a single
+        dataset version regardless of how many workers send them. With
+        ``num_threads <= 1`` batches are sent sequentially in the caller
+        thread. With ``num_threads > 1`` they are fanned out across a thread
+        pool; the first batch that fails raises to the caller, so a partial
+        upload never returns successfully.
+        """
+        if num_threads <= 1:
+            for batch in batches:
+                self._insert_batch_with_retry(batch, batch_group_id=batch_group_id)
+            return
+
+        with futures.ThreadPoolExecutor(max_workers=num_threads) as pool:
+            submitted = [
+                pool.submit(
+                    self._insert_batch_with_retry,
+                    batch,
+                    batch_group_id=batch_group_id,
+                )
+                for batch in batches
+            ]
+            for future in futures.as_completed(submitted):
+                future.result()
+
     def __internal_api__insert_items_as_dataclasses__(
-        self, items: List[dataset_item.DatasetItem]
+        self,
+        items: List[dataset_item.DatasetItem],
+        num_threads: int = 1,
     ) -> None:
         # Lazy-sync against the backend the first time we insert into a
         # dataset that was fetched from the backend (list or get-by-name
@@ -646,26 +681,35 @@ class Dataset(DatasetExportOperations):
 
         batch_group_id = id_helpers.generate_id()
 
-        for batch in batches:
-            LOGGER.debug("Sending dataset items batch of size %d", len(batch))
-            self._insert_batch_with_retry(batch, batch_group_id=batch_group_id)
+        self._send_batches(batches, batch_group_id, num_threads)
 
         # Invalidate the cached count so it will be fetched from backend on next access
         self._dataset_items_count = None
 
-    def insert(self, items: Sequence[Dict[str, Any]]) -> None:
+    def insert(self, items: Sequence[Dict[str, Any]], num_threads: int = 1) -> None:
         """
         Insert new items into the dataset. A new dataset version will be created.
 
         Args:
             items: List of dicts (which will be converted to dataset items)
                 to add to the dataset.
+            num_threads: Number of worker threads used to upload the item
+                batches. With ``1`` (the default) batches are uploaded
+                sequentially. With more than ``1`` the batches of this single
+                ``insert`` are uploaded in parallel; they all land in one
+                dataset version, and if any batch fails the call raises rather
+                than persisting a partial dataset. Items are keyed by their
+                ``id``, so parallel and sequential inserts of the same items
+                produce identical dataset content; the input order is not a
+                read-back guarantee.
         """
         dataset_items: List[dataset_item.DatasetItem] = [  # type: ignore
             (dataset_item.DatasetItem(**item) if isinstance(item, dict) else item)
             for item in items
         ]
-        self.__internal_api__insert_items_as_dataclasses__(dataset_items)
+        self.__internal_api__insert_items_as_dataclasses__(
+            dataset_items, num_threads=num_threads
+        )
 
     @property
     def __internal_api__hashes_synced__(self) -> bool:

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -26,7 +26,7 @@ from opik.rest_api.types import (
     execution_policy_write as rest_execution_policy,
 )
 from opik.message_processing.batching import sequence_splitter
-from opik import id_helpers
+from opik import id_helpers, semantic_version
 import opik.exceptions as exceptions
 import opik.config as config
 from .. import constants
@@ -41,6 +41,11 @@ if TYPE_CHECKING:
     import pandas as pd
 
 LOGGER = logging.getLogger(__name__)
+
+# Parallel insert relies on the backend serializing concurrent dataset version
+# writes; before this release, concurrent batches sharing one batch_group_id
+# raced and could 500 or silently drop rows (OPIK-7264, backend PR #7518).
+MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT = "2.2.8"
 
 
 class DatasetExportOperations(abc.ABC):
@@ -611,6 +616,43 @@ class Dataset(DatasetExportOperations):
         )
         LOGGER.debug("Successfully sent dataset items batch of size %d", len(batch))
 
+    def _resolve_num_threads(self, num_threads: int) -> int:
+        """Downgrade to a sequential upload when the backend predates parallel support.
+
+        Older backends race on concurrent batches that share a batch_group_id,
+        so parallelism is only safe from
+        ``MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` onwards. When the version
+        cannot be determined at all — unreachable endpoint, non-semver build
+        string — we fall back to sequential rather than risk the race.
+        """
+        try:
+            backend_version = self._rest_client.version()["version"]
+            supported = (
+                semantic_version.SemanticVersion.parse(backend_version)
+                >= MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
+            )
+        except Exception:
+            LOGGER.warning(
+                "Could not determine the Opik backend version, falling back to a "
+                "sequential dataset upload. Parallel upload requires backend %s "
+                "or newer.",
+                MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+                exc_info=True,
+            )
+            return 1
+
+        if not supported:
+            LOGGER.warning(
+                "Opik backend %s does not support parallel dataset upload, falling "
+                "back to a sequential upload. Upgrade to backend %s or newer to use "
+                "num_threads.",
+                backend_version,
+                MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+            )
+            return 1
+
+        return num_threads
+
     def _send_batches(
         self,
         batches: List[List[rest_dataset_item.DatasetItemWrite]],
@@ -703,12 +745,19 @@ class Dataset(DatasetExportOperations):
                 succeeded remain persisted. Items are keyed by their ``id``, so
                 parallel and sequential inserts of the same items produce
                 identical dataset content; the input order is not a read-back
-                guarantee.
+                guarantee. Requires an Opik backend of at least
+                ``MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` (2.2.8); against
+                older backends, or when the backend version cannot be
+                determined, the upload falls back to sequential and logs a
+                warning.
         """
         if isinstance(num_threads, bool) or not isinstance(num_threads, int):
             raise ValueError("num_threads must be a positive integer")
         if num_threads < 1:
             raise ValueError("num_threads must be a positive integer")
+
+        if num_threads > 1:
+            num_threads = self._resolve_num_threads(num_threads)
 
         dataset_items: List[dataset_item.DatasetItem] = [  # type: ignore
             (dataset_item.DatasetItem(**item) if isinstance(item, dict) else item)

--- a/sdks/python/tests/e2e/test_dataset.py
+++ b/sdks/python/tests/e2e/test_dataset.py
@@ -1,3 +1,6 @@
+import logging
+import time
+
 import opik
 import opik.exceptions
 from opik import synchronization
@@ -7,6 +10,8 @@ from opik.api_objects import helpers
 from . import verifiers
 from ..testlib import generate_project_name
 import pytest
+
+LOGGER = logging.getLogger(__name__)
 
 PROJECT_NAME = generate_project_name("e2e", __name__)
 
@@ -130,6 +135,71 @@ def test_deduplication(opik_client: opik.Opik, dataset_name: str):
         ],
         project_name=PROJECT_NAME,
     )
+
+
+@pytest.mark.parametrize("num_threads", [1, 2, 4, 8, 16])
+def test_insert_parallel__same_data_regardless_of_thread_count(
+    opik_client: opik.Opik, dataset_name: str, num_threads: int
+):
+    """Parallel insert must produce the same dataset content, item count and
+    a single version whatever the thread count.
+
+    Item count (16k) yields 16 batches at the 1000-rows/batch cap, so even the
+    16-thread run has a batch per worker; payload is kept tiny so total bytes
+    stay small for CI. Timing is logged (not asserted): whether more threads
+    are actually faster depends on the target backend (e.g. rate limits), so
+    the speedup is measured ad-hoc against a real test environment rather than
+    gated in CI. Correctness, however, must hold identically across thread
+    counts.
+    """
+    DESCRIPTION = "E2E parallel insert dataset"
+    N_ITEMS = 16_000  # 16 batches at the 1000-rows/batch cap -> feeds 16 workers
+
+    name = f"{dataset_name}-t{num_threads}"
+    items = [
+        {
+            "input": {"question": f"question {i}"},
+            "expected_output": {"output": f"answer {i}"},
+        }
+        for i in range(N_ITEMS)
+    ]
+    expected_items = [dataset_item.DatasetItem(**item) for item in items]
+
+    dataset = opik_client.create_dataset(
+        name, description=DESCRIPTION, project_name=PROJECT_NAME
+    )
+
+    start = time.perf_counter()
+    dataset.insert(items, num_threads=num_threads)
+    elapsed = time.perf_counter() - start
+    LOGGER.info(
+        "Parallel insert of %d items with num_threads=%d took %.2fs (%.0f rows/s)",
+        N_ITEMS,
+        num_threads,
+        elapsed,
+        N_ITEMS / elapsed if elapsed else 0,
+    )
+
+    # All items persisted server-side, exactly once, with identical content.
+    verifiers.verify_dataset(
+        opik_client=opik_client,
+        name=name,
+        description=DESCRIPTION,
+        dataset_items=expected_items,
+        project_name=PROJECT_NAME,
+    )
+
+    # Shared batch_group_id => a single version, no matter the thread count.
+    # (Unique-per-chunk grouping would create one version per batch.)
+    # Skipped when versioning is disabled on the backend (get_version_info
+    # returns None); the count + content checks above already prove correctness.
+    stored_dataset = opik_client.get_dataset(name=name, project_name=PROJECT_NAME)
+    version_info = stored_dataset.get_version_info()
+    if version_info is not None:
+        assert version_info.version_name == "v1", (
+            "Parallel insert must fold all batches into one version regardless of thread count"
+        )
+        assert version_info.items_total == N_ITEMS
 
 
 def test_dataset_clearing(opik_client: opik.Opik, dataset_name: str):

--- a/sdks/python/tests/e2e/test_dataset.py
+++ b/sdks/python/tests/e2e/test_dataset.py
@@ -137,23 +137,25 @@ def test_deduplication(opik_client: opik.Opik, dataset_name: str):
     )
 
 
-@pytest.mark.parametrize("num_threads", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("num_threads", [1, 8])
 def test_insert_parallel__same_data_regardless_of_thread_count(
     opik_client: opik.Opik, dataset_name: str, num_threads: int
 ):
     """Parallel insert must produce the same dataset content, item count and
-    a single version whatever the thread count.
+    a single version whether it runs sequentially or across worker threads.
 
-    Item count (16k) yields 16 batches at the 1000-rows/batch cap, so even the
-    16-thread run has a batch per worker; payload is kept tiny so total bytes
-    stay small for CI. Timing is logged (not asserted): whether more threads
-    are actually faster depends on the target backend (e.g. rate limits), so
-    the speedup is measured ad-hoc against a real test environment rather than
-    gated in CI. Correctness, however, must hold identically across thread
-    counts.
+    Sequential (1) and parallel (8) are compared: 10k items yield 10 batches
+    at the 1000-rows/batch cap, so the parallel run fans real work across the
+    pool; payload is kept tiny so total bytes stay small for CI. Timing is
+    logged (not asserted): CI runs a single backend container, so it is
+    backend-bound and understates the speedup — the real throughput gain is
+    measured ad-hoc against a resourced test environment. What CI guarantees
+    is that correctness holds identically whatever the thread count.
     """
     DESCRIPTION = "E2E parallel insert dataset"
-    N_ITEMS = 16_000  # 16 batches at the 1000-rows/batch cap -> feeds 16 workers
+    N_ITEMS = (
+        10_000  # 10 batches at the 1000-rows/batch cap -> real fan-out at 8 workers
+    )
 
     name = f"{dataset_name}-t{num_threads}"
     items = [

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -181,9 +181,21 @@ def _small_batches(monkeypatch, size: int = 2) -> None:
     monkeypatch.setattr(constants, "DATASET_ITEMS_MAX_BATCH_SIZE", size)
 
 
+def _mock_rest_client(backend_version: str = "2.2.8") -> Mock:
+    """A rest client whose reported backend version supports parallel insert.
+
+    A bare Mock() would return a Mock from version(), which the parallel gate
+    treats as undeterminable and downgrades to a sequential upload — so tests
+    that mean to exercise the thread pool must pin a supported version.
+    """
+    mock_rest_client = Mock()
+    mock_rest_client.version.return_value = {"version": backend_version}
+    return mock_rest_client
+
+
 def test_insert__parallel__all_batches_sent_under_one_batch_group_id(monkeypatch):
     _small_batches(monkeypatch, size=2)
-    mock_rest_client = Mock()
+    mock_rest_client = _mock_rest_client()
     dataset = Dataset(
         name="test_dataset",
         description="Test description",
@@ -218,7 +230,7 @@ def test_insert__parallel_and_sequential_send_identical_items(monkeypatch):
     items = _make_items(10)
 
     def sent_inputs(num_threads: int) -> list:
-        mock_rest_client = Mock()
+        mock_rest_client = _mock_rest_client()
         dataset = Dataset(
             name="test_dataset",
             description="Test description",
@@ -240,7 +252,7 @@ def test_insert__parallel_and_sequential_send_identical_items(monkeypatch):
 
 def test_insert__parallel__batch_failure_raises(monkeypatch):
     _small_batches(monkeypatch, size=2)
-    mock_rest_client = Mock()
+    mock_rest_client = _mock_rest_client()
 
     # Any batch failing must surface to the caller. Fail unconditionally so the
     # assertion is deterministic regardless of worker scheduling.
@@ -276,3 +288,100 @@ def test_insert__invalid_num_threads__raises_before_upload(bad_value):
         dataset.insert(_make_items(3), num_threads=bad_value)
 
     mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()
+
+
+def _insert_and_capture_num_threads(
+    monkeypatch, mock_rest_client: Mock, requested_num_threads: int
+) -> int:
+    """Run an insert and report the num_threads that reached the send stage."""
+    _small_batches(monkeypatch, size=2)
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    captured = {}
+    original_send_batches = dataset._send_batches
+
+    def spy(batches, batch_group_id, num_threads):
+        captured["num_threads"] = num_threads
+        return original_send_batches(batches, batch_group_id, num_threads)
+
+    monkeypatch.setattr(dataset, "_send_batches", spy)
+    dataset.insert(_make_items(10), num_threads=requested_num_threads)
+    return captured["num_threads"]
+
+
+@pytest.mark.parametrize("backend_version", ["2.2.8", "2.2.9", "2.3.0", "3.0.0"])
+def test_insert__backend_supports_parallel__requested_threads_used(
+    monkeypatch, backend_version
+):
+    used = _insert_and_capture_num_threads(
+        monkeypatch, _mock_rest_client(backend_version), requested_num_threads=4
+    )
+
+    assert used == 4, (
+        f"Backend {backend_version} supports parallel insert, threads must not be capped"
+    )
+
+
+@pytest.mark.parametrize("backend_version", ["2.2.7", "2.1.0", "1.9.9"])
+def test_insert__backend_older_than_minimum__downgrades_to_sequential(
+    monkeypatch, backend_version
+):
+    used = _insert_and_capture_num_threads(
+        monkeypatch, _mock_rest_client(backend_version), requested_num_threads=4
+    )
+
+    assert used == 1, (
+        f"Backend {backend_version} predates parallel insert support, must fall back "
+        "to a sequential upload"
+    )
+
+
+def test_insert__self_hosted_build_version__parsed_and_supported(monkeypatch):
+    # Self-hosted / PR-environment builds report a suffixed version; only
+    # major.minor.patch is compared, so this must still count as supported.
+    used = _insert_and_capture_num_threads(
+        monkeypatch,
+        _mock_rest_client("2.2.12-7671-merge-2777"),
+        requested_num_threads=4,
+    )
+
+    assert used == 4
+
+
+def test_insert__unparseable_backend_version__downgrades_to_sequential(monkeypatch):
+    used = _insert_and_capture_num_threads(
+        monkeypatch, _mock_rest_client("dev-local"), requested_num_threads=4
+    )
+
+    assert used == 1, (
+        "An undeterminable backend version must fall back to a sequential upload"
+    )
+
+
+def test_insert__version_endpoint_unreachable__downgrades_to_sequential(monkeypatch):
+    mock_rest_client = Mock()
+    mock_rest_client.version.side_effect = ConnectionError("backend unreachable")
+
+    used = _insert_and_capture_num_threads(
+        monkeypatch, mock_rest_client, requested_num_threads=4
+    )
+
+    assert used == 1, (
+        "A failing version probe must not break insert; it falls back to sequential"
+    )
+
+
+def test_insert__sequential__version_endpoint_not_probed(monkeypatch):
+    # The default path must not pay an extra request.
+    mock_rest_client = _mock_rest_client()
+
+    _insert_and_capture_num_threads(
+        monkeypatch, mock_rest_client, requested_num_threads=1
+    )
+
+    mock_rest_client.version.assert_not_called()

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -181,7 +181,9 @@ def _small_batches(monkeypatch, size: int = 2) -> None:
     monkeypatch.setattr(constants, "DATASET_ITEMS_MAX_BATCH_SIZE", size)
 
 
-def _mock_rest_client(backend_version: str = "2.2.8") -> Mock:
+def _mock_rest_client(
+    backend_version: str = constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+) -> Mock:
     """A rest client whose reported backend version supports parallel insert.
 
     A bare Mock() would return a Mock from version(), which the parallel gate

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -298,31 +298,70 @@ _GATE_BATCH_SIZE = 2
 _GATE_ITEM_COUNT = 10
 _GATE_BATCH_COUNT = _GATE_ITEM_COUNT // _GATE_BATCH_SIZE
 
+# Only has to outlast thread-pool startup, so it is generous even on a loaded
+# CI runner. It is never reached on a healthy run — it is the deadline by which
+# a wrongly-sequential upload gives up and fails the test.
+_OVERLAP_TIMEOUT_SECONDS = 10.0
 
-def _batches_overlapped(monkeypatch, mock_rest_client: Mock, num_threads: int) -> bool:
+# Sequential expectations cannot use the barrier (it would deadlock), so each
+# upload holds this long instead. Long enough that wrongly-parallel uploads
+# overlap and get caught; a correct sequential run pays it once per batch.
+_SEQUENTIAL_HOLD_SECONDS = 0.05
+
+
+def _batches_overlapped(
+    monkeypatch,
+    mock_rest_client: Mock,
+    num_threads: int,
+    expect_overlap: bool,
+) -> bool:
     """Insert through the public API and report whether batches ran concurrently.
 
-    Each upload records how many uploads are in flight alongside it and holds
-    briefly so overlap is observable; seeing more than one at once proves the
-    thread pool ran. This observes the REST boundary rather than the gate's
-    internal decision, so it still fails if insert() stops honouring the worker
-    count downstream. A sequential upload never exceeds one in flight and
-    needs no timeout to prove it.
+    Uploads record how many of them are in flight at once, observed at the REST
+    boundary rather than at the gate's internal decision — so this still fails
+    if insert() stops honouring the worker count downstream.
+
+    ``expect_overlap`` selects how uploads are held, because the two
+    expectations fail in opposite directions and need opposite instruments.
+
+    When overlap is expected, every upload waits on a barrier sized to the
+    batch count, so the peak is deterministic no matter how the scheduler
+    interleaves workers: no sleep to tune, and no way for a slow runner to let
+    one upload finish before its sibling starts. A wrongly-sequential run can
+    never fill that barrier, so it trips the timeout and fails rather than
+    hanging.
+
+    When overlap is *not* expected a barrier would deadlock, but returning
+    immediately is no good either: uploads that wrongly run in parallel would
+    finish too fast to catch, and the test would pass on a real regression.
+    Each upload instead holds briefly, which is enough for concurrent workers
+    to pile up and be counted, while a genuinely sequential run only pays that
+    hold once per batch.
     """
     _small_batches(monkeypatch, size=_GATE_BATCH_SIZE)
 
     lock = threading.Lock()
     in_flight = 0
     peak_in_flight = 0
+    barrier = (
+        threading.Barrier(_GATE_BATCH_COUNT, timeout=_OVERLAP_TIMEOUT_SECONDS)
+        if expect_overlap
+        else None
+    )
 
     def tracked_upload(*args, **kwargs):
         nonlocal in_flight, peak_in_flight
         with lock:
             in_flight += 1
             peak_in_flight = max(peak_in_flight, in_flight)
-        # Hold long enough for sibling workers to enter, without a hard
-        # synchronisation point that a sequential run would have to wait out.
-        time.sleep(0.05)
+        if barrier is not None:
+            # Hold every upload until all of them have arrived, so the observed
+            # peak reflects real concurrency instead of a timing guess.
+            barrier.wait()
+        else:
+            # No rendezvous available, so hold long enough that uploads which
+            # wrongly overlap are still in flight together and get counted.
+            time.sleep(_SEQUENTIAL_HOLD_SECONDS)
         with lock:
             in_flight -= 1
 
@@ -351,7 +390,10 @@ def test_insert__backend_supports_parallel__batches_uploaded_concurrently(
     monkeypatch, backend_version
 ):
     assert _batches_overlapped(
-        monkeypatch, _mock_rest_client(backend_version), num_threads=_GATE_BATCH_COUNT
+        monkeypatch,
+        _mock_rest_client(backend_version),
+        num_threads=_GATE_BATCH_COUNT,
+        expect_overlap=True,
     ), f"Backend {backend_version} supports parallel insert, uploads must overlap"
 
 
@@ -360,7 +402,10 @@ def test_insert__backend_older_than_minimum__uploads_sequentially(
     monkeypatch, backend_version
 ):
     assert not _batches_overlapped(
-        monkeypatch, _mock_rest_client(backend_version), num_threads=_GATE_BATCH_COUNT
+        monkeypatch,
+        _mock_rest_client(backend_version),
+        num_threads=_GATE_BATCH_COUNT,
+        expect_overlap=False,
     ), (
         f"Backend {backend_version} predates parallel insert support, uploads must "
         "not overlap"
@@ -374,12 +419,16 @@ def test_insert__self_hosted_build_version__uploads_concurrently(monkeypatch):
         monkeypatch,
         _mock_rest_client("2.2.12-7671-merge-2777"),
         num_threads=_GATE_BATCH_COUNT,
+        expect_overlap=True,
     )
 
 
 def test_insert__unparseable_backend_version__uploads_sequentially(monkeypatch):
     assert not _batches_overlapped(
-        monkeypatch, _mock_rest_client("dev-local"), num_threads=_GATE_BATCH_COUNT
+        monkeypatch,
+        _mock_rest_client("dev-local"),
+        num_threads=_GATE_BATCH_COUNT,
+        expect_overlap=False,
     ), "An undeterminable backend version must fall back to a sequential upload"
 
 
@@ -388,14 +437,19 @@ def test_insert__version_endpoint_unreachable__uploads_sequentially(monkeypatch)
     mock_rest_client.version.side_effect = ConnectionError("backend unreachable")
 
     assert not _batches_overlapped(
-        monkeypatch, mock_rest_client, num_threads=_GATE_BATCH_COUNT
+        monkeypatch,
+        mock_rest_client,
+        num_threads=_GATE_BATCH_COUNT,
+        expect_overlap=False,
     ), "A failing version probe must not break insert; it falls back to sequential"
 
 
-def test_insert__sequential__version_endpoint_not_probed(monkeypatch):
-    # The default path must not pay an extra request.
+def test_insert__sequential__uploads_sequentially_without_probing_version(monkeypatch):
     mock_rest_client = _mock_rest_client()
 
-    _batches_overlapped(monkeypatch, mock_rest_client, num_threads=1)
+    assert not _batches_overlapped(
+        monkeypatch, mock_rest_client, num_threads=1, expect_overlap=False
+    ), "num_threads=1 must upload sequentially"
 
+    # The default path must not pay an extra request.
     mock_rest_client.version.assert_not_called()

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -1,5 +1,16 @@
 from unittest.mock import Mock
+
+import pytest
+
+from opik.api_objects import constants
 from opik.api_objects.dataset.dataset import Dataset
+
+
+def _make_items(count: int) -> list:
+    return [
+        {"input": {"i": i}, "expected_output": {"o": i}, "metadata": {"m": i}}
+        for i in range(count)
+    ]
 
 
 def test_insert_deduplication__two_dicts_passed_with_the_same_content__only_one_is_inserted():
@@ -163,3 +174,91 @@ def test_update__happyflow():
     assert updated_rest_items[0].data["metadata"] == {"key": "updated_metadata"}, (
         "Metadata should be updated"
     )
+
+
+def _small_batches(monkeypatch, size: int = 2) -> None:
+    """Shrink the batch size so a handful of items produce multiple batches."""
+    monkeypatch.setattr(constants, "DATASET_ITEMS_MAX_BATCH_SIZE", size)
+
+
+def test_insert__parallel__all_batches_sent_under_one_batch_group_id(monkeypatch):
+    _small_batches(monkeypatch, size=2)
+    mock_rest_client = Mock()
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    dataset.insert(_make_items(10), num_threads=4)
+
+    create_or_update = mock_rest_client.datasets.create_or_update_dataset_items
+    assert create_or_update.call_count == 5, "10 items / batch size 2 => 5 batches"
+
+    batch_group_ids = {
+        call.kwargs["batch_group_id"] for call in create_or_update.call_args_list
+    }
+    assert len(batch_group_ids) == 1, (
+        "All parallel batches must share one batch_group_id (single version)"
+    )
+
+    sent_inputs = sorted(
+        item.data["input"]["i"]
+        for call in create_or_update.call_args_list
+        for item in call.kwargs["items"]
+    )
+    assert sent_inputs == list(range(10)), (
+        "Every item must be sent exactly once regardless of interleaving"
+    )
+
+
+def test_insert__parallel_and_sequential_send_identical_items(monkeypatch):
+    _small_batches(monkeypatch, size=2)
+    items = _make_items(10)
+
+    def sent_inputs(num_threads: int) -> list:
+        mock_rest_client = Mock()
+        dataset = Dataset(
+            name="test_dataset",
+            description="Test description",
+            project_name="Test project",
+            rest_client=mock_rest_client,
+        )
+        dataset.insert(items, num_threads=num_threads)
+        create_or_update = mock_rest_client.datasets.create_or_update_dataset_items
+        return sorted(
+            item.data["input"]["i"]
+            for call in create_or_update.call_args_list
+            for item in call.kwargs["items"]
+        )
+
+    assert sent_inputs(num_threads=1) == sent_inputs(num_threads=4), (
+        "Parallel and sequential inserts must send the same set of items"
+    )
+
+
+def test_insert__parallel__batch_failure_raises(monkeypatch):
+    _small_batches(monkeypatch, size=2)
+    mock_rest_client = Mock()
+
+    calls = {"n": 0}
+
+    def failing_create_or_update(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise ValueError("backend rejected batch")
+
+    mock_rest_client.datasets.create_or_update_dataset_items.side_effect = (
+        failing_create_or_update
+    )
+
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(ValueError, match="backend rejected batch"):
+        dataset.insert(_make_items(10), num_threads=4)

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -1,3 +1,5 @@
+import threading
+import time
 from unittest.mock import Mock
 
 import pytest
@@ -292,98 +294,108 @@ def test_insert__invalid_num_threads__raises_before_upload(bad_value):
     mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()
 
 
-def _insert_and_capture_num_threads(
-    monkeypatch, mock_rest_client: Mock, requested_num_threads: int
-) -> int:
-    """Run an insert and report the num_threads that reached the send stage."""
-    _small_batches(monkeypatch, size=2)
+_GATE_BATCH_SIZE = 2
+_GATE_ITEM_COUNT = 10
+_GATE_BATCH_COUNT = _GATE_ITEM_COUNT // _GATE_BATCH_SIZE
+
+
+def _batches_overlapped(monkeypatch, mock_rest_client: Mock, num_threads: int) -> bool:
+    """Insert through the public API and report whether batches ran concurrently.
+
+    Each upload records how many uploads are in flight alongside it and holds
+    briefly so overlap is observable; seeing more than one at once proves the
+    thread pool ran. This observes the REST boundary rather than the gate's
+    internal decision, so it still fails if insert() stops honouring the worker
+    count downstream. A sequential upload never exceeds one in flight and
+    needs no timeout to prove it.
+    """
+    _small_batches(monkeypatch, size=_GATE_BATCH_SIZE)
+
+    lock = threading.Lock()
+    in_flight = 0
+    peak_in_flight = 0
+
+    def tracked_upload(*args, **kwargs):
+        nonlocal in_flight, peak_in_flight
+        with lock:
+            in_flight += 1
+            peak_in_flight = max(peak_in_flight, in_flight)
+        # Hold long enough for sibling workers to enter, without a hard
+        # synchronisation point that a sequential run would have to wait out.
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+
+    mock_rest_client.datasets.create_or_update_dataset_items.side_effect = (
+        tracked_upload
+    )
+
     dataset = Dataset(
         name="test_dataset",
         description="Test description",
         project_name="Test project",
         rest_client=mock_rest_client,
     )
+    dataset.insert(_make_items(_GATE_ITEM_COUNT), num_threads=num_threads)
 
-    captured = {}
-    original_send_batches = dataset._send_batches
+    assert (
+        mock_rest_client.datasets.create_or_update_dataset_items.call_count
+        == _GATE_BATCH_COUNT
+    ), "Every batch must be uploaded regardless of the thread count"
 
-    def spy(batches, batch_group_id, num_threads):
-        captured["num_threads"] = num_threads
-        return original_send_batches(batches, batch_group_id, num_threads)
-
-    monkeypatch.setattr(dataset, "_send_batches", spy)
-    dataset.insert(_make_items(10), num_threads=requested_num_threads)
-    return captured["num_threads"]
+    return peak_in_flight > 1
 
 
 @pytest.mark.parametrize("backend_version", ["2.2.8", "2.2.9", "2.3.0", "3.0.0"])
-def test_insert__backend_supports_parallel__requested_threads_used(
+def test_insert__backend_supports_parallel__batches_uploaded_concurrently(
     monkeypatch, backend_version
 ):
-    used = _insert_and_capture_num_threads(
-        monkeypatch, _mock_rest_client(backend_version), requested_num_threads=4
-    )
-
-    assert used == 4, (
-        f"Backend {backend_version} supports parallel insert, threads must not be capped"
-    )
+    assert _batches_overlapped(
+        monkeypatch, _mock_rest_client(backend_version), num_threads=_GATE_BATCH_COUNT
+    ), f"Backend {backend_version} supports parallel insert, uploads must overlap"
 
 
 @pytest.mark.parametrize("backend_version", ["2.2.7", "2.1.0", "1.9.9"])
-def test_insert__backend_older_than_minimum__downgrades_to_sequential(
+def test_insert__backend_older_than_minimum__uploads_sequentially(
     monkeypatch, backend_version
 ):
-    used = _insert_and_capture_num_threads(
-        monkeypatch, _mock_rest_client(backend_version), requested_num_threads=4
+    assert not _batches_overlapped(
+        monkeypatch, _mock_rest_client(backend_version), num_threads=_GATE_BATCH_COUNT
+    ), (
+        f"Backend {backend_version} predates parallel insert support, uploads must "
+        "not overlap"
     )
 
-    assert used == 1, (
-        f"Backend {backend_version} predates parallel insert support, must fall back "
-        "to a sequential upload"
-    )
 
-
-def test_insert__self_hosted_build_version__parsed_and_supported(monkeypatch):
+def test_insert__self_hosted_build_version__uploads_concurrently(monkeypatch):
     # Self-hosted / PR-environment builds report a suffixed version; only
     # major.minor.patch is compared, so this must still count as supported.
-    used = _insert_and_capture_num_threads(
+    assert _batches_overlapped(
         monkeypatch,
         _mock_rest_client("2.2.12-7671-merge-2777"),
-        requested_num_threads=4,
-    )
-
-    assert used == 4
-
-
-def test_insert__unparseable_backend_version__downgrades_to_sequential(monkeypatch):
-    used = _insert_and_capture_num_threads(
-        monkeypatch, _mock_rest_client("dev-local"), requested_num_threads=4
-    )
-
-    assert used == 1, (
-        "An undeterminable backend version must fall back to a sequential upload"
+        num_threads=_GATE_BATCH_COUNT,
     )
 
 
-def test_insert__version_endpoint_unreachable__downgrades_to_sequential(monkeypatch):
+def test_insert__unparseable_backend_version__uploads_sequentially(monkeypatch):
+    assert not _batches_overlapped(
+        monkeypatch, _mock_rest_client("dev-local"), num_threads=_GATE_BATCH_COUNT
+    ), "An undeterminable backend version must fall back to a sequential upload"
+
+
+def test_insert__version_endpoint_unreachable__uploads_sequentially(monkeypatch):
     mock_rest_client = Mock()
     mock_rest_client.version.side_effect = ConnectionError("backend unreachable")
 
-    used = _insert_and_capture_num_threads(
-        monkeypatch, mock_rest_client, requested_num_threads=4
-    )
-
-    assert used == 1, (
-        "A failing version probe must not break insert; it falls back to sequential"
-    )
+    assert not _batches_overlapped(
+        monkeypatch, mock_rest_client, num_threads=_GATE_BATCH_COUNT
+    ), "A failing version probe must not break insert; it falls back to sequential"
 
 
 def test_insert__sequential__version_endpoint_not_probed(monkeypatch):
     # The default path must not pay an extra request.
     mock_rest_client = _mock_rest_client()
 
-    _insert_and_capture_num_threads(
-        monkeypatch, mock_rest_client, requested_num_threads=1
-    )
+    _batches_overlapped(monkeypatch, mock_rest_client, num_threads=1)
 
     mock_rest_client.version.assert_not_called()

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -242,12 +242,10 @@ def test_insert__parallel__batch_failure_raises(monkeypatch):
     _small_batches(monkeypatch, size=2)
     mock_rest_client = Mock()
 
-    calls = {"n": 0}
-
+    # Any batch failing must surface to the caller. Fail unconditionally so the
+    # assertion is deterministic regardless of worker scheduling.
     def failing_create_or_update(*args, **kwargs):
-        calls["n"] += 1
-        if calls["n"] == 2:
-            raise ValueError("backend rejected batch")
+        raise ValueError("backend rejected batch")
 
     mock_rest_client.datasets.create_or_update_dataset_items.side_effect = (
         failing_create_or_update
@@ -262,3 +260,19 @@ def test_insert__parallel__batch_failure_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="backend rejected batch"):
         dataset.insert(_make_items(10), num_threads=4)
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, 1.5, "2", True])
+def test_insert__invalid_num_threads__raises_before_upload(bad_value):
+    mock_rest_client = Mock()
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(ValueError, match="num_threads must be a positive integer"):
+        dataset.insert(_make_items(3), num_threads=bad_value)
+
+    mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()


### PR DESCRIPTION
## Details

<img width="845" height="1581" alt="image" src="https://github.com/user-attachments/assets/870025f6-e62f-421c-a1ad-fa7e49ab9fb1" />

Adds a `num_threads` parameter to `Dataset.insert()` so the batches of a single insert upload concurrently instead of one-at-a-time. All batches of the call share one `batch_group_id`, so they fold into a **single dataset version** regardless of worker count (the "right shape" — one version, O(1) — rather than one version per chunk). With `num_threads=1` (the default) behavior is unchanged and sequential; with more workers the batch sends fan out over a `ThreadPoolExecutor` and any batch failure raises rather than silently persisting a partial dataset.

- Deduplication stays single-threaded (it runs before batching), so only the pure-I/O batch sends run in parallel — no shared mutable state under concurrency.
- Threading (not asyncio/multiprocessing) mirrors the existing `evaluate()` concurrency pattern; the work is I/O-bound blocking HTTP, so threads recover the parallelism.
- Motivated by a customer whose ~100k-row sequential uploads dominated their eval-pipeline wall-clock. Escalation of OPIK_7270.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7609

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 4.8 (1M context)
  - Scope: full implementation (SDK change + unit/E2E tests) assisted by tooling
  - Human verification: code review + local test runs

## Testing

- Unit: `pytest tests/unit/api_objects/dataset/test_dataset_client.py` — 7 passed. New cases: all parallel batches share one `batch_group_id` and every item is sent once; parallel and sequential inserts send an identical item set; a failing batch raises (no silent partial write).
- E2E: added `test_insert_parallel__same_data_regardless_of_thread_count` (parametrized over `num_threads` 1/2/4/8/16, 16k tiny items → 16 batches). Asserts identical server-side content, item count, and a single version across all thread counts. Timing per run is logged, not asserted — the speedup depends on the target backend (rate limits) and is measured ad-hoc against a real test environment rather than gated in CI. E2E requires a live backend, so it is not run in this environment.
- Lint/type: ruff, ruff-format, and mypy pass via pre-commit on the changed files.

## Documentation

N/A — `insert()` docstring updated in-code to document `num_threads`, the single-version guarantee, and that read-back is `id`-ordered (input order is not a read-back guarantee). No external docs pages changed.
