### PR TITLE
[OPIK-7711] [QA][FE] test: add E2E coverage for multi-trace deletion

### DIFF
--- a/.agents/skills/explore-feature/SKILL.md
+++ b/.agents/skills/explore-feature/SKILL.md
@@ -208,8 +208,16 @@ dev's local stack."
 
 ## Phase 5 — Confirm
 
-- The spec exists at `targetPath`, tagged `@release-gate` + `@release-gate:<version>` + a feature
-  tag.
+- The spec exists at `targetPath`, tagged `@release-gate` + `@release-gate:<version>` +
+  `@area:<area>`, with a `@cap:` per test.
+- Those `@area:`/`@cap:` values resolve in `tests_end_to_end/coverage/taxonomy.yaml`, and the
+  taxonomy was updated in the same change (spec added to `specs:`, covered capabilities flipped to
+  `covered: true`).
+- `tag_lint.py` reports `0 problem(s)` — this is the CI `tag-lint` job, so a miss here is a red
+  build:
+  ```bash
+  python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
+  ```
 - It runs green locally: `cd tests_end_to_end/e2e && npm run test:release-gate`.
 - The plan was posted to Jira (or printed for manual posting).
 - Report the committed spec path and the Jira comment link back to the dev.

--- a/.agents/skills/explore-feature/release-gate-contract.md
+++ b/.agents/skills/explore-feature/release-gate-contract.md
@@ -14,14 +14,31 @@ test must be **staging-ready** and stamped. This contract overrides those defaul
 ## Tags (on the `test.describe`)
 
 ```ts
-{ tag: ['@release-gate', '@release-gate:<version>', '@<feature>'] }
+test.describe('<feature>', { tag: ['@release-gate', '@release-gate:<version>', '@area:<area>'] }, () => {
+  test('<flow>', { tag: ['@cap:<area>.<capability>'] }, async ({ ... }) => {
 ```
 
 - `@release-gate` — always.
 - `@release-gate:<version>` — the stamp. `<version>` = `git show origin/main:version.txt` read at
   authoring time (see the stamp rules in SKILL.md). Never `@t1-smoke`/`@t2-cuj`/`@t3-nightly` —
   gate tests are not part of the curated tiers.
-- `@<feature>` — the page-family tag matching the change (`@datasets`, `@trace-explore`, …).
+- `@area:<area>` — the area this change belongs to.
+- `@cap:<area>.<capability>` — at least one per test, matching the spec's own area.
+
+**`@area:` and `@cap:` must exist in `tests_end_to_end/coverage/taxonomy.yaml`.** They are a fixed
+vocabulary, not free text, and CI's `tag-lint` job fails the build on an unregistered value. Grep
+the taxonomy for the feature before writing the tag — the capability is often already reserved
+there as `covered: false`. If nothing fits, add a new entry under the right area in this same
+change. Being tier-less does **not** exempt a gate spec from this: the linter allows a
+suite-selector spec to skip the tier tag, but still requires a valid area and capability.
+
+Update the taxonomy alongside the spec: add the spec path to the area's `specs:` list, and set
+each capability you now cover to `covered: true`. Then run the linter — it's instant and it is
+exactly what CI runs:
+
+```bash
+python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
+```
 
 **Append reconciliation:** if appending, the describe block keeps the **earliest un-shipped**
 `@release-gate:<v>` across its tests, so the assembled feature gates the earliest-targeted release.
@@ -78,3 +95,6 @@ minimal — ticket key + one-line scope only; no restated plan (it lives in Jira
 
 Explore the live UI and run the spec **green against the dev's local stack** (see the local-run
 gate in SKILL.md). Local-green is the PR gate; staging-green (CI, later) is the release gate.
+
+Also run `tag_lint.py` (above) and, if you touched a shared POM, the whole feature directory — a
+passing spec hides both tag errors and sibling breakage.

--- a/.agents/skills/writing-e2e-tests/SKILL.md
+++ b/.agents/skills/writing-e2e-tests/SKILL.md
@@ -79,7 +79,8 @@ When discovery is done, report a short summary — the selectors you'll use per 
 ### Step 4 — Write the POM + spec
 
 - Write or extend the POM in `pom/<name>.page.ts` using the selectors from discovery. Each method wraps its body in `test.step()` and returns through the callback (see [conventions.md](conventions.md)).
-- Write the spec in `tests/<feature>/<name>.spec.ts`: tier + feature tag on the describe block, coarse `test.step()` phases, UI-first assertions.
+- Write the spec in `tests/<feature>/<name>.spec.ts`: tier + `@area:` on the describe block, a `@cap:` per test, coarse `test.step()` phases, UI-first assertions.
+- **Take the `@area:`/`@cap:` values from `tests_end_to_end/coverage/taxonomy.yaml` — never invent them.** Grep it for the feature first; the capability you're covering is usually already reserved as `covered: false`. Update the taxonomy in the same change: add the spec to the area's `specs:` list and flip each covered capability to `covered: true` with its tier. See the Tags section of [conventions.md](conventions.md).
 - If discovery flagged a missing/brittle selector, add a descriptive `data-testid` to the FE component in the **same change**.
 
 #### Rebuilding the FE after adding a `data-testid`
@@ -121,6 +122,22 @@ npx playwright test tests/<feature>/<name>.spec.ts --reporter=list
 
 The bridge auto-spawns (you'll see its startup line in the output). If a test fails, **read the failure trace** (`npx playwright show-trace`) rather than adjusting selectors blindly — see "verify the test render before blaming the backend" in [conventions.md](conventions.md). Fix and re-run until green. Report the actual run output.
 
+Three checks before you call it done — each catches something the single-spec run can't:
+
+```bash
+# 1. Tags resolve in the taxonomy (this is the CI `tag-lint` job — run it locally, it's instant)
+python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
+
+# 2. If you touched a shared POM, the whole feature directory still passes
+npx playwright test tests/<feature>/ --reporter=list
+
+# 3. Types
+npx tsc --noEmit
+```
+
+"My spec passes" is not "I didn't break anything": a shared POM is used by sibling specs, and
+tag-lint failures never surface in a Playwright run at all.
+
 ## Safety: verify local config before seeding
 
 The Python SDK behind the bridge reads `~/.opik.config`. If it points at a cloud environment, seeding would create real data there. Before any seed against a local target:
@@ -151,3 +168,5 @@ When the work is done, remind the dev to restore: `cp ~/.opik.config.bak ~/.opik
 | "I'll write the POM and find out if it works when the whole suite runs" | Run-until-green in isolation — iterate on the one spec, don't debug it inside a full suite run. |
 | "`page.locator('tbody tr:nth-child(3)')` is fine" | Flagging the missing testid — brittle structural selectors are the top source of flake; add a `data-testid`. |
 | "I'll create the dataset through the UI so the page has data" | SDK/bridge seeding — UI-create is what the test exercises, not how you set up. |
+| "`@cap:traces.bulk-delete-traces` describes what my test does" | Checking the taxonomy — `@area:`/`@cap:` values are a fixed vocabulary in `taxonomy.yaml`, not free text. CI's `tag-lint` rejects invented names, and the capability you want is usually already reserved there. |
+| "The spec passes, so I'm done" | `tag_lint.py`, the feature-directory run, and `tsc` — a green single spec hides tag errors and sibling breakage from a shared POM. |

--- a/.agents/skills/writing-e2e-tests/conventions.md
+++ b/.agents/skills/writing-e2e-tests/conventions.md
@@ -85,20 +85,57 @@ When something "isn't appearing," the usual cause is a DOM race (a loading spinn
 
 ## Tags
 
-Every test carries a tier tag and a feature tag. Tiers are inclusive: `test:t2` runs `@t1-smoke|@t2-cuj`, `test:t3` runs all three.
+Every spec carries a tier tag and an `@area:` tag on the describe block, and at least one
+`@cap:` tag naming the capability it asserts. Tiers are inclusive: `test:t2` runs
+`@t1-smoke|@t2-cuj`, `test:t3` runs all three.
 
 - `@t1-smoke` — fast, deterministic, always-on core checks.
 - `@t2-cuj` — core user journeys; multi-step flows.
 - `@t3-nightly` — broader / slower coverage.
 
-Apply them on the describe block alongside the feature tag:
-
 ```ts
-test.describe('Dataset CRUD — smoke', { tag: ['@t1-smoke', '@datasets'] }, () => {
-  // ...
+test.describe('Trace Explore — smoke', { tag: ['@t1-smoke', '@area:traces'] }, () => {
+  test('Logs view shows seeded traces', { tag: ['@cap:traces.list-traces'] }, async ({ page }) => {
+    // ...
+  });
 });
 ```
 
-Pick the tier by what the test costs and how core it is; pick the feature tag to match the page family (`@datasets`, `@trace-explore`, `@experiments`, …).
+### `@area:` and `@cap:` values MUST exist in the taxonomy
+
+`tests_end_to_end/coverage/taxonomy.yaml` is the source of truth for both, and CI enforces it via
+the **`tag-lint`** job. **Never invent a tag name.** An unregistered value fails the build with
+`unknown capability '@cap:x.y' — not in taxonomy`.
+
+The taxonomy usually already reserves the capability you're about to cover, as
+`covered: false`. Grep before you write:
+
+```bash
+grep -n "your-feature" tests_end_to_end/coverage/taxonomy.yaml
+```
+
+If an entry exists, **use that exact name** and flip it to `covered: true` with the tier you
+assigned. If none fits, add a new one under the right area — a kebab-case name describing the
+user-facing capability, not the test's mechanics.
+
+A `@cap:` is written `@cap:<area>.<capability>` and must sit under the spec's own `@area:`.
+
+### Keeping the taxonomy in sync
+
+Adding or changing a spec means editing `taxonomy.yaml` in the **same** change:
+
+1. Add the spec's path to the area's `specs:` list.
+2. For each capability the spec now covers: set `covered: true` and record the `tier:`.
+3. If you're covering something not yet listed, add the capability entry first.
+
+### Run the linter before you push
+
+It's fast, needs no browser, and catches exactly the class of mistake CI would:
+
+```bash
+python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
+```
+
+Expect `0 problem(s)`. Full grammar: `tests_end_to_end/TESTING-TAGS.md`.
 
 **Exception — release-gate specs.** Dev-authored release-gate tests are the one case that does *not* follow the rules above: they live at `tests/_release-gate/<lead-ticket>.spec.ts` (not `tests/<feature>/`) and carry `@release-gate` + `@release-gate:<version>` instead of a tier tag, so they stay out of the curated `@t1-smoke`/`@t2-cuj`/`@t3-nightly` suites. They are governed by `.agents/skills/explore-feature/release-gate-contract.md`, not this file. If you're following these conventions, treat a spec under `_release-gate/` as intentional, not a violation.

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -209,6 +209,7 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
               resetKeyRef.current = resetKeyRef.current + 1;
             }}
             disabled={disabled}
+            data-testid="traces-bulk-delete-button"
           >
             <Trash />
           </Button>

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -181,6 +181,7 @@ areas:
     specs:
       - trace-explore/trace-explore-smoke.spec.ts
       - trace-explore/trace-spans-depth.spec.ts
+      - trace-explore/trace-delete.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -198,7 +199,8 @@ areas:
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
       agent-graph-tab:        { covered: false }
       attachments-media:      { covered: false }
-      delete-traces:          { covered: false }
+      delete-traces:          { covered: true,  tier: t2-cuj }
+      delete-traces-api:      { covered: true,  tier: t2-cuj, note: "SDK/API delete reflected in the Logs table" }
       export-traces:          { covered: false, note: "EXPORT_ENABLED flag" }
 
     # ---- visual dimension (opt-in; page/state-shaped) ----

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -314,6 +314,10 @@ export function makeBackendClient(apiKey: string | null = null) {
 
     getTrace: localGetTrace,
 
+    async deleteTraces(ids: string[]): Promise<void> {
+      await opik.api.traces.deleteTraces({ ids });
+    },
+
     async pollTraceForFeedbackScore(
       traceId: string,
       scoreName: string,

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -131,6 +131,46 @@ export class LogsPage {
     return this.page.locator('tr[data-row-id]');
   }
 
+  /** A trace row, keyed by trace id (the row's data-row-id IS the trace id). */
+  traceRow(traceId: string): Locator {
+    return this.page.locator(`tr[data-row-id="${traceId}"]`);
+  }
+
+  /** Tick the selection checkbox on a trace's row. */
+  async selectTrace(traceId: string): Promise<void> {
+    return test.step(`Select trace ${traceId}`, async () => {
+      await this.traceRow(traceId).getByRole('checkbox', { name: 'Select row' }).click();
+    });
+  }
+
+  /**
+   * The bulk-delete (trash) button in the traces actions panel. It renders as an
+   * icon-only button with no accessible name — the "Delete" label lives in a
+   * hover tooltip portal — so the testid is the only stable handle.
+   */
+  get bulkDeleteButton(): Locator {
+    return this.page.getByTestId('traces-bulk-delete-button');
+  }
+
+  /** The "Delete traces" confirmation dialog. */
+  get deleteTracesDialog(): Locator {
+    return this.page.getByRole('dialog').filter({ hasText: 'Delete traces' });
+  }
+
+  /**
+   * Bulk-delete the currently selected traces: open the confirm dialog and
+   * accept it. Callers select rows first via selectTrace().
+   */
+  async bulkDeleteSelected(): Promise<void> {
+    return test.step('Bulk-delete selected traces', async () => {
+      await this.bulkDeleteButton.click();
+      const dialog = this.deleteTracesDialog;
+      await dialog.waitFor({ state: 'visible' });
+      await dialog.getByRole('button', { name: 'Delete traces' }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
+  }
+
   /** The Errors/Duration/Estimated cost cell for a trace row, keyed by Ollie explain kind. */
   explainCell(traceId: string, kind: ExplainKind): Locator {
     return this.page.locator(`[data-cell-id="${traceId}_${EXPLAIN_COLUMN[kind]}"]`);

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -131,7 +131,13 @@ export class LogsPage {
     return this.page.locator('tr[data-row-id]');
   }
 
-  /** A trace row, keyed by trace id (the row's data-row-id IS the trace id). */
+  /**
+   * A trace row, keyed by trace id. `data-row-id` is set from the row model by
+   * the shared DataTable, so it is a first-class hook rather than a structural
+   * fallback — the same one datasets/dataset-items/compare-experiments key on.
+   * There is no text-based alternative: the id is a filter field, not a rendered
+   * column, so it appears nowhere in the row's visible cells.
+   */
   traceRow(traceId: string): Locator {
     return this.page.locator(`tr[data-row-id="${traceId}"]`);
   }

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
-import type { SdkClient } from '../../core/sdk';
+import type { SdkClient } from '@e2e/core/sdk';
 
 interface SeededTrace {
   id: string;

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
@@ -28,7 +28,7 @@ async function seedTraces(
 }
 
 test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces'] }, () => {
-  test('Bulk-deleting traces from the Logs table removes them from the UI and the API', { tag: ['@cap:traces.bulk-delete-traces'] }, async ({
+  test('Bulk-deleting traces from the Logs table removes them from the UI and the API', { tag: ['@cap:traces.delete-traces'] }, async ({
     project,
     sdkClient,
     backendClient,
@@ -69,7 +69,7 @@ test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces
     });
   });
 
-  test('Traces deleted through the API disappear from the Logs table', { tag: ['@cap:traces.bulk-delete-traces-api'] }, async ({
+  test('Traces deleted through the API disappear from the Logs table', { tag: ['@cap:traces.delete-traces-api'] }, async ({
     project,
     sdkClient,
     backendClient,

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+import type { SdkClient } from '../../core/sdk';
+
+interface SeededTrace {
+  id: string;
+  name: string;
+}
+
+/** Seed `count` traces named <namespace>-trace-<i>, oldest first. */
+async function seedTraces(
+  sdkClient: SdkClient,
+  projectName: string,
+  namespace: string,
+  count: number,
+): Promise<SeededTrace[]> {
+  const traces: SeededTrace[] = [];
+  for (let i = 0; i < count; i++) {
+    const created = await sdkClient.python.createTrace({
+      project_name: projectName,
+      name: `${namespace}-trace-${i}`,
+      input: `input-${i}`,
+      output: `output-${i}`,
+    });
+    traces.push({ id: created.id, name: created.name });
+  }
+  return traces;
+}
+
+test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test('Bulk-deleting traces from the Logs table removes them from the UI and the API', { tag: ['@cap:traces.bulk-delete-traces'] }, async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    const traces = await test.step('Seed three traces via the Python SDK', async () =>
+      seedTraces(sdkClient, project.name, testNamespace, 3));
+
+    const [survivor, doomedA, doomedB] = traces;
+    const logs = new LogsPage(page);
+
+    await test.step('Open Logs and verify all three traces are listed', async () => {
+      await logs.goto(project.id);
+      await logs.waitForReady();
+      await expect(logs.traceRows).toHaveCount(3);
+    });
+
+    await test.step('Select two traces and bulk-delete them', async () => {
+      await logs.selectTrace(doomedA.id);
+      await logs.selectTrace(doomedB.id);
+      await expect(logs.bulkDeleteButton).toBeEnabled();
+      await logs.bulkDeleteSelected();
+    });
+
+    await test.step('Verify the deleted rows are gone and the survivor remains', async () => {
+      await expect(logs.traceRow(doomedA.id)).toHaveCount(0);
+      await expect(logs.traceRow(doomedB.id)).toHaveCount(0);
+      await expect(logs.traceRow(survivor.id)).toBeVisible();
+      await expect(logs.traceRows).toHaveCount(1);
+      await expect.poll(() => logs.countTraces()).toBe(1);
+    });
+
+    await test.step('Verify the deleted traces are gone from the API too', async () => {
+      expect(await backendClient.getTrace(doomedA.id)).toBeNull();
+      expect(await backendClient.getTrace(doomedB.id)).toBeNull();
+      expect(await backendClient.getTrace(survivor.id)).not.toBeNull();
+    });
+  });
+
+  test('Traces deleted through the API disappear from the Logs table', { tag: ['@cap:traces.bulk-delete-traces-api'] }, async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    const traces = await test.step('Seed three traces via the Python SDK', async () =>
+      seedTraces(sdkClient, project.name, testNamespace, 3));
+
+    const [survivor, doomedA, doomedB] = traces;
+    const logs = new LogsPage(page);
+
+    await test.step('Open Logs and verify all three traces are listed', async () => {
+      await logs.goto(project.id);
+      await logs.waitForReady();
+      await expect(logs.traceRows).toHaveCount(3);
+    });
+
+    await test.step('Delete two traces through the REST API', async () => {
+      await backendClient.deleteTraces([doomedA.id, doomedB.id]);
+      expect(await backendClient.getTrace(doomedA.id)).toBeNull();
+      expect(await backendClient.getTrace(doomedB.id)).toBeNull();
+    });
+
+    await test.step('Reload Logs and verify only the survivor is rendered', async () => {
+      await page.reload();
+      await logs.waitForReady();
+      await expect(logs.traceRow(doomedA.id)).toHaveCount(0);
+      await expect(logs.traceRow(doomedB.id)).toHaveCount(0);
+      await expect(logs.traceRow(survivor.id)).toBeVisible();
+      await expect(logs.traceRows).toHaveCount(1);
+      await expect.poll(() => logs.countTraces()).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Details

Trace deletion had no end-to-end coverage despite being destructive and irreversible — a regression there silently loses customer observability data. This adds two mirrored tests in `trace-explore`: one deletes through the UI and verifies the traces are gone from the API, the other deletes through the API and verifies the Logs table reflects it. The pairing is deliberate — the second direction is what catches a stale-cache regression that the first cannot see.

- Adds `data-testid="traces-bulk-delete-button"` to `TracesActionsPanel`. The button is icon-only with no `aria-label` or `title` (its "Delete" text lives only in a hover tooltip portal), so no role- or text-based selector can reach it. Named to match the existing `dataset-items-bulk-delete-button` convention.
- Adds `deleteTraces(ids)` to the E2E REST client via the public `opik.api.traces` surface, and four locator/action methods to the shared `LogsPage` POM.
- Marks `traces.delete-traces` (already reserved as `covered: false`) as covered in `coverage/taxonomy.yaml` and registers a `delete-traces-api` sibling for the API-side flow.
- Fixes both E2E skills, which documented a stale feature-tag vocabulary that predates the `@area:`/`@cap:` grammar — see below.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7711

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Test authoring, POM/REST-client methods, the frontend `data-testid`, the taxonomy entries, and the skill documentation fix. Selectors were chosen by exploring the live rendered DOM, not inferred from source.
- Human verification: Flows reviewed and approved before authoring; test runs and their results reviewed.

## Testing

Run against a local OSS stack (frontend from source on `:5174`, backend `2.2.9` via the compose stack), `OPIK_DEPLOYMENT=oss`:

```
npx playwright test tests/trace-explore/trace-delete.spec.ts --reporter=list
npx playwright test tests/trace-explore/trace-delete.spec.ts --repeat-each=3   # 6/6 passed — stability check
npx playwright test tests/trace-explore/                                        # 10/10 passed — regression check
python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end   # 0 problem(s)
npx tsc --noEmit                                                                # clean
```

The full-directory run matters because this modifies the shared `logs.page.ts` POM used by the other `trace-explore` specs. `pre-commit` on the changed files passes (frontend eslint + typecheck).

**One test is expected to fail right now.** "Bulk-deleting traces from the Logs table…" fails on its final count-card assertion because of a separate frontend bug: `useTracesBatchDeleteMutation` does not invalidate the `"traces-statistic"` query key that feeds the metrics cards, so the Traces card keeps its pre-delete value until an unrelated refetch. The table itself updates correctly, and every other assertion in the test passes.

That bug is filed separately as OPIK_7710 with a screen recording and a suggested one-line fix. The assertion here deliberately encodes the *correct* behaviour rather than the current one, so this test turns green when that bug is fixed. Two sibling mutations in the same directory already perform that invalidation, so it reads as an omission rather than a design choice.

Not covered, flagged on the ticket for a later pass: Threads delete, the Spans-tab absence of delete, the "Select all N items" delete-by-filter path, the cancel path, the experiment-sample cascade, and permission gating (`canDeleteTraces=false` is not reachable in OSS).

## Skill fix

The first push of this branch failed `tag-lint` with invented `@cap:` names. Root cause was the skills themselves: `writing-e2e-tests/conventions.md` and `explore-feature/release-gate-contract.md` both documented a page-family tag vocabulary (`@datasets`, `@trace-explore`) that predates the `@area:`/`@cap:` grammar `tag_lint.py` enforces, with no mention of `taxonomy.yaml` at all. Following the skill produced a red build.

Both now state that `@area:`/`@cap:` are a fixed vocabulary sourced from `coverage/taxonomy.yaml`, that the capability is usually already reserved there as `covered: false`, and that the taxonomy is updated in the same change. `tag_lint.py`, the feature-directory run, and `tsc --noEmit` are added to the verification steps of both skills, plus two anti-pattern rows.

## Documentation

No product documentation changes — tests, one test hook, taxonomy bookkeeping, and internal skill docs.
