### PR TITLE
[OPIK-7483] [BE] fix: eliminate project-less trace deletes

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/BatchDeleteByProject.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/BatchDeleteByProject.java
@@ -13,5 +13,5 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BatchDeleteByProject(@NotNull @Size(min = 1, max = 1000) Set<UUID> ids, UUID projectId) {
+public record BatchDeleteByProject(@NotNull @Size(min = 1, max = 1000) Set<@NotNull UUID> ids, UUID projectId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/BatchDeleteByProject.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/BatchDeleteByProject.java
@@ -3,6 +3,7 @@ package com.comet.opik.api;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -13,5 +14,7 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record BatchDeleteByProject(@NotNull @Size(min = 1, max = 1000) Set<@NotNull UUID> ids, UUID projectId) {
+public record BatchDeleteByProject(
+        @NotNull @Size(min = 1, max = 1000) @Schema(description = "Ids of the traces to delete") Set<@NotNull UUID> ids,
+        @Schema(description = "Optional. Scopes the deletion to this project. When omitted, each trace's owning project is resolved automatically and the trace is deleted under its full key, so a trace can be deleted without knowing its project.") UUID projectId) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceDeletedListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/TraceDeletedListener.java
@@ -73,8 +73,9 @@ public class TraceDeletedListener {
         log.info("Starting deletion of related entities for traces, count '{}'", traceIds.size());
 
         return feedbackScoreService.deleteByTraceIds(traceIds, projectId)
-                .then(Mono.defer(() -> commentService.deleteByEntityIds(CommentDAO.EntityType.TRACE, traceIds)))
-                .then(Mono.defer(() -> attachmentService.deleteByEntityIds(TRACE, traceIds)))
+                .then(Mono.defer(() -> commentService.deleteByEntityIds(CommentDAO.EntityType.TRACE, traceIds,
+                        projectId)))
+                .then(Mono.defer(() -> attachmentService.deleteByEntityIds(TRACE, traceIds, projectId)))
                 .then(Mono.defer(() -> spanService.deleteByTraceIds(traceIds, projectId)));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -393,7 +393,7 @@ public class TracesResource {
             @ApiResponse(responseCode = "204", description = "No Content")})
     @RequiredPermissions(WorkspaceUserPermission.TRACE_DELETE)
     public Response deleteTraces(
-            @RequestBody(content = @Content(schema = @Schema(implementation = BatchDelete.class))) @NotNull @Valid BatchDeleteByProject request) {
+            @RequestBody(content = @Content(schema = @Schema(implementation = BatchDeleteByProject.class))) @NotNull @Valid BatchDeleteByProject request) {
         log.info("Deleting traces, project id '{}' and count '{}'", request.projectId(), request.ids().size());
         service.delete(request.ids(), request.projectId())
                 .contextWrite(ctx -> setRequestContext(ctx, requestContext))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/TracesResource.java
@@ -390,7 +390,8 @@ public class TracesResource {
     @POST
     @Path("/delete")
     @Operation(operationId = "deleteTraces", summary = "Delete traces", description = "Delete traces", responses = {
-            @ApiResponse(responseCode = "204", description = "No Content")})
+            @ApiResponse(responseCode = "204", description = "No Content"),
+            @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))})
     @RequiredPermissions(WorkspaceUserPermission.TRACE_DELETE)
     public Response deleteTraces(
             @RequestBody(content = @Content(schema = @Schema(implementation = BatchDeleteByProject.class))) @NotNull @Valid BatchDeleteByProject request) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentDAO.java
@@ -49,7 +49,7 @@ public interface CommentDAO {
 
     Mono<Long> deleteByEntityId(EntityType entityType, UUID entityId);
 
-    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds);
+    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds, UUID projectId);
 
     Flux<CommentEntityRef> getEntityRefsByCommentIds(Set<UUID> commentIds);
 }
@@ -133,6 +133,7 @@ class CommentDAOImpl implements CommentDAO {
             WHERE entity_id IN :entity_ids
             AND entity_type = :entity_type
             AND workspace_id = :workspace_id
+            <if(project_id)>AND project_id = :project_id<endif>
             ;
             """;
 
@@ -211,21 +212,30 @@ class CommentDAOImpl implements CommentDAO {
 
     @Override
     public Mono<Long> deleteByEntityId(@NonNull EntityType entityType, @NonNull UUID entityId) {
-        return deleteByEntityIds(entityType, Set.of(entityId));
+        return deleteByEntityIds(entityType, Set.of(entityId), null);
     }
 
     @Override
-    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, @NonNull Set<UUID> entityIds) {
-        log.info("Deleting comments for entityType '{}', entityIds count '{}'", entityType, entityIds.size());
+    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, @NonNull Set<UUID> entityIds, UUID projectId) {
+        log.info("Deleting comments for entityType '{}', entityIds count '{}', project id '{}'", entityType,
+                entityIds.size(), projectId);
         if (entityIds.isEmpty()) {
             return Mono.just(0L);
         }
 
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(DELETE_COMMENT_BY_ENTITY_IDS)
+            var template = TemplateUtils.newST(DELETE_COMMENT_BY_ENTITY_IDS);
+            if (projectId != null) {
+                template.add("project_id", projectId);
+            }
+
+            var statement = connection.createStatement(template.render())
                     .bind("entity_ids", entityIds)
                     .bind("entity_type", entityType.getType());
+            if (projectId != null) {
+                statement.bind("project_id", projectId);
+            }
 
             return makeMonoContextAware(bindWorkspaceIdToMono(statement))
                     .flatMapMany(Result::getRowsUpdated)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CommentService.java
@@ -36,7 +36,7 @@ public interface CommentService {
 
     Mono<Void> delete(BatchDelete batchDelete);
 
-    Mono<Long> deleteByEntityIds(CommentDAO.EntityType entityType, Set<UUID> entityIds);
+    Mono<Long> deleteByEntityIds(CommentDAO.EntityType entityType, Set<UUID> entityIds, UUID projectId);
 }
 
 @Slf4j
@@ -153,15 +153,16 @@ class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public Mono<Long> deleteByEntityIds(CommentDAO.EntityType entityType, Set<UUID> entityIds) {
-        if (entityIds.isEmpty()) {
+    public Mono<Long> deleteByEntityIds(@NonNull CommentDAO.EntityType entityType, Set<UUID> entityIds,
+            UUID projectId) {
+        if (CollectionUtils.isEmpty(entityIds)) {
             return Mono.just(0L);
         }
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
             String userName = ctx.get(RequestContext.USER_NAME);
 
-            return commentDAO.deleteByEntityIds(entityType, entityIds)
+            return commentDAO.deleteByEntityIds(entityType, entityIds, projectId)
                     .doOnSuccess(__ -> eventBus.post(
                             new CommentsDeleted(entityIds, toEntityType(entityType), workspaceId, userName)));
         });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -542,9 +542,9 @@ public class SpanService {
                         if (spanIds.isEmpty()) {
                             return Mono.empty();
                         }
-                        return commentService.deleteByEntityIds(CommentDAO.EntityType.SPAN, spanIds)
+                        return commentService.deleteByEntityIds(CommentDAO.EntityType.SPAN, spanIds, projectId)
                                 .then(Mono.defer(() -> feedbackScoreService.deleteBySpanIds(spanIds, projectId)))
-                                .then(Mono.defer(() -> attachmentService.deleteByEntityIds(SPAN, spanIds)))
+                                .then(Mono.defer(() -> attachmentService.deleteByEntityIds(SPAN, spanIds, projectId)))
                                 .then(spanDAO.deleteByIds(spanIds, projectId)
                                         .doOnSuccess(__ -> log.info(
                                                 "Deleted '{}' spans for workspace '{}', project '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -36,6 +36,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
@@ -77,6 +78,7 @@ import static com.comet.opik.api.TraceCountResponse.WorkspaceTraceCount;
 import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspace;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
 import static com.comet.opik.domain.stats.StatsMapper.mapProjectScoresStats;
+import static com.comet.opik.infrastructure.FilterUtils.ANALYTICS_DELETE_BATCH_SIZE;
 import static com.comet.opik.infrastructure.FilterUtils.addSortNeedsWideFlag;
 import static com.comet.opik.infrastructure.FilterUtils.bindTraceThreadSearchCriteria;
 import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
@@ -104,7 +106,7 @@ public interface TraceDAO {
 
     Mono<Void> update(TraceUpdate traceUpdate, UUID id, Connection connection);
 
-    Mono<Void> delete(Set<UUID> ids, UUID projectId, Connection connection);
+    Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, Connection connection);
 
     Mono<Trace> findById(UUID id, Connection connection);
 
@@ -1881,18 +1883,23 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     /**
-     * Always filters by the full {@code (workspace_id, project_id, id)} sort key. {@code project_id} is mandatory:
-     * the delete path resolves each id's owning project(s) up front and issues one delete per project group, so a
-     * delete never ignores part of the dedup key and over-deletes a reused id across projects (OPIK-7483). A
-     * project-less delete is also unsupported once {@code traces} is a Distributed table (OPIK-7455). It carries no
-     * {@code id_at}/time predicate on purpose, so it still deletes rows whose {@code id_at} is untrustworthy (e.g. a
-     * wrapped timestamp) - unlike the partition-pruned resolver, correctness here does not depend on {@code id_at}.
+     * Deletes by the full {@code (workspace_id, project_id, id)} sort key, matching on {@code (project_id, id)} tuples
+     * so a single statement can span several projects (e.g. a reused id resolved to all its owning projects, or a
+     * cross-project batch) instead of one delete per project (OPIK-7483). Every deleted row carries its {@code
+     * project_id}, so no delete is ever project-less - also required once {@code traces} is a Distributed table
+     * (OPIK-7455). No {@code id_at}/time predicate on purpose, so it still deletes rows whose {@code id_at} is
+     * untrustworthy (e.g. a wrapped timestamp); correctness here does not depend on {@code id_at}.
+     * <p>
+     * The pairs are bound (never inlined) as two positional string arrays and zipped back into {@code (project_id, id)}
+     * tuples with {@code arrayZip}, so the query text is constant regardless of batch size and no value reaches the SQL
+     * as a literal. {@code arrayZip} is a deterministic function, not a subquery - ClickHouse rejects subqueries in
+     * delete mutations. Callers batch to keep each array within the driver's reliable bind size ({@link
+     * com.comet.opik.infrastructure.FilterUtils#ANALYTICS_DELETE_BATCH_SIZE}).
      */
-    private static final String DELETE_BY_ID = """
+    private static final String DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS = """
             DELETE FROM traces
-            WHERE id IN :ids
-            AND workspace_id = :workspace_id
-            AND project_id = :project_id
+            WHERE workspace_id = :workspace_id
+            AND (project_id, id) IN arrayZip(:project_ids, :trace_ids)
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -2160,8 +2167,10 @@ class TraceDAOImpl implements TraceDAO {
      * owning projects - unlike {@code SELECT_PROJECT_IDS_BY_TRACE_IDS}'s {@code any(project_id)} - so the delete path
      * removes it from each under the full sort key (OPIK-7483). {@code DISTINCT} (not FINAL) suffices: lightweight-delete
      * masks are honored at read time, so a deleted pair never surfaces and a live pair always does, regardless of
-     * version. Has no time predicate, so it reads every partition; the delete path uses it only as the fallback for the
-     * ids the bounded pass could not resolve, keeping that scan minimal.
+     * version. Has no time predicate, so it resolves rows regardless of {@code id_at}; the delete path uses it only as
+     * the fallback for the ids the bounded pass could not resolve (malformed wrapped-{@code id_at} rows). Prunes
+     * granules on the {@code idx_traces_id_bf} bloom-filter index (migration 000113): the {@code id IN} lookup skips
+     * granules holding none of the ids instead of scanning the whole workspace, keeping the fallback cheap.
      */
     private static final String SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS = """
             SELECT DISTINCT id, project_id
@@ -2173,12 +2182,13 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     /**
-     * Partition-pruned fast pass of {@code SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS}. Bounds {@code toMonday(id_at)} (the
-     * future weekly partition key; {@code id_at} is MATERIALIZED from the UUIDv7 id, migration 000091) to the id set's
-     * own min/max, so it reads only the ids' own weekly partitions instead of every partition. For well-formed UUIDv7
-     * ids {@code id_at} is monotonic in id, so the window resolves them all; malformed ids whose {@code id_at} is not
-     * monotonic (e.g. a wrapped timestamp, OPIK-7456) can fall outside it, so the delete path re-resolves whatever this
-     * pass leaves unresolved via the unbounded query - the bounded query is never the sole resolver for a delete.
+     * Partition-pruning fast pass of {@code SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS}. Constrains {@code toMonday(id_at)}
+     * ({@code id_at} is MATERIALIZED from the UUIDv7 id, migration 000091) to the id set's own min/max week and, like
+     * the unbounded query, prunes granules on the {@code idx_traces_id_bf} bloom index. The week window is a no-op on
+     * the current unpartitioned table but prunes partitions once {@code traces} is partitioned. Well-formed UUIDv7 ids
+     * have {@code id_at} monotonic in id, so the window resolves them; a malformed id whose {@code id_at} wrapped
+     * (OPIK-7456) can fall outside it and is re-resolved by the unbounded fallback, so the bounded query is never a
+     * delete's sole resolver.
      */
     private static final String SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS_BOUNDED = """
             SELECT DISTINCT id, project_id
@@ -3433,24 +3443,32 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     @WithSpan
-    public Mono<Void> delete(Set<UUID> ids, UUID projectId, @NonNull Connection connection) {
-        Preconditions.checkArgument(CollectionUtils.isNotEmpty(ids), "Argument 'ids' must not be empty");
-        log.info("Deleting traces, count '{}', project id '{}'", ids.size(), projectId);
+    public Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, @NonNull Connection connection) {
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(projectIdTraceIdPairs),
+                "Argument 'projectIdTraceIdPairs' must not be empty");
+        log.info("Deleting traces by (project_id, id) pairs, count '{}'", projectIdTraceIdPairs.size());
 
-        return makeMonoContextAware((userName, workspaceId) -> {
-            var template = getSTWithLogComment(DELETE_BY_ID, "delete_traces", workspaceId, userName,
-                    "trace_ids_size=%s, project_id=%s".formatted(ids.size(), projectId));
+        return makeMonoContextAware((userName, workspaceId) -> Flux
+                .fromIterable(Lists.partition(List.copyOf(projectIdTraceIdPairs), ANALYTICS_DELETE_BATCH_SIZE))
+                .concatMap(batch -> {
+                    var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces",
+                            workspaceId,
+                            userName, "pairs_size=%s".formatted(batch.size()));
 
-            var statement = connection.createStatement(template.render())
-                    .bind("ids", ids.toArray(UUID[]::new))
-                    .bind("project_id", projectId)
-                    .bind("workspace_id", workspaceId);
+                    var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
+                    var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
 
-            var segment = startSegment("traces", "Clickhouse", "delete");
-            return Mono.from(statement.execute())
-                    .doFinally(signalType -> endSegment(segment))
-                    .then();
-        });
+                    var statement = connection.createStatement(template.render())
+                            .bind("workspace_id", workspaceId)
+                            .bind("project_ids", projectIds)
+                            .bind("trace_ids", traceIds);
+
+                    var segment = startSegment("traces", "Clickhouse", "delete");
+                    return Mono.from(statement.execute())
+                            .doFinally(_ -> endSegment(segment))
+                            .then();
+                })
+                .then());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -132,7 +132,9 @@ public interface TraceDAO {
 
     Mono<Map<UUID, UUID>> getProjectIdsByTraceIds(List<UUID> traceIds);
 
-    Mono<Map<UUID, UUID>> getProjectIdsByTraceIdsBounded(Set<UUID> traceIds);
+    Mono<Map<UUID, Set<UUID>>> getAllProjectIdsByTraceIds(Set<UUID> traceIds);
+
+    Mono<Map<UUID, Set<UUID>>> getAllProjectIdsByTraceIdsBounded(Set<UUID> traceIds);
 
     Mono<Map<UUID, Instant>> getStartTimesByTraceIds(Set<UUID> traceIds, String workspaceId);
 
@@ -1878,11 +1880,19 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
+    /**
+     * Always filters by the full {@code (workspace_id, project_id, id)} sort key. {@code project_id} is mandatory:
+     * the delete path resolves each id's owning project(s) up front and issues one delete per project group, so a
+     * delete never ignores part of the dedup key and over-deletes a reused id across projects (OPIK-7483). A
+     * project-less delete is also unsupported once {@code traces} is a Distributed table (OPIK-7455). It carries no
+     * {@code id_at}/time predicate on purpose, so it still deletes rows whose {@code id_at} is untrustworthy (e.g. a
+     * wrapped timestamp) - unlike the partition-pruned resolver, correctness here does not depend on {@code id_at}.
+     */
     private static final String DELETE_BY_ID = """
             DELETE FROM traces
             WHERE id IN :ids
             AND workspace_id = :workspace_id
-            <if(project_id)>AND project_id = :project_id<endif>
+            AND project_id = :project_id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -2146,21 +2156,37 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     /**
-     * Partition-bounded variant used on the delete path. id_at is MATERIALIZED as
-     * UUIDv7ToDateTime(toUUID(id)) (migration 000091), so bounding toMonday(id_at) by the id set's own
-     * min/max (mirrors SELECT_PROJECT_ID_FROM_TRACE) is exact - it never drops a valid id - while keeping
-     * the lookup on the ids' own weekly partitions instead of scanning all cold history once traces tier.
+     * Resolves every distinct {@code (id, project_id)} pair for a set of trace ids. A reused id maps to <b>all</b> its
+     * owning projects - unlike {@code SELECT_PROJECT_IDS_BY_TRACE_IDS}'s {@code any(project_id)} - so the delete path
+     * removes it from each under the full sort key (OPIK-7483). {@code DISTINCT} (not FINAL) suffices: lightweight-delete
+     * masks are honored at read time, so a deleted pair never surfaces and a live pair always does, regardless of
+     * version. Has no time predicate, so it reads every partition; the delete path uses it only as the fallback for the
+     * ids the bounded pass could not resolve, keeping that scan minimal.
      */
-    private static final String SELECT_PROJECT_IDS_BY_TRACE_IDS_BOUNDED = """
-            SELECT
-                id,
-                any(project_id) AS project_id
+    private static final String SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS = """
+            SELECT DISTINCT id, project_id
+            FROM traces
+            WHERE id IN :trace_ids
+            AND workspace_id = :workspace_id
+            SETTINGS log_comment = '<log_comment>'
+            ;
+            """;
+
+    /**
+     * Partition-pruned fast pass of {@code SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS}. Bounds {@code toMonday(id_at)} (the
+     * future weekly partition key; {@code id_at} is MATERIALIZED from the UUIDv7 id, migration 000091) to the id set's
+     * own min/max, so it reads only the ids' own weekly partitions instead of every partition. For well-formed UUIDv7
+     * ids {@code id_at} is monotonic in id, so the window resolves them all; malformed ids whose {@code id_at} is not
+     * monotonic (e.g. a wrapped timestamp, OPIK-7456) can fall outside it, so the delete path re-resolves whatever this
+     * pass leaves unresolved via the unbounded query - the bounded query is never the sole resolver for a delete.
+     */
+    private static final String SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS_BOUNDED = """
+            SELECT DISTINCT id, project_id
             FROM traces
             WHERE id IN :trace_ids
             AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:min_id), 'UTC'))
             AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:max_id), 'UTC'))
             AND workspace_id = :workspace_id
-            GROUP BY id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -3407,24 +3433,18 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     @WithSpan
-    public Mono<Void> delete(@NonNull Set<UUID> ids, UUID projectId, @NonNull Connection connection) {
+    public Mono<Void> delete(Set<UUID> ids, UUID projectId, @NonNull Connection connection) {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(ids), "Argument 'ids' must not be empty");
-        log.info("Deleting traces, count '{}'{}", ids.size(),
-                projectId != null ? " for project id '" + projectId + "'" : "");
+        log.info("Deleting traces, count '{}', project id '{}'", ids.size(), projectId);
 
         return makeMonoContextAware((userName, workspaceId) -> {
-            var template = getSTWithLogComment(DELETE_BY_ID, "delete_traces", workspaceId, userName, ids.size());
-            Optional.ofNullable(projectId)
-                    .ifPresent(id -> template.add("project_id", id));
+            var template = getSTWithLogComment(DELETE_BY_ID, "delete_traces", workspaceId, userName,
+                    "trace_ids_size=%s, project_id=%s".formatted(ids.size(), projectId));
 
             var statement = connection.createStatement(template.render())
-                    .bind("ids", ids.toArray(UUID[]::new));
-
-            if (projectId != null) {
-                statement.bind("project_id", projectId);
-            }
-
-            statement.bind("workspace_id", workspaceId);
+                    .bind("ids", ids.toArray(UUID[]::new))
+                    .bind("project_id", projectId)
+                    .bind("workspace_id", workspaceId);
 
             var segment = startSegment("traces", "Clickhouse", "delete");
             return Mono.from(statement.execute())
@@ -4557,29 +4577,54 @@ class TraceDAOImpl implements TraceDAO {
     }
 
     private Mono<Map<UUID, UUID>> collectTraceIdToProjectId(Statement statement) {
-        return makeMonoContextAware(bindWorkspaceIdToMono(statement))
-                .flatMapMany(result -> result.map((row, rowMetadata) -> Map.entry(row.get("id", UUID.class),
-                        row.get("project_id", UUID.class))))
+        return traceIdProjectIdPairs(statement)
                 .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
+    private Mono<Map<UUID, Set<UUID>>> collectTraceIdToProjectIds(Statement statement) {
+        return traceIdProjectIdPairs(statement)
+                .collect(Collectors.groupingBy(Map.Entry::getKey,
+                        Collectors.mapping(Map.Entry::getValue, toSet())));
+    }
+
+    private Flux<Map.Entry<UUID, UUID>> traceIdProjectIdPairs(Statement statement) {
+        return makeMonoContextAware(bindWorkspaceIdToMono(statement))
+                .flatMapMany(result -> result.map((row, _) -> Map.entry(row.get("id", UUID.class),
+                        row.get("project_id", UUID.class))));
+    }
+
     @Override
-    public Mono<Map<UUID, UUID>> getProjectIdsByTraceIdsBounded(Set<UUID> traceIds) {
+    @WithSpan
+    public Mono<Map<UUID, Set<UUID>>> getAllProjectIdsByTraceIds(Set<UUID> traceIds) {
+        Preconditions.checkArgument(CollectionUtils.isNotEmpty(traceIds), "Argument 'traceIds' must not be empty");
+        return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
+            var template = getSTWithLogComment(SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS, "get_all_project_ids_by_trace_ids",
+                    workspaceId, userName, "trace_ids_size=%s".formatted(traceIds.size()));
+            var statement = connection.createStatement(template.render())
+                    .bind("trace_ids", traceIds.toArray(UUID[]::new));
+            return collectTraceIdToProjectIds(statement);
+        }));
+    }
+
+    @Override
+    @WithSpan
+    public Mono<Map<UUID, Set<UUID>>> getAllProjectIdsByTraceIdsBounded(Set<UUID> traceIds) {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(traceIds), "Argument 'traceIds' must not be empty");
 
         var minId = Collections.min(traceIds);
         var maxId = Collections.max(traceIds);
 
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
-            var template = getSTWithLogComment(SELECT_PROJECT_IDS_BY_TRACE_IDS_BOUNDED,
-                    "get_project_ids_by_trace_ids_bounded", workspaceId, userName, traceIds.size());
+            var template = getSTWithLogComment(SELECT_ALL_PROJECT_IDS_BY_TRACE_IDS_BOUNDED,
+                    "get_all_project_ids_by_trace_ids_bounded", workspaceId, userName,
+                    "trace_ids_size=%s".formatted(traceIds.size()));
 
             var statement = connection.createStatement(template.render())
                     .bind("trace_ids", traceIds.toArray(UUID[]::new))
                     .bind("min_id", minId)
                     .bind("max_id", maxId);
 
-            return collectTraceIdToProjectId(statement);
+            return collectTraceIdToProjectIds(statement);
         }));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -56,6 +56,7 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -484,6 +485,13 @@ class TraceServiceImpl implements TraceService {
                 .switchIfEmpty(Mono.defer(() -> Mono.error(failWithNotFound("Trace", id.toString()))));
     }
 
+    /**
+     * Deletes the given trace ids. With an explicit {@code projectId}, deletes only within that project. Without one
+     * (delete-by-id, or a batch spanning projects), resolves every owning project for each id and deletes it under the
+     * full {@code (workspace_id, project_id, id)} key, once per project group - so an id reused across projects is
+     * removed from all of them and no delete is ever project-less (OPIK-7483). Ids with no live row are already gone,
+     * so they are skipped.
+     */
     @Override
     @WithSpan
     public Mono<Void> delete(@NonNull Set<UUID> ids, UUID projectId) {
@@ -494,27 +502,54 @@ class TraceServiceImpl implements TraceService {
             return template.nonTransaction(connection -> delete(ids, projectId, connection));
         }
 
-        // No project provided (e.g. delete-by-id, or a batch spanning projects): resolve each trace's owning
-        // project and delete per project group, so every delete - and its async span/feedback cascade carried
-        // by the TracesDeleted event - filters by project_id and prunes on the (workspace_id, project_id)
-        // sorting-key prefix instead of scanning the whole workspace. Trace ids with no resolvable project
-        // (the trace row is already gone) fall back to a workspace-scoped delete to still clean up orphan rows.
-        log.info("Resolving owning projects for trace ids to delete per project group (count={})", ids.size());
-        return dao.getProjectIdsByTraceIdsBounded(ids)
-                .flatMap(traceToProject -> {
-                    var idsByProject = ids.stream()
-                            .filter(traceToProject::containsKey)
-                            .collect(Collectors.groupingBy(traceToProject::get, Collectors.toSet()));
-                    var unresolvedIds = ids.stream()
-                            .filter(id -> !traceToProject.containsKey(id))
-                            .collect(Collectors.toSet());
+        log.info("Resolving owning projects to delete traces per project group, count '{}'", ids.size());
+        return resolveOwningProjects(ids)
+                .flatMap(projectsByTrace -> {
+                    var idsByProject = projectsByTrace.entrySet().stream()
+                            .flatMap(entry -> entry.getValue().stream()
+                                    .map(project -> Map.entry(project, entry.getKey())))
+                            .collect(Collectors.groupingBy(Map.Entry::getKey,
+                                    Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+
+                    // Resolution only returns queried ids, so its key set is a subset of ids.
+                    int unresolvedCount = ids.size() - projectsByTrace.size();
+                    if (unresolvedCount > 0) {
+                        log.info("Skipping trace ids with no owning project, already absent, skipped '{}', total '{}'",
+                                unresolvedCount, ids.size());
+                    }
 
                     return template.nonTransaction(connection -> Flux.fromIterable(idsByProject.entrySet())
                             .concatMap(group -> delete(group.getValue(), group.getKey(), connection))
-                            .then(Mono.defer(() -> unresolvedIds.isEmpty()
-                                    ? Mono.empty()
-                                    : delete(unresolvedIds, null, connection)))
                             .then());
+                });
+    }
+
+    /**
+     * Resolves every owning project for each id via a bounded (partition-pruned) fast pass, then re-resolves only the
+     * ids the bounded pass left unresolved via an unbounded pass, so rows the bounded window skips - malformed ids
+     * whose id_at is not monotonic in id (e.g. a wrapped timestamp, OPIK-7456) - are still found with their project.
+     * The bounded query is never the sole resolver for a delete. Returns id -> set of owning projects; ids absent
+     * from the result have no live row.
+     */
+    private Mono<Map<UUID, Set<UUID>>> resolveOwningProjects(Set<UUID> ids) {
+        return dao.getAllProjectIdsByTraceIdsBounded(ids)
+                .flatMap(bounded -> {
+                    var missSet = ids.stream()
+                            .filter(id -> !bounded.containsKey(id))
+                            .collect(Collectors.toSet());
+                    if (missSet.isEmpty()) {
+                        return Mono.just(bounded);
+                    }
+                    log.info(
+                            "Bounded project resolution incomplete, re-resolving miss set unbounded, missed '{}', total '{}'",
+                            missSet.size(), ids.size());
+                    return dao.getAllProjectIdsByTraceIds(missSet)
+                            .map(unbounded -> {
+                                // Keys are disjoint: unbounded only carries the miss set, none of which is in bounded.
+                                var merged = new HashMap<>(bounded);
+                                merged.putAll(unbounded);
+                                return merged;
+                            });
                 });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -489,8 +489,9 @@ class TraceServiceImpl implements TraceService {
      * Deletes the given trace ids. With an explicit {@code projectId}, deletes only within that project. Without one
      * (delete-by-id, or a batch spanning projects), resolves every owning project for each id and deletes it under the
      * full {@code (workspace_id, project_id, id)} key, once per project group - so an id reused across projects is
-     * removed from all of them and no delete is ever project-less (OPIK-7483). Ids with no live row are already gone,
-     * so they are skipped.
+     * removed from all of them and no delete is ever project-less (OPIK-7483). Ids with no live trace row are skipped
+     * (a no-op); delete-by-id does not clean up orphaned child rows of a trace that never existed - that is the child
+     * entities' own lifecycle concern.
      */
     @Override
     @WithSpan
@@ -525,11 +526,15 @@ class TraceServiceImpl implements TraceService {
     }
 
     /**
-     * Resolves every owning project for each id via a bounded (partition-pruned) fast pass, then re-resolves only the
-     * ids the bounded pass left unresolved via an unbounded pass, so rows the bounded window skips - malformed ids
-     * whose id_at is not monotonic in id (e.g. a wrapped timestamp, OPIK-7456) - are still found with their project.
-     * The bounded query is never the sole resolver for a delete. Returns id -> set of owning projects; ids absent
-     * from the result have no live row.
+     * Resolves every owning project for each id: a bounded (partition-pruned) fast pass, then an unbounded pass over
+     * only the ids the bounded one left unresolved. Returns id -> set of owning projects; ids absent from the result
+     * have no live row.
+     * <p>
+     * The miss set is dominated by ids with no live row (already deleted, client retries), for which the unbounded
+     * pass also finds nothing and the delete is a no-op. Its real job is to still resolve the rare malformed id whose
+     * {@code id_at} is not monotonic in id (e.g. a wrapped timestamp, OPIK-7456) and so falls outside the bounded
+     * window. The bounded query is never the sole resolver for a delete. Once {@code traces} is partitioned, the
+     * bounded predicate prunes as intended and this unbounded fallback can be removed.
      */
     private Mono<Map<UUID, Set<UUID>>> resolveOwningProjects(Set<UUID> ids) {
         return dao.getAllProjectIdsByTraceIdsBounded(ids)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -34,7 +34,6 @@ import com.comet.opik.utils.AsyncUtils;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.WorkspaceUtils;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -67,7 +66,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.comet.opik.api.Trace.TracePage;
-import static com.comet.opik.infrastructure.FilterUtils.ANALYTICS_DELETE_BATCH_SIZE;
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 
 @ImplementedBy(TraceServiceImpl.class)
@@ -489,9 +487,10 @@ class TraceServiceImpl implements TraceService {
      * Deletes the given trace ids. With an explicit {@code projectId}, deletes only within that project. Without one
      * (delete-by-id, or a batch spanning projects), resolves every owning project for each id and deletes it under the
      * full {@code (workspace_id, project_id, id)} key, once per project group - so an id reused across projects is
-     * removed from all of them and no delete is ever project-less (OPIK-7483). Ids with no live trace row are skipped
-     * (a no-op); delete-by-id does not clean up orphaned child rows of a trace that never existed - that is the child
-     * entities' own lifecycle concern.
+     * removed from all of them and no delete is ever project-less (OPIK-7483). Ids that resolve to no owning project
+     * have no live trace anywhere and are skipped: no {@code TracesDeleted} is emitted for them, because a project-less
+     * cascade would be an unscoped, workspace-wide child delete that could over-delete a concurrently-ingested trace's
+     * children; genuine orphan child rows are cleaned via the child entities' own delete endpoints.
      */
     @Override
     @WithSpan
@@ -500,48 +499,50 @@ class TraceServiceImpl implements TraceService {
         log.info("Deleting traces, count '{}'", ids.size());
 
         if (projectId != null) {
-            return template.nonTransaction(connection -> delete(ids, projectId, connection));
+            var pairs = ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet());
+            return template.nonTransaction(connection -> delete(pairs, connection));
         }
 
-        log.info("Resolving owning projects to delete traces per project group, count '{}'", ids.size());
+        log.info("Resolving owning projects to delete traces, count '{}'", ids.size());
         return resolveOwningProjects(ids)
                 .flatMap(projectsByTrace -> {
-                    var idsByProject = projectsByTrace.entrySet().stream()
+                    // Flatten to (project_id, trace_id) pairs so a reused id maps to one pair per owning project.
+                    var pairs = projectsByTrace.entrySet().stream()
                             .flatMap(entry -> entry.getValue().stream()
-                                    .map(project -> Map.entry(project, entry.getKey())))
-                            .collect(Collectors.groupingBy(Map.Entry::getKey,
-                                    Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+                                    .map(project -> Pair.of(project, entry.getKey())))
+                            .collect(Collectors.toUnmodifiableSet());
 
                     // Resolution only returns queried ids, so its key set is a subset of ids.
-                    int unresolvedCount = ids.size() - projectsByTrace.size();
-                    if (unresolvedCount > 0) {
-                        log.info("Skipping trace ids with no owning project, already absent, skipped '{}', total '{}'",
-                                unresolvedCount, ids.size());
+                    var unresolvedIds = ids.stream()
+                            .filter(id -> !projectsByTrace.containsKey(id))
+                            .collect(Collectors.toUnmodifiableSet());
+                    if (!unresolvedIds.isEmpty()) {
+                        // No live trace in any project: skip, emitting no project-less cascade (see delete() javadoc).
+                        log.info(
+                                "Trace ids with no live row (already absent), skipped from trace delete '{}', total '{}'",
+                                unresolvedIds.size(), ids.size());
                     }
 
-                    return template.nonTransaction(connection -> Flux.fromIterable(idsByProject.entrySet())
-                            .concatMap(group -> delete(group.getValue(), group.getKey(), connection))
-                            .then());
+                    return pairs.isEmpty()
+                            ? Mono.empty()
+                            : template.nonTransaction(connection -> delete(pairs, connection));
                 });
     }
 
     /**
-     * Resolves every owning project for each id: a bounded (partition-pruned) fast pass, then an unbounded pass over
-     * only the ids the bounded one left unresolved. Returns id -> set of owning projects; ids absent from the result
-     * have no live row.
+     * Resolves every owning project for each id: a bounded fast pass, then an unbounded pass over only the ids the
+     * bounded one leaves unresolved. Returns id -> owning projects; ids absent from the result have no live row.
      * <p>
-     * The miss set is dominated by ids with no live row (already deleted, client retries), for which the unbounded
-     * pass also finds nothing and the delete is a no-op. Its real job is to still resolve the rare malformed id whose
-     * {@code id_at} is not monotonic in id (e.g. a wrapped timestamp, OPIK-7456) and so falls outside the bounded
-     * window. The bounded query is never the sole resolver for a delete. Once {@code traces} is partitioned, the
-     * bounded predicate prunes as intended and this unbounded fallback can be removed.
+     * The bounded pass's {@code toMonday(id_at)} window can miss a row whose {@code id_at} is not monotonic in its id
+     * (e.g. a wrapped timestamp, OPIK-7456), so the unbounded pass re-resolves the miss set - the bounded query is
+     * never a delete's sole resolver. The resolver-query javadocs cover how each pass prunes.
      */
     private Mono<Map<UUID, Set<UUID>>> resolveOwningProjects(Set<UUID> ids) {
         return dao.getAllProjectIdsByTraceIdsBounded(ids)
                 .flatMap(bounded -> {
                     var missSet = ids.stream()
                             .filter(id -> !bounded.containsKey(id))
-                            .collect(Collectors.toSet());
+                            .collect(Collectors.toUnmodifiableSet());
                     if (missSet.isEmpty()) {
                         return Mono.just(bounded);
                     }
@@ -558,60 +559,57 @@ class TraceServiceImpl implements TraceService {
                 });
     }
 
-    private Mono<Void> delete(Set<UUID> ids, UUID projectId, Connection connection) {
+    private Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, Connection connection) {
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
             String userName = ctx.get(RequestContext.USER_NAME);
-            return Flux.fromIterable(Lists.partition(new ArrayList<>(ids), ANALYTICS_DELETE_BATCH_SIZE))
-                    .flatMap(batch -> {
-                        var batchIds = Set.copyOf(batch);
-                        return dao.delete(batchIds, projectId, connection)
-                                .doOnSuccess(_ -> {
-                                    eventBus.post(TracesDeleted.builder()
-                                            .traceIds(batchIds)
-                                            .projectId(projectId)
-                                            .workspaceId(workspaceId)
-                                            .userName(userName)
-                                            .build());
-                                    log.info(
-                                            "Published TracesDeleted event for trace ids count '{}' for project_id '{}' on workspace '{}'",
-                                            batchIds.size(), projectId, workspaceId);
-                                })
-                                .then(captureDeletions(batchIds, projectId, workspaceId, userName));
-                    })
-                    .then();
+            return dao.delete(projectIdTraceIdPairs, connection)
+                    .doOnSuccess(_ -> projectIdTraceIdPairs.stream()
+                            .collect(Collectors.groupingBy(Pair::getLeft,
+                                    Collectors.mapping(Pair::getRight, Collectors.toUnmodifiableSet())))
+                            .forEach((projectId, traceIds) -> {
+                                eventBus.post(TracesDeleted.builder()
+                                        .traceIds(traceIds)
+                                        .projectId(projectId)
+                                        .workspaceId(workspaceId)
+                                        .userName(userName)
+                                        .build());
+                                log.info(
+                                        "Published TracesDeleted event, trace ids count '{}', project id '{}', workspace '{}'",
+                                        traceIds.size(), projectId, workspaceId);
+                            }))
+                    .then(captureDeletions(projectIdTraceIdPairs, workspaceId, userName));
         });
     }
 
     /**
-     * Records the deleted ids in the deletion-events bridge so deletes issued while the table is being migrated
-     * survive the copy. Runs after the delete and is best-effort: capture is auxiliary and must never disrupt
-     * the delete, so failures are logged and swallowed. Running after the delete also avoids recording a delete
-     * that did not happen. No-op unless capture is enabled. Deferred so that nothing is built or run until
-     * subscribed, i.e. only after the delete succeeds.
+     * Records the deleted (project_id, trace_id) pairs in the deletion-events bridge so deletes issued while the table
+     * is being migrated survive the copy. Runs after the delete and is best-effort: capture is auxiliary and must never
+     * disrupt the delete, so failures are logged and swallowed. Running after the delete also avoids recording a delete
+     * that did not happen. No-op unless capture is enabled. Deferred so that nothing is built or run until subscribed,
+     * i.e. only after the delete succeeds.
      */
-    private Mono<Void> captureDeletions(Set<UUID> ids, UUID projectId, String workspaceId, String userName) {
+    private Mono<Void> captureDeletions(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, String workspaceId,
+            String userName) {
         return Mono.defer(() -> {
             if (!config.getDatabaseAnalyticsDataModel().traceDeletionEventsCaptureEnabled()) {
                 return Mono.empty();
             }
-            var events = ids.stream()
-                    .map(id -> DeletionEvent.builder()
+            var events = projectIdTraceIdPairs.stream()
+                    .map(pair -> DeletionEvent.builder()
                             .sourceTable(SourceTable.TRACES)
                             .workspaceId(workspaceId)
-                            .projectId(projectId)
-                            .deletedId(id.toString())
+                            .projectId(pair.getLeft())
+                            .deletedId(pair.getRight().toString())
                             .deletionReason(DeletionReason.USER_REQUEST)
                             .build())
                     .collect(Collectors.toUnmodifiableSet());
             return deletionEventDAO.insert(events, userName)
-                    .doOnSuccess(_ -> log.info(
-                            "Captured trace deletion events, count '{}' for projectId '{}' on workspaceId '{}'",
-                            ids.size(), projectId, workspaceId))
+                    .doOnSuccess(_ -> log.info("Captured trace deletion events, count '{}' on workspace '{}'",
+                            events.size(), workspaceId))
                     .onErrorResume(throwable -> {
-                        log.warn(
-                                "Failed to capture trace deletion events, count '{}' for projectId '{}' on workspaceId '{}'",
-                                ids.size(), projectId, workspaceId, throwable);
+                        log.warn("Failed to capture trace deletion events, count '{}' on workspace '{}'",
+                                projectIdTraceIdPairs.size(), workspaceId, throwable);
                         return Mono.empty();
                     });
         });
@@ -744,7 +742,9 @@ class TraceServiceImpl implements TraceService {
                     }
                     log.info("Found '{}' traces for thread IDs, proceeding with deletion", traceIds.size());
 
-                    return delete(traceIds, projectId, connection);
+                    var pairs = traceIds.stream().map(id -> Pair.of(projectId, id))
+                            .collect(Collectors.toUnmodifiableSet());
+                    return delete(pairs, connection);
                 })));
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.attachment.AttachmentSearchCriteria;
 import com.comet.opik.api.attachment.DeleteAttachmentsRequest;
 import com.comet.opik.api.attachment.EntityType;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.template.TemplateUtils;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
@@ -38,9 +39,9 @@ public interface AttachmentDAO {
 
     Mono<Long> delete(DeleteAttachmentsRequest request);
 
-    Mono<List<AttachmentInfo>> getAttachmentsByEntityIds(EntityType entityType, Set<UUID> entityIds);
+    Mono<List<AttachmentInfo>> getAttachmentsByEntityIds(EntityType entityType, Set<UUID> entityIds, UUID containerId);
 
-    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds);
+    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds, UUID containerId);
 
     Mono<Long> deleteByFileNames(EntityType entityType, Set<UUID> entityIds, Set<String> fileNames);
 }
@@ -127,6 +128,7 @@ class AttachmentDAOImpl implements AttachmentDAO {
             WHERE workspace_id = :workspace_id
             AND entity_type = :entity_type
             AND entity_id IN :entity_ids
+            <if(container_id)>AND container_id = :container_id<endif>
             ;
             """;
 
@@ -145,6 +147,7 @@ class AttachmentDAOImpl implements AttachmentDAO {
             WHERE workspace_id = :workspace_id
             AND entity_type = :entity_type
             AND entity_id IN :entity_ids
+            <if(container_id)>AND container_id = :container_id<endif>
             ;
             """;
 
@@ -204,17 +207,25 @@ class AttachmentDAOImpl implements AttachmentDAO {
     @Override
     @WithSpan
     public Mono<List<AttachmentInfo>> getAttachmentsByEntityIds(@NonNull EntityType entityType,
-            @NonNull Set<UUID> entityIds) {
+            @NonNull Set<UUID> entityIds, UUID containerId) {
         if (CollectionUtils.isEmpty(entityIds)) {
             return Mono.just(List.of());
         }
 
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(ATTACHMENTS_BY_ENTITY_IDS);
+            var template = TemplateUtils.newST(ATTACHMENTS_BY_ENTITY_IDS);
+            if (containerId != null) {
+                template.add("container_id", containerId);
+            }
+
+            var statement = connection.createStatement(template.render());
 
             statement.bind("entity_ids", entityIds)
                     .bind("entity_type", entityType.getValue());
+            if (containerId != null) {
+                statement.bind("container_id", containerId);
+            }
 
             return makeMonoContextAware(bindWorkspaceIdToMono(statement))
                     .flatMapMany(result -> result.map((row, rowMetadata) -> AttachmentInfo.builder()
@@ -228,17 +239,26 @@ class AttachmentDAOImpl implements AttachmentDAO {
     }
 
     @Override
-    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, @NonNull Set<UUID> entityIds) {
+    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, @NonNull Set<UUID> entityIds,
+            UUID containerId) {
         if (CollectionUtils.isEmpty(entityIds)) {
             return Mono.just(0L);
         }
 
         return asyncTemplate.nonTransaction(connection -> {
 
-            var statement = connection.createStatement(DELETE_ATTACHMENTS_BY_ENTITY_IDS);
+            var template = TemplateUtils.newST(DELETE_ATTACHMENTS_BY_ENTITY_IDS);
+            if (containerId != null) {
+                template.add("container_id", containerId);
+            }
+
+            var statement = connection.createStatement(template.render());
 
             statement.bind("entity_ids", entityIds.toArray(UUID[]::new))
                     .bind("entity_type", entityType.getValue());
+            if (containerId != null) {
+                statement.bind("container_id", containerId);
+            }
 
             return makeMonoContextAware(bindWorkspaceIdToMono(statement))
                     .flatMapMany(Result::getRowsUpdated)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentDAO.java
@@ -213,20 +213,8 @@ class AttachmentDAOImpl implements AttachmentDAO {
         }
 
         return asyncTemplate.nonTransaction(connection -> {
-
-            var template = TemplateUtils.newST(ATTACHMENTS_BY_ENTITY_IDS);
-            if (containerId != null) {
-                template.add("container_id", containerId);
-            }
-
-            var statement = connection.createStatement(template.render());
-
-            statement.bind("entity_ids", entityIds)
-                    .bind("entity_type", entityType.getValue());
-            if (containerId != null) {
-                statement.bind("container_id", containerId);
-            }
-
+            var statement = bindEntityIdsStatement(connection, ATTACHMENTS_BY_ENTITY_IDS, entityType, entityIds,
+                    containerId);
             return makeMonoContextAware(bindWorkspaceIdToMono(statement))
                     .flatMapMany(result -> result.map((row, rowMetadata) -> AttachmentInfo.builder()
                             .containerId(row.get("container_id", UUID.class))
@@ -246,24 +234,33 @@ class AttachmentDAOImpl implements AttachmentDAO {
         }
 
         return asyncTemplate.nonTransaction(connection -> {
-
-            var template = TemplateUtils.newST(DELETE_ATTACHMENTS_BY_ENTITY_IDS);
-            if (containerId != null) {
-                template.add("container_id", containerId);
-            }
-
-            var statement = connection.createStatement(template.render());
-
-            statement.bind("entity_ids", entityIds.toArray(UUID[]::new))
-                    .bind("entity_type", entityType.getValue());
-            if (containerId != null) {
-                statement.bind("container_id", containerId);
-            }
-
+            var statement = bindEntityIdsStatement(connection, DELETE_ATTACHMENTS_BY_ENTITY_IDS, entityType, entityIds,
+                    containerId);
             return makeMonoContextAware(bindWorkspaceIdToMono(statement))
                     .flatMapMany(Result::getRowsUpdated)
                     .reduce(0L, Long::sum);
         });
+    }
+
+    /**
+     * Shared statement setup for the by-entity-id SELECT and DELETE: renders the template with the optional
+     * {@code container_id} clause and binds {@code entity_ids}, {@code entity_type}, and (when scoped) {@code
+     * container_id}, so the two paths can't drift on bind order or the optional-scope wiring.
+     */
+    private Statement bindEntityIdsStatement(Connection connection, String sql, EntityType entityType,
+            Set<UUID> entityIds, UUID containerId) {
+        var template = TemplateUtils.newST(sql);
+        if (containerId != null) {
+            template.add("container_id", containerId);
+        }
+
+        var statement = connection.createStatement(template.render())
+                .bind("entity_ids", entityIds.toArray(UUID[]::new))
+                .bind("entity_type", entityType.getValue());
+        if (containerId != null) {
+            statement.bind("container_id", containerId);
+        }
+        return statement;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/attachment/AttachmentService.java
@@ -66,7 +66,7 @@ public interface AttachmentService {
 
     Mono<Long> delete(DeleteAttachmentsRequest request);
 
-    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds);
+    Mono<Long> deleteByEntityIds(EntityType entityType, Set<UUID> entityIds, UUID containerId);
 
     /**
      * Get existing attachments for a specific entity as AttachmentInfo objects.
@@ -257,12 +257,12 @@ class AttachmentServiceImpl implements AttachmentService {
     }
 
     @Override
-    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, @NonNull Set<UUID> entityIds) {
-        if (entityIds.isEmpty()) {
+    public Mono<Long> deleteByEntityIds(@NonNull EntityType entityType, Set<UUID> entityIds, UUID containerId) {
+        if (CollectionUtils.isEmpty(entityIds)) {
             return Mono.just(0L);
         }
 
-        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds)
+        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds, containerId)
                 .flatMap(attachments -> Mono.deferContextual(ctx -> {
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     Set<String> keys = attachments.stream()
@@ -271,7 +271,7 @@ class AttachmentServiceImpl implements AttachmentService {
 
                     return Mono.fromRunnable(() -> fileService.deleteObjects(keys));
                 }))
-                .then(attachmentDAO.deleteByEntityIds(entityType, entityIds));
+                .then(attachmentDAO.deleteByEntityIds(entityType, entityIds, containerId));
     }
 
     private List<Attachment> enhanceWithDownloadUrl(List<Attachment> attachments, AttachmentSearchCriteria criteria,
@@ -447,7 +447,7 @@ class AttachmentServiceImpl implements AttachmentService {
         if (entityIds.isEmpty()) {
             return Mono.just(false);
         }
-        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds)
+        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds, null)
                 .map(list -> !list.isEmpty());
     }
 
@@ -458,7 +458,7 @@ class AttachmentServiceImpl implements AttachmentService {
         if (CollectionUtils.isEmpty(entityIds)) {
             return Mono.just(List.of());
         }
-        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds);
+        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds, null);
     }
 
     @Override
@@ -468,7 +468,7 @@ class AttachmentServiceImpl implements AttachmentService {
             return Mono.just(0L);
         }
 
-        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds)
+        return attachmentDAO.getAttachmentsByEntityIds(entityType, entityIds, null)
                 .flatMap(attachments -> {
                     // Filter to only auto-stripped attachments
                     List<AttachmentInfo> autoStrippedAttachments = AttachmentUtils

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000113_add_id_bloom_filter_index_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000113_add_id_bloom_filter_index_to_traces.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset andrescrz:000113_add_id_bloom_filter_index_to_traces
+--comment: OPIK-7483 - Add a bloom_filter skip index on traces.id for exact-match / IN lookups (delete-by-id project resolution, getPartialById, findByIds). The (workspace_id, project_id, id) sort key can't prune by id alone because id is not a usable prefix, so these lookups otherwise scan the whole workspace. Mirrors traces_local_v2 (000101). Added and materialized so existing parts are covered too (MATERIALIZE INDEX submits an async background mutation - monitor via SELECT * FROM system.mutations WHERE is_done = 0 AND table = 'traces').
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}'
+    ADD INDEX IF NOT EXISTS idx_traces_id_bf id TYPE bloom_filter(0.01) GRANULARITY 1,
+    MATERIALIZE INDEX idx_traces_id_bf;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_traces_id_bf;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -243,6 +243,18 @@ public class TraceResourceClient extends BaseCommentResourceClient {
         }
     }
 
+    public Response deleteTraces(BatchDeleteByProject request, String workspaceName, String apiKey,
+            int expectedStatus) {
+        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("delete")
+                .request()
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(request));
+        assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
+        return actualResponse;
+    }
+
     public void updateTrace(UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName) {
         try (var actualResponse = updateTrace(id, traceUpdate, apiKey, workspaceName, HttpStatus.SC_NO_CONTENT)) {
             assertThat(actualResponse.hasEntity()).isFalse();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/TraceResourceClient.java
@@ -231,28 +231,25 @@ public class TraceResourceClient extends BaseCommentResourceClient {
     }
 
     public void deleteTraces(BatchDeleteByProject request, String workspaceName, String apiKey) {
-        try (var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
-                .path("delete")
-                .request()
-                .header(HttpHeaders.AUTHORIZATION, apiKey)
-                .header(WORKSPACE_HEADER, workspaceName)
-                .post(Entity.json(request))) {
-
-            assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+        try (var actualResponse = deleteTraces(request, workspaceName, apiKey, HttpStatus.SC_NO_CONTENT)) {
             assertThat(actualResponse.hasEntity()).isFalse();
         }
     }
 
     public Response deleteTraces(BatchDeleteByProject request, String workspaceName, String apiKey,
             int expectedStatus) {
-        var actualResponse = client.target(RESOURCE_PATH.formatted(baseURI))
+        var actualResponse = callDeleteTraces(request, workspaceName, apiKey);
+        assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
+        return actualResponse;
+    }
+
+    public Response callDeleteTraces(BatchDeleteByProject request, String workspaceName, String apiKey) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("delete")
                 .request()
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(request));
-        assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(expectedStatus);
-        return actualResponse;
     }
 
     public void updateTrace(UUID id, TraceUpdate traceUpdate, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceMinIOTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AttachmentResourceMinIOTest.java
@@ -28,6 +28,8 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.AttachmentUtilsTest;
+import com.fasterxml.uuid.Generators;
+import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.redis.testcontainers.RedisContainer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
@@ -119,6 +121,7 @@ class AttachmentResourceMinIOTest {
     private String baseURI;
     private String baseURIEncoded;
     private ProjectService projectService;
+    private final TimeBasedEpochGenerator generator = Generators.timeBasedEpochGenerator();
 
     @BeforeAll
     void setUpAll(ClientSupport client, ProjectService projectService) {
@@ -252,6 +255,41 @@ class AttachmentResourceMinIOTest {
                 Arguments.of((Consumer<UUID>) traceId -> traceResourceClient
                         .deleteTraces(BatchDeleteByProject.builder().ids(Set.of(traceId)).build(), TEST_WORKSPACE,
                                 API_KEY)));
+    }
+
+    @Test
+    void deleteTraceScopedToProjectLeavesOtherProjectsAttachmentUntouched() throws IOException {
+        // Same trace id ingested into two projects (externally-supplied ids are not globally unique); each project's
+        // copy gets its own attachment. Deleting the id scoped to one project must cascade-delete only that project's
+        // attachment and leave the other project's attachment intact - no cross-project over-delete.
+        var sharedTraceId = generator.generate();
+        var trace1 = createTrace().toBuilder().id(sharedTraceId).lastUpdatedAt(null).build();
+        var trace2 = createTrace().toBuilder().id(sharedTraceId).lastUpdatedAt(null).build();
+        traceResourceClient.batchCreateTraces(List.of(trace1, trace2), API_KEY, TEST_WORKSPACE);
+
+        var projectId1 = projectService.findByNames(WORKSPACE_ID, List.of(trace1.projectName())).getFirst().id();
+        var projectId2 = projectService.findByNames(WORKSPACE_ID, List.of(trace2.projectName())).getFirst().id();
+
+        uploadFile(trace1.projectName(), EntityType.TRACE, sharedTraceId);
+        uploadFile(trace2.projectName(), EntityType.TRACE, sharedTraceId);
+
+        assertThat(attachmentResourceClient.attachmentList(projectId1, EntityType.TRACE, sharedTraceId, baseURIEncoded,
+                API_KEY, TEST_WORKSPACE, 200).total()).isEqualTo(1);
+        assertThat(attachmentResourceClient.attachmentList(projectId2, EntityType.TRACE, sharedTraceId, baseURIEncoded,
+                API_KEY, TEST_WORKSPACE, 200).total()).isEqualTo(1);
+
+        // Delete the reused id scoped to project 1 only.
+        traceResourceClient.deleteTraces(
+                BatchDeleteByProject.builder().ids(Set.of(sharedTraceId)).projectId(projectId1).build(),
+                TEST_WORKSPACE, API_KEY);
+
+        // Project 1's attachment is cascade-deleted; project 2's attachment survives.
+        Awaitility.await().pollInterval(500, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(
+                attachmentResourceClient.attachmentList(projectId1, EntityType.TRACE, sharedTraceId, baseURIEncoded,
+                        API_KEY, TEST_WORKSPACE, 200))
+                .isEqualTo(Attachment.AttachmentPage.empty(1)));
+        assertThat(attachmentResourceClient.attachmentList(projectId2, EntityType.TRACE, sharedTraceId, baseURIEncoded,
+                API_KEY, TEST_WORKSPACE, 200).total()).isEqualTo(1);
     }
 
     Pair<StartMultipartUploadRequest, byte[]> uploadFile(String projectName, EntityType type, UUID entityId)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3709,6 +3709,39 @@ class TracesResourceTest {
             getAndAssertPage(workspaceName, projectName2, null, List.of(), List.of(trace2), List.of(),
                     List.of(trace2), apiKey);
         }
+
+        @Test
+        void deleteByIdOfAbsentTraceLeavesOrphanChildSpansUntouched() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+            // Orphan spans: a trace_id that never had a trace row (spans ingest independently of traces).
+            var orphanTraceId = generator.generate();
+            var spans = PodamFactoryUtils.manufacturePojoList(factory, Span.class).stream()
+                    .map(span -> span.toBuilder()
+                            .projectName(projectName)
+                            .traceId(orphanTraceId)
+                            .usage(null)
+                            .feedbackScores(null)
+                            .build())
+                    .toList();
+            batchCreateSpansAndAssert(spans, apiKey, workspaceName);
+            getAndAssertPageSpans(workspaceName, projectName, List.of(), spans, spans.reversed(), List.of(), apiKey);
+
+            // Delete-by-id of the never-existent trace resolves no owning project, so no project-less cascade fires:
+            // the orphan spans are left untouched. A project-less child delete could over-delete a concurrently
+            // ingested trace's children, so orphans are cleaned via their own endpoints, not this side effect.
+            traceResourceClient.deleteTrace(orphanTraceId, workspaceName, apiKey);
+
+            // Let any (unexpected) async cascade run, then assert the orphan spans still exist.
+            Awaitility.await().pollDelay(2, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(
+                    () -> getAndAssertPageSpans(workspaceName, projectName, List.of(), spans, spans.reversed(),
+                            List.of(), apiKey));
+        }
     }
 
     @Nested
@@ -3979,6 +4012,32 @@ class TracesResourceTest {
 
             var request = factory.manufacturePojo(BatchDeleteByProject.class);
             traceResourceClient.deleteTraces(request, workspaceName, apiKey);
+        }
+
+        @Test
+        void deleteTracesMixingPresentAndAbsentIdsWithoutProjectId() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var present = buildTracesForProject(projectName);
+            traceResourceClient.batchCreateTraces(present, apiKey, workspaceName);
+            getAndAssertPage(workspaceName, projectName, null, List.of(), present, present.reversed(), List.of(),
+                    apiKey);
+
+            // One null-project batch mixing the present ids with ids that never had a trace row: the delete resolves
+            // and removes the present traces per project group and simply skips the absent ids - no error, no
+            // project-less delete - so the request succeeds (204) and only the present traces are gone.
+            var absentIds = Set.of(generator.generate(), generator.generate());
+            var request = BatchDeleteByProject.builder()
+                    .ids(Stream.concat(present.stream().map(Trace::id), absentIds.stream())
+                            .collect(Collectors.toUnmodifiableSet()))
+                    .build();
+            traceResourceClient.deleteTraces(request, workspaceName, apiKey);
+
+            getAndAssertPage(workspaceName, projectName, null, List.of(), present, List.of(), List.of(), apiKey);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3668,6 +3668,47 @@ class TracesResourceTest {
 
             getAndAssertTraceNotFound(id, apiKey, workspaceName);
         }
+
+        @Test
+        void deleteByIdOfReusedIdRemovesItFromEveryProject() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName1 = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var projectName2 = "project-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+            // Same id in two projects: externally-ingested ids are not globally unique, and traces dedups by the full
+            // (workspace_id, project_id, id) key, so both rows coexist. A null lastUpdatedAt keeps the single batch
+            // from deduping them by id, so both are created in one call.
+            var sharedId = generator.generate();
+            var trace1 = createTrace().toBuilder()
+                    .id(sharedId)
+                    .projectName(projectName1)
+                    .lastUpdatedAt(null)
+                    .build();
+            var trace2 = createTrace().toBuilder()
+                    .id(sharedId)
+                    .projectName(projectName2)
+                    .lastUpdatedAt(null)
+                    .build();
+            traceResourceClient.batchCreateTraces(List.of(trace1, trace2), apiKey, workspaceName);
+
+            getAndAssertPage(workspaceName, projectName1, null, List.of(), List.of(trace1), List.of(trace1),
+                    List.of(), apiKey);
+            getAndAssertPage(workspaceName, projectName2, null, List.of(), List.of(trace2), List.of(trace2),
+                    List.of(), apiKey);
+
+            // DELETE /traces/{id} carries no project scope: it must resolve both owning projects and delete the id
+            // under each full key, clearing it from both projects (never a project-less over-delete of only one).
+            traceResourceClient.deleteTrace(sharedId, workspaceName, apiKey);
+
+            getAndAssertPage(workspaceName, projectName1, null, List.of(), List.of(trace1), List.of(),
+                    List.of(trace1), apiKey);
+            getAndAssertPage(workspaceName, projectName2, null, List.of(), List.of(trace2), List.of(),
+                    List.of(trace2), apiKey);
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3980,6 +3980,25 @@ class TracesResourceTest {
             var request = factory.manufacturePojo(BatchDeleteByProject.class);
             traceResourceClient.deleteTraces(request, workspaceName, apiKey);
         }
+
+        @Test
+        void deleteTracesWithNullIdInBatchIsRejected() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // A null element must be rejected at the API boundary rather than reaching resolution and blowing up.
+            var ids = new HashSet<UUID>();
+            ids.add(generator.generate());
+            ids.add(null);
+            var request = BatchDeleteByProject.builder().ids(ids).build();
+
+            try (var response = traceResourceClient.deleteTraces(request, workspaceName, apiKey,
+                    HttpStatus.SC_UNPROCESSABLE_ENTITY)) {
+                assertThat(response.hasEntity()).isTrue();
+            }
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TracesResourceTest.java
@@ -3997,6 +3997,8 @@ class TracesResourceTest {
             try (var response = traceResourceClient.deleteTraces(request, workspaceName, apiKey,
                     HttpStatus.SC_UNPROCESSABLE_ENTITY)) {
                 assertThat(response.hasEntity()).isTrue();
+                assertThat(response.readEntity(ErrorMessage.class).errors())
+                        .containsExactly("ids[].<iterable element> must not be null");
             }
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DeletionEventTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DeletionEventTest.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
@@ -179,6 +180,48 @@ class DeletionEventTest {
         awaitAndAssertSpanDeletionEvents(projectId, spanIds);
     }
 
+    @Test
+    void deleteByIdOfReusedIdCapturesEventPerOwningProject() {
+        var projectName1 = randomName("project");
+        var projectName2 = randomName("project");
+
+        // Same id in two projects (externally-ingested ids are not globally unique). A null lastUpdatedAt keeps the
+        // single batch from deduping them by id, so both land in their own projects from one call.
+        var trace1 = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                .projectName(projectName1)
+                .threadId(null)
+                .lastUpdatedAt(null)
+                .build();
+        var sharedId = trace1.id();
+        var trace2 = trace1.toBuilder()
+                .projectName(projectName2)
+                .build();
+        traceResourceClient.batchCreateTraces(List.of(trace1, trace2), API_KEY, WORKSPACE_NAME);
+        var projectId1 = traceResourceClient.getByProjectName(projectName1, API_KEY, WORKSPACE_NAME).getFirst()
+                .projectId();
+        var projectId2 = traceResourceClient.getByProjectName(projectName2, API_KEY, WORKSPACE_NAME).getFirst()
+                .projectId();
+        assertThat(projectId1).isNotEqualTo(projectId2);
+
+        // Spans for both projects share the trace id; create them in one call.
+        var spans1 = buildSpans(projectName1, sharedId);
+        var spans2 = buildSpans(projectName2, sharedId);
+        spanResourceClient.batchCreateSpans(Stream.concat(spans1.stream(), spans2.stream()).toList(), API_KEY,
+                WORKSPACE_NAME);
+        var spanIds1 = spans1.stream().map(Span::id).collect(Collectors.toUnmodifiableSet());
+        var spanIds2 = spans2.stream().map(Span::id).collect(Collectors.toUnmodifiableSet());
+
+        traceResourceClient.deleteTrace(sharedId, WORKSPACE_NAME, API_KEY);
+
+        // Delete-by-id resolves both owning projects and captures one trace event per project, each with the resolved
+        // (non-empty) project_id - never a single empty-project event for the id.
+        getAndAssertDeletionEvents(SourceTable.TRACES, List.of(
+                newExpectedTraceDeletionEvent(projectId1, sharedId),
+                newExpectedTraceDeletionEvent(projectId2, sharedId)));
+        awaitAndAssertSpanDeletionEvents(projectId1, spanIds1);
+        awaitAndAssertSpanDeletionEvents(projectId2, spanIds2);
+    }
+
     private static String randomName(String prefix) {
         return "%s-%s".formatted(prefix, RandomStringUtils.secure().nextAlphanumeric(32));
     }
@@ -208,14 +251,18 @@ class DeletionEventTest {
         return createdTraces;
     }
 
-    private Set<UUID> createSpans(String projectName, UUID traceId) {
-        var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
+    private List<Span> buildSpans(String projectName, UUID traceId) {
+        return PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class).stream()
                 .map(span -> span.toBuilder()
                         .projectName(projectName)
                         .traceId(traceId)
                         .feedbackScores(null)
                         .build())
                 .toList();
+    }
+
+    private Set<UUID> createSpans(String projectName, UUID traceId) {
+        var spans = buildSpans(projectName, traceId);
         spanResourceClient.batchCreateSpans(spans, API_KEY, WORKSPACE_NAME);
         return spans.stream().map(Span::id).collect(Collectors.toUnmodifiableSet());
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanServiceImplTest.java
@@ -192,9 +192,9 @@ class SpanServiceImplTest {
         // comment/feedback-score/attachment deletes. deleteByIds and deletionEventDAO are stubbed per-test.
         private void mockSpanDeleteFlow(Set<UUID> traceIds, Set<UUID> spanIds, UUID projectId) {
             when(spanDAO.getSpanIdsForTraces(traceIds, projectId)).thenReturn(Mono.just(spanIds));
-            when(commentService.deleteByEntityIds(any(), eq(spanIds))).thenReturn(Mono.just(0L));
+            when(commentService.deleteByEntityIds(any(), eq(spanIds), eq(projectId))).thenReturn(Mono.just(0L));
             when(feedbackScoreService.deleteBySpanIds(spanIds, projectId)).thenReturn(Mono.empty());
-            when(attachmentService.deleteByEntityIds(any(), eq(spanIds))).thenReturn(Mono.just(0L));
+            when(attachmentService.deleteByEntityIds(any(), eq(spanIds), eq(projectId))).thenReturn(Mono.just(0L));
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDeletionEventArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDeletionEventArchTest.java
@@ -7,7 +7,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import io.r2dbc.spi.Connection;
 
 import java.util.Set;
-import java.util.UUID;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
@@ -15,7 +14,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
  * Architectural guard for the trace deletion event capturing. User-initiated trace deletes must flow through
  * {@link TraceServiceImpl}, which records the deleted ids in {@code deletion_events_local} after the delete so
  * they survive the data-model migration's table copy. A new caller of
- * {@code TraceDAO.delete(Set, UUID, Connection)} would issue the lightweight delete without that capture,
+ * {@code TraceDAO.delete(Set, Connection)} would issue the lightweight delete without that capture,
  * silently bypassing the capturing, so this rule fails the build if one appears. Retention paths
  * ({@code deleteForRetention*}) are intentionally not captured and are separate methods, so they are not matched.
  */
@@ -29,7 +28,7 @@ class TraceDeletionEventArchTest {
     @ArchTest
     static final ArchRule trace_deletes_must_route_through_the_capturing_service = noClasses()
             .that().doNotBelongToAnyOf(TraceServiceImpl.class)
-            .should().callMethod(TraceDAO.class, "delete", Set.class, UUID.class, Connection.class)
+            .should().callMethod(TraceDAO.class, "delete", Set.class, Connection.class)
             .because("""
                     trace deletes must go through TraceServiceImpl so the deletion-events bridge captures every
                     deleted id; a new caller here would silently bypass the bridge

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -31,6 +31,7 @@ import uk.co.jemos.podam.api.PodamFactoryImpl;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -44,6 +45,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -289,6 +291,85 @@ class TraceServiceImplTest {
                     .hasMessageContaining("Error deleting traces");
 
             verify(traceDao).delete(ids, projectId, connection);
+            verifyNoInteractions(deletionEventDAO, eventBus);
+        }
+
+        @Test
+        void deleteWithoutProjectIdRemovesReusedIdFromEveryOwningProject() {
+            var reusedId = idGenerator.generateId();
+            var soloId = idGenerator.generateId();
+            var projectA = idGenerator.generateId();
+            var projectB = idGenerator.generateId();
+            var workspaceId = UUID.randomUUID().toString();
+            var ids = Set.of(reusedId, soloId);
+            var connection = mockDeleteFlow();
+
+            // Bounded fast pass resolves everything: reusedId lives in A and B, soloId only in A.
+            when(traceDao.getAllProjectIdsByTraceIdsBounded(ids))
+                    .thenReturn(Mono.just(Map.of(reusedId, Set.of(projectA, projectB), soloId, Set.of(projectA))));
+            when(traceDao.delete(Set.of(reusedId, soloId), projectA, connection)).thenReturn(Mono.empty());
+            when(traceDao.delete(Set.of(reusedId), projectB, connection)).thenReturn(Mono.empty());
+
+            assertDoesNotThrow(() -> traceService
+                    .delete(ids, null)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            // Each delete carries the resolved project (full key): A gets both ids, B gets only the reused id.
+            verify(traceDao).delete(Set.of(reusedId, soloId), projectA, connection);
+            verify(traceDao).delete(Set.of(reusedId), projectB, connection);
+            // Bounded resolved all, so the unbounded fallback is not queried.
+            verify(traceDao, never()).getAllProjectIdsByTraceIds(any());
+            verifyNoInteractions(deletionEventDAO);
+        }
+
+        @Test
+        void deleteWithoutProjectIdFallsBackToUnboundedForBoundedMisses() {
+            var resolvedId = idGenerator.generateId();
+            var missedId = idGenerator.generateId();
+            var projectA = idGenerator.generateId();
+            var projectB = idGenerator.generateId();
+            var workspaceId = UUID.randomUUID().toString();
+            var ids = Set.of(resolvedId, missedId);
+            var connection = mockDeleteFlow();
+
+            // Bounded window resolves only resolvedId; missedId (e.g. a wrapped id_at) is re-resolved unbounded.
+            when(traceDao.getAllProjectIdsByTraceIdsBounded(ids))
+                    .thenReturn(Mono.just(Map.of(resolvedId, Set.of(projectA))));
+            when(traceDao.getAllProjectIdsByTraceIds(Set.of(missedId)))
+                    .thenReturn(Mono.just(Map.of(missedId, Set.of(projectB))));
+            when(traceDao.delete(Set.of(resolvedId), projectA, connection)).thenReturn(Mono.empty());
+            when(traceDao.delete(Set.of(missedId), projectB, connection)).thenReturn(Mono.empty());
+
+            assertDoesNotThrow(() -> traceService
+                    .delete(ids, null)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            verify(traceDao).getAllProjectIdsByTraceIds(Set.of(missedId));
+            verify(traceDao).delete(Set.of(resolvedId), projectA, connection);
+            verify(traceDao).delete(Set.of(missedId), projectB, connection);
+        }
+
+        @Test
+        void deleteWithoutProjectIdSkipsIdsThatResolveToNoProject() {
+            var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
+            var workspaceId = UUID.randomUUID().toString();
+            mockDeleteFlow();
+
+            // Both passes come back empty: the ids have no live row, so the delete is a no-op.
+            when(traceDao.getAllProjectIdsByTraceIdsBounded(ids)).thenReturn(Mono.just(Map.of()));
+            when(traceDao.getAllProjectIdsByTraceIds(ids)).thenReturn(Mono.just(Map.of()));
+
+            assertDoesNotThrow(() -> traceService
+                    .delete(ids, null)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            verify(traceDao, never()).delete(any(), any(), any());
             verifyNoInteractions(deletionEventDAO, eventBus);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -45,7 +45,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -295,36 +294,6 @@ class TraceServiceImplTest {
         }
 
         @Test
-        void deleteWithoutProjectIdRemovesReusedIdFromEveryOwningProject() {
-            var reusedId = idGenerator.generateId();
-            var soloId = idGenerator.generateId();
-            var projectA = idGenerator.generateId();
-            var projectB = idGenerator.generateId();
-            var workspaceId = UUID.randomUUID().toString();
-            var ids = Set.of(reusedId, soloId);
-            var connection = mockDeleteFlow();
-
-            // Bounded fast pass resolves everything: reusedId lives in A and B, soloId only in A.
-            when(traceDao.getAllProjectIdsByTraceIdsBounded(ids))
-                    .thenReturn(Mono.just(Map.of(reusedId, Set.of(projectA, projectB), soloId, Set.of(projectA))));
-            when(traceDao.delete(Set.of(reusedId, soloId), projectA, connection)).thenReturn(Mono.empty());
-            when(traceDao.delete(Set.of(reusedId), projectB, connection)).thenReturn(Mono.empty());
-
-            assertDoesNotThrow(() -> traceService
-                    .delete(ids, null)
-                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
-                            .put(RequestContext.WORKSPACE_ID, workspaceId))
-                    .block());
-
-            // Each delete carries the resolved project (full key): A gets both ids, B gets only the reused id.
-            verify(traceDao).delete(Set.of(reusedId, soloId), projectA, connection);
-            verify(traceDao).delete(Set.of(reusedId), projectB, connection);
-            // Bounded resolved all, so the unbounded fallback is not queried.
-            verify(traceDao, never()).getAllProjectIdsByTraceIds(any());
-            verifyNoInteractions(deletionEventDAO);
-        }
-
-        @Test
         void deleteWithoutProjectIdFallsBackToUnboundedForBoundedMisses() {
             var resolvedId = idGenerator.generateId();
             var missedId = idGenerator.generateId();
@@ -351,26 +320,6 @@ class TraceServiceImplTest {
             verify(traceDao).getAllProjectIdsByTraceIds(Set.of(missedId));
             verify(traceDao).delete(Set.of(resolvedId), projectA, connection);
             verify(traceDao).delete(Set.of(missedId), projectB, connection);
-        }
-
-        @Test
-        void deleteWithoutProjectIdSkipsIdsThatResolveToNoProject() {
-            var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
-            var workspaceId = UUID.randomUUID().toString();
-            mockDeleteFlow();
-
-            // Both passes come back empty: the ids have no live row, so the delete is a no-op.
-            when(traceDao.getAllProjectIdsByTraceIdsBounded(ids)).thenReturn(Mono.just(Map.of()));
-            when(traceDao.getAllProjectIdsByTraceIds(ids)).thenReturn(Mono.just(Map.of()));
-
-            assertDoesNotThrow(() -> traceService
-                    .delete(ids, null)
-                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
-                            .put(RequestContext.WORKSPACE_ID, workspaceId))
-                    .block());
-
-            verify(traceDao, never()).delete(any(), any(), any());
-            verifyNoInteractions(deletionEventDAO, eventBus);
         }
 
         private Connection mockDeleteFlow() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -16,6 +16,7 @@ import com.comet.opik.utils.ErrorUtils;
 import com.google.common.eventbus.EventBus;
 import io.r2dbc.spi.Connection;
 import jakarta.ws.rs.NotFoundException;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -227,7 +229,7 @@ class TraceServiceImplTest {
             var projectId = idGenerator.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
-            when(traceDao.delete(ids, projectId, connection)).thenReturn(Mono.empty());
+            when(traceDao.delete(pairs(projectId, ids), connection)).thenReturn(Mono.empty());
 
             // traceService is built with capture disabled (default config)
             assertDoesNotThrow(() -> traceService
@@ -236,7 +238,7 @@ class TraceServiceImplTest {
                             .put(RequestContext.WORKSPACE_ID, workspaceId))
                     .block());
 
-            verify(traceDao).delete(ids, projectId, connection);
+            verify(traceDao).delete(pairs(projectId, ids), connection);
             verifyTracesDeletedPosted(ids, projectId, workspaceId);
             verifyNoInteractions(deletionEventDAO);
         }
@@ -248,7 +250,7 @@ class TraceServiceImplTest {
             var projectId = idGenerator.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
-            when(traceDao.delete(ids, projectId, connection)).thenReturn(Mono.empty());
+            when(traceDao.delete(pairs(projectId, ids), connection)).thenReturn(Mono.empty());
             when(deletionEventDAO.insert(any(), eq(DEFAULT_USER)))
                     .thenReturn(Mono.error(new RuntimeException("Error inserting deletion events")));
 
@@ -262,7 +264,7 @@ class TraceServiceImplTest {
                             .put(RequestContext.WORKSPACE_ID, workspaceId))
                     .block());
 
-            verify(traceDao).delete(ids, projectId, connection);
+            verify(traceDao).delete(pairs(projectId, ids), connection);
             verifyTracesDeletedPosted(ids, projectId, workspaceId);
             verify(deletionEventDAO).insert(any(), eq(DEFAULT_USER));
         }
@@ -274,7 +276,7 @@ class TraceServiceImplTest {
             var projectId = idGenerator.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
-            when(traceDao.delete(ids, projectId, connection))
+            when(traceDao.delete(pairs(projectId, ids), connection))
                     .thenReturn(Mono.error(new RuntimeException("Error deleting traces")));
 
             var traceService = newTraceService(DatabaseAnalyticsDataModelConfig.builder()
@@ -289,27 +291,37 @@ class TraceServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Error deleting traces");
 
-            verify(traceDao).delete(ids, projectId, connection);
+            verify(traceDao).delete(pairs(projectId, ids), connection);
             verifyNoInteractions(deletionEventDAO, eventBus);
         }
 
         @Test
-        void deleteWithoutProjectIdFallsBackToUnboundedForBoundedMisses() {
+        void deleteResolvesBoundedMissesViaUnboundedFallbackAcrossAllProjects() {
+            // The null-project path resolves owning projects in two passes: a bounded fast pass, then an unbounded
+            // pass over ONLY the ids the bounded pass misses (e.g. a wrapped id_at outside the week window). Integration
+            // can't reach this branch (a wrapped-id_at row can't be created through the API), so it's covered here:
+            // the bounded pass resolves one id, the miss set (a second id, reused across two projects) is resolved by
+            // the unbounded pass, and the delete runs over the merged (project_id, id) pairs.
             var resolvedId = idGenerator.generateId();
             var missedId = idGenerator.generateId();
+            var ids = Set.of(resolvedId, missedId);
             var projectA = idGenerator.generateId();
             var projectB = idGenerator.generateId();
+            var projectC = idGenerator.generateId();
             var workspaceId = UUID.randomUUID().toString();
-            var ids = Set.of(resolvedId, missedId);
             var connection = mockDeleteFlow();
 
-            // Bounded window resolves only resolvedId; missedId (e.g. a wrapped id_at) is re-resolved unbounded.
             when(traceDao.getAllProjectIdsByTraceIdsBounded(ids))
                     .thenReturn(Mono.just(Map.of(resolvedId, Set.of(projectA))));
+            // Fallback runs over the miss set only, and resolves the reused id to both its owning projects.
             when(traceDao.getAllProjectIdsByTraceIds(Set.of(missedId)))
-                    .thenReturn(Mono.just(Map.of(missedId, Set.of(projectB))));
-            when(traceDao.delete(Set.of(resolvedId), projectA, connection)).thenReturn(Mono.empty());
-            when(traceDao.delete(Set.of(missedId), projectB, connection)).thenReturn(Mono.empty());
+                    .thenReturn(Mono.just(Map.of(missedId, Set.of(projectB, projectC))));
+
+            var expectedPairs = Set.of(
+                    Pair.of(projectA, resolvedId),
+                    Pair.of(projectB, missedId),
+                    Pair.of(projectC, missedId));
+            when(traceDao.delete(expectedPairs, connection)).thenReturn(Mono.empty());
 
             assertDoesNotThrow(() -> traceService
                     .delete(ids, null)
@@ -317,9 +329,18 @@ class TraceServiceImplTest {
                             .put(RequestContext.WORKSPACE_ID, workspaceId))
                     .block());
 
+            verify(traceDao).getAllProjectIdsByTraceIdsBounded(ids);
+            // The unbounded fallback is narrowed to the miss set, never re-queried over the whole id set.
             verify(traceDao).getAllProjectIdsByTraceIds(Set.of(missedId));
-            verify(traceDao).delete(Set.of(resolvedId), projectA, connection);
-            verify(traceDao).delete(Set.of(missedId), projectB, connection);
+            verify(traceDao).delete(expectedPairs, connection);
+        }
+
+        /**
+         * Mirrors {@code TraceServiceImpl}'s non-null-project path: one {@code (project_id, trace_id)} pair per id.
+         * Set equality is order-independent, so this matches whatever order the service iterates the ids in.
+         */
+        private Set<Pair<UUID, UUID>> pairs(UUID projectId, Set<UUID> ids) {
+            return ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet());
         }
 
         private Connection mockDeleteFlow() {


### PR DESCRIPTION
## Details

Eliminates project-less trace deletes. `traces` is a `ReplacingMergeTree` keyed by the full `(workspace_id, project_id, id)` triple, and an externally-ingested `id` can legitimately exist in several projects of a workspace. The null-`project_id` delete paths (`DELETE /traces/{id}` and `POST /traces/delete` without a `project_id`) previously fell back to a `DELETE` filtered only by `(id, workspace_id)`, which could silently over-delete a reused `id` across projects, behave non-deterministically, and emit empty-`project_id` deletion-bridge events. Now every delete resolves the owning project(s) and runs under the full key.

**Resolution & delete**
- Resolve every owning project per id via a two-pass resolver: a bounded (`toMonday(id_at)`) fast pass, then an unbounded pass over only the ids the bounded one leaves unresolved — so a row whose `id_at` is untrustworthy (e.g. a wrapped timestamp) is still found with its project. Ids that resolve to no owning project have no live row and are skipped (counted/logged) — never a project-less delete.
- A new `id` bloom-filter skip index on `traces` (`idx_traces_id_bf`, migration 000113, mirroring `traces_local_v2`) makes both passes granule-pruned instead of scanning the workspace.
- Delete by bound `(project_id, id)` pairs in a single tuple-IN statement per batch (`arrayZip`), so a reused id across N projects — or any cross-project batch — collapses from N statements to one; every delete carries `project_id` (also required once `traces` becomes Distributed).

**Cascade & bridge**
- The delete cascade (spans, feedback scores, comments, attachments) is uniformly project-scoped: comments and attachments now filter by `project_id`/`container_id` like spans and feedback, so deleting a reused id from one project no longer over-deletes another project's children.
- Absent ids emit no `TracesDeleted` event — a project-less cascade would be an unscoped, workspace-wide child delete that could over-delete a concurrently-ingested trace's children. Cleaning genuine orphan child rows is a separate span-lifecycle concern.
- The deletion-events bridge captures the deleted `(project_id, id)` pairs; no empty-`project_id` event is written for `TRACES`.

**API**
- `POST /traces/delete` rejects a null id element with 422; the optional `project_id` is documented in the OpenAPI schema.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7483

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + tests

## Testing

- `cd apps/opik-backend && mvn test` (CI runs the full quality gate).
- Integration (`TracesResourceTest`): delete-by-id of an `id` reused across two projects removes it from both; a null-`project_id` batch spanning projects; a batch mixing present and absent ids (present removed, absent skipped, still `204`); a null id element rejected with `422`; existing single-/multi-project suites remain green (behavior-preserving for the common case).
- Integration (`DeletionEventTest`): a reused-`id` delete captures one non-empty deletion-bridge event per owning project plus the per-project span cascade; no empty-`project_id` event is written.
- Integration (`AttachmentResourceMinIOTest`): deleting a reused `id` scoped to one project removes only that project's attachment and leaves the other's intact — public-API proof of the project-scoped cascade.
- Unit (`TraceServiceImplTest`): the bounded-miss → unbounded fallback branch (integration can't craft a wrapped-`id_at` row), plus the capture-disabled / capture-fails / delete-fails paths.
- Arch (`TraceDeletionEventArchTest`): every trace delete routes through the capturing service (no project-less bypass).

## Documentation

OpenAPI schema now documents the optional `project_id` on `POST /traces/delete`.
