### PR TITLE
[NA] [BE] fix: register deepinfra as a canonical provider so DeepInfra model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -52,7 +52,8 @@ public class CostService {
             Map.entry("inception", "inception"),
             Map.entry("meta", "meta"),
             Map.entry("zai", "zai"),
-            Map.entry("z-ai", "zai"));
+            Map.entry("z-ai", "zai"),
+            Map.entry("deepinfra", "deepinfra"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider
@@ -78,6 +79,7 @@ public class CostService {
                     Map.entry("deepseek", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("fireworks_ai", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("moonshot", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("deepinfra", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock),
                     Map.entry("bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock),
                     Map.entry("vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -55,7 +55,8 @@ public class CostService {
             Map.entry("z-ai", "zai"),
             Map.entry("sambanova", "sambanova"),
             Map.entry("nebius", "nebius"),
-            Map.entry("snowflake", "snowflake"));
+            Map.entry("snowflake", "snowflake"),
+            Map.entry("deepinfra", "deepinfra"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider
@@ -82,6 +83,7 @@ public class CostService {
                     Map.entry("fireworks_ai", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("moonshot", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("snowflake", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
+                    Map.entry("deepinfra", SpanCostCalculator::textGenerationWithCacheCostOpenAI),
                     Map.entry("bedrock", SpanCostCalculator::textGenerationWithCacheCostBedrock),
                     Map.entry("bedrock_converse", SpanCostCalculator::textGenerationWithCacheCostBedrock),
                     Map.entry("vertex_ai-language-models", SpanCostCalculator::textGenerationWithCacheCostGoogle),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -778,6 +778,48 @@ class CostServiceTest {
     }
 
     /**
+     * Covers both branches of registering {@code deepinfra} as a canonical provider so that the
+     * ~67 non-zero-cost entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "deepinfra"} (the {@code deepinfra/<org>/<model>} catalog) are no
+     * longer silently dropped at load time:
+     * <ul>
+     *   <li>DeepInfra model with no cache rates falls through to
+     *       {@link SpanCostCalculator#textGenerationCost}.</li>
+     *   <li>DeepInfra model with cache rates routes through
+     *       {@link SpanCostCalculator#textGenerationWithCacheCostOpenAI}; DeepInfra exposes an
+     *       OpenAI-compatible API, so even Claude models it hosts report cached tokens under
+     *       {@code prompt_tokens_details.cached_tokens} rather than the Anthropic shape.</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideDeepinfraProviderCases")
+    void calculateCostHandlesDeepinfraModels(String description, String model, Map<String, Integer> usage,
+            String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, "deepinfra", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideDeepinfraProviderCases() {
+        // deepinfra/Gryphe/MythoMax-L2-13b: input 8e-8, output 9e-8 (no cache) -> textGenerationCost
+        // 1000 * 8e-8 + 200 * 9e-8 = 0.00008 + 0.000018 = 0.000098
+        // deepinfra/anthropic/claude-3-7-sonnet-latest: input 3.3e-6, output 1.65e-5, cache_read 3.3e-7
+        // -> textGenerationWithCacheCostOpenAI
+        // non-cached input = 1000 - 300 = 700
+        // 700 * 3.3e-6 + 200 * 1.65e-5 + 300 * 3.3e-7 = 0.00231 + 0.0033 + 0.000099 = 0.005709
+        return Stream.of(
+                Arguments.of("plain text-generation route",
+                        "deepinfra/Gryphe/MythoMax-L2-13b",
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 200), "0.000098"),
+                Arguments.of("cache-aware route via OpenAI calc",
+                        "deepinfra/anthropic/claude-3-7-sonnet-latest",
+                        Map.of("original_usage.prompt_tokens", 1000,
+                                "original_usage.completion_tokens", 200,
+                                "original_usage.prompt_tokens_details.cached_tokens", 300),
+                        "0.005709"));
+    }
+
+    /**
      * Covers the provider-prefix fallback in {@link CostService#findModelPrice}. Callers that
      * route a model through an aggregator ({@link com.comet.opik.api.resources.v1.events.BudgetGuard}
      * calls {@code CostService.calculateCost} via {@code LlmProviderFactoryImpl.getResolvedModelInfo},

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1020,4 +1020,46 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers both branches of registering {@code deepinfra} as a canonical provider so that the
+     * ~67 non-zero-cost entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "deepinfra"} (the {@code deepinfra/<org>/<model>} catalog) are no
+     * longer silently dropped at load time:
+     * <ul>
+     *   <li>DeepInfra model with no cache rates falls through to
+     *       {@link SpanCostCalculator#textGenerationCost}.</li>
+     *   <li>DeepInfra model with cache rates routes through
+     *       {@link SpanCostCalculator#textGenerationWithCacheCostOpenAI}; DeepInfra exposes an
+     *       OpenAI-compatible API, so even Claude models it hosts report cached tokens under
+     *       {@code prompt_tokens_details.cached_tokens} rather than the Anthropic shape.</li>
+     * </ul>
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideDeepinfraProviderCases")
+    void calculateCostHandlesDeepinfraModels(String description, String model, Map<String, Integer> usage,
+            String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, "deepinfra", usage, null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideDeepinfraProviderCases() {
+        // deepinfra/Gryphe/MythoMax-L2-13b: input 8e-8, output 9e-8 (no cache) -> textGenerationCost
+        // 1000 * 8e-8 + 200 * 9e-8 = 0.00008 + 0.000018 = 0.000098
+        // deepinfra/anthropic/claude-3-7-sonnet-latest: input 3.3e-6, output 1.65e-5, cache_read 3.3e-7
+        // -> textGenerationWithCacheCostOpenAI
+        // non-cached input = 1000 - 300 = 700
+        // 700 * 3.3e-6 + 200 * 1.65e-5 + 300 * 3.3e-7 = 0.00231 + 0.0033 + 0.000099 = 0.005709
+        return Stream.of(
+                Arguments.of("plain text-generation route",
+                        "deepinfra/Gryphe/MythoMax-L2-13b",
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 200), "0.000098"),
+                Arguments.of("cache-aware route via OpenAI calc",
+                        "deepinfra/anthropic/claude-3-7-sonnet-latest",
+                        Map.of("original_usage.prompt_tokens", 1000,
+                                "original_usage.completion_tokens", 200,
+                                "original_usage.prompt_tokens_details.cached_tokens", 300),
+                        "0.005709"));
+    }
 }


### PR DESCRIPTION
## Details

DeepInfra model prices are silently dropped by Opik today. `model_prices_and_context_window.json` carries ~67 non-zero-cost entries tagged `litellm_provider: "deepinfra"` (the `deepinfra/<org>/<model>` catalog, 5 of them with `cache_read_input_token_cost`), and none load because `deepinfra` is not in `PROVIDERS_MAPPING`; `buildModelPrice` returns `null` for each. One of the gaps listed in #7697, same pattern as the merged azure / xai / deepseek / perplexity / fireworks_ai / moonshot registrations.

- Register `deepinfra -> deepinfra` in `PROVIDERS_MAPPING` so the entries load
- Route `deepinfra` through `textGenerationWithCacheCostOpenAI`; DeepInfra exposes an OpenAI-compatible API, so even the Claude models it hosts report cached tokens under `prompt_tokens_details.cached_tokens` (OpenAI shape), not the Anthropic shape

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

Part of #7697

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: the two mapping entries and the parameterized test
- Human verification: model resolution and both cost figures checked against the bundled model_prices_and_context_window.json before submission

## Testing

Added `calculateCostHandlesDeepinfraModels` covering both branches:

- `deepinfra/Gryphe/MythoMax-L2-13b` (input 8e-8, output 9e-8, no cache) routes through `textGenerationCost`; 1000 + 200 tokens = 0.000098
- `deepinfra/anthropic/claude-3-7-sonnet-latest` (input 3.3e-6, output 1.65e-5, cache_read 3.3e-7) routes through `textGenerationWithCacheCostOpenAI`; with 300 of 1000 prompt tokens cached, 700 * 3.3e-6 + 200 * 1.65e-5 + 300 * 3.3e-7 = 0.005709

Both cases fail against the current code (models do not resolve without the mapping entry, so cost is zero) and pass with the fix.

## Documentation

No documentation changes needed; provider pricing is driven by the bundled price map and the provider registration in CostService.
