### PR TITLE
[OPIK-7710] [FE] fix: refresh Logs metrics cards after deleting traces and threads

### DIFF
--- a/apps/opik-frontend/src/api/traces/deleteMutationsStatisticInvalidation.test.tsx
+++ b/apps/opik-frontend/src/api/traces/deleteMutationsStatisticInvalidation.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const post = vi.fn(() => Promise.resolve({ data: {} }));
+const del = vi.fn(() => Promise.resolve({ data: {} }));
+
+vi.mock("@/api/api", () => ({
+  default: {
+    post: () => post(),
+    delete: () => del(),
+  },
+  TRACES_REST_ENDPOINT: "/v1/private/traces/",
+  TRACES_KEY: "traces",
+  SPANS_KEY: "spans",
+  THREADS_KEY: "threads",
+  COMPARE_EXPERIMENTS_KEY: "compare-experiments",
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import useTracesBatchDeleteMutation from "./useTraceBatchDeleteMutation";
+import useTraceDeleteMutation from "./useTraceDeleteMutation";
+import useThreadBatchDeleteMutation from "./useThreadBatchDeleteMutation";
+
+const PROJECT_ID = "project-1";
+
+const renderMutation = <T,>(hook: () => T) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+  });
+  const invalidated: unknown[][] = [];
+  queryClient.invalidateQueries = vi.fn(({ queryKey }) => {
+    invalidated.push(queryKey as unknown[]);
+    return Promise.resolve();
+  }) as never;
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { ...renderHook(hook, { wrapper }), invalidated };
+};
+
+const invalidatedPrefixes = (invalidated: unknown[][]) =>
+  invalidated.map((key) => key[0]);
+
+describe("trace/thread delete mutations invalidate the metrics-card queries", () => {
+  it("useTracesBatchDeleteMutation invalidates trace/span statistics and the KPI cards", async () => {
+    const { result, invalidated } = renderMutation(() =>
+      useTracesBatchDeleteMutation(),
+    );
+
+    await act(async () => {
+      result.current.mutate({ ids: ["t1", "t2"], projectId: PROJECT_ID });
+    });
+
+    await waitFor(() => expect(invalidated.length).toBeGreaterThan(0));
+
+    expect(invalidatedPrefixes(invalidated)).toContain("traces-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("spans-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("project-kpi-cards");
+  });
+
+  it("useTraceDeleteMutation invalidates trace/span statistics and the KPI cards", async () => {
+    const { result, invalidated } = renderMutation(() =>
+      useTraceDeleteMutation(),
+    );
+
+    await act(async () => {
+      result.current.mutate({ traceId: "t1", projectId: PROJECT_ID });
+    });
+
+    await waitFor(() => expect(invalidated.length).toBeGreaterThan(0));
+
+    expect(invalidatedPrefixes(invalidated)).toContain("traces-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("spans-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("project-kpi-cards");
+  });
+
+  it("useThreadBatchDeleteMutation invalidates thread/trace/span statistics and the KPI cards", async () => {
+    const { result, invalidated } = renderMutation(() =>
+      useThreadBatchDeleteMutation(),
+    );
+
+    await act(async () => {
+      result.current.mutate({ ids: ["th1"], projectId: PROJECT_ID });
+    });
+
+    await waitFor(() => expect(invalidated.length).toBeGreaterThan(0));
+
+    expect(invalidatedPrefixes(invalidated)).toContain("threads-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("traces-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("spans-statistic");
+    expect(invalidatedPrefixes(invalidated)).toContain("project-kpi-cards");
+  });
+});

--- a/apps/opik-frontend/src/api/traces/useThreadBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useThreadBatchDeleteMutation.ts
@@ -63,6 +63,10 @@ const useThreadBatchDeleteMutation = () => {
           },
         ],
       });
+      queryClient.invalidateQueries({ queryKey: ["threads-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["project-kpi-cards"] });
     },
   });
 };

--- a/apps/opik-frontend/src/api/traces/useTraceBatchDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceBatchDeleteMutation.ts
@@ -54,6 +54,9 @@ const useTracesBatchDeleteMutation = () => {
           },
         ],
       });
+      queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["project-kpi-cards"] });
     },
   });
 };

--- a/apps/opik-frontend/src/api/traces/useTraceDeleteMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceDeleteMutation.ts
@@ -60,6 +60,10 @@ const useTraceDeleteMutation = () => {
       }
     },
     onSettled: (data, error, variables, context) => {
+      queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
+      queryClient.invalidateQueries({ queryKey: ["project-kpi-cards"] });
+
       if (context) {
         queryClient.invalidateQueries({
           queryKey: [SPANS_KEY, { projectId: variables.projectId }],


### PR DESCRIPTION
## Details

After bulk-deleting traces from the Logs table the "Traces" metrics card kept showing the pre-delete count — the table updated correctly, only the card was stale, and it stayed stale until a page reload. The cards are rendered by `MetricsSummary`, which reads `useProjectKpiCards` (query key `["project-kpi-cards"]`, endpoint `projects/{id}/kpi-cards`), and **nothing in the frontend invalidated that key**. This adds the invalidation to all three delete mutations.

- The ticket's stated root cause was wrong and is corrected on the ticket. It blamed a missing `"traces-statistic"` invalidation; adding that alone does **not** fix the card — verified against a local stack, where the count still read 3 after deleting 2 of 3 traces. `project-kpi-cards` is a separate data source.
- The `*-statistic` keys are invalidated too. They were genuinely stale on the same paths and drive the per-column aggregates in the table headers (via `HeaderStatistic`) — a real second surface, just not the reported one.
- Applied to `useTraceBatchDeleteMutation` (the reported path), plus `useTraceDeleteMutation` and `useThreadBatchDeleteMutation`, which had the identical gap and are reachable from the same UI.
- The other cards (Error rate, Avg duration, Total cost) need no separate change — they share the same `kpi-cards` payload.

Number in the Traces card now refreshes instantly

https://github.com/user-attachments/assets/63ebc8c2-48d5-438b-9b5b-c7b0f71a7031



## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7710

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Root-cause investigation, the fix across the three mutations, and the unit test.
- Human verification: Author reviewed the diff and the corrected diagnosis. Fix verified end-to-end against a local stack (see Testing); causation confirmed by isolating the single operative line.

## Testing

Local OSS stack from source in a worktree (`./scripts/dev-runner.sh --restart`, FE on :5181, BE on :8087), v2 UI.

Commands:
- `npm run typecheck` — clean
- `npx eslint <changed files> --max-warnings=0` — exit 0
- `npx vitest run` — 155 files, 2303 tests passing
- `pre-commit run --files <changed files>` — exit 0 (eslint + typecheck frontend)
- `OPIK_BASE_URL=http://localhost:5181 npx playwright test tests/trace-explore/ --workers=2` — 10/10 passing

Scenarios validated:
- Bulk-delete 2 of 3 traces from the Logs table: table drops to 1 row **and** the card now reads `Traces 1` with no reload. This is the assertion (`expect.poll(() => logs.countTraces()).toBe(1)`) that was red before the fix.
- Traces deleted through the REST API: Logs table and card both correct after reload.
- Regression sweep across the whole `trace-explore/` E2E area (traces, threads, span tree, tags, feedback scores) — no regressions.
- Causation isolated: removing only the `["project-kpi-cards"]` line reproduces the failure (`Received: 3`); restoring it returns to `1`. So the fix is attributable to that line, not to something incidental.
- New unit test `deleteMutationsStatisticInvalidation.test.tsx` asserts the invalidation contract for all three mutations; confirmed it fails against the pre-fix code rather than passing vacuously.

Note on the E2E spec: `trace-explore/trace-delete.spec.ts` is **not** part of this PR — it lands with OPIK_7711 (PR #7707), together with a `data-testid` and a `deleteTraces` backend-client method. Those were borrowed locally for verification and reverted; this branch contains only the 4 files in the diff. That spec's count assertion only goes green once this PR lands.

Not run: backend and SDK suites (frontend-only change, no API surface touched).

## Documentation

No documentation changes — internal cache-invalidation fix with no user-facing API or behaviour change beyond the counts now being correct.
