### PR TITLE
[OPIK-7653] test: add visual test coverage for logs spans view and trace sidebar agent graph tab

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -209,8 +209,8 @@ areas:
       trace-sidebar-details:  { covered: true,  state: default, spec: "trace-sidebar.spec.ts S02" }
       trace-sidebar-feedback: { covered: true,  state: default, spec: "trace-sidebar.spec.ts S03" }
       trace-sidebar-prompts:  { covered: true,  state: default, spec: "trace-sidebar.spec.ts S04" }
-      logs-spans-view:        { covered: false, state: default }
-      trace-sidebar-agent-graph: { covered: false, state: default }
+      logs-spans-view:        { covered: true,  state: default, spec: "visual-comparison.spec.ts 07" }
+      trace-sidebar-agent-graph: { covered: true, state: default, spec: "trace-sidebar.spec.ts S05" }
 
     # ---- load dimension (opt-in; axis-shaped; status: planned) ----
     load:

--- a/tests_end_to_end/test-helper-service/routes/traces.py
+++ b/tests_end_to_end/test-helper-service/routes/traces.py
@@ -376,6 +376,46 @@ def create_rich_trace_for_sidebar():
     )
 
 
+@traces_bp.route("/create-trace-with-agent-graph-span", methods=["POST"])
+def create_trace_with_agent_graph_span():
+    data = request.get_json()
+    validate_required_fields(data, ["project_name", "trace_name"])
+
+    project_name = data["project_name"]
+    trace_name = data["trace_name"]
+
+    client = get_opik_client()
+
+    # Fixed start/end time so the sidebar always renders a "0s" duration badge.
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    trace = client.trace(
+        name=trace_name,
+        project_name=project_name,
+        input={"messages": [{"role": "user", "content": "Plan a trip to Paris"}]},
+        output={"choices": [{"message": {"role": "assistant", "content": "Here is your itinerary."}}]},
+        start_time=now,
+        end_time=now,
+    )
+
+    span_name = "orchestrator"
+    trace.span(
+        name=span_name,
+        input={"input": "Plan a trip to Paris"},
+        output={"output": "Here is your itinerary."},
+        start_time=now,
+        end_time=now,
+        metadata={
+            "_opik_graph_definition": {
+                "format": "mermaid",
+                "data": "graph TD;\n  Orchestrator-->Researcher;\n  Orchestrator-->Planner;\n  Planner-->Booking;",
+            },
+        },
+    )
+
+    return success_response({"span_name": span_name})
+
+
 @traces_bp.route("/get-traces", methods=["POST"])
 def get_traces():
     data = request.get_json()

--- a/tests_end_to_end/visual-tests/helpers/test-helper-client.ts
+++ b/tests_end_to_end/visual-tests/helpers/test-helper-client.ts
@@ -591,6 +591,22 @@ export class TestHelperClient {
     }
   }
 
+  async createTraceWithAgentGraphSpan(
+    projectName: string,
+    traceName: string
+  ): Promise<{ spanName: string }> {
+    try {
+      const response = await this.client.post('/api/traces/create-trace-with-agent-graph-span', {
+        project_name: projectName,
+        trace_name: traceName,
+      });
+
+      return { spanName: response.data.span_name };
+    } catch (error) {
+      throw this.handleError(error, 'Failed to create trace with agent graph span');
+    }
+  }
+
   async searchTraces(
     projectName: string,
     options?: {

--- a/tests_end_to_end/visual-tests/page-objects/logs.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/logs.page.ts
@@ -32,6 +32,18 @@ export class LogsPage extends BasePage {
     ]);
   }
 
+  async switchToSpans(): Promise<void> {
+    await this.page.getByRole('radio', { name: 'Spans' }).click();
+    await this.page.waitForLoadState('load');
+  }
+
+  async waitForSpansReady(expectedCellText: string): Promise<void> {
+    await Promise.race([
+      this.page.locator('tbody tr td').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 20000 }),
+      this.page.getByRole('heading', { name: /no spans yet/i }).waitFor({ state: 'visible', timeout: 20000 }),
+    ]);
+  }
+
   async openTrace(rowText: string): Promise<void> {
     await this.page.locator('tbody tr').filter({ hasText: rowText }).first().click();
     await this.page.waitForURL(url => url.searchParams.get('trace') !== null, { timeout: 20000 });

--- a/tests_end_to_end/visual-tests/page-objects/trace-details-panel.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/trace-details-panel.page.ts
@@ -33,4 +33,20 @@ export class TraceDetailsPanelPage {
     await tabPanel.waitFor({ state: 'visible', timeout: 15000 });
     await tabPanel.getByText('Loading', { exact: true }).waitFor({ state: 'hidden', timeout: 15000 });
   }
+
+  /** A node in the trace/span tree, keyed by the span/trace name. */
+  spanTreeNode(name: string): Locator {
+    return this.root.getByTestId(`trace-tree-node-${name}`);
+  }
+
+  /** Select a span in the tree, switching the data viewer to that span's data. */
+  async selectSpan(name: string): Promise<void> {
+    await this.spanTreeNode(name).click();
+    await this.page.waitForURL((url) => (url.searchParams.get('span') ?? '') !== '');
+  }
+
+  /** Mermaid renders asynchronously with no loading placeholder — wait for its SVG output. */
+  async waitForAgentGraphRendered(): Promise<void> {
+    await this.root.locator('.mermaid svg').waitFor({ state: 'visible', timeout: 15000 });
+  }
 }

--- a/tests_end_to_end/visual-tests/tests/trace-sidebar.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/trace-sidebar.spec.ts
@@ -12,6 +12,11 @@ const ATTACHMENT_PATH = 'visual-tests/fixtures/sidebar-attachment.png';
 // The traces table doesn't show a Name column by default, so rows are located by their input text instead.
 const TRACE_INPUT_TEXT = 'What is Opik?';
 
+// A separate trace (not the rich sidebar trace above) so its extra span doesn't
+// add a row to that trace's tree and shift the S01-S04 baselines.
+const AGENT_GRAPH_TRACE_NAME = 'visual-sidebar-agent-graph-trace';
+const AGENT_GRAPH_TRACE_INPUT_TEXT = 'Plan a trip to Paris';
+
 test.setTimeout(300000);
 
 test.describe('Visual Comparison - Trace Sidebar', () => {
@@ -22,6 +27,7 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
   test.beforeAll(async ({ browser }) => {
     const client = new TestHelperClient();
     await client.createRichTraceForSidebar(projectName(), TRACE_NAME, PROMPT_NAME, ATTACHMENT_PATH);
+    await client.createTraceWithAgentGraphSpan(projectName(), AGENT_GRAPH_TRACE_NAME);
 
     const page = await browser.newPage();
     const projectsPage = new ProjectsPage(page, baseUrl, workspace);
@@ -83,5 +89,19 @@ test.describe('Visual Comparison - Trace Sidebar', () => {
     await panel.selectTab('Prompts');
     await panel.root.getByText(PROMPT_NAME).waitFor({ state: 'visible' });
     await screenshot(page, 'S04-trace-sidebar-prompts', [panel.statsRowMask]);
+  });
+
+  test('S05: Trace sidebar - Agent graph tab', { tag: ['@vcap:traces.trace-sidebar-agent-graph'] }, async ({ page }) => {
+    const logsPage = new LogsPage(page, baseUrl, workspace);
+    await logsPage.goto(projectId);
+    await logsPage.waitForTracesReady(AGENT_GRAPH_TRACE_INPUT_TEXT);
+    await logsPage.openTrace(AGENT_GRAPH_TRACE_INPUT_TEXT);
+
+    const panel = new TraceDetailsPanelPage(page);
+    await panel.waitForLoaded();
+    await panel.selectSpan('orchestrator');
+    await panel.selectTab('Agent graph');
+    await panel.waitForAgentGraphRendered();
+    await screenshot(page, 'S05-trace-sidebar-agent-graph', [panel.statsRowMask]);
   });
 });

--- a/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/visual-comparison.spec.ts
@@ -114,4 +114,12 @@ test.describe('Visual Comparison - Opik UI', () => {
     await experimentsPage.waitForExperiment(experimentName());
     await screenshot(page, '06-experiments-page', tableMasks(page));
   });
+
+  test('07: Logs - Spans view', { tag: ['@vcap:traces.logs-spans-view'] }, async ({ page }) => {
+    const logsPage = new LogsPage(page, baseUrl, workspace);
+    await logsPage.goto(projectId);
+    await logsPage.switchToSpans();
+    await logsPage.waitForSpansReady('input-0');
+    await screenshot(page, '07-logs-spans', tableMasks(page));
+  });
 });


### PR DESCRIPTION
## Details
Adds two missing visual test cases: coverage for the Logs page Spans view, and coverage for the trace sidebar's Agent graph tab. Both areas were listed as uncovered in the visual test taxonomy.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7653


## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation
- Human verification: code review

## Testing
Added two new visual regression tests under `tests_end_to_end/visual-tests/`:
- `visual-comparison.spec.ts` test `07: Logs - Spans view` — switches the Logs page to the Spans view and screenshots it.
- `trace-sidebar.spec.ts` test `S05: Trace sidebar - Agent graph tab` — creates a trace with a span carrying a mermaid agent-graph definition via a new test-helper-service endpoint, opens the span in the sidebar, and screenshots the rendered Agent graph tab.

Updated `tests_end_to_end/coverage/taxonomy.yaml` to mark `logs-spans-view` and `trace-sidebar-agent-graph` as covered.

## Documentation
N/A
