### PR TITLE
[OPIK-6880] [HELM] Gate internal_replication on the sharding flag

### DIFF
--- a/deployment/helm_chart/opik/templates/clickhouseinstallation.yaml
+++ b/deployment/helm_chart/opik/templates/clickhouseinstallation.yaml
@@ -93,14 +93,19 @@ spec:
           replicasCount: {{ .Values.clickhouse.replicasCount }}
           # internal_replication pins Distributed-engine inserts to one live replica per shard and
           # lets ReplicatedMergeTree replication fan the parts out, instead of the Distributed table
-          # writing every replica itself. Only meaningful with more than one replica, so the shards
-          # list is rendered only then — a single-replica deployment keeps the plain shardsCount /
-          # replicasCount layout it has today. This states explicitly what the operator would
-          # otherwise infer from replicasCount > 1. Shard names are left unset so the operator keeps
-          # generating them by index — host identity is unchanged. A non-positive shardsCount renders
-          # no list at all rather than one clamped entry, which would contradict the shardsCount
-          # above and leave the operator to reconcile the two.
-          {{- if and (gt (int .Values.clickhouse.replicasCount) 1) (gt (int .Values.clickhouse.shardsCount) 0) }}
+          # writing every replica itself.
+          #
+          # Gated on sharding.enabled so that upgrading the chart never reshapes an existing
+          # ClickHouseInstallation on its own: with the flag off the operator keeps inferring
+          # internal_replication from replicasCount > 1, which is what every current deployment
+          # already runs with. Without that gate, any deployment on 2+ replicas would pick up an
+          # explicit shards list from a plain version bump, with no flag flipped.
+          #
+          # Also requires more than one replica, since internal_replication has nothing to route to
+          # on a single replica, and a positive shardsCount, so an invalid count renders no list at
+          # all rather than a null or a clamped entry contradicting the shardsCount above. Shard
+          # names are left unset so the operator keeps generating them by index.
+          {{- if and .Values.clickhouse.sharding.enabled (gt (int .Values.clickhouse.replicasCount) 1) (gt (int .Values.clickhouse.shardsCount) 0) }}
           shards:
             {{- range $i := until (int .Values.clickhouse.shardsCount) }}
             - internalReplication: "true"

--- a/deployment/helm_chart/opik/tests/cluster_topology_test.yaml
+++ b/deployment/helm_chart/opik/tests/cluster_topology_test.yaml
@@ -47,11 +47,18 @@ tests:
       - notExists:
           path: spec.configuration.clusters[0].layout.shards
 
-  - it: pins internal_replication once sharding is switched on
+  # Deliberately still pinned on a SINGLE shard: internal_replication governs replica
+  # fan-out within a shard, so on 1 shard x 2 replicas it decides whether a Distributed
+  # INSERT writes one replica or both. That is the near-term target topology, so this
+  # must not be gated on shardsCount > 1.
+  - it: pins internal_replication on a single shard once sharding is switched on
     set:
       clickhouse.sharding.enabled: true
       clickhouse.replicasCount: 2
     asserts:
+      - equal:
+          path: spec.configuration.clusters[0].layout.shardsCount
+          value: 1
       - lengthEqual:
           path: spec.configuration.clusters[0].layout.shards
           count: 1

--- a/deployment/helm_chart/opik/tests/cluster_topology_test.yaml
+++ b/deployment/helm_chart/opik/tests/cluster_topology_test.yaml
@@ -1,16 +1,21 @@
 suite: clickhouse cluster topology flags (shards, internal_replication, sharding switch)
 
 # Hyperscale topology flags landed ahead of the slices that flip them (OPIK-6880).
-# internal_replication is only meaningful with more than one replica, so the explicit
-# shards[] list is rendered only then and the single-replica default keeps the plain
-# layout it has today. clickhouse.sharding.enabled drives the backend's
-# Distributed-cluster readiness probe, not the rendered topology.
+# The explicit shards[] list carrying internal_replication is gated on
+# clickhouse.sharding.enabled, so upgrading the chart never reshapes an existing
+# ClickHouseInstallation on its own — the critical property, since every current
+# deployment runs replicasCount: 2 and would otherwise pick up the list from a plain
+# version bump. It additionally requires more than one replica (nothing to route to
+# on a single one) and a positive shardsCount.
 
 templates:
   - templates/clickhouseinstallation.yaml
 
 tests:
-  - it: keeps the plain single-replica layout by default
+  # The no-op guarantee: the layout must be untouched at any replica count while the
+  # flag is off. The 2-replica case is the one that matters — that is what staging and
+  # production run.
+  - it: keeps the plain layout by default
     asserts:
       - equal:
           path: spec.configuration.clusters[0].layout.shardsCount
@@ -21,8 +26,30 @@ tests:
       - notExists:
           path: spec.configuration.clusters[0].layout.shards
 
-  - it: pins internal_replication on the shard once there is more than one replica
+  - it: keeps the plain layout on a replicated cluster while sharding is off
     set:
+      clickhouse.replicasCount: 2
+    asserts:
+      - equal:
+          path: spec.configuration.clusters[0].layout.replicasCount
+          value: 2
+      - notExists:
+          path: spec.configuration.clusters[0].layout.shards
+
+  - it: keeps the plain layout on a sharded cluster while sharding is off
+    set:
+      clickhouse.shardsCount: 3
+      clickhouse.replicasCount: 2
+    asserts:
+      - equal:
+          path: spec.configuration.clusters[0].layout.shardsCount
+          value: 3
+      - notExists:
+          path: spec.configuration.clusters[0].layout.shards
+
+  - it: pins internal_replication once sharding is switched on
+    set:
+      clickhouse.sharding.enabled: true
       clickhouse.replicasCount: 2
     asserts:
       - lengthEqual:
@@ -34,6 +61,7 @@ tests:
 
   - it: leaves shard names unset so the operator keeps generating them by index
     set:
+      clickhouse.sharding.enabled: true
       clickhouse.replicasCount: 2
     asserts:
       - notExists:
@@ -41,6 +69,7 @@ tests:
 
   - it: pins internal_replication on every shard when sharded and replicated
     set:
+      clickhouse.sharding.enabled: true
       clickhouse.shardsCount: 3
       clickhouse.replicasCount: 2
     asserts:
@@ -54,8 +83,11 @@ tests:
           path: spec.configuration.clusters[0].layout.shards[2].internalReplication
           value: "true"
 
-  - it: renders no shards list for a sharded single-replica cluster
+  # internal_replication has nothing to route to on a single replica, so the flag alone
+  # is not enough.
+  - it: renders no shards list for a single-replica cluster even with sharding on
     set:
+      clickhouse.sharding.enabled: true
       clickhouse.shardsCount: 3
       clickhouse.replicasCount: 1
     asserts:
@@ -70,18 +102,9 @@ tests:
   # emitting an empty list, which would be a null where the CRD expects an array.
   - it: omits the shards list for a non-positive shard count
     set:
+      clickhouse.sharding.enabled: true
       clickhouse.shardsCount: 0
       clickhouse.replicasCount: 2
     asserts:
-      - notExists:
-          path: spec.configuration.clusters[0].layout.shards
-
-  - it: sharding.enabled does not alter the rendered cluster layout
-    set:
-      clickhouse.sharding.enabled: true
-    asserts:
-      - equal:
-          path: spec.configuration.clusters[0].layout.shardsCount
-          value: 1
       - notExists:
           path: spec.configuration.clusters[0].layout.shards

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -730,11 +730,16 @@ partitionMetrics:
 clickhouse:
   enabled: true
   shardsCount: 1
-  # Switches the deployment to the sharded (Hyperscale) topology. A no-op while shardsCount is 1: it
-  # only drives the backend's `clickhouse-cluster` readiness probe, which verifies the Distributed
-  # cluster definition is visible from the node (ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED — set that
-  # key explicitly under component.backend.env to decouple the two). Turn on together with
-  # shardsCount > 1 once the Distributed tables are in place.
+  # Switches the deployment to the sharded (Hyperscale) topology. Turn on together with
+  # shardsCount > 1 once the Distributed tables are in place. While off, nothing here is rendered,
+  # so upgrading the chart never reshapes an existing cluster on its own. Turning it on does two
+  # things:
+  #   - enables the backend's `clickhouse-cluster` readiness probe, which verifies the Distributed
+  #     cluster definition is visible from the node (ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED — set
+  #     that key explicitly under component.backend.env to decouple the two)
+  #   - pins internal_replication on each shard of the ClickHouseInstallation, when replicasCount > 1.
+  #     With the flag off the operator infers it from replicasCount > 1 instead, which is the
+  #     behaviour every deployment already has.
   sharding:
     enabled: false
   # For a FRESH High-Availability install, use the two-phase flow: install with replicasCount 1, let

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -730,16 +730,24 @@ partitionMetrics:
 clickhouse:
   enabled: true
   shardsCount: 1
-  # Switches the deployment to the sharded (Hyperscale) topology. Turn on together with
-  # shardsCount > 1 once the Distributed tables are in place. While off, nothing here is rendered,
-  # so upgrading the chart never reshapes an existing cluster on its own. Turning it on does two
-  # things:
+  # Declares that this deployment fronts its tables with Distributed tables (the Hyperscale
+  # topology). While off, nothing here is rendered, so upgrading the chart never reshapes an
+  # existing cluster on its own. Turning it on does two things:
   #   - enables the backend's `clickhouse-cluster` readiness probe, which verifies the Distributed
   #     cluster definition is visible from the node (ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED — set
   #     that key explicitly under component.backend.env to decouple the two)
-  #   - pins internal_replication on each shard of the ClickHouseInstallation, when replicasCount > 1.
-  #     With the flag off the operator infers it from replicasCount > 1 instead, which is the
-  #     behaviour every deployment already has.
+  #   - pins internal_replication on each shard of the ClickHouseInstallation, whenever
+  #     replicasCount > 1. With the flag off the operator infers it from replicasCount > 1 instead,
+  #     which is the behaviour every deployment already has.
+  #
+  # Note this is deliberately NOT tied to shardsCount > 1. internal_replication governs replica
+  # fan-out *within* a shard, not the number of shards: on a single shard with 2 replicas it decides
+  # whether an INSERT into the Distributed table writes one replica and lets ReplicatedMergeTree
+  # replicate the parts, or writes both directly. That single-shard case is the near-term target —
+  # the traces cutover fronts the table with a Distributed table that is "transparent on a single
+  # shard", with real sharding turned on later — so gating on shardsCount > 1 would exclude the very
+  # deployment this is meant to cover. Turn the flag on when the Distributed tables land, whatever
+  # shardsCount is.
   sharding:
     enabled: false
   # For a FRESH High-Availability install, use the two-phase flow: install with replicasCount 1, let


### PR DESCRIPTION
## Details

Follow-up to #7675. That PR gated the explicit `shards[]` list on `replicasCount > 1`, which breaks the property OPIK-6880 actually asked for: nothing changes until a flag is switched. Every current deployment runs `clickhouse.replicasCount: 2`, so staging and production would each pick up an explicit `shards` list from a plain chart version bump with no flag flipped — reshaping the `ClickHouseInstallation` and making the operator reconcile it.

This gates it on `clickhouse.sharding.enabled` as well. With the flag off the operator keeps inferring `internal_replication` from `replicasCount > 1` — which is what every deployment already runs with, confirmed against the operator-generated `chi-opik-clickhouse-common-configd` in production. The explicit pin appears when sharding is turned on, which is when it actually matters.

Caught while reviewing the dev/staging chart bumps: the staging bump would have carried a ClickHouse layout change, and production would have taken the same change on its next bump.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-6880

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Template gate, values documentation, and the topology test suite.
- Human verification: Author identified the contract violation and directed the fix.

## Testing

From `deployment/helm_chart/opik`:

- `helm lint --values values.yaml .` — passes.
- The key check: rendered the CHI against the **pre-OPIK-6880 chart (2.2.6)** and this branch at `shardsCount/replicasCount` of `1/1`, `1/2` and `3/2` with the flag off. The `clusters[].layout` block is **byte-identical** in all three, including the `1/2` shape that staging and production run.
- With `sharding.enabled=true` and 2 replicas the `shards` list still renders with `internalReplication: "true"`, and shard names stay unset so the operator keeps generating them by index.
- Full default `helm template` differs from `main` only by the comment block — no rendered object changes shape.
- Verified every assertion in `cluster_topology_test.yaml` by rendering with the same `--set` overrides (7 combinations); `helm-unittest` itself runs in CI, the plugin is not installed locally.

`cluster_topology_test.yaml` now pins the no-op guarantee explicitly: the layout must be untouched at 1/1, 1/2 and 3/2 while the flag is off, with the 2-replica cases called out as the staging/production shape.

## Documentation

`clickhouse.sharding.enabled` in `values.yaml` now documents both effects — the backend readiness probe and the `internal_replication` pin — and states that nothing is rendered while it is off.
