### PR TITLE
[NA] [PYBE] fix: pin litellm to 1.94.1 to unbreak the image build

### DIFF
--- a/apps/opik-python-backend/requirements.txt
+++ b/apps/opik-python-backend/requirements.txt
@@ -35,5 +35,9 @@ opik-optimizer==3.1.1
 # template markers and the reflection_prompt_template kwarg, neither of which
 # exists on 0.0.x. See OPIK-7510 / OPIK-7639.
 gepa==0.0.17
+# Transitive via opik-optimizer, pinned because this image builds it from source: litellm
+# publishes no musllinux or pure-python wheel, and 1.95.0 raised its Rust dependencies to
+# aws-* crates requiring rustc 1.94.1, while the Alpine builder ships rustc 1.91.1.
+litellm==1.94.1
 pyrate-limiter>=3.0.0,<4.0.0
 python-jsonpath>=2.0.0,<3.0.0


### PR DESCRIPTION
## Details

`main` has two red workflows since 2026-08-02, both from the same cause and neither from a change on
our side:

| Workflow | Fails at | Result |
|---|---|---|
| `Build Opik Docker Images` | `Build and Push Docker Image` (amd64 **and** arm64) | no images published |
| `E2E Tests - Post Merge (v2)` | `🔨 Build and start Opik server` | suite never runs; zero tests executed |

`litellm` is not pinned — it arrives transitively through `opik-optimizer==3.1.1` — so the build
resolves whatever is newest, and `litellm 1.95.0` was published that morning. Pinning it to
`1.94.1`, the version the last green build used, restores both.

Why the new release breaks the image: `litellm` publishes no musllinux or pure-python wheel, so this
Alpine-based image compiles it from the sdist. `1.95.0` added a Rust extension
(`litellm-rust/crates/python-bridge`) whose dependencies are the AWS SDK crates, with an MSRV of
rustc 1.94.1, while the builder installs Rust from Alpine's repos (rustc 1.91.1):

```
× Failed to build `litellm==1.95.0`
╰─▶ Call to `maturin.build_wheel` failed (exit status: 1)
    error: rustc 1.91.1 is not supported by the following packages:
      aws-config@1.9.0            requires rustc 1.94.1
      aws-credential-types@1.3.0  requires rustc 1.94.1
      aws-runtime@1.8.1           requires rustc 1.94.1
      aws-sdk-sts@1.108.0         requires rustc 1.94.1
      aws-sigv4@1.5.1             requires rustc 1.94.1
      aws-smithy-async@1.3.0      requires rustc 1.94.1
    💥 maturin failed

hint: `litellm` (v1.95.0) was included because `opik-optimizer` (v3.1.1) depends on `litellm`
```

The Dockerfile comment above `apk add … rust cargo` states the toolchain is there "only for
compiling native wheels (rust/cargo for pydantic-core)", so a transitive dependency pulling a whole
Rust SDK was never in scope for it.

Follow-up worth considering separately: install a newer rustc in the builder stage (Alpine
edge/testing or rustup) so the image is not held to whatever MSRV upstream crates adopt next. This
PR deliberately does the smaller thing — an unpinned transitive dependency in a Docker build is the
defect that let an upstream release break `main` unannounced.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: diagnosis of the two failing workflows and the one-line pin plus its comment.
- Human verification: reviewed by the author, who also triggered the build and E2E runs on this
  branch.

## Testing

Version chosen by comparing the failing and last-green builds rather than by guessing:

- Last green run of `Build Opik Docker Images` on `main` (run `30645351801`, 2026-07-31) installed
  `litellm==1.94.1`; the first red run (`30739293214`, 2026-08-02) resolved `litellm==1.95.0`.
- PyPI shows `1.95.0` uploaded 2026-08-02, matching the first failure the same day.
- Neither `1.94.1` nor `1.95.0` ships a musllinux or `py3-none-any` wheel, confirming both are built
  from sdist on this image and that the difference is the crate graph, not packaging.
- `opik-optimizer==3.1.1` declares `litellm!=1.81.*,!=1.82.*,!=1.83.0..6,!=1.92.*,>=1.79.2`, so
  `1.94.1` satisfies its constraint.
- The same `maturin`/rustc failure appears in the post-merge E2E log (run `30739293070`), which is
  why both workflows are covered by this one-line change.

Both failing workflows were then re-run on this branch and pass:

- `Build Opik Docker Images` (run `30743029800`) — `amd64 opik-python-backend`, `arm64
  opik-python-backend` and `merge (regular)` all green, i.e. the two jobs that fail on `main`.
- `E2E Tests v2 (t1)` (run `30743068524`) — 13m36s, green through `🔨 Build and start Opik server`,
  `🔍 Verify Docker pods are running`, `🏥 Verify backend health` and `🧪 Run E2E test suite`. On
  `main` the run dies at the build step and the suite never executes.

## Documentation

None — the pin carries an inline comment explaining why it exists and what has to be true before it
can be lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
