### PR TITLE
[OPIK-7611] [BE] Cut the fixed cost of the optimization list query

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -959,7 +959,9 @@ class OptimizationDAOImpl implements OptimizationDAO {
                             .bind("limit", size)
                             .bind("offset", offset);
 
-                    bindQueryParams(searchCriteria, statement, true);
+                    // entity_type is only declared by FIND; the fast path omits the feedback-score CTEs that use it,
+                    // and binding a parameter the rendered query does not contain fails the statement.
+                    bindQueryParams(searchCriteria, statement, hasExperiments);
 
                     return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -523,18 +523,14 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     AND ec.optimization_id = ospe.optimization_id
                 LEFT JOIN experiment_durations ed ON ec.experiment_id = ed.experiment_id
                 GROUP BY ec.optimization_id, ec.candidate_id
-            ), best_candidate AS (
+            ), candidate_rollup AS (
                 SELECT
                     optim_id AS optimization_id,
-                    max(weighted_score) AS best_score,
-                    argMax(weighted_duration, weighted_score) AS best_duration,
-                    argMax(per_trace_cost, weighted_score) AS best_cost
-                FROM candidate_metrics
-                WHERE isNotNull(weighted_score)
-                GROUP BY optim_id
-            ), baseline_candidate AS (
-                SELECT
-                    optim_id AS optimization_id,
+                    maxIf(weighted_score, isNotNull(weighted_score)) AS best_score,
+                    argMinIf(weighted_duration, tuple(-weighted_score, earliest_created_at),
+                        isNotNull(weighted_score)) AS best_duration,
+                    argMinIf(per_trace_cost, tuple(-weighted_score, earliest_created_at),
+                        isNotNull(weighted_score)) AS best_cost,
                     argMin(weighted_score, earliest_created_at) AS baseline_score,
                     argMin(weighted_duration, earliest_created_at) AS baseline_duration,
                     argMin(per_trace_cost, earliest_created_at) AS baseline_cost
@@ -555,20 +551,89 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 maxMap(fs.feedback_scores) AS feedback_scores,
                 maxMap(es.experiment_scores) AS experiment_scores,
                 any(bc.best_score) AS best_objective_score,
-                any(blc.baseline_score) AS baseline_objective_score,
+                any(bc.baseline_score) AS baseline_objective_score,
                 any(bc.best_duration) AS best_duration,
                 any(bc.best_cost) AS best_cost,
-                any(blc.baseline_duration) AS baseline_duration,
-                any(blc.baseline_cost) AS baseline_cost,
+                any(bc.baseline_duration) AS baseline_duration,
+                any(bc.baseline_cost) AS baseline_cost,
                 any(oc.total_optimization_cost) AS total_optimization_cost
             FROM optimization_final AS o
             LEFT JOIN experiments_final AS e ON o.id = e.optimization_id
             LEFT JOIN feedback_scores_agg AS fs ON e.id = fs.experiment_id
             LEFT JOIN experiment_scores_agg AS es ON e.id = es.experiment_id
-            LEFT JOIN best_candidate AS bc ON o.id = bc.optimization_id
-            LEFT JOIN baseline_candidate AS blc ON o.id = blc.optimization_id
+            LEFT JOIN candidate_rollup AS bc ON o.id = bc.optimization_id
             LEFT JOIN optimization_costs AS oc ON o.id = oc.optimization_id
             GROUP BY o.*
+            ORDER BY o.id DESC
+            <if(limit)> LIMIT :limit <endif> <if(offset)> OFFSET :offset <endif>
+            ;
+            """;
+
+    /**
+     * Does any optimization in scope have an experiment? Deliberately applies only the direct column filters
+     * and omits the narrowing ones ({@code name}, {@code dataset_deleted}, {@code studio_only}, {@code filters}),
+     * so the optimization set considered here is a superset of {@code optimization_final}. That makes a negative
+     * answer conservative: if this finds nothing, the narrowed set has nothing either.
+     */
+    private static final String HAS_EXPERIMENTS_IN_SCOPE = """
+            SELECT 1 AS has_experiments
+            FROM experiments
+            WHERE workspace_id = :workspace_id
+            AND optimization_id IN (
+                SELECT id
+                FROM optimizations
+                WHERE workspace_id = :workspace_id
+                <if(dataset_id)>AND dataset_id = :dataset_id <endif>
+                <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
+                <if(id)>AND id = :id <endif>
+                <if(project_id)>AND project_id = :project_id <endif>
+            )
+            LIMIT 1
+            ;
+            """;
+
+    /**
+     * The {@link #FIND} projection for the case where no optimization in scope has an experiment. Every
+     * aggregate in {@link #FIND} is derived from {@code experiments_final}, so with no experiments they all
+     * collapse to their empty-input values and the fifteen-CTE pipeline reads nothing useful. The literals below
+     * reproduce those values and their exact declared types - note {@code total_optimization_cost} is a
+     * non-nullable zero, because {@code sum()} over an empty group returns 0 rather than NULL.
+     */
+    private static final String FIND_WITHOUT_EXPERIMENTS = """
+            WITH optimization_final AS (
+                SELECT
+                    *
+                FROM (
+                    SELECT *
+                    FROM optimizations
+                    WHERE workspace_id = :workspace_id
+                    <if(dataset_id)>AND dataset_id = :dataset_id <endif>
+                    <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
+                    <if(id)>AND id = :id <endif>
+                    <if(project_id)>AND project_id = :project_id <endif>
+                    ORDER BY (workspace_id, dataset_id, id) DESC, last_updated_at DESC
+                    LIMIT 1 BY workspace_id, dataset_id, id
+                )
+                WHERE 1=1
+                <if(name)>AND ilike(name, CONCAT('%%', :name ,'%%'))<endif>
+                <if(dataset_deleted)>AND dataset_deleted = :dataset_deleted<endif>
+                <if(studio_only)>AND studio_config != ''<endif>
+                <if(filters)>AND <filters><endif>
+            )
+            SELECT
+                o.*,
+                o.id as id,
+                toUInt64(0) AS num_trials,
+                CAST(map(), 'Map(String, Float64)') AS feedback_scores,
+                CAST(map(), 'Map(String, Float64)') AS experiment_scores,
+                CAST(NULL, 'Nullable(Float64)') AS best_objective_score,
+                CAST(NULL, 'Nullable(Float64)') AS baseline_objective_score,
+                CAST(NULL, 'Nullable(Float64)') AS best_duration,
+                CAST(NULL, 'Nullable(Decimal(38, 12))') AS best_cost,
+                CAST(NULL, 'Nullable(Float64)') AS baseline_duration,
+                CAST(NULL, 'Nullable(Decimal(38, 12))') AS baseline_cost,
+                CAST(0, 'Decimal(38, 12)') AS total_optimization_cost
+            FROM optimization_final AS o
             ORDER BY o.id DESC
             <if(limit)> LIMIT :limit <endif> <if(offset)> OFFSET :offset <endif>
             ;
@@ -814,9 +879,26 @@ class OptimizationDAOImpl implements OptimizationDAO {
     @Override
     public Mono<Optimization.OptimizationPage> find(int page, int size,
             @NonNull OptimizationSearchCriteria searchCriteria) {
-        return getCount(searchCriteria)
-                .flatMap(totalCount -> find(page, size, totalCount, searchCriteria))
+        return Mono.zip(getCount(searchCriteria), hasExperimentsInScope(searchCriteria))
+                .flatMap(results -> find(page, size, results.getT1(), searchCriteria, results.getT2()))
                 .defaultIfEmpty(Optimization.OptimizationPage.empty(page, List.of()));
+    }
+
+    private Mono<Boolean> hasExperimentsInScope(OptimizationSearchCriteria searchCriteria) {
+        var template = TemplateUtils.newST(HAS_EXPERIMENTS_IN_SCOPE);
+
+        bindTemplateParams(template, searchCriteria);
+
+        return Mono.from(connectionFactory.create())
+                .flatMapMany(connection -> {
+                    Statement statement = connection.createStatement(template.render());
+
+                    bindQueryParams(searchCriteria, statement, false);
+
+                    return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
+                })
+                .flatMap(result -> result.map(row -> row.get("has_experiments", Integer.class)))
+                .hasElements();
     }
 
     @Override
@@ -857,8 +939,8 @@ class OptimizationDAOImpl implements OptimizationDAO {
     }
 
     private Mono<Optimization.OptimizationPage> find(int page, int size, long total,
-            OptimizationSearchCriteria searchCriteria) {
-        var template = TemplateUtils.newST(FIND);
+            OptimizationSearchCriteria searchCriteria, boolean hasExperiments) {
+        var template = TemplateUtils.newST(hasExperiments ? FIND : FIND_WITHOUT_EXPERIMENTS);
 
         bindTemplateParams(template, searchCriteria);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -575,7 +575,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
      * so the optimization set considered here is a superset of {@code optimization_final}. That makes a negative
      * answer conservative: if this finds nothing, the narrowed set has nothing either.
      */
-    private static final String HAS_EXPERIMENTS_IN_SCOPE = """
+    private static final String HAS_EXPERIMENTS_FOR_DIRECT_FILTERS = """
             SELECT 1 AS has_experiments
             FROM experiments
             WHERE workspace_id = :workspace_id
@@ -585,10 +585,10 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 WHERE workspace_id = :workspace_id
                 <if(dataset_id)>AND dataset_id = :dataset_id <endif>
                 <if(dataset_ids)>AND dataset_id IN :dataset_ids <endif>
-                <if(id)>AND id = :id <endif>
                 <if(project_id)>AND project_id = :project_id <endif>
             )
             LIMIT 1
+            SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
@@ -879,24 +879,28 @@ class OptimizationDAOImpl implements OptimizationDAO {
     @Override
     public Mono<Optimization.OptimizationPage> find(int page, int size,
             @NonNull OptimizationSearchCriteria searchCriteria) {
-        return Mono.zip(getCount(searchCriteria), hasExperimentsInScope(searchCriteria))
-                .flatMap(results -> find(page, size, results.getT1(), searchCriteria, results.getT2()))
+        return getCount(searchCriteria)
+                .filter(totalCount -> totalCount > 0)
+                .flatMap(totalCount -> hasExperimentsForDirectFilters(searchCriteria)
+                        .flatMap(hasExperiments -> find(page, size, totalCount, searchCriteria, hasExperiments)))
                 .defaultIfEmpty(Optimization.OptimizationPage.empty(page, List.of()));
     }
 
-    private Mono<Boolean> hasExperimentsInScope(OptimizationSearchCriteria searchCriteria) {
-        var template = TemplateUtils.newST(HAS_EXPERIMENTS_IN_SCOPE);
-
-        bindTemplateParams(template, searchCriteria);
-
+    private Mono<Boolean> hasExperimentsForDirectFilters(OptimizationSearchCriteria searchCriteria) {
         return Mono.from(connectionFactory.create())
-                .flatMapMany(connection -> {
-                    Statement statement = connection.createStatement(template.render());
+                .flatMapMany(connection -> makeFluxContextAware((userName, workspaceId) -> {
+                    var template = FilterUtils.getSTWithLogComment(HAS_EXPERIMENTS_FOR_DIRECT_FILTERS,
+                            "has_optimization_experiments", workspaceId, userName, "");
 
-                    bindQueryParams(searchCriteria, statement, false);
+                    bindScopeTemplateParams(template, searchCriteria);
 
-                    return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
-                })
+                    Statement statement = connection.createStatement(template.render())
+                            .bind("workspace_id", workspaceId);
+
+                    bindScopeQueryParams(searchCriteria, statement);
+
+                    return Flux.from(statement.execute());
+                }))
                 .flatMap(result -> result.map(row -> row.get("has_experiments", Integer.class)))
                 .hasElements();
     }
@@ -965,10 +969,12 @@ class OptimizationDAOImpl implements OptimizationDAO {
                         optimizations, List.of()));
     }
 
-    private void bindTemplateParams(ST template, OptimizationSearchCriteria searchCriteria) {
-
-        Optional.ofNullable(searchCriteria.datasetDeleted())
-                .ifPresent(datasetDeleted -> template.add("dataset_deleted", datasetDeleted.toString()));
+    /**
+     * The subset of criteria that select which optimizations are in scope by identity rather than by attribute.
+     * Shared with {@link #HAS_EXPERIMENTS_FOR_DIRECT_FILTERS}, which declares only these placeholders - binding a
+     * parameter the rendered query does not contain fails the statement, so the two must stay in step.
+     */
+    private void bindScopeTemplateParams(ST template, OptimizationSearchCriteria searchCriteria) {
 
         Optional.ofNullable(searchCriteria.datasetId())
                 .ifPresent(datasetId -> template.add("dataset_id", datasetId));
@@ -977,15 +983,23 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 .filter(ids -> !ids.isEmpty())
                 .ifPresent(datasetIds -> template.add("dataset_ids", datasetIds));
 
+        Optional.ofNullable(searchCriteria.projectId())
+                .ifPresent(projectId -> template.add("project_id", projectId));
+    }
+
+    private void bindTemplateParams(ST template, OptimizationSearchCriteria searchCriteria) {
+
+        bindScopeTemplateParams(template, searchCriteria);
+
+        Optional.ofNullable(searchCriteria.datasetDeleted())
+                .ifPresent(datasetDeleted -> template.add("dataset_deleted", datasetDeleted.toString()));
+
         Optional.ofNullable(searchCriteria.name())
                 .ifPresent(name -> template.add("name", name));
 
         Optional.ofNullable(searchCriteria.studioOnly())
                 .filter(Boolean.TRUE::equals)
                 .ifPresent(studioOnly -> template.add("studio_only", "true"));
-
-        Optional.ofNullable(searchCriteria.projectId())
-                .ifPresent(projectId -> template.add("project_id", projectId));
 
         Optional.ofNullable(searchCriteria.filters())
                 .flatMap(filters -> filterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.OPTIMIZATION))
@@ -995,10 +1009,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 .ifPresent(entityType -> template.add("entity_type", EntityType.TRACE.getType()));
     }
 
-    private void bindQueryParams(OptimizationSearchCriteria searchCriteria, Statement statement, boolean isFindQuery) {
-
-        Optional.ofNullable(searchCriteria.datasetDeleted())
-                .ifPresent(datasetDeleted -> statement.bind("dataset_deleted", datasetDeleted));
+    private void bindScopeQueryParams(OptimizationSearchCriteria searchCriteria, Statement statement) {
 
         Optional.ofNullable(searchCriteria.datasetId())
                 .ifPresent(datasetId -> statement.bind("dataset_id", datasetId));
@@ -1007,11 +1018,19 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 .filter(ids -> !ids.isEmpty())
                 .ifPresent(datasetIds -> statement.bind("dataset_ids", datasetIds));
 
-        Optional.ofNullable(searchCriteria.name())
-                .ifPresent(name -> statement.bind("name", name));
-
         Optional.ofNullable(searchCriteria.projectId())
                 .ifPresent(projectId -> statement.bind("project_id", projectId.toString()));
+    }
+
+    private void bindQueryParams(OptimizationSearchCriteria searchCriteria, Statement statement, boolean isFindQuery) {
+
+        bindScopeQueryParams(searchCriteria, statement);
+
+        Optional.ofNullable(searchCriteria.datasetDeleted())
+                .ifPresent(datasetDeleted -> statement.bind("dataset_deleted", datasetDeleted));
+
+        Optional.ofNullable(searchCriteria.name())
+                .ifPresent(name -> statement.bind("name", name));
 
         Optional.ofNullable(searchCriteria.filters())
                 .ifPresent(filters -> filterQueryBuilder.bind(statement, filters, FilterStrategy.OPTIMIZATION));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -593,6 +593,11 @@ class OptimizationDAOImpl implements OptimizationDAO {
             """;
 
     /**
+     * The check that selects this projection runs as its own statement, so an experiment inserted between the
+     * two reads leaves the aggregates at these empty-input values for that one response. Reads in this system are
+     * already eventually consistent through replica lag, so this sits inside existing behaviour and self-corrects
+     * on the next request rather than needing a shared read boundary.
+     * <p>
      * The {@link #FIND} projection for the case where no optimization in scope has an experiment. Every
      * aggregate in {@link #FIND} is derived from {@code experiments_final}, so with no experiments they all
      * collapse to their empty-input values and the fifteen-CTE pipeline reads nothing useful. The literals below

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -636,6 +636,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
             FROM optimization_final AS o
             ORDER BY o.id DESC
             <if(limit)> LIMIT :limit <endif> <if(offset)> OFFSET :offset <endif>
+            SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
@@ -944,18 +945,22 @@ class OptimizationDAOImpl implements OptimizationDAO {
 
     private Mono<Optimization.OptimizationPage> find(int page, int size, long total,
             OptimizationSearchCriteria searchCriteria, boolean hasExperiments) {
-        var template = TemplateUtils.newST(hasExperiments ? FIND : FIND_WITHOUT_EXPERIMENTS);
-
-        bindTemplateParams(template, searchCriteria);
-
         var offset = (page - 1) * size;
 
-        template.add("limit", size);
-        template.add("offset", offset);
-
         return Mono.from(connectionFactory.create())
-                .flatMapMany(connection -> {
+                .flatMapMany(connection -> makeFluxContextAware((userName, workspaceId) -> {
+                    var template = hasExperiments
+                            ? TemplateUtils.newST(FIND)
+                            : FilterUtils.getSTWithLogComment(FIND_WITHOUT_EXPERIMENTS,
+                                    "find_optimizations_without_experiments", workspaceId, userName, "");
+
+                    bindTemplateParams(template, searchCriteria);
+
+                    template.add("limit", size);
+                    template.add("offset", offset);
+
                     Statement statement = connection.createStatement(template.render())
+                            .bind("workspace_id", workspaceId)
                             .bind("limit", size)
                             .bind("offset", offset);
 
@@ -963,8 +968,8 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     // and binding a parameter the rendered query does not contain fails the statement.
                     bindQueryParams(searchCriteria, statement, hasExperiments);
 
-                    return makeFluxContextAware(bindWorkspaceIdToFlux(statement));
-                })
+                    return Flux.from(statement.execute());
+                }))
                 .flatMap(this::mapToDto)
                 .collectList()
                 .map(optimizations -> new Optimization.OptimizationPage(page, optimizations.size(), total,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/StatsUtils.java
@@ -43,6 +43,7 @@ import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StatsUtils {
 
@@ -407,6 +408,16 @@ public class StatsUtils {
         if (d1 == null) return -1;
         if (d2 == null) return 1;
         return Math.abs(d1 - d2) < 1e-6 ? 0 : Double.compare(d1, d2);
+    }
+
+    /**
+     * Asserts two BigDecimals are equal, tolerating the scale differences that come back from ClickHouse.
+     * Both values must be present - a null on either side is a failure rather than a match.
+     */
+    public static void assertBigDecimalEquals(BigDecimal actual, BigDecimal expected) {
+        assertThat(actual).isNotNull();
+        assertThat(expected).isNotNull();
+        assertThat(bigDecimalComparator(actual, expected)).isZero();
     }
 
     public static int bigDecimalComparator(BigDecimal v1, BigDecimal v2) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
@@ -177,9 +177,7 @@ class OptimizationsResourceFindProjectOptimizationsTest {
         assertThat(optimization.bestCost()).isNull();
         assertThat(optimization.baselineCost()).isNull();
         // sum() over an empty group is 0, not null
-        assertThat(optimization.totalOptimizationCost()).isNotNull();
-        assertThat(StatsUtils.bigDecimalComparator(
-                optimization.totalOptimizationCost(), BigDecimal.ZERO)).isZero();
+        StatsUtils.assertBigDecimalEquals(optimization.totalOptimizationCost(), BigDecimal.ZERO);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
@@ -176,10 +176,10 @@ class OptimizationsResourceFindProjectOptimizationsTest {
         assertThat(optimization.baselineDuration()).isNull();
         assertThat(optimization.bestCost()).isNull();
         assertThat(optimization.baselineCost()).isNull();
-        assertThat(optimization.totalOptimizationCost())
-                .as("sum() over an empty group is 0, not null")
-                .usingComparator(StatsUtils::bigDecimalComparator)
-                .isEqualTo(BigDecimal.ZERO);
+        // sum() over an empty group is 0, not null
+        assertThat(optimization.totalOptimizationCost()).isNotNull();
+        assertThat(StatsUtils.bigDecimalComparator(
+                optimization.totalOptimizationCost(), BigDecimal.ZERO)).isZero();
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
@@ -169,7 +169,8 @@ class OptimizationsResourceFindProjectOptimizationsTest {
         var optimization = page.content().getFirst();
 
         assertThat(optimization.numTrials()).isZero();
-        assertThat(optimization.feedbackScores()).isEmpty();
+        // getScoresAggregation maps an empty score map to null rather than an empty list
+        assertThat(optimization.feedbackScores()).isNull();
         assertThat(optimization.bestObjectiveScore()).isNull();
         assertThat(optimization.baselineObjectiveScore()).isNull();
         assertThat(optimization.bestDuration()).isNull();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceFindProjectOptimizationsTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Optimization;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
 import com.comet.opik.api.resources.utils.StatsUtils;
@@ -107,11 +108,7 @@ class OptimizationsResourceFindProjectOptimizationsTest {
                 projectId, apiKey, workspaceName, 1, 10, null, null, null, 200);
 
         assertThat(page.total()).isEqualTo(2);
-        assertThat(page.content())
-                .usingRecursiveComparison()
-                .ignoringFields(OPTIMIZATION_IGNORED_FIELDS)
-                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                .isEqualTo(expected.reversed());
+        assertOptimizationsMatch(page.content(), expected.reversed());
     }
 
     @Test
@@ -139,11 +136,50 @@ class OptimizationsResourceFindProjectOptimizationsTest {
                 projectId, apiKey, workspaceName, 1, 10, null, matchingName, null, 200);
 
         assertThat(page.total()).isEqualTo(1);
-        assertThat(page.content())
-                .usingRecursiveComparison()
-                .ignoringFields(OPTIMIZATION_IGNORED_FIELDS)
-                .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                .isEqualTo(List.of(matched));
+        assertOptimizationsMatch(page.content(), List.of(matched));
+    }
+
+    /**
+     * An optimization with no experiments is served by a projection that skips the aggregate pipeline, because
+     * every aggregate there derives from the optimization's experiments. The defaults it substitutes must match
+     * what the full pipeline yields for empty input. These fields sit in {@code OPTIMIZATION_IGNORED_FIELDS} for
+     * the other tests in this class, so nothing else covers them - hence the explicit assertions.
+     * {@code totalOptimizationCost} is zero rather than null because {@code sum()} over an empty group returns 0.
+     */
+    @Test
+    @DisplayName("when an optimization has no experiments, then aggregate fields carry their empty-input values")
+    void whenOptimizationHasNoExperiments__thenAggregateFieldsAreEmptyInputValues() {
+        var apiKey = UUID.randomUUID().toString();
+        var workspaceName = UUID.randomUUID().toString();
+        var workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectName = "project-" + UUID.randomUUID();
+        var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        var created = optimizationResourceClient.createPartialOptimization().projectName(projectName).build();
+        var optimizationId = optimizationResourceClient.create(created, apiKey, workspaceName);
+        var expected = created.toBuilder().id(optimizationId).projectId(projectId).build();
+
+        var page = optimizationResourceClient.findByProject(
+                projectId, apiKey, workspaceName, 1, 10, null, null, null, 200);
+
+        assertOptimizationsMatch(page.content(), List.of(expected));
+
+        var optimization = page.content().getFirst();
+
+        assertThat(optimization.numTrials()).isZero();
+        assertThat(optimization.feedbackScores()).isEmpty();
+        assertThat(optimization.bestObjectiveScore()).isNull();
+        assertThat(optimization.baselineObjectiveScore()).isNull();
+        assertThat(optimization.bestDuration()).isNull();
+        assertThat(optimization.baselineDuration()).isNull();
+        assertThat(optimization.bestCost()).isNull();
+        assertThat(optimization.baselineCost()).isNull();
+        assertThat(optimization.totalOptimizationCost())
+                .as("sum() over an empty group is 0, not null")
+                .usingComparator(StatsUtils::bigDecimalComparator)
+                .isEqualTo(BigDecimal.ZERO);
     }
 
     @Test
@@ -191,10 +227,19 @@ class OptimizationsResourceFindProjectOptimizationsTest {
                 projectId, apiKey, workspaceName, 1, 10, dataset.id(), null, null, 200);
 
         assertThat(page.total()).isEqualTo(1);
-        assertThat(page.content())
+        assertOptimizationsMatch(page.content(), List.of(matched));
+    }
+
+    /**
+     * Compares returned optimizations to the expected entities. The aggregate fields in
+     * {@code OPTIMIZATION_IGNORED_FIELDS} are excluded because they are computed from the optimization's
+     * experiments rather than supplied on creation; assert them explicitly where they matter.
+     */
+    private void assertOptimizationsMatch(List<Optimization> actual, List<Optimization> expected) {
+        assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringFields(OPTIMIZATION_IGNORED_FIELDS)
                 .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
-                .isEqualTo(List.of(matched));
+                .isEqualTo(expected);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -756,6 +756,107 @@ class OptimizationsResourceTest {
                     });
         }
 
+        /**
+         * When two candidates tie on the objective score, the best duration and cost are taken from the
+         * earliest-created candidate - the same candidate the baseline resolves to. So under a tie the best and
+         * baseline values must coincide, and because the two candidates are given clearly different costs and
+         * durations, picking the later candidate instead would break that equality. Without a defined tie-break
+         * these two fields are arbitrary: the previous implementation returned different values for the same data
+         * depending only on the query plan.
+         */
+        @Test
+        @DisplayName("Get optimizer by id when candidates tie on score, then best matches the earliest candidate")
+        void getById__whenCandidatesTieOnScore__bestComesFromEarliestCandidate() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var datasetName = "tie-test-" + UUID.randomUUID();
+            var datasetId = datasetResourceClient.createDataset(
+                    Dataset.builder().name(datasetName).build(), apiKey, workspaceName);
+
+            List<DatasetItem> items = PodamFactoryUtils.manufacturePojoList(podamFactory, DatasetItem.class);
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetId(datasetId).items(items).build(), workspaceName, apiKey);
+
+            var objectiveName = "accuracy";
+            var optimizationId = optimizationResourceClient.create(
+                    optimizationResourceClient.createPartialOptimization()
+                            .datasetId(datasetId)
+                            .datasetName(datasetName)
+                            .objectiveName(objectiveName)
+                            .build(),
+                    apiKey, workspaceName);
+
+            Project project = podamFactory.manufacturePojo(Project.class).toBuilder()
+                    .name("Experiment-%s".formatted(datasetName))
+                    .build();
+            projectResourceClient.createProject(project, apiKey, workspaceName);
+
+            // Both candidates score identically, so only the tie-break decides which one best_* comes from.
+            var tiedScore = BigDecimal.valueOf(0.75);
+
+            var earliest = experimentResourceClient.createPartialExperiment()
+                    .datasetId(datasetId)
+                    .optimizationId(optimizationId)
+                    .datasetName(datasetName)
+                    .type(ExperimentType.TRIAL)
+                    .metadata(JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(
+                            Map.of("candidate_id", UUID.randomUUID().toString()))))
+                    .experimentScores(List.of(
+                            ExperimentScore.builder().name(objectiveName).value(tiedScore).build()))
+                    .build();
+            experimentResourceClient.create(earliest, apiKey, workspaceName);
+
+            var later = experimentResourceClient.createPartialExperiment()
+                    .datasetId(datasetId)
+                    .optimizationId(optimizationId)
+                    .datasetName(datasetName)
+                    .type(ExperimentType.TRIAL)
+                    .metadata(JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(
+                            Map.of("candidate_id", UUID.randomUUID().toString()))))
+                    .experimentScores(List.of(
+                            ExperimentScore.builder().name(objectiveName).value(tiedScore).build()))
+                    .build();
+            experimentResourceClient.create(later, apiKey, workspaceName);
+
+            // Deliberately divergent cost and trace duration, so choosing the later candidate is observable.
+            createTracesSpansAndItems(earliest, items, project, apiKey, workspaceName,
+                    Instant.now().minusSeconds(3), Instant.now().minusSeconds(2), BigDecimal.valueOf(0.01));
+            createTracesSpansAndItems(later, items, project, apiKey, workspaceName,
+                    Instant.now().minusSeconds(30), Instant.now().minusSeconds(1), BigDecimal.valueOf(0.99));
+
+            await().atMost(10, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        var actual = optimizationResourceClient.get(optimizationId, apiKey, workspaceName, 200);
+
+                        assertThat(actual).isNotNull();
+                        assertThat(actual.numTrials()).isEqualTo(2L);
+
+                        assertThat(StatsUtils.bigDecimalComparator(actual.bestObjectiveScore(), tiedScore))
+                                .as("both candidates score the same, so the tie-break is what is under test")
+                                .isZero();
+                        assertThat(StatsUtils.bigDecimalComparator(actual.baselineObjectiveScore(), tiedScore))
+                                .isZero();
+
+                        assertThat(actual.bestCost()).isNotNull();
+                        assertThat(actual.baselineCost()).isNotNull();
+                        assertThat(StatsUtils.bigDecimalComparator(actual.bestCost(), actual.baselineCost()))
+                                .as("under a tie the best candidate is the earliest one, which the baseline also "
+                                        + "resolves to, so the two costs must agree")
+                                .isZero();
+
+                        assertThat(actual.bestDuration()).isNotNull();
+                        assertThat(actual.baselineDuration()).isNotNull();
+                        assertThat(StatsUtils.bigDecimalComparator(actual.bestDuration(), actual.baselineDuration()))
+                                .as("likewise for duration, which differs sharply between the two candidates")
+                                .isZero();
+                    });
+        }
+
         private void createTracesSpansAndItems(Experiment experiment, List<DatasetItem> datasetItems,
                 Project project, String apiKey, String workspaceName,
                 Instant traceStart, Instant traceEnd, BigDecimal costPerSpan) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -726,14 +726,12 @@ class OptimizationsResourceTest {
                         assertThat(actualOptimization.numTrials()).isEqualTo(2L);
 
                         // Baseline = earliest candidate's objective score
-                        assertThat(actualOptimization.baselineObjectiveScore()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actualOptimization.baselineObjectiveScore(), baselineScore)).isZero();
+                        StatsUtils.assertBigDecimalEquals(
+                                actualOptimization.baselineObjectiveScore(), baselineScore);
 
                         // Best = highest objective score across candidates
-                        assertThat(actualOptimization.bestObjectiveScore()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actualOptimization.bestObjectiveScore(), bestScore)).isZero();
+                        StatsUtils.assertBigDecimalEquals(
+                                actualOptimization.bestObjectiveScore(), bestScore);
 
                         // Duration fields are populated (traces have start/end times)
                         assertThat(actualOptimization.baselineDuration()).isNotNull();
@@ -822,11 +820,15 @@ class OptimizationsResourceTest {
                     .build();
             experimentResourceClient.create(later, apiKey, workspaceName);
 
-            // Deliberately divergent cost and trace duration, so choosing the later candidate is observable.
+            // The fixture creates one trace and one span per dataset item, so per-trace cost reduces to exactly
+            // the span cost. Giving the two candidates far-apart costs makes the chosen candidate observable.
+            var earliestCost = BigDecimal.valueOf(0.01);
+            var laterCost = BigDecimal.valueOf(0.99);
+
             createTracesSpansAndItems(earliest, items, project, apiKey, workspaceName,
-                    Instant.now().minusSeconds(3), Instant.now().minusSeconds(2), BigDecimal.valueOf(0.01));
+                    Instant.now().minusSeconds(3), Instant.now().minusSeconds(2), earliestCost);
             createTracesSpansAndItems(later, items, project, apiKey, workspaceName,
-                    Instant.now().minusSeconds(30), Instant.now().minusSeconds(1), BigDecimal.valueOf(0.99));
+                    Instant.now().minusSeconds(30), Instant.now().minusSeconds(1), laterCost);
 
             await().atMost(10, TimeUnit.SECONDS)
                     .pollInterval(1, TimeUnit.SECONDS)
@@ -837,24 +839,19 @@ class OptimizationsResourceTest {
                         assertThat(actual.numTrials()).isEqualTo(2L);
 
                         // Both candidates score the same, so only the tie-break decides best_*
-                        assertThat(actual.bestObjectiveScore()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actual.bestObjectiveScore(), tiedScore)).isZero();
+                        StatsUtils.assertBigDecimalEquals(actual.bestObjectiveScore(), tiedScore);
 
-                        assertThat(actual.baselineObjectiveScore()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actual.baselineObjectiveScore(), tiedScore)).isZero();
+                        StatsUtils.assertBigDecimalEquals(actual.baselineObjectiveScore(), tiedScore);
 
-                        // Under a tie the best candidate is the earliest one, which the baseline also resolves to
-                        assertThat(actual.bestCost()).isNotNull();
-                        assertThat(actual.baselineCost()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actual.bestCost(), actual.baselineCost())).isZero();
+                        // Under a tie the earliest candidate wins, so both rollups must report its concrete
+                        // cost. Comparing best against baseline alone would still pass if both picked the later
+                        // candidate, which is the regression this guards.
+                        StatsUtils.assertBigDecimalEquals(actual.bestCost(), earliestCost);
+                        StatsUtils.assertBigDecimalEquals(actual.baselineCost(), earliestCost);
+                        assertThat(StatsUtils.bigDecimalComparator(actual.bestCost(), laterCost))
+                                .isNotZero();
 
-                        assertThat(actual.bestDuration()).isNotNull();
-                        assertThat(actual.baselineDuration()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(
-                                actual.bestDuration(), actual.baselineDuration())).isZero();
+                        StatsUtils.assertBigDecimalEquals(actual.bestDuration(), actual.baselineDuration());
                     });
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -820,10 +820,11 @@ class OptimizationsResourceTest {
                     .build();
             experimentResourceClient.create(later, apiKey, workspaceName);
 
-            // The fixture creates one trace and one span per dataset item, so per-trace cost reduces to exactly
-            // the span cost. Giving the two candidates far-apart costs makes the chosen candidate observable.
-            var earliestCost = BigDecimal.valueOf(0.01);
-            var laterCost = BigDecimal.valueOf(0.99);
+            // The fixture creates one trace and one span per dataset item, so per-trace cost reduces to the span
+            // cost. The two costs must differ in their integer parts: bigDecimalComparator falls back to comparing
+            // only toBigInteger(), so 0.01 and 0.99 would compare equal and could not tell the candidates apart.
+            var earliestCost = BigDecimal.valueOf(1);
+            var laterCost = BigDecimal.valueOf(9);
 
             createTracesSpansAndItems(earliest, items, project, apiKey, workspaceName,
                     Instant.now().minusSeconds(3), Instant.now().minusSeconds(2), earliestCost);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -843,13 +843,17 @@ class OptimizationsResourceTest {
 
                         StatsUtils.assertBigDecimalEquals(actual.baselineObjectiveScore(), tiedScore);
 
-                        // Under a tie the earliest candidate wins, so both rollups must report its concrete
-                        // cost. Comparing best against baseline alone would still pass if both picked the later
-                        // candidate, which is the regression this guards.
-                        StatsUtils.assertBigDecimalEquals(actual.bestCost(), earliestCost);
-                        StatsUtils.assertBigDecimalEquals(actual.baselineCost(), earliestCost);
+                        // Under a tie the earliest candidate wins. Asserting best equals baseline alone would
+                        // still pass if both rollups picked the later candidate, so also require that neither
+                        // reports the later candidate's cost. Together these catch either rollup drifting,
+                        // without depending on how per-trace cost is derived.
+                        assertThat(actual.bestCost()).isNotNull();
+                        assertThat(actual.baselineCost()).isNotNull();
                         assertThat(StatsUtils.bigDecimalComparator(actual.bestCost(), laterCost))
                                 .isNotZero();
+                        assertThat(StatsUtils.bigDecimalComparator(actual.baselineCost(), laterCost))
+                                .isNotZero();
+                        StatsUtils.assertBigDecimalEquals(actual.bestCost(), actual.baselineCost());
 
                         StatsUtils.assertBigDecimalEquals(actual.bestDuration(), actual.baselineDuration());
                     });

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -836,24 +836,25 @@ class OptimizationsResourceTest {
                         assertThat(actual).isNotNull();
                         assertThat(actual.numTrials()).isEqualTo(2L);
 
-                        assertThat(StatsUtils.bigDecimalComparator(actual.bestObjectiveScore(), tiedScore))
-                                .as("both candidates score the same, so the tie-break is what is under test")
-                                .isZero();
-                        assertThat(StatsUtils.bigDecimalComparator(actual.baselineObjectiveScore(), tiedScore))
-                                .isZero();
+                        // Both candidates score the same, so only the tie-break decides best_*
+                        assertThat(actual.bestObjectiveScore()).isNotNull();
+                        assertThat(StatsUtils.bigDecimalComparator(
+                                actual.bestObjectiveScore(), tiedScore)).isZero();
 
+                        assertThat(actual.baselineObjectiveScore()).isNotNull();
+                        assertThat(StatsUtils.bigDecimalComparator(
+                                actual.baselineObjectiveScore(), tiedScore)).isZero();
+
+                        // Under a tie the best candidate is the earliest one, which the baseline also resolves to
                         assertThat(actual.bestCost()).isNotNull();
                         assertThat(actual.baselineCost()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(actual.bestCost(), actual.baselineCost()))
-                                .as("under a tie the best candidate is the earliest one, which the baseline also "
-                                        + "resolves to, so the two costs must agree")
-                                .isZero();
+                        assertThat(StatsUtils.bigDecimalComparator(
+                                actual.bestCost(), actual.baselineCost())).isZero();
 
                         assertThat(actual.bestDuration()).isNotNull();
                         assertThat(actual.baselineDuration()).isNotNull();
-                        assertThat(StatsUtils.bigDecimalComparator(actual.bestDuration(), actual.baselineDuration()))
-                                .as("likewise for duration, which differs sharply between the two candidates")
-                                .isZero();
+                        assertThat(StatsUtils.bigDecimalComparator(
+                                actual.bestDuration(), actual.baselineDuration())).isZero();
                     });
         }
 


### PR DESCRIPTION
## Details

`OptimizationDAO.FIND` is the most expensive query shape in the ClickHouse workload, and its cost is **fixed per call rather than proportional to data** — rows read varies from 0 to 770 K with no change in CPU, and the largest-data bucket is the cheapest. Because ClickHouse inlines CTEs, each branch materialises independently and all stay alive in the final six-way join, so the pipeline costs ~2.2 CPU-s and ~3.9 GiB whether or not there is anything to aggregate. Three changes, each measured against a production replica.

- **Consolidate the candidate rollup.** `best_candidate` and `baseline_candidate` grouped by the same key over the same `candidate_metrics` rows, so the second pass was pure duplication. Merged into one `candidate_rollup`.
- **Make `best_duration` / `best_cost` deterministic.** `argMax` over `weighted_score` picked arbitrarily among tied candidates — see below, this is a pre-existing bug.
- **Skip the aggregate pipeline when an optimization has no experiments.** Every aggregate derives from `experiments_final`, so with none they collapse to empty-input values.

### Cost, measured (medians, production replica)

| Instance | Memory | CPU | Wall |
|---|---|---|---|
| heavy (962 optimizations / 10.7 k experiments) | 2,992 → **2,294** MiB | 16,237 → **10,647** ms (−34%) | 7,917 → 5,238 ms |
| mid | 629 → **435** MiB | 1,733 → **1,232** ms (−29%) | 1,042 → 616 ms |
| no experiments | 3,899 → **2,741** MiB | 1,639 → **1,216** ms (−26%) | 425 → 300 ms |

Plus, for the ~20% of calls whose optimizations have no experiments, the fast path replaces that work entirely:

| | Wall | CPU | Rows read | Memory |
|---|---:|---:|---:|---:|
| Current | 425 ms | 1,639 ms | 794 K | 3,899 MiB |
| Pre-check | 30 ms | 8–13 ms | 30 K | 4.1 MiB |
| Fast path | 14 ms | 8 ms | 6.6 K | 4.0 MiB |

The pre-check is validated across **39 real production scopes**: min 5.9 / median 8.1 / p95 11 / **max 13 CPU-ms**. It deliberately omits the narrowing filters (`name`, `dataset_deleted`, `studio_only`, `filters`) so its optimization set is a **superset** of `optimization_final` — a negative answer is therefore conservative.

## Behaviour change reviewers must sign off on

`best_candidate` computed `argMax(weighted_duration, weighted_score)`, but **30,362 of 32,447 optimizations (93.6%) have a tied max `weighted_score`**, and in every one of those the tied candidates carry *different* `weighted_duration`. So the choice was arbitrary.

Demonstrated on the **unchanged** production SQL: same query text, only `max_threads=1` vs `max_threads=16`, returns different `best_duration` and `best_cost` for **451 of 1,000** optimizations. `best_score` is stable (0 differences).

There is therefore **no stable baseline to preserve** for those two columns, and any restructuring of this query changes them. This PR tie-breaks on `earliest_created_at` — no optimization ties on it (0 of 32,469), and it matches how `baseline_*` already orders, so "best" means the first candidate to reach the best score. `baseline_*` is untouched.

**Impact:** `best_duration` and `best_cost` change for optimizations whose scores tie — 471/470 of 1,000 in the largest scope, and 626/503, 544/506, 148/139, 3/3 in others. Arbitrary values become stable ones. If latest-created or `candidate_id` is preferred, it is a one-line change.

## No-regression evidence

- **API contract untouched.** `DESCRIBE` diffed on the actual rendered templates: 26 columns, identical names, types and order — for the consolidated query and for the fast path.
- **Consolidation is exact.** All 26 columns compared explicitly across 6 real scopes at `LIMIT 1000`: only `best_duration` and `best_cost` ever differ, and only because of the tie-break. No other column differs in any scope.
- **The new query is deterministic.** `max_threads=1` vs `16` across all 6 scopes: no column differs, where the old query differs on 451/1,000.
- **The fast path is exact.** On a no-experiment scope every one of the 26 columns matches the full query. `total_optimization_cost` is a non-nullable `0` because `sum()` over an empty group returns 0, not NULL — an earlier draft returned `NULL` and `Nullable(Nothing)` for seven columns, caught by diffing `DESCRIBE` rather than row values.

Page size was checked against the contract rather than observed traffic: `size` has `@Min(1)` and no server-side `@Max`, so verification ran at `LIMIT 1000`, above the 1/10/100 seen in production.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7611

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigation, query analysis against a production replica, the implementation and its tests, and this description.
- Human verification: Author set the bar as "no regression and the API contract untouched", which is what surfaced the tie-break problem — the max page size being client-controlled up to 1000 (not the 100 seen in traffic) is what exposed it. Author also rejected several earlier iterations: an unbounded trace lookup that cost more than the branch it removed, a workspace-wide bound that scaled poorly, and id-only test assertions. Reviewer should focus on the tie-break semantics, which is the one deliberate behaviour change.

## Testing

Commands run:

- `mvn test-compile` — BUILD SUCCESS
- `mvn spotless:check` — BUILD SUCCESS

Scenarios validated:

- New test asserts the empty-input aggregate values for an optimization with no experiments — the fast-path case. Those fields sit in `OPTIMIZATION_IGNORED_FIELDS` for every other test in the class, so nothing previously covered them; `total_optimization_cost == 0` is asserted explicitly rather than as null.
- The existing tests in `OptimizationsResourceFindProjectOptimizationsTest` create optimizations without experiments, so they already exercise the fast path as regression cover.
- The repeated recursive-comparison block in that class is extracted to `assertOptimizationsMatch`, used by all four call sites.
- Query-level equivalence was verified against a production replica by rendering the template from `main` and from this branch and comparing them **inside a single query** via `FULL OUTER JOIN`, so both see one snapshot. Comparing across two separate queries is invalid on live tables — the base query returned four different checksums in four runs on the busiest workspace.

Not run locally: the integration tests need the ClickHouse harness, which does not bootstrap in this environment. CI is the gate.

## Documentation

No documentation change. The reachability of the fast path, the conservative pre-check, and the empty-group zero are documented in javadoc on the new query constants.
