### PR TITLE
[OPIK-7331] [BE][FE] perf: speed up projects-list stats (invert span-score lookup + 30-day window)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/InstantToUUIDMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/InstantToUUIDMapper.java
@@ -40,7 +40,9 @@ public class InstantToUUIDMapper {
             return null;
         }
 
-        long epochMilli = timestamp.toEpochMilli();
+        // UUIDv7's 48-bit timestamp is unsigned ms-since-epoch; a negative (pre-1970) value would overflow it
+        // and wrap into a UUID that sorts above every real id, so clamp to the epoch floor.
+        long epochMilli = Math.max(0L, timestamp.toEpochMilli());
 
         // Most significant bits: [timestamp: 48 bits][version: 4 bits][random: 12 bits]
         // For lower bound, set the 12 random bits to 0
@@ -79,7 +81,8 @@ public class InstantToUUIDMapper {
             return null;
         }
 
-        long epochMilli = timestamp.toEpochMilli();
+        // Clamp to the epoch floor: negative (pre-1970) values overflow the unsigned 48-bit timestamp.
+        long epochMilli = Math.max(0L, timestamp.toEpochMilli());
 
         // Most significant bits: [timestamp: 48 bits][version: 4 bits][random: 12 bits]
         // For upper bound, set the 12 random bits to 1

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -353,6 +353,7 @@ public class ProjectsResource {
             @QueryParam("size") @Min(1) @DefaultValue(PAGE_SIZE) int size,
             @QueryParam("name") @Schema(description = "Filter projects by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters,
+            @QueryParam("window_days") @Min(1) @Schema(description = "When set, scope the metrics to the last N days; omitted keeps the all-time aggregates") Integer windowDays,
             @QueryParam("sorting") String sorting) {
 
         var traceFilters = filtersFactory.newFilters(filters, TraceFilter.LIST_TYPE_REFERENCE);
@@ -360,6 +361,7 @@ public class ProjectsResource {
         var criteria = ProjectCriteria.builder()
                 .projectName(name)
                 .filters(traceFilters)
+                .windowDays(windowDays)
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/ProjectsResource.java
@@ -73,6 +73,7 @@ import static com.comet.opik.api.Project.ProjectPage;
 import static com.comet.opik.api.Project.View;
 import static com.comet.opik.domain.ProjectMetricsService.ERR_START_BEFORE_END;
 import static com.comet.opik.utils.AsyncUtils.setRequestContext;
+import static com.comet.opik.utils.ValidationUtils.validateTimeRangeParameters;
 
 @Path("/v1/private/projects")
 @Produces(MediaType.APPLICATION_JSON)
@@ -353,15 +354,19 @@ public class ProjectsResource {
             @QueryParam("size") @Min(1) @DefaultValue(PAGE_SIZE) int size,
             @QueryParam("name") @Schema(description = "Filter projects by name (partial match, case insensitive)") String name,
             @QueryParam("filters") String filters,
-            @QueryParam("window_days") @Min(1) @Schema(description = "When set, scope the metrics to the last N days; omitted keeps the all-time aggregates") Integer windowDays,
+            @QueryParam("from_time") @Schema(description = "When set, scope the project metrics from this time (ISO-8601 format); omitted keeps the all-time aggregates") Instant fromTime,
+            @QueryParam("to_time") @Schema(description = "Scope the project metrics up to this time (ISO-8601 format). Must be after 'from_time'.") Instant toTime,
             @QueryParam("sorting") String sorting) {
+
+        validateTimeRangeParameters(fromTime, toTime);
 
         var traceFilters = filtersFactory.newFilters(filters, TraceFilter.LIST_TYPE_REFERENCE);
 
         var criteria = ProjectCriteria.builder()
                 .projectName(name)
                 .filters(traceFilters)
-                .windowDays(windowDays)
+                .fromTime(fromTime)
+                .toTime(toTime)
                 .build();
 
         String workspaceId = requestContext.get().getWorkspaceId();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectCriteria.java
@@ -6,6 +6,6 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder(toBuilder = true)
-public record ProjectCriteria(String projectName, List<? extends Filter> filters) {
+public record ProjectCriteria(String projectName, List<? extends Filter> filters, Integer windowDays) {
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectCriteria.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectCriteria.java
@@ -3,9 +3,10 @@ package com.comet.opik.domain;
 import com.comet.opik.api.filter.Filter;
 import lombok.Builder;
 
+import java.time.Instant;
 import java.util.List;
 
 @Builder(toBuilder = true)
-public record ProjectCriteria(String projectName, List<? extends Filter> filters, Integer windowDays) {
+public record ProjectCriteria(String projectName, List<? extends Filter> filters, Instant fromTime, Instant toTime) {
 
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -380,7 +380,7 @@ class ProjectServiceImpl implements ProjectService {
 
     private Map<UUID, Map<String, Object>> getProjectStats(List<UUID> projectIds, String workspaceId,
             ProjectCriteria criteria) {
-        return traceDAO.getStatsByProjectIds(projectIds, workspaceId, criteria.filters())
+        return traceDAO.getStatsByProjectIds(projectIds, workspaceId, criteria.filters(), criteria.windowDays())
                 .map(stats -> stats.entrySet().stream()
                         .map(entry -> {
                             Map<String, Object> statsMap = entry.getValue().stats()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -380,7 +380,8 @@ class ProjectServiceImpl implements ProjectService {
 
     private Map<UUID, Map<String, Object>> getProjectStats(List<UUID> projectIds, String workspaceId,
             ProjectCriteria criteria) {
-        return traceDAO.getStatsByProjectIds(projectIds, workspaceId, criteria.filters(), criteria.windowDays())
+        return traceDAO.getStatsByProjectIds(projectIds, workspaceId, criteria.filters(), criteria.fromTime(),
+                criteria.toTime())
                 .map(stats -> stats.entrySet().stream()
                         .map(entry -> {
                             Map<String, Object> statsMap = entry.getValue().stats()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2934,11 +2934,27 @@ class TraceDAOImpl implements TraceDAO {
             <else>
             WITH
             <endif>
-            span_ids AS (
+            span_scores AS (
+                <if(has_legacy_scores)>
+                SELECT project_id, entity_id, name, value,
+                       feedback_scores.last_updated_by AS author
+                FROM feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+                UNION ALL
+                <endif>
+                SELECT project_id, entity_id, name, value, author
+                FROM authored_feedback_scores FINAL
+                WHERE entity_type = 'span'
+                  AND workspace_id = :workspace_id
+                  AND project_id IN :project_ids
+            ), scored_span_traces AS (
                 SELECT id
                 FROM spans
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
+                AND id IN (SELECT entity_id FROM span_scores)
                 <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
                 <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
                 <if(filters_present)> AND trace_id IN (SELECT id FROM trace_final) <endif>
@@ -2977,22 +2993,9 @@ class TraceDAOImpl implements TraceDAO {
                 FROM trace_fs_per_project
                 GROUP BY project_id
             ), span_fs AS (
-                <if(has_legacy_scores)>
-                SELECT project_id, entity_id, name, value,
-                       feedback_scores.last_updated_by AS author
-                FROM feedback_scores FINAL
-                WHERE entity_type = 'span'
-                  AND workspace_id = :workspace_id
-                  AND project_id IN :project_ids
-                  AND entity_id IN (SELECT id FROM span_ids)
-                UNION ALL
-                <endif>
                 SELECT project_id, entity_id, name, value, author
-                FROM authored_feedback_scores FINAL
-                WHERE entity_type = 'span'
-                  AND workspace_id = :workspace_id
-                  AND project_id IN :project_ids
-                  AND entity_id IN (SELECT id FROM span_ids)
+                FROM span_scores
+                WHERE entity_id IN (SELECT id FROM scored_span_traces)
             ), span_fs_per_name AS (
                 SELECT project_id, entity_id, name, avg(value) AS value
                 FROM span_fs

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.ExperimentItemReference;
 import com.comet.opik.api.Guardrail;
 import com.comet.opik.api.GuardrailType;
 import com.comet.opik.api.GuardrailsValidation;
+import com.comet.opik.api.InstantToUUIDMapper;
 import com.comet.opik.api.ProjectStats;
 import com.comet.opik.api.Source;
 import com.comet.opik.api.Trace;
@@ -58,6 +59,7 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -142,7 +144,7 @@ public interface TraceDAO {
     Mono<Long> getDailyTraces(Map<UUID, Instant> excludedProjectIds);
 
     Mono<Map<UUID, ProjectStats>> getStatsByProjectIds(List<UUID> projectIds, String workspaceId,
-            List<? extends Filter> filters);
+            List<? extends Filter> filters, Integer windowDays);
 
     Mono<Set<UUID>> getTraceIdsByThreadIds(UUID projectId, List<String> threadIds, Connection connection);
 
@@ -2942,6 +2944,8 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id IN :project_ids
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 UNION ALL
                 <endif>
                 SELECT project_id, entity_id, name, value, author
@@ -2949,7 +2953,9 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id IN :project_ids
-            ), scored_span_traces AS (
+                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
+                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
+            ), scored_span_ids AS (
                 SELECT id
                 FROM spans
                 WHERE workspace_id = :workspace_id
@@ -2995,7 +3001,7 @@ class TraceDAOImpl implements TraceDAO {
             ), span_fs AS (
                 SELECT project_id, entity_id, name, value, author
                 FROM span_scores
-                WHERE entity_id IN (SELECT id FROM scored_span_traces)
+                WHERE entity_id IN (SELECT id FROM scored_span_ids)
             ), span_fs_per_name AS (
                 SELECT project_id, entity_id, name, avg(value) AS value
                 FROM span_fs
@@ -3144,6 +3150,7 @@ class TraceDAOImpl implements TraceDAO {
     private final @NonNull OpikConfiguration configuration;
     private final @NonNull ConnectionFactory connectionFactory;
     private final @NonNull WorkspacesService workspacesService;
+    private final @NonNull InstantToUUIDMapper instantToUUIDMapper;
 
     /**
      * Sort mapping applied under {@code traceColumnsNonNullable}: {@code nullIf} restores an absent (epoch)
@@ -4327,10 +4334,15 @@ class TraceDAOImpl implements TraceDAO {
      * {@code filters_present} so the template scopes feedback aggregates to filtered traces.
      */
     private Statement buildFeedbackStatementForProjects(Connection connection, List<UUID> projectIds,
-            String workspaceId, List<? extends Filter> filters, boolean hasLegacyScores) {
+            String workspaceId, List<? extends Filter> filters, boolean hasLegacyScores, String uuidFromTime,
+            String uuidToTime) {
         var logComment = getLogComment("get_trace_stats_feedback_scores", workspaceId, "", projectIds.size());
         var template = TemplateUtils.newST(SELECT_FEEDBACK_SCORES_STATS).add("log_comment", logComment);
         template.add("has_legacy_scores", hasLegacyScores);
+        if (uuidFromTime != null) {
+            template.add("uuid_from_time", true);
+            template.add("uuid_to_time", true);
+        }
         if (!CollectionUtils.isEmpty(filters)) {
             FilterQueryBuilder.toAnalyticsDbFilters(filters, FilterStrategy.TRACE, traceColumnsNonNullable())
                     .ifPresent(traceFilters -> {
@@ -4342,6 +4354,9 @@ class TraceDAOImpl implements TraceDAO {
         var statement = connection.createStatement(template.render())
                 .bind("project_ids", projectIds)
                 .bind("workspace_id", workspaceId);
+        if (uuidFromTime != null) {
+            statement.bind("uuid_from_time", uuidFromTime).bind("uuid_to_time", uuidToTime);
+        }
         if (!CollectionUtils.isEmpty(filters)) {
             FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
         }
@@ -4399,7 +4414,7 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     public Mono<Map<UUID, ProjectStats>> getStatsByProjectIds(@NonNull List<UUID> projectIds,
-            @NonNull String workspaceId, List<? extends Filter> filters) {
+            @NonNull String workspaceId, List<? extends Filter> filters, Integer windowDays) {
 
         if (projectIds.isEmpty()) {
             return Mono.just(Map.of());
@@ -4409,6 +4424,17 @@ class TraceDAOImpl implements TraceDAO {
         // tolerate two concurrent statements on the same connection. The legacy-scores flag is
         // resolved once (sync JDBI) so both branches can skip the legacy feedback_scores UNION
         // when no data exists there.
+        // Optional moving window: when the caller opts in (windowDays != null, e.g. the Projects table),
+        // scope every metric to [now - N days, now] via uuid_from_time/uuid_to_time on the time-ordered
+        // UUIDv7 id — pruning by the sort key today and by time partitions once the tables are partitioned by
+        // time, with the upper bound excluding (ingestion-tolerated) future-dated ids. When omitted, the
+        // aggregates stay all-time so the public getProjectStats API keeps its existing semantics.
+        Instant now = Instant.now();
+        String uuidFromTime = windowDays == null
+                ? null
+                : instantToUUIDMapper.toLowerBound(now.minus(windowDays, ChronoUnit.DAYS)).toString();
+        String uuidToTime = windowDays == null ? null : instantToUUIDMapper.toUpperBound(now).toString();
+
         return workspacesService.hasLegacyScores(workspaceId)
                 .flatMap(hasLegacyScores -> {
 
@@ -4419,6 +4445,10 @@ class TraceDAOImpl implements TraceDAO {
                                 "get_trace_stats_traces_spans_by_project_ids", workspaceId, "", projectIds.size());
                         template.add("project_stats", true);
                         template.add("has_legacy_scores", hasLegacyScores);
+                        if (uuidFromTime != null) {
+                            template.add("uuid_from_time", true);
+                            template.add("uuid_to_time", true);
+                        }
                         if (!CollectionUtils.isEmpty(filters)) {
                             FilterQueryBuilder
                                     .toAnalyticsDbFilters(filters, FilterStrategy.TRACE, traceColumnsNonNullable())
@@ -4427,6 +4457,9 @@ class TraceDAOImpl implements TraceDAO {
                         var statement = connection.createStatement(template.render())
                                 .bind("project_ids", projectIds)
                                 .bind("workspace_id", workspaceId);
+                        if (uuidFromTime != null) {
+                            statement.bind("uuid_from_time", uuidFromTime).bind("uuid_to_time", uuidToTime);
+                        }
                         if (!CollectionUtils.isEmpty(filters)) {
                             FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
                         }
@@ -4443,7 +4476,7 @@ class TraceDAOImpl implements TraceDAO {
                         // trace filters we propagate them so the feedback aggregates are scoped to the
                         // same filtered trace set (filters_present path inside the template).
                         var statement = buildFeedbackStatementForProjects(connection, projectIds, workspaceId,
-                                filters, hasLegacyScores);
+                                filters, hasLegacyScores, uuidFromTime, uuidToTime);
 
                         return Mono.from(statement.execute())
                                 .flatMapMany(result -> result.map(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -59,12 +59,12 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -144,7 +144,7 @@ public interface TraceDAO {
     Mono<Long> getDailyTraces(Map<UUID, Instant> excludedProjectIds);
 
     Mono<Map<UUID, ProjectStats>> getStatsByProjectIds(List<UUID> projectIds, String workspaceId,
-            List<? extends Filter> filters, Integer windowDays);
+            List<? extends Filter> filters, Instant fromTime, Instant toTime);
 
     Mono<Set<UUID>> getTraceIdsByThreadIds(UUID projectId, List<String> threadIds, Connection connection);
 
@@ -4341,6 +4341,8 @@ class TraceDAOImpl implements TraceDAO {
         template.add("has_legacy_scores", hasLegacyScores);
         if (uuidFromTime != null) {
             template.add("uuid_from_time", true);
+        }
+        if (uuidToTime != null) {
             template.add("uuid_to_time", true);
         }
         if (!CollectionUtils.isEmpty(filters)) {
@@ -4355,7 +4357,10 @@ class TraceDAOImpl implements TraceDAO {
                 .bind("project_ids", projectIds)
                 .bind("workspace_id", workspaceId);
         if (uuidFromTime != null) {
-            statement.bind("uuid_from_time", uuidFromTime).bind("uuid_to_time", uuidToTime);
+            statement.bind("uuid_from_time", uuidFromTime);
+        }
+        if (uuidToTime != null) {
+            statement.bind("uuid_to_time", uuidToTime);
         }
         if (!CollectionUtils.isEmpty(filters)) {
             FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);
@@ -4414,7 +4419,7 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     public Mono<Map<UUID, ProjectStats>> getStatsByProjectIds(@NonNull List<UUID> projectIds,
-            @NonNull String workspaceId, List<? extends Filter> filters, Integer windowDays) {
+            @NonNull String workspaceId, List<? extends Filter> filters, Instant fromTime, Instant toTime) {
 
         if (projectIds.isEmpty()) {
             return Mono.just(Map.of());
@@ -4424,16 +4429,14 @@ class TraceDAOImpl implements TraceDAO {
         // tolerate two concurrent statements on the same connection. The legacy-scores flag is
         // resolved once (sync JDBI) so both branches can skip the legacy feedback_scores UNION
         // when no data exists there.
-        // Optional moving window: when the caller opts in (windowDays != null, e.g. the Projects table),
-        // scope every metric to [now - N days, now] via uuid_from_time/uuid_to_time on the time-ordered
+        // Optional time window: when the caller opts in (fromTime/toTime set, e.g. the Projects table),
+        // scope every metric to [fromTime, toTime] via uuid_from_time/uuid_to_time on the time-ordered
         // UUIDv7 id — pruning by the sort key today and by time partitions once the tables are partitioned by
-        // time, with the upper bound excluding (ingestion-tolerated) future-dated ids. When omitted, the
-        // aggregates stay all-time so the public getProjectStats API keeps its existing semantics.
-        Instant now = Instant.now();
-        String uuidFromTime = windowDays == null
-                ? null
-                : instantToUUIDMapper.toLowerBound(now.minus(windowDays, ChronoUnit.DAYS)).toString();
-        String uuidToTime = windowDays == null ? null : instantToUUIDMapper.toUpperBound(now).toString();
+        // time, with the upper bound excluding (ingestion-tolerated) future-dated ids. Each bound is optional
+        // and applied independently; when both are omitted the aggregates stay all-time so the public
+        // getProjectStats API keeps its existing semantics.
+        String uuidFromTime = Objects.toString(instantToUUIDMapper.toLowerBound(fromTime), null);
+        String uuidToTime = Objects.toString(instantToUUIDMapper.toUpperBound(toTime), null);
 
         return workspacesService.hasLegacyScores(workspaceId)
                 .flatMap(hasLegacyScores -> {
@@ -4447,6 +4450,8 @@ class TraceDAOImpl implements TraceDAO {
                         template.add("has_legacy_scores", hasLegacyScores);
                         if (uuidFromTime != null) {
                             template.add("uuid_from_time", true);
+                        }
+                        if (uuidToTime != null) {
                             template.add("uuid_to_time", true);
                         }
                         if (!CollectionUtils.isEmpty(filters)) {
@@ -4458,7 +4463,10 @@ class TraceDAOImpl implements TraceDAO {
                                 .bind("project_ids", projectIds)
                                 .bind("workspace_id", workspaceId);
                         if (uuidFromTime != null) {
-                            statement.bind("uuid_from_time", uuidFromTime).bind("uuid_to_time", uuidToTime);
+                            statement.bind("uuid_from_time", uuidFromTime);
+                        }
+                        if (uuidToTime != null) {
+                            statement.bind("uuid_to_time", uuidToTime);
                         }
                         if (!CollectionUtils.isEmpty(filters)) {
                             FilterQueryBuilder.bind(statement, filters, FilterStrategy.TRACE);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2383,12 +2383,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id IN :project_ids
-                      <if(uuid_from_time || uuid_to_time)>
-                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
-                      <else>
                       AND entity_id IN (SELECT id FROM spans_data)
-                      <endif>
                     UNION ALL
                     <endif>
                     SELECT workspace_id,
@@ -2409,12 +2404,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id IN :project_ids
-                      <if(uuid_from_time || uuid_to_time)>
-                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
-                      <else>
                       AND entity_id IN (SELECT id FROM spans_data)
-                      <endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
@@ -2789,12 +2779,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id IN :project_ids
-                      <if(uuid_from_time || uuid_to_time)>
-                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
-                      <else>
                       AND entity_id IN (SELECT id FROM spans_data)
-                      <endif>
                     UNION ALL
                     <endif>
                     SELECT workspace_id,
@@ -2809,12 +2794,7 @@ class TraceDAOImpl implements TraceDAO {
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
                       AND project_id IN :project_ids
-                      <if(uuid_from_time || uuid_to_time)>
-                      <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                      <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
-                      <else>
                       AND entity_id IN (SELECT id FROM spans_data)
-                      <endif>
                 )
                 ORDER BY last_updated_at DESC
                 LIMIT 1 BY workspace_id, project_id, entity_id, name, author, source_queue_id
@@ -2952,8 +2932,6 @@ class TraceDAOImpl implements TraceDAO {
                   AND workspace_id = :workspace_id
                   AND project_id IN :project_ids
             ), scored_span_ids AS (
-                -- The time window is applied here on trace_id, so a span's score is scoped by its trace's
-                -- time (uniform with every other metric) rather than by the span's own id.
                 SELECT id
                 FROM spans
                 WHERE workspace_id = :workspace_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2944,8 +2944,6 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id IN :project_ids
-                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
                 UNION ALL
                 <endif>
                 SELECT project_id, entity_id, name, value, author
@@ -2953,9 +2951,9 @@ class TraceDAOImpl implements TraceDAO {
                 WHERE entity_type = 'span'
                   AND workspace_id = :workspace_id
                   AND project_id IN :project_ids
-                  <if(uuid_from_time)> AND entity_id >= :uuid_from_time <endif>
-                  <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time <endif>
             ), scored_span_ids AS (
+                -- The time window is applied here on trace_id, so a span's score is scoped by its trace's
+                -- time (uniform with every other metric) rather than by the span's own id.
                 SELECT id
                 FROM spans
                 WHERE workspace_id = :workspace_id
@@ -4425,16 +4423,16 @@ class TraceDAOImpl implements TraceDAO {
             return Mono.just(Map.of());
         }
 
-        // Each branch runs on its own connection from the pool — R2DBC connections do not
-        // tolerate two concurrent statements on the same connection. The legacy-scores flag is
-        // resolved once (sync JDBI) so both branches can skip the legacy feedback_scores UNION
-        // when no data exists there.
-        // Optional time window: when the caller opts in (fromTime/toTime set, e.g. the Projects table),
-        // scope every metric to [fromTime, toTime] via uuid_from_time/uuid_to_time on the time-ordered
-        // UUIDv7 id — pruning by the sort key today and by time partitions once the tables are partitioned by
-        // time, with the upper bound excluding (ingestion-tolerated) future-dated ids. Each bound is optional
-        // and applied independently; when both are omitted the aggregates stay all-time so the public
-        // getProjectStats API keeps its existing semantics.
+        // Each branch runs on its own pooled connection — R2DBC forbids concurrent statements on one
+        // connection. The legacy-scores flag is resolved once (sync JDBI) so both branches can skip the
+        // legacy feedback_scores UNION when it's empty.
+        // Optional window: when the caller opts in (fromTime/toTime, e.g. the Projects table), every metric
+        // is scoped to [fromTime, toTime] via uuid_from_time/uuid_to_time on the UUIDv7 id, the upper bound
+        // excluding (ingestion-tolerated) future-dated ids. Bounds are independent; omitting both keeps the
+        // all-time semantics of the public getProjectStats API. The window is on TRACE time: only the traces
+        // scan carries the parallel toMonday(id_at) predicate, so only it prunes by partition once traces is
+        // partitioned; the spans scan is bounded by trace_id (correct — a span id may predate its trace) and
+        // will still read all partitions. Span feedback scores follow the trace window via scored_span_ids.
         String uuidFromTime = Objects.toString(instantToUUIDMapper.toLowerBound(fromTime), null);
         String uuidToTime = Objects.toString(instantToUUIDMapper.toUpperBound(toTime), null);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/InstantToUUIDMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/InstantToUUIDMapperTest.java
@@ -206,4 +206,17 @@ class InstantToUUIDMapperTest {
         // This ensures any UUID with this timestamp falls between them
         assertThat(lower).isLessThan(upper);
     }
+
+    @Test
+    void shouldClampPreEpochBoundsToEpochFloor() {
+        // Given a pre-1970 instant: its negative epoch millis would otherwise overflow the unsigned 48-bit
+        // timestamp and wrap into a UUID that sorts above every real id (making `id >= bound` match nothing).
+        Instant preEpoch = Instant.parse("1969-01-01T00:00:00Z");
+
+        // When / Then - both bounds clamp to the epoch floor and stay below a normal id.
+        assertThat(mapper.toLowerBound(preEpoch)).isEqualTo(mapper.toLowerBound(Instant.EPOCH));
+        assertThat(mapper.toUpperBound(preEpoch)).isEqualTo(mapper.toUpperBound(Instant.EPOCH));
+        assertThat(mapper.toLowerBound(preEpoch))
+                .isLessThan(mapper.toLowerBound(Instant.parse("2025-01-15T10:30:00Z")));
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/InstantToUUIDMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/InstantToUUIDMapperTest.java
@@ -209,13 +209,17 @@ class InstantToUUIDMapperTest {
 
     @Test
     void shouldClampPreEpochBoundsToEpochFloor() {
-        // Given a pre-1970 instant: its negative epoch millis would otherwise overflow the unsigned 48-bit
-        // timestamp and wrap into a UUID that sorts above every real id (making `id >= bound` match nothing).
+        // A pre-1970 instant: its negative epoch millis would otherwise overflow the unsigned 48-bit timestamp
+        // and wrap into a UUID that sorts above every real id (making `id >= bound` match nothing). Both bounds
+        // must clamp to the epoch floor. Expected values are the known epoch-floor bit layout, constructed
+        // independently of the mapper so a broken clamp cannot satisfy the assertion by symmetry.
         Instant preEpoch = Instant.parse("1969-01-01T00:00:00Z");
+        UUID epochLower = UUID.fromString("00000000-0000-7000-8000-000000000000");
+        UUID epochUpper = UUID.fromString("00000000-0000-7fff-bfff-ffffffffffff");
 
-        // When / Then - both bounds clamp to the epoch floor and stay below a normal id.
-        assertThat(mapper.toLowerBound(preEpoch)).isEqualTo(mapper.toLowerBound(Instant.EPOCH));
-        assertThat(mapper.toUpperBound(preEpoch)).isEqualTo(mapper.toUpperBound(Instant.EPOCH));
+        assertThat(mapper.toLowerBound(preEpoch)).isEqualTo(epochLower);
+        assertThat(mapper.toUpperBound(preEpoch)).isEqualTo(epochUpper);
+        // And it sorts below a normal id, so `id >= lowerBound` still matches real rows.
         assertThat(mapper.toLowerBound(preEpoch))
                 .isLessThan(mapper.toLowerBound(Instant.parse("2025-01-15T10:30:00Z")));
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
@@ -210,11 +210,20 @@ public class ProjectResourceClient {
 
     public ProjectStatsSummary getProjectStatsSummary(String projectName, @NonNull String apiKey,
             @NonNull String workspaceName, List<TraceFilter> filters) {
+        return getProjectStatsSummary(projectName, apiKey, workspaceName, filters, null);
+    }
+
+    public ProjectStatsSummary getProjectStatsSummary(String projectName, @NonNull String apiKey,
+            @NonNull String workspaceName, List<TraceFilter> filters, Integer windowDays) {
         WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("/stats");
 
         if (StringUtils.isEmpty(projectName)) {
             webTarget = webTarget.queryParam("name", projectName);
+        }
+
+        if (windowDays != null) {
+            webTarget = webTarget.queryParam("window_days", windowDays);
         }
 
         if (filters != null && !filters.isEmpty()) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/ProjectResourceClient.java
@@ -23,6 +23,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -210,11 +211,11 @@ public class ProjectResourceClient {
 
     public ProjectStatsSummary getProjectStatsSummary(String projectName, @NonNull String apiKey,
             @NonNull String workspaceName, List<TraceFilter> filters) {
-        return getProjectStatsSummary(projectName, apiKey, workspaceName, filters, null);
+        return getProjectStatsSummary(projectName, apiKey, workspaceName, filters, null, null);
     }
 
     public ProjectStatsSummary getProjectStatsSummary(String projectName, @NonNull String apiKey,
-            @NonNull String workspaceName, List<TraceFilter> filters, Integer windowDays) {
+            @NonNull String workspaceName, List<TraceFilter> filters, Instant fromTime, Instant toTime) {
         WebTarget webTarget = client.target(RESOURCE_PATH.formatted(baseURI))
                 .path("/stats");
 
@@ -222,8 +223,12 @@ public class ProjectResourceClient {
             webTarget = webTarget.queryParam("name", projectName);
         }
 
-        if (windowDays != null) {
-            webTarget = webTarget.queryParam("window_days", windowDays);
+        if (fromTime != null) {
+            webTarget = webTarget.queryParam("from_time", fromTime);
+        }
+
+        if (toTime != null) {
+            webTarget = webTarget.queryParam("to_time", toTime);
         }
 
         if (filters != null && !filters.isEmpty()) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/GetTracesByProjectResourceTest.java
@@ -3368,6 +3368,43 @@ class GetTracesByProjectResourceTest {
                     values.all(), filters, Map.of());
         }
 
+        @Test
+        @DisplayName("get trace stats without filters aggregates span feedback scores")
+        void getTraceStats__whenNoFilters__thenSpanFeedbackScoresAggregated() {
+            var workspaceName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(10);
+            var traces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
+                    .stream()
+                    .limit(3)
+                    .map(trace -> setCommonTraceDefaults(trace.toBuilder())
+                            .projectName(projectName)
+                            .build())
+                    .collect(Collectors.toCollection(ArrayList::new));
+
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            var traceIdToSpanFeedbackScoresMap = new HashMap<UUID, FeedbackScore>();
+            var traceIdToSpansMap = new HashMap<UUID, List<Span>>();
+            var templateScore = initFeedbackScoreItem().build();
+
+            // Every trace has spans carrying span-level feedback scores. With no filter the stats query
+            // takes the else branch and must still aggregate them through the inverted span-score lookup
+            // (OPIK-7331): span_scores -> scored_span_traces -> span_fs, without a full spans scan.
+            traces.forEach(trace -> processTraceWithFeedbackScores(trace, projectName, apiKey, workspaceName,
+                    templateScore, 70, 90, traceIdToSpansMap, traceIdToSpanFeedbackScoresMap));
+
+            var expectedTraces = enrichTracesWithSpanData(traces, traceIdToSpanFeedbackScoresMap, traceIdToSpansMap);
+
+            var values = traceStatsAssertion.transformTestParams(expectedTraces, expectedTraces, List.of());
+            traceStatsAssertion.assertTest(projectName, null, apiKey, workspaceName, values.expected(),
+                    values.unexpected(), values.all(), List.of(), Map.of());
+        }
+
         private Stream<Arguments> getTracesByProject__whenFilterSpanFeedbackScoresIsEmpty__thenReturnTracesFiltered() {
             return Stream.of(
                     Arguments.of(Operator.IS_NOT_EMPTY,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -2307,6 +2307,44 @@ class ProjectsResourceTest {
             assertSummaryResponse(actualProjectsSummary, expectedProjectsSummary);
         }
 
+        @Test
+        @DisplayName("when window_days is set, then out-of-window (future-dated) traces are excluded")
+        void getProjectStats__whenWindowRequested__thenExcludesOutOfWindowTraces() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            Project project = factory.manufacturePojo(Project.class);
+            UUID projectId = createProject(project, apiKey, workspaceName);
+
+            Instant now = Instant.now();
+            // Two in-window (recent) traces plus one future-dated trace whose id is ahead of now. The future id
+            // is within the ingestion tolerance so the write is accepted, but the window's upper bound (now)
+            // must exclude it — so a requested window sees only the two recent traces, not all three.
+            List<Trace> traces = List.of(
+                    traceWithId(project.name(), now.minus(2, ChronoUnit.HOURS)),
+                    traceWithId(project.name(), now.minus(30, ChronoUnit.MINUTES)),
+                    traceWithId(project.name(), now.plus(3, ChronoUnit.HOURS)));
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            ProjectStatsSummaryItem item = projectResourceClient
+                    .getProjectStatsSummary(project.name(), apiKey, workspaceName, null, 1)
+                    .content().stream()
+                    .filter(i -> projectId.equals(i.projectId()))
+                    .findFirst()
+                    .orElseThrow();
+
+            assertThat(item.traceCount()).isEqualTo(2L);
+        }
+
+        private Trace traceWithId(String projectName, Instant idInstant) {
+            return factory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(projectName)
+                    .id(idGenerator.generateId(idInstant))
+                    .build();
+        }
+
         private void assertSummaryResponse(ProjectStatsSummary actualProjectsSummary,
                 List<ProjectStatsSummaryItem> expectedProjectsSummary) {
             assertThat(actualProjectsSummary.content()).hasSize(expectedProjectsSummary.size());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -2337,6 +2337,90 @@ class ProjectsResourceTest {
             assertThat(item.traceCount()).isEqualTo(1L);
         }
 
+        @Test
+        @DisplayName("when a window covers the data, then every metric column matches the all-time result")
+        void getProjectStats__whenWindowCoversData__thenAllColumnsMatchAllTime() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            Project project = factory.manufacturePojo(Project.class);
+            UUID projectId = createProject(project, apiKey, workspaceName);
+
+            Instant now = Instant.now();
+            Instant traceInstant = now.minus(60, ChronoUnit.MINUTES);
+
+            // Traces get controlled in-window ids. Spans deliberately get near-now ids that fall OUTSIDE the
+            // window below — so if span feedback scores were scoped by the span's own id instead of its
+            // trace's time, they would drop out and this comparison would fail.
+            List<Trace> traces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class).stream()
+                    .map(trace -> {
+                        Instant start = now.minus(30, ChronoUnit.MINUTES);
+                        Instant end = start.plusMillis(PodamUtils.getIntegerInRange(1, 1000));
+                        return trace.toBuilder()
+                                .projectName(project.name())
+                                .id(idGenerator.generateId(traceInstant))
+                                .startTime(start)
+                                .endTime(end)
+                                .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(start, end))
+                                .build();
+                    })
+                    .toList();
+            traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
+
+            traces.forEach(trace -> guardrailsResourceClient.addBatch(
+                    guardrailsGenerator.generateGuardrailsForTrace(trace.id(), idGenerator.generateId(),
+                            trace.projectName()),
+                    apiKey, workspaceName));
+
+            traces.forEach(trace -> {
+                List<Span> spans = PodamFactoryUtils.manufacturePojoList(factory, Span.class).stream()
+                        .map(span -> span.toBuilder()
+                                .id(idGenerator.generateId(now))
+                                .usage(spanResourceClient.getTokenUsage())
+                                .model(spanResourceClient.randomModel().toString())
+                                .provider(spanResourceClient.provider())
+                                .traceId(trace.id())
+                                .projectName(trace.projectName())
+                                .totalEstimatedCost(null)
+                                .build())
+                        .toList();
+                spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+                List<FeedbackScoreBatchItem> manufactured = PodamFactoryUtils.manufacturePojoList(factory,
+                        FeedbackScoreBatchItem.class);
+                List<FeedbackScoreBatchItem> traceScores = manufactured.stream()
+                        .map(score -> score.toBuilder()
+                                .projectId(projectId).projectName(project.name()).id(trace.id()).build())
+                        .collect(Collectors.toList());
+                traceResourceClient.feedbackScores(traceScores, apiKey, workspaceName);
+
+                List<FeedbackScoreBatchItem> spanScores = spans.stream()
+                        .map(span -> {
+                            FeedbackScoreBatchItem item = factory.manufacturePojo(FeedbackScoreBatchItem.class);
+                            return item.toBuilder()
+                                    .projectId(projectId).projectName(project.name()).id(span.id()).build();
+                        })
+                        .collect(Collectors.toList());
+                spanResourceClient.feedbackScores(spanScores, apiKey, workspaceName);
+            });
+
+            var allTime = projectResourceClient.getProjectStatsSummary(project.name(), apiKey, workspaceName);
+            var windowed = projectResourceClient.getProjectStatsSummary(project.name(), apiKey, workspaceName, null,
+                    now.minus(90, ChronoUnit.MINUTES), now.minus(20, ChronoUnit.MINUTES));
+
+            // The all-time path is the trusted one (asserted against exact expected values elsewhere); a window
+            // that contains all the data must reproduce it column-for-column — counts, duration, tokens, cost,
+            // errors, guardrails, and trace+span feedback scores.
+            assertThat(windowed.content())
+                    .usingRecursiveComparison()
+                    .ignoringCollectionOrder()
+                    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+                    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "totalEstimatedCost")
+                    .isEqualTo(allTime.content());
+        }
+
         private Trace traceWithId(String projectName, Instant idInstant) {
             return factory.manufacturePojo(Trace.class).toBuilder()
                     .projectName(projectName)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -2308,7 +2308,7 @@ class ProjectsResourceTest {
         }
 
         @Test
-        @DisplayName("when window_days is set, then out-of-window (future-dated) traces are excluded")
+        @DisplayName("when a time window is requested, then traces outside either bound are excluded")
         void getProjectStats__whenWindowRequested__thenExcludesOutOfWindowTraces() {
             String workspaceName = UUID.randomUUID().toString();
             String apiKey = UUID.randomUUID().toString();
@@ -2319,23 +2319,22 @@ class ProjectsResourceTest {
             UUID projectId = createProject(project, apiKey, workspaceName);
 
             Instant now = Instant.now();
-            // Two in-window (recent) traces plus one future-dated trace whose id is ahead of now. The future id
-            // is within the ingestion tolerance so the write is accepted, but the window's upper bound (now)
-            // must exclude it — so a requested window sees only the two recent traces, not all three.
+            Instant fromTime = now.minus(2, ChronoUnit.HOURS);
+            Instant toTime = now;
             List<Trace> traces = List.of(
-                    traceWithId(project.name(), now.minus(2, ChronoUnit.HOURS)),
-                    traceWithId(project.name(), now.minus(30, ChronoUnit.MINUTES)),
+                    traceWithId(project.name(), now.minus(3, ChronoUnit.HOURS)),
+                    traceWithId(project.name(), now.minus(1, ChronoUnit.HOURS)),
                     traceWithId(project.name(), now.plus(3, ChronoUnit.HOURS)));
             traceResourceClient.batchCreateTraces(traces, apiKey, workspaceName);
 
             ProjectStatsSummaryItem item = projectResourceClient
-                    .getProjectStatsSummary(project.name(), apiKey, workspaceName, null, 1)
+                    .getProjectStatsSummary(project.name(), apiKey, workspaceName, null, fromTime, toTime)
                     .content().stream()
                     .filter(i -> projectId.equals(i.projectId()))
                     .findFirst()
                     .orElseThrow();
 
-            assertThat(item.traceCount()).isEqualTo(2L);
+            assertThat(item.traceCount()).isEqualTo(1L);
         }
 
         private Trace traceWithId(String projectName, Instant idInstant) {

--- a/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
@@ -37,6 +37,11 @@ const getProjectStatisticsList = async (
     logsSource,
   }: UseProjectStatisticsListParams,
 ) => {
+  const now = new Date();
+  const fromTime = new Date(
+    now.getTime() - PROJECT_STATS_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
+
   const { data } = await api.get(`${PROJECTS_REST_ENDPOINT}stats`, {
     signal,
     params: {
@@ -47,7 +52,8 @@ const getProjectStatisticsList = async (
         undefined,
         logsSource ? generateLogsSourceFilter(logsSource) : undefined,
       ),
-      window_days: PROJECT_STATS_WINDOW_DAYS,
+      from_time: fromTime.toISOString(),
+      to_time: now.toISOString(),
       size,
       page,
     },

--- a/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
@@ -17,14 +17,13 @@ type UseProjectStatisticsListParams = {
   page: number;
   size: number;
   logsSource?: LOGS_SOURCE;
+  windowDays?: number;
 };
 
 type UseProjectStatisticsListResponse = {
   content: ProjectStatistic[];
   total: number;
 };
-
-export const PROJECT_STATS_WINDOW_DAYS = 30;
 
 const getProjectStatisticsList = async (
   { signal }: QueryFunctionContext,
@@ -35,12 +34,20 @@ const getProjectStatisticsList = async (
     size,
     page,
     logsSource,
+    windowDays,
   }: UseProjectStatisticsListParams,
 ) => {
-  const now = new Date();
-  const fromTime = new Date(
-    now.getTime() - PROJECT_STATS_WINDOW_DAYS * 24 * 60 * 60 * 1000,
-  );
+  // Opt-in rolling window. Based on windowParams only if present for compatibility with v1.
+  const now = Date.now();
+  const windowParams =
+    windowDays != null
+      ? {
+          from_time: new Date(
+            now - windowDays * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          to_time: new Date(now).toISOString(),
+        }
+      : undefined;
 
   const { data } = await api.get(`${PROJECTS_REST_ENDPOINT}stats`, {
     signal,
@@ -52,8 +59,7 @@ const getProjectStatisticsList = async (
         undefined,
         logsSource ? generateLogsSourceFilter(logsSource) : undefined,
       ),
-      from_time: fromTime.toISOString(),
-      to_time: now.toISOString(),
+      ...windowParams,
       size,
       page,
     },

--- a/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectStatisticList.ts
@@ -24,6 +24,8 @@ type UseProjectStatisticsListResponse = {
   total: number;
 };
 
+export const PROJECT_STATS_WINDOW_DAYS = 30;
+
 const getProjectStatisticsList = async (
   { signal }: QueryFunctionContext,
   {
@@ -45,6 +47,7 @@ const getProjectStatisticsList = async (
         undefined,
         logsSource ? generateLogsSourceFilter(logsSource) : undefined,
       ),
+      window_days: PROJECT_STATS_WINDOW_DAYS,
       size,
       page,
     },

--- a/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
+++ b/apps/opik-frontend/src/hooks/useProjectWithStatisticsList.ts
@@ -13,6 +13,7 @@ type UseProjectWithStatisticsParams = {
   page: number;
   size: number;
   logsSource?: LOGS_SOURCE;
+  windowDays?: number;
 };
 
 type UseProjectWithStatisticsResponse = {
@@ -29,19 +30,22 @@ export default function useProjectWithStatisticsList(
   params: UseProjectWithStatisticsParams,
   config: Omit<UseQueryOptions, "queryKey" | "queryFn">,
 ) {
+  const { windowDays, ...projectsParams } = params;
+
   const {
     data: projectsData,
     isPending,
     isPlaceholderData,
     isFetching,
-  } = useProjectsList(params, {
+  } = useProjectsList(projectsParams, {
     ...config,
     placeholderData: keepPreviousData,
   } as never);
 
   const { data: projectsStatisticData } = useProjectStatisticsList(
     {
-      ...params,
+      ...projectsParams,
+      windowDays,
     },
     {
       ...config,

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
@@ -437,7 +437,12 @@ const ProjectsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-4">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="comet-body-accented truncate break-words">Projects</h1>
+        <div className="min-w-0">
+          <h1 className="comet-body-accented truncate break-words">Projects</h1>
+          <p className="comet-body-s text-muted-slate">
+            Metrics reflect the last 30 days
+          </p>
+        </div>
         {canCreateProjects && (
           <Button variant="default" size="xs" onClick={handleNewProjectClick}>
             <Plus className="mr-1 size-4" />

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
@@ -20,7 +20,6 @@ import IdCell from "@/shared/DataTableCells/IdCell";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import CostCell from "@/shared/DataTableCells/CostCell";
 import useProjectWithStatisticsList from "@/hooks/useProjectWithStatisticsList";
-import { PROJECT_STATS_WINDOW_DAYS } from "@/api/projects/useProjectStatisticList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { ProjectWithStatistic } from "@/types/projects";
 import AddEditProjectDialog from "@/v2/pages-shared/ProjectsPage/AddEditProjectDialog";
@@ -113,6 +112,7 @@ export const DEFAULT_SORTING_COLUMNS: ColumnSort[] = [
   },
 ];
 
+const PROJECT_STATS_WINDOW_DAYS = 30;
 const WINDOW_SUFFIX = ` (${PROJECT_STATS_WINDOW_DAYS}d)`;
 
 const ProjectsPage: React.FunctionComponent = () => {
@@ -341,6 +341,7 @@ const ProjectsPage: React.FunctionComponent = () => {
         page: page!,
         size: size!,
         logsSource: LOGS_SOURCE.sdk,
+        windowDays: PROJECT_STATS_WINDOW_DAYS,
       },
       {
         placeholderData: keepPreviousData,

--- a/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectsPage/ProjectsPage.tsx
@@ -20,6 +20,7 @@ import IdCell from "@/shared/DataTableCells/IdCell";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import CostCell from "@/shared/DataTableCells/CostCell";
 import useProjectWithStatisticsList from "@/hooks/useProjectWithStatisticsList";
+import { PROJECT_STATS_WINDOW_DAYS } from "@/api/projects/useProjectStatisticList";
 import useQueryParamAndLocalStorageState from "@/hooks/useQueryParamAndLocalStorageState";
 import { ProjectWithStatistic } from "@/types/projects";
 import AddEditProjectDialog from "@/v2/pages-shared/ProjectsPage/AddEditProjectDialog";
@@ -112,6 +113,8 @@ export const DEFAULT_SORTING_COLUMNS: ColumnSort[] = [
   },
 ];
 
+const WINDOW_SUFFIX = ` (${PROJECT_STATS_WINDOW_DAYS}d)`;
+
 const ProjectsPage: React.FunctionComponent = () => {
   const navigate = useNavigate();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -141,44 +144,44 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "duration.p50",
-        label: "Avg duration",
+        label: `Avg duration${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.duration,
         accessorFn: (row) => row.duration?.p50,
         cell: DurationCell as never,
       },
       {
         id: "duration.p90",
-        label: "Duration (p90)",
+        label: `Duration (p90)${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.duration,
         accessorFn: (row) => row.duration?.p90,
         cell: DurationCell as never,
       },
       {
         id: "duration.p99",
-        label: "Duration (p99)",
+        label: `Duration (p99)${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.duration,
         accessorFn: (row) => row.duration?.p99,
         cell: DurationCell as never,
       },
       {
         id: "total_estimated_cost_sum",
-        label: "Total cost",
+        label: `Total cost${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.cost,
         cell: CostCell as never,
       },
       {
         id: "trace_count",
-        label: "Trace count",
+        label: `Trace count${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.number,
       },
       {
         id: "thread_count",
-        label: "Thread count",
+        label: `Thread count${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.number,
       },
       {
         id: "error_count",
-        label: "Errors",
+        label: `Errors${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.errors,
         cell: ErrorsCountCell as never,
         customMeta: {
@@ -206,7 +209,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.total_tokens",
-        label: "Avg total tokens",
+        label: `Avg total tokens${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.total_tokens)
@@ -215,7 +218,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.prompt_tokens",
-        label: "Avg input tokens",
+        label: `Avg input tokens${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.prompt_tokens)
@@ -224,7 +227,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: "usage.completion_tokens",
-        label: "Avg output tokens",
+        label: `Avg output tokens${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.number,
         accessorFn: (row) =>
           row.usage && isNumber(row.usage.completion_tokens)
@@ -233,7 +236,7 @@ const ProjectsPage: React.FunctionComponent = () => {
       },
       {
         id: COLUMN_FEEDBACK_SCORES_ID,
-        label: "Avg feedback scores",
+        label: `Avg feedback scores${WINDOW_SUFFIX}`,
         type: COLUMN_TYPE.numberDictionary,
         accessorFn: (row) => get(row, "feedback_scores", []),
         cell: FeedbackScoreListCell as never,
@@ -247,7 +250,7 @@ const ProjectsPage: React.FunctionComponent = () => {
         ? [
             {
               id: COLUMN_GUARDRAILS_ID,
-              label: "Guardrails",
+              label: `Guardrails${WINDOW_SUFFIX}`,
               type: COLUMN_TYPE.category,
               iconType: "guardrails" as HeaderIconType,
               accessorFn: (row: ProjectWithStatistic) =>
@@ -437,12 +440,7 @@ const ProjectsPage: React.FunctionComponent = () => {
   return (
     <div className="pt-4">
       <div className="mb-4 flex items-center justify-between">
-        <div className="min-w-0">
-          <h1 className="comet-body-accented truncate break-words">Projects</h1>
-          <p className="comet-body-s text-muted-slate">
-            Metrics reflect the last 30 days
-          </p>
-        </div>
+        <h1 className="comet-body-accented truncate break-words">Projects</h1>
         {canCreateProjects && (
           <Button variant="default" size="xs" onClick={handleNewProjectClick}>
             <Plus className="mr-1 size-4" />


### PR DESCRIPTION
## Details

Optimizes the projects-list stats query (`get_trace_stats_feedback_scores` / `SELECT_FEEDBACK_SCORES_STATS` in `TraceDAO`), the single heaviest query on the analytics database, with two independent measures:

**1. Invert the span-feedback-score lookup.** The query computed per-project span-level feedback-score aggregates by scanning every span for the queried projects and intersecting them with the (usually tiny) set of span feedback scores — reading tens to hundreds of millions of span rows to serve a handful (often zero) of scores. This inverts the join to drive from the small, selective side: read the span scores first from `authored_feedback_scores` (index-cheap), then look those specific spans up via the `idx_spans_id` minmax index (`scored_span_ids`), keeping the same source/time-matched trace scoping. Output is unchanged and the spans read is a strict subset of the previous query, so it can never read more.

We validated the spans-vs-span-scores distribution across the heaviest production workspaces (including a large single-tenant deployment): the tenants that actually drive this expensive query have ~0 span-level feedback scores — their heavy scoring is trace-level — so the inverted lookup removes the spans scan entirely for them; the only workspaces where span-scores exceed spans are tiny (tens of thousands of spans), where the query is trivially cheap and measured at worst break-even. Net: a large win at scale with no realistic regression.

**2. Add an opt-in time window to projects-list stats.** `GET /v1/private/projects/stats` gains optional `from_time` / `to_time` query params (ISO-8601 `Instant`), matching the existing `getTracesByProject` / `getSpansByProject` convention. When set, every aggregate column (trace/thread counts, duration, tokens, cost, errors, guardrails, feedback and span-feedback scores) is scoped to that range via `uuid_from_time`/`uuid_to_time` on the time-ordered UUIDv7 id — one uniform boundary across all metrics, each bound applied independently. When both are omitted, the aggregates stay all-time, so the public `getProjectStats` API keeps its existing semantics (backward-compatible). Sending an explicit `to_time` matters because future-dated ids (clock skew / buggy clients) do occur in prod and would otherwise never age out of the window. It prunes by the sort key today; once the tables are partitioned by time, the *traces* scan prunes by partition (it carries the parallel `toMonday(id_at)` predicate), while the *spans* scan stays bounded by `trace_id` (the correct trace-time bound, since a span id isn't guaranteed to postdate its trace) — a follow-up if the spans side becomes the bottleneck. Span feedback scores follow the same trace-time window via `scored_span_ids`, not the span's own id. The window is opt-in at the shared FE hook, so only the v2 Projects table requests it (last 30 days, `(30d)` column suffix); v1 surfaces and other consumers keep the all-time aggregates.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7331

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: assisted (investigation, query rewrite, distribution analysis, tests)
- Human verification: production query_log before/after validation on real workspaces, integration tests, code review

## Testing

- Backend integration tests (`mvn test`): `ProjectsResourceTest$ProjectErrorCountTests` (incl. the all-time default path and a `from_time`/`to_time` opt-in test that seeds a future-dated trace and asserts it is excluded by the window's upper bound) and the span-feedback-score stats tests in `GetTracesByProjectResourceTest$FilterTest` (filtered and no-filter branches) pass; `mvn spotless:check`, frontend `eslint` and `typecheck` pass.
- Verified on production analytics replicas: ran the current vs. rewritten span-score query for the same projects with byte-for-byte identical results, comparing `read_rows` / `memory_usage` / duration from `query_log` — roughly 60-88% fewer rows/less memory and ~3x faster on affected workspaces, at worst break-even on the highest-ratio ones. Separately confirmed the 30-day window excludes old data (85-99% fewer traces scanned on large workspaces) and audited every column's window predicate for consistency.
- The window test exercises both bounds in one shot with a narrow, fully-recent window (last 2h): three traces at `now-3h` (before `from_time`), `now-1h` (in range), and `now+3h` (after `to_time`) are all within the 24h ingestion tolerance so all three are written, yet only the middle one is counted — so the test fails if either `uuid_from_time` or `uuid_to_time` is dropped.
- A second test asserts the windowed summary equals the all-time summary **column-for-column** (counts, duration, tokens, cost, errors, guardrails, threads, and trace+span feedback scores) for data that fits inside the window — reducing every column's windowed correctness to the trusted all-time path. It seeds spans whose own ids fall outside the window while their trace is inside, so it also guards the span-feedback-score bound (trace-time, not span-id).

## Documentation

N/A