### PR TITLE
[OPIK-7455] [BE] feat: retarget trace mutation DAOs to traces_local behind a wrap toggle

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -145,6 +145,14 @@ databaseAnalyticsDataModel:
   #   than the ClickHouse driver binds reliably in one statement (5 columns per row), so the insert is split into
   #   chunks of this size.
   deletionEventsInsertBatchSize: ${ANALYTICS_DB_DATA_MODEL_DELETION_EVENTS_INSERT_BATCH_SIZE:-1000}
+  #  Default: false
+  #  Description: The final sharding-readiness step wraps `traces` as a Distributed table over the `traces_local`
+  #   shard. A Distributed table supports SELECT and INSERT but NOT mutations, so once the wrap is live every trace
+  #   mutation must target the local shard. Leave false at deploy time and while `traces` is still a MergeTree (deletes
+  #   work directly); set true in lockstep with applying the wrap (exchange_and_wrap.sh --with-wrap / --wrap-only). While
+  #   true, TraceDAO routes delete/retention mutations to `traces_local`; reads and inserts stay on the Distributed
+  #   `traces`. Any future mutation/ALTER/OPTIMIZE targeting `traces` must likewise target `traces_local` when this is on.
+  tracesDistributedWrapEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -151,7 +151,9 @@ databaseAnalyticsDataModel:
   #   mutation must target the local shard. Leave false at deploy time and while `traces` is still a MergeTree (deletes
   #   work directly); set true in lockstep with applying the wrap (exchange_and_wrap.sh --with-wrap / --wrap-only). While
   #   true, TraceDAO routes delete/retention mutations to `traces_local`; reads and inserts stay on the Distributed
-  #   `traces`. Any future mutation/ALTER/OPTIMIZE targeting `traces` must likewise target `traces_local` when this is on.
+  #   `traces`. Post-wrap, changes to `traces` split by kind: row mutations (DELETE) + MATERIALIZE COLUMN/ADD INDEX/
+  #   MODIFY TTL target `traces_local` only (the Distributed `traces` rejects them); ADD/DROP/MODIFY COLUMN must target
+  #   both `traces_local` and `traces`, else reads can't see the column (code 47).
   tracesDistributedWrapEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -164,11 +164,21 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > that shipped **before** the wrap (OPIK-7455): `TraceDAO` renders its mutation table through a single toggle,
 > `databaseAnalyticsDataModel.tracesDistributedWrapEnabled`. Set it **`true` in lockstep with applying the wrap** so those
 > deletes run against `traces_local`; reads and inserts stay on the Distributed `traces`. While it is `false` (the deploy
-> default, and correct while `traces` is still a `MergeTree`) the deletes target `traces` directly. **General rule:** any
-> future mutation / `ALTER` / `OPTIMIZE` path — or Liquibase migration — that touches `traces` must likewise switch to
-> `traces_local` under this flag. The `EXCHANGE` alone is the data cutover and leaves `traces` a `MergeTree` where deletes
-> still work — which is why the wrap is **opt-in** (`--with-wrap`) and the default stops after the EXCHANGE. Defer the
+> default, and correct while `traces` is still a `MergeTree`) the deletes target `traces` directly. **General rule (splits
+> by kind of change):** row mutations (`DELETE`, `ALTER … DELETE`) and `MATERIALIZE COLUMN` / `ADD INDEX` / `MODIFY TTL`
+> target **`traces_local` only** — the `Distributed` `traces` rejects them (code 36/48), so a slip fails loudly; but
+> `ADD` / `DROP` / `MODIFY COLUMN` (the shape of every trace schema migration) must be applied to **both** `traces_local`
+> **and** the `Distributed` `traces` — the wrapper accepts them as metadata-only, and targeting only `traces_local` leaves
+> the wrapper without the column so reads fail with code 47. The `EXCHANGE` alone is the data cutover and leaves `traces` a
+> `MergeTree` where deletes still work — which is why the wrap is **opt-in** (`--with-wrap`) and the default stops after
+> the EXCHANGE. Defer the
 > wrap until the retarget flag is wired into the deploy. The wrap is the sharding-readiness layer, not the cutover.
+>
+> **Monitoring consequence of the flip:** `system.parts` only knows `traces_local` post-wrap, so the
+> `opik.clickhouse.partition.*` parts gauges relabel from `table="traces"` to `table="traces_local"`, while the
+> lightweight-delete-mask gauge (read through the wrapper) stays labelled `traces`. Any dashboard/alert keyed on
+> `table="traces"` goes blank when the wrap lands — update them in the same window, or point
+> `PARTITION_METRICS_LWD_TABLES` (default `traces,spans`) at `traces_local` for label consistency.
 >
 > **Applying the deferred wrap later:** once the retarget flag (`tracesDistributedWrapEnabled=true`) is live across the
 > backend fleet, run
@@ -502,7 +512,8 @@ Pick the stage by how far the cutover got (`cutover_start` is the value `exchang
   makes `traces` a `MergeTree` again and parks `traces_local`, so a still-`true` flag would send `TraceDAO` deletes at
   the missing `traces_local`. This is the inverse of the flip that enabled the wrap (see "HARD PREREQUISITE for the
   wrap"); it applies to every deferred `--wrap-only` topology, not the EXCHANGE-only default (where the flag was never
-  set).
+  set). The partition-metrics relabel reverses too: the `opik.clickhouse.partition.*` parts gauges move back from
+  `table="traces_local"` to `table="traces"`, so restore any dashboards/alerts adjusted at wrap time.
 
 > **Multi-replica note (production is multi-replica).** Stages B and C promote via a single `ON CLUSTER` RENAME of the
 > **live** `traces`. It runs synchronously across the shard's replicas — the client blocks until each applies it, or fails

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -495,6 +495,11 @@ Pick the stage by how far the cutover got (`cutover_start` is the value `exchang
   --confirm-retention-paused --accept-post-cutover-write-loss`. Drops the `Distributed` wrapper, then one atomic
   `RENAME` promotes the original (`traces_pre_cutover_backup`) back to `traces` and parks the successor as
   `traces_post_rollback_backup`, then the reverse replay. (Guarded: aborts unless `traces` is `Distributed`.)
+  **Set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` back to `false` before backends resume** — Stage C
+  makes `traces` a `MergeTree` again and parks `traces_local`, so a still-`true` flag would send `TraceDAO` deletes at
+  the missing `traces_local`. This is the inverse of the flip that enabled the wrap (see "HARD PREREQUISITE for the
+  wrap"); it applies to every deferred `--wrap-only` topology, not the EXCHANGE-only default (where the flag was never
+  set).
 
 > **Multi-replica note (production is multi-replica).** Stages B and C promote via a single `ON CLUSTER` RENAME of the
 > **live** `traces`. It runs synchronously across the shard's replicas — the client blocks until each applies it, or fails

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -159,12 +159,16 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > - `DELETE FROM <distributed>` → `Code 36 BAD_ARGUMENTS: DELETE query is not supported`
 > - `ALTER TABLE <distributed> DELETE` → `Code 48 NOT_IMPLEMENTED: Distributed doesn't support mutations`
 >
-> So the moment the wrap is applied, **both** the product's delete-by-id (`TraceDAO.DELETE_BY_ID`) **and** the retention
-> sweep (`DELETE_FOR_RETENTION`) start returning 500 against `traces`. This is prep work that must ship **before** the
-> wrap: point those DAO paths at `traces_local` (reads and inserts can stay on the Distributed `traces`). The `EXCHANGE`
-> alone is the data cutover and leaves `traces` a `MergeTree` where deletes still work — which is why the wrap is
-> **opt-in** (`--with-wrap`) and the default stops after the EXCHANGE. Defer the wrap until the sharding-aware DAO
-> ships. The wrap is the sharding-readiness layer, not the cutover.
+> So the moment the wrap is applied, **both** the product's delete-by-id path **and** the retention
+> sweep (`DELETE_FOR_RETENTION` / `deleteForRetentionBounded`) start returning 500 against `traces`. This is prep work
+> that shipped **before** the wrap (OPIK-7455): `TraceDAO` renders its mutation table through a single toggle,
+> `databaseAnalyticsDataModel.tracesDistributedWrapEnabled`. Set it **`true` in lockstep with applying the wrap** so those
+> deletes run against `traces_local`; reads and inserts stay on the Distributed `traces`. While it is `false` (the deploy
+> default, and correct while `traces` is still a `MergeTree`) the deletes target `traces` directly. **General rule:** any
+> future mutation / `ALTER` / `OPTIMIZE` path — or Liquibase migration — that touches `traces` must likewise switch to
+> `traces_local` under this flag. The `EXCHANGE` alone is the data cutover and leaves `traces` a `MergeTree` where deletes
+> still work — which is why the wrap is **opt-in** (`--with-wrap`) and the default stops after the EXCHANGE. Defer the
+> wrap until the retarget flag is wired into the deploy. The wrap is the sharding-readiness layer, not the cutover.
 >
 > **Applying the deferred wrap later:** once the sharding-aware DAO has shipped, run
 > `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it runs the settle

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -170,7 +170,8 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > still work — which is why the wrap is **opt-in** (`--with-wrap`) and the default stops after the EXCHANGE. Defer the
 > wrap until the retarget flag is wired into the deploy. The wrap is the sharding-readiness layer, not the cutover.
 >
-> **Applying the deferred wrap later:** once the sharding-aware DAO has shipped, run
+> **Applying the deferred wrap later:** once the retarget flag (`tracesDistributedWrapEnabled=true`) is live across the
+> backend fleet, run
 > `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it runs the settle
 > gate and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new `cutover_start`).
 > `--confirm-daos-retargeted` is required for **any** wrap (same-run or deferred), since the wrap makes `traces`
@@ -353,11 +354,13 @@ on a large backfill for no gain.
 - The anchor is captured **before** the backfill, not at its end — a cutoff taken at the end would miss writes that
   landed during the backfill itself. The same `backfill_start` bounds the replay window.
 
-**Replay matches on two branches — full key, or `(workspace_id, id)` — mirroring the product's two delete paths.**
-`TraceService.delete(ids, projectId)` resolves each id's owning project and deletes per project (full key); ids it can't
-resolve fall back to a **workspace-scoped** delete — `TraceDAO.DELETE_BY_ID` with the project filter omitted, i.e.
-`DELETE … WHERE id IN … AND workspace_id = …` across every project. The bridge records the first with the project and the
-second with an **empty `project_id`** (`DeletionEventDAO`: "project_id is empty for workspace-scoped source tables"). The
+**Replay matches on two branches — full key, or `(workspace_id, id)` — mirroring the two delete shapes recorded in the bridge.**
+`TraceService.delete(ids, projectId)` resolves each id's owning project and deletes per project (full key). **Pre-OPIK-7483**,
+ids it could not resolve fell back to a **workspace-scoped** delete (`DELETE … WHERE id IN … AND workspace_id = …` across
+every project), recorded in the bridge with an **empty `project_id`** (`DeletionEventDAO`: "project_id is empty for
+workspace-scoped source tables"). OPIK-7483 removed that fallback, so current `TraceService.delete` always carries
+`project_id` and the empty-project branch now replays **only** legacy bridge rows written before OPIK-7483 (still resident
+under the 2-year TTL). The
 replay mirrors both: full-key events delete by `(workspace_id, project_id, id)` (exact; prunes on the destination primary
 key — correct even though trace ids are not globally unique), and empty-project events delete by `(workspace_id, id)`.
 The second branch is a **mirror, not an over-delete**: the workspace-scoped fallback fires only for ids the resolver
@@ -538,7 +541,8 @@ backup with `finalize.sh` is the one irreversible step, so gate it on an explici
   `traces_post_rollback_backup` after a rollback) for a defined window (recommend ~2 weeks; it fits well inside the
   bridge's 2-year TTL) so any latent read/query regression surfaces while rollback is still an option.
 - **Finalize exit criteria** — before retiring the backup: `verify.sh` clean, query p99 within budget over the soak, no
-  cutover-related incidents open, and (if the wrap was applied) the sharding-aware DAO healthy in production.
+  cutover-related incidents open, and (if the wrap was applied) the retarget flag (`tracesDistributedWrapEnabled`) live
+  and healthy across the backend fleet.
 
 Once those hold, run [`scripts/finalize.sh`](scripts/finalize.sh) — it auto-detects whichever parked table is present
 (`traces_pre_cutover_backup` or `traces_post_rollback_backup`), never the live `traces`/`traces_local` or the working

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -30,8 +30,10 @@ RENAME TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 TO ${ANALYTICS_DB_DAT
 -- HARD PREREQUISITE: a Distributed table supports SELECT and INSERT but NOT mutations — a lightweight DELETE returns
 -- "DELETE query is not supported" (code 36) and ALTER ... DELETE returns "Distributed doesn't support mutations"
 -- (code 48). So the product's delete-by-id AND retention deletes both break the moment this wrap is applied. Do NOT run
--- the wrap until those DAO paths target `traces_local` (see README "The Distributed wrap"). The EXCHANGE above is the
--- data cutover and leaves `traces` a MergeTree where deletes still work; the wrap is a separate, gated step.
+-- the wrap until the DAO is retargeted: set backend config databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true
+-- (OPIK-7455) in lockstep with the wrap so TraceDAO mutations run against `traces_local` (see the README's
+-- "HARD PREREQUISITE for the wrap" note). The EXCHANGE above is the data cutover and leaves `traces` a MergeTree where
+-- deletes still work; the wrap is a separate, gated step.
 --
 -- GAPLESS per node: build the Distributed wrapper under a temp name FIRST (its 'traces_local' target need not exist
 -- yet — Distributed resolves it lazily), then a SINGLE atomic multi-target RENAME rotates the data to `traces_local`

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_stage_c_promote_original.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_stage_c_promote_original.sql
@@ -20,6 +20,10 @@
 --
 -- rollback.sh runs the reverse-replay (000004_rollback_reverse_replay.sql) right after this so deletes since
 -- cutover_start do not resurrect, and asserts the post-wrap topology (traces = Distributed) before running it.
+--
+-- BEFORE backends resume: set databaseAnalyticsDataModel.tracesDistributedWrapEnabled=false (OPIK-7455). This stage
+-- makes `traces` a MergeTree again and parks `traces_local`, so a still-true flag would send TraceDAO mutations at the
+-- missing `traces_local`. It is the inverse of the flip that enabled the wrap.
 
 -- 1. Gapless promote: rotate all three names atomically.
 SET log_comment = 'traces_local_v2_rollback:stage_c';

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -39,9 +39,11 @@
 #                     EXCHANGE), --wrap-only runs later against live, unbuffered ingestion. This flag asserts the
 #                     async-insert buffer is re-raised (or ingestion quiesced / a maintenance window is in effect).
 #   --confirm-daos-retargeted  REQUIRED whenever the wrap is applied (--with-wrap or --wrap-only). Asserts the trace
-#                     delete/mutation DAOs already target `traces_local` (OPIK-7455) — a Distributed `traces` rejects
-#                     mutations, so without the retarget delete-by-id and retention deletes return 500 the moment the
-#                     wrap lands. The script cannot inspect backend code, so the operator must assert it.
+#                     delete/mutation DAOs already target `traces_local`: set backend config
+#                     databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true (OPIK-7455) in lockstep with the wrap.
+#                     A Distributed `traces` rejects mutations, so without the flag delete-by-id and retention deletes
+#                     return 500 the moment the wrap lands. The script cannot inspect backend config, so the operator
+#                     must assert it.
 #   --confirm-buffer-raised  REQUIRED for every EXCHANGE path (the default and --with-wrap; not --wrap-only). Asserts the
 #                     async-insert buffer (asyncInsertBusyTimeoutMaxMs) is raised on every backend instance — it holds
 #                     writes across the swap so they land on the new table; at the default, a write in the final window
@@ -106,11 +108,12 @@ if [[ "$WRAP_ONLY" == "1" && "$CONFIRM_MAINTENANCE" != "1" ]]; then
     exit 2
 fi
 # HARD PREREQUISITE (OPIK-7455): a Distributed table rejects mutations, so once the wrap is applied the product's
-# DELETE_BY_ID and retention deletes return 500 against `traces` unless those DAO paths already target `traces_local`.
-# The script can't inspect backend code, so any wrap-applying mode must assert it. Fail fast, before touching ClickHouse.
+# delete-by-id and retention deletes return 500 against `traces` unless those DAO paths already target `traces_local`.
+# The script can't inspect backend config, so any wrap-applying mode must assert it. Fail fast, before touching ClickHouse.
 if [[ ( "$WITH_WRAP" == "1" || "$WRAP_ONLY" == "1" ) && "$CONFIRM_DAOS_RETARGETED" != "1" ]]; then
-    echo "ERROR: applying the wrap requires --confirm-daos-retargeted. The trace delete/mutation DAOs must target" >&2
-    echo "       'traces_local' (OPIK-7455) before 'traces' becomes Distributed, or deletes/retention break at runtime." >&2
+    echo "ERROR: applying the wrap requires --confirm-daos-retargeted. Set backend config" >&2
+    echo "       databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true (OPIK-7455) so the trace delete/mutation" >&2
+    echo "       DAOs target 'traces_local' before 'traces' becomes Distributed, or deletes/retention break at runtime." >&2
     exit 2
 fi
 # The EXCHANGE is the zero-loss step: writes in the final-delta -> EXCHANGE gap must be held by the raised async-insert

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3326,6 +3326,17 @@ class TraceDAOImpl implements TraceDAO {
     }
 
     /**
+     * Selects the {@code <if(distributed_wrap)>traces_local<else>traces<endif>} branch on a mutation template. The
+     * flag decision lives only here and in {@link #tracesDistributedWrapEnabled()}; every ST-based trace mutation adds
+     * its table through this method so the branches cannot drift apart.
+     */
+    private void addTracesMutationTable(ST template) {
+        if (tracesDistributedWrapEnabled()) {
+            template.add("distributed_wrap", true);
+        }
+    }
+
+    /**
      * Binds input, output, metadata, and their slim versions (input_slim, output_slim) to a statement.
      * Centralizes the JSON conversion and binding logic for consistency across single and batch inserts.
      *
@@ -3493,9 +3504,7 @@ class TraceDAOImpl implements TraceDAO {
                     var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces",
                             workspaceId,
                             userName, "pairs_size=%s".formatted(batch.size()));
-                    if (tracesDistributedWrapEnabled()) {
-                        template.add("distributed_wrap", true);
-                    }
+                    addTracesMutationTable(template);
 
                     var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
                     var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
@@ -5016,9 +5025,7 @@ class TraceDAOImpl implements TraceDAO {
 
         var template = getSTWithLogComment(DELETE_FOR_RETENTION, "retention_delete_traces", null, "",
                 workspaceIds.size());
-        if (tracesDistributedWrapEnabled()) {
-            template.add("distributed_wrap", true);
-        }
+        addTracesMutationTable(template);
 
         return Mono.from(connectionFactory.create())
                 .flatMap(connection -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3311,8 +3311,11 @@ class TraceDAOImpl implements TraceDAO {
      * {@code OPTIMIZE}) must target the {@code traces_local} shard instead; while it is off {@code traces} is still a
      * {@code MergeTree} where deletes work directly. Reads and inserts always route through {@code traces}. Each
      * mutation query carries both table names in an {@code <if(distributed_wrap)>traces_local<else>traces<endif>}
-     * branch and passes this flag; any new mutation path — or Liquibase migration — that touches {@code traces} must
-     * do the same rather than hardcoding a single table.
+     * branch and passes this flag; a new mutation path must do the same. Liquibase migrations split by kind:
+     * {@code DELETE} / {@code MATERIALIZE COLUMN} / {@code ADD INDEX} / {@code MODIFY TTL} target {@code traces_local}
+     * only (the Distributed {@code traces} rejects them), but {@code ADD}/{@code DROP}/{@code MODIFY COLUMN} must target
+     * <b>both</b> {@code traces_local} and {@code traces} — the wrapper takes them as metadata-only, and skipping it
+     * leaves reads unable to see the column (code 47).
      * <p>
      * The cluster is single-shard today and {@code traces_local} is a {@code ReplicatedMergeTree}, so a lightweight
      * delete fans out to every replica via the replication log and reaches every matching row — no {@code ON CLUSTER}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1897,7 +1897,7 @@ class TraceDAOImpl implements TraceDAO {
      * com.comet.opik.infrastructure.FilterUtils#ANALYTICS_DELETE_BATCH_SIZE}).
      */
     private static final String DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS = """
-            DELETE FROM traces
+            DELETE FROM <if(distributed_wrap)>traces_local<else>traces<endif>
             WHERE workspace_id = :workspace_id
             AND (project_id, id) IN arrayZip(:project_ids, :trace_ids)
             SETTINGS log_comment = '<log_comment>'
@@ -1914,7 +1914,7 @@ class TraceDAOImpl implements TraceDAO {
      * upper bound advances one week so rows sharing the cutoff's week stay in scope.
      */
     private static final String DELETE_FOR_RETENTION = """
-            DELETE FROM traces
+            DELETE FROM <if(distributed_wrap)>traces_local<else>traces<endif>
             WHERE workspace_id IN :workspace_ids
             AND id >= :lower_bound
             AND id \\< :cutoff_id
@@ -3306,6 +3306,26 @@ class TraceDAOImpl implements TraceDAO {
     }
 
     /**
+     * Whether the sharding-readiness wrap is live. When it is, {@code traces} is a {@code Distributed} table that
+     * rejects mutations (code 36 / 48), so every trace <b>mutation</b> ({@code DELETE} / {@code ALTER} /
+     * {@code OPTIMIZE}) must target the {@code traces_local} shard instead; while it is off {@code traces} is still a
+     * {@code MergeTree} where deletes work directly. Reads and inserts always route through {@code traces}. Each
+     * mutation query carries both table names in an {@code <if(distributed_wrap)>traces_local<else>traces<endif>}
+     * branch and passes this flag; any new mutation path — or Liquibase migration — that touches {@code traces} must
+     * do the same rather than hardcoding a single table.
+     * <p>
+     * The cluster is single-shard today and {@code traces_local} is a {@code ReplicatedMergeTree}, so a lightweight
+     * delete fans out to every replica via the replication log and reaches every matching row — no {@code ON CLUSTER}
+     * needed (no DAO uses it). Activating sharding is a separate, deferred effort with its own rebalance cutover; only
+     * then does a delete issued on one shard miss rows on the others and trace mutations need fanning across shards.
+     * That belongs to the activation work: adding {@code ON CLUSTER} now would not be a no-op (it would run the
+     * mutation on every replica node and stall on a down one), for no single-shard benefit.
+     */
+    private boolean tracesDistributedWrapEnabled() {
+        return configuration.getDatabaseAnalyticsDataModel().tracesDistributedWrapEnabled();
+    }
+
+    /**
      * Binds input, output, metadata, and their slim versions (input_slim, output_slim) to a statement.
      * Centralizes the JSON conversion and binding logic for consistency across single and batch inserts.
      *
@@ -3473,6 +3493,9 @@ class TraceDAOImpl implements TraceDAO {
                     var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces",
                             workspaceId,
                             userName, "pairs_size=%s".formatted(batch.size()));
+                    if (tracesDistributedWrapEnabled()) {
+                        template.add("distributed_wrap", true);
+                    }
 
                     var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
                     var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
@@ -4993,6 +5016,9 @@ class TraceDAOImpl implements TraceDAO {
 
         var template = getSTWithLogComment(DELETE_FOR_RETENTION, "retention_delete_traces", null, "",
                 workspaceIds.size());
+        if (tracesDistributedWrapEnabled()) {
+            template.add("distributed_wrap", true);
+        }
 
         return Mono.from(connectionFactory.create())
                 .flatMap(connection -> {
@@ -5038,7 +5064,8 @@ class TraceDAOImpl implements TraceDAO {
         var logComment = getLogComment("retention_delete_traces_bounded", null, "", workspaceMinIds.size());
         var entries = List.copyOf(workspaceMinIds.entrySet());
 
-        var sb = new StringBuilder("DELETE FROM traces WHERE (");
+        var sb = new StringBuilder(
+                tracesDistributedWrapEnabled() ? "DELETE FROM traces_local WHERE (" : "DELETE FROM traces WHERE (");
         for (int i = 0; i < entries.size(); i++) {
             if (i > 0) sb.append(" OR ");
             sb.append("(workspace_id = :ws_").append(i)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -3329,11 +3329,12 @@ class TraceDAOImpl implements TraceDAO {
     }
 
     /**
-     * Selects the {@code <if(distributed_wrap)>traces_local<else>traces<endif>} branch on a mutation template. The
-     * flag decision lives only here and in {@link #tracesDistributedWrapEnabled()}; every ST-based trace mutation adds
-     * its table through this method so the branches cannot drift apart.
+     * Selects the {@code <if(distributed_wrap)>traces_local<else>traces<endif>} branch on a mutation template by adding
+     * the {@code distributed_wrap} attribute when the wrap is live. The flag decision lives only here and in
+     * {@link #tracesDistributedWrapEnabled()}; every ST-based trace mutation routes its table through this method so the
+     * branches cannot drift apart.
      */
-    private void addTracesMutationTable(ST template) {
+    private void selectTracesMutationTable(ST template) {
         if (tracesDistributedWrapEnabled()) {
             template.add("distributed_wrap", true);
         }
@@ -3507,7 +3508,7 @@ class TraceDAOImpl implements TraceDAO {
                     var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces",
                             workspaceId,
                             userName, "pairs_size=%s".formatted(batch.size()));
-                    addTracesMutationTable(template);
+                    selectTracesMutationTable(template);
 
                     var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
                     var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
@@ -5028,7 +5029,7 @@ class TraceDAOImpl implements TraceDAO {
 
         var template = getSTWithLogComment(DELETE_FOR_RETENTION, "retention_delete_traces", null, "",
                 workspaceIds.size());
-        addTracesMutationTable(template);
+        selectTracesMutationTable(template);
 
         return Mono.from(connectionFactory.create())
                 .flatMap(connection -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -44,8 +44,12 @@ import lombok.Builder;
  * directly); set {@code true} in lockstep with applying the {@code Distributed} wrap
  * ({@code exchange_and_wrap.sh --with-wrap} / {@code --wrap-only}). While {@code true}, {@code TraceDAO} routes its
  * delete/retention mutations to {@code traces_local} while reads and inserts continue through the Distributed
- * {@code traces}. <b>General rule:</b> any future mutation / {@code ALTER} / {@code OPTIMIZE} path — or Liquibase
- * migration — that targets {@code traces} must likewise target {@code traces_local} once this flag is on.</p>
+ * {@code traces}. <b>General rule, by kind of change:</b> row mutations ({@code DELETE}) and
+ * {@code MATERIALIZE COLUMN} / {@code ADD INDEX} / {@code MODIFY TTL} target {@code traces_local} only — the
+ * {@code Distributed} {@code traces} rejects them (code 36/48), so a slip fails loudly; {@code ADD}/{@code DROP}/
+ * {@code MODIFY COLUMN} must be applied to <b>both</b> {@code traces_local} and the {@code Distributed} {@code traces}
+ * (the wrapper accepts them as metadata-only, and targeting only {@code traces_local} leaves the wrapper without the
+ * column, so reads fail with code 47).</p>
  */
 @Builder(toBuilder = true)
 public record DatabaseAnalyticsDataModelConfig(

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -35,6 +35,17 @@ import lombok.Builder;
  * far more ids than the ClickHouse driver binds reliably in one statement (5 columns per row), so the insert is split
  * into chunks of this size. Bounded to a positive value so a misconfiguration fails startup rather than silently
  * disabling capture, and to a sensible ceiling that keeps the per-statement bind count in the safe range.</p>
+ *
+ * <p>{@code tracesDistributedWrapEnabled}: the final sharding-readiness step of the traces cutover wraps {@code traces}
+ * as a {@code Distributed} table over the {@code traces_local} shard. A {@code Distributed} table supports
+ * {@code SELECT} and {@code INSERT} but <b>not</b> mutations ({@code DELETE FROM <distributed>} → code 36;
+ * {@code ALTER ... DELETE} → code 48), so once the wrap is live every mutation path must target the local shard.
+ * Left {@code false} at deploy time (and while {@code traces} is still a {@code MergeTree}, where deletes work
+ * directly); set {@code true} in lockstep with applying the {@code Distributed} wrap
+ * ({@code exchange_and_wrap.sh --with-wrap} / {@code --wrap-only}). While {@code true}, {@code TraceDAO} routes its
+ * delete/retention mutations to {@code traces_local} while reads and inserts continue through the Distributed
+ * {@code traces}. <b>General rule:</b> any future mutation / {@code ALTER} / {@code OPTIMIZE} path — or Liquibase
+ * migration — that targets {@code traces} must likewise target {@code traces_local} once this flag is on.</p>
  */
 @Builder(toBuilder = true)
 public record DatabaseAnalyticsDataModelConfig(
@@ -42,5 +53,6 @@ public record DatabaseAnalyticsDataModelConfig(
         boolean spanColumnsNonNullable,
         boolean traceDeletionEventsCaptureEnabled,
         boolean spanDeletionEventsCaptureEnabled,
-        @Min(1) @Max(2_000) int deletionEventsInsertBatchSize) {
+        @Min(1) @Max(2_000) int deletionEventsInsertBatchSize,
+        boolean tracesDistributedWrapEnabled) {
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesDistributedWrapMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesDistributedWrapMutationTest.java
@@ -1,0 +1,263 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
+import com.comet.opik.domain.TraceDAO;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import io.r2dbc.spi.Statement;
+import lombok.Builder;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises {@code TraceDAO}'s mutation paths against the post-wrap topology, where {@code traces} is a
+ * {@code Distributed} table over the {@code traces_local} shard (OPIK-7455). A {@code Distributed} table supports
+ * {@code SELECT} and {@code INSERT} but <b>not</b> mutations, so before the retarget every trace delete returned 500
+ * the instant the wrap was applied. With {@code databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true} the DAO
+ * routes its deletes to {@code traces_local} while reads and inserts keep flowing through the Distributed {@code traces}.
+ *
+ * <p>The suite is deliberately black-box: it drives the public trace API (create / list / delete) so a delete that
+ * still hit the Distributed {@code traces} would surface as a 500 from the API, and the outcome is read back through
+ * the same public list endpoint. Two internal touches are justified: the wrap has no public API, so {@link #beforeAll}
+ * builds it in raw SQL identical to the {@code 000003_exchange_and_wrap.sql} wrap block; and retention sweeps have no
+ * public endpoint (retention is disabled everywhere and runs only from the internal {@code RetentionCatchUpJob}), so
+ * those two DAO methods are invoked directly. {@link #distributedTracesRejectsDirectMutation} is the guard that keeps
+ * the positive tests honest — it proves {@code traces} really is a mutation-rejecting {@code Distributed} table, so a
+ * green delete could only have run against {@code traces_local}.
+ *
+ * <p>Dedicated, non-reused ClickHouse and ZooKeeper containers are required because the wrap destructively renames the
+ * live {@code traces} table; a reused container would corrupt other suites and reruns. No Awaitility: the trace
+ * create/delete API is synchronous with respect to trace reads (an INSERT to a single local shard is direct, not
+ * spooled), as the existing trace-delete suites rely on too.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class TracesDistributedWrapMutationTest {
+
+    private static final String API_KEY = "apiKey-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
+
+    // Dedicated, non-reused ClickHouse + ZooKeeper on their own network: the wrap destructively renames `traces`, so a
+    // shared/reused container would corrupt other suites and reruns. Redis/MySQL are only read, so the shared ones are
+    // fine.
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeperContainer = ClickHouseContainerUtils.newZookeeperContainer(false,
+            network);
+    private final ClickHouseContainer clickHouseContainer = ClickHouseContainerUtils
+            .newClickHouseContainer(false, network, zookeeperContainer);
+    private final RedisContainer redisContainer = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer mysqlContainer = MySQLContainerUtils.newMySQLContainer();
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(redisContainer, mysqlContainer, clickHouseContainer, zookeeperContainer)
+                .join();
+        wireMock = WireMockUtils.startWireMock();
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME);
+        MigrationUtils.runMysqlDbMigration(mysqlContainer);
+        MigrationUtils.runClickhouseDbMigration(clickHouseContainer);
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(mysqlContainer.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(redisContainer.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .customConfigs(List.of(
+                                new CustomConfig("databaseAnalyticsDataModel.tracesDistributedWrapEnabled", "true")))
+                        .build());
+    }
+
+    private TraceResourceClient traceResourceClient;
+    private TransactionTemplateAsync template;
+    private TraceDAO traceDAO;
+
+    @BeforeAll
+    void beforeAll(ClientSupport clientSupport, TransactionTemplateAsync template, TraceDAO traceDAO) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+        mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
+        traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        this.template = template;
+        this.traceDAO = traceDAO;
+        applyDistributedWrap();
+    }
+
+    @AfterAll
+    void afterAll() {
+        wireMock.server().stop();
+        clickHouseContainer.stop();
+        zookeeperContainer.stop();
+        network.close();
+    }
+
+    @Test
+    void deleteByIdRemovesTraceThroughTheLocalShardUnderTheDistributedWrap() {
+        var trace = newTrace().build();
+
+        traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+        // Insert and read both routed through the Distributed `traces`.
+        assertThat(getTraceIds(trace.projectName())).contains(trace.id());
+
+        // Delete-by-id via the live user path. Against the Distributed `traces` the mutation 500s (see the guard
+        // below), so a NO_CONTENT here means it ran against `traces_local`.
+        traceResourceClient.deleteTrace(trace.id(), WORKSPACE_NAME, API_KEY);
+
+        assertThat(getTraceIds(trace.projectName())).doesNotContain(trace.id());
+    }
+
+    @Test
+    void deleteForRetentionRunsAgainstTheLocalShard() {
+        var window = RetentionWindow.aroundNow();
+        var trace = newTrace().id(window.middleId()).build();
+        traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+        assertThat(getTraceIds(trace.projectName())).contains(trace.id());
+
+        traceDAO.deleteForRetention(List.of(WORKSPACE_ID), window.cutoffId(), window.lowerBound()).block();
+
+        assertThat(getTraceIds(trace.projectName())).doesNotContain(trace.id());
+    }
+
+    @Test
+    void deleteForRetentionBoundedRunsAgainstTheLocalShard() {
+        var window = RetentionWindow.aroundNow();
+        var trace = newTrace().id(window.middleId()).build();
+        traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+        assertThat(getTraceIds(trace.projectName())).contains(trace.id());
+
+        traceDAO.deleteForRetentionBounded(Map.of(WORKSPACE_ID, window.lowerBound()), window.cutoffId(),
+                window.lowerBound()).block();
+
+        assertThat(getTraceIds(trace.projectName())).doesNotContain(trace.id());
+    }
+
+    @Test
+    void distributedTracesRejectsDirectMutation() {
+        // Guard: a lightweight DELETE against the Distributed `traces` is what the DAO used to issue and what the wrap
+        // rejects (ClickHouse code 36 BAD_ARGUMENTS). Asserting the specific rejection — not merely that something
+        // threw — is what proves `traces` really is a mutation-rejecting Distributed table, so the positive deletes
+        // above could only have run against `traces_local`.
+        var id = ID_GENERATOR.generateId();
+        assertThatThrownBy(() -> execute("DELETE FROM traces WHERE workspace_id = :workspace_id AND id = :id",
+                statement -> statement.bind("workspace_id", WORKSPACE_ID).bind("id", id)))
+                .hasMessageContaining("DELETE query is not supported for table");
+    }
+
+    /**
+     * A UUIDv7 id-range bracketing one seeded trace within a single UTC week, so the retention queries'
+     * {@code id >= lower AND id < cutoff} and {@code toMonday(id_at)} bounds both select exactly it. Derived from
+     * {@code now} (not a fixed calendar date, so it never ages) and only ±1s wide; {@code middleId} always sits between
+     * the bounds, so the seed matches even across a Monday boundary.
+     */
+    @Builder(toBuilder = true)
+    private record RetentionWindow(UUID lowerBound, UUID middleId, UUID cutoffId) {
+        private static RetentionWindow aroundNow() {
+            var now = Instant.now();
+            return RetentionWindow.builder()
+                    .lowerBound(ID_GENERATOR.generateId(now.minusSeconds(1)))
+                    .middleId(ID_GENERATOR.generateId(now))
+                    .cutoffId(ID_GENERATOR.generateId(now.plusSeconds(1)))
+                    .build();
+        }
+    }
+
+    /**
+     * A trace with every trace-table column populated. Only the span-derived aggregates podam would otherwise
+     * fabricate ({@code feedbackScores}, {@code usage}) are nulled, since they are not columns of the {@code traces}
+     * table and would only add noise.
+     */
+    private Trace.TraceBuilder newTrace() {
+        return factory.manufacturePojo(Trace.class).toBuilder()
+                .feedbackScores(null)
+                .usage(null);
+    }
+
+    private List<UUID> getTraceIds(String projectName) {
+        return traceResourceClient
+                .getTraces(projectName, null, API_KEY, WORKSPACE_NAME, List.of(), List.of(), 100, Map.of())
+                .content().stream()
+                .map(Trace::id)
+                .toList();
+    }
+
+    /**
+     * Wraps {@code traces} as a {@code Distributed} table over the {@code traces_local} shard. The statements are kept
+     * identical to the wrap block of {@code 000003_exchange_and_wrap.sql} (the cutover's source of truth, also mirrored
+     * inline by {@code TracesLocalV2CutoverTest.wrapInDistributed}): build the wrapper under a temp name, then one
+     * atomic multi-target {@code RENAME} rotates the data to {@code traces_local} and the wrapper into {@code traces}.
+     * Only the resulting topology matters to this suite, so — as with the cutover gate test — the copies are kept in
+     * step by eye rather than shared, avoiding a parser for two statements.
+     */
+    private void applyDistributedWrap() {
+        execute("""
+                CREATE TABLE traces_dist ON CLUSTER '{cluster}' AS traces
+                ENGINE = Distributed('{cluster}', '%s', 'traces_local', sipHash64(project_id))
+                """.formatted(DATABASE_NAME), _ -> {
+        });
+        execute("""
+                RENAME TABLE
+                    traces TO traces_local,
+                    traces_dist TO traces
+                    ON CLUSTER '{cluster}'
+                """, _ -> {
+        });
+    }
+
+    private void execute(String sql, Consumer<Statement> binder) {
+        template.nonTransaction(connection -> {
+            var statement = connection.createStatement(sql);
+            binder.accept(statement);
+            return Mono.from(statement.execute()).flatMap(result -> Mono.from(result.getRowsUpdated()));
+        }).block();
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -124,7 +124,9 @@ databaseAnalyticsDataModel:
   #   mutation must target the local shard. Leave false at deploy time and while `traces` is still a MergeTree (deletes
   #   work directly); set true in lockstep with applying the wrap (exchange_and_wrap.sh --with-wrap / --wrap-only). While
   #   true, TraceDAO routes delete/retention mutations to `traces_local`; reads and inserts stay on the Distributed
-  #   `traces`. Any future mutation/ALTER/OPTIMIZE targeting `traces` must likewise target `traces_local` when this is on.
+  #   `traces`. Post-wrap, changes to `traces` split by kind: row mutations (DELETE) + MATERIALIZE COLUMN/ADD INDEX/
+  #   MODIFY TTL target `traces_local` only (the Distributed `traces` rejects them); ADD/DROP/MODIFY COLUMN must target
+  #   both `traces_local` and `traces`, else reads can't see the column (code 47).
   tracesDistributedWrapEnabled: false
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -118,6 +118,14 @@ databaseAnalyticsDataModel:
   #   than the ClickHouse driver binds reliably in one statement (5 columns per row), so the insert is split into
   #   chunks of this size.
   deletionEventsInsertBatchSize: 1000
+  #  Default: false
+  #  Description: The final sharding-readiness step wraps `traces` as a Distributed table over the `traces_local`
+  #   shard. A Distributed table supports SELECT and INSERT but NOT mutations, so once the wrap is live every trace
+  #   mutation must target the local shard. Leave false at deploy time and while `traces` is still a MergeTree (deletes
+  #   work directly); set true in lockstep with applying the wrap (exchange_and_wrap.sh --with-wrap / --wrap-only). While
+  #   true, TraceDAO routes delete/retention mutations to `traces_local`; reads and inserts stay on the Distributed
+  #   `traces`. Any future mutation/ALTER/OPTIMIZE targeting `traces` must likewise target `traces_local` when this is on.
+  tracesDistributedWrapEnabled: false
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -185,6 +185,9 @@ services:
       # non-nullable sentinel columns; a null bind would be rejected). The SPAN sibling is for the later spans cutover.
       ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE: ${ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE:-false}
       ANALYTICS_DB_DATA_MODEL_SPAN_COLUMNS_NON_NULLABLE: ${ANALYTICS_DB_DATA_MODEL_SPAN_COLUMNS_NON_NULLABLE:-false}
+      # Flip TRACES_DISTRIBUTED_WRAP_ENABLED to true in lockstep with applying the Distributed wrap: it routes trace
+      # delete/retention mutations to traces_local, since a Distributed traces rejects mutations.
+      ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
       # Readiness probes for the Hyperscale topology, both off for the single-node Compose stack: the cluster probe
       # checks the Distributed cluster definition is visible, the cold-storage probe checks the cold_s3 tiered disk.
       ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED: ${ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED:-false}

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -473,6 +473,7 @@ Call opik api on http://localhost:5173/api
 | databaseAnalyticsDataModel.spanDeletionEventsCaptureEnabled | bool | `false` |  |
 | databaseAnalyticsDataModel.traceColumnsNonNullable | bool | `false` |  |
 | databaseAnalyticsDataModel.traceDeletionEventsCaptureEnabled | bool | `false` |  |
+| databaseAnalyticsDataModel.tracesDistributedWrapEnabled | bool | `false` |  |
 | demoDataJob.enabled | bool | `true` |  |
 | fullnameOverride | string | `""` |  |
 | global.argocd | bool | `false` |  |

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -49,6 +49,7 @@ data:
         "ANALYTICS_DB_DATA_MODEL_TRACE_DELETION_EVENTS_CAPTURE_ENABLED" $dm.traceDeletionEventsCaptureEnabled
         "ANALYTICS_DB_DATA_MODEL_SPAN_DELETION_EVENTS_CAPTURE_ENABLED" $dm.spanDeletionEventsCaptureEnabled
         "ANALYTICS_DB_DATA_MODEL_DELETION_EVENTS_INSERT_BATCH_SIZE" $dm.deletionEventsInsertBatchSize
+        "ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED" $dm.tracesDistributedWrapEnabled
         "PARTITION_METRICS_ENABLED" $pm.enabled
         "PARTITION_METRICS_INTERVAL" $pm.interval
         "PARTITION_METRICS_LWD_TABLES" $pm.lwdTables

--- a/deployment/helm_chart/opik/tests/configmap_env_test.yaml
+++ b/deployment/helm_chart/opik/tests/configmap_env_test.yaml
@@ -71,6 +71,9 @@ tests:
           path: data.ANALYTICS_DB_DATA_MODEL_DELETION_EVENTS_INSERT_BATCH_SIZE
           value: "1000"
       - equal:
+          path: data.ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED
+          value: "false"
+      - equal:
           path: data.PARTITION_METRICS_ENABLED
           value: "false"
       - equal:

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -716,6 +716,9 @@ databaseAnalyticsDataModel:
   spanDeletionEventsCaptureEnabled: false
   # Rows per INSERT into the deletion_events_local bridge.
   deletionEventsInsertBatchSize: 1000
+  # Turn true in lockstep with applying the Distributed wrap, so trace delete/retention mutations target
+  # traces_local (a Distributed traces rejects mutations). Leave false while traces is still a MergeTree.
+  tracesDistributedWrapEnabled: false
 
 # ClickHouse partition-health observability (OPIK-6904). Polls system.parts plus the
 # lightweight-delete mask and publishes opik.clickhouse.partition.* gauges; a distributed lock keeps


### PR DESCRIPTION
## Details

The traces cutover's final, deferred step wraps `traces` as a `Distributed` table over the `traces_local` shard. A `Distributed` table supports `SELECT`/`INSERT` but not mutations (ClickHouse: `DELETE` → code 36, `ALTER … DELETE` → code 48), so every trace delete would return 500 the instant the wrap is applied. This ships the code prerequisite so the wrap can be enabled safely.

- `TraceDAO`'s three mutation paths (`DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS`, `DELETE_FOR_RETENTION`, and the dynamic `deleteForRetentionBounded`) now carry both table names in an `<if(distributed_wrap)>traces_local<else>traces<endif>` branch, gated by the new `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` toggle. Default `false` keeps mutations on `traces` (still a `MergeTree` pre-wrap, byte-identical to today); set `true` in lockstep with applying the wrap to route them at `traces_local`. Reads and inserts always stay on the `Distributed` `traces`.
- A repo-wide audit confirmed these are the only `DELETE`/`ALTER`/`OPTIMIZE` paths on `traces`; the accessor documents the general rule so future mutation paths and migrations switch tables the same way.
- The toggle is wired through `config.yml`, `config-test.yml`, docker-compose, and the Helm chart (values, configmap, and its unittest), mirroring the sibling cutover toggles so operators can set it. The cutover runbook and `exchange_and_wrap.sh` name the flag as the concrete prerequisite for the wrap.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-7455

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: iterative code review + local test runs

## Testing

- Added `TracesDistributedWrapMutationTest` — a black-box integration suite on dedicated (non-reused) ClickHouse/ZooKeeper containers that builds the post-wrap `Distributed` topology and drives the public trace API. It proves delete-by-id and both retention paths run against `traces_local`, that reads/inserts flow through the `Distributed` `traces`, and a guard test asserts a direct mutation on the `Distributed` `traces` is rejected (`DELETE query is not supported`, code 36).
- Ran locally: `mvn -o test -Dtest=TracesDistributedWrapMutationTest` (4/4 green), plus `mvn -o compile`, `mvn spotless:apply`, and `helm unittest` for the configmap env test (9/9). The flag-off (default → `traces`) branch is exercised by the existing trace-delete suites. Full quality checks run in CI.

## Documentation

- Updated the traces-local-v2 cutover runbook README, `000003_exchange_and_wrap.sql`, and `exchange_and_wrap.sh` to name `tracesDistributedWrapEnabled` as the DAO-retarget prerequisite for the wrap.
- Added config descriptions in `config.yml` / `config-test.yml` and Javadoc on `DatabaseAnalyticsDataModelConfig` and the `TraceDAO` accessor (including why single-shard mutations need no `ON CLUSTER`).
