### PR TITLE
[DND-335][HELM] Add optional ClickHouse restore job

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -555,5 +555,5 @@ Set up monitoring for backup operations:
 For additional help with ClickHouse backups:
 
 - [ClickHouse Backup Documentation](https://github.com/Altinity/clickhouse-backup)
-- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/operations/backup)
+- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
 - [Opik Community Support](https://github.com/comet-ml/opik/issues)

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -323,10 +323,12 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     (`7171` by default).
   </Step>
   <Step title="Render the job manifest">
-    Put the restore settings in their own values file:
+    The backup server has to be running in the release already. The command below renders **only**
+    the Job, so nothing under `backupServer` reaches the cluster through it — if the server is not
+    enabled yet, roll it out with `helm upgrade` first:
 
     ```yaml
-    # restore-values.yaml
+    # part of your release values
     clickhouse:
       backupServer:
         enabled: true
@@ -336,6 +338,13 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
           S3_BUCKET: YOURBUCKET
           S3_PATH: YOURPATH
           RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
+    ```
+
+    Then put the restore settings, which are only needed at render time, in their own values file:
+
+    ```yaml
+    # restore-values.yaml
+    clickhouse:
       backup:
         restore:
           createJob: true
@@ -421,9 +430,12 @@ kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespac
   -- curl -s localhost:7171/backup/list/remote
 ```
 
-Two `df` readings a few minutes apart give the throughput and a usable ETA. Prefer `df` over
-`du -sb` on the backup directory: `du` walks every file in a multi-terabyte tree and adds
-significant I/O to the volume the restore is already saturating.
+Two `df` readings a few minutes apart give a rough throughput and ETA, but treat that as a coarse
+capacity check rather than restore progress: `df` reports the whole volume, so merges, system tables
+and any other writes land in the same delta, and the total can pass the backup's `data_size` before
+the restore is done. The per-table `download_data` lines above are the authoritative signal. Prefer
+`df` over `du -sb` on the backup directory either way: `du` walks every file in a multi-terabyte tree
+and adds significant I/O to the volume the restore is already saturating.
 
 <Note>
 The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -296,91 +296,90 @@ The restore **replaces data**. `clickhouse-backup` drops and recreates every tab
 The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
 </Warning>
 
-#### 1. Find the backup name
+<Steps>
+  <Step title="Find the backup name">
+    `backupName` is required, and must match a name the backup server knows:
 
-`backupName` is required, and must match a name the backup server knows:
+    ```bash
+    kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
 
-```bash
-kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
+    # Backups in S3
+    curl -s "http://localhost:7171/backup/list/remote"
 
-# Backups in S3
-curl -s "http://localhost:7171/backup/list/remote"
+    # Backups already on local disk
+    curl -s "http://localhost:7171/backup/list/local"
+    ```
 
-# Backups already on local disk
-curl -s "http://localhost:7171/backup/list/local"
-```
+    Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
+    `s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
 
-Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
-`s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
+    The service, pod and port used throughout this section are the chart defaults, matching the
+    `RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
+    `clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
+    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
+    `clickhouse.backupServer.port` in place of `7171`.
+  </Step>
+  <Step title="Render the job manifest">
+    Put the restore settings in their own values file:
 
-The service, pod and port used throughout this section are the chart defaults, matching the
-`RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
-`clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
-`kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
-`clickhouse.backupServer.port` in place of `7171`.
+    ```yaml
+    # restore-values.yaml
+    clickhouse:
+      backupServer:
+        enabled: true
+        # S3 settings the backup server needs for restore_remote (downloads from S3)
+        env:
+          REMOTE_STORAGE: s3
+          S3_BUCKET: YOURBUCKET
+          S3_PATH: YOURPATH
+          RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
+      backup:
+        restore:
+          createJob: true
+          backupName: "2026-07-28"          # from step 1
+          activeDeadlineSeconds: 604800     # 7 days; default is 24h
+          image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
+    ```
 
-#### 2. Render the job manifest
+    Render only the restore job. Pass your existing values file first, so the job inherits the same
+    service account, node selector and tolerations as your ClickHouse pods:
 
-Put the restore settings in their own values file:
+    ```bash
+    helm template opik opik/opik \
+      -f your-values.yaml -f restore-values.yaml \
+      --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
+    ```
 
-```yaml
-# restore-values.yaml
-clickhouse:
-  backupServer:
-    enabled: true
-    # S3 settings the backup server needs for restore_remote (downloads from S3)
-    env:
-      REMOTE_STORAGE: s3
-      S3_BUCKET: YOURBUCKET
-      S3_PATH: YOURPATH
-      RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
-  backup:
-    restore:
-      createJob: true
-      backupName: "2026-07-28"          # from step 1
-      activeDeadlineSeconds: 604800     # 7 days; default is 24h
-      image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
-```
+    `helm template` does not write a namespace into the manifest, so either add `namespace:` to the
+    job's metadata or pass `-n` when you apply it.
+  </Step>
+  <Step title="Create the job">
+    ```bash
+    kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
+    ```
 
-Render only the restore job. Pass your existing values file first, so the job inherits the same
-service account, node selector and tolerations as your ClickHouse pods:
+    The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
+    again:
 
-```bash
-helm template opik opik/opik \
-  -f your-values.yaml -f restore-values.yaml \
-  --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
-```
+    ```bash
+    kubectl delete job opik-clickhouse-restore -n <namespace>
+    ```
 
-`helm template` does not write a namespace into the manifest, so either add `namespace:` to the
-job's metadata or pass `-n` when you apply it.
+    Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
+    and if a restore is still running — for example after its pod was rescheduled — it follows that one
+    instead of starting a second.
+  </Step>
+  <Step title="Watch the restore">
+    ```bash
+    kubectl get job opik-clickhouse-restore -n <namespace>
 
-#### 3. Create the job
+    kubectl logs -f job/opik-clickhouse-restore -n <namespace>
+    ```
 
-```bash
-kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
-```
-
-The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
-again:
-
-```bash
-kubectl delete job opik-clickhouse-restore -n <namespace>
-```
-
-Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
-and if a restore is still running — for example after its pod was rescheduled — it follows that one
-instead of starting a second.
-
-#### 4. Watch the restore
-
-```bash
-kubectl get job opik-clickhouse-restore -n <namespace>
-
-kubectl logs -f job/opik-clickhouse-restore -n <namespace>
-```
-
-The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
-runs for hours. It prints the final status and fails the job if the restore failed.
+    The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
+    runs for hours. It prints the final status and fails the job if the restore failed.
+  </Step>
+</Steps>
 
 #### Checking progress during a long restore
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -293,6 +293,8 @@ The backup server must be enabled **before** the restore, and the backup must al
 
 The restore **replaces data**. `clickhouse-backup` drops and recreates every table contained in the backup (`ON CLUSTER` when `RESTORE_SCHEMA_ON_CLUSTER` is set) before restoring it, so you do not need to drop databases or tables yourself. Tables that are not part of the backup are left untouched.
 
+One exception: if `restore_schema_on_cluster` is set through a config file while the `RESTORE_SCHEMA_ON_CLUSTER` environment variable is empty, `clickhouse-backup` refuses to drop tables that still hold data and the restore aborts. Set it as an environment variable, as the values example below does.
+
 The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
 </Warning>
 
@@ -316,8 +318,9 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     The service, pod and port used throughout this section are the chart defaults, matching the
     `RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
     `clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
-    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
-    `clickhouse.backupServer.port` in place of `7171`.
+    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi`. The port is
+    `clickhouse.backupServer.service.port` when set, and otherwise `clickhouse.backupServer.port`
+    (`7171` by default).
   </Step>
   <Step title="Render the job manifest">
     Put the restore settings in their own values file:
@@ -358,8 +361,10 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
     ```
 
-    The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
-    again:
+    The job is named `<opik.name>-clickhouse-restore` — `opik-clickhouse-restore` unless you set
+    `nameOverride`, and always readable as `metadata.name` in the manifest you just rendered. Use
+    that name in the commands here and in the next step. It is fixed per release, so delete the
+    previous job before restoring again:
 
     ```bash
     kubectl delete job opik-clickhouse-restore -n <namespace>

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -282,6 +282,153 @@ spec:
           restartPolicy: OnFailure
 ```
 
+### Automated Restore with Kubernetes Job
+
+The Opik helm chart ships a Kubernetes Job that runs a complete restore: it picks `restore` or
+`restore_remote` depending on whether the backup is already on local disk, starts it through the
+backup server API, and polls until it finishes.
+
+<Warning>
+The backup server must be enabled **before** the restore, and the backup must already exist and have been created **by the backup server** — not by the SQL-based backup in Option 1.
+
+The restore **replaces data**. `clickhouse-backup` drops and recreates every table contained in the backup (`ON CLUSTER` when `RESTORE_SCHEMA_ON_CLUSTER` is set) before restoring it, so you do not need to drop databases or tables yourself. Tables that are not part of the backup are left untouched.
+
+The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
+</Warning>
+
+#### 1. Find the backup name
+
+`backupName` is required, and must match a name the backup server knows:
+
+```bash
+kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
+
+# Backups in S3
+curl -s "http://localhost:7171/backup/list/remote"
+
+# Backups already on local disk
+curl -s "http://localhost:7171/backup/list/local"
+```
+
+Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
+`s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
+
+#### 2. Render the job manifest
+
+Put the restore settings in their own values file:
+
+```yaml
+# restore-values.yaml
+clickhouse:
+  backupServer:
+    enabled: true
+    # S3 settings the backup server needs for restore_remote (downloads from S3)
+    env:
+      REMOTE_STORAGE: s3
+      S3_BUCKET: YOURBUCKET
+      S3_PATH: YOURPATH
+      RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
+  backup:
+    restore:
+      createJob: true
+      backupName: "2026-07-28"          # from step 1
+      activeDeadlineSeconds: 604800     # 7 days; default is 24h
+      image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
+```
+
+Render only the restore job. Pass your existing values file first, so the job inherits the same
+service account, node selector and tolerations as your ClickHouse pods:
+
+```bash
+helm template opik opik/opik \
+  -f your-values.yaml -f restore-values.yaml \
+  --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
+```
+
+`helm template` does not write a namespace into the manifest, so either add `namespace:` to the
+job's metadata or pass `-n` when you apply it.
+
+#### 3. Create the job
+
+```bash
+kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
+```
+
+The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
+again:
+
+```bash
+kubectl delete job opik-clickhouse-restore -n <namespace>
+```
+
+#### 4. Watch the restore
+
+```bash
+kubectl get job opik-clickhouse-restore -n <namespace>
+
+kubectl logs -f job/opik-clickhouse-restore -n <namespace>
+```
+
+The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
+runs for hours. It prints the final status and fails the job if the restore failed.
+
+#### Checking progress during a long restore
+
+The job's own log only reports `in progress`. For actual progress, use these — in increasing
+cost order.
+
+Per-table progress, from the backup server's log:
+
+```bash
+kubectl logs chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  | grep download_data | tail -5
+```
+
+Each line is one finished table: `progress=9/44 size=457.38GiB table=opik_prod.spans`. Note that
+`9/44` is the table's **position in the list**, not a count of finished tables — count the
+distinct positions you have seen, or the numerator will look stuck while most tables are done.
+
+Current status and start time:
+
+```bash
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- curl -s localhost:7171/backup/actions | tail -3
+```
+
+Bytes landed on disk, against the backup's own size:
+
+```bash
+# how much is on the data volume now
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- df -h /var/lib/clickhouse
+
+# the size the finished restore should reach (data_size)
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- curl -s localhost:7171/backup/list/remote
+```
+
+Two `df` readings a few minutes apart give the throughput and a usable ETA. Prefer `df` over
+`du -sb` on the backup directory: `du` walks every file in a multi-terabyte tree and adds
+significant I/O to the volume the restore is already saturating.
+
+<Note>
+The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.
+</Note>
+
+#### How the Restore Job Works
+
+1. **Attaches to an existing restore**: if this backup was already restored it exits successfully
+   without restoring again; if a restore is still running (for example after the pod was
+   rescheduled) it follows that one instead of starting a second.
+2. **Chooses the restore method**: `restore` when the backup is on local disk, `restore_remote`
+   (download and restore in one step) when it is only in S3.
+3. **Monitors progress**: polls `/backup/actions` every 15 minutes for this backup's status.
+4. **Reports completion**: logs success, or the server's error message, and fails the job.
+
+<Note>
+Setting `createJob: true` in your release values works too — `helm upgrade` then creates the same job. If you do that, set it back to `false` afterwards, otherwise the next `helm upgrade` re-creates the job and restores again. The "already restored" check reads the backup server's in-memory action history, so it does not survive a backup server restart.
+</Note>
+
 ## Comparison
 
 | Feature                 | SQL-based Backup | ClickHouse Backup Tool |

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/backup.mdx
@@ -313,6 +313,12 @@ curl -s "http://localhost:7171/backup/list/local"
 Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
 `s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
 
+The service, pod and port used throughout this section are the chart defaults, matching the
+`RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
+`clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
+`kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
+`clickhouse.backupServer.port` in place of `7171`.
+
 #### 2. Render the job manifest
 
 Put the restore settings in their own values file:
@@ -360,6 +366,10 @@ again:
 ```bash
 kubectl delete job opik-clickhouse-restore -n <namespace>
 ```
+
+Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
+and if a restore is still running — for example after its pod was rescheduled — it follows that one
+instead of starting a second.
 
 #### 4. Watch the restore
 
@@ -414,16 +424,6 @@ significant I/O to the volume the restore is already saturating.
 <Note>
 The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.
 </Note>
-
-#### How the Restore Job Works
-
-1. **Attaches to an existing restore**: if this backup was already restored it exits successfully
-   without restoring again; if a restore is still running (for example after the pod was
-   rescheduled) it follows that one instead of starting a second.
-2. **Chooses the restore method**: `restore` when the backup is on local disk, `restore_remote`
-   (download and restore in one step) when it is only in S3.
-3. **Monitors progress**: polls `/backup/actions` every 15 minutes for this backup's status.
-4. **Reports completion**: logs success, or the server's error message, and fails the job.
 
 <Note>
 Setting `createJob: true` in your release values works too — `helm upgrade` then creates the same job. If you do that, set it back to `false` afterwards, otherwise the next `helm upgrade` re-creates the job and restores again. The "already restored" check reads the backup server's in-memory action history, so it does not survive a backup server restart.
@@ -555,5 +555,5 @@ Set up monitoring for backup operations:
 For additional help with ClickHouse backups:
 
 - [ClickHouse Backup Documentation](https://github.com/Altinity/clickhouse-backup)
-- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
+- [ClickHouse Backup and Restore](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
 - [Opik Community Support](https://github.com/comet-ml/opik/issues)

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -283,6 +283,84 @@ spec:
           restartPolicy: OnFailure
 ```
 
+### Automated Restore with Kubernetes Job
+
+Opik helm chart provides a Kubernetes Job for automated backup restoration. This job handles the complete restore process, including downloading backups from S3 (if needed) and restoring them to ClickHouse.
+
+#### Configuration
+<Warning>
+The backup server must be enabled **before** the restore and the backup must already exist, created using the backup server (not the default ClickHouse SQL backup).
+
+Once the restore has completed, set `createJob` back to `false`. If it is left as `true`, the next `helm upgrade` re-creates the job and runs the restore again.
+</Warning>
+To create the restore job, configure the following values in your Helm chart:
+
+```yaml
+clickhouse:
+  backupServer:
+    enabled: true  # Required: backup server must be enabled and configured
+    # S3 settings the backup server needs for restore_remote (downloads from S3)
+    env:
+      REMOTE_STORAGE: s3
+      S3_BUCKET: YOURBUCKET
+      S3_PATH: YOURPATH
+  backup:
+    restore:
+      createJob: true
+      backupName: "202501010"  # Name of the backup to restore (required)
+      image: "amazon/aws-cli:2.27.49"  # Image with curl and jq
+```
+
+#### How the Restore Job Works
+
+The restore job automatically:
+
+1. **Checks local availability**: Determines if the backup exists locally in ClickHouse
+2. **Chooses restore method**:
+   - If backup exists locally: Uses `restore` command (faster)
+   - If backup not local: Uses `restore_remote` command (downloads and restores in one step)
+3. **Monitors progress**: Polls the backup server API every 15 minutes to check restore status
+4. **Reports completion**: Logs success or failure with detailed status information
+
+#### Creating the Restore Job
+
+1. **Update your Helm values** with the restore configuration 
+
+   ```bash
+   # Create or update values file
+   cat > restore-values.yaml <<EOF
+   clickhouse:
+     backupServer:
+       enabled: true
+     backup:
+       restore:
+         createJob: true
+         backupName: "backup-20240101-120000"
+   EOF
+   ```
+2. **Run the job** — apply the Helm upgrade with the restore values file from step 1:
+   ```bash
+   helm upgrade opik opik/opik -f restore-values.yaml
+   ```
+   or use this job template as an example and apply the job manually:
+   ```bash
+   helm template opik opik/opik -f restore-values.yaml > opik.yaml
+   ```
+   copy the clickhouse-restore job from opik.yaml into separate file clickhouse-restore-job.yaml and apply
+   ```bash
+   kubectl apply -f clickhouse-restore-job.yaml
+   ```
+
+  
+3. **Monitor the restore job**:
+
+   ```bash
+   # Check job status
+   kubectl get jobs -l app=clickhouse-restore
+   
+   # Watch job logs
+   kubectl logs -f job/opik-clickhouse-restore
+   ```
 ## Comparison
 
 | Feature                 | SQL-based Backup | ClickHouse Backup Tool |

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -294,6 +294,8 @@ The backup server must be enabled **before** the restore, and the backup must al
 
 The restore **replaces data**. `clickhouse-backup` drops and recreates every table contained in the backup (`ON CLUSTER` when `RESTORE_SCHEMA_ON_CLUSTER` is set) before restoring it, so you do not need to drop databases or tables yourself. Tables that are not part of the backup are left untouched.
 
+One exception: if `restore_schema_on_cluster` is set through a config file while the `RESTORE_SCHEMA_ON_CLUSTER` environment variable is empty, `clickhouse-backup` refuses to drop tables that still hold data and the restore aborts. Set it as an environment variable, as the values example below does.
+
 The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
 </Warning>
 
@@ -317,8 +319,9 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     The service, pod and port used throughout this section are the chart defaults, matching the
     `RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
     `clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
-    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
-    `clickhouse.backupServer.port` in place of `7171`.
+    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi`. The port is
+    `clickhouse.backupServer.service.port` when set, and otherwise `clickhouse.backupServer.port`
+    (`7171` by default).
   </Step>
   <Step title="Render the job manifest">
     Put the restore settings in their own values file:
@@ -359,8 +362,10 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
     ```
 
-    The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
-    again:
+    The job is named `<opik.name>-clickhouse-restore` — `opik-clickhouse-restore` unless you set
+    `nameOverride`, and always readable as `metadata.name` in the manifest you just rendered. Use
+    that name in the commands here and in the next step. It is fixed per release, so delete the
+    previous job before restoring again:
 
     ```bash
     kubectl delete job opik-clickhouse-restore -n <namespace>

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -324,10 +324,12 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
     (`7171` by default).
   </Step>
   <Step title="Render the job manifest">
-    Put the restore settings in their own values file:
+    The backup server has to be running in the release already. The command below renders **only**
+    the Job, so nothing under `backupServer` reaches the cluster through it — if the server is not
+    enabled yet, roll it out with `helm upgrade` first:
 
     ```yaml
-    # restore-values.yaml
+    # part of your release values
     clickhouse:
       backupServer:
         enabled: true
@@ -337,6 +339,13 @@ The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSecon
           S3_BUCKET: YOURBUCKET
           S3_PATH: YOURPATH
           RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
+    ```
+
+    Then put the restore settings, which are only needed at render time, in their own values file:
+
+    ```yaml
+    # restore-values.yaml
+    clickhouse:
       backup:
         restore:
           createJob: true
@@ -422,9 +431,12 @@ kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespac
   -- curl -s localhost:7171/backup/list/remote
 ```
 
-Two `df` readings a few minutes apart give the throughput and a usable ETA. Prefer `df` over
-`du -sb` on the backup directory: `du` walks every file in a multi-terabyte tree and adds
-significant I/O to the volume the restore is already saturating.
+Two `df` readings a few minutes apart give a rough throughput and ETA, but treat that as a coarse
+capacity check rather than restore progress: `df` reports the whole volume, so merges, system tables
+and any other writes land in the same delta, and the total can pass the backup's `data_size` before
+the restore is done. The per-table `download_data` lines above are the authoritative signal. Prefer
+`df` over `du -sb` on the backup directory either way: `du` walks every file in a multi-terabyte tree
+and adds significant I/O to the volume the restore is already saturating.
 
 <Note>
 The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -297,91 +297,90 @@ The restore **replaces data**. `clickhouse-backup` drops and recreates every tab
 The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
 </Warning>
 
-#### 1. Find the backup name
+<Steps>
+  <Step title="Find the backup name">
+    `backupName` is required, and must match a name the backup server knows:
 
-`backupName` is required, and must match a name the backup server knows:
+    ```bash
+    kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
 
-```bash
-kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
+    # Backups in S3
+    curl -s "http://localhost:7171/backup/list/remote"
 
-# Backups in S3
-curl -s "http://localhost:7171/backup/list/remote"
+    # Backups already on local disk
+    curl -s "http://localhost:7171/backup/list/local"
+    ```
 
-# Backups already on local disk
-curl -s "http://localhost:7171/backup/list/local"
-```
+    Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
+    `s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
 
-Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
-`s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
+    The service, pod and port used throughout this section are the chart defaults, matching the
+    `RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
+    `clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
+    `kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
+    `clickhouse.backupServer.port` in place of `7171`.
+  </Step>
+  <Step title="Render the job manifest">
+    Put the restore settings in their own values file:
 
-The service, pod and port used throughout this section are the chart defaults, matching the
-`RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
-`clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
-`kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
-`clickhouse.backupServer.port` in place of `7171`.
+    ```yaml
+    # restore-values.yaml
+    clickhouse:
+      backupServer:
+        enabled: true
+        # S3 settings the backup server needs for restore_remote (downloads from S3)
+        env:
+          REMOTE_STORAGE: s3
+          S3_BUCKET: YOURBUCKET
+          S3_PATH: YOURPATH
+          RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
+      backup:
+        restore:
+          createJob: true
+          backupName: "2026-07-28"          # from step 1
+          activeDeadlineSeconds: 604800     # 7 days; default is 24h
+          image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
+    ```
 
-#### 2. Render the job manifest
+    Render only the restore job. Pass your existing values file first, so the job inherits the same
+    service account, node selector and tolerations as your ClickHouse pods:
 
-Put the restore settings in their own values file:
+    ```bash
+    helm template opik opik/opik \
+      -f your-values.yaml -f restore-values.yaml \
+      --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
+    ```
 
-```yaml
-# restore-values.yaml
-clickhouse:
-  backupServer:
-    enabled: true
-    # S3 settings the backup server needs for restore_remote (downloads from S3)
-    env:
-      REMOTE_STORAGE: s3
-      S3_BUCKET: YOURBUCKET
-      S3_PATH: YOURPATH
-      RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
-  backup:
-    restore:
-      createJob: true
-      backupName: "2026-07-28"          # from step 1
-      activeDeadlineSeconds: 604800     # 7 days; default is 24h
-      image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
-```
+    `helm template` does not write a namespace into the manifest, so either add `namespace:` to the
+    job's metadata or pass `-n` when you apply it.
+  </Step>
+  <Step title="Create the job">
+    ```bash
+    kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
+    ```
 
-Render only the restore job. Pass your existing values file first, so the job inherits the same
-service account, node selector and tolerations as your ClickHouse pods:
+    The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
+    again:
 
-```bash
-helm template opik opik/opik \
-  -f your-values.yaml -f restore-values.yaml \
-  --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
-```
+    ```bash
+    kubectl delete job opik-clickhouse-restore -n <namespace>
+    ```
 
-`helm template` does not write a namespace into the manifest, so either add `namespace:` to the
-job's metadata or pass `-n` when you apply it.
+    Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
+    and if a restore is still running — for example after its pod was rescheduled — it follows that one
+    instead of starting a second.
+  </Step>
+  <Step title="Watch the restore">
+    ```bash
+    kubectl get job opik-clickhouse-restore -n <namespace>
 
-#### 3. Create the job
+    kubectl logs -f job/opik-clickhouse-restore -n <namespace>
+    ```
 
-```bash
-kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
-```
-
-The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
-again:
-
-```bash
-kubectl delete job opik-clickhouse-restore -n <namespace>
-```
-
-Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
-and if a restore is still running — for example after its pod was rescheduled — it follows that one
-instead of starting a second.
-
-#### 4. Watch the restore
-
-```bash
-kubectl get job opik-clickhouse-restore -n <namespace>
-
-kubectl logs -f job/opik-clickhouse-restore -n <namespace>
-```
-
-The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
-runs for hours. It prints the final status and fails the job if the restore failed.
+    The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
+    runs for hours. It prints the final status and fails the job if the restore failed.
+  </Step>
+</Steps>
 
 #### Checking progress during a long restore
 

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -314,6 +314,12 @@ curl -s "http://localhost:7171/backup/list/local"
 Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
 `s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
 
+The service, pod and port used throughout this section are the chart defaults, matching the
+`RESTORE_SERVICE` the Job computes. If you set `nameOverride`, a different shard/replica layout, or
+`clickhouse.backupServer.service.name` / `.port`, substitute your own — list them with
+`kubectl get pods,svc -n <namespace> -l clickhouse.altinity.com/chi` and use
+`clickhouse.backupServer.port` in place of `7171`.
+
 #### 2. Render the job manifest
 
 Put the restore settings in their own values file:
@@ -361,6 +367,10 @@ again:
 ```bash
 kubectl delete job opik-clickhouse-restore -n <namespace>
 ```
+
+Re-applying is safe: if this backup was already restored the Job exits without restoring it again,
+and if a restore is still running — for example after its pod was rescheduled — it follows that one
+instead of starting a second.
 
 #### 4. Watch the restore
 
@@ -415,16 +425,6 @@ significant I/O to the volume the restore is already saturating.
 <Note>
 The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.
 </Note>
-
-#### How the Restore Job Works
-
-1. **Attaches to an existing restore**: if this backup was already restored it exits successfully
-   without restoring again; if a restore is still running (for example after the pod was
-   rescheduled) it follows that one instead of starting a second.
-2. **Chooses the restore method**: `restore` when the backup is on local disk, `restore_remote`
-   (download and restore in one step) when it is only in S3.
-3. **Monitors progress**: polls `/backup/actions` every 15 minutes for this backup's status.
-4. **Reports completion**: logs success, or the server's error message, and fails the job.
 
 <Note>
 Setting `createJob: true` in your release values works too — `helm upgrade` then creates the same job. If you do that, set it back to `false` afterwards, otherwise the next `helm upgrade` re-creates the job and restores again. The "already restored" check reads the backup server's in-memory action history, so it does not survive a backup server restart.
@@ -556,5 +556,5 @@ Set up monitoring for backup operations:
 For additional help with ClickHouse backups:
 
 - [ClickHouse Backup Documentation](https://github.com/Altinity/clickhouse-backup)
-- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
+- [ClickHouse Backup and Restore](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
 - [Opik Community Support](https://github.com/comet-ml/opik/issues)

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -556,5 +556,5 @@ Set up monitoring for backup operations:
 For additional help with ClickHouse backups:
 
 - [ClickHouse Backup Documentation](https://github.com/Altinity/clickhouse-backup)
-- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/operations/backup)
+- [ClickHouse Backup Command Reference](https://clickhouse.com/docs/concepts/features/backup-restore/overview)
 - [Opik Community Support](https://github.com/comet-ml/opik/issues)

--- a/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/backup.mdx
@@ -285,82 +285,151 @@ spec:
 
 ### Automated Restore with Kubernetes Job
 
-Opik helm chart provides a Kubernetes Job for automated backup restoration. This job handles the complete restore process, including downloading backups from S3 (if needed) and restoring them to ClickHouse.
+The Opik helm chart ships a Kubernetes Job that runs a complete restore: it picks `restore` or
+`restore_remote` depending on whether the backup is already on local disk, starts it through the
+backup server API, and polls until it finishes.
 
-#### Configuration
 <Warning>
-The backup server must be enabled **before** the restore and the backup must already exist, created using the backup server (not the default ClickHouse SQL backup).
+The backup server must be enabled **before** the restore, and the backup must already exist and have been created **by the backup server** — not by the SQL-based backup in Option 1.
 
-Once the restore has completed, set `createJob` back to `false`. If it is left as `true`, the next `helm upgrade` re-creates the job and runs the restore again.
+The restore **replaces data**. `clickhouse-backup` drops and recreates every table contained in the backup (`ON CLUSTER` when `RESTORE_SCHEMA_ON_CLUSTER` is set) before restoring it, so you do not need to drop databases or tables yourself. Tables that are not part of the backup are left untouched.
+
+The job does not retry (`backoffLimit: 0`) and is capped by `activeDeadlineSeconds` — 24 hours by default. Raise it for large restores, or Kubernetes will kill the job mid-restore.
 </Warning>
-To create the restore job, configure the following values in your Helm chart:
+
+#### 1. Find the backup name
+
+`backupName` is required, and must match a name the backup server knows:
+
+```bash
+kubectl port-forward -n <namespace> svc/chi-opik-clickhouse-cluster-0-0 7171:7171
+
+# Backups in S3
+curl -s "http://localhost:7171/backup/list/remote"
+
+# Backups already on local disk
+curl -s "http://localhost:7171/backup/list/local"
+```
+
+Use the `name` field, not the S3 prefix. With `S3_PATH: shard-{shard}`, a backup stored at
+`s3://your-bucket/shard-0/2026-07-28/` has the name `2026-07-28`.
+
+#### 2. Render the job manifest
+
+Put the restore settings in their own values file:
 
 ```yaml
+# restore-values.yaml
 clickhouse:
   backupServer:
-    enabled: true  # Required: backup server must be enabled and configured
+    enabled: true
     # S3 settings the backup server needs for restore_remote (downloads from S3)
     env:
       REMOTE_STORAGE: s3
       S3_BUCKET: YOURBUCKET
       S3_PATH: YOURPATH
+      RESTORE_SCHEMA_ON_CLUSTER: cluster  # so the schema is restored on every replica
   backup:
     restore:
       createJob: true
-      backupName: "202501010"  # Name of the backup to restore (required)
-      image: "amazon/aws-cli:2.27.49"  # Image with curl and jq
+      backupName: "2026-07-28"          # from step 1
+      activeDeadlineSeconds: 604800     # 7 days; default is 24h
+      image: "amazon/aws-cli:2.27.49"   # any image with bash and curl
 ```
+
+Render only the restore job. Pass your existing values file first, so the job inherits the same
+service account, node selector and tolerations as your ClickHouse pods:
+
+```bash
+helm template opik opik/opik \
+  -f your-values.yaml -f restore-values.yaml \
+  --show-only templates/clickhouse_restore_job.yaml > clickhouse-restore-job.yaml
+```
+
+`helm template` does not write a namespace into the manifest, so either add `namespace:` to the
+job's metadata or pass `-n` when you apply it.
+
+#### 3. Create the job
+
+```bash
+kubectl apply -f clickhouse-restore-job.yaml -n <namespace>
+```
+
+The job name is fixed (`opik-clickhouse-restore`), so delete the previous one before restoring
+again:
+
+```bash
+kubectl delete job opik-clickhouse-restore -n <namespace>
+```
+
+#### 4. Watch the restore
+
+```bash
+kubectl get job opik-clickhouse-restore -n <namespace>
+
+kubectl logs -f job/opik-clickhouse-restore -n <namespace>
+```
+
+The job polls every 15 minutes, so the log stays quiet between checks — a large `restore_remote`
+runs for hours. It prints the final status and fails the job if the restore failed.
+
+#### Checking progress during a long restore
+
+The job's own log only reports `in progress`. For actual progress, use these — in increasing
+cost order.
+
+Per-table progress, from the backup server's log:
+
+```bash
+kubectl logs chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  | grep download_data | tail -5
+```
+
+Each line is one finished table: `progress=9/44 size=457.38GiB table=opik_prod.spans`. Note that
+`9/44` is the table's **position in the list**, not a count of finished tables — count the
+distinct positions you have seen, or the numerator will look stuck while most tables are done.
+
+Current status and start time:
+
+```bash
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- curl -s localhost:7171/backup/actions | tail -3
+```
+
+Bytes landed on disk, against the backup's own size:
+
+```bash
+# how much is on the data volume now
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- df -h /var/lib/clickhouse
+
+# the size the finished restore should reach (data_size)
+kubectl exec chi-opik-clickhouse-cluster-0-0-0 -c clickhouse-backup -n <namespace> \
+  -- curl -s localhost:7171/backup/list/remote
+```
+
+Two `df` readings a few minutes apart give the throughput and a usable ETA. Prefer `df` over
+`du -sb` on the backup directory: `du` walks every file in a multi-terabyte tree and adds
+significant I/O to the volume the restore is already saturating.
+
+<Note>
+The `/backup/actions` history is kept in memory. It is empty if the backup-server container restarted since the restore began, so this is a live-progress tool only — after the fact there is no local record. If you scrape metrics, `kubelet_volume_stats_used_bytes` for the ClickHouse PVC is the durable equivalent and needs no `exec`.
+</Note>
 
 #### How the Restore Job Works
 
-The restore job automatically:
+1. **Attaches to an existing restore**: if this backup was already restored it exits successfully
+   without restoring again; if a restore is still running (for example after the pod was
+   rescheduled) it follows that one instead of starting a second.
+2. **Chooses the restore method**: `restore` when the backup is on local disk, `restore_remote`
+   (download and restore in one step) when it is only in S3.
+3. **Monitors progress**: polls `/backup/actions` every 15 minutes for this backup's status.
+4. **Reports completion**: logs success, or the server's error message, and fails the job.
 
-1. **Checks local availability**: Determines if the backup exists locally in ClickHouse
-2. **Chooses restore method**:
-   - If backup exists locally: Uses `restore` command (faster)
-   - If backup not local: Uses `restore_remote` command (downloads and restores in one step)
-3. **Monitors progress**: Polls the backup server API every 15 minutes to check restore status
-4. **Reports completion**: Logs success or failure with detailed status information
+<Note>
+Setting `createJob: true` in your release values works too — `helm upgrade` then creates the same job. If you do that, set it back to `false` afterwards, otherwise the next `helm upgrade` re-creates the job and restores again. The "already restored" check reads the backup server's in-memory action history, so it does not survive a backup server restart.
+</Note>
 
-#### Creating the Restore Job
-
-1. **Update your Helm values** with the restore configuration 
-
-   ```bash
-   # Create or update values file
-   cat > restore-values.yaml <<EOF
-   clickhouse:
-     backupServer:
-       enabled: true
-     backup:
-       restore:
-         createJob: true
-         backupName: "backup-20240101-120000"
-   EOF
-   ```
-2. **Run the job** — apply the Helm upgrade with the restore values file from step 1:
-   ```bash
-   helm upgrade opik opik/opik -f restore-values.yaml
-   ```
-   or use this job template as an example and apply the job manually:
-   ```bash
-   helm template opik opik/opik -f restore-values.yaml > opik.yaml
-   ```
-   copy the clickhouse-restore job from opik.yaml into separate file clickhouse-restore-job.yaml and apply
-   ```bash
-   kubectl apply -f clickhouse-restore-job.yaml
-   ```
-
-  
-3. **Monitor the restore job**:
-
-   ```bash
-   # Check job status
-   kubectl get jobs -l app=clickhouse-restore
-   
-   # Watch job logs
-   kubectl logs -f job/opik-clickhouse-restore
-   ```
 ## Comparison
 
 | Feature                 | SQL-based Backup | ClickHouse Backup Tool |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -116,6 +116,18 @@ Call opik api on http://localhost:5173/api
 | clickhouse.backup.command[2] | string | `"export backupname=backup$(date +'%Y%m%d%H%M')\necho \"BACKUP ALL EXCEPT DATABASE system TO S3('${CLICKHOUSE_BACKUP_BUCKET}/${backupname}/', '$ACCESS_KEY', '$SECRET_KEY');\" > /tmp/backQuery.sql\nclickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql"` |  |
 | clickhouse.backup.enabled | bool | `false` |  |
 | clickhouse.backup.extraEnv | object | `{}` |  |
+| clickhouse.backup.restore.activeDeadlineSeconds | int | `86400` |  |
+| clickhouse.backup.restore.affinity | object | `{}` |  |
+| clickhouse.backup.restore.backupName | string | `""` |  |
+| clickhouse.backup.restore.createJob | bool | `false` |  |
+| clickhouse.backup.restore.extraEnv | object | `{}` |  |
+| clickhouse.backup.restore.image | string | `"amazon/aws-cli:2.27.49"` |  |
+| clickhouse.backup.restore.nodeSelector | object | `{}` |  |
+| clickhouse.backup.restore.resources.limits.cpu | string | `"10m"` |  |
+| clickhouse.backup.restore.resources.limits.memory | string | `"64Mi"` |  |
+| clickhouse.backup.restore.resources.requests.cpu | string | `"10m"` |  |
+| clickhouse.backup.restore.resources.requests.memory | string | `"32Mi"` |  |
+| clickhouse.backup.restore.tolerations | list | `[]` |  |
 | clickhouse.backup.schedule | string | `"0 0 * * *"` |  |
 | clickhouse.backup.serviceAccount.annotations | object | `{}` |  |
 | clickhouse.backup.serviceAccount.create | bool | `false` |  |
@@ -148,6 +160,8 @@ Call opik api on http://localhost:5173/api
 | clickhouse.backupServer.monitoring.serviceMonitor.relabelings | list | `[]` |  |
 | clickhouse.backupServer.monitoring.serviceMonitor.scrapeTimeout | string | `"30s"` |  |
 | clickhouse.backupServer.port | int | `7171` |  |
+| clickhouse.backupServer.service.name | string | `""` |  |
+| clickhouse.backupServer.service.port | string | `""` |  |
 | clickhouse.configuration.files."conf.d/memory.xml" | string | `"<yandex>\n  <max_server_memory_usage_to_ram_ratio>0.85</max_server_memory_usage_to_ram_ratio>\n</yandex>\n"` |  |
 | clickhouse.configuration.files."conf.d/profiles.xml" | string | `"<clickhouse>\n  <profiles>\n    <default>\n        <max_bytes_ratio_before_external_sort>0.2</max_bytes_ratio_before_external_sort>\n        <max_bytes_ratio_before_external_group_by>0.2</max_bytes_ratio_before_external_group_by>\n        <!-- CH 25.8 made the experimental Time type opt-in; required for fresh installs to replay migration 000030. -->\n        <enable_time_time64_type>1</enable_time_time64_type>\n        <!-- the new CH 25.x default (1) makes FINAL reads on skip-indexed tables over-read massively; our queries already prune on the PK/project_id, so exact mode isn't needed. -->\n        <use_skip_indexes_if_final_exact_mode>0</use_skip_indexes_if_final_exact_mode>\n    </default>\n  </profiles>\n</clickhouse>\n"` |  |
 | clickhouse.configuration.files."conf.d/system_tables.xml" | string | `"<clickhouse>\n  <opentelemetry_span_log remove=\"1\"/>\n  <asynchronous_metric_log remove=\"1\"/>\n  <processors_profile_log remove=\"1\"/>\n  <text_log remove=\"1\"/>\n  <trace_log remove=\"1\"/>\n  <blob_storage_log remove=\"1\"/>\n  <error_log>\n      <engine>\n          ENGINE MergeTree\n          PARTITION BY toYYYYMM(event_date)\n          ORDER BY (event_date, event_time)\n          TTL event_date + toIntervalDay(30)\n          SETTINGS index_granularity = 8192\n      </engine>\n      <database>system</database>\n      <table>error_log</table>\n  </error_log>\n  <latency_log>\n      <engine>\n          ENGINE = MergeTree\n          PARTITION BY toYYYYMM(event_date)\n          ORDER BY (event_date, event_time)\n          TTL event_date + toIntervalDay(30)\n          SETTINGS index_granularity = 8192\n      </engine>\n      <database>system</database>\n      <table>latency_log</table>\n  </latency_log>\n  <metric_log>\n      <engine>\n          ENGINE = MergeTree\n          PARTITION BY toYYYYMM(event_date)\n          ORDER BY (event_date, event_time)\n          TTL event_date + toIntervalDay(30)\n          SETTINGS index_granularity = 8192\n      </engine>\n      <database>system</database>\n      <table>metric_log</table>\n  </metric_log>\n  <query_metric_log>\n      <engine>\n          ENGINE = MergeTree\n          PARTITION BY toYYYYMM(event_date)\n          ORDER BY (event_date, event_time)\n          TTL event_date + toIntervalDay(30)\n          SETTINGS index_granularity = 8192\n      </engine>\n      <database>system</database>\n      <table>query_metric_log</table>\n  </query_metric_log>\n</clickhouse>\n"` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -118,7 +118,7 @@ Call opik api on http://localhost:5173/api
 | clickhouse.backup.extraEnv | object | `{}` |  |
 | clickhouse.backup.restore.activeDeadlineSeconds | int | `86400` |  |
 | clickhouse.backup.restore.affinity | object | `{}` |  |
-| clickhouse.backup.restore.backupName | string | `""` |  |
+| clickhouse.backup.restore.backupName | string | `""` | Name of the backup to restore, REQUIRED when createJob is true (Helm rendering fails otherwise). Must be a `name` from the backup server's `/backup/list`, e.g. "2026-01-16" — a backup the backup server created. Backups written by the SQL-based CronJob above cannot be restored by it. |
 | clickhouse.backup.restore.createJob | bool | `false` |  |
 | clickhouse.backup.restore.extraEnv | object | `{}` |  |
 | clickhouse.backup.restore.image | string | `"amazon/aws-cli:2.27.49"` |  |

--- a/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
@@ -1,0 +1,159 @@
+{{ if and .Values.clickhouse.enabled .Values.clickhouse.backupServer.enabled .Values.clickhouse.backup.restore.createJob }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "opik.name" $ }}-clickhouse-restore
+  labels:
+    {{- include "opik.labels" $  | nindent 4 }}
+spec:
+  backoffLimit: 0
+  activeDeadlineSeconds: {{ .Values.clickhouse.backup.restore.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: clickhouse-restore
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "clickhouse.backup.serviceAccountName" . }}
+      containers:
+      - command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          CHECK_INTERVAL=900  # 15 minutes in seconds
+
+          # Fetch the most recent restore action for this backup from the backup
+          # server's action history. The /backup/actions endpoint returns NDJSON
+          # (one action object per line), so no --slurp is needed. Matches the
+          # exact command ("restore <name>" or "restore_remote <name>") so a
+          # backup like "backup-1" can't match "backup-10". Tolerates a transient
+          # server error by returning an empty string.
+          get_restore_action() {
+            curl --silent "http://${RESTORE_SERVICE}/backup/actions" 2>/dev/null \
+              | jq -c --arg name "$BACKUP_NAME" \
+                  'select(.command == "restore " + $name or .command == "restore_remote " + $name)' 2>/dev/null \
+              | tail -1 || true
+          }
+
+          # Idempotency / reschedule safety: if a restore for this backup already
+          # ran (or is running), attach to it instead of starting a duplicate.
+          echo ""
+          echo "=== Checking for an existing restore of ${BACKUP_NAME} ==="
+          EXISTING_ACTION=$(get_restore_action)
+          SKIP_INITIATE="false"
+          if [ -n "$EXISTING_ACTION" ]; then
+            EXISTING_STATUS=$(echo "$EXISTING_ACTION" | jq -r '.status')
+            echo "Found existing restore action with status: ${EXISTING_STATUS}"
+            if [ "$EXISTING_STATUS" = "success" ]; then
+              echo "✓ Backup ${BACKUP_NAME} has already been restored successfully. Nothing to do."
+              exit 0
+            elif [ "$EXISTING_STATUS" != "error" ]; then
+              echo "A restore is already in progress (pod likely rescheduled), attaching to it."
+              RESTORE_COMMAND=$(echo "$EXISTING_ACTION" | jq -r '.command | split(" ")[0]')
+              SKIP_INITIATE="true"
+            fi
+          fi
+
+          if [ "$SKIP_INITIATE" = "false" ]; then
+            echo ""
+            echo "=== Checking if backup ${BACKUP_NAME} is available locally ==="
+            LOCAL_BACKUPS=$(curl --silent --fail "http://${RESTORE_SERVICE}/backup/list/local")
+            echo "$LOCAL_BACKUPS" | jq '.'
+
+            # Check if backup exists locally (handle both single object and array responses).
+            # Use jq -r (not -e): with -e jq exits non-zero on a "false" result, which
+            # under `set -euo pipefail` would abort the job and skip the restore_remote fallback.
+            BACKUP_LOCAL=$(echo "$LOCAL_BACKUPS" | jq -r --arg name "$BACKUP_NAME" 'if type == "array" then any(.[]; .name == $name) elif type == "object" then .name == $name else false end')
+
+            if [ "$BACKUP_LOCAL" = "true" ]; then
+              echo "✓ Backup found locally, using local restore"
+              RESTORE_COMMAND="restore"
+            else
+              echo "✗ Backup not found locally, using restore_remote (download + restore)"
+              RESTORE_COMMAND="restore_remote"
+            fi
+
+            echo ""
+            echo "=== Starting ${RESTORE_COMMAND} of backup ${BACKUP_NAME} at $(date) ==="
+            RESTORE_RESPONSE=$(curl --silent --fail -X POST "http://${RESTORE_SERVICE}/backup/${RESTORE_COMMAND}/${BACKUP_NAME}")
+            echo "$RESTORE_RESPONSE" | jq '.'
+
+            # Check if restore initiation failed
+            if echo "$RESTORE_RESPONSE" | jq -e '.status == "error"' > /dev/null; then
+              echo "ERROR: Restore failed to start!"
+              exit 1
+            fi
+          fi
+
+          # Poll for restore completion
+          echo ""
+          echo "=== Waiting for restore to complete (checking every 15 minutes) ==="
+          while true; do
+            echo "$(date): Checking restore status for backup ${BACKUP_NAME}..."
+
+            # Latest restore action for this backup (NDJSON stream, no --slurp).
+            RESTORE_ACTION=$(curl --silent "http://${RESTORE_SERVICE}/backup/actions" 2>/dev/null \
+              | jq -c --arg name "$BACKUP_NAME" --arg command "$RESTORE_COMMAND" \
+                  'select(.command == $command + " " + $name)' 2>/dev/null \
+              | tail -1 || true)
+
+            if [ -z "$RESTORE_ACTION" ]; then
+              echo "No restore operation found for ${BACKUP_NAME} yet, checking again..."
+            else
+              echo "$RESTORE_ACTION"
+              STATUS=$(echo "$RESTORE_ACTION" | jq -r '.status')
+
+              if [ "$STATUS" = "error" ]; then
+                echo "ERROR: Restore failed!"
+                exit 1
+              elif [ "$STATUS" = "success" ]; then
+                echo "✓ Restore completed successfully at $(date)"
+                break
+              else
+                echo "Restore in progress (status: ${STATUS})..."
+              fi
+            fi
+
+            echo "Waiting ${CHECK_INTERVAL} seconds before next check..."
+            sleep ${CHECK_INTERVAL}
+          done
+
+          echo ""
+          echo "=== Restore finished successfully at $(date) ==="
+        env:
+        - name: BACKUP_NAME
+          value: {{ required "clickhouse.backup.restore.backupName must be set when clickhouse.backup.restore.createJob is true" .Values.clickhouse.backup.restore.backupName | quote }}
+        - name: RESTORE_SERVICE
+          value: {{ .Values.clickhouse.backupServer.service.name | default (printf "chi-%s-clickhouse-cluster-0-0" (include "opik.name" $)) }}:{{ .Values.clickhouse.backupServer.service.port | default .Values.clickhouse.backupServer.port }}
+        {{- range $key, $value := .Values.clickhouse.backup.restore.extraEnv }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        name: clickhouse-restore-job
+        image: {{ .Values.clickhouse.backup.restore.image }}
+        imagePullPolicy: IfNotPresent
+        {{- with .Values.clickhouse.backup.restore.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.clickhouse.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with ( default .Values.clickhouse.nodeSelector .Values.clickhouse.backup.restore.nodeSelector ) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ( default .Values.clickhouse.affinity .Values.clickhouse.backup.restore.affinity ) }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ( default .Values.clickhouse.tolerations .Values.clickhouse.backup.restore.tolerations ) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+{{- end }}

--- a/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
@@ -1,4 +1,8 @@
 {{ if and .Values.clickhouse.enabled .Values.clickhouse.backupServer.enabled .Values.clickhouse.backup.restore.createJob }}
+{{- $bsPort := .Values.clickhouse.backupServer.service.port | default .Values.clickhouse.backupServer.port -}}
+{{- if not (regexMatch "^[0-9]+$" (printf "%v" $bsPort)) -}}
+{{- fail (printf "clickhouse.backupServer.service.port (or clickhouse.backupServer.port) must be a number, got %q" (printf "%v" $bsPort)) -}}
+{{- end -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -30,7 +34,7 @@ spec:
             exit 1
           }
 
-          # Most recent action for this backup from the backup server's history,
+          # Latest started action for this backup from the backup server's history,
           # optionally restricted to one command. /backup/actions returns NDJSON (one
           # compact object per line) and the quoted command value is matched whole, so
           # "restore backup-1" cannot match "restore backup-10". Empty result means no
@@ -144,7 +148,7 @@ spec:
         - name: BACKUP_NAME
           value: {{ required "clickhouse.backup.restore.backupName must be set when clickhouse.backup.restore.createJob is true" .Values.clickhouse.backup.restore.backupName | quote }}
         - name: RESTORE_SERVICE
-          value: {{ .Values.clickhouse.backupServer.service.name | default (printf "chi-%s-clickhouse-cluster-0-0" (include "opik.name" $)) }}:{{ .Values.clickhouse.backupServer.service.port | default .Values.clickhouse.backupServer.port }}
+          value: {{ .Values.clickhouse.backupServer.service.name | default (printf "chi-%s-clickhouse-cluster-0-0" (include "opik.name" $)) }}:{{ $bsPort }}
         {{- range $key, $value := .Values.clickhouse.backup.restore.extraEnv }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouse_restore_job.yaml
@@ -25,17 +25,37 @@ spec:
           set -euo pipefail
           CHECK_INTERVAL=900  # 15 minutes in seconds
 
-          # Fetch the most recent restore action for this backup from the backup
-          # server's action history. The /backup/actions endpoint returns NDJSON
-          # (one action object per line), so no --slurp is needed. Matches the
-          # exact command ("restore <name>" or "restore_remote <name>") so a
-          # backup like "backup-1" can't match "backup-10". Tolerates a transient
-          # server error by returning an empty string.
+          command -v curl >/dev/null || {
+            echo "ERROR: curl not found; clickhouse.backup.restore.image needs bash and curl"
+            exit 1
+          }
+
+          # Most recent action for this backup from the backup server's history,
+          # optionally restricted to one command. /backup/actions returns NDJSON (one
+          # compact object per line) and the quoted command value is matched whole, so
+          # "restore backup-1" cannot match "restore backup-10". Empty result means no
+          # action found — including when the server errors.
+          # Fed by process substitution, not a pipe, so $result survives the loop.
           get_restore_action() {
-            curl --silent "http://${RESTORE_SERVICE}/backup/actions" 2>/dev/null \
-              | jq -c --arg name "$BACKUP_NAME" \
-                  'select(.command == "restore " + $name or .command == "restore_remote " + $name)' 2>/dev/null \
-              | tail -1 || true
+            local want="${1:-}" line result=""
+            while IFS= read -r line; do
+              if [ -n "$want" ]; then
+                case "$line" in *"\"${want} ${BACKUP_NAME}\""*) result="$line" ;; esac
+              else
+                case "$line" in
+                  *"\"restore ${BACKUP_NAME}\""*|*"\"restore_remote ${BACKUP_NAME}\""*) result="$line" ;;
+                esac
+              fi
+            done < <(curl --silent "http://${RESTORE_SERVICE}/backup/actions" 2>/dev/null || true)
+            printf '%s' "$result"
+          }
+
+          # First value of a top-level string field on one JSON line. Pure bash, so the
+          # job needs no jq — slim images (incl. amazon/aws-cli) do not ship it.
+          json_field() {
+            local rest="${2#*\"${1}\":\"}"
+            [ "$rest" = "${2}" ] && return 0
+            printf '%s' "${rest%%\"*}"
           }
 
           # Idempotency / reschedule safety: if a restore for this backup already
@@ -45,14 +65,15 @@ spec:
           EXISTING_ACTION=$(get_restore_action)
           SKIP_INITIATE="false"
           if [ -n "$EXISTING_ACTION" ]; then
-            EXISTING_STATUS=$(echo "$EXISTING_ACTION" | jq -r '.status')
+            EXISTING_STATUS=$(json_field status "$EXISTING_ACTION")
             echo "Found existing restore action with status: ${EXISTING_STATUS}"
             if [ "$EXISTING_STATUS" = "success" ]; then
               echo "✓ Backup ${BACKUP_NAME} has already been restored successfully. Nothing to do."
               exit 0
             elif [ "$EXISTING_STATUS" != "error" ]; then
               echo "A restore is already in progress (pod likely rescheduled), attaching to it."
-              RESTORE_COMMAND=$(echo "$EXISTING_ACTION" | jq -r '.command | split(" ")[0]')
+              EXISTING_COMMAND=$(json_field command "$EXISTING_ACTION")
+              RESTORE_COMMAND="${EXISTING_COMMAND%% *}"
               SKIP_INITIATE="true"
             fi
           fi
@@ -60,32 +81,32 @@ spec:
           if [ "$SKIP_INITIATE" = "false" ]; then
             echo ""
             echo "=== Checking if backup ${BACKUP_NAME} is available locally ==="
-            LOCAL_BACKUPS=$(curl --silent --fail "http://${RESTORE_SERVICE}/backup/list/local")
-            echo "$LOCAL_BACKUPS" | jq '.'
+            # On a list failure, fall back to restore_remote — it works either way.
+            LOCAL_BACKUPS=$(curl --silent --fail "http://${RESTORE_SERVICE}/backup/list/local" || true)
+            printf '%s\n' "$LOCAL_BACKUPS"
 
-            # Check if backup exists locally (handle both single object and array responses).
-            # Use jq -r (not -e): with -e jq exits non-zero on a "false" result, which
-            # under `set -euo pipefail` would abort the job and skip the restore_remote fallback.
-            BACKUP_LOCAL=$(echo "$LOCAL_BACKUPS" | jq -r --arg name "$BACKUP_NAME" 'if type == "array" then any(.[]; .name == $name) elif type == "object" then .name == $name else false end')
-
-            if [ "$BACKUP_LOCAL" = "true" ]; then
-              echo "✓ Backup found locally, using local restore"
-              RESTORE_COMMAND="restore"
-            else
-              echo "✗ Backup not found locally, using restore_remote (download + restore)"
-              RESTORE_COMMAND="restore_remote"
-            fi
+            case "$LOCAL_BACKUPS" in
+              *"\"name\":\"${BACKUP_NAME}\""*)
+                echo "✓ Backup found locally, using local restore"
+                RESTORE_COMMAND="restore"
+                ;;
+              *)
+                echo "✗ Backup not found locally, using restore_remote (download + restore)"
+                RESTORE_COMMAND="restore_remote"
+                ;;
+            esac
 
             echo ""
             echo "=== Starting ${RESTORE_COMMAND} of backup ${BACKUP_NAME} at $(date) ==="
             RESTORE_RESPONSE=$(curl --silent --fail -X POST "http://${RESTORE_SERVICE}/backup/${RESTORE_COMMAND}/${BACKUP_NAME}")
-            echo "$RESTORE_RESPONSE" | jq '.'
+            printf '%s\n' "$RESTORE_RESPONSE"
 
-            # Check if restore initiation failed
-            if echo "$RESTORE_RESPONSE" | jq -e '.status == "error"' > /dev/null; then
-              echo "ERROR: Restore failed to start!"
-              exit 1
-            fi
+            case "$RESTORE_RESPONSE" in
+              *'"status":"error"'*)
+                echo "ERROR: Restore failed to start!"
+                exit 1
+                ;;
+            esac
           fi
 
           # Poll for restore completion
@@ -94,20 +115,16 @@ spec:
           while true; do
             echo "$(date): Checking restore status for backup ${BACKUP_NAME}..."
 
-            # Latest restore action for this backup (NDJSON stream, no --slurp).
-            RESTORE_ACTION=$(curl --silent "http://${RESTORE_SERVICE}/backup/actions" 2>/dev/null \
-              | jq -c --arg name "$BACKUP_NAME" --arg command "$RESTORE_COMMAND" \
-                  'select(.command == $command + " " + $name)' 2>/dev/null \
-              | tail -1 || true)
+            RESTORE_ACTION=$(get_restore_action "$RESTORE_COMMAND")
 
             if [ -z "$RESTORE_ACTION" ]; then
               echo "No restore operation found for ${BACKUP_NAME} yet, checking again..."
             else
               echo "$RESTORE_ACTION"
-              STATUS=$(echo "$RESTORE_ACTION" | jq -r '.status')
+              STATUS=$(json_field status "$RESTORE_ACTION")
 
               if [ "$STATUS" = "error" ]; then
-                echo "ERROR: Restore failed!"
+                echo "ERROR: Restore failed! $(json_field error "$RESTORE_ACTION")"
                 exit 1
               elif [ "$STATUS" = "success" ]; then
                 echo "✓ Restore completed successfully at $(date)"

--- a/deployment/helm_chart/opik/templates/serviceaccount.yaml
+++ b/deployment/helm_chart/opik/templates/serviceaccount.yaml
@@ -28,7 +28,7 @@ metadata:
   {{- end }}
 {{- end }}
 
-{{- if and .Values.clickhouse.enabled .Values.clickhouse.backup.enabled .Values.clickhouse.backup.serviceAccount.create }}
+{{- if and .Values.clickhouse.enabled .Values.clickhouse.backup.serviceAccount.create (or .Values.clickhouse.backup.enabled (and .Values.clickhouse.backupServer.enabled .Values.clickhouse.backup.restore.createJob)) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -931,10 +931,10 @@ clickhouse:
       # IMPORTANT: set this back to false once the restore has completed.
       # Otherwise the next `helm upgrade` re-creates the job and restores again.
       createJob: false
-      # Name of the backup to restore. REQUIRED when createJob is true (Helm
-      # rendering fails otherwise). Must match a backup name from the backup
-      # server's /backup/list, e.g. "backup202401011200" as produced by the
-      # backup CronJob above.
+      # -- Name of the backup to restore, REQUIRED when createJob is true (Helm
+      # rendering fails otherwise). Must be a `name` from the backup server's
+      # `/backup/list`, e.g. "2026-01-16" — a backup the backup server created.
+      # Backups written by the SQL-based CronJob above cannot be restored by it.
       backupName: ""
       # Override with any image that has bash and curl — the job needs nothing else.
       image: "amazon/aws-cli:2.27.49"
@@ -958,8 +958,9 @@ clickhouse:
     port: 7171
     # Service the restore job uses to reach the clickhouse-backup REST API.
     # The backup port is exposed on the operator's per-replica service, so this
-    # defaults (in the restore job template) to chi-<release>-clickhouse-cluster-0-0
-    # on backupServer.port. Override name/port if your shard/replica layout differs.
+    # defaults (in the restore job template) to chi-<opik.name>-clickhouse-cluster-0-0
+    # — opik.name, not the release name — on service.port, falling back to
+    # backupServer.port. Override name/port if your shard/replica layout differs.
     service:
       name: ""
       port: ""

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -926,10 +926,42 @@ clickhouse:
         export backupname=backup$(date +'%Y%m%d%H%M')
         echo "BACKUP ALL EXCEPT DATABASE system TO S3('${CLICKHOUSE_BACKUP_BUCKET}/${backupname}/', '$ACCESS_KEY', '$SECRET_KEY');" > /tmp/backQuery.sql
         clickhouse-client -h clickhouse-opik-clickhouse --send_timeout 600000 --receive_timeout 600000 --port 9000 --queries-file=/tmp/backQuery.sql
+    restore:
+      # Set to true to create the restore job (does not run by default).
+      # IMPORTANT: set this back to false once the restore has completed.
+      # Otherwise the next `helm upgrade` re-creates the job and restores again.
+      createJob: false
+      # Name of the backup to restore. REQUIRED when createJob is true (Helm
+      # rendering fails otherwise). Must match a backup name from the backup
+      # server's /backup/list, e.g. "backup202401011200" as produced by the
+      # backup CronJob above.
+      backupName: ""
+      image: "amazon/aws-cli:2.27.49"
+      # Hard cap on the job runtime (seconds) so a stuck restore whose status
+      # never resolves cannot run forever. Default: 24h.
+      activeDeadlineSeconds: 86400
+      extraEnv: {}
+      resources:
+        limits:
+          cpu: 10m
+          memory: 64Mi
+        requests:
+          cpu: 10m
+          memory: 32Mi
+      nodeSelector: {}  # Defaults to .Values.clickhouse.nodeSelector if not specified
+      affinity: {}  # Defaults to .Values.clickhouse.affinity if not specified
+      tolerations: []  # Defaults to .Values.clickhouse.tolerations if not specified
   backupServer:
     enabled: false
     image: altinity/clickhouse-backup:2.6.39
     port: 7171
+    # Service the restore job uses to reach the clickhouse-backup REST API.
+    # The backup port is exposed on the operator's per-replica service, so this
+    # defaults (in the restore job template) to chi-<release>-clickhouse-cluster-0-0
+    # on backupServer.port. Override name/port if your shard/replica layout differs.
+    service:
+      name: ""
+      port: ""
     monitoring:
       enabled: false
       additionalLabels: {}

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -936,6 +936,7 @@ clickhouse:
       # server's /backup/list, e.g. "backup202401011200" as produced by the
       # backup CronJob above.
       backupName: ""
+      # Override with any image that has bash and curl — the job needs nothing else.
       image: "amazon/aws-cli:2.27.49"
       # Hard cap on the job runtime (seconds) so a stuck restore whose status
       # never resolves cannot run forever. Default: 24h.


### PR DESCRIPTION
## Details

Adds an optional Kubernetes Job that restores a `clickhouse-backup` backup end to end: it picks
`restore` or `restore_remote` depending on whether the backup is already on local disk, starts it
through the backup server's REST API, and polls until it finishes. Off by default — the Job renders
only when `clickhouse.backupServer.enabled` and `clickhouse.backup.restore.createJob` are both true.

- The polling script needs only `bash` and `curl`. It parses the server's NDJSON with shell
  built-ins instead of `jq`, because slim images — including the default `amazon/aws-cli` — do not
  ship `jq`, and the first `jq` call would otherwise abort the Job under `set -o pipefail`. A
  one-line preflight fails loudly, naming the values key, if `curl` is missing.
- Local-backup detection matches the quoted backup name against the whole `/backup/list/local`
  response, handling both the NDJSON and array shapes. Matching includes the closing quote, so
  `restore backup-1` cannot match `restore backup-10`.
- A transient `/backup/list/local` failure falls back to `restore_remote` (which works either way)
  rather than aborting a Job that has `backoffLimit: 0`. If the backup was already restored the Job
  exits successfully without repeating it; if a restore is still running — for example after the pod
  was rescheduled — it attaches to that instead of starting a second one.

New values under `clickhouse.backup.restore`: `createJob`, `backupName` (required when enabled),
`image`, `activeDeadlineSeconds`, `extraEnv`, `resources`, and `nodeSelector` / `affinity` /
`tolerations`, each inheriting the ClickHouse values when unset. Also adds
`clickhouse.backupServer.service.name` / `.port` so the Job can target a non-default shard/replica
layout.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-2865

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the Job template's polling script (jq removal, local-backup detection, failure handling),
  the scenario test harness, and the `self-host/backup.mdx` restore documentation.
- Human verification: reviewed by the author, who also ran the Job end to end against a real
  multi-terabyte restore in an internal environment before this PR.

## Testing

Scenario tests with `curl` and `sleep` stubbed, asserting exit codes, which endpoint was POSTed,
and the log output — 31 assertions across 9 scenarios:

- fresh backup not held locally, polling through to success
- attach to an in-flight restore with no duplicate POST
- early exit when the backup was already restored
- re-initiate after a previously failed attempt
- local restore when the backup is on disk (multi-line NDJSON response)
- name-prefix collision, `backup-1` vs `backup-10`
- POST rejected by the server
- restore failing mid-flight, surfacing the server's error message
- `/backup/list/local` unavailable, falling back to `restore_remote`

The same suite passes inside the default `amazon/aws-cli:2.27.49` image (bash 4.2), confirming the
parameter expansions and process substitution work on an older bash. `helm template` renders the Job
unchanged apart from the script body.

Validated end to end on a real ~24 TiB `restore_remote` that ran for 24 hours and completed
successfully, with both replicas verified in sync afterwards.

Not run: no automated chart test covers the Job, since exercising it needs a live backup server.

## Documentation

`self-host/backup.mdx` — the restore section is reorganised into a procedure (find the backup name,
render the manifest, create the Job, watch it) and gains a section on checking progress during a
long restore. It now also documents that the restore drops and recreates every table contained in
the backup, so no manual `DROP` is needed, and that the 24h `activeDeadlineSeconds` default will
kill a large restore mid-flight. Applied to both documentation versions (`docs/` and `docs-v2/`);
the restore job was previously documented in neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
