### PR TITLE
[OPIK-7705] [BE] perf: bound the existing-item lookup in insertItemsIntoVersion

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1700,29 +1700,16 @@ class DatasetItemServiceImpl implements DatasetItemService {
             return validateSpans(workspaceId, normalizedItems)
                     .then(validateTraces(workspaceId, normalizedItems))
                     .then(Mono.defer(() -> {
-                        // Get existing item IDs to determine which are new vs updates
-                        return versionDao.getItemIdsAndHashes(datasetId, versionId)
-                                .collectList()
-                                .flatMap(existingItems -> {
-                                    Set<UUID> existingItemIds = existingItems.stream()
-                                            .map(DatasetItemIdAndHash::itemId)
-                                            .collect(Collectors.toSet());
+                        // Classify incoming items as new vs updates with a lookup bounded by the batch,
+                        // rather than reading the whole version out of ClickHouse (OPIK-7705).
+                        Set<UUID> incomingItemIds = normalizedItems.stream()
+                                .map(DatasetItem::datasetItemId)
+                                .collect(Collectors.toSet());
 
-                                    // Classify items as new or updates
-                                    int newItemsCount = 0;
-                                    int updatedItemsCount = 0;
-
-                                    for (DatasetItem item : normalizedItems) {
-                                        UUID stableId = item.datasetItemId();
-                                        if (existingItemIds.contains(stableId)) {
-                                            updatedItemsCount++;
-                                        } else {
-                                            newItemsCount++;
-                                        }
-                                    }
-
-                                    int finalNewItemsCount = newItemsCount;
-                                    int finalUpdatedItemsCount = updatedItemsCount;
+                        return versionDao.countExistingItemIds(datasetId, versionId, incomingItemIds)
+                                .flatMap(existingCount -> {
+                                    int finalUpdatedItemsCount = existingCount.intValue();
+                                    int finalNewItemsCount = incomingItemIds.size() - finalUpdatedItemsCount;
 
                                     log.info("Inserting into version '{}': new='{}', updated='{}'",
                                             versionId, finalNewItemsCount, finalUpdatedItemsCount);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -60,6 +60,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
+import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.Segment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
@@ -97,6 +98,18 @@ public interface DatasetItemVersionDAO {
             @NonNull List<DatasetItemFilter> filters);
 
     Flux<DatasetItemIdAndHash> getItemIdsAndHashes(UUID datasetId, UUID versionId);
+
+    /**
+     * Counts how many of {@code itemIds} already exist in the given version.
+     * <p>
+     * Bounded alternative to {@link #getItemIdsAndHashes(UUID, UUID)} for the insert path, which only needs
+     * to classify an incoming batch as new vs. updated and does not need the hashes. Rows read scale with
+     * the batch size instead of the version size.
+     *
+     * @param itemIds the stable ids to look up; must be deduplicated by the caller
+     * @return the number of distinct {@code itemIds} present in the version
+     */
+    Mono<Long> countExistingItemIds(UUID datasetId, UUID versionId, Set<UUID> itemIds);
 
     /**
      * Copies items from a source version to a new target version directly within dataset_item_versions.
@@ -379,6 +392,24 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             AND workspace_id = :workspace_id
             ORDER BY dataset_item_id DESC, last_updated_at DESC
             LIMIT 1 BY dataset_item_id
+            """;
+
+    /**
+     * Counts how many of the given stable ids already exist in a version.
+     * <p>
+     * The first three predicates are a prefix of the table's ordering key
+     * {@code (workspace_id, dataset_id, dataset_version_id, id)}, narrowing to the version's granules;
+     * {@code dataset_item_id} is not in the sort key and is instead served by the bloom-filter and
+     * minmax skip indexes added in migration {@code 000074}. This keeps rows read bounded by the
+     * incoming batch rather than by the size of the version being written to.
+     */
+    private static final String COUNT_EXISTING_ITEM_IDS = """
+            SELECT count(DISTINCT dataset_item_id) AS count
+            FROM dataset_item_versions
+            WHERE workspace_id = :workspace_id
+            AND dataset_id = :datasetId
+            AND dataset_version_id = :versionId
+            AND dataset_item_id IN :itemIds
             """;
 
     private static final String SELECT_DATASET_ITEM_VERSIONS = """
@@ -2630,6 +2661,35 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     .doOnSuccess(items -> log.info("Retrieved '{}' item IDs and hashes for version '{}'", items.size(),
                             versionId))
                     .flatMapMany(Flux::fromIterable);
+        });
+    }
+
+    @Override
+    @WithSpan
+    public Mono<Long> countExistingItemIds(@NonNull UUID datasetId, @NonNull UUID versionId,
+            @NonNull Set<UUID> itemIds) {
+        if (itemIds.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        log.debug("Counting existing item IDs among '{}' for dataset '{}', version '{}'", itemIds.size(), datasetId,
+                versionId);
+
+        return asyncTemplate.nonTransaction(connection -> {
+            var statement = connection.createStatement(COUNT_EXISTING_ITEM_IDS)
+                    .bind("datasetId", datasetId)
+                    .bind("versionId", versionId)
+                    .bind("itemIds", itemIds.stream().map(UUID::toString).toArray(String[]::new));
+
+            Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "count_existing_item_ids");
+
+            return makeMonoContextAware(bindWorkspaceIdToMono(statement))
+                    .flatMapMany(result -> result.map((row, metadata) -> row.get("count", Long.class)))
+                    .next()
+                    .defaultIfEmpty(0L)
+                    .doOnSuccess(count -> log.debug("Found '{}' existing items among '{}' for version '{}'", count,
+                            itemIds.size(), versionId))
+                    .doFinally(signalType -> endSegment(segment));
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -106,7 +106,8 @@ public interface DatasetItemVersionDAO {
      * to classify an incoming batch as new vs. updated and does not need the hashes. Rows read scale with
      * the batch size instead of the version size.
      *
-     * @param itemIds the stable ids to look up; must be deduplicated by the caller
+     * @param itemIds the stable ids to look up; should be deduplicated by the caller. Null or empty
+     *                yields {@code 0} without querying.
      * @return the number of distinct {@code itemIds} present in the version
      */
     Mono<Long> countExistingItemIds(UUID datasetId, UUID versionId, Set<UUID> itemIds);
@@ -2667,8 +2668,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     @Override
     @WithSpan
     public Mono<Long> countExistingItemIds(@NonNull UUID datasetId, @NonNull UUID versionId,
-            @NonNull Set<UUID> itemIds) {
-        if (itemIds.isEmpty()) {
+            Set<UUID> itemIds) {
+        if (CollectionUtils.isEmpty(itemIds)) {
             return Mono.just(0L);
         }
 
@@ -2687,8 +2688,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     .flatMapMany(result -> result.map((row, metadata) -> row.get("count", Long.class)))
                     .next()
                     .defaultIfEmpty(0L)
-                    .doOnSuccess(count -> log.debug("Found '{}' existing items among '{}' for version '{}'", count,
-                            itemIds.size(), versionId))
+                    .doOnSuccess(count -> log.debug(
+                            "Found existing items for version '{}' among '{}' incoming ids: '{}'", versionId,
+                            itemIds.size(), count))
                     .doFinally(signalType -> endSegment(segment));
         });
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -77,6 +77,7 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1794,6 +1795,126 @@ class DatasetVersionResourceTest {
                 assertThat(item.data()).containsKey("updated");
                 assertThat(item.data()).containsKey("newField");
             }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Insert Classification Counts")
+    class InsertClassificationCounts {
+
+        private final IdGenerator idGenerator = TestIdGeneratorFactory.create();
+
+        @Test
+        @DisplayName("Success: Re-inserting existing items counts them as modified, not added")
+        void insertItems__whenItemsAlreadyExistInVersion__thenCountedAsModifiedNotAdded() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(generateDatasetItems(5))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version1 = getLatestVersion(datasetId);
+            assertThat(version1)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded, DatasetVersion::itemsModified)
+                    .containsExactly(5, 5, 0);
+
+            var v1Items = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, version1.versionHash(), API_KEY, TEST_WORKSPACE).content();
+
+            // Re-insert 3 of the existing items (updates) alongside 2 brand-new ones
+            var mixedItems = new ArrayList<DatasetItem>();
+            v1Items.stream().limit(3)
+                    .map(item -> DatasetItem.builder()
+                            .id(item.id())
+                            .datasetItemId(item.datasetItemId())
+                            .source(item.source())
+                            .data(Map.of("updated", JsonUtils.getJsonNodeFromString("true")))
+                            .build())
+                    .forEach(mixedItems::add);
+            mixedItems.addAll(generateDatasetItems(2));
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(mixedItems)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var latestVersion = getLatestVersion(datasetId);
+            assertThat(latestVersion.id()).isEqualTo(version1.id());
+            assertThat(latestVersion)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded, DatasetVersion::itemsModified)
+                    .containsExactly(7, 7, 3);
+        }
+
+        @Test
+        @DisplayName("Success: Duplicate stable id within one batch increments added by one")
+        void insertItems__whenBatchContainsDuplicateStableId__thenCountedOnce() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(generateDatasetItems(2))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version1 = getLatestVersion(datasetId);
+            assertThat(version1.itemsTotal()).isEqualTo(2);
+
+            // Same stable id appearing twice in one batch must count as a single new item.
+            // The stable id must be supplied via `id`: `datasetItemId` is READ_ONLY on the write view
+            // and is derived from `id` server-side.
+            var duplicatedId = idGenerator.generateId();
+            var duplicateBatch = List.of(
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
+                            .build(),
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
+                            .build());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(duplicateBatch)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var latestVersion = getLatestVersion(datasetId);
+            assertThat(latestVersion.id()).isEqualTo(version1.id());
+            assertThat(latestVersion)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded, DatasetVersion::itemsModified)
+                    .containsExactly(3, 3, 0);
+        }
+
+        @Test
+        @DisplayName("Success: Multi-batch insert into existing version accumulates counts correctly")
+        void insertItems__whenMultipleBatchesIntoExistingVersion__thenCountsAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(generateDatasetItems(10))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version1 = getLatestVersion(datasetId);
+
+            for (int i = 0; i < 3; i++) {
+                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                        .datasetId(datasetId)
+                        .items(generateDatasetItems(10))
+                        .build(), TEST_WORKSPACE, API_KEY);
+            }
+
+            var versions = datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE);
+            assertThat(versions.content()).hasSize(1);
+
+            var latestVersion = getLatestVersion(datasetId);
+            assertThat(latestVersion.id()).isEqualTo(version1.id());
+            assertThat(latestVersion)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded, DatasetVersion::itemsModified)
+                    .containsExactly(40, 40, 0);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -110,6 +110,7 @@ class DatasetVersionResourceTest {
     private static final String USER = UUID.randomUUID().toString();
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
     private static final String TEST_WORKSPACE = UUID.randomUUID().toString();
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
@@ -1803,8 +1804,6 @@ class DatasetVersionResourceTest {
     @DisplayName("Insert Classification Counts")
     class InsertClassificationCounts {
 
-        private final IdGenerator idGenerator = TestIdGeneratorFactory.create();
-
         @Test
         @DisplayName("Success: Re-inserting existing items counts them as modified, not added")
         void insertItems__whenItemsAlreadyExistInVersion__thenCountedAsModifiedNotAdded() {
@@ -1863,7 +1862,7 @@ class DatasetVersionResourceTest {
             // Same stable id appearing twice in one batch must count as a single new item.
             // The stable id must be supplied via `id`: `datasetItemId` is READ_ONLY on the write view
             // and is derived from `id` server-side.
-            var duplicatedId = idGenerator.generateId();
+            var duplicatedId = ID_GENERATOR.generateId();
             var duplicateBatch = List.of(
                     DatasetItem.builder()
                             .id(duplicatedId)
@@ -2948,8 +2947,6 @@ class DatasetVersionResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ExperimentDatasetVersionLinking {
 
-        private static final IdGenerator idGenerator = TestIdGeneratorFactory.create();
-
         private Experiment getExperiment(UUID id) {
             return experimentResourceClient.getExperiment(id, API_KEY, TEST_WORKSPACE);
         }
@@ -3190,7 +3187,7 @@ class DatasetVersionResourceTest {
             var datasetId = createDataset(datasetName);
             createDatasetItems(datasetId, 1);
 
-            var nonExistentVersionId = idGenerator.generateId();
+            var nonExistentVersionId = ID_GENERATOR.generateId();
 
             // when - create experiment with non-existent version ID
             var experiment = experimentResourceClient.createPartialExperiment()


### PR DESCRIPTION
## Details

<img width="1920" height="2978" alt="image" src="https://github.com/user-attachments/assets/7cad30fd-c73e-48fd-8314-ee547901f0e2" />

Every batch written into an existing dataset version read the *entire* version out of ClickHouse purely to work out how many incoming items were new versus updates — decoding `data_hash`, `tags`, `evaluators_hash`, `execution_policy_hash` and `description_hash` only to discard them, and building a full-version `Set<UUID>` on the heap to produce two integers. The cost was quadratic across a multi-batch upload (batch *k* read *k × N* rows to classify *N* items), and because it runs inside `withDatasetVersionLock` the per-batch cost is additive rather than amortised.

This replaces the full-version scan on the insert path with a lookup bounded by the incoming batch, so classification cost scales with batch size instead of version size.

- Adds a narrow `countExistingItemIds` DAO method that computes the intersection server-side with `count(DISTINCT dataset_item_id) ... WHERE dataset_item_id IN :itemIds`. `getItemIdsAndHashes` is left untouched for its two other callers (version-delta computation and the copy-version path), which legitimately need the hashes.
- Deduplicates the incoming batch by stable id before classifying. This also corrects a latent miscount: a batch repeating the same id previously counted it twice as new, despite the endpoint contract treating `id` as the upsert key.
- No full-version collection is materialised in application heap on the insert path. Both entrypoints benefit — `mutateLatestVersionWithInsert` and the `batch_group_id` path in `handleGroupedInsertion`.

Behaviour is otherwise unchanged: same items written, same version counts recorded, same `DatasetVersion` returned.

**Measured** on a 100k-item version with a full-size (1000-item) batch, against a local ClickHouse holding 7.5M rows across 2999 versions:

| | rows read | bytes read | wall clock |
|---|---|---|---|
| Before — full-version scan | 112,990 | 22.0 MB | 419 ms |
| After — bounded lookup | 6,437 | 0.41 MB | 57 ms |

~17.5x fewer rows and ~54x fewer bytes for a single batch; the win compounds across a multi-batch upload. `EXPLAIN indexes=1` confirms both `dataset_item_id` skip indexes from migration `000074` are exercised rather than assumed — the primary-key prefix narrows 1405 → 73 granules, the minmax index cuts 73 → 4, and the bloom filter holds at 4.

The `IN` list needs no chunking: `DatasetItemBatch` caps `items` at `@Size(min = 1, max = 1000)`, so it is bounded by construction.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7705

Escalated from OPIK_7270 (parallel bulk-upload SDK call for the Dataset API); related prior work in OPIK_7264 (per-dataset version lock).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (DAO query, service rewiring, tests, benchmarking)
- Human verification: code review + integration test run + before/after query measurement reviewed against `EXPLAIN indexes=1` output

## Testing

Commands run, from `apps/opik-backend`:

- `mvn compile -DskipTests` — clean
- `mvn spotless:check` — clean
- `mvn test -Dtest='DatasetVersionResourceTest'` — **121/121 pass**, covering both insert entrypoints
- `mvn test -Dtest='DatasetsResourceTest$ApiKey'` — **48/48 pass**

Scenarios validated by a new `InsertClassificationCounts` nested class in `DatasetVersionResourceTest`. No prior test on this path asserted `itemsAdded`/`itemsModified` — only `itemsTotal` — so a bounded lookup that failed to see a pre-existing item could have drifted the counters silently. Each new test asserts the full `(itemsTotal, itemsAdded, itemsModified)` triple:

- Re-inserting existing items alongside new ones counts them as modified, not added
- A stable id repeated within one batch increments `items_added` by one, not two
- Multi-batch insert into an existing version accumulates counts correctly and stays on a single version

Environment: local Testcontainers (ClickHouse + MySQL + Redis + Zookeeper), JDK 25. Measurement taken against a local Docker ClickHouse seeded with 7.5M rows.

Not run: the full backend suite. A combined `DatasetsResourceTest` run did surface one failure (`ApiKey.createDatasetItems__whenApiKeyIsPresent__thenReturnProperResponse`, HTTP 500), which was traced to the ClickHouse testcontainer dying mid-run — 98 × `Connection refused`, no `DB::Exception`. That class passes 48/48 in isolation. CI is the authority here.

## Documentation

N/A — internal performance change with no user-facing API or behavioural surface.
