### PR TITLE
[OPIK-7707] [BE] perf: make dataset version count updates atomic

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1780,13 +1780,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @param workspaceId The workspace ID
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
-        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
-
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1662,7 +1662,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         UUID latestVersionId = latestVersion.get().id();
         log.info("Inserting '{}' items into existing version '{}'", batch.items().size(), latestVersionId);
 
-        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName);
+        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName).then(Mono.empty());
     }
 
     /**
@@ -1670,14 +1670,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * Handles validation, classification of new vs updated items, and count updates.
      * Used by mutateLatestVersionWithInsert and handleGroupedInsertion.
      *
+     * Completes empty: no caller reads the resulting version, so the counters are applied with a single atomic
+     * increment and the row is not read back.
+     *
      * @param batch the batch of items to insert
      * @param datasetId the dataset ID
      * @param versionId the version ID to insert into
      * @param workspaceId the workspace ID
      * @param userName the username
-     * @return Mono emitting the updated dataset version
+     * @return Mono completing when the items are inserted and the counts updated
      */
-    private Mono<DatasetVersion> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+    private Mono<Void> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         // Validate and prepare items
         List<DatasetItem> validatedItems = addIdIfAbsent(batch);
@@ -1717,11 +1720,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     // Insert items directly into the existing version
                                     return versionDao
                                             .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
-                                            .then(Mono.fromCallable(() -> {
-                                                updateVersionCountsForInsert(versionId, workspaceId, finalNewItemsCount,
-                                                        finalUpdatedItemsCount, userName);
-                                                return versionService.getVersionById(workspaceId, datasetId, versionId);
-                                            }).subscribeOn(Schedulers.boundedElastic()));
+                                            .then(Mono.fromRunnable(() -> updateVersionCountsForInsert(versionId,
+                                                    workspaceId, finalNewItemsCount, finalUpdatedItemsCount, userName))
+                                                    .subscribeOn(Schedulers.boundedElastic()))
+                                            .then();
                                 });
                     }));
         }).contextWrite(c -> c.put(RequestContext.WORKSPACE_ID, workspaceId)
@@ -1742,43 +1744,36 @@ class DatasetItemServiceImpl implements DatasetItemService {
             int updatedItemsCount, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            var currentVersion = dao.findById(versionId, workspaceId)
-                    .orElseThrow(() -> new NotFoundException(
-                            "Version not found: '%s'".formatted(versionId)));
 
             // Only increment total by new items (not updates)
-            int newTotal = currentVersion.itemsTotal() + newItemsCount;
-            int newAdded = currentVersion.itemsAdded() + newItemsCount;
-            int newModified = currentVersion.itemsModified() + updatedItemsCount;
+            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
+                    workspaceId, userName);
 
-            dao.updateCounts(versionId, newTotal, newAdded, newModified,
-                    currentVersion.itemsDeleted(), workspaceId, userName);
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * <p>
+     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
+     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
+     * both callers fetch the version for their own purposes regardless.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
-     * @param currentVersion The current version before deletion
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
      */
-    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, DatasetVersion currentVersion,
-            int deletedCount, String userName) {
-        int newTotal = currentVersion.itemsTotal() - deletedCount;
-        int newDeleted = currentVersion.itemsDeleted() + deletedCount;
-
-        log.info("deleteItemsFromExistingVersion: updating counts - newTotal='{}', newDeleted='{}'",
-                newTotal, newDeleted);
+    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
 
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.updateCounts(versionId, newTotal, currentVersion.itemsAdded(),
-                    currentVersion.itemsModified(), newDeleted, workspaceId, userName);
+            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
             return null;
         });
     }
@@ -2173,8 +2168,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2218,8 +2212,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2344,7 +2337,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
+                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
+                                .then(Mono.<DatasetVersion>empty());
                     } else {
                         // No version with this batch_group_id - create new one
                         log.info("Creating new version with batch_group_id '{}' for dataset '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1767,13 +1767,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @param workspaceId The workspace ID
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
-        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
-
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -132,18 +132,15 @@ public interface DatasetItemService {
      *   <li>If batchGroupId is null: Mutates the latest version by appending items (backwards compatibility)</li>
      *   <li>If batchGroupId is provided: Creates a new version with batch grouping (multiple batches can share the same version)</li>
      *   <li>If no versions exist, creates the first version regardless of batchGroupId</li>
-     *   <li>Returns the DatasetVersion (newly created or mutated)</li>
      * </ul>
-     * When versioning is disabled (legacy mode):
-     * <ul>
-     *   <li>Saves items to the legacy dataset_items table</li>
-     *   <li>Returns empty Mono</li>
-     * </ul>
+     * When versioning is disabled (legacy mode), saves items to the legacy dataset_items table.
      *
      * @param batch the batch of items to save (must include datasetId or datasetName, may include batchGroupId)
-     * @return Mono emitting the DatasetVersion when versioning is enabled, or empty when disabled
+     * @return Mono completing when the batch is persisted. No version is emitted: appending to an existing version
+     *         has nothing to read back, and the only caller discards the value, so the type says so rather than
+     *         promising a value that arrives on some paths and not others.
      */
-    Mono<DatasetVersion> save(DatasetItemBatch batch);
+    Mono<Void> save(DatasetItemBatch batch);
 
 }
 
@@ -1610,12 +1607,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     @Override
     @WithSpan
-    public Mono<DatasetVersion> save(@NonNull DatasetItemBatch batch) {
+    public Mono<Void> save(@NonNull DatasetItemBatch batch) {
 
         if (!featureFlags.isDatasetVersioningEnabled()) {
             // Legacy: save to legacy table
             log.info("Saving items to legacy table for dataset '{}'", batch.datasetId());
-            return verifyDatasetExistsAndSave(batch).then(Mono.empty());
+            return verifyDatasetExistsAndSave(batch).then();
         }
 
         return getDatasetId(batch)
@@ -1636,7 +1633,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
-                })));
+                })))
+                .then();
     }
 
     /**
@@ -1749,8 +1747,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
     /**
      * Updates version counts after deleting items from an existing version.
      * <p>
-     * Unlike the insert path this saves no round-trip: both callers fetch the version for their own purposes
-     * regardless. What it buys is that the arithmetic no longer depends on that snapshot still being current.
+     * Expressing the update as a delta removed the last reason either caller had to read the version first, so
+     * both now skip that round-trip entirely and the arithmetic no longer depends on a snapshot staying current.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
@@ -2152,14 +2150,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
         }
 
         return Mono.defer(() -> {
-            // Get current version to update counts
-            DatasetVersion currentVersion = versionService.getVersionById(workspaceId, datasetId, versionId);
-
-            log.info(
-                    "deleteItemsFromExistingVersion: currentVersion itemsTotal='{}', itemsDeleted='{}', versionId='{}'",
-                    currentVersion.itemsTotal(), currentVersion.itemsDeleted(), versionId);
-
-            log.info("deleteItemsFromExistingVersion: attempting to remove '{}' items", ids.size());
+            // The counters are applied as a delta, so no pre-delete snapshot of the version is read here:
+            // fetching one would be a synchronous MySQL round-trip per batch purely to enrich a log line.
+            log.info("deleteItemsFromExistingVersion: attempting to remove '{}' items from version '{}'",
+                    ids.size(), versionId);
 
             // Remove items from the version
             return versionDao.removeItemsFromVersion(datasetId, versionId, ids, workspaceId)
@@ -2175,8 +2169,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
                             updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
-                            log.info("Deleted '{}' items from version '{}', new total '{}'",
-                                    deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
+                            log.info("Deleted '{}' items from version '{}'", deletedCount, versionId);
                             return null;
                         }).subscribeOn(Schedulers.boundedElastic());
                     })
@@ -2197,12 +2190,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 versionId, datasetId);
 
         return Mono.defer(() -> {
-            // Get current version to update counts
-            DatasetVersion currentVersion = versionService.getVersionById(workspaceId, datasetId, versionId);
-
-            log.info(
-                    "deleteItemsFromExistingVersionByFilters: currentVersion itemsTotal='{}', itemsDeleted='{}', versionId='{}'",
-                    currentVersion.itemsTotal(), currentVersion.itemsDeleted(), versionId);
+            // Counters are applied as a delta, so no pre-delete version snapshot is read here -- see
+            // deleteItemsFromExistingVersion for why.
 
             // Remove items matching filters from the version
             return versionDao.removeItemsFromVersionByFilters(datasetId, versionId, filters, workspaceId)
@@ -2219,8 +2208,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
                             updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
-                            log.info("Deleted '{}' items from version '{}', new total '{}'",
-                                    deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
+                            log.info("Deleted '{}' items from version '{}'", deletedCount, versionId);
                             return null;
                         }).subscribeOn(Schedulers.boundedElastic());
                     })
@@ -2331,7 +2319,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @param datasetId the dataset ID
      * @param workspaceId the workspace ID
      * @param userName the username
-     * @return Mono emitting the dataset version
+     * @return Mono emitting the newly created version when this batch mints one, or completing empty when the
+     *         batch appends to a version an earlier batch in the same group already created
      */
     private Mono<DatasetVersion> handleGroupedInsertion(UUID batchGroupId, DatasetItemBatch batch,
             UUID datasetId, String workspaceId, String userName) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1732,36 +1732,25 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     /**
      * Updates version counts after inserting items into an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * Only the new items move the total; re-sent items count as modifications.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
      * @param newItemsCount Number of new items inserted
      * @param updatedItemsCount Number of items updated
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForInsert(UUID versionId, String workspaceId, int newItemsCount,
             int updatedItemsCount, String userName) {
-        template.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(DatasetVersionDAO.class);
-
-            // Only increment total by new items (not updates)
-            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
-                    workspaceId, userName);
-
-            if (updated == 0) {
-                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
-            }
-            return null;
-        });
+        updateVersionCounts(versionId, workspaceId, newItemsCount, newItemsCount, updatedItemsCount, 0, userName);
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
      * <p>
-     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
-     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
-     * both callers fetch the version for their own purposes regardless.
+     * Unlike the insert path this saves no round-trip: both callers fetch the version for their own purposes
+     * regardless. What it buys is that the arithmetic no longer depends on that snapshot still being current.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
@@ -1770,10 +1759,23 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        updateVersionCounts(versionId, workspaceId, -deletedCount, 0, 0, deletedCount, userName);
+    }
+
+    /**
+     * Applies signed counter deltas to a version in a single atomic statement, so the arithmetic does not depend on
+     * {@code withDatasetVersionLock} for mutual exclusion. A zero affected-row count means the version was removed or
+     * belongs to another workspace.
+     *
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
+     */
+    private void updateVersionCounts(UUID versionId, String workspaceId, int totalDelta, int addedDelta,
+            int modifiedDelta, int deletedDelta, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
 
-            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+            int updated = dao.incrementCounts(versionId, totalDelta, addedDelta, modifiedDelta, deletedDelta,
+                    workspaceId, userName);
 
             if (updated == 0) {
                 throw new NotFoundException("Version not found: '%s'".formatted(versionId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1662,7 +1662,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         UUID latestVersionId = latestVersion.get().id();
         log.info("Inserting '{}' items into existing version '{}'", batch.items().size(), latestVersionId);
 
-        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName);
+        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName).then(Mono.empty());
     }
 
     /**
@@ -1670,14 +1670,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * Handles validation, classification of new vs updated items, and count updates.
      * Used by mutateLatestVersionWithInsert and handleGroupedInsertion.
      *
+     * Completes empty: no caller reads the resulting version, so the counters are applied with a single atomic
+     * increment and the row is not read back.
+     *
      * @param batch the batch of items to insert
      * @param datasetId the dataset ID
      * @param versionId the version ID to insert into
      * @param workspaceId the workspace ID
      * @param userName the username
-     * @return Mono emitting the updated dataset version
+     * @return Mono completing when the items are inserted and the counts updated
      */
-    private Mono<DatasetVersion> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+    private Mono<Void> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         // Validate and prepare items
         List<DatasetItem> validatedItems = addIdIfAbsent(batch);
@@ -1730,11 +1733,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     // Insert items directly into the existing version
                                     return versionDao
                                             .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
-                                            .then(Mono.fromCallable(() -> {
-                                                updateVersionCountsForInsert(versionId, workspaceId, finalNewItemsCount,
-                                                        finalUpdatedItemsCount, userName);
-                                                return versionService.getVersionById(workspaceId, datasetId, versionId);
-                                            }).subscribeOn(Schedulers.boundedElastic()));
+                                            .then(Mono.fromRunnable(() -> updateVersionCountsForInsert(versionId,
+                                                    workspaceId, finalNewItemsCount, finalUpdatedItemsCount, userName))
+                                                    .subscribeOn(Schedulers.boundedElastic()))
+                                            .then();
                                 });
                     }));
         }).contextWrite(c -> c.put(RequestContext.WORKSPACE_ID, workspaceId)
@@ -1755,43 +1757,36 @@ class DatasetItemServiceImpl implements DatasetItemService {
             int updatedItemsCount, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            var currentVersion = dao.findById(versionId, workspaceId)
-                    .orElseThrow(() -> new NotFoundException(
-                            "Version not found: '%s'".formatted(versionId)));
 
             // Only increment total by new items (not updates)
-            int newTotal = currentVersion.itemsTotal() + newItemsCount;
-            int newAdded = currentVersion.itemsAdded() + newItemsCount;
-            int newModified = currentVersion.itemsModified() + updatedItemsCount;
+            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
+                    workspaceId, userName);
 
-            dao.updateCounts(versionId, newTotal, newAdded, newModified,
-                    currentVersion.itemsDeleted(), workspaceId, userName);
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * <p>
+     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
+     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
+     * both callers fetch the version for their own purposes regardless.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
-     * @param currentVersion The current version before deletion
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
      */
-    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, DatasetVersion currentVersion,
-            int deletedCount, String userName) {
-        int newTotal = currentVersion.itemsTotal() - deletedCount;
-        int newDeleted = currentVersion.itemsDeleted() + deletedCount;
-
-        log.info("deleteItemsFromExistingVersion: updating counts - newTotal='{}', newDeleted='{}'",
-                newTotal, newDeleted);
+    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
 
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.updateCounts(versionId, newTotal, currentVersion.itemsAdded(),
-                    currentVersion.itemsModified(), newDeleted, workspaceId, userName);
+            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
             return null;
         });
     }
@@ -2186,8 +2181,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2231,8 +2225,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2357,7 +2350,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
+                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
+                                .then(Mono.<DatasetVersion>empty());
                     } else {
                         // No version with this batch_group_id - create new one
                         log.info("Creating new version with batch_group_id '{}' for dataset '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -33,6 +33,14 @@ import java.util.UUID;
 @RegisterConstructorMapper(DatasetVersion.class)
 public interface DatasetVersionDAO {
 
+    /**
+     * Sentinel written by Liquibase migration {@code 000046} for versions whose {@code items_total} has not been
+     * backfilled yet. {@link #findVersionsNeedingItemsTotalMigration} selects on it, and {@link #incrementCounts}
+     * refuses to do arithmetic on it — adding a delta to {@code -1} would both corrupt the counter and hide the row
+     * from the backfill forever.
+     */
+    int ITEMS_TOTAL_NOT_MIGRATED = -1;
+
     @SqlUpdate("""
             INSERT INTO dataset_versions (
                 id, dataset_id, version_hash, items_total, items_added, items_modified, items_deleted,
@@ -541,7 +549,19 @@ public interface DatasetVersionDAO {
 
     /**
      * Applies signed deltas to the version counters in a single statement, so the arithmetic happens in the database
-     * rather than as a read-modify-write in the application. Correct under concurrent callers without an external lock.
+     * rather than as a read-modify-write in the application.
+     * <p>
+     * Concurrent <em>delta</em> writers compose without an external lock. The guarantee does not extend to the
+     * absolute writers in this interface ({@link #updateItemsTotal}, {@link #batchUpdateItemsTotal}, both driven by
+     * the items-total backfill), which still write a value derived from an earlier read and can overwrite an
+     * increment that landed in between. Those are gated on the not-migrated sentinel so a row an increment has
+     * already touched is skipped rather than clobbered.
+     * <p>
+     * Rows still holding {@link #ITEMS_TOTAL_NOT_MIGRATED} are excluded: adding a delta to the sentinel would
+     * corrupt the counter and also hide the row from the backfill, which selects on that exact value. Such a row
+     * reports zero affected rows, same as a missing or cross-workspace version. The predicate is the NULL-safe
+     * {@code <=>} rather than {@code <>} so a NULL counter — which the COALESCE above exists to repair — is still
+     * incremented instead of being skipped by three-valued logic.
      */
     @SqlUpdate("""
             UPDATE dataset_versions
@@ -553,6 +573,7 @@ public interface DatasetVersionDAO {
                 last_updated_by = :last_updated_by
             WHERE id = :version_id
               AND workspace_id = :workspace_id
+              AND NOT (items_total <=> :items_total_not_migrated)
             """)
     int incrementCounts(@Bind("version_id") UUID versionId,
             @Bind("items_total_delta") int itemsTotalDelta,
@@ -560,7 +581,20 @@ public interface DatasetVersionDAO {
             @Bind("items_modified_delta") int itemsModifiedDelta,
             @Bind("items_deleted_delta") int itemsDeletedDelta,
             @Bind("workspace_id") String workspaceId,
-            @Bind("last_updated_by") String lastUpdatedBy);
+            @Bind("last_updated_by") String lastUpdatedBy,
+            @Bind("items_total_not_migrated") int itemsTotalNotMigrated);
+
+    /**
+     * Applies the deltas, supplying the not-migrated sentinel so callers cannot forget the guard.
+     *
+     * @return affected rows: {@code 0} when the version is missing, belongs to another workspace, or still holds
+     *         {@link #ITEMS_TOTAL_NOT_MIGRATED}
+     */
+    default int incrementCounts(UUID versionId, int itemsTotalDelta, int itemsAddedDelta, int itemsModifiedDelta,
+            int itemsDeletedDelta, String workspaceId, String lastUpdatedBy) {
+        return incrementCounts(versionId, itemsTotalDelta, itemsAddedDelta, itemsModifiedDelta, itemsDeletedDelta,
+                workspaceId, lastUpdatedBy, ITEMS_TOTAL_NOT_MIGRATED);
+    }
 
     @SqlUpdate("""
             INSERT INTO dataset_versions (
@@ -595,20 +629,41 @@ public interface DatasetVersionDAO {
             @Bind("version_id") UUID versionId,
             @Bind("workspace_id") String workspaceId);
 
+    /**
+     * Backfills {@code items_total} for a version that has not been migrated yet.
+     * <p>
+     * The value is absolute and derived from a ClickHouse count taken earlier, so it is gated on the row still
+     * holding {@link #ITEMS_TOTAL_NOT_MIGRATED}: if an API write incremented the counter between that count and
+     * this update, the row is skipped rather than overwritten with a stale total.
+     *
+     * @return affected rows: {@code 0} when the version no longer holds the sentinel
+     */
     @SqlUpdate("""
             UPDATE dataset_versions
             SET items_total = :items_total,
                 last_updated_at = NOW()
             WHERE workspace_id = :workspace_id
               AND id = :version_id
+              AND items_total = :items_total_not_migrated
             """)
-    void updateItemsTotal(@Bind("workspace_id") String workspaceId,
+    int updateItemsTotal(@Bind("workspace_id") String workspaceId,
             @Bind("version_id") UUID versionId,
-            @Bind("items_total") long itemsTotal);
+            @Bind("items_total") long itemsTotal,
+            @Bind("items_total_not_migrated") int itemsTotalNotMigrated);
+
+    /**
+     * Backfills {@code items_total}, supplying the not-migrated sentinel so callers cannot forget the guard.
+     */
+    default int updateItemsTotal(String workspaceId, UUID versionId, long itemsTotal) {
+        return updateItemsTotal(workspaceId, versionId, itemsTotal, ITEMS_TOTAL_NOT_MIGRATED);
+    }
 
     /**
      * Batch update items_total for multiple dataset versions.
      * Uses JDBI's @SqlBatch to execute multiple updates efficiently in a single batch.
+     * <p>
+     * Gated on the not-migrated sentinel for the same reason as {@link #updateItemsTotal}: these totals come from
+     * a ClickHouse count taken before the write, and must not clobber an increment that landed in between.
      *
      * @param workspaceIds list of workspace IDs (must match versionIds order and size)
      * @param versionIds list of version IDs to update
@@ -620,10 +675,19 @@ public interface DatasetVersionDAO {
                 last_updated_at = NOW()
             WHERE workspace_id = :workspace_id
               AND id = :version_id
+              AND items_total = :items_total_not_migrated
             """)
     void batchUpdateItemsTotal(@Bind("workspace_id") List<String> workspaceIds,
             @Bind("version_id") List<UUID> versionIds,
-            @Bind("items_total") List<Long> itemsTotals);
+            @Bind("items_total") List<Long> itemsTotals,
+            @Bind("items_total_not_migrated") int itemsTotalNotMigrated);
+
+    /**
+     * Batch backfill, supplying the not-migrated sentinel so callers cannot forget the guard.
+     */
+    default void batchUpdateItemsTotal(List<String> workspaceIds, List<UUID> versionIds, List<Long> itemsTotals) {
+        batchUpdateItemsTotal(workspaceIds, versionIds, itemsTotals, ITEMS_TOTAL_NOT_MIGRATED);
+    }
 
     /**
      * Finds dataset versions that need items_total migration using cursor-based pagination.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -539,22 +539,26 @@ public interface DatasetVersionDAO {
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 
+    /**
+     * Applies signed deltas to the version counters in a single statement, so the arithmetic happens in the database
+     * rather than as a read-modify-write in the application. Correct under concurrent callers without an external lock.
+     */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = :items_total,
-                items_added = :items_added,
-                items_modified = :items_modified,
-                items_deleted = :items_deleted,
+            SET items_total = items_total + :items_total_delta,
+                items_added = items_added + :items_added_delta,
+                items_modified = items_modified + :items_modified_delta,
+                items_deleted = items_deleted + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id
               AND workspace_id = :workspace_id
             """)
-    void updateCounts(@Bind("version_id") UUID versionId,
-            @Bind("items_total") int itemsTotal,
-            @Bind("items_added") int itemsAdded,
-            @Bind("items_modified") int itemsModified,
-            @Bind("items_deleted") int itemsDeleted,
+    int incrementCounts(@Bind("version_id") UUID versionId,
+            @Bind("items_total_delta") int itemsTotalDelta,
+            @Bind("items_added_delta") int itemsAddedDelta,
+            @Bind("items_modified_delta") int itemsModifiedDelta,
+            @Bind("items_deleted_delta") int itemsDeletedDelta,
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -623,6 +623,7 @@ public interface DatasetVersionDAO {
               AND NOT EXISTS (
                   SELECT 1 FROM dataset_versions
                   WHERE dataset_id = :dataset_id
+                    AND workspace_id = :workspace_id
               )
             """)
     int ensureVersion1Exists(@Bind("dataset_id") UUID datasetId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -606,7 +606,7 @@ public interface DatasetVersionDAO {
                 :version_id,
                 :dataset_id,
                 'v1',
-                0,
+                :items_total_not_migrated,
                 0,
                 0,
                 0,
@@ -627,7 +627,20 @@ public interface DatasetVersionDAO {
             """)
     int ensureVersion1Exists(@Bind("dataset_id") UUID datasetId,
             @Bind("version_id") UUID versionId,
-            @Bind("workspace_id") String workspaceId);
+            @Bind("workspace_id") String workspaceId,
+            @Bind("items_total_not_migrated") int itemsTotalNotMigrated);
+
+    /**
+     * Creates v1 for a lazily-migrated dataset, seeding {@code items_total} with
+     * {@link #ITEMS_TOTAL_NOT_MIGRATED} rather than {@code 0}.
+     * <p>
+     * The row is created before its items are counted, so a literal {@code 0} would be indistinguishable from a
+     * genuinely empty version: {@link #updateItemsTotal} would refuse to write the real count, and the batch
+     * backfill would never select the row. Seeding the sentinel keeps both paths able to fix it.
+     */
+    default int ensureVersion1Exists(UUID datasetId, UUID versionId, String workspaceId) {
+        return ensureVersion1Exists(datasetId, versionId, workspaceId, ITEMS_TOTAL_NOT_MIGRATED);
+    }
 
     /**
      * Backfills {@code items_total} for a version that has not been migrated yet.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -545,10 +545,10 @@ public interface DatasetVersionDAO {
      */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = items_total + :items_total_delta,
-                items_added = items_added + :items_added_delta,
-                items_modified = items_modified + :items_modified_delta,
-                items_deleted = items_deleted + :items_deleted_delta,
+            SET items_total = COALESCE(items_total, 0) + :items_total_delta,
+                items_added = COALESCE(items_added, 0) + :items_added_delta,
+                items_modified = COALESCE(items_modified, 0) + :items_modified_delta,
+                items_deleted = COALESCE(items_deleted, 0) + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
@@ -329,20 +329,17 @@ public class DatasetVersioningMigrationService {
                     log.debug("Dataset '{}' has '{}' items in version 1", datasetId, count);
 
                     return Mono.<Void>fromCallable(() -> {
-                        template.inTransaction(WRITE, handle -> {
-                            int updated = handle.attach(DatasetVersionDAO.class)
-                                    .updateItemsTotal(workspaceId, versionId, count);
+                        int updated = template.inTransaction(WRITE,
+                                handle -> handle.attach(DatasetVersionDAO.class)
+                                        .updateItemsTotal(workspaceId, versionId, count));
 
-                            if (updated == 0) {
-                                // The backfill only writes rows still holding the sentinel. Zero rows means an
-                                // API write already incremented this version from a real baseline, so its
-                                // counter is live and this (older) count would overwrite it with a stale value.
-                                log.info(
-                                        "Skipped items_total backfill for dataset '{}' version '{}': already migrated",
-                                        datasetId, versionId);
-                            }
-                            return null;
-                        });
+                        if (updated == 0) {
+                            // The backfill only writes rows still holding the sentinel. Zero rows means an API
+                            // write already incremented this version from a real baseline, so its counter is
+                            // live and this (older) count would overwrite it with a stale value.
+                            log.info("Skipped items_total backfill for dataset '{}' version '{}': already migrated",
+                                    datasetId, versionId);
+                        }
                         return null;
                     }).subscribeOn(Schedulers.boundedElastic());
                 });

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
@@ -330,8 +330,17 @@ public class DatasetVersioningMigrationService {
 
                     return Mono.<Void>fromCallable(() -> {
                         template.inTransaction(WRITE, handle -> {
-                            handle.attach(DatasetVersionDAO.class)
+                            int updated = handle.attach(DatasetVersionDAO.class)
                                     .updateItemsTotal(workspaceId, versionId, count);
+
+                            if (updated == 0) {
+                                // The backfill only writes rows still holding the sentinel. Zero rows means an
+                                // API write already incremented this version from a real baseline, so its
+                                // counter is live and this (older) count would overwrite it with a stale value.
+                                log.info(
+                                        "Skipped items_total backfill for dataset '{}' version '{}': already migrated",
+                                        datasetId, versionId);
+                            }
                             return null;
                         });
                         return null;

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersioningMigrationService.java
@@ -337,7 +337,8 @@ public class DatasetVersioningMigrationService {
                             // The backfill only writes rows still holding the sentinel. Zero rows means an API
                             // write already incremented this version from a real baseline, so its counter is
                             // live and this (older) count would overwrite it with a stale value.
-                            log.info("Skipped items_total backfill for dataset '{}' version '{}': already migrated",
+                            log.info(
+                                    "Skipped items_total backfill: datasetId='{}' versionId='{}' reason='already migrated'",
                                     datasetId, versionId);
                         }
                         return null;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -77,6 +77,7 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5204,6 +5206,152 @@ class DatasetVersionResourceTest {
                     datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
             assertThat(latestItems).hasSize(1);
             assertThat(latestItems.getFirst().description()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Atomic version count updates (OPIK-7707):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AtomicVersionCountUpdates {
+
+        private int incrementCounts(UUID versionId, int total, int added, int modified, int deleted) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(versionId, total, added, modified, deleted, WORKSPACE_ID, USER));
+        }
+
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException | TimeoutException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Test
+        @DisplayName("Success: single-batch append accumulates the full counter triple")
+        void insertItems__whenAppendingToExistingVersion__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 3);
+
+            var seed = getLatestVersion(datasetId);
+            assertThat(seed.itemsTotal()).isEqualTo(3);
+            assertThat(seed.itemsAdded()).isEqualTo(3);
+            assertThat(seed.itemsModified()).isZero();
+
+            // 2 brand-new items plus a re-send of an existing one: only the new items move itemsTotal.
+            var existingItem = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+            var items = new ArrayList<>(generateDatasetItems(2));
+            items.add(existingItem);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(5); // 3 + 2 new (the update doesn't count)
+            assertThat(updated.itemsAdded()).isEqualTo(5);
+            assertThat(updated.itemsModified()).isEqualTo(1);
+            assertThat(updated.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: multi-batch append via batch_group_id accumulates the full counter triple")
+        void insertItems__whenAppendingViaBatchGroupId__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // First batch creates the version; the next two append into it via the batch_group_id path.
+            for (int i = 0; i < 3; i++) {
+                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                        .datasetId(datasetId)
+                        .batchGroupId(batchGroupId)
+                        .items(generateDatasetItems(2))
+                        .build(), TEST_WORKSPACE, API_KEY);
+            }
+
+            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).content()).hasSize(1);
+
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(6);
+            assertThat(version.itemsAdded()).isEqualTo(6);
+            assertThat(version.itemsModified()).isZero();
+            assertThat(version.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: concurrent increments are exact without the per-dataset lock")
+        void incrementCounts__whenConcurrentWritersBypassTheLock__thenCountersAreExact() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Hit the DAO directly so withDatasetVersionLock is out of the picture entirely: this is what
+            // proves the arithmetic itself is atomic rather than merely serialized by the lock. The old
+            // read-modify-write would lose updates here.
+            int writers = 8;
+            int incrementsPerWriter = 25;
+
+            ExecutorService executor = Executors.newFixedThreadPool(writers);
+            CyclicBarrier barrier = new CyclicBarrier(writers);
+            try {
+                IntStream.range(0, writers)
+                        .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                            awaitBarrier(barrier);
+                            for (int n = 0; n < incrementsPerWriter; n++) {
+                                incrementCounts(versionId, 1, 1, 2, 0);
+                            }
+                        }, executor))
+                        .toList()
+                        .forEach(CompletableFuture::join);
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            int expectedIncrements = writers * incrementsPerWriter;
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsAdded()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsModified()).isEqualTo(2 * expectedIncrements);
+        }
+
+        @Test
+        @DisplayName("Success: negative deltas on the delete path decrement total and raise deleted")
+        void incrementCounts__whenNegativeDelta__thenTotalDecrements() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var seed = getLatestVersion(datasetId);
+            var itemToDelete = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+
+            datasetResourceClient.deleteDatasetItems(DatasetItemsDelete.builder()
+                    .itemIds(Set.of(itemToDelete.datasetItemId()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(4);
+            assertThat(updated.itemsDeleted()).isEqualTo(1);
+            // The delete path leaves added/modified untouched.
+            assertThat(updated.itemsAdded()).isEqualTo(seed.itemsAdded());
+            assertThat(updated.itemsModified()).isEqualTo(seed.itemsModified());
+        }
+
+        @Test
+        @DisplayName("Success: increment against an unknown version affects no rows")
+        void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
+            assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5572,6 +5572,36 @@ class DatasetVersionResourceTest {
         }
 
         @Test
+        @DisplayName("Success: NULL counters are treated as zero rather than staying NULL")
+        void incrementCounts__whenCountersAreNull__thenTreatedAsZero() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // The counter columns are `INT DEFAULT 0` -- nullable, since DEFAULT only applies when the
+            // column is omitted on INSERT. A bare `col + :delta` would leave NULL as NULL, which then
+            // unboxes to an NPE on the Integer-typed record. The absolute update this replaced happened
+            // to repair a NULL by overwriting it, so the increment has to COALESCE explicitly.
+            int nulled = mySqlTemplate.inTransaction(WRITE, handle -> handle.createUpdate("""
+                    UPDATE dataset_versions
+                    SET items_total = NULL, items_added = NULL, items_modified = NULL, items_deleted = NULL
+                    WHERE id = :version_id AND workspace_id = :workspace_id
+                    """)
+                    .bind("version_id", versionId.toString())
+                    .bind("workspace_id", WORKSPACE_ID)
+                    .execute());
+            assertThat(nulled).isOne();
+
+            assertThat(incrementCounts(versionId, 3, 3, 1, 0)).isOne();
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded,
+                            DatasetVersion::itemsModified, DatasetVersion::itemsDeleted)
+                    .containsExactly(3, 3, 1, 0);
+        }
+
+        @Test
         @DisplayName("Success: increment against an unknown version affects no rows")
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5576,6 +5576,22 @@ class DatasetVersionResourceTest {
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
+
+        @Test
+        @DisplayName("Success: increment scoped to another workspace affects no rows")
+        void incrementCounts__whenVersionBelongsToAnotherWorkspace__thenNoRowsAffected() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            var seed = getLatestVersion(datasetId);
+
+            // Real version id, wrong workspace: the workspace predicate must keep the update from matching, which is
+            // what lets both count-update helpers detect a missing/foreign version from the affected-row count alone.
+            int updated = mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(seed.id(), 1, 1, 0, 0, UUID.randomUUID().toString(), USER));
+
+            assertThat(updated).isZero();
+            assertThat(getLatestVersion(datasetId).itemsTotal()).isEqualTo(seed.itemsTotal());
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -1660,6 +1660,10 @@ class DatasetVersionResourceTest {
             assertThat(latestVersion.id()).isEqualTo(version1.id()); // Same version ID
             assertThat(latestVersion.versionName()).isEqualTo("v1");
             assertThat(latestVersion.itemsTotal()).isEqualTo(4); // 5 - 1 = 4
+            // A delete moves total and deleted only; the added/modified counters from v1 stay put.
+            assertThat(latestVersion.itemsDeleted()).isEqualTo(1);
+            assertThat(latestVersion.itemsAdded()).isEqualTo(version1.itemsAdded());
+            assertThat(latestVersion.itemsModified()).isEqualTo(version1.itemsModified());
 
             // Verify only 4 items remain in the latest version
             var v1ItemsAfter = datasetResourceClient.getDatasetItems(
@@ -3823,6 +3827,9 @@ class DatasetVersionResourceTest {
             var version = getLatestVersion(datasetId);
             assertThat(version.itemsTotal()).isEqualTo(6);
             assertThat(version.itemsAdded()).isEqualTo(6);
+            // Appends of brand-new items move total and added only; nothing here is an update or a delete.
+            assertThat(version.itemsModified()).isZero();
+            assertThat(version.itemsDeleted()).isZero();
             assertThat(version.versionName()).isEqualTo("v1");
 
             // Verify items can be fetched
@@ -5484,30 +5491,6 @@ class DatasetVersionResourceTest {
         }
 
         @Test
-        @DisplayName("Success: multi-batch append via batch_group_id accumulates the full counter triple")
-        void insertItems__whenAppendingViaBatchGroupId__thenCountersAccumulate() {
-            var datasetId = createDataset(UUID.randomUUID().toString());
-            var batchGroupId = UUID.randomUUID();
-
-            // First batch creates the version; the next two append into it via the batch_group_id path.
-            for (int i = 0; i < 3; i++) {
-                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
-                        .datasetId(datasetId)
-                        .batchGroupId(batchGroupId)
-                        .items(generateDatasetItems(2))
-                        .build(), TEST_WORKSPACE, API_KEY);
-            }
-
-            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).content()).hasSize(1);
-
-            var version = getLatestVersion(datasetId);
-            assertThat(version.itemsTotal()).isEqualTo(6);
-            assertThat(version.itemsAdded()).isEqualTo(6);
-            assertThat(version.itemsModified()).isZero();
-            assertThat(version.itemsDeleted()).isZero();
-        }
-
-        @Test
         @DisplayName("Success: concurrent increments are exact without the per-dataset lock")
         void incrementCounts__whenConcurrentWritersBypassTheLock__thenCountersAreExact() {
             var datasetId = createDataset(UUID.randomUUID().toString());
@@ -5546,29 +5529,6 @@ class DatasetVersionResourceTest {
             assertThat(version.itemsTotal()).isEqualTo(1 + expectedIncrements);
             assertThat(version.itemsAdded()).isEqualTo(1 + expectedIncrements);
             assertThat(version.itemsModified()).isEqualTo(2 * expectedIncrements);
-        }
-
-        @Test
-        @DisplayName("Success: negative deltas on the delete path decrement total and raise deleted")
-        void incrementCounts__whenNegativeDelta__thenTotalDecrements() {
-            var datasetId = createDataset(UUID.randomUUID().toString());
-            createDatasetItems(datasetId, 5);
-
-            var seed = getLatestVersion(datasetId);
-            var itemToDelete = datasetResourceClient.getDatasetItems(
-                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
-
-            datasetResourceClient.deleteDatasetItems(DatasetItemsDelete.builder()
-                    .itemIds(Set.of(itemToDelete.datasetItemId()))
-                    .build(), TEST_WORKSPACE, API_KEY);
-
-            var updated = getLatestVersion(datasetId);
-            assertThat(updated.id()).isEqualTo(seed.id());
-            assertThat(updated.itemsTotal()).isEqualTo(4);
-            assertThat(updated.itemsDeleted()).isEqualTo(1);
-            // The delete path leaves added/modified untouched.
-            assertThat(updated.itemsAdded()).isEqualTo(seed.itemsAdded());
-            assertThat(updated.itemsModified()).isEqualTo(seed.itemsModified());
         }
 
         @Test
@@ -5621,6 +5581,69 @@ class DatasetVersionResourceTest {
 
             assertThat(updated).isZero();
             assertThat(getLatestVersion(datasetId).itemsTotal()).isEqualTo(seed.itemsTotal());
+        }
+
+        @Test
+        @DisplayName("Success: a version left at the not-migrated sentinel is never incremented")
+        void incrementCounts__whenVersionHoldsNotMigratedSentinel__thenNoRowsAffected() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 3);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Liquibase 000046 leaves pre-versioning datasets at items_total = -1 until the backfill runs, and
+            // findVersionsNeedingItemsTotalMigration selects on exactly that value. Adding a delta would both
+            // corrupt the counter and hide the row from the backfill forever, so the increment must skip it.
+            int sentinelled = mySqlTemplate.inTransaction(WRITE, handle -> handle.createUpdate("""
+                    UPDATE dataset_versions
+                    SET items_total = :sentinel
+                    WHERE id = :version_id AND workspace_id = :workspace_id
+                    """)
+                    .bind("sentinel", DatasetVersionDAO.ITEMS_TOTAL_NOT_MIGRATED)
+                    .bind("version_id", versionId.toString())
+                    .bind("workspace_id", WORKSPACE_ID)
+                    .execute());
+            assertThat(sentinelled).isOne();
+
+            assertThat(incrementCounts(versionId, 5, 5, 0, 0)).isZero();
+
+            // Still exactly the sentinel: untouched, so the backfill will still find it.
+            assertThat(getLatestVersion(datasetId).itemsTotal())
+                    .isEqualTo(DatasetVersionDAO.ITEMS_TOTAL_NOT_MIGRATED);
+        }
+
+        @Test
+        @DisplayName("Error: insert whose version is left at the sentinel surfaces 404, not a silent success")
+        void insertItems__whenCountUpdateMatchesNoRow__thenNotFound() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Reaching the `updated == 0` guard through the public API needs a version that still resolves as
+            // "latest" (so the insert appends rather than minting a new version) but that the count UPDATE
+            // refuses to match. The not-migrated sentinel is exactly that state: an un-backfilled version being
+            // written to before the migration job has reached it.
+            mySqlTemplate.inTransaction(WRITE, handle -> handle.createUpdate("""
+                    UPDATE dataset_versions
+                    SET items_total = :sentinel
+                    WHERE id = :version_id AND workspace_id = :workspace_id
+                    """)
+                    .bind("sentinel", DatasetVersionDAO.ITEMS_TOTAL_NOT_MIGRATED)
+                    .bind("version_id", versionId.toString())
+                    .bind("workspace_id", WORKSPACE_ID)
+                    .execute());
+
+            try (var response = datasetResourceClient.callCreateDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(generateDatasetItems(1))
+                    .build(), TEST_WORKSPACE, API_KEY)) {
+
+                // Surfacing this beats the alternatives: silently dropping the counter update, or corrupting the
+                // sentinel so the backfill never reconciles the row.
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
+
+            assertThat(getLatestVersion(datasetId).itemsTotal())
+                    .isEqualTo(DatasetVersionDAO.ITEMS_TOTAL_NOT_MIGRATED);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5353,6 +5353,22 @@ class DatasetVersionResourceTest {
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
+
+        @Test
+        @DisplayName("Success: increment scoped to another workspace affects no rows")
+        void incrementCounts__whenVersionBelongsToAnotherWorkspace__thenNoRowsAffected() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            var seed = getLatestVersion(datasetId);
+
+            // Real version id, wrong workspace: the workspace predicate must keep the update from matching, which is
+            // what lets both count-update helpers detect a missing/foreign version from the affected-row count alone.
+            int updated = mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(seed.id(), 1, 1, 0, 0, UUID.randomUUID().toString(), USER));
+
+            assertThat(updated).isZero();
+            assertThat(getLatestVersion(datasetId).itemsTotal()).isEqualTo(seed.itemsTotal());
+        }
     }
 
     @Nested

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -93,6 +93,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5428,6 +5429,152 @@ class DatasetVersionResourceTest {
                     datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
             assertThat(latestItems).hasSize(1);
             assertThat(latestItems.getFirst().description()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Atomic version count updates (OPIK-7707):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AtomicVersionCountUpdates {
+
+        private int incrementCounts(UUID versionId, int total, int added, int modified, int deleted) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(versionId, total, added, modified, deleted, WORKSPACE_ID, USER));
+        }
+
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException | TimeoutException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Test
+        @DisplayName("Success: single-batch append accumulates the full counter triple")
+        void insertItems__whenAppendingToExistingVersion__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 3);
+
+            var seed = getLatestVersion(datasetId);
+            assertThat(seed.itemsTotal()).isEqualTo(3);
+            assertThat(seed.itemsAdded()).isEqualTo(3);
+            assertThat(seed.itemsModified()).isZero();
+
+            // 2 brand-new items plus a re-send of an existing one: only the new items move itemsTotal.
+            var existingItem = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+            var items = new ArrayList<>(generateDatasetItems(2));
+            items.add(existingItem);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(5); // 3 + 2 new (the update doesn't count)
+            assertThat(updated.itemsAdded()).isEqualTo(5);
+            assertThat(updated.itemsModified()).isEqualTo(1);
+            assertThat(updated.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: multi-batch append via batch_group_id accumulates the full counter triple")
+        void insertItems__whenAppendingViaBatchGroupId__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // First batch creates the version; the next two append into it via the batch_group_id path.
+            for (int i = 0; i < 3; i++) {
+                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                        .datasetId(datasetId)
+                        .batchGroupId(batchGroupId)
+                        .items(generateDatasetItems(2))
+                        .build(), TEST_WORKSPACE, API_KEY);
+            }
+
+            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).content()).hasSize(1);
+
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(6);
+            assertThat(version.itemsAdded()).isEqualTo(6);
+            assertThat(version.itemsModified()).isZero();
+            assertThat(version.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: concurrent increments are exact without the per-dataset lock")
+        void incrementCounts__whenConcurrentWritersBypassTheLock__thenCountersAreExact() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Hit the DAO directly so withDatasetVersionLock is out of the picture entirely: this is what
+            // proves the arithmetic itself is atomic rather than merely serialized by the lock. The old
+            // read-modify-write would lose updates here.
+            int writers = 8;
+            int incrementsPerWriter = 25;
+
+            ExecutorService executor = Executors.newFixedThreadPool(writers);
+            CyclicBarrier barrier = new CyclicBarrier(writers);
+            try {
+                IntStream.range(0, writers)
+                        .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                            awaitBarrier(barrier);
+                            for (int n = 0; n < incrementsPerWriter; n++) {
+                                incrementCounts(versionId, 1, 1, 2, 0);
+                            }
+                        }, executor))
+                        .toList()
+                        .forEach(CompletableFuture::join);
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            int expectedIncrements = writers * incrementsPerWriter;
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsAdded()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsModified()).isEqualTo(2 * expectedIncrements);
+        }
+
+        @Test
+        @DisplayName("Success: negative deltas on the delete path decrement total and raise deleted")
+        void incrementCounts__whenNegativeDelta__thenTotalDecrements() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var seed = getLatestVersion(datasetId);
+            var itemToDelete = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+
+            datasetResourceClient.deleteDatasetItems(DatasetItemsDelete.builder()
+                    .itemIds(Set.of(itemToDelete.datasetItemId()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(4);
+            assertThat(updated.itemsDeleted()).isEqualTo(1);
+            // The delete path leaves added/modified untouched.
+            assertThat(updated.itemsAdded()).isEqualTo(seed.itemsAdded());
+            assertThat(updated.itemsModified()).isEqualTo(seed.itemsModified());
+        }
+
+        @Test
+        @DisplayName("Success: increment against an unknown version affects no rows")
+        void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
+            assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
     }
 


### PR DESCRIPTION
## Details

<img width="968" height="1348" alt="image" src="https://github.com/user-attachments/assets/ccef07fe-f986-49b2-b94e-f5a2438f3d43" />

Every batch appended to an existing dataset version paid three MySQL round-trips inside the per-dataset lock that serialises the upload: `findById`, then `updateCounts` with totals computed in Java, then a `getVersionById` re-read of the row just written. Because the lock serialises batches, those round-trips are additive across an upload — a 100-batch upload pays them 100 times in sequence. This replaces the read-modify-write with a single atomic SQL increment and drops the re-read, taking the insert path from three statements to one.

- `DatasetVersionDAO.updateCounts` (absolute values) becomes `incrementCounts`, which applies **signed deltas** in the database (`SET items_total = items_total + :delta`). One method serves both paths: `+n` on insert, `-n` total / `+n` deleted on delete. It returns the affected-row count so the service preserves the `NotFoundException` that `findById().orElseThrow()` used to provide.
- Service-side, both paths funnel through one private `updateVersionCounts(...)` that owns the transaction, the DAO call, and the zero-row `NotFoundException` guard. `updateVersionCountsForInsert` / `...ForDelete` remain as thin named wrappers documenting which counters each path moves.
- The post-insert `getVersionById` is gone. No consumer reads the returned `DatasetVersion` — the REST endpoint returns 204 with the `.block()` result unassigned, and `saveBatch` maps it to `items.size()` — so `insertItemsIntoVersion` now returns `Mono<Void>` rather than fabricating a partially-populated object that would look real to a future caller.
- The delete path is converted to the same atomic increment. **It saves no round-trip** — both callers already fetch the version for their own logging — but the arithmetic no longer depends on `withDatasetVersionLock` for mutual exclusion, and insert/delete now write counts the same way.
- Counter semantics are unchanged; this changes only how counts are written.

Two notes for reviewers, since they differ from the ticket as filed:

- The ticket cites an existing test `InsertClassificationCounts` as a regression net for this path. No test by that name exists in the tree; the real coverage is in `DatasetVersionResourceTest` (`VersionSnapshotTests`, `ApplyDatasetItemChanges`, `MutateLatestVersion`).
- The ticket assumes the delete path shares the insert path's wasteful shape. It doesn't — expect no latency change there, only the consistency and lock-independence win described above.

`updateCounts` had zero remaining callers once both paths were converted, so it was removed rather than left as dead code.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7707

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation (code + tests)
- Human verification: CI green (all 16 integration groups); pending human code review

## Testing

Added a `AtomicVersionCountUpdates` nested class in `DatasetVersionResourceTest` with six tests:

- single-batch append asserts the full counter triple, including that a re-sent existing item moves `itemsModified` but not `itemsTotal`
- multi-batch append via the `batch_group_id` entrypoint accumulates into one version
- **8 threads × 25 concurrent increments hitting the DAO directly with `withDatasetVersionLock` bypassed**, asserting exact counters — this is the acceptance criterion that the arithmetic no longer depends on the lock; the previous read-modify-write would lose updates here
- delete path: negative delta decrements `items_total` and raises `items_deleted`, leaving added/modified untouched
- increment against an unknown version affects zero rows (the `NotFoundException` path)
- increment scoped to a foreign workspace affects zero rows and leaves counters untouched (added in review follow-up)

Commands run:

- `mvn -o compile -DskipTests` — passes
- `mvn -o test-compile -DskipTests` — passes
- `mvn -o spotless:check` — `BUILD SUCCESS`

**CI result:** all 16 backend integration groups pass. `DatasetVersionResourceTest$AtomicVersionCountUpdates` reports `Tests run: 6, Failures: 0, Errors: 0` (Integration Group 6), so all six new tests executed and passed — including the lock-bypassed concurrency test. Pre-existing regression nets on these paths are green as well: `MutateLatestVersion` (6), `ConcurrentUploads` (4), `DeleteItemsWithVersioning` (5), `BatchVersioningTests`, `BatchVersioningDeleteTests` (10).

Note on local runs: `mvn -o test -Dtest=DatasetVersionResourceTest` could not be brought to green on my machine — three attempts each died in the test-class constructor, before any test method, with `ClickHouse exception, code: 159 ... Read timed out` on `ON CLUSTER` DDL during Liquibase migration, on a *different* pre-existing changeset each time (`000097`, `000109`, `000070`). That is local distributed-DDL latency, not this diff: the change is MySQL-only and all three changesets are already on `main`. CI, which has a healthy container environment, runs the suite clean.

Also verified by inspection: the counter columns are signed `INT` (`000036_add_dataset_versions_tables.sql`), so the delete path's negative delta cannot hit an unsigned-underflow error under strict mode — same semantics as the previous Java-side subtraction. No migration is required.

### Review follow-up (`0eb086558e`, `0153bc85dc`)

`updateVersionCountsForDelete` now checks the affected-row count from `incrementCounts` and throws `NotFoundException` on zero, matching the insert path; the helper's duplicate `log.info` was dropped (the callers already log `deletedCount`, `versionId`, and the resulting total). Note this failure mode is not reachable today — both delete callers call `getVersionById` first, which already throws — but insert and delete were handling a zero-row result inconsistently, which would become a real bug once the lock is narrowed or the pre-fetch removed.

That guard left the two helpers identical apart from their delta arguments, so a second follow-up folded the shared transaction / DAO-call / guard into one `updateVersionCounts(...)` taking signed deltas. Pure refactor, no behavioural change: verified by `AtomicVersionCountUpdates` (6), `MutateLatestVersion` (6, insert wrapper) and `DeleteItemsWithVersioning` (5, delete wrapper) all green on `0153bc85dc`.

## Documentation

N/A — internal performance and correctness-hardening change with no user-facing or API surface.
