### PR TITLE
[OPIK-7706] [DOCS] docs: document AssertJ whole-object assertion conventions

### DIFF
--- a/.agents/skills/opik-backend/testing.md
+++ b/.agents/skills/opik-backend/testing.md
@@ -284,6 +284,27 @@ assertThat(actual)
 `containsExactly` asserts size and content together — `hasSize` plus per-index checks does not,
 and lets an extra element through.
 
+These `containsExactly*` variants compare elements with the element type's own `equals`, which is
+what you want for exact-valued models. When the elements carry `BigDecimal` or `double`, the same
+exception that justifies a comparator on a single object applies per element — otherwise a
+difference in numeric scale fails the assertion even though the values are equal:
+
+```java
+// ✅ GOOD - inexact numeric elements (see TraceAssertions for the real usage)
+var config = new RecursiveComparisonConfiguration();
+config.ignoreFields(IGNORED_FIELDS_SCORES);
+config.registerComparatorForType(BigDecimal::compareTo, BigDecimal.class);
+
+assertThat(actual.feedbackScores())
+    .usingRecursiveFieldByFieldElementComparator(config)
+    .containsExactlyInAnyOrderElementsOf(expected.feedbackScores());
+```
+
+This is the same escalation rule as for single objects, not a separate one: plain
+`containsExactly*` by default, element comparator only when an element field can't be compared by
+`equals`. `FeedbackScore.value` is a `BigDecimal`, which is why
+`api/resources/utils/traces/TraceAssertions.java` needs it — most models don't.
+
 ### When Per-Field Assertions Are Still Right
 
 - **Spot checks against literals** — `assertThat(result.getName()).isEqualTo("John Doe")` is not

--- a/.agents/skills/opik-backend/testing.md
+++ b/.agents/skills/opik-backend/testing.md
@@ -155,12 +155,16 @@ assertThatThrownBy(() -> service.create(invalid))
     .hasMessageContaining("Name is required");
 ```
 
-### Comparing Two Objects — Use Recursive Comparison
+### Comparing Two Objects — Plain `isEqualTo` by Default
 
 Comparing two objects field by field is the default failure mode to avoid. It isn't just
 verbose: when a field is later added to the record, the test keeps passing while silently not
 covering the new field. Nothing fails and nothing flags it, so coverage erodes with every model
 change.
+
+Compare the whole object instead. `equals`/`hashCode` are the source of truth for equality in
+Java, so plain `isEqualTo` is the default — our API models are overwhelmingly records, whose
+generated `equals` covers every component and picks up new ones automatically:
 
 ```java
 // ❌ BAD - add a field to the record later and this still passes, now covering less
@@ -169,19 +173,40 @@ assertThat(actual.temperature()).isEqualTo(request.temperature());
 assertThat(actual.topP()).isEqualTo(request.topP());
 assertThat(actual.maxOutputTokens()).isEqualTo(request.maxCompletionTokens());
 
-// ✅ GOOD - new fields are compared automatically
+// ✅ GOOD - new components are compared automatically, via the type's own equals
+assertThat(actual).isEqualTo(expected);
+```
+
+Prefer records for new models. For Java POJOs/Beans that need equality, implement it with Lombok
+— `@Value`, `@Data`, `@EqualsAndHashCode`, in that order of preference — rather than reaching for
+reflection-based comparison in the test.
+
+### When to Use `usingRecursiveComparison`
+
+`usingRecursiveComparison` bypasses `equals` and walks fields reflectively via AssertJ internals.
+That is the right tool only for **exceptional cases**:
+
+- **Excluding fields** from the comparison (`ignoringFields`).
+- **Applying an AssertJ feature** during comparison, such as a custom comparator.
+- **The type has no usable `equals`/`hashCode`** — realistically only third-party types we don't
+  control. For our own code, fix the model instead.
+
+```java
+// ✅ GOOD - exceptional case: server-generated fields must be excluded
 assertThat(actual)
     .usingRecursiveComparison()
+    .ignoringFields("id", "createdAt", "createdBy", "lastUpdatedAt", "lastUpdatedBy")
     .isEqualTo(expected);
 ```
 
-`isEqualTo` alone works only when the type's `equals` covers what you mean — which is not true
-once you need to skip server-generated fields or compare `BigDecimal` by value. Prefer recursive
-comparison for object-to-object assertions.
+Recursive comparison is widespread in this codebase, largely as a side effect of JSON views on
+response objects rather than a deliberate default. Existing bare
+`usingRecursiveComparison().isEqualTo(...)` calls with no exclusion or comparator are not the
+pattern to copy — a plain `isEqualTo` is what those want.
 
 ### Partial Comparison — `ignoringFields`, Not Dropped Assertions
 
-When only some fields should match, still use recursive comparison and name the exclusions. The
+When only some fields should match, use recursive comparison and name the exclusions. The
 ignore list is then explicit and reviewable, instead of the exclusions being implied by whichever
 assertions someone chose not to write.
 
@@ -216,9 +241,10 @@ assertThat(actual.lastUpdatedAt()).isAfter(expected.lastUpdatedAt());
 
 ### Comparators, Not Exclusions, for Inexact Types
 
-Don't ignore a field just because it doesn't compare exactly. `BigDecimal.equals` is
-scale-sensitive and doubles need an epsilon, so give the comparison a comparator and keep the
-field covered:
+Inexact types are the second exceptional case: `BigDecimal.equals` is scale-sensitive and doubles
+need an epsilon, so plain `isEqualTo` on the whole object is too strict. Reach for recursive
+comparison here — but give it a comparator rather than ignoring the field, so the field stays
+covered:
 
 ```java
 // ❌ BAD - the field is now untested
@@ -261,12 +287,14 @@ and lets an extra element through.
 ### When Per-Field Assertions Are Still Right
 
 - **Spot checks against literals** — `assertThat(result.getName()).isEqualTo("John Doe")` is not
-  an object comparison and needs no recursive machinery.
+  an object comparison at all.
 - **Non-equality semantics** — `isAfter`, `isNotNull`, `isNotBlank`, `hasMessageContaining`.
 - **Deliberately narrow assertions on an ignored field**, as shown above.
 
 The rule targets *object-to-object* field-by-field comparison, not every use of a single-field
-assertion.
+assertion. In short: compare whole objects with `isEqualTo`, escalate to
+`usingRecursiveComparison` only for the exceptional cases above, and keep per-field assertions for
+the cases in this list.
 
 ## Don't Run Two ClickHouse-Migrating Test Classes in One `mvn` Reactor
 

--- a/.agents/skills/opik-backend/testing.md
+++ b/.agents/skills/opik-backend/testing.md
@@ -145,10 +145,7 @@ Awaitility.await()
 ## Assertion Patterns
 
 ```java
-// Object equality when you have expected object
-assertThat(actualUser).isEqualTo(expectedUser);
-
-// Field assertions for specific checks
+// Spot checks against literals - fine, this is not an object comparison
 assertThat(result.getName()).isEqualTo("John Doe");
 assertThat(result.getId()).isNotBlank();
 
@@ -157,6 +154,119 @@ assertThatThrownBy(() -> service.create(invalid))
     .isInstanceOf(BadRequestException.class)
     .hasMessageContaining("Name is required");
 ```
+
+### Comparing Two Objects — Use Recursive Comparison
+
+Comparing two objects field by field is the default failure mode to avoid. It isn't just
+verbose: when a field is later added to the record, the test keeps passing while silently not
+covering the new field. Nothing fails and nothing flags it, so coverage erodes with every model
+change.
+
+```java
+// ❌ BAD - add a field to the record later and this still passes, now covering less
+assertThat(actual.modelName()).isEqualTo(request.model());
+assertThat(actual.temperature()).isEqualTo(request.temperature());
+assertThat(actual.topP()).isEqualTo(request.topP());
+assertThat(actual.maxOutputTokens()).isEqualTo(request.maxCompletionTokens());
+
+// ✅ GOOD - new fields are compared automatically
+assertThat(actual)
+    .usingRecursiveComparison()
+    .isEqualTo(expected);
+```
+
+`isEqualTo` alone works only when the type's `equals` covers what you mean — which is not true
+once you need to skip server-generated fields or compare `BigDecimal` by value. Prefer recursive
+comparison for object-to-object assertions.
+
+### Partial Comparison — `ignoringFields`, Not Dropped Assertions
+
+When only some fields should match, still use recursive comparison and name the exclusions. The
+ignore list is then explicit and reviewable, instead of the exclusions being implied by whichever
+assertions someone chose not to write.
+
+```java
+// ❌ BAD - which fields are deliberately unchecked? Unknowable from the test
+assertThat(actual.name()).isEqualTo(expected.name());
+assertThat(actual.projectId()).isEqualTo(expected.projectId());
+
+// ✅ GOOD - exclusions are visible and reviewed
+assertThat(actual)
+    .usingRecursiveComparison()
+    .ignoringFields("id", "createdAt", "createdBy", "lastUpdatedAt", "lastUpdatedBy")
+    .isEqualTo(expected);
+```
+
+Server-generated audit fields (`id`, `createdAt`, `createdBy`, `lastUpdatedAt`, `lastUpdatedBy`)
+are the usual exclusions. Hoist a shared list into a constant when a test class repeats it — see
+`EXPERIMENT_IGNORED_FIELDS` in `api/resources/utils/resources/ExperimentTestAssertions.java`.
+
+Ignoring a field and then asserting it separately is a deliberate, valid idiom — not a
+redundancy — when the field needs different semantics than plain equality:
+
+```java
+// ✅ GOOD - lastUpdatedAt is ignored above so each caller can pick == vs isAfter
+assertThat(actual)
+    .usingRecursiveComparison()
+    .ignoringFields(EXPERIMENT_IGNORED_FIELDS)
+    .isEqualTo(expected);
+
+assertThat(actual.lastUpdatedAt()).isAfter(expected.lastUpdatedAt());
+```
+
+### Comparators, Not Exclusions, for Inexact Types
+
+Don't ignore a field just because it doesn't compare exactly. `BigDecimal.equals` is
+scale-sensitive and doubles need an epsilon, so give the comparison a comparator and keep the
+field covered:
+
+```java
+// ❌ BAD - the field is now untested
+.ignoringFields("totalEstimatedCost")
+
+// ✅ GOOD - still asserted, compared by value
+assertThat(actual)
+    .usingRecursiveComparison()
+    .withComparatorForType(StatsUtils::bigDecimalComparator, BigDecimal.class)
+    .withComparatorForFields(StatsUtils::closeToEpsilonComparator, "duration")
+    .isEqualTo(expected);
+```
+
+### Collections — `containsExactly`, Not Index-by-Index
+
+```java
+// ❌ BAD - misses a 4th unexpected element entirely
+assertThat(page.content().get(0).name()).isEqualTo("Alice");
+assertThat(page.content().get(1).name()).isEqualTo("Bob");
+assertThat(page.content().get(2).name()).isEqualTo("Charlie");
+
+// ✅ GOOD - order matters (sorting/pagination tests)
+assertThat(page.content())
+    .extracting(Entity::getName)
+    .containsExactly("Alice", "Bob", "Charlie");
+
+// ✅ GOOD - order is not part of the contract
+assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+
+// ✅ GOOD - whole objects, order-insensitive nested collections
+assertThat(actual)
+    .usingRecursiveComparison()
+    .ignoringCollectionOrderInFields("feedbackScores", "comments")
+    .isEqualTo(expected);
+```
+
+`containsExactly` asserts size and content together — `hasSize` plus per-index checks does not,
+and lets an extra element through.
+
+### When Per-Field Assertions Are Still Right
+
+- **Spot checks against literals** — `assertThat(result.getName()).isEqualTo("John Doe")` is not
+  an object comparison and needs no recursive machinery.
+- **Non-equality semantics** — `isAfter`, `isNotNull`, `isNotBlank`, `hasMessageContaining`.
+- **Deliberately narrow assertions on an ignored field**, as shown above.
+
+The rule targets *object-to-object* field-by-field comparison, not every use of a single-field
+assertion.
 
 ## Don't Run Two ClickHouse-Migrating Test Classes in One `mvn` Reactor
 


### PR DESCRIPTION
## Details

<img width="915" height="1240" alt="image" src="https://github.com/user-attachments/assets/147814b4-cc46-4a3d-b37e-ae1c9a1bc17d" />

Documents `usingRecursiveComparison()` as the default for object-to-object equality in backend Java tests, and `containsExactly` / `containsExactlyInAnyOrder` for collections. The motivation is correctness rather than brevity: when a field is later added to a record, a field-by-field test keeps passing while silently not covering the new field — nothing fails and nothing flags it, so assertion coverage erodes with every model change.

The convention was already in practice (45 of 431 backend test files use recursive comparison) but was never written down, so it wasn't applied consistently. The `## Assertion Patterns` section of the backend testing skill didn't mention it at all.

- Partial comparisons must use `ignoringFields(...)` rather than dropped assertions, so exclusions stay explicit and reviewable instead of being implied by whichever assertions someone chose not to write.
- Inexact types (`BigDecimal`, `double`) get a comparator rather than an exclusion, so the field stays covered instead of being silently dropped to stop flakiness.
- Documents where per-field assertions remain correct — literal spot checks, non-equality semantics (`isAfter`, `isNotBlank`), and deliberately narrow assertions on an ignored field — so the rule doesn't read as absolute.

Existing tests are intentionally not migrated. That is separate tech debt, to be picked up when someone is already working in the code under test or when flagged in review.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7706

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (research, drafting, and verification of the documented conventions)
- Human verification: author review of the rendered guidance and of every cited symbol

## Testing

Documentation-only change — no test or production code is touched, so no test suite exercises it. Verification focused on making sure the guidance is accurate and the examples are real:

- `pre-commit run --files .agents/skills/opik-backend/testing.md` — passes (exit 0).
- Confirmed every cited symbol exists in the repo rather than being invented: `StatsUtils.bigDecimalComparator`, `StatsUtils.closeToEpsilonComparator`, and `EXPERIMENT_IGNORED_FIELDS` in `ExperimentTestAssertions`.
- Confirmed each documented AssertJ API is supported by the version the backend actually resolves (3.27.7), including `withComparatorForFields`, `ignoringCollectionOrderInFields`, and `containsExactlyInAnyOrderElementsOf`.
- Confirmed the documented APIs are already in real use in the tree (`containsExactlyInAnyOrderElementsOf` in 14 files, `ignoringCollectionOrderInFields` in 5), so examples reflect house style rather than a style imported from elsewhere.
- Not run: Maven, frontend, and SDK suites. No Java, TypeScript, or Python source changed.

Worth flagging for the reviewer: the ignore-then-assert-narrowly pattern in `ExperimentTestAssertions` initially looked like redundancy, but the re-asserted fields are the ones listed in `EXPERIMENT_IGNORED_FIELDS`, so recursive comparison skips them and those lines are what actually covers them. It's deliberate — it lets `lastUpdatedAt` mean `==` or `isAfter` per scenario — and is documented as a valid idiom rather than something to clean up.

## Documentation

This PR is itself the documentation change: `.agents/skills/opik-backend/testing.md`, the backend testing skill. No user-facing or external docs are affected.

One open question left for review: whether a `.claude/rules/apps/opik-backend/` pointer should be added so this guidance loads automatically for backend work, matching how `.claude/rules/sdks/python/testing.md` points at the Python SDK testing skill. That is a routing change beyond this ticket's scope and is not included here.
