### PR TITLE
[NA] [QA] fix: wait on experiment-creation response in Playground smoke

### DIFF
--- a/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-smoke.spec.ts
@@ -24,6 +24,8 @@ test.describe('Playground — smoke', { tag: ['@t1-smoke', '@playground'] }, () 
 
     const playground = new PlaygroundPage(page, project.id);
 
+    let experimentCreated!: Promise<unknown>;
+
     await test.step('Navigate to Playground, configure variant, load dataset, run', async () => {
       await playground.goto();
       await playground.waitForReady();
@@ -35,23 +37,39 @@ test.describe('Playground — smoke', { tag: ['@t1-smoke', '@playground'] }, () 
       await playground.clickRunExperiment();
       await playground.selectRunExperimentSource({ mode: 'dataset', entityName: dataset.name });
       await expect(playground.loadedSourcePill()).toBeVisible();
+
+      // The frontend queues experiment creation independently of the trace/span
+      // batches that paint the result rows, so the POST can land before or well
+      // after the table finishes rendering. Latch it BEFORE clicking Re-run —
+      // registering afterwards races the request and can miss it entirely.
+      // Match the collection endpoint exactly: `items` and `finish` share the prefix.
+      experimentCreated = page.waitForResponse(
+        (r) =>
+          /\/v1\/private\/experiments\/?$/.test(new URL(r.url()).pathname) &&
+          r.request().method() === 'POST' &&
+          r.ok(),
+        { timeout: 120_000 },
+      );
+
       await playground.clickReRun();
       await playground.waitForRunsComplete({ expectedRows: 3, timeoutMs: 120_000 });
       expect(await playground.countOutputRows()).toBeGreaterThanOrEqual(3);
     });
 
     await test.step('SDK-verify an experiment landed under the project (auto-named)', async () => {
-      // The playground generates experiment names server-side (e.g.
-      // "redundant_landaulet_8244"), and the experiment record is written
-      // shortly AFTER the result rows render. Poll briefly to ride out that
-      // window. We match on datasetId since the name is auto-generated.
+      // Wait on the creation request itself rather than guessing how long the
+      // write takes; the poll below then only has to cover read-after-write
+      // visibility. We match on datasetId since the name is auto-generated
+      // server-side (e.g. "redundant_landaulet_8244").
+      await experimentCreated;
+
       await expect
         .poll(
           async () => {
             const all = await backendClient.listExperimentsWithPrefix('');
             return all.filter((e) => e.datasetId === dataset.id).length;
           },
-          { timeout: 15_000, intervals: [500, 1000, 2000] },
+          { timeout: 60_000, intervals: [500, 1000, 2000, 5000] },
         )
         .toBeGreaterThanOrEqual(1);
     });


### PR DESCRIPTION
## Details

`playground-smoke.spec.ts` polled the experiments API for only 15s after the result rows rendered, then asserted an experiment existed. The frontend queues experiment creation independently of the trace/span batches that paint those rows ([`createLogPlaygroundProcessor.ts`](https://github.com/comet-ml/opik/blob/main/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts)), so `POST /v1/private/experiments/` can land well after the table is complete — there is no ordering guarantee between the two paths. On the production t3 run the window exceeded 15s and the test failed after 25 consecutive passes.

- Latch the experiment-creation response **before** clicking Re-run, and await it before polling — the test now waits on the actual write rather than a fixed budget. Registering the listener afterwards would race the request and could miss it entirely.
- The predicate matches the collection endpoint exactly (`/v1/private/experiments/`), since `items` and `finish` share the prefix and would otherwise match.
- Raise the residual read-after-write poll from 15s → 60s, matching the analogous wait in `prompt-playground-traces.spec.ts:92`. It was the shortest poll in the suite by a wide margin.

Costs nothing on the happy path: `expect.poll` returns as soon as the predicate holds, so a passing run is unchanged in duration.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA — test-infrastructure flake, no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Diagnosis of the failing run (TestOps launch 89203), and authoring of the test change and PR description.
- Human verification: Pending review by @andreic — see the Testing section for exactly what was and was not verified locally.

## Testing

Environment: local OSS stack at `http://localhost:5173`, suite at `tests_end_to_end/e2e/`.

Verified:
- `./node_modules/.bin/tsc --noEmit` — clean.
- `playwright test tests/playground/playground-smoke.spec.ts --list` — spec collects correctly (1 test).
- **The `waitForResponse` predicate was verified against live traffic** with a throwaway probe spec (since removed): it fired on a real `POST /api/v1/private/experiments/ -> 201` and correctly ignored a `POST .../experiments/finish` issued immediately beforehand. An earlier probe iteration returned 400 (`Experiment id must be a version 7 UUID`) and the latch correctly did *not* fire, confirming the `r.ok()` guard behaves as intended.
- Matcher regex checked against the local and cloud base paths, the trailing-slash and no-slash variants, query strings, and the `items` / `finish` / `traces/batch` siblings.

**Not run:** the full `playground-smoke` test itself. It `test.skip`s in this environment because no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` is set, and the flow requires a live LLM model to produce output rows. The seeding and bridge infrastructure came up correctly (project + dataset created) before the skip. CI, which has provider keys, will exercise the full path.

Since the failure is an intermittent timing race, a single green run would not have proven the fix regardless — the argument rests on the FE source showing the two async paths are unordered, plus the verified latch.

## Documentation

None — test-only change.
