### PR TITLE
[OPIK-7532] [QA] chore: normalise the annotation-queues area tag to plural

### DIFF
--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@e2e/fixtures';
 import { AnnotationQueuePage } from '@e2e/pom/annotation-queue.page';
 
-test.describe('Annotation queue — UI scoring, SDK verify', { tag: ['@t2-cuj', '@annotation-queue'] }, () => {
+test.describe('Annotation queue — UI scoring, SDK verify', { tag: ['@t2-cuj', '@annotation-queues'] }, () => {
   test('Scoring two items and skipping a third reflects on the source traces', async ({
     annotationQueue,
     backendClient,


### PR DESCRIPTION
## Details

Every e2e area tag matches its spec directory name 1:1 — `@datasets` in `tests/datasets/`, `@prompts` in `tests/prompts/`, and so on — except one: the directory is `annotation-queues` but the tag was `@annotation-queue` (singular). This renames the tag to `@annotation-queues`.

The coverage map being built under OPIK-7532 derives an area's identity from its tag and lints that it matches the directory name. This was the only case in the estate that would have needed a special-case exemption, so it is cheaper to fix the tag than to carry the exception.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7532

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: located the mismatch while surveying tag usage across `tests_end_to_end/`; made the one-line edit and verified the blast radius.
- Human verification: Andrei Cautisanu reviewed and approved the change and the reasoning before it was pushed.

## Testing

No behaviour change is expected, and the verification was targeted at proving that.

Commands run (from the repo root, against this branch):

```
grep -rn "'@annotation-queue'"  --include="*.ts" tests_end_to_end/   # -> no matches (no stale singular tag)
grep -rn "'@annotation-queues'" --include="*.ts" tests_end_to_end/   # -> the one expected hit
```

Scenarios validated:

- **Tier selection unchanged.** This spec's tier is driven by `@t2-cuj`, which is untouched. Confirmed against the `--grep` patterns in `tests_end_to_end/e2e/package.json`: `@t1-smoke` does not match the file (correctly excluded from `test:t1`), and `"@t1-smoke|@t2-cuj"` does match (correctly included in `test:t2` and `test:t3`).
- **No other consumer.** Before the change, `@annotation-queue` appeared exactly once in the whole repository — this line. It is not referenced by any npm script, CI grep, or workflow input, so nothing selects tests by it.

Tests not run, with reason:

- `playwright test --list` was **not** executed. Playwright is not installed in the local checkout, and installing the toolchain to confirm a string literal inside a `tag:` array was not proportionate. The grep-level verification above covers the same selection semantics that `--grep` uses. Flagging so a reviewer can run it if they would rather see it.

## Documentation

None needed — the tag is internal to the test suite and is not documented outside it.

Note for anyone querying Allure: results predating this merge carry the tag `annotation-queue` and results after it carry `annotation-queues` (Allure ingests Playwright tags automatically, minus the leading `@`). Any query spanning the merge should accept both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)