### PR TITLE
[OPIK-7532] [QA] feat: capability coverage map — taxonomy, spec tags, and tag-lint PR gate

### DIFF
--- a/.github/workflows/qa_coverage_reconcile.yml
+++ b/.github/workflows/qa_coverage_reconcile.yml
@@ -1,0 +1,149 @@
+name: QA Coverage Reconcile
+run-name: "QA Coverage Reconcile ${{ github.ref_name }}"
+
+# Keeps the derived fields in tests_end_to_end/coverage/taxonomy.yaml in step with
+# the actual spec tags, and opens a PR when they drift (OPIK-7631).
+#
+# The tags are the source of truth: a capability is covered when a spec carries
+# its @cap:/@vcap: tag. The `covered:`/`tier:` values in the taxonomy are a cache
+# of that, refreshed here. Nobody edits them by hand.
+#
+# Authored fields — areas, capability keys, notes, cloud_only, state, axes — are
+# never touched by this job. Those change via the discovery job (OPIK-7632) or a
+# human PR.
+#
+# Runs after merges land rather than on PRs: on a PR the tags and the taxonomy
+# are *meant* to disagree until the reviewer accepts the new coverage claim, and
+# tag_lint.yml already gates tag validity there.
+
+on:
+  schedule:
+    - cron: '30 2 * * *'   # 02:30 UTC daily, after the nightly t3 suite settles
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'tests_end_to_end/e2e/tests/**'
+      - 'tests_end_to_end/visual-tests/tests/**'
+      - 'tests_end_to_end/coverage/**'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false   # never abandon a run that may have opened a PR
+
+permissions:
+  contents: read
+
+jobs:
+
+  reconcile:
+    name: reconcile taxonomy with spec tags
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      # Tags are read via `playwright test --list`, not a regex, because tags
+      # union from describe to test and a file may hold several tiers. No browser
+      # is launched, so `playwright install` is deliberately skipped.
+      - name: Install e2e deps
+        working-directory: tests_end_to_end/e2e
+        run: npm ci --ignore-scripts
+
+      - name: Install visual-tests deps
+        working-directory: tests_end_to_end/visual-tests
+        run: npm ci --ignore-scripts
+
+      - name: Set branch name
+        run: echo "BRANCH_NAME=github-actions/OPIK-7532-reconcile-qa-taxonomy-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
+
+      - name: Reconcile
+        id: reconcile
+        run: |
+          set -o pipefail
+          python3 tests_end_to_end/coverage/reconcile.py \
+            --taxonomy tests_end_to_end/coverage/taxonomy.yaml \
+            --estate tests_end_to_end \
+            --summary | tee /tmp/reconcile.txt
+          {
+            echo 'summary<<RECONCILE_EOF'
+            cat /tmp/reconcile.txt
+            echo 'RECONCILE_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for changes
+        id: check_changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          set -ex
+          git config --local user.email "github-actions@comet.com"
+          git config --local user.name "Github Actions (${{ github.actor }})"
+          git add tests_end_to_end/coverage/taxonomy.yaml
+          git commit -m "[OPIK-7532] [QA] chore: reconcile coverage taxonomy with spec tags"
+
+      - name: Create Pull Request
+        if: steps.check_changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.COMET_ACTION_CREATE_PR }}
+          branch: ${{ env.BRANCH_NAME }}
+          title: "[OPIK-7532] [QA] chore: reconcile coverage taxonomy with spec tags"
+          body: |
+            ## Details
+
+            Automated sync of the **derived** fields in
+            `tests_end_to_end/coverage/taxonomy.yaml` with the `@cap:`/`@vcap:` tags
+            actually present in the test estate.
+
+            Only `covered:` and `tier:` are touched. Areas, capability keys, notes,
+            `cloud_only`, `state` and `axes` are authored and left alone.
+
+            ```
+            ${{ steps.reconcile.outputs.summary }}
+            ```
+
+            See the job log for the full change list.
+
+            **Why this is safe to merge on green:** the tags are the source of
+            truth for coverage, so this PR only ever makes the file agree with
+            what the specs already claim. If a line here looks wrong, the tag is
+            wrong — fix the spec, not the taxonomy.
+
+            ## Change checklist
+            - [ ] User facing change
+            - [ ] Documentation update
+
+            ## Issues
+            OPIK-7631
+
+            ## Testing
+            - `tag_lint` + `reconcile --check` pass on this branch
+
+            ## Documentation
+            - `tests_end_to_end/TESTING-TAGS.md`

--- a/.github/workflows/qa_coverage_reconcile.yml
+++ b/.github/workflows/qa_coverage_reconcile.yml
@@ -72,8 +72,11 @@ jobs:
         working-directory: tests_end_to_end/visual-tests
         run: npm ci --ignore-scripts
 
+      # Deliberately stable, with no timestamp: create-pull-request force-updates
+      # this branch and reuses the open PR. A per-run branch name would open a
+      # fresh reconciliation PR every night and leave the old ones to rot.
       - name: Set branch name
-        run: echo "BRANCH_NAME=github-actions/OPIK-7532-reconcile-qa-taxonomy-$(date +%Y-%m-%d-%H-%M-%S)" >> "$GITHUB_ENV"
+        run: echo "BRANCH_NAME=github-actions/OPIK-7532-reconcile-qa-taxonomy" >> "$GITHUB_ENV"
 
       - name: Reconcile
         id: reconcile

--- a/.github/workflows/tag_lint.yml
+++ b/.github/workflows/tag_lint.yml
@@ -1,0 +1,64 @@
+name: Lint Test Tags
+run-name: "Lint Test Tags ${{ github.ref_name }} by @${{ github.actor }}"
+
+# Guards the coverage-map tags in tests_end_to_end/ (OPIK-7532).
+#
+# Why this gates PRs rather than running nightly: tier selection is `--grep`, so
+# a spec with a missing or typo'd tag is not a failure — it is silently never
+# selected, and `npm test` even passes `--pass-with-no-tests`. Catching that at
+# review time is the whole point; a nightly job would report it the next morning,
+# after the spec had already stopped running.
+#
+# Deliberately needs no secrets, no internal runner and no cross-repo checkout,
+# so it works on pull requests from external contributors too. That is also why
+# the taxonomy lives here in the repo next to the specs it describes rather than
+# in the (private) comet-automation-tests repo.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "tests_end_to_end/**"
+      - ".github/workflows/tag_lint.yml"
+  push:
+    branches:
+      - 'main'
+    paths:
+      - "tests_end_to_end/**"
+      - ".github/workflows/tag_lint.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Read-only: the lint never edits specs or the taxonomy.
+permissions:
+  contents: read
+
+jobs:
+
+  tag-lint:
+    name: tag-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+
+      - name: Lint test tags
+        # --format github turns findings into ::error:: annotations, so they land
+        # on the offending line in the PR's Files-changed view.
+        run: |
+          python3 tests_end_to_end/coverage/tag_lint.py \
+            --taxonomy tests_end_to_end/coverage/taxonomy.yaml \
+            --estate tests_end_to_end \
+            --format github

--- a/tests_end_to_end/TESTING-TAGS.md
+++ b/tests_end_to_end/TESTING-TAGS.md
@@ -1,0 +1,229 @@
+# Testing tags
+
+How tests in `tests_end_to_end/` declare what they are and what they cover.
+
+Tags are the coverage map. Nobody maintains a spreadsheet of "which tests cover
+prompts" — the specs are the map, and the coverage builder reads these tags.
+That only works if the grammar holds, so CI enforces it.
+
+**Scope:** `tests_end_to_end/e2e` (Playwright functional) and
+`tests_end_to_end/visual-tests` (Playwright visual). Nothing else.
+
+---
+
+## The four kinds of tag
+
+Tags live **only** in Playwright's `tag` option — never in the test title.
+
+```ts
+test.describe('Prompt Library — smoke', {
+  tag: ['@t1-smoke', '@area:prompts', '@cap:prompts.list-prompts'],
+}, () => { /* ... */ });
+```
+
+| Kind | Cardinality | Example | Answers |
+|---|---|---|---|
+| **tier** | exactly 1 | `@t1-smoke` | how deep / how often does this run? |
+| **suite** | 0 or more | `@t1-stsaas` | *where* does this run, outside the ladder? |
+| **area** | exactly 1 | `@area:prompts` | which product area is this? |
+| **cap** | 1 or more | `@cap:prompts.list-prompts` | which capabilities does it cover? |
+
+### tier — depth
+
+| Tag | Runs | Cost |
+|---|---|---|
+| `@t1-smoke` | post-merge + prod 3×/day | must be cheap and stable |
+| `@t2-cuj` | nightly (as part of t3) | real user journeys |
+| `@t3-nightly` | nightly on staging | slowest, most thorough |
+
+Tiers are **cumulative**: `test:t2` runs t1+t2, `test:t3` runs t1+t2+t3.
+So pick the tier by *how often it should run*, not by how important it is.
+
+### suite — where, not how deep
+
+**Suites are orthogonal to tier.** This is the part people get wrong.
+
+A suite tag says "also include me in this run", independent of depth. A spec can
+be `@t2-cuj` *and* `@t1-stsaas`: t2 depth, but also part of the STSaaS sanity set.
+
+| Tag | Meaning |
+|---|---|
+| `@t1-stsaas` | include in the STSaaS customer-env sanity run (`test:t1-stsaas`) |
+| `@provider-sanity` | LLM-provider matrix; own cadence, no deploy gating |
+| `@release-gate` | release-gate spec (see `e2e/tests/_release-gate/README.md`) |
+| `@release-gate:<version>` | version-stamped gate spec |
+
+Worked example — `optimization-studio.spec.ts`:
+
+```ts
+{ tag: ['@t2-cuj', '@t1-stsaas', '@area:optimization-studio', '@cap:...'] }
+```
+
+t2 depth because it's a full user journey. `@t1-stsaas` because Optimization
+Studio was historically unstable on customer envs and must be verified there.
+**Not** `@t1-smoke`, because every run spends real LLM budget and t1 runs 3×/day.
+
+A spec carrying only a suite tag and no tier is valid — that's a deliberate
+opt-out of the ladder (`playground-providers.spec.ts` does this).
+
+### area and cap — coverage
+
+`@area:` must match the spec's directory name. `@cap:` must be
+`<area>.<capability>` and both halves must exist in `coverage/taxonomy.yaml`.
+
+```ts
+// tests/datasets/dataset-items.spec.ts
+{ tag: ['@t2-cuj', '@area:datasets', '@cap:datasets.edit-item-versions'] }
+```
+
+Add a `@cap:` for **every** capability the spec actually asserts, not just the
+headline one. A capability counts as covered when a test carrying its tag passed
+in the last 7 days — so an unlisted assertion is invisible coverage, and a listed
+one you don't really assert is a false green.
+
+### Visual specs
+
+Visual specs carry `@vcap:` and **no tier** — they run as one suite.
+
+```ts
+// visual-tests/tests/empty-states.spec.ts
+{ tag: ['@vcap:datasets.datasets-empty'] }
+```
+
+Visual capabilities are *page/state*-shaped, not behaviour-shaped: one screenshot
+asserts a whole page renders. They live in the `visual:` block of each area and
+each declares a `state:` from `default | empty | loading | error`.
+
+---
+
+## Where tags go: describe vs test
+
+Put shared tags on the `describe`, per-test tags on the `test`. The builder unions
+them, so a test inherits everything from its enclosing describe.
+
+```ts
+test.describe('Dataset items', { tag: ['@area:datasets'] }, () => {
+  test('editing commits a version', {
+    tag: ['@t2-cuj', '@cap:datasets.edit-item-versions'],
+  }, async () => { /* ... */ });
+
+  test('bulk delete commits a version', {
+    tag: ['@t3-nightly', '@cap:datasets.bulk-delete-items'],
+  }, async () => { /* ... */ });
+});
+```
+
+A file may hold several describes at **different tiers** — `ollie-agentic.spec.ts`
+has three. That's fine and often right.
+
+---
+
+## Naming
+
+**Tags:** kebab-case, lowercase. `@cap:` is `<area>.<capability>`, both kebab.
+
+**Test titles:** `<capability>: <behavior>` — state the behaviour, not the mechanic.
+
+```ts
+// good — says what must be true
+test('Editing an item field commits as a new version and round-trips to the SDK')
+
+// bad — describes clicking, not the guarantee
+test('click edit then save then check')
+```
+
+**Directory = area.** `tests/<area>/` and `@area:<area>` must match. Enforced.
+
+---
+
+## test.step()
+
+Wrap each phase in `test.step()`. On failure Allure names the failing step, which
+turns "the test broke" into "seeding worked, the assertion on version 2 failed".
+
+```ts
+const dataset = await test.step('Seed a dataset via the SDK', async () => { /* ... */ });
+await test.step('Edit an item field and commit', async () => { /* ... */ });
+await test.step('Verify the edit round-trips to the SDK', async () => { /* ... */ });
+```
+
+Already the house style: 22 of 24 functional specs and 16 of 21 page objects use
+it. Steps may return values, and step titles may be template literals.
+
+---
+
+## Allure
+
+Playwright tags reach Allure automatically — **no `allure.label()` calls needed.**
+
+Allure strips the leading `@`, so `@cap:prompts.list-prompts` is queryable as:
+
+```
+tag = "cap:prompts.list-prompts"
+```
+
+Compound queries work, which is what the coverage builder uses:
+
+```
+tag = "area:traces" and status = "passed"
+```
+
+Everything reports to project **1** at `https://comet.testops.cloud/` — both Opik
+and EM, so segment by launch name or tag, never by project id.
+
+---
+
+## Adding an area or capability
+
+The taxonomy is a **reviewed** file: it defines 100%, so adding to it changes the
+denominator and lowers coverage until tests exist. That's intended — it makes a
+known gap visible instead of silently absent.
+
+1. Add the area or capability to `coverage/taxonomy.yaml` (with `covered: false`).
+2. Get it reviewed — this is a QA-owned decision, not an implementation detail.
+3. Tag specs with the new `@cap:` as coverage lands, flipping `covered: true`.
+
+Capability altitude: aim for **5–15 per area**, each a user-visible behaviour a
+test could plausibly assert. "Create a prompt" is a capability. "Click the save
+button" is not. Tabs usually *are* separate capabilities.
+
+Renaming an area: add the old name to `tag_aliases:` so historical Allure results
+still resolve. If the old tag no longer maps to exactly one area, add it to
+`retired_tags:` instead and resolve per spec — see `trace-explore`, which split
+into `traces` and `threads`.
+
+---
+
+## CI enforcement
+
+`.github/workflows/tag_lint.yml` runs on every PR touching `tests_end_to_end/`.
+Hard failure, not a warning — an untagged spec is invisible to `--grep`, so it
+silently never runs and `npm test` even passes `--pass-with-no-tests`. That's the
+failure mode this prevents.
+
+Run it locally the same way CI does, from the repo root:
+
+```bash
+pip install pyyaml
+python3 tests_end_to_end/coverage/tag_lint.py \
+  --taxonomy tests_end_to_end/coverage/taxonomy.yaml \
+  --estate tests_end_to_end
+```
+
+Findings are line-anchored, so in CI (`--format github`) they appear on the
+offending line in the PR's Files-changed view.
+
+Enforced:
+
+1. every non-exempt e2e spec has exactly one tier (or a suite opt-out) and one `@area:`
+2. `@area:` / `@cap:` / `@vcap:` all resolve in the taxonomy
+3. `@cap:` sits under the spec's declared area
+4. visual specs carry `@vcap:` and no tier
+5. every visual capability's `state:` is in the enum
+6. no unrecognised tags
+
+Exempt (`rules.exempt_dirs`): `_seed` (harness self-test), `_release-gate`
+(ephemeral, version-stamped).
+
+Legacy and retired tags get a specific message telling you the replacement,
+rather than a generic "unrecognised".

--- a/tests_end_to_end/TESTING-TAGS.md
+++ b/tests_end_to_end/TESTING-TAGS.md
@@ -77,9 +77,11 @@ opt-out of the ladder (`playground-providers.spec.ts` does this).
 ```
 
 Add a `@cap:` for **every** capability the spec actually asserts, not just the
-headline one. A capability counts as covered when a test carrying its tag passed
-in the last 7 days — so an unlisted assertion is invisible coverage, and a listed
-one you don't really assert is a false green.
+headline one — and only for what it really asserts. A capability counts as covered
+when a test carrying its tag **exists**; test health (green/flaky/red) is tracked
+and reported separately, so a broken nightly never makes coverage appear to drop.
+That makes the tag the claim: an unlisted assertion is invisible coverage, and a
+listed one you don't actually assert is a permanent false green.
 
 ### Visual specs
 
@@ -215,12 +217,24 @@ offending line in the PR's Files-changed view.
 
 Enforced:
 
-1. every non-exempt e2e spec has exactly one tier (or a suite opt-out) and one `@area:`
-2. `@area:` / `@cap:` / `@vcap:` all resolve in the taxonomy
-3. `@cap:` sits under the spec's declared area
-4. visual specs carry `@vcap:` and no tier
-5. every visual capability's `state:` is in the enum
-6. no unrecognised tags
+1. every non-exempt e2e spec has a tier (or a suite opt-out) and exactly one `@area:`
+2. every non-visual spec declares at least one `@cap:`
+3. `@area:` / `@cap:` / `@vcap:` all resolve in the taxonomy
+4. `@cap:` sits under the spec's declared area
+5. visual specs carry `@vcap:` and no tier
+6. every visual capability in `taxonomy.yaml` has a `state:` from the enum
+7. no unrecognised tags
+
+**Not** enforced: tier *cardinality*. "Exactly one tier" is a rule about a single
+test after describe-inheritance, and the linter reads string literals, not the TS
+AST — it cannot tell a file whose sibling describes differ (legitimate, and four
+specs do it) from one test carrying two tiers (wrong). Keep it right by hand.
+
+A computed tag is invisible. `tag: [variant.cap]` passes the lint and silently
+contributes nothing to coverage, because both the lint and the builder match
+quoted literals inside `tag: [...]`. If you find yourself generating tests in a
+loop where each iteration covers a *different* capability, write them as separate
+`test()` calls with literal tags — see `prompt-library-smoke.spec.ts`.
 
 Exempt (`rules.exempt_dirs`): `_seed` (harness self-test), `_release-gate`
 (ephemeral, version-stamped).

--- a/tests_end_to_end/coverage/reconcile.py
+++ b/tests_end_to_end/coverage/reconcile.py
@@ -11,14 +11,19 @@ fact, and this job refreshes the cache. Nobody edits those flags by hand.
                      state, axes. Never touched here. Those change via the
                      discovery job (OPIK-7632) or a human PR.
 
-Run nightly after merges land. Exits 0 with no changes when the file already
-agrees, so it is cheap to run on every push.
+Run nightly after merges land.
+
+Exit codes: 0 when the taxonomy already agrees (or, without --check, once it has
+been updated); 1 from --check when derived fields drifted; 1 from either mode
+when a spec tags a capability the taxonomy does not define, since that is drift
+this job cannot repair on its own.
 
 Reads tags via `playwright test --list --reporter=json`, not a regex, so it needs
 `npm ci` in e2e/ and visual-tests/ first. That is deliberate: tags union from
 describe to test, so the tier covering a given `@cap:` is only knowable after
-inheritance is resolved. A regex version of this job was measured "correcting"
-5 accurate `tier:` fields to wrong values.
+inheritance is resolved. A regex version of this job mis-attributed tiers in
+every spec whose sibling describes ran at different tiers, and would have
+rewritten accurate `tier:` values to wrong ones.
 
 Why line surgery instead of yaml.safe_load + dump: the taxonomy carries 175
 comments and 242 column-aligned flow mappings that a load/dump round-trip
@@ -83,8 +88,17 @@ def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]
         ("visual-tests", vcaps, "@vcap:"),
     ):
         root = estate / sub
+        # Both projects are required. Skipping a missing one would leave that
+        # dimension's tag map empty, which reads as "nothing is covered" and
+        # would flip every capability in it to covered: false — the same
+        # corruption as parsing a partial --list. If the estate layout changes,
+        # this job must be updated deliberately, not fail open.
         if not (root / "package.json").is_file():
-            continue
+            raise RuntimeError(
+                f"expected a Playwright project at {root} (no package.json). "
+                "reconcile refuses to run against an incomplete estate — it would "
+                "mark every capability in this dimension as uncovered."
+            )
         for tags in playwright_test_tags(root):
             tiers = {t.lstrip("@") for t in tags if t.lstrip("@") in TIER_ORDER}
             for t in tags:
@@ -94,18 +108,51 @@ def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]
 
 
 def playwright_test_tags(project_root: Path) -> list[set[str]]:
-    """Every test's fully-resolved tag set, via `playwright test --list`."""
+    """Every test's fully-resolved tag set, via `playwright test --list`.
+
+    Raises rather than returning a partial list. This matters more than it looks:
+    a single spec with a syntax error makes `--list` exit 1 while still printing
+    *valid* JSON with `suites: []` and an `errors` array. Parsing that happily
+    would tell the reconciler no capability is tagged, flipping every `covered:`
+    to false and committing the wipe. Verified: one bad spec => exit 1, 3.7 kB of
+    parseable JSON, 0 tests, 1 error.
+    """
+    cmd = ["npx", "playwright", "test", "--list", "--reporter=json"]
     proc = subprocess.run(
-        ["npx", "playwright", "test", "--list", "--reporter=json"],
-        cwd=project_root, capture_output=True, text=True, timeout=300,
+        cmd, cwd=project_root, capture_output=True, text=True, timeout=300,
     )
-    # Playwright writes the JSON report to stdout even when it also warns on
-    # stderr; only a missing/!0-with-empty-stdout run is a real failure.
-    if not proc.stdout.strip():
-        raise RuntimeError(
-            f"playwright --list produced no output in {project_root}\n{proc.stderr[-800:]}"
+
+    def fail(why: str) -> RuntimeError:
+        # Playwright puts collection errors in the report's `errors` array, not on
+        # stderr, so surface those rather than a slice of the JSON header.
+        detail = proc.stderr.strip()[-800:]
+        if not detail:
+            try:
+                errs = (json.loads(proc.stdout) or {}).get("errors") or []
+                detail = "\n".join(
+                    f"    {(e.get('message') or str(e)).strip()[:300]}" for e in errs[:5]
+                )
+            except Exception:
+                detail = proc.stdout.strip()[:300]
+        return RuntimeError(
+            f"{why}\n  cmd: {' '.join(cmd)}\n  cwd: {project_root}\n"
+            f"  exit: {proc.returncode}\n  detail:\n{detail or '    (none)'}"
         )
-    report = json.loads(proc.stdout)
+
+    if proc.returncode != 0:
+        raise fail("playwright --list failed; refusing to reconcile from a partial estate")
+    if not proc.stdout.strip():
+        raise fail("playwright --list produced no output")
+
+    try:
+        report = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        raise fail(f"playwright --list emitted unparseable JSON: {e}") from None
+
+    # Belt and braces: --list can report collection errors without a non-zero
+    # exit in some Playwright versions.
+    if report.get("errors"):
+        raise fail(f"playwright --list reported {len(report['errors'])} collection error(s)")
 
     out: list[set[str]] = []
 
@@ -302,7 +349,13 @@ def main() -> int:
     ap.add_argument("--summary", action="store_true", help="print the change list")
     args = ap.parse_args()
 
-    lines, changes, warnings = reconcile(args.taxonomy, args.estate)
+    # These are operational failures with actionable messages (a broken spec, a
+    # missing project), not bugs — print the reason, not a traceback.
+    try:
+        lines, changes, warnings = reconcile(args.taxonomy, args.estate)
+    except RuntimeError as e:
+        print(f"reconcile: {e}", file=sys.stderr)
+        return 1
 
     for w in warnings:
         print(f"warning: {w}", file=sys.stderr)

--- a/tests_end_to_end/coverage/reconcile.py
+++ b/tests_end_to_end/coverage/reconcile.py
@@ -118,9 +118,22 @@ def playwright_test_tags(project_root: Path) -> list[set[str]]:
     parseable JSON, 0 tests, 1 error.
     """
     cmd = ["npx", "playwright", "test", "--list", "--reporter=json"]
-    proc = subprocess.run(
-        cmd, cwd=project_root, capture_output=True, text=True, timeout=300,
-    )
+    try:
+        proc = subprocess.run(
+            cmd, cwd=project_root, capture_output=True, text=True, timeout=300,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"playwright --list timed out after {e.timeout:.0f}s\n"
+            f"  cmd: {' '.join(cmd)}\n  cwd: {project_root}"
+        ) from None
+    except OSError as e:
+        # npx missing, cwd gone, not executable — never reaches Playwright.
+        raise RuntimeError(
+            f"could not run playwright --list: {e}\n"
+            f"  cmd: {' '.join(cmd)}\n  cwd: {project_root}\n"
+            "  is `npm ci` done in this project?"
+        ) from None
 
     def fail(why: str) -> RuntimeError:
         # Playwright puts collection errors in the report's `errors` array, not on
@@ -252,7 +265,16 @@ class Change:
 
 def reconcile(taxonomy: Path, estate: Path) -> tuple[list[str], list[Change], list[str]]:
     """-> (new lines, changes, warnings). Never writes."""
-    tax = yaml.safe_load(taxonomy.read_text())
+    try:
+        text = taxonomy.read_text()
+    except OSError as e:
+        raise RuntimeError(f"could not read {taxonomy}: {e}") from None
+    try:
+        tax = yaml.safe_load(text)
+    except yaml.YAMLError as e:
+        raise RuntimeError(f"{taxonomy} is not valid YAML: {e}") from None
+    if not isinstance(tax, dict):
+        raise RuntimeError(f"{taxonomy} did not parse to a mapping (got {type(tax).__name__})")
     caps, vcaps = scan_estate(estate)
 
     # The load dimension is `status: planned` and reports to JUnit, not Allure.
@@ -261,7 +283,9 @@ def reconcile(taxonomy: Path, estate: Path) -> tuple[list[str], list[Change], li
     dims = tax.get("dimensions") or {}
     skip_load = (dims.get("load") or {}).get("status") != "active"
 
-    lines = taxonomy.read_text().splitlines()
+    # Same text the parse above used — re-reading could pick up a mid-run edit
+    # and desynchronise the line numbers from the parsed structure.
+    lines = text.splitlines()
     changes: list[Change] = []
     warnings: list[str] = []
 
@@ -349,8 +373,11 @@ def main() -> int:
     ap.add_argument("--summary", action="store_true", help="print the change list")
     args = ap.parse_args()
 
-    # These are operational failures with actionable messages (a broken spec, a
-    # missing project), not bugs — print the reason, not a traceback.
+    # Operational failures — a broken spec, a missing project, an unreadable or
+    # malformed taxonomy, npx absent, --list timing out — are converted to
+    # RuntimeError at their source and reported as a message, not a traceback.
+    # Deliberately not `except Exception`: anything else IS a bug, and a stack
+    # trace is the right output for it.
     try:
         lines, changes, warnings = reconcile(args.taxonomy, args.estate)
     except RuntimeError as e:
@@ -372,7 +399,11 @@ def main() -> int:
         return 1 if (changes or warnings) else 0
 
     if changes:
-        args.taxonomy.write_text("\n".join(lines) + "\n")
+        try:
+            args.taxonomy.write_text("\n".join(lines) + "\n")
+        except OSError as e:
+            print(f"reconcile: could not write {args.taxonomy}: {e}", file=sys.stderr)
+            return 1
         print(f"reconcile: updated {args.taxonomy} ({len(changes)} field(s))")
     else:
         print("reconcile: no changes")

--- a/tests_end_to_end/coverage/reconcile.py
+++ b/tests_end_to_end/coverage/reconcile.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Reconcile taxonomy.yaml's derived fields with the actual spec tags.
+
+The tags are the source of truth. A capability is covered when some spec carries
+its `@cap:`/`@vcap:` tag; the `covered:` flag in taxonomy.yaml is a cache of that
+fact, and this job refreshes the cache. Nobody edits those flags by hand.
+
+  covered:   derived — does any spec tag this capability
+  tier:      derived — the shallowest tier among the tagging tests
+  (everything else)  authored — areas, capability keys, notes, cloud_only,
+                     state, axes. Never touched here. Those change via the
+                     discovery job (OPIK-7632) or a human PR.
+
+Run nightly after merges land. Exits 0 with no changes when the file already
+agrees, so it is cheap to run on every push.
+
+Reads tags via `playwright test --list --reporter=json`, not a regex, so it needs
+`npm ci` in e2e/ and visual-tests/ first. That is deliberate: tags union from
+describe to test, so the tier covering a given `@cap:` is only knowable after
+inheritance is resolved. A regex version of this job was measured "correcting"
+5 accurate `tier:` fields to wrong values.
+
+Why line surgery instead of yaml.safe_load + dump: the taxonomy carries 175
+comments and 242 column-aligned flow mappings that a load/dump round-trip
+flattens. That would produce a ~700-line diff every night and make the PRs
+unreviewable. Here every edit rewrites values *inside* one existing line, so the
+nightly diff is exactly the capabilities whose coverage actually moved.
+
+Usage:
+  reconcile.py --taxonomy <t.yaml> --estate <tests_end_to_end>          # apply
+  reconcile.py ... --check                    # exit 1 if drifted, write nothing
+  reconcile.py ... --summary                  # human-readable change list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("pyyaml required: pip install pyyaml")
+
+TAG_BLOCK = re.compile(r"tag:\s*\[(.*?)\]", re.S)
+TAG_LITERAL = re.compile(r"['\"](@[^'\"]+)['\"]")
+
+# Shallowest tier wins: if a capability is exercised by both a t1 smoke test and
+# a t3 nightly, the honest answer to "how often is this verified" is t1.
+TIER_ORDER = ("t1-smoke", "t2-cuj", "t3-nightly")
+
+# `  key:   { covered: true,  tier: t1-smoke }` — captures indent, key, and the
+# inside of the braces so we can rewrite values without touching alignment.
+FLOW_ENTRY = re.compile(r"^(?P<indent>\s+)(?P<key>[\w.-]+):(?P<pad>\s*)\{(?P<body>[^}]*)\}\s*$")
+SECTION = re.compile(r"^(?P<indent>\s+)(?P<name>[\w.-]+):\s*$")
+
+
+# --------------------------------------------------------------------------- #
+# read the estate
+# --------------------------------------------------------------------------- #
+
+def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
+    """-> (functional cap -> tiers covering it, visual cap -> tiers).
+
+    Asks Playwright, not a regex. Tags union from describe to test, so the tier
+    that applies to a given `@cap:` is only knowable after describe-inheritance
+    is resolved — and a file may hold several describes at different tiers.
+    A whole-file regex scan gets this wrong in both directions: it was measured
+    attributing t1 to t3-only capabilities in `ollie-agentic.spec.ts` and
+    `dataset-items.spec.ts`, which would have made the nightly job "correct" 5
+    accurate fields to wrong values. `--list --reporter=json` is the same
+    resolution Playwright uses to select tests, so it is the ground truth.
+    """
+    caps: dict[str, set[str]] = {}
+    vcaps: dict[str, set[str]] = {}
+
+    for sub, sink, prefix in (
+        ("e2e", caps, "@cap:"),
+        ("visual-tests", vcaps, "@vcap:"),
+    ):
+        root = estate / sub
+        if not (root / "package.json").is_file():
+            continue
+        for tags in playwright_test_tags(root):
+            tiers = {t.lstrip("@") for t in tags if t.lstrip("@") in TIER_ORDER}
+            for t in tags:
+                if t.startswith(prefix):
+                    sink.setdefault(t.split(":", 1)[1], set()).update(tiers)
+    return caps, vcaps
+
+
+def playwright_test_tags(project_root: Path) -> list[set[str]]:
+    """Every test's fully-resolved tag set, via `playwright test --list`."""
+    proc = subprocess.run(
+        ["npx", "playwright", "test", "--list", "--reporter=json"],
+        cwd=project_root, capture_output=True, text=True, timeout=300,
+    )
+    # Playwright writes the JSON report to stdout even when it also warns on
+    # stderr; only a missing/!0-with-empty-stdout run is a real failure.
+    if not proc.stdout.strip():
+        raise RuntimeError(
+            f"playwright --list produced no output in {project_root}\n{proc.stderr[-800:]}"
+        )
+    report = json.loads(proc.stdout)
+
+    out: list[set[str]] = []
+
+    def walk(suite: dict) -> None:
+        for spec in suite.get("specs") or []:
+            for test in spec.get("tests") or []:
+                tags = set(test.get("tags") or [])
+                # Older reporter shapes hang tags off the spec, not the test.
+                tags.update(spec.get("tags") or [])
+                # Normalise: the reporter may or may not keep the leading '@'.
+                out.append({t if t.startswith("@") else f"@{t}" for t in tags})
+        for child in suite.get("suites") or []:
+            walk(child)
+
+    for suite in report.get("suites") or []:
+        walk(suite)
+    return out
+
+
+def shallowest(tiers: set[str]) -> str | None:
+    for t in TIER_ORDER:
+        if t in tiers:
+            return t
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# rewrite one flow-mapping body
+# --------------------------------------------------------------------------- #
+
+def parse_body(body: str) -> list[tuple[str, str]]:
+    """`covered: true,  tier: t1-smoke` -> [('covered','true'), ('tier','t1-smoke')].
+
+    Order-preserving and splits only on top-level commas, so a quoted note
+    containing a comma survives.
+    """
+    out, depth, cur = [], 0, ""
+    for ch in body:
+        if ch in "\"'":
+            depth ^= 1
+        if ch == "," and not depth:
+            out.append(cur)
+            cur = ""
+        else:
+            cur += ch
+    out.append(cur)
+    pairs = []
+    for chunk in out:
+        if ":" not in chunk:
+            continue
+        k, v = chunk.split(":", 1)
+        pairs.append((k.strip(), v.strip()))
+    return pairs
+
+
+def render_body(pairs: list[tuple[str, str]]) -> str:
+    """Re-emit `k: v` pairs in the file's house style.
+
+    `covered: true,  tier: t1-smoke` uses two spaces so the tier column lines up
+    with neighbouring entries; a trailing `note:` uses one. Matching this keeps
+    an unrelated capability from showing up as whitespace noise in the diff.
+    """
+    parts = []
+    for i, (k, v) in enumerate(pairs):
+        if i:
+            parts.append(", " if k == "note" else ",  ")
+        parts.append(f"{k}: {v}")
+    return "".join(parts)
+
+
+def set_field(pairs: list[tuple[str, str]], key: str, value: str | None) -> list[tuple[str, str]]:
+    """Set, insert (right after `covered`), or drop a field, preserving order."""
+    out = [(k, v) for k, v in pairs if k != key]
+    if value is None:
+        return out
+    if any(k == key for k, _ in pairs):
+        return [(k, value if k == key else v) for k, v in pairs]
+    idx = next((i for i, (k, _) in enumerate(out) if k == "covered"), -1)
+    out.insert(idx + 1, (key, value))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# reconcile
+# --------------------------------------------------------------------------- #
+
+class Change:
+    __slots__ = ("line", "area", "cap", "kind", "before", "after")
+
+    def __init__(self, line, area, cap, kind, before, after):
+        self.line, self.area, self.cap = line, area, cap
+        self.kind, self.before, self.after = kind, before, after
+
+    def __str__(self) -> str:
+        return f"  {self.area}.{self.cap}: {self.kind} {self.before} -> {self.after}"
+
+
+def reconcile(taxonomy: Path, estate: Path) -> tuple[list[str], list[Change], list[str]]:
+    """-> (new lines, changes, warnings). Never writes."""
+    tax = yaml.safe_load(taxonomy.read_text())
+    caps, vcaps = scan_estate(estate)
+
+    # The load dimension is `status: planned` and reports to JUnit, not Allure.
+    # Its specs are also outside the agreed estate, so it has no tags to read —
+    # leaving it alone is correct, not an omission.
+    dims = tax.get("dimensions") or {}
+    skip_load = (dims.get("load") or {}).get("status") != "active"
+
+    lines = taxonomy.read_text().splitlines()
+    changes: list[Change] = []
+    warnings: list[str] = []
+
+    # Track where we are: which area, and which block within it.
+    area: str | None = None
+    block: str | None = None
+    area_indent = 0
+
+    known_areas = set((tax.get("areas") or {}).keys())
+    seen: dict[str, set[str]] = {"capabilities": set(), "visual": set()}
+
+    for i, raw in enumerate(lines):
+        m_sec = SECTION.match(raw)
+        if m_sec:
+            name, indent = m_sec.group("name"), len(m_sec.group("indent"))
+            if name in known_areas and indent <= 4:
+                area, block, area_indent = name, None, indent
+                continue
+            if area and name in ("capabilities", "visual", "load") and indent > area_indent:
+                block = name
+                continue
+            # A nested key inside a block-style entry (load axes) — not a section.
+            if block and indent > area_indent + 2:
+                continue
+            if indent <= area_indent and name not in ("capabilities", "visual", "load"):
+                block = None
+            continue
+
+        if not area or block not in ("capabilities", "visual"):
+            continue
+        if block == "load" and skip_load:
+            continue
+
+        m = FLOW_ENTRY.match(raw)
+        if not m:
+            continue
+
+        cap = m.group("key")
+        pairs = parse_body(m.group("body"))
+        fq = f"{area}.{cap}"
+        seen[block].add(fq)
+
+        if block == "capabilities":
+            tiers = caps.get(fq)
+        else:
+            tiers = vcaps.get(fq)
+
+        is_covered = tiers is not None
+        declared = dict(pairs).get("covered", "false").strip().lower() == "true"
+
+        new_pairs = pairs
+        if declared != is_covered:
+            new_pairs = set_field(new_pairs, "covered", "true" if is_covered else "false")
+            changes.append(Change(i + 1, area, cap, "covered", declared, is_covered))
+
+        # tier is meaningful only for functional caps, and only when covered.
+        if block == "capabilities":
+            want = shallowest(tiers) if tiers else None
+            have = dict(pairs).get("tier")
+            if want != have:
+                new_pairs = set_field(new_pairs, "tier", want)
+                changes.append(Change(i + 1, area, cap, "tier", have or "-", want or "-"))
+
+        if new_pairs is not pairs:
+            lines[i] = f"{m.group('indent')}{cap}:{m.group('pad')}{{ {render_body(new_pairs)} }}"
+
+    # A tag pointing at a capability the taxonomy doesn't have. tag_lint blocks
+    # this on PRs, so reaching here means the taxonomy was edited to remove a
+    # capability that specs still tag. Report, never invent an entry: the
+    # denominator is authored, and silently growing it would let a typo'd tag
+    # mint its own capability.
+    for fq in sorted(set(caps) - seen["capabilities"]):
+        warnings.append(f"@cap:{fq} is tagged in a spec but absent from the taxonomy")
+    for fq in sorted(set(vcaps) - seen["visual"]):
+        warnings.append(f"@vcap:{fq} is tagged in a spec but absent from the taxonomy")
+
+    return lines, changes, warnings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--taxonomy", required=True, type=Path)
+    ap.add_argument("--estate", required=True, type=Path)
+    ap.add_argument("--check", action="store_true", help="exit 1 if drifted; write nothing")
+    ap.add_argument("--summary", action="store_true", help="print the change list")
+    args = ap.parse_args()
+
+    lines, changes, warnings = reconcile(args.taxonomy, args.estate)
+
+    for w in warnings:
+        print(f"warning: {w}", file=sys.stderr)
+
+    if args.summary or args.check:
+        if changes:
+            print(f"{len(changes)} derived field(s) drifted from the tags:")
+            for c in changes:
+                print(c)
+        else:
+            print("taxonomy already agrees with the spec tags — nothing to do.")
+
+    if args.check:
+        return 1 if (changes or warnings) else 0
+
+    if changes:
+        args.taxonomy.write_text("\n".join(lines) + "\n")
+        print(f"reconcile: updated {args.taxonomy} ({len(changes)} field(s))")
+    else:
+        print("reconcile: no changes")
+
+    # An orphan tag is not drift this job can repair — the capability it names
+    # was removed from the authored denominator while specs still claim it, so
+    # coverage is understated until a human decides whether the capability or the
+    # tag is wrong. tag_lint blocks this on PRs; reaching here means it arrived
+    # some other way, and it must not pass silently.
+    return 1 if warnings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_end_to_end/coverage/tag_lint.py
+++ b/tests_end_to_end/coverage/tag_lint.py
@@ -3,10 +3,20 @@
 
 Enforces the tag grammar in TESTING-TAGS.md against a taxonomy YAML:
 
-  1. tier_and_area_required     every non-exempt e2e spec declares exactly one
-                                tier tag and exactly one @area: tag
-  2. tags_must_exist_in_taxonomy @area:/@cap:/@vcap: values resolve in taxonomy
-  3. visual_state_enum          every `state:` in a visual: block is in the enum
+  1. tier_and_area_required     every non-exempt e2e spec declares a tier tag
+                                and exactly one @area: tag. A spec carrying a
+                                valid suite selector (@provider-sanity,
+                                @release-gate[:version], @t1-stsaas) may be
+                                tier-less — it runs on its own cadence, outside
+                                the t1/t2/t3 ladder. Tier *cardinality* is not
+                                enforced; see the note in lint_spec().
+  2. cap_required               every non-visual spec declares at least one
+                                @cap:, and every visual spec at least one @vcap:
+  3. tags_must_exist_in_taxonomy @area:/@cap:/@vcap: values resolve in taxonomy,
+                                and a @cap: sits under the spec's declared area
+  4. visual_state_enum          every visual capability in taxonomy.yaml declares
+                                a `state:` from the dimensions.visual.states enum
+                                (this checks the taxonomy, not the spec files)
 
 Exits non-zero on any violation. Read-only; never edits specs.
 
@@ -117,10 +127,17 @@ def lint_spec(path: Path, rel: str, idx, retired: dict, *, visual: bool) -> list
         # A spec carrying only a selector suite (e.g. @provider-sanity) is
         # legitimately tier-less: it runs on its own cadence, deliberately
         # outside the t1/t2/t3 ladder. Documented in playground-providers.spec.ts.
-        elif len({t for _, t in tiers}) > 1 and len(tiers) > 1:
-            # Sibling describes may legitimately differ; only flag one *test*
-            # carrying two tiers, which regex alone can't prove. Report as info.
-            pass
+        #
+        # Tier cardinality is deliberately NOT enforced. "Exactly one tier"
+        # constrains a single test, but tags union from describe to test, so the
+        # scope that must hold the invariant is a test *after* inheritance — not
+        # a file and not a `tag: [...]` block. Four specs legitimately carry
+        # several tiers across sibling describes (ollie-agentic has three).
+        # Checking this correctly needs the TS AST to resolve describe nesting;
+        # a file- or block-level count would fail those valid specs, so the hole
+        # is left open on purpose rather than closed wrongly.
+        if not cap_tags:
+            f.append(Finding(rel, 1, "no @cap: tag: a spec must declare every capability it asserts"))
         if not area_tags:
             f.append(Finding(rel, 1, "no @area: tag"))
         elif len({t for _, t in area_tags}) > 1:

--- a/tests_end_to_end/coverage/tag_lint.py
+++ b/tests_end_to_end/coverage/tag_lint.py
@@ -131,10 +131,10 @@ def lint_spec(path: Path, rel: str, idx, retired: dict, *, visual: bool) -> list
         # Tier cardinality is deliberately NOT enforced. "Exactly one tier"
         # constrains a single test, but tags union from describe to test, so the
         # scope that must hold the invariant is a test *after* inheritance — not
-        # a file and not a `tag: [...]` block. Four specs legitimately carry
-        # several tiers across sibling describes (ollie-agentic has three).
-        # Checking this correctly needs the TS AST to resolve describe nesting;
-        # a file- or block-level count would fail those valid specs, so the hole
+        # a file, and not a `tag: [...]` block either (a describe and its tests
+        # are separate blocks whose tags combine). Specs legitimately carry
+        # several tiers across sibling describes, so any file- or block-level
+        # count would fail valid specs. Enforcing it needs the TS AST; the hole
         # is left open on purpose rather than closed wrongly.
         if not cap_tags:
             f.append(Finding(rel, 1, "no @cap: tag: a spec must declare every capability it asserts"))

--- a/tests_end_to_end/coverage/tag_lint.py
+++ b/tests_end_to_end/coverage/tag_lint.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Tag lint for the Opik e2e + visual test estate.
+
+Enforces the tag grammar in TESTING-TAGS.md against a taxonomy YAML:
+
+  1. tier_and_area_required     every non-exempt e2e spec declares exactly one
+                                tier tag and exactly one @area: tag
+  2. tags_must_exist_in_taxonomy @area:/@cap:/@vcap: values resolve in taxonomy
+  3. visual_state_enum          every `state:` in a visual: block is in the enum
+
+Exits non-zero on any violation. Read-only; never edits specs.
+
+Usage:
+  tag_lint.py --taxonomy taxonomy.yaml --estate /path/to/opik/tests_end_to_end
+  tag_lint.py ... --format github     # emit ::error:: annotations for CI
+
+Why regex and not the TS AST: the tags we lint are always string literals inside
+a `tag: [...]` array, which is reliably greppable. Test *titles* are not (3 specs
+pass a variable, 5 use template literals) — but titles are not linted here. The
+coverage builder resolves runtime titles via `playwright test --list` instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.exit("pyyaml required: pip install pyyaml")
+
+TIERS = {"@t1-smoke", "@t2-cuj", "@t3-nightly"}
+# Selectors are orthogonal to tier — they say WHERE a test runs, not how deep.
+# A spec may carry any number of these, including none.
+SUITES = {"@t1-stsaas", "@provider-sanity", "@release-gate"}
+RELEASE_GATE_VERSIONED = re.compile(r"^@release-gate:[\w.\-]+$")
+
+# Any `tag: [ ... ]` array, single or multi-line.
+TAG_BLOCK = re.compile(r"tag:\s*\[(.*?)\]", re.S)
+TAG_LITERAL = re.compile(r"['\"](@[^'\"]+)['\"]")
+
+
+class Finding:
+    __slots__ = ("path", "line", "msg")
+
+    def __init__(self, path: str, line: int, msg: str):
+        self.path, self.line, self.msg = path, line, msg
+
+    def render(self, fmt: str) -> str:
+        if fmt == "github":
+            return f"::error file={self.path},line={self.line}::{self.msg}"
+        return f"{self.path}:{self.line}: {self.msg}"
+
+
+def load_taxonomy(p: Path) -> dict:
+    with p.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def build_index(tax: dict) -> tuple[set[str], set[str], set[str], set[str], dict[str, str]]:
+    """-> (areas, functional caps, visual caps, visual states, alias -> canonical)."""
+    areas, caps, vcaps = set(), set(), set()
+    canonical: dict[str, str] = {}
+    for area, body in (tax.get("areas") or {}).items():
+        areas.add(area)
+        for alias in body.get("tag_aliases") or []:
+            areas.add(alias)
+            # Remember the real name so lint messages suggest the canonical area,
+            # not the deprecated alias the spec already has.
+            canonical[alias] = area
+        for cap in (body.get("capabilities") or {}):
+            caps.add(f"{area}.{cap}")
+        for vcap in (body.get("visual") or {}):
+            vcaps.add(f"{area}.{vcap}")
+    states = set((tax.get("dimensions", {}).get("visual", {}) or {}).get("states") or [])
+    return areas, caps, vcaps, states, canonical
+
+
+def tags_in(text: str) -> list[tuple[int, str]]:
+    """Every tag literal with the 1-indexed line of its enclosing tag: array."""
+    out = []
+    for block in TAG_BLOCK.finditer(text):
+        line = text.count("\n", 0, block.start()) + 1
+        for lit in TAG_LITERAL.finditer(block.group(1)):
+            out.append((line, lit.group(1)))
+    return out
+
+
+def is_valid_suite(tag: str) -> bool:
+    return tag in SUITES or bool(RELEASE_GATE_VERSIONED.match(tag))
+
+
+def lint_spec(path: Path, rel: str, idx, retired: dict, *, visual: bool) -> list[Finding]:
+    areas, caps, vcaps, _, canonical = idx
+    text = path.read_text(encoding="utf-8")
+    found = tags_in(text)
+    f: list[Finding] = []
+
+    tiers = [(l, t) for l, t in found if t in TIERS]
+    area_tags = [(l, t) for l, t in found if t.startswith("@area:")]
+    cap_tags = [(l, t) for l, t in found if t.startswith("@cap:")]
+    vcap_tags = [(l, t) for l, t in found if t.startswith("@vcap:")]
+
+    if visual:
+        # Visual specs are asserted per screenshot; they carry @vcap: and no tier.
+        if not vcap_tags:
+            f.append(Finding(rel, 1, "visual spec declares no @vcap: tag"))
+        for line, t in tiers:
+            f.append(Finding(rel, line, f"visual spec must not carry a tier tag ({t})"))
+    else:
+        suites_present = [(l, t) for l, t in found if is_valid_suite(t)]
+        if not tiers and not suites_present:
+            f.append(Finding(rel, 1, "no tier tag: expected exactly one of @t1-smoke / @t2-cuj / @t3-nightly"))
+        # A spec carrying only a selector suite (e.g. @provider-sanity) is
+        # legitimately tier-less: it runs on its own cadence, deliberately
+        # outside the t1/t2/t3 ladder. Documented in playground-providers.spec.ts.
+        elif len({t for _, t in tiers}) > 1 and len(tiers) > 1:
+            # Sibling describes may legitimately differ; only flag one *test*
+            # carrying two tiers, which regex alone can't prove. Report as info.
+            pass
+        if not area_tags:
+            f.append(Finding(rel, 1, "no @area: tag"))
+        elif len({t for _, t in area_tags}) > 1:
+            names = ", ".join(sorted({t for _, t in area_tags}))
+            f.append(Finding(rel, area_tags[0][0], f"multiple @area: tags ({names}); a spec belongs to exactly one area"))
+
+    for line, t in area_tags:
+        if t.split(":", 1)[1] not in areas:
+            f.append(Finding(rel, line, f"unknown area '{t}' — not in taxonomy"))
+    for line, t in cap_tags:
+        if t.split(":", 1)[1] not in caps:
+            f.append(Finding(rel, line, f"unknown capability '{t}' — not in taxonomy"))
+    for line, t in vcap_tags:
+        if t.split(":", 1)[1] not in vcaps:
+            f.append(Finding(rel, line, f"unknown visual capability '{t}' — not in taxonomy"))
+
+    # A @cap: must sit under the spec's declared area.
+    if len({t for _, t in area_tags}) == 1:
+        area = area_tags[0][1].split(":", 1)[1]
+        for line, t in cap_tags:
+            val = t.split(":", 1)[1]
+            if "." in val and val.split(".", 1)[0] != area:
+                f.append(Finding(rel, line, f"'{t}' does not belong to declared area '@area:{area}'"))
+
+    for line, t in found:
+        if t in TIERS or t.startswith(("@area:", "@cap:", "@vcap:")) or is_valid_suite(t):
+            continue
+        # Legacy bare area tags (@datasets, @prompts, ...) predate the @area:
+        # prefix. Name the migration explicitly rather than calling them junk.
+        bare = t.lstrip("@")
+        if bare in areas:
+            target = canonical.get(bare, bare)
+            f.append(Finding(rel, line, f"legacy bare area tag '{t}' — replace with '@area:{target}'"))
+        elif bare in retired:
+            info = retired[bare]
+            opts = " or ".join(f"@area:{a}" for a in info.get("replaced_by") or [])
+            f.append(Finding(rel, line, f"retired tag '{t}' ({info.get('reason')}) — use {opts}"))
+        else:
+            f.append(Finding(rel, line, f"unrecognised tag '{t}' — not a tier, suite selector, or taxonomy tag"))
+
+    return f
+
+
+def lint_taxonomy(tax: dict, idx) -> list[Finding]:
+    """Rule 3: visual state values must be in the enum."""
+    _, _, _, states, _ = idx
+    out = []
+    for area, body in (tax.get("areas") or {}).items():
+        for vcap, spec in (body.get("visual") or {}).items():
+            st = (spec or {}).get("state")
+            if st is None:
+                out.append(Finding("taxonomy.yaml", 1, f"{area}.{vcap}: visual capability has no `state:`"))
+            elif st not in states:
+                allowed = ", ".join(sorted(states))
+                out.append(Finding("taxonomy.yaml", 1, f"{area}.{vcap}: state '{st}' not in [{allowed}]"))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--taxonomy", required=True, type=Path)
+    ap.add_argument("--estate", required=True, type=Path, help="path to tests_end_to_end/")
+    ap.add_argument("--format", choices=["text", "github"], default="text")
+    args = ap.parse_args()
+
+    tax = load_taxonomy(args.taxonomy)
+    idx = build_index(tax)
+    exempt = set((tax.get("rules") or {}).get("exempt_dirs") or [])
+    retired = tax.get("retired_tags") or {}
+
+    e2e = sorted((args.estate / "e2e" / "tests").rglob("*.spec.ts"))
+    vis = sorted((args.estate / "visual-tests" / "tests").rglob("*.spec.ts"))
+
+    findings = lint_taxonomy(tax, idx)
+    checked = skipped = 0
+
+    for p in e2e:
+        rel = str(p.relative_to(args.estate.parent))
+        if any(part in exempt for part in p.parts):
+            skipped += 1
+            continue
+        checked += 1
+        findings += lint_spec(p, rel, idx, retired, visual=False)
+
+    for p in vis:
+        rel = str(p.relative_to(args.estate.parent))
+        checked += 1
+        findings += lint_spec(p, rel, idx, retired, visual=True)
+
+    for f in findings:
+        print(f.render(args.format))
+
+    print(f"\ntag-lint: {checked} specs checked, {skipped} exempt, {len(findings)} problem(s)")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -323,7 +323,7 @@ areas:
       sdk-seeded-visible:      { covered: true,  tier: t1-smoke }
       edit-creates-version:    { covered: true,  tier: t1-smoke }
       old-version-preserved:   { covered: true,  tier: t1-smoke }
-      version-history:         { covered: true,  tier: t2-cuj }
+      version-history:         { covered: true,  tier: t1-smoke }
       compare-versions:        { covered: false }
       experiments-tab:         { covered: false, note: "prompt detail -> Experiments tab" }
       delete-prompt:           { covered: false }

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -1,0 +1,731 @@
+# Opik QA capability taxonomy
+#
+# This file defines "100%". Coverage % of an area = capabilities with >=1 recent
+# passing test / total capabilities in that area. Adding a capability here lowers
+# coverage until a test covers it — that is the point: it makes a known gap
+# visible instead of silently absent.
+#
+# It is a REVIEWED file. Changes to the denominator are a QA-owned decision, not
+# an implementation detail. See ../TESTING-TAGS.md for the tag grammar and the
+# process for adding areas and capabilities.
+#
+# Enforced by coverage/tag_lint.py, which runs on every PR touching
+# tests_end_to_end/ (.github/workflows/tag_lint.yml).
+#
+# SCOPE: tests_end_to_end/ only — e2e (Playwright) + visual-tests. Nothing else.
+#
+# Verified against main @ c54a6a99d7 (2026-07-29):
+#   24 e2e specs across 13 dirs, 3 visual specs.
+#
+# ---------------------------------------------------------------------------
+# TAG GRAMMAR (two orthogonal dimensions — see PHASE-1-FINDINGS.md Q2')
+#
+#   tier    exactly one of @t1-smoke | @t2-cuj | @t3-nightly     -> drives coverage %
+#   suites  zero or more of @t1-stsaas | @provider-sanity        -> drives WHERE it runs
+#           | @release-gate | @release-gate:<version>
+#   area    exactly one @area:<area>                             -> from `areas:` keys below
+#   caps    one or more @cap:<area>.<capability>                 -> from `capabilities:` keys
+#
+# Why the split: optimization-studio.spec.ts is @t2-cuj + @t1-stsaas — t2 depth,
+# but included in the STSaaS sanity set (deliberate: it was unstable on client
+# envs) and excluded from the 3x/day t1 prod runs because each run incurs real
+# LLM cost. A flat tag enum would model t1-stsaas as a fifth tier and mis-report
+# this spec. Confirmed: `test:t1` greps @t1-smoke only.
+#
+# Allure note: Allure strips the leading `@`. `@cap:prompts.create-text` arrives
+# as tag `cap:prompts.create-text` and is queryable via AQL `tag = "..."`.
+# No allure.label() calls needed — verified live against project 1.
+# ---------------------------------------------------------------------------
+
+version: 1
+product: opik
+
+# ---------------------------------------------------------------------------
+# DIMENSIONS — coverage is not one number
+#
+# A capability can be covered functionally, visually, and under load. These are
+# independent questions ("does it work?" / "does it look right?" / "does it hold
+# up?"), so each capability carries a per-dimension coverage state and each area
+# reports one % per dimension. Never blended into a single figure.
+#
+# Rationale for keeping them in ONE file rather than three: the *denominator*
+# (area -> capability) is shared. Splitting the file would fork the taxonomy and
+# guarantee drift. Splitting the *percentages* is the actual requirement.
+#
+# `applicability` is what stops the load column from being dishonest. Most UI
+# capabilities are not load-bearing; counting them as "0% load covered" would
+# invent a 180-capability gap that nobody intends to close. Only capabilities
+# marked applicable enter that dimension's denominator.
+# ---------------------------------------------------------------------------
+
+dimensions:
+
+  functional:
+    label: Functional
+    source: tests_end_to_end/e2e
+    tag_prefix: "@cap:"
+    applicability: all            # every capability should work
+    status: active
+
+  visual:
+    label: Visual
+    source: tests_end_to_end/visual-tests
+    tag_prefix: "@vcap:"
+    applicability: opt_in         # only capabilities with `visual: {...}`
+    status: active
+    # Visual coverage is page/state-shaped, not behaviour-shaped: one screenshot
+    # asserts a whole page renders. So visual capabilities are coarser than
+    # functional ones and get their own sub-keys (see `visual:` blocks below)
+    # rather than being forced onto functional capability names.
+    states: [default, empty, loading, error]
+
+  load:
+    label: Load / performance
+    source: tests_load            # NOTE: outside tests_end_to_end/ — see below
+    tag_prefix: "@lcap:"
+    applicability: opt_in         # only capabilities with `load: {...}`
+    status: planned               # long-term goal; denominator defined, not yet wired
+    # Load coverage is dimension-shaped, not capability-shaped. A load test
+    # exercises an *axis* against a capability, so a covered load capability
+    # declares which axes are exercised. Axes derived from the existing
+    # tests_load/suite/python_sdk scenarios.
+    axes:
+      ingestion-rate:   "sustained writes/sec (test_many_traces_one_span_each)"
+      fan-out:          "many children per parent (test_many_spans_per_trace)"
+      payload-size:     "large single payloads (test_traces_with_one_megabyte_payload)"
+      burstiness:       "spike then idle (test_burst_single_loop, test_spread_over_time)"
+      concurrency:      "parallel writers sharing a client (test_concurrent_writers_share_one_client)"
+      attachments:      "binary/media upload paths (test_traces_with_explicit_attachments)"
+      retrieval:        "read-path latency under volume (test_trace_span_retrieval)"
+      versioning-depth: "many versions of one entity (test_dataset_insert_many_versions)"
+
+# ---------------------------------------------------------------------------
+# SCOPE NOTE ON tests_load/
+#
+# The agreed estate is tests_end_to_end/ only, and that remains true for the
+# functional and visual dimensions — the two this task ships.
+#
+# `tests_load/` is a real third estate in the opik repo (5 pytest scenario files
+# under suite/python_sdk, run weekly by .github/workflows/load_tests.yml, cron
+# '0 4 * * 0', on ubuntu-latest-m against a docker-compose stack). It reports to
+# JUnit XML, NOT to Allure, so it is invisible to the Allure-joined builder.
+#
+# It is declared here so the schema is ready, but the load dimension is
+# `status: planned` and the v1 builder MUST skip it. Wiring it up needs a
+# separate decision (does tests_load report to Allure? does it get @lcap: tags?)
+# and is not in scope for OPIK-7532. Flagging rather than assuming.
+# ---------------------------------------------------------------------------
+
+# Legacy bare area tags that no longer map to exactly one area. The retro-tagging
+# pass replaces each with the right @area:/@cap: pair per spec, so these are
+# recorded for the lint's benefit (clear message instead of "unrecognised") and
+# then removed once the pass lands.
+#
+# @trace-explore is the interesting one: it predates the split of the Logs surface
+# into `traces` and `threads`, which are distinct nav toggles with distinct
+# capabilities. The three specs carrying it divide cleanly —
+#   trace-explore-smoke.spec.ts  -> @area:traces
+#   trace-spans-depth.spec.ts    -> @area:traces
+#   thread-logging-smoke.spec.ts -> @area:threads
+retired_tags:
+  trace-explore:
+    reason: "split into `traces` and `threads` — resolve per spec, not by rename"
+    replaced_by: [traces, threads]
+
+# Coverage-counting rules the builder must apply.
+rules:
+  # A capability counts as covered when a test carrying its tag passed
+  # within this window. Tunable; 7d matches the dashboard's pass-rate window.
+  recent_window_days: 7
+  # Specs in these dirs are infrastructure, not product coverage. Excluded from
+  # both numerator and denominator, and exempt from the area/cap tag lint.
+  exempt_dirs:
+    - _seed          # sdk-clients.spec.ts — harness self-test
+    - _release-gate  # ephemeral, version-stamped gate specs
+  # Capabilities flagged `cloud_only: true` are excluded from the self-hosted
+  # coverage view but counted in the cloud view. They depend on the out-of-tree
+  # `comet` frontend plugin (PluginsStore) and cannot run self-hosted.
+  cloud_only_separate_view: true
+  # Report one % per dimension per area. Never a blended figure.
+  report_per_dimension: true
+  # Tag-lint enforcement. All three are hard CI failures, not warnings.
+  enforce:
+    # every non-exempt e2e spec declares exactly one tier and one @area:
+    tier_and_area_required: true
+    # @area:/@cap:/@vcap: values must exist in this file
+    tags_must_exist_in_taxonomy: true
+    # every `state:` in a visual: block must be one of dimensions.visual.states
+    visual_state_enum: true
+
+# ---------------------------------------------------------------------------
+# AREAS
+#
+# Spine = the app's own v2 nav grouping (getMenuItems.ts), which is what users
+# see. `nav_group` records it so the Notion dashboard can order areas the way
+# the product does.
+#
+# `specs:` lists CURRENT covering specs (informational — the tags are the real
+# source of truth once Phase 3 lands). `covered: false` capabilities are the
+# gap list the radar ranks.
+# ---------------------------------------------------------------------------
+
+areas:
+
+  # ===================== OBSERVABILITY =====================
+
+  traces:
+    label: Traces & Spans
+    nav_group: Observability
+    routes: ["/projects/$projectId/logs?type=traces", "/logs?type=spans"]
+    spec_dir: trace-explore   # NOTE: dir name != product vocabulary ("Logs")
+    specs:
+      - trace-explore/trace-explore-smoke.spec.ts
+      - trace-explore/trace-spans-depth.spec.ts
+
+    # ---- functional dimension ----
+    capabilities:
+      list-traces:            { covered: true,  tier: t1-smoke }
+      trace-ordering:         { covered: true,  tier: t1-smoke }
+      open-trace-panel:       { covered: true,  tier: t1-smoke }
+      span-tree-expand:       { covered: true,  tier: t2-cuj }
+      span-model-cost-tokens: { covered: true,  tier: t2-cuj }
+      trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
+      manual-feedback-score:  { covered: true,  tier: t2-cuj }
+      toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
+      filter-traces:          { covered: false, note: "OQL / FiltersButton" }
+      configure-columns:      { covered: false }
+      add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
+      add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
+      agent-graph-tab:        { covered: false }
+      attachments-media:      { covered: false }
+      delete-traces:          { covered: false }
+      export-traces:          { covered: false, note: "EXPORT_ENABLED flag" }
+
+    # ---- visual dimension (opt-in; page/state-shaped) ----
+    visual:
+      logs-traces-view:       { covered: true,  state: default, spec: "visual-comparison.spec.ts 02" }
+      logs-traces-empty:      { covered: true,  state: empty,   spec: "empty-states.spec.ts E01" }
+      trace-sidebar-messages: { covered: true,  state: default, spec: "trace-sidebar.spec.ts S01" }
+      trace-sidebar-details:  { covered: true,  state: default, spec: "trace-sidebar.spec.ts S02" }
+      trace-sidebar-feedback: { covered: true,  state: default, spec: "trace-sidebar.spec.ts S03" }
+      trace-sidebar-prompts:  { covered: true,  state: default, spec: "trace-sidebar.spec.ts S04" }
+      logs-spans-view:        { covered: false, state: default }
+      trace-sidebar-agent-graph: { covered: false, state: default }
+
+    # ---- load dimension (opt-in; axis-shaped; status: planned) ----
+    load:
+      trace-span-ingestion:
+        covered: false
+        axes: [ingestion-rate, fan-out, burstiness, concurrency]
+        existing_scenarios:
+          - "tests_load/suite/python_sdk/test_ingestion_rate.py::test_many_traces_one_span_each"
+          - "tests_load/suite/python_sdk/test_ingestion_rate.py::test_many_spans_per_trace"
+          - "tests_load/suite/python_sdk/test_bursts.py::test_burst_single_loop"
+        note: "scenarios exist in tests_load/ but report to JUnit, not Allure — not yet joinable"
+      trace-heavy-payload:
+        covered: false
+        axes: [payload-size]
+        existing_scenarios:
+          - "tests_load/suite/python_sdk/test_heavy_payload.py::test_traces_with_one_megabyte_payload"
+          - "tests_load/suite/python_sdk/test_heavy_payload.py::test_spans_with_heavy_payload"
+      trace-attachments:
+        covered: false
+        axes: [attachments]
+        existing_scenarios:
+          - "tests_load/suite/python_sdk/test_attachments.py::test_traces_with_explicit_attachments"
+      trace-retrieval:
+        covered: false
+        axes: [retrieval]
+        existing_scenarios:
+          - "tests_load/tests/test_trace_span_retrieval.py"
+
+  threads:
+    label: Threads & Conversations
+    nav_group: Observability
+    routes: ["/projects/$projectId/logs?type=threads"]
+    spec_dir: trace-explore
+    specs:
+      - trace-explore/thread-logging-smoke.spec.ts
+    capabilities:
+      list-threads:            { covered: true,  tier: t1-smoke }
+      thread-message-count:    { covered: true,  tier: t1-smoke }
+      open-thread-panel:       { covered: true,  tier: t1-smoke }
+      turn-order-io:           { covered: true,  tier: t1-smoke }
+      thread-feedback-score:   { covered: false }
+      thread-actions-panel:    { covered: false }
+      thread-level-metrics:    { covered: false, note: "conversational metrics" }
+
+    visual:
+      logs-threads-view:   { covered: true,  state: default, spec: "visual-comparison.spec.ts 03" }
+      logs-threads-empty:  { covered: true,  state: empty,   spec: "empty-states.spec.ts E02" }
+      thread-panel:        { covered: false, state: default }
+
+    load:
+      thread-ingestion:
+        covered: false
+        axes: [ingestion-rate, fan-out]
+        existing_scenarios: ["tests_load/tests/test_thread_ingestion.py"]
+
+  diagnostics:
+    label: Diagnostics
+    nav_group: Observability
+    routes: ["/projects/$projectId/diagnostics", "/diagnostics/resolved"]
+    cloud_only: true   # requires AssistantSidebar plugin + OLLIE_ENABLED + AGENT_INSIGHTS_ENABLED
+    specs: []
+    capabilities:
+      list-issues:          { covered: false }
+      issue-detail:         { covered: false }
+      severity-badge:       { covered: false }
+      occurrence-chart:     { covered: false }
+      affected-traces:      { covered: false }
+      resolve-issue:        { covered: false }
+      view-resolved:        { covered: false }
+      enable-diagnostics:   { covered: false }
+      configure-settings:   { covered: false }
+
+    visual:
+      diagnostics-list:   { covered: false, state: default }
+      diagnostics-empty:  { covered: false, state: empty }
+
+  dashboards:
+    label: Dashboards
+    nav_group: Observability
+    routes: ["/$workspaceName/dashboards", "/dashboards/$dashboardId", "/projects/$projectId/dashboards"]
+    specs:
+    capabilities:
+      list-dashboards:      { covered: false }
+      create-dashboard:     { covered: false }
+      open-dashboard:       { covered: false }
+      edit-dashboard:       { covered: false }
+      delete-dashboard:     { covered: false }
+      add-widget:           { covered: false }
+      configure-widget:     { covered: false }
+      widget-filters:       { covered: false }
+      metric-date-range:    { covered: false }
+
+  # ===================== DEVELOPMENT =====================
+
+    visual:
+      dashboards-default:  { covered: true,  state: default, spec: "empty-states.spec.ts E06" }
+      dashboard-detail:    { covered: false, state: default }
+
+  prompts:
+    label: Prompt library
+    nav_group: Development
+    routes: ["/projects/$projectId/prompts", "/prompts/$promptId"]
+    spec_dir: prompts
+    specs:
+      - prompts/prompt-library-smoke.spec.ts
+    capabilities:
+      list-prompts:            { covered: true,  tier: t1-smoke }
+      create-text-prompt-ui:   { covered: true,  tier: t1-smoke }
+      create-chat-prompt-ui:   { covered: true,  tier: t1-smoke }
+      sdk-seeded-visible:      { covered: true,  tier: t1-smoke }
+      edit-creates-version:    { covered: true,  tier: t1-smoke }
+      old-version-preserved:   { covered: true,  tier: t1-smoke }
+      version-history:         { covered: true,  tier: t2-cuj }
+      compare-versions:        { covered: false }
+      experiments-tab:         { covered: false, note: "prompt detail -> Experiments tab" }
+      delete-prompt:           { covered: false }
+
+    visual:
+      prompt-library-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E07" }
+      prompt-library-list:  { covered: false, state: default }
+      prompt-detail:        { covered: false, state: default }
+
+  playground:
+    label: Prompt playground
+    nav_group: Development
+    routes: ["/projects/$projectId/playground"]
+    spec_dir: playground
+    specs:
+      - playground/playground-smoke.spec.ts
+      - playground/playground-providers.spec.ts
+      - prompts/prompt-playground-new-prompt.spec.ts
+      - prompts/prompt-playground-save.spec.ts
+      - prompts/prompt-playground-traces.spec.ts
+      - prompts/prompt-version-playground.spec.ts
+    capabilities:
+      compose-run-prompt:        { covered: true,  tier: t1-smoke }
+      select-model-provider:     { covered: true,  suites: [provider-sanity] }
+      run-against-dataset:       { covered: true,  tier: t1-smoke, note: "auto-creates experiment" }
+      save-new-prompt:           { covered: true,  tier: t1-smoke }
+      save-prompt-version:       { covered: true,  tier: t2-cuj }
+      load-prompt-version:       { covered: true,  tier: t2-cuj }
+      verify-trace-from-run:     { covered: true,  tier: t2-cuj }
+      playground-logs-sidebar:   { covered: true,  tier: t2-cuj }
+      configure-model-settings:  { covered: false, note: "PromptModelSettings / providerConfigs" }
+
+    visual:
+      playground-default: { covered: false, state: default }
+      playground-empty:   { covered: false, state: empty }
+
+    load:
+      playground-batch-run:
+        covered: false
+        axes: [concurrency, ingestion-rate]
+        note: "run-against-dataset fans out one LLM call per item; no load scenario yet"
+
+  agent-playground:
+    label: Agent playground
+    nav_group: Development
+    routes: ["/projects/$projectId/agent-playground"]
+    spec_dir: agent-playground
+    specs:
+      - agent-playground/agent-playground-local-runner.spec.ts
+    capabilities:
+      drive-connected-agent:  { covered: true,  tier: t3-nightly }
+      connected-state-ui:     { covered: false }
+      agent-input-form:       { covered: false }
+      select-prompt-to-run:   { covered: false }
+      view-agent-result:      { covered: false }
+      sandbox-flow-diagram:   { covered: false }
+
+    visual:
+      agent-playground-empty: { covered: true,  state: empty, spec: "empty-states.spec.ts E08" }
+      agent-playground-run:   { covered: false, state: default }
+
+  optimization-studio:
+    label: Optimization runs
+    nav_group: Development
+    routes: ["/projects/$projectId/optimizations", "/optimizations/$optimizationId"]
+    spec_dir: optimization-studio
+    specs:
+      - optimization-studio/optimization-studio.spec.ts
+    capabilities:
+      new-run-form-validation:  { covered: true, tier: t2-cuj, suites: [t1-stsaas] }
+      launch-gepa-run:          { covered: true, tier: t2-cuj, suites: [t1-stsaas] }
+      launch-hier-reflective:   { covered: true, tier: t2-cuj, suites: [t1-stsaas] }
+      run-completes-healthy:    { covered: true, tier: t2-cuj, suites: [t1-stsaas] }
+      studio-logs-download:     { covered: true, tier: t2-cuj, suites: [t1-stsaas] }
+      list-optimization-runs:   { covered: false }
+      trials-table:             { covered: false }
+      trial-detail:             { covered: false }
+      best-trial-prompt:        { covered: false }
+      kpi-cards:                { covered: false }
+      compare-runs:             { covered: false }
+      delete-run:               { covered: false }
+      other-algorithms:         { covered: false, note: "MetaPrompt, Few-Shot Bayesian, Evolutionary, Parameter, Tool — 2 of 7 covered" }
+
+  # ===================== EVALUATION =====================
+
+    visual:
+      optimization-runs-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E09" }
+      optimization-runs-list:  { covered: false, state: default }
+      optimization-detail:     { covered: false, state: default }
+
+  datasets:
+    label: Datasets
+    nav_group: Evaluation
+    routes: ["/projects/$projectId/datasets", "/datasets/$datasetId/items"]
+    spec_dir: datasets
+    specs:
+      - datasets/dataset-crud-smoke.spec.ts
+      - datasets/dataset-items.spec.ts
+    capabilities:
+      list-datasets:          { covered: true,  tier: t1-smoke }
+      create-dataset-ui:      { covered: true,  tier: t1-smoke }
+      create-dataset-sdk:     { covered: true,  tier: t1-smoke }
+      view-items:             { covered: true,  tier: t1-smoke }
+      add-item-ui:            { covered: true,  tier: t1-smoke }
+      edit-item-versions:     { covered: true,  tier: t2-cuj }
+      bulk-delete-items:      { covered: true,  tier: t3-nightly }
+      search-items:           { covered: true,  tier: t3-nightly }
+      sdk-round-trip:         { covered: true,  tier: t1-smoke }
+      version-history-view:   { covered: false }
+      export-dataset:         { covered: false, note: "DATASET_EXPORT_ENABLED" }
+      import-huggingface:     { covered: false }
+
+    visual:
+      datasets-page:   { covered: true,  state: default, spec: "visual-comparison.spec.ts 04" }
+      datasets-empty:  { covered: true,  state: empty,   spec: "empty-states.spec.ts E03" }
+      dataset-items:   { covered: false, state: default }
+
+    load:
+      dataset-item-volume:
+        covered: false
+        axes: [ingestion-rate, versioning-depth]
+        existing_scenarios:
+          - "tests_load/suite/python_sdk/test_dataset_items.py::test_dataset_insert_many_versions"
+
+  test-suites:
+    label: Test suites
+    nav_group: Evaluation
+    routes: ["/projects/$projectId/test-suites", "/test-suites/$suiteId/items"]
+    spec_dir: test-suites
+    specs:
+      - test-suites/test-suites-smoke.spec.ts
+    capabilities:
+      list-suites:           { covered: true,  tier: t1-smoke }
+      create-suite-ui:       { covered: true,  tier: t1-smoke }
+      create-suite-sdk:      { covered: true,  tier: t1-smoke }
+      view-suite-items:      { covered: true,  tier: t1-smoke }
+      run-suite-sdk:         { covered: true,  tier: t1-smoke, note: "3/3 pass experiment" }
+      run-suite-playground:  { covered: true,  tier: t1-smoke }
+      pass-rate-display:     { covered: true,  tier: t1-smoke }
+      global-assertions:     { covered: true,  tier: t1-smoke }
+      delete-suite:          { covered: false }
+
+    visual:
+      test-suites-page:  { covered: true,  state: default, spec: "visual-comparison.spec.ts 05" }
+      test-suites-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E04" }
+      suite-items:       { covered: false, state: default }
+
+  experiments:
+    label: Experiments
+    nav_group: Evaluation
+    routes: ["/projects/$projectId/experiments", "/experiments/$datasetId/compare"]
+    spec_dir: experiments
+    specs:
+      - experiments/experiments-smoke.spec.ts
+      - experiments/experiments-compare.spec.ts
+    capabilities:
+      list-experiments:        { covered: true,  tier: t1-smoke }
+      per-item-scores:         { covered: true,  tier: t1-smoke }
+      compare-side-by-side:    { covered: true,  tier: t2-cuj }
+      compare-sort-search:     { covered: true,  tier: t2-cuj }
+      compare-feedback-tab:    { covered: true,  tier: t2-cuj }
+      compare-row-detail:      { covered: true,  tier: t2-cuj }
+      insights-tab:            { covered: false }
+      configuration-tab:       { covered: false }
+      export-comparison:       { covered: false }
+      delete-experiment:       { covered: false }
+
+    visual:
+      experiments-page:   { covered: true,  state: default, spec: "visual-comparison.spec.ts 06" }
+      experiments-empty:  { covered: true,  state: empty,   spec: "empty-states.spec.ts E05" }
+      compare-view:       { covered: false, state: default }
+
+    load:
+      experiment-item-bulk:
+        covered: false
+        axes: [ingestion-rate, payload-size]
+        note: "backend exposes ExperimentItemBulkUpload; no load scenario yet"
+
+  annotation-queues:
+    label: Annotation queues
+    nav_group: Evaluation
+    routes: ["/projects/$projectId/annotation-queues", "/annotation-queues/$id", "/$workspaceName/sme"]
+    spec_dir: annotation-queues
+    # Was the one dir<->tag mismatch (@annotation-queue singular). Normalised to
+    # plural @annotation-queues so dir == area == tag holds everywhere.
+    # opik PR #7676.
+    #
+    # BUILDER: Allure results predating that merge carry tag "annotation-queue";
+    # results after it carry "annotation-queues". Accept both when querying, or a
+    # 7-day window spanning the merge reports a false gap.
+    tag_aliases: [annotation-queue]
+    specs:
+      - annotation-queues/annotation-queue-scoring.spec.ts
+    capabilities:
+      score-queue-item:        { covered: true,  tier: t2-cuj }
+      score-with-reason:       { covered: true,  tier: t2-cuj }
+      skip-item:               { covered: true,  tier: t2-cuj }
+      scores-reach-traces:     { covered: true,  tier: t2-cuj, note: "SDK-verified" }
+      list-queues:             { covered: false }
+      create-queue:            { covered: false }
+      edit-queue:              { covered: false }
+      delete-queue:            { covered: false }
+      queue-configuration-tab: { covered: false }
+      add-traces-to-queue:     { covered: false }
+      sme-flow:                { covered: false, note: "/sme route, dedicated layout" }
+      export-annotated-data:   { covered: false }
+
+  # ===================== PRODUCTION =====================
+
+    visual:
+      annotation-queues-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E10" }
+      annotation-queues-list:  { covered: false, state: default }
+      queue-detail:            { covered: false, state: default }
+
+  online-evaluation:
+    label: Online evaluation
+    nav_group: Production
+    routes: ["/projects/$projectId/online-evaluation", "/$workspaceName/automation-logs"]
+    spec_dir: online-evaluation
+    specs:
+      - online-evaluation/online-evaluation-smoke.spec.ts
+    capabilities:
+      create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
+      llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
+      create-python-rule:      { covered: true,  tier: t1-smoke }
+      python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0" }
+      scores-in-trace-panel:   { covered: true,  tier: t1-smoke }
+      list-rules:              { covered: false }
+      rule-scope-thread-span:  { covered: false, note: "span/thread scope flags" }
+      rule-filters:            { covered: false }
+      sampling-rate:           { covered: false }
+      clone-rule:              { covered: false }
+      edit-rule:               { covered: false }
+      enable-disable-rule:     { covered: false }
+      delete-rule:             { covered: false }
+      automation-logs:         { covered: false }
+
+    visual:
+      online-evaluation-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E11" }
+      online-evaluation-list:  { covered: false, state: default }
+
+    load:
+      rule-evaluation-throughput:
+        covered: false
+        axes: [ingestion-rate, concurrency]
+        note: "online scoring is the known prod bottleneck (see /check-online-scoring)"
+
+  alerts:
+    label: Alerts
+    nav_group: Production
+    routes: ["/projects/$projectId/alerts", "/alerts/new", "/alerts/$alertId"]
+    specs:
+    capabilities:
+      list-alerts:         { covered: false }
+      create-alert:        { covered: false }
+      edit-alert:          { covered: false }
+      event-triggers:      { covered: false }
+      webhook-destination: { covered: false }
+      enable-disable:      { covered: false }
+      delete-alert:        { covered: false }
+      test-alert:          { covered: false }
+
+  # ===================== ASSISTANT / CONNECT =====================
+
+    visual:
+      alerts-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E12" }
+      alerts-list:  { covered: false, state: default }
+      alert-editor: { covered: false, state: default }
+
+  ollie:
+    label: Opik Connect
+    nav_group: Home
+    routes: ["/projects/$projectId/ollie", "/pair/v1"]
+    spec_dir: ollie
+    cloud_only: true   # requires AssistantSidebar plugin + OLLIE_ENABLED
+    specs:
+      - ollie/ollie-smoke.spec.ts
+      - ollie/ollie-agentic.spec.ts
+      - ollie/ollie-connect.spec.ts
+      - ollie/ollie-explain.spec.ts
+    capabilities:
+      surface-mounts:          { covered: true,  tier: t1-smoke }
+      sidebar-persists-nav:    { covered: true,  tier: t1-smoke }
+      basic-completion:        { covered: true,  tier: t2-cuj }
+      context-badge-count:     { covered: true,  tier: t2-cuj }
+      analyze-command:         { covered: true,  tier: t3-nightly }
+      explain-cells:           { covered: true,  tier: t3-nightly, note: "Errors/cost/duration cells" }
+      explain-continue-convo:  { covered: true,  tier: t3-nightly }
+      instrument-command:      { covered: true,  tier: t3-nightly, note: "local runner" }
+      improve-command:         { covered: true,  tier: t3-nightly, note: "local runner" }
+      pairing-approve:         { covered: true,  tier: t3-nightly }
+      daily-briefing:          { covered: false, note: "project home" }
+
+    visual:
+      ollie-surface: { covered: false, state: default }
+      ollie-sidebar: { covered: false, state: default }
+
+  # ===================== PLATFORM / WORKSPACE =====================
+
+  projects:
+    label: Projects
+    nav_group: Workspace
+    routes: ["/$workspaceName/projects", "/projects/$projectId/home"]
+    specs:
+    capabilities:
+      list-projects:         { covered: false }
+      create-project:        { covered: false }
+      delete-project:        { covered: false }
+      project-selector:      { covered: false }
+      pin-unpin-project:     { covered: false }
+      project-home:          { covered: false }
+      recent-activity:       { covered: false }
+      breadcrumb-selector:   { covered: false, note: "trace-explore-smoke checks the breadcrumb, but only as project context for the trace panel — not as coverage of the selector itself. A cross-area @cap: here would over-claim." }
+
+    visual:
+      projects-page: { covered: true,  state: default, spec: "visual-comparison.spec.ts 01" }
+      project-home:  { covered: false, state: default }
+
+  configuration:
+    label: Configuration
+    nav_group: Workspace
+    routes: ["/$workspaceName/configuration"]
+    specs: []
+    # A configuration.page.ts POM exists with no spec using it — half-built surface.
+    # Split per-tab: the page has 5 distinct tabs (CONFIGURATION_TABS), each with
+    # its own CRUD surface, so one capability per tab was too coarse. Capabilities
+    # below are read off the tab components on origin/main.
+    capabilities:
+      # -- Feedback definitions tab --
+      feedback-def-list:        { covered: false }
+      feedback-def-create:      { covered: false, note: "AddEditFeedbackDefinitionDialog" }
+      feedback-def-edit:        { covered: false }
+      feedback-def-delete:      { covered: false }
+      feedback-def-search:      { covered: false, note: "search by name" }
+      # -- Environments tab --
+      environment-list:         { covered: false }
+      environment-create:       { covered: false, note: "AddEditEnvironmentDialog" }
+      environment-edit:         { covered: false }
+      environment-delete:       { covered: false }
+      # -- AI providers tab --
+      ai-provider-list:         { covered: false }
+      ai-provider-add:          { covered: false, note: "exercised indirectly by playground provider setup (configuration.page.ts), never asserted here" }
+      ai-provider-edit:         { covered: false }
+      ai-provider-delete:       { covered: false }
+      # -- Workspace preferences tab --
+      pref-thread-timeout:      { covered: false, note: "EditThreadTimeoutDialog" }
+      pref-truncation-toggle:   { covered: false, note: "EditTruncationToggleDialog" }
+      # -- Members tab (plugin-only) --
+      members-list:             { covered: false, cloud_only: true }
+      members-invite:           { covered: false, cloud_only: true }
+      members-change-role:      { covered: false, cloud_only: true }
+
+    visual:
+      config-feedback-definitions: { covered: false, state: default }
+      config-feedback-def-empty:   { covered: false, state: empty, note: "'No feedback definitions yet'" }
+      config-environments:         { covered: false, state: default }
+      config-environments-empty:   { covered: false, state: empty, note: "'No environments yet'" }
+      config-ai-providers:         { covered: false, state: default }
+      config-ai-providers-empty:   { covered: false, state: empty, note: "'No AI providers yet'" }
+      config-workspace-prefs:      { covered: false, state: default }
+
+  onboarding:
+    label: Get started
+    nav_group: Onboarding
+    routes: ["/$workspaceName/get-started", "/$workspaceName/quickstart"]
+    specs: []
+    capabilities:
+      quickstart-page:      { covered: false }
+      start-preference:     { covered: false }
+      integration-explorer: { covered: false }
+      copy-snippet:         { covered: false }
+      api-key-generate:     { covered: false }
+      demo-project-banner:  { covered: false }
+      welcome-wizard:       { covered: false, cloud_only: true }
+
+# ---------------------------------------------------------------------------
+# VISUAL DIMENSION
+#
+# The 3 visual specs currently carry NO tags at all, so they are invisible to
+# every tier run and to the coverage map. Phase 3 tags them. Mapping of the
+# existing visual tests onto areas above:
+#
+#   visual-comparison.spec.ts  01 Projects page    -> projects
+#                              02 Logs/Traces view -> traces
+#                              03 Logs/Threads     -> threads
+#                              04 Datasets page    -> datasets
+#                              05 Test Suites page -> test-suites
+#                              06 Experiments page -> experiments
+#   empty-states.spec.ts       E01..E12 -> traces, threads, datasets, test-suites,
+#                              experiments, dashboards, prompts, agent-playground,
+#                              optimization-studio, annotation-queues,
+#                              online-evaluation, alerts
+#   trace-sidebar.spec.ts      S01 Messages, S02 Details, S03 Feedback scores,
+#                              S04 Prompts -> traces (tab-level)
+#
+# Open question for review: should visual coverage count toward the same
+# capability denominator as functional coverage (current draft: yes, marked
+# `tier: visual`), or be a separate percentage per area? Counting an empty-state
+# screenshot as "alerts is covered" flatters the number — hence `alerts` reads
+# 1/9 rather than 0/9 today.
+# ---------------------------------------------------------------------------
+
+    visual:
+      get-started-page: { covered: false, state: default }
+

--- a/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
+++ b/tests_end_to_end/e2e/tests/agent-playground/agent-playground-local-runner.spec.ts
@@ -5,7 +5,7 @@ import { startEndpointRunner, type EndpointRunner } from '@e2e/core/local-runner
 
 const AGENTS_DIR = path.resolve(__dirname, '../../agents');
 
-test.describe('Agent Playground — Local Runner', { tag: ['@t3-nightly', '@agent-playground'] }, () => {
+test.describe('Agent Playground — Local Runner', { tag: ['@t3-nightly', '@area:agent-playground', '@cap:agent-playground.drive-connected-agent'] }, () => {
   test('drives a connected entrypoint agent from the Agent Playground', async ({
     project,
     scratchDir,

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-scoring.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@e2e/fixtures';
 import { AnnotationQueuePage } from '@e2e/pom/annotation-queue.page';
 
-test.describe('Annotation queue — UI scoring, SDK verify', { tag: ['@t2-cuj', '@annotation-queues'] }, () => {
+test.describe('Annotation queue — UI scoring, SDK verify', { tag: ['@t2-cuj', '@area:annotation-queues', '@cap:annotation-queues.score-queue-item', '@cap:annotation-queues.score-with-reason', '@cap:annotation-queues.skip-item', '@cap:annotation-queues.scores-reach-traces'] }, () => {
   test('Scoring two items and skipping a third reflects on the source traces', async ({
     annotationQueue,
     backendClient,

--- a/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-crud-smoke.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@e2e/fixtures';
 import { DatasetsPage } from '@e2e/pom/datasets.page';
 
-test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () => {
+test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@area:datasets'] }, () => {
   /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
   test.use({ viewport: { width: 1600, height: 900 } });
 
-  test('SDK-seeded dataset renders in list and items page; UI add and delete commit as new versions', async ({
+  test('SDK-seeded dataset renders in list and items page; UI add and delete commit as new versions', { tag: ['@cap:datasets.list-datasets', '@cap:datasets.create-dataset-sdk', '@cap:datasets.view-items', '@cap:datasets.add-item-ui'] }, async ({
     dataset,
     project,
     page,
@@ -40,7 +40,7 @@ test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () 
     expect(await items.countItems()).toBe(3);
   });
 
-  test('UI-created dataset and UI-added first item round-trip to the SDK', async ({
+  test('UI-created dataset and UI-added first item round-trip to the SDK', { tag: ['@cap:datasets.create-dataset-ui', '@cap:datasets.sdk-round-trip'] }, async ({
     project,
     backendClient,
     testNamespace,

--- a/tests_end_to_end/e2e/tests/datasets/dataset-items.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-items.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@e2e/fixtures';
 import { DatasetsPage } from '@e2e/pom/datasets.page';
 
-test.describe('Dataset items — direct coverage', { tag: ['@datasets'] }, () => {
+test.describe('Dataset items — direct coverage', { tag: ['@area:datasets'] }, () => {
   /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
   test.use({ viewport: { width: 1600, height: 900 } });
 
   test('Editing an item field commits as a new version and round-trips to the SDK', {
-    tag: ['@t2-cuj'],
+    tag: ['@t2-cuj', '@cap:datasets.edit-item-versions'],
   }, async ({
     dataset,
     project,
@@ -44,7 +44,7 @@ test.describe('Dataset items — direct coverage', { tag: ['@datasets'] }, () =>
 
   test(
     'Bulk-deleting selected items commits as a new version and round-trips to the SDK',
-    { tag: ['@t3-nightly'] },
+    { tag: ['@t3-nightly', '@cap:datasets.bulk-delete-items'] },
     async ({ dataset, project, backendClient, page }) => {
       const items = await test.step('Open the dataset items page', async () => {
         const datasets = new DatasetsPage(page);
@@ -75,7 +75,7 @@ test.describe('Dataset items — direct coverage', { tag: ['@datasets'] }, () =>
 
   test(
     'Searching filters the items table to matching rows',
-    { tag: ['@t3-nightly'] },
+    { tag: ['@t3-nightly', '@cap:datasets.search-items'] },
     async ({ dataset, project, page }) => {
       const items = await test.step('Open the dataset items page', async () => {
         const datasets = new DatasetsPage(page);

--- a/tests_end_to_end/e2e/tests/experiments/experiments-compare.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-compare.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@e2e/fixtures';
 import { CompareExperimentsPage } from '@e2e/pom/compare-experiments.page';
 
-test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@experiments'] }, () => {
-  test('two SDK-seeded experiments compare side by side with divergent per-item scores and outputs', async ({
+test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@area:experiments'] }, () => {
+  test('two SDK-seeded experiments compare side by side with divergent per-item scores and outputs', { tag: ['@cap:experiments.compare-side-by-side'] }, async ({
     comparison,
     project,
     page,
@@ -61,7 +61,7 @@ test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@experiments
     });
   });
 
-  test('the grid can be sorted by score and searched by item', async ({ comparison, project, page }) => {
+  test('the grid can be sorted by score and searched by item', { tag: ['@cap:experiments.compare-sort-search'] }, async ({ comparison, project, page }) => {
     const [expA, expB] = comparison.experiments;
     const compare = new CompareExperimentsPage(page, project.id, comparison.datasetId, [
       expA.experimentId,
@@ -95,7 +95,7 @@ test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@experiments
     });
   });
 
-  test('feedback scores tab shows each experiment aggregate, and they differ', async ({
+  test('feedback scores tab shows each experiment aggregate, and they differ', { tag: ['@cap:experiments.compare-feedback-tab'] }, async ({
     comparison,
     project,
     page,
@@ -123,7 +123,7 @@ test.describe('Experiments comparison — CUJ', { tag: ['@t2-cuj', '@experiments
     });
   });
 
-  test('the row detail panel shows both experiments side by side for one item', async ({
+  test('the row detail panel shows both experiments side by side for one item', { tag: ['@cap:experiments.compare-row-detail'] }, async ({
     comparison,
     project,
     page,

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@e2e/fixtures';
 import { ExperimentsPage } from '@e2e/pom/experiments.page';
 
-test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@experiments'] }, () => {
-  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', async ({
+test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments'] }, () => {
+  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores'] }, async ({
     experiment,
     project,
     page,

--- a/tests_end_to_end/e2e/tests/ollie/ollie-agentic.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-agentic.spec.ts
@@ -19,7 +19,7 @@ function skipIfOllieDisabled(envConfig: { features: { ollie: boolean } }): void 
   test.skip(!envConfig.features.ollie, 'Ollie is cloud/client-only (OLLIE_ENABLED off)');
 }
 
-test.describe('Ollie — sidebar surface', { tag: ['@t1-smoke', '@ollie'] }, () => {
+test.describe('Ollie — sidebar surface', { tag: ['@t1-smoke', '@area:ollie', '@cap:ollie.sidebar-persists-nav'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('Ollie sidebar mounts on a project page and persists across navigation', async ({
@@ -45,7 +45,7 @@ test.describe('Ollie — sidebar surface', { tag: ['@t1-smoke', '@ollie'] }, () 
   });
 });
 
-test.describe('Ollie — context awareness', { tag: ['@t2-cuj', '@ollie'] }, () => {
+test.describe('Ollie — context awareness', { tag: ['@t2-cuj', '@area:ollie', '@cap:ollie.context-badge-count'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   const SEEDED_TRACES = 3;
@@ -79,7 +79,7 @@ test.describe('Ollie — context awareness', { tag: ['@t2-cuj', '@ollie'] }, () 
   });
 });
 
-test.describe('Ollie — /analyze flow', { tag: ['@t3-nightly', '@ollie'] }, () => {
+test.describe('Ollie — /analyze flow', { tag: ['@t3-nightly', '@area:ollie', '@cap:ollie.analyze-command'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('Ollie returns a structured response for /analyze on a project with traces', async ({

--- a/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-connect.spec.ts
@@ -35,7 +35,7 @@ function skipIfOllieDisabled(envConfig: { features: { ollie: boolean }; apiKey: 
 
 const AGENTS_DIR = path.resolve(__dirname, '../../agents');
 
-test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@ollie'] }, () => {
+test.describe('Ollie — Local Runner', { tag: ['@t3-nightly', '@area:ollie', '@cap:ollie.instrument-command', '@cap:ollie.improve-command', '@cap:ollie.pairing-approve'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('/instrument adds Opik tracing to a connected uninstrumented agent', async ({

--- a/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-explain.spec.ts
@@ -32,7 +32,7 @@ const KEYWORD_PATTERN: Record<'cost' | 'duration', RegExp> = {
 // button label) that isn't part of the answer itself.
 const normalize = (text: string) => text.replace(/\s+/g, ' ').trim();
 
-test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@ollie'] }, () => {
+test.describe('Ollie — explain cells', { tag: ['@t3-nightly', '@area:ollie', '@cap:ollie.explain-cells', '@cap:ollie.explain-continue-convo'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('Explain renders on-topic text for the Errors, Estimated cost, and Duration cell of every seeded trace', async ({

--- a/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/ollie/ollie-smoke.spec.ts
@@ -5,7 +5,7 @@ function skipIfOllieDisabled(envConfig: { features: { ollie: boolean } }): void 
   test.skip(!envConfig.features.ollie, 'Ollie is cloud/client-only (OLLIE_ENABLED off)');
 }
 
-test.describe('Ollie — smoke', { tag: ['@t1-smoke', '@ollie'] }, () => {
+test.describe('Ollie — smoke', { tag: ['@t1-smoke', '@area:ollie', '@cap:ollie.surface-mounts'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('Ollie surface mounts and reaches a ready state', async ({ project, page }) => {
@@ -23,7 +23,7 @@ test.describe('Ollie — smoke', { tag: ['@t1-smoke', '@ollie'] }, () => {
   });
 });
 
-test.describe('Ollie — completion', { tag: ['@t2-cuj', '@ollie'] }, () => {
+test.describe('Ollie — completion', { tag: ['@t2-cuj', '@area:ollie', '@cap:ollie.basic-completion'] }, () => {
   test.beforeEach(({ envConfig }) => skipIfOllieDisabled(envConfig));
 
   test('Ollie returns a completion for a basic prompt', async ({ project, page }) => {

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-smoke.spec.ts
@@ -24,8 +24,8 @@ const UNSAFE_OUTPUTS = [
   'Here is a step-by-step phishing email template designed to deceive recipients into revealing their banking credentials.',
 ];
 
-test.describe('Online Evaluation — smoke', { tag: ['@t1-smoke', '@online-evaluation'] }, () => {
-  test('LLM-judge Moderation rule scores safe/unsafe traces bimodally and renders in the trace panel', async ({
+test.describe('Online Evaluation — smoke', { tag: ['@t1-smoke', '@area:online-evaluation'] }, () => {
+  test('LLM-judge Moderation rule scores safe/unsafe traces bimodally and renders in the trace panel', { tag: ['@cap:online-evaluation.create-llm-judge-rule', '@cap:online-evaluation.llm-judge-scores', '@cap:online-evaluation.scores-in-trace-panel'] }, async ({
     project,
     sdkClient,
     backendClient,
@@ -165,7 +165,7 @@ test.describe('Online Evaluation — smoke', { tag: ['@t1-smoke', '@online-evalu
     });
   });
 
-  test('Python Equals rule scores 5 traces deterministically (3 matching = 1.0, 2 non-matching = 0.0)', async ({
+  test('Python Equals rule scores 5 traces deterministically (3 matching = 1.0, 2 non-matching = 0.0)', { tag: ['@cap:online-evaluation.create-python-rule', '@cap:online-evaluation.python-rule-scores'] }, async ({
     project,
     sdkClient,
     backendClient,

--- a/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
+++ b/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
@@ -29,8 +29,8 @@ function seedSentimentDataset(sdkClient: SdkClient, projectName: string, name: s
   });
 }
 
-test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '@optimization-studio'] }, () => {
-  test('the new-run form renders its sections and enables Optimize only once valid', async ({
+test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '@area:optimization-studio'] }, () => {
+  test('the new-run form renders its sections and enables Optimize only once valid', { tag: ['@cap:optimization-studio.new-run-form-validation'] }, async ({
     project,
     sdkClient,
     backendClient,
@@ -70,7 +70,7 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
     });
   });
 
-  test('launches a GEPA + Equals run from the studio UI and it completes end-to-end', async ({
+  test('launches a GEPA + Equals run from the studio UI and it completes end-to-end', { tag: ['@cap:optimization-studio.launch-gepa-run', '@cap:optimization-studio.run-completes-healthy', '@cap:optimization-studio.studio-logs-download'] }, async ({
     project,
     sdkClient,
     backendClient,
@@ -174,8 +174,8 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
   });
 });
 
-test.describe('Optimization Studio — variant', { tag: ['@t2-cuj', '@t1-stsaas', '@optimization-studio'] }, () => {
-  test('launches a Hierarchical Reflective + Equals run and it completes end-to-end', async ({
+test.describe('Optimization Studio — variant', { tag: ['@t2-cuj', '@t1-stsaas', '@area:optimization-studio'] }, () => {
+  test('launches a Hierarchical Reflective + Equals run and it completes end-to-end', { tag: ['@cap:optimization-studio.launch-hier-reflective', '@cap:optimization-studio.run-completes-healthy'] }, async ({
     project,
     sdkClient,
     backendClient,

--- a/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
@@ -53,7 +53,7 @@ const enabled = Object.values(config.providers).flatMap((p) =>
  *   3. Runs a simple prompt + model-options tweak via the Playground.
  *   4. Asserts a non-empty, non-error response came back.
  */
-test.describe('Playground — provider sanity', { tag: ['@provider-sanity', '@playground'] }, () => {
+test.describe('Playground — provider sanity', { tag: ['@provider-sanity', '@area:playground', '@cap:playground.select-model-provider'] }, () => {
   for (const { provider, model } of enabled) {
     test(`${provider.display_name} ${model.name} returns a completion`, async ({
       project,

--- a/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
@@ -9,7 +9,7 @@ import { ensureModelAvailable } from '@e2e/pom/model-availability';
  * The Playground has no separate "Save as experiment" step — every Re-run click
  * creates a new experiment automatically (verified Phase 3 discovery).
  */
-test.describe('Playground — smoke', { tag: ['@t1-smoke', '@playground'] }, () => {
+test.describe('Playground — smoke', { tag: ['@t1-smoke', '@area:playground', '@cap:playground.compose-run-prompt', '@cap:playground.run-against-dataset'] }, () => {
   test('Run prompts against a dataset auto-creates an experiment', async ({
     dataset,
     project,

--- a/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
@@ -29,10 +29,10 @@ async function runVersioningSteps(detail: PromptDetailPage, opts: VersioningOpts
   });
 }
 
-test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, () => {
+test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@area:prompts'] }, () => {
   test.use({ viewport: { width: 1600, height: 900 } });
 
-  test('SDK-seeded text prompt appears in library, edit creates new version, old version is preserved', async ({
+  test('SDK-seeded text prompt appears in library, edit creates new version, old version is preserved', { tag: ['@cap:prompts.list-prompts', '@cap:prompts.sdk-seeded-visible', '@cap:prompts.edit-creates-version', '@cap:prompts.old-version-preserved'] }, async ({
     project,
     textPrompt,
     page,
@@ -64,7 +64,7 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
     });
   });
 
-  test('SDK-seeded chat prompt appears in library, edit creates new version, old version is preserved', async ({
+  test('SDK-seeded chat prompt appears in library, edit creates new version, old version is preserved', { tag: ['@cap:prompts.sdk-seeded-visible', '@cap:prompts.edit-creates-version', '@cap:prompts.version-history'] }, async ({
     project,
     chatPrompt,
     page,
@@ -136,7 +136,7 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@prompts'] }, ()
   ];
 
   for (const variant of UI_VARIANTS) {
-    test(`UI-created ${variant.label} prompt shows content, edit creates new version, old version is preserved`, async ({
+    test(`UI-created ${variant.label} prompt shows content, edit creates new version, old version is preserved`, { tag: ['@cap:prompts.create-text-prompt-ui', '@cap:prompts.create-chat-prompt-ui', '@cap:prompts.edit-creates-version'] }, async ({
       project,
       page,
       registerPromptCleanup,

--- a/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-library-smoke.spec.ts
@@ -98,73 +98,95 @@ test.describe('Prompt Library — smoke', { tag: ['@t1-smoke', '@area:prompts'] 
   });
 
   type UiVariant = {
-    label: string;
     nameSuffix: string;
     template: string;
-    updatedContent: string;
     create: (prompts: PromptsPage, name: string, content: string) => Promise<PromptDetailPage>;
     versioning: VersioningOpts;
   };
 
-  const UI_VARIANTS: UiVariant[] = [
-    {
-      label: 'text',
-      nameSuffix: 'ui-text',
-      template: 'You are a helpful assistant. Answer: {{question}}',
+  const TEXT_VARIANT: UiVariant = {
+    nameSuffix: 'ui-text',
+    template: 'You are a helpful assistant. Answer: {{question}}',
+    create: (prompts, name, content) => prompts.createTextPromptViaUI(name, content),
+    versioning: {
+      contentLocator: (d) => d.textContent(),
+      initialContent: 'You are a helpful assistant',
       updatedContent: 'You are an expert assistant. Respond concisely to: {{question}}',
-      create: (prompts, name, content) => prompts.createTextPromptViaUI(name, content),
-      versioning: {
-        contentLocator: (d) => d.textContent(),
-        initialContent: 'You are a helpful assistant',
-        updatedContent: 'You are an expert assistant. Respond concisely to: {{question}}',
-        edit: (d, content) => d.editTextPrompt(content),
-      },
+      edit: (d, content) => d.editTextPrompt(content),
     },
-    {
-      label: 'chat',
-      nameSuffix: 'ui-chat',
-      template: 'Answer the following: {{question}}',
+  };
+
+  const CHAT_VARIANT: UiVariant = {
+    nameSuffix: 'ui-chat',
+    template: 'Answer the following: {{question}}',
+    create: (prompts, name, content) => prompts.createChatPromptViaUI(name, content),
+    versioning: {
+      contentLocator: (d) => d.chatMessages(),
+      initialContent: 'Answer the following',
       updatedContent: 'Provide a concise expert answer to: {{question}}',
-      create: (prompts, name, content) => prompts.createChatPromptViaUI(name, content),
-      versioning: {
-        contentLocator: (d) => d.chatMessages(),
-        initialContent: 'Answer the following',
-        updatedContent: 'Provide a concise expert answer to: {{question}}',
-        edit: (d, content) => d.editChatFirstMessage(content),
-      },
+      edit: (d, content) => d.editChatFirstMessage(content),
     },
-  ];
+  };
 
-  for (const variant of UI_VARIANTS) {
-    test(`UI-created ${variant.label} prompt shows content, edit creates new version, old version is preserved`, { tag: ['@cap:prompts.create-text-prompt-ui', '@cap:prompts.create-chat-prompt-ui', '@cap:prompts.edit-creates-version'] }, async ({
-      project,
-      page,
-      registerPromptCleanup,
-      testNamespace,
-    }) => {
-      const promptName = `${testNamespace}-${variant.nameSuffix}`;
-      const prompts = new PromptsPage(page);
+  type UiFlowFixtures = Pick<
+    Parameters<Parameters<typeof test>[2]>[0],
+    'project' | 'page' | 'registerPromptCleanup' | 'testNamespace'
+  >;
 
-      await test.step('Navigate to empty Prompts Library', async () => {
-        await prompts.goto(project.id);
-        await prompts.waitForReady();
-      });
+  async function runUiCreateAndVersionFlow(
+    variant: UiVariant,
+    { project, page, registerPromptCleanup, testNamespace }: UiFlowFixtures,
+  ): Promise<void> {
+    const promptName = `${testNamespace}-${variant.nameSuffix}`;
+    const prompts = new PromptsPage(page);
 
-      const detail = await variant.create(prompts, promptName, variant.template);
-
-      const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
-      const promptsIdx = urlParts.lastIndexOf('prompts');
-      const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
-      expect(promptId, 'Expected to extract promptId from URL after prompt creation').toBeTruthy();
-      registerPromptCleanup(promptId, promptName);
-
-      await test.step('Verify detail page shows correct content', async () => {
-        await detail.waitForReady();
-        await expect(detail.promptNameHeading()).toHaveText(promptName);
-        await expect(variant.versioning.contentLocator(detail)).toContainText(variant.versioning.initialContent);
-      });
-
-      await runVersioningSteps(detail, variant.versioning);
+    await test.step('Navigate to empty Prompts Library', async () => {
+      await prompts.goto(project.id);
+      await prompts.waitForReady();
     });
+
+    const detail = await variant.create(prompts, promptName, variant.template);
+
+    const urlParts = new URL(page.url()).pathname.split('/').filter(Boolean);
+    const promptsIdx = urlParts.lastIndexOf('prompts');
+    const promptId = promptsIdx >= 0 ? (urlParts[promptsIdx + 1] ?? '') : '';
+    expect(promptId, 'Expected to extract promptId from URL after prompt creation').toBeTruthy();
+    registerPromptCleanup(promptId, promptName);
+
+    await test.step('Verify detail page shows correct content', async () => {
+      await detail.waitForReady();
+      await expect(detail.promptNameHeading()).toHaveText(promptName);
+      await expect(variant.versioning.contentLocator(detail)).toContainText(variant.versioning.initialContent);
+    });
+
+    await runVersioningSteps(detail, variant.versioning);
   }
+
+  // Text and chat are two separate tests rather than a loop over variants so
+  // that each declares only the creation capability it actually exercises. A
+  // loop would have to build its tag array from the variant, and both the tag
+  // lint and the coverage builder read tags as string literals — a computed tag
+  // is invisible to them, which would silently drop the capability instead of
+  // mis-attributing it.
+  test('UI-created text prompt shows content, edit creates new version, old version is preserved', {
+    tag: [
+      '@cap:prompts.create-text-prompt-ui',
+      '@cap:prompts.edit-creates-version',
+      '@cap:prompts.old-version-preserved',
+      '@cap:prompts.version-history',
+    ],
+  }, async ({ project, page, registerPromptCleanup, testNamespace }) => {
+    await runUiCreateAndVersionFlow(TEXT_VARIANT, { project, page, registerPromptCleanup, testNamespace });
+  });
+
+  test('UI-created chat prompt shows content, edit creates new version, old version is preserved', {
+    tag: [
+      '@cap:prompts.create-chat-prompt-ui',
+      '@cap:prompts.edit-creates-version',
+      '@cap:prompts.old-version-preserved',
+      '@cap:prompts.version-history',
+    ],
+  }, async ({ project, page, registerPromptCleanup, testNamespace }) => {
+    await runUiCreateAndVersionFlow(CHAT_VARIANT, { project, page, registerPromptCleanup, testNamespace });
+  });
 });

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-new-prompt.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-new-prompt.spec.ts
@@ -19,7 +19,7 @@ const PROMPT_VARIANTS = [
 
 test.describe(
   'Playground → save new prompt to library',
-  { tag: ['@t1-smoke', '@prompts', '@playground'] },
+  { tag: ['@t1-smoke', '@area:playground', '@cap:playground.save-new-prompt'] },
   () => {
     test.use({ viewport: { width: 1600, height: 900 } });
 

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-save.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-save.spec.ts
@@ -19,7 +19,7 @@ const PROMPT_VARIANTS = [
 
 test.describe(
   'Playground → save prompt to library',
-  { tag: ['@t2-cuj', '@prompts', '@playground'] },
+  { tag: ['@t2-cuj', '@area:playground', '@cap:playground.save-prompt-version'] },
   () => {
     test.use({ viewport: { width: 1600, height: 900 } });
 

--- a/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-playground-traces.spec.ts
@@ -28,7 +28,7 @@ const PROMPT_VARIANTS: PromptVariant[] = [
   },
 ];
 
-test.describe('Prompt → Playground → Traces', { tag: ['@t2-cuj', '@prompts', '@playground'] }, () => {
+test.describe('Prompt → Playground → Traces', { tag: ['@t2-cuj', '@area:playground', '@cap:playground.verify-trace-from-run', '@cap:playground.playground-logs-sidebar'] }, () => {
   test.use({ viewport: { width: 1600, height: 900 } });
 
   for (const variant of PROMPT_VARIANTS) {

--- a/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
+++ b/tests_end_to_end/e2e/tests/prompts/prompt-version-playground.spec.ts
@@ -16,7 +16,7 @@ const PROMPT_VARIANTS = [
 
 test.describe(
   'Prompt versioning → Playground → Trace verification',
-  { tag: ['@t2-cuj', '@prompts', '@playground'] },
+  { tag: ['@t2-cuj', '@area:playground', '@cap:playground.load-prompt-version', '@cap:playground.verify-trace-from-run'] },
   () => {
     test.use({ viewport: { width: 1600, height: 900 } });
 

--- a/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/test-suites/test-suites-smoke.spec.ts
@@ -3,7 +3,7 @@ import { TestSuitesPage } from '@e2e/pom/test-suites.page';
 import { TestSuiteItemsPage } from '@e2e/pom/test-suite-items.page';
 import { ensureModelAvailable } from '@e2e/pom/model-availability';
 
-test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, () => {
+test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@area:test-suites'] }, () => {
   /**
    * Test A — SDK-create + SDK-run + UI-verify.
    *
@@ -11,7 +11,7 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
    * LLM-judged assertions. The SDK-run uses task_output="PASS" so the LLM
    * judge's verdict is mechanically predictable (3/3 pass).
    */
-  test('SDK-seeded suite renders + SDK-run produces a 3/3 pass experiment', async ({
+  test('SDK-seeded suite renders + SDK-run produces a 3/3 pass experiment', { tag: ['@cap:test-suites.list-suites', '@cap:test-suites.create-suite-sdk', '@cap:test-suites.view-suite-items', '@cap:test-suites.run-suite-sdk', '@cap:test-suites.pass-rate-display', '@cap:test-suites.global-assertions'] }, async ({
     testSuite,
     sdkClient,
     project,
@@ -83,7 +83,7 @@ test.describe('Test Suites — smoke', { tag: ['@t1-smoke', '@test-suites'] }, (
    * Exercises the FE write path (create-suite dialog + add-item flow) and the
    * end-to-end Playground "Open in Playground" → run path.
    */
-  test('UI-created suite is visible via SDK; UI-run via Playground produces outputs', async ({
+  test('UI-created suite is visible via SDK; UI-run via Playground produces outputs', { tag: ['@cap:test-suites.create-suite-ui', '@cap:test-suites.run-suite-playground'] }, async ({
     project,
     sdkClient,
     backendClient,

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-logging-smoke.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
 
-test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@trace-explore'] }, () => {
-  test('Threads view groups a multi-turn conversation with the correct message count and endpoints', async ({
+test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@area:threads'] }, () => {
+  test('Threads view groups a multi-turn conversation with the correct message count and endpoints', { tag: ['@cap:threads.list-threads', '@cap:threads.thread-message-count'] }, async ({
     conversation,
     page,
   }) => {
@@ -39,7 +39,7 @@ test.describe('Thread logging — smoke', { tag: ['@t1-smoke', '@trace-explore']
     });
   });
 
-  test('Thread detail panel renders the conversation turns in order with the right input and output', async ({
+  test('Thread detail panel renders the conversation turns in order with the right input and output', { tag: ['@cap:threads.open-thread-panel', '@cap:threads.turn-order-io'] }, async ({
     conversation,
     page,
   }) => {

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-explore-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-explore-smoke.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
 
-test.describe('Trace Explore — smoke', { tag: ['@t1-smoke', '@trace-explore'] }, () => {
-  test('Logs view shows seeded traces with correct count and ordering', async ({
+test.describe('Trace Explore — smoke', { tag: ['@t1-smoke', '@area:traces'] }, () => {
+  test('Logs view shows seeded traces with correct count and ordering', { tag: ['@cap:traces.list-traces', '@cap:traces.trace-ordering'] }, async ({
     project,
     sdkClient,
     testNamespace,
@@ -45,7 +45,7 @@ test.describe('Trace Explore — smoke', { tag: ['@t1-smoke', '@trace-explore'] 
     });
   });
 
-  test('Trace panel renders the seeded trace header, input, output, span count, and project breadcrumb', async ({
+  test('Trace panel renders the seeded trace header, input, output, span count, and project breadcrumb', { tag: ['@cap:traces.open-trace-panel'] }, async ({
     opikTrace,
     project,
     page,

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-spans-depth.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-spans-depth.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
 
-test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@trace-explore'] }, () => {
-  test('Span tree renders the seeded nested hierarchy with working expand/collapse', async ({
+test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test('Span tree renders the seeded nested hierarchy with working expand/collapse', { tag: ['@cap:traces.span-tree-expand'] }, async ({
     tracedAgent,
     project,
     page,
@@ -35,7 +35,7 @@ test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@trace-explore'
     });
   });
 
-  test('Selecting the LLM span shows its model, token usage, and cost', async ({
+  test('Selecting the LLM span shows its model, token usage, and cost', { tag: ['@cap:traces.span-model-cost-tokens'] }, async ({
     tracedAgent,
     project,
     page,
@@ -62,7 +62,7 @@ test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@trace-explore'
     });
   });
 
-  test('A tag can be added to a trace from the panel and removed', async ({
+  test('A tag can be added to a trace from the panel and removed', { tag: ['@cap:traces.trace-tag-add-remove'] }, async ({
     tracedAgent,
     project,
     page,
@@ -85,7 +85,7 @@ test.describe('Trace spans — panel depth', { tag: ['@t2-cuj', '@trace-explore'
     });
   });
 
-  test('A manual feedback score can be added, edited, and deleted from the Annotate panel', async ({
+  test('A manual feedback score can be added, edited, and deleted from the Annotate panel', { tag: ['@cap:traces.manual-feedback-score'] }, async ({
     tracedAgent,
     feedbackDefinition,
     project,

--- a/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
@@ -31,14 +31,14 @@ test.describe('Visual Comparison - Empty States', () => {
     await page.close();
   });
 
-  test('E01: Logs - Traces empty state', async ({ page }) => {
+  test('E01: Logs - Traces empty state', { tag: ['@vcap:traces.logs-traces-empty'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForEmptyTraces();
     await screenshot(page, 'E01-logs-traces-empty');
   });
 
-  test('E02: Logs - Threads empty state', async ({ page }) => {
+  test('E02: Logs - Threads empty state', { tag: ['@vcap:threads.logs-threads-empty'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.switchToThreads();
@@ -46,70 +46,70 @@ test.describe('Visual Comparison - Empty States', () => {
     await screenshot(page, 'E02-logs-threads-empty');
   });
 
-  test('E03: Datasets empty state', async ({ page }) => {
+  test('E03: Datasets empty state', { tag: ['@vcap:datasets.datasets-empty'] }, async ({ page }) => {
     const datasetsPage = new DatasetsPage(page, baseUrl, workspace);
     await datasetsPage.goto(projectId);
     await datasetsPage.waitForEmpty();
     await screenshot(page, 'E03-datasets-empty');
   });
 
-  test('E04: Test Suites empty state', async ({ page }) => {
+  test('E04: Test Suites empty state', { tag: ['@vcap:test-suites.test-suites-empty'] }, async ({ page }) => {
     const testSuitesPage = new TestSuitesPage(page, baseUrl, workspace);
     await testSuitesPage.goto(projectId);
     await testSuitesPage.waitForEmpty();
     await screenshot(page, 'E04-testsuites-empty');
   });
 
-  test('E05: Experiments empty state', async ({ page }) => {
+  test('E05: Experiments empty state', { tag: ['@vcap:experiments.experiments-empty'] }, async ({ page }) => {
     const experimentsPage = new ExperimentsPage(page, baseUrl, workspace);
     await experimentsPage.goto(projectId);
     await experimentsPage.waitForEmpty();
     await screenshot(page, 'E05-experiments-empty');
   });
 
-  test('E06: Dashboards default view', async ({ page }) => {
+  test('E06: Dashboards default view', { tag: ['@vcap:dashboards.dashboards-default'] }, async ({ page }) => {
     const dashboardsPage = new DashboardsPage(page, baseUrl, workspace);
     await dashboardsPage.goto(projectId);
     await dashboardsPage.waitForLoaded();
     await screenshot(page, 'E06-dashboards-default');
   });
 
-  test('E07: Prompt Library empty state', async ({ page }) => {
+  test('E07: Prompt Library empty state', { tag: ['@vcap:prompts.prompt-library-empty'] }, async ({ page }) => {
     const promptsPage = new PromptsPage(page, baseUrl, workspace);
     await promptsPage.goto(projectId);
     await promptsPage.waitForEmpty();
     await screenshot(page, 'E07-prompts-empty');
   });
 
-  test('E08: Agent Playground empty state', async ({ page }) => {
+  test('E08: Agent Playground empty state', { tag: ['@vcap:agent-playground.agent-playground-empty'] }, async ({ page }) => {
     const agentPlaygroundPage = new AgentPlaygroundPage(page, baseUrl, workspace);
     await agentPlaygroundPage.goto(projectId);
     await agentPlaygroundPage.waitForEmpty();
     await screenshot(page, 'E08-agent-playground-empty');
   });
 
-  test('E09: Optimization runs empty state', async ({ page }) => {
+  test('E09: Optimization runs empty state', { tag: ['@vcap:optimization-studio.optimization-runs-empty'] }, async ({ page }) => {
     const optimizationsPage = new OptimizationsPage(page, baseUrl, workspace);
     await optimizationsPage.goto(projectId);
     await optimizationsPage.waitForEmpty();
     await screenshot(page, 'E09-optimizations-empty');
   });
 
-  test('E10: Annotation queues empty state', async ({ page }) => {
+  test('E10: Annotation queues empty state', { tag: ['@vcap:annotation-queues.annotation-queues-empty'] }, async ({ page }) => {
     const annotationQueuesPage = new AnnotationQueuesPage(page, baseUrl, workspace);
     await annotationQueuesPage.goto(projectId);
     await annotationQueuesPage.waitForEmpty();
     await screenshot(page, 'E10-annotation-queues-empty');
   });
 
-  test('E11: Online evaluation empty state', async ({ page }) => {
+  test('E11: Online evaluation empty state', { tag: ['@vcap:online-evaluation.online-evaluation-empty'] }, async ({ page }) => {
     const onlineEvaluationPage = new OnlineEvaluationPage(page, baseUrl, workspace);
     await onlineEvaluationPage.goto(projectId);
     await onlineEvaluationPage.waitForEmpty();
     await screenshot(page, 'E11-online-evaluation-empty');
   });
 
-  test('E12: Alerts empty state', async ({ page }) => {
+  test('E12: Alerts empty state', { tag: ['@vcap:alerts.alerts-empty'] }, async ({ page }) => {
     const alertsPage = new AlertsPage(page, baseUrl, workspace);
     await alertsPage.goto(projectId);
     await alertsPage.waitForEmpty();

--- a/tests_end_to_end/visual-tests/tests/trace-sidebar.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/trace-sidebar.spec.ts
@@ -32,7 +32,7 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
     await page.close();
   });
 
-  test('S01: Trace sidebar - Messages tab', async ({ page }) => {
+  test('S01: Trace sidebar - Messages tab', { tag: ['@vcap:traces.trace-sidebar-messages'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady(TRACE_INPUT_TEXT);
@@ -45,7 +45,7 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
     await screenshot(page, 'S01-trace-sidebar-messages', [panel.statsRowMask]);
   });
 
-  test('S02: Trace sidebar - Details tab', async ({ page }) => {
+  test('S02: Trace sidebar - Details tab', { tag: ['@vcap:traces.trace-sidebar-details'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady(TRACE_INPUT_TEXT);
@@ -59,7 +59,7 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
     await screenshot(page, 'S02-trace-sidebar-details', [panel.statsRowMask]);
   });
 
-  test('S03: Trace sidebar - Feedback scores tab', async ({ page }) => {
+  test('S03: Trace sidebar - Feedback scores tab', { tag: ['@vcap:traces.trace-sidebar-feedback'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady(TRACE_INPUT_TEXT);
@@ -72,7 +72,7 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
     await screenshot(page, 'S03-trace-sidebar-feedback-scores', [panel.statsRowMask]);
   });
 
-  test('S04: Trace sidebar - Prompts tab', async ({ page }) => {
+  test('S04: Trace sidebar - Prompts tab', { tag: ['@vcap:traces.trace-sidebar-prompts'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady(TRACE_INPUT_TEXT);

--- a/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
@@ -68,7 +68,7 @@ test.describe('Visual Comparison - Opik UI', () => {
     await page.close();
   });
 
-  test('01: Projects page', async ({ page }) => {
+  test('01: Projects page', { tag: ['@vcap:projects.projects-page'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady('input-0');
@@ -79,14 +79,14 @@ test.describe('Visual Comparison - Opik UI', () => {
     await screenshot(page, '01-projects-page', tableMasks(page));
   });
 
-  test('02: Logs - Traces view', async ({ page }) => {
+  test('02: Logs - Traces view', { tag: ['@vcap:traces.logs-traces-view'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.waitForTracesReady('input-0');
     await screenshot(page, '02-logs-traces', tableMasks(page));
   });
 
-  test('03: Logs - Threads view', async ({ page }) => {
+  test('03: Logs - Threads view', { tag: ['@vcap:threads.logs-threads-view'] }, async ({ page }) => {
     const logsPage = new LogsPage(page, baseUrl, workspace);
     await logsPage.goto(projectId);
     await logsPage.switchToThreads();
@@ -94,21 +94,21 @@ test.describe('Visual Comparison - Opik UI', () => {
     await screenshot(page, '03-logs-threads', tableMasks(page));
   });
 
-  test('04: Datasets page', async ({ page }) => {
+  test('04: Datasets page', { tag: ['@vcap:datasets.datasets-page'] }, async ({ page }) => {
     const datasetsPage = new DatasetsPage(page, baseUrl, workspace);
     await datasetsPage.goto(projectId);
     await datasetsPage.waitForReady('visual-dataset');
     await screenshot(page, '04-datasets-page', tableMasks(page));
   });
 
-  test('05: Test Suites page', async ({ page }) => {
+  test('05: Test Suites page', { tag: ['@vcap:test-suites.test-suites-page'] }, async ({ page }) => {
     const testSuitesPage = new TestSuitesPage(page, baseUrl, workspace);
     await testSuitesPage.goto(projectId);
     await testSuitesPage.waitForReady('visual-testsuite');
     await screenshot(page, '05-testsuites-page', tableMasks(page));
   });
 
-  test('06: Experiments page', async ({ page }) => {
+  test('06: Experiments page', { tag: ['@vcap:experiments.experiments-page'] }, async ({ page }) => {
     const experimentsPage = new ExperimentsPage(page, baseUrl, workspace);
     await experimentsPage.goto(projectId);
     await experimentsPage.waitForExperiment(experimentName());


### PR DESCRIPTION
## Details

Establishes the coverage map for `tests_end_to_end/`: a reviewed taxonomy that defines the denominator, `@area:`/`@cap:` tags on every spec, and a PR gate that keeps the two in sync. This is the D3 foundation the coverage dashboard and radar build on (OPIK-7532).

Two commits, reviewable separately:

1. **`test:`** — tags all 26 specs. Tags only; no logic, selectors or assertions changed.
2. **`ci:`** — adds the taxonomy, the lint, the conventions doc, and the workflow.

```
tests_end_to_end/coverage/taxonomy.yaml   18 areas, ~188 capabilities
tests_end_to_end/coverage/tag_lint.py     6 rules, exits non-zero on any
tests_end_to_end/TESTING-TAGS.md          the grammar and how to extend it
.github/workflows/tag_lint.yml            PR gate on tests_end_to_end/**
```

### The tags

```
@area:<area>              which product area a spec belongs to (one per spec)
@cap:<area>.<capability>  which capabilities a test proves
@vcap:<area>.<capability> same, for visual specs
```

Existing tier tags (`@t1-smoke`/`@t2-cuj`/`@t3-nightly`) and suite selectors (`@t1-stsaas`, `@provider-sanity`) are untouched, so **nothing about which tests run in which job changes** — verified below.

`@area:` on the describe; `@cap:` per test where a describe holds several distinct tests, on the describe where its tests are variants of one capability (the prompt text/chat loops). Per-test is what lets a red run name the capability that regressed rather than just the area.

### Why this gates PRs rather than running nightly

Tier selection is `--grep`, so a spec with a missing or typo'd tag is **not a failure** — it is silently never selected, and the root `npm test` even passes `--pass-with-no-tests`. An untagged spec stops running with no signal at all. Catching that at review time is the point; a nightly job reports it the morning after.

### Why the taxonomy lives in this repo

A gate that reads the taxonomy must work on PRs from external contributors, where no cross-repo checkout token is available. Keeping it beside the specs it describes means the check needs no secrets, no internal runner, and no cross-repo checkout. The coverage builder reads it from here.

### Coverage as it stands

Reported per dimension, never blended into one number:

| dimension | covered | note |
|---|---|---|
| functional | 75/188 | 41% self-hosted, excluding the two cloud-only areas |
| visual | 22/54 | opt-in denominator |
| load | 0/9 | denominator defined, `status: planned` |

The load dimension is declared but deliberately inert — `tests_load/` reports to JUnit rather than Allure, so it is not joinable yet, and wiring it up is a separate decision.

Three tags were deliberately left off, each because including them would have overcounted:

- The bare `@prompts` tag on the four prompt-playground specs becomes **`@area:playground`, not `@area:prompts`** — those specs drive the Playground and only assert on the library as an outcome.
- `trace-explore-smoke` asserts the project breadcrumb, but only as project context for the trace panel, so it does **not** claim `@cap:projects.breadcrumb-selector`. A cross-area cap there would report the Projects area as covered on an incidental assertion. (The lint caught this one.)
- `@trace-explore` is retired: it predated the split of the Logs surface into distinct `traces` and `threads` areas. Its three specs resolve to `@area:traces` (trace-explore-smoke, trace-spans-depth) and `@area:threads` (thread-logging-smoke).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-7532

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: derived the taxonomy from the frontend routes, nav and docs; mapped each test to the capabilities it actually asserts by reading the test bodies; wrote the lint and workflow; ran the verification below.
- Human verification: Andrei Cautisanu reviewed the taxonomy and its altitude, chose the per-test granularity, decided where the taxonomy and gate live, and approved the diff and verification results before this was pushed.

## Testing

The risk in a tagging change is silently altering which tests get selected, so verification focused on proving selection is unchanged. Ran from `tests_end_to_end/e2e` and `tests_end_to_end/visual-tests` (`npm install`, then Playwright's own resolver) on this branch and on unmodified `main`:

```
./node_modules/.bin/tsc --noEmit
./node_modules/.bin/playwright test --list --grep '@t1-smoke'
./node_modules/.bin/playwright test --list --grep '@t1-smoke|@t1-stsaas'
./node_modules/.bin/playwright test --list --grep '@t1-smoke|@t2-cuj'
./node_modules/.bin/playwright test --list --grep '@t1-smoke|@t2-cuj|@t3-nightly'
./node_modules/.bin/playwright test --list
```

| selection | before (main) | after |
|---|---|---|
| `test:t1` | 20 tests / 11 files | 20 tests / 11 files |
| `test:t1-stsaas` | 23 / 12 | 23 / 12 |
| `test:t2` | 41 / 19 | 41 / 19 |
| `test:t3` | 49 / 22 | 49 / 22 |
| all e2e | 56 / 24 | 56 / 24 |
| all visual | 22 / 3 | 22 / 3 |

Identical on every selection. `tsc --noEmit` clean.

New tags resolve at the intended granularity:

```
--grep '@area:playground'                  -> 13 tests in 6 files
--grep '@area:traces'                      ->  6 tests in 2 files
--grep '@cap:datasets.edit-item-versions'  ->  1 test  in 1 file
--grep '@vcap:traces'                      ->  6 tests in 3 files
```

The gate was verified to fail, not just to pass — a lint that cannot fail is worthless:

| scenario | result |
|---|---|
| this branch as-is | `26 specs checked, 1 exempt, 0 problems`, exit 0 |
| typo a cap to `@cap:datasets.serch-items` | exit 1, `unknown capability … not in taxonomy`, annotated on line 78 |
| add a new spec with no tags at all | exit 1, `no tier tag` + `no @area: tag` |

Both injected faults were reverted and the clean run re-confirmed.

Tests not run, with reason:

- **The suites themselves were not executed locally.** They need a live Opik stack plus provider API keys. The only edits to spec files are string literals in `tag` arrays, and `--list` (which performs full test discovery and tag resolution) is identical before and after. CI's `Run v2 suite: t1` executes them.

## Documentation

`tests_end_to_end/TESTING-TAGS.md` — tag grammar, describe-vs-test placement, naming, `test.step()` usage, the Allure mapping, and the process for adding areas and capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)