### PR TITLE
fix: support analytics migrations on managed ClickHouse

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
@@ -13,6 +13,7 @@ import com.comet.opik.infrastructure.auth.AuthModule;
 import com.comet.opik.infrastructure.aws.AwsModule;
 import com.comet.opik.infrastructure.bi.OpikGuiceyLifecycleEventListener;
 import com.comet.opik.infrastructure.bundle.LiquibaseBundle;
+import com.comet.opik.infrastructure.bundle.ManagedClickHouseMigrationResourceAccessor;
 import com.comet.opik.infrastructure.cache.CacheModule;
 import com.comet.opik.infrastructure.db.DatabaseAnalyticsModule;
 import com.comet.opik.infrastructure.db.NameGeneratorModule;
@@ -92,6 +93,7 @@ public class OpikApplication extends Application<OpikConfiguration> {
                 .name(DB_APP_ANALYTICS_NAME)
                 .migrationsFileName(DB_APP_ANALYTICS_MIGRATIONS_FILE_NAME)
                 .dataSourceFactoryFunction(OpikConfiguration::getDatabaseAnalyticsMigrations)
+                .resourceAccessorSupplier(ManagedClickHouseMigrationResourceAccessor::createIfEnabled)
                 .build());
         bootstrap.addBundle(GuiceBundle.builder()
                 .bundles(JdbiBundle

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/LiquibaseBundle.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/LiquibaseBundle.java
@@ -3,12 +3,17 @@ package com.comet.opik.infrastructure.bundle;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import io.dropwizard.db.DataSourceFactory;
 import io.dropwizard.migrations.MigrationsBundle;
+import liquibase.Scope;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.ResourceAccessor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
 
+import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 @Builder
 public class LiquibaseBundle extends MigrationsBundle<OpikConfiguration> {
@@ -29,8 +34,17 @@ public class LiquibaseBundle extends MigrationsBundle<OpikConfiguration> {
 
     @NonNull private final Function<OpikConfiguration, DataSourceFactory> dataSourceFactoryFunction;
 
+    @Builder.Default
+    @NonNull
+    private final Supplier<ResourceAccessor> resourceAccessorSupplier = ClassLoaderResourceAccessor::new;
+
     @Override
     public DataSourceFactory getDataSourceFactory(OpikConfiguration configuration) {
         return dataSourceFactoryFunction.apply(configuration);
+    }
+
+    @Override
+    public Map<String, Object> getScopedObjects() {
+        return Map.of(Scope.Attr.resourceAccessor.name(), resourceAccessorSupplier.get());
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/LiquibaseBundle.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/LiquibaseBundle.java
@@ -35,8 +35,7 @@ public class LiquibaseBundle extends MigrationsBundle<OpikConfiguration> {
     @NonNull private final Function<OpikConfiguration, DataSourceFactory> dataSourceFactoryFunction;
 
     @Builder.Default
-    @NonNull
-    private final Supplier<ResourceAccessor> resourceAccessorSupplier = ClassLoaderResourceAccessor::new;
+    @NonNull private final Supplier<ResourceAccessor> resourceAccessorSupplier = ClassLoaderResourceAccessor::new;
 
     @Override
     public DataSourceFactory getDataSourceFactory(OpikConfiguration configuration) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessor.java
@@ -1,0 +1,255 @@
+package com.comet.opik.infrastructure.bundle;
+
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.OpenOptions;
+import liquibase.resource.Resource;
+import liquibase.resource.ResourceAccessor;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class ManagedClickHouseMigrationResourceAccessor extends ClassLoaderResourceAccessor {
+
+    public static final String ENABLED_ENVIRONMENT_VARIABLE = "ANALYTICS_DB_MANAGED_CLICKHOUSE";
+
+    private static final String ANALYTICS_MIGRATIONS_PREFIX = "liquibase/db-app-analytics/";
+    private static final String REPLICA_ARGUMENT = "'{replica}'";
+    private static final String REPLICATED_REPLACING_MERGE_TREE = "ReplicatedReplacingMergeTree";
+    private static final Pattern REPLICATED_ENGINE_PATTERN = Pattern.compile(
+            "(?i)\\bENGINE\\s*=\\s*(ReplicatedReplacingMergeTree|ReplicatedMergeTree)\\s*\\(");
+
+    public static ResourceAccessor createIfEnabled() {
+        return create(Boolean.parseBoolean(System.getenv(ENABLED_ENVIRONMENT_VARIABLE)));
+    }
+
+    static ResourceAccessor create(boolean enabled) {
+        if (enabled) {
+            return new ManagedClickHouseMigrationResourceAccessor();
+        }
+        return new ClassLoaderResourceAccessor();
+    }
+
+    @Override
+    public List<Resource> search(String path, SearchOptions searchOptions) throws IOException {
+        return wrap(super.search(path, searchOptions));
+    }
+
+    @Override
+    public List<Resource> search(String path, boolean recursive) throws IOException {
+        return wrap(super.search(path, recursive));
+    }
+
+    @Override
+    public List<Resource> getAll(String path) throws IOException {
+        return wrap(super.getAll(path));
+    }
+
+    private List<Resource> wrap(List<Resource> resources) {
+        if (resources == null) {
+            return null;
+        }
+        return resources.stream().map(this::wrap).toList();
+    }
+
+    private Resource wrap(Resource resource) {
+        if (resource instanceof ManagedClickHouseMigrationResource || !isAnalyticsSql(resource.getPath())) {
+            return resource;
+        }
+        return new ManagedClickHouseMigrationResource(resource);
+    }
+
+    private static boolean isAnalyticsSql(String path) {
+        return path.startsWith(ANALYTICS_MIGRATIONS_PREFIX) && path.endsWith(".sql");
+    }
+
+    static String transform(String resourcePath, String sql) throws IOException {
+        var matcher = REPLICATED_ENGINE_PATTERN.matcher(sql);
+        var transformed = new StringBuilder(sql.length());
+        int previousEnd = 0;
+
+        while (matcher.find(previousEnd)) {
+            int openingParenthesis = matcher.end() - 1;
+            int closingParenthesis = findClosingParenthesis(resourcePath, sql, openingParenthesis);
+            var engine = matcher.group(1);
+            var arguments = splitArguments(resourcePath, sql.substring(openingParenthesis + 1, closingParenthesis));
+            var managedArguments = classifyArguments(resourcePath, engine, arguments);
+
+            transformed.append(sql, previousEnd, openingParenthesis + 1);
+            transformed.append(String.join(", ", managedArguments));
+            transformed.append(')');
+            previousEnd = closingParenthesis + 1;
+        }
+
+        if (previousEnd == 0) {
+            return sql;
+        }
+        return transformed.append(sql, previousEnd, sql.length()).toString();
+    }
+
+    private static int findClosingParenthesis(String resourcePath, String sql, int openingParenthesis)
+            throws IOException {
+        int depth = 0;
+        boolean inString = false;
+
+        for (int index = openingParenthesis; index < sql.length(); index++) {
+            char current = sql.charAt(index);
+            if (current == '\'' && inString && index + 1 < sql.length() && sql.charAt(index + 1) == '\'') {
+                index++;
+                continue;
+            }
+            if (current == '\'') {
+                inString = !inString;
+            } else if (!inString && current == '(') {
+                depth++;
+            } else if (!inString && current == ')' && --depth == 0) {
+                return index;
+            }
+        }
+
+        throw unsafeArguments(resourcePath, "unterminated replicated engine argument list");
+    }
+
+    private static List<String> splitArguments(String resourcePath, String rawArguments) throws IOException {
+        if (rawArguments.isBlank()) {
+            return List.of();
+        }
+
+        var arguments = new ArrayList<String>();
+        int argumentStart = 0;
+        int depth = 0;
+        boolean inString = false;
+
+        for (int index = 0; index < rawArguments.length(); index++) {
+            char current = rawArguments.charAt(index);
+            if (current == '\'' && inString && index + 1 < rawArguments.length()
+                    && rawArguments.charAt(index + 1) == '\'') {
+                index++;
+                continue;
+            }
+            if (current == '\'') {
+                inString = !inString;
+            } else if (!inString && current == '(') {
+                depth++;
+            } else if (!inString && current == ')') {
+                depth--;
+            } else if (!inString && depth == 0 && current == ',') {
+                arguments.add(rawArguments.substring(argumentStart, index).trim());
+                argumentStart = index + 1;
+            }
+        }
+
+        arguments.add(rawArguments.substring(argumentStart).trim());
+        if (inString || depth != 0 || arguments.stream().anyMatch(String::isEmpty)) {
+            throw unsafeArguments(resourcePath, "malformed replicated engine argument list");
+        }
+        return arguments;
+    }
+
+    private static List<String> classifyArguments(String resourcePath, String engine, List<String> arguments)
+            throws IOException {
+        boolean replacing = REPLICATED_REPLACING_MERGE_TREE.equalsIgnoreCase(engine);
+        int maximumSemanticArguments = replacing ? 2 : 0;
+
+        if (arguments.size() >= 2 && isZooKeeperPath(arguments.get(0)) && REPLICA_ARGUMENT.equals(arguments.get(1))) {
+            var semanticArguments = arguments.subList(2, arguments.size());
+            if (semanticArguments.size() <= maximumSemanticArguments) {
+                return semanticArguments;
+            }
+        } else if (arguments.size() <= maximumSemanticArguments && arguments.stream().noneMatch(
+                argument -> argument.contains("/clickhouse/") || argument.contains("{replica}"))) {
+            return arguments;
+        }
+
+        throw unsafeArguments(resourcePath, "unrecognized %s argument list".formatted(engine));
+    }
+
+    private static boolean isZooKeeperPath(String argument) {
+        return argument.startsWith("'") && argument.endsWith("'")
+                && argument.contains("/clickhouse/tables/{shard}/");
+    }
+
+    private static IOException unsafeArguments(String resourcePath, String reason) {
+        return new IOException("Cannot render managed ClickHouse migration resource '%s': %s"
+                .formatted(resourcePath, reason));
+    }
+
+    private final class ManagedClickHouseMigrationResource implements Resource {
+
+        private final Resource delegate;
+
+        private ManagedClickHouseMigrationResource(Resource delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String getPath() {
+            return delegate.getPath();
+        }
+
+        @Override
+        public InputStream openInputStream() throws IOException {
+            try (var inputStream = delegate.openInputStream()) {
+                var sql = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+                return new ByteArrayInputStream(transform(getPath(), sql).getBytes(StandardCharsets.UTF_8));
+            }
+        }
+
+        @Override
+        public boolean isWritable() {
+            return delegate.isWritable();
+        }
+
+        @Override
+        public boolean exists() {
+            return delegate.exists();
+        }
+
+        @Override
+        public Resource resolve(String other) {
+            return wrap(delegate.resolve(other));
+        }
+
+        @Override
+        public Resource resolveSibling(String other) {
+            return wrap(delegate.resolveSibling(other));
+        }
+
+        @Override
+        public OutputStream openOutputStream(OpenOptions openOptions) throws IOException {
+            return delegate.openOutputStream(openOptions);
+        }
+
+        @Override
+        public URI getUri() {
+            return delegate.getUri();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            }
+            if (other instanceof ManagedClickHouseMigrationResource managedResource) {
+                return delegate.equals(managedResource.delegate);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessor.java
@@ -22,6 +22,8 @@ public class ManagedClickHouseMigrationResourceAccessor extends ClassLoaderResou
     private static final String ANALYTICS_MIGRATIONS_PREFIX = "liquibase/db-app-analytics/";
     private static final String REPLICA_ARGUMENT = "'{replica}'";
     private static final String REPLICATED_REPLACING_MERGE_TREE = "ReplicatedReplacingMergeTree";
+    private static final Pattern NON_CODE_PATTERN = Pattern.compile(
+            "(?s)'(?:''|\\\\.|[^'\\\\])*(?:'|\\z)|--[^\\r\\n]*|/\\*.*?(?:\\*/|\\z)");
     private static final Pattern REPLICATED_ENGINE_PATTERN = Pattern.compile(
             "(?i)\\bENGINE\\s*=\\s*(ReplicatedReplacingMergeTree|ReplicatedMergeTree)\\s*\\(");
 
@@ -73,8 +75,13 @@ public class ManagedClickHouseMigrationResourceAccessor extends ClassLoaderResou
         var matcher = REPLICATED_ENGINE_PATTERN.matcher(sql);
         var transformed = new StringBuilder(sql.length());
         int previousEnd = 0;
+        int searchIndex = 0;
 
-        while (matcher.find(previousEnd)) {
+        while (matcher.find(searchIndex)) {
+            searchIndex = matcher.end();
+            if (isNonCode(sql, matcher.start())) {
+                continue;
+            }
             int openingParenthesis = matcher.end() - 1;
             int closingParenthesis = findClosingParenthesis(resourcePath, sql, openingParenthesis);
             var engine = matcher.group(1);
@@ -85,12 +92,23 @@ public class ManagedClickHouseMigrationResourceAccessor extends ClassLoaderResou
             transformed.append(String.join(", ", managedArguments));
             transformed.append(')');
             previousEnd = closingParenthesis + 1;
+            searchIndex = previousEnd;
         }
 
         if (previousEnd == 0) {
             return sql;
         }
         return transformed.append(sql, previousEnd, sql.length()).toString();
+    }
+
+    private static boolean isNonCode(String sql, int offset) {
+        var matcher = NON_CODE_PATTERN.matcher(sql);
+        while (matcher.find() && matcher.start() <= offset) {
+            if (offset < matcher.end()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static int findClosingParenthesis(String resourcePath, String sql, int openingParenthesis)
@@ -162,10 +180,11 @@ public class ManagedClickHouseMigrationResourceAccessor extends ClassLoaderResou
             if (semanticArguments.size() <= maximumSemanticArguments) {
                 return semanticArguments;
             }
-        } else if (arguments.size() <= maximumSemanticArguments && arguments.stream().noneMatch(
-                argument -> argument.contains("/clickhouse/") || argument.contains("{replica}"))) {
-            return arguments;
-        }
+        } else
+            if (arguments.size() <= maximumSemanticArguments && arguments.stream().noneMatch(
+                    argument -> argument.contains("/clickhouse/") || argument.contains("{replica}"))) {
+                        return arguments;
+                    }
 
         throw unsafeArguments(resourcePath, "unrecognized %s argument list".formatted(engine));
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
@@ -7,6 +7,7 @@ import liquibase.database.jvm.JdbcConnection;
 import liquibase.exception.LiquibaseException;
 import liquibase.exception.UnexpectedLiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.ResourceAccessor;
 import lombok.experimental.UtilityClass;
 import org.jdbi.v3.core.Jdbi;
 import org.testcontainers.clickhouse.ClickHouseContainer;
@@ -39,10 +40,15 @@ public class MigrationUtils {
     }
 
     public static void runClickhouseDbMigration(ClickHouseContainer container) {
+        runClickhouseDbMigration(container, new ClassLoaderResourceAccessor());
+    }
+
+    public static void runClickhouseDbMigration(ClickHouseContainer container, ResourceAccessor resourceAccessor) {
         try (var connection = container.createConnection("")) {
             DatabaseConnection dbConnection = new JdbcConnection(
                     new ClickHouseConnectionImpl(connection.getMetaData().getURL()));
-            runDbMigration(CLICKHOUSE_CHANGELOG_FILE, ClickHouseContainerUtils.migrationParameters(), dbConnection);
+            runDbMigration(CLICKHOUSE_CHANGELOG_FILE, ClickHouseContainerUtils.migrationParameters(), dbConnection,
+                    resourceAccessor);
         } catch (SQLException e) {
             throw new RuntimeException("Failed to run ClickHouse DB migration", e);
         }
@@ -50,10 +56,15 @@ public class MigrationUtils {
 
     private static void runDbMigration(String changeLogFile, Map<String, String> parameters,
             DatabaseConnection connection) {
+        runDbMigration(changeLogFile, parameters, connection, new ClassLoaderResourceAccessor());
+    }
+
+    private static void runDbMigration(String changeLogFile, Map<String, String> parameters,
+            DatabaseConnection connection, ResourceAccessor resourceAccessor) {
         try {
             var database = DatabaseFactory.getInstance()
                     .findCorrectDatabaseImplementation(connection);
-            try (var liquibase = new Liquibase(changeLogFile, new ClassLoaderResourceAccessor(), database)) {
+            try (var liquibase = new Liquibase(changeLogFile, resourceAccessor, database)) {
                 parameters.forEach(liquibase::setChangeLogParameter);
                 liquibase.update("updateSql");
             }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessorTest.java
@@ -64,6 +64,23 @@ class ManagedClickHouseMigrationResourceAccessorTest {
     }
 
     @Test
+    void leavesReplicatedEnginesInCommentsAndStringsUnchanged() throws IOException {
+        var sql = """
+                -- ENGINE = ReplicatedMergeTree('/invalid')
+                SELECT 'ENGINE = ReplicatedMergeTree(''also invalid'')';
+                /* ENGINE = ReplicatedReplacingMergeTree('/invalid') */
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/opik/events', '{replica}')
+                """;
+
+        assertThat(ManagedClickHouseMigrationResourceAccessor.transform("test.sql", sql)).isEqualTo("""
+                -- ENGINE = ReplicatedMergeTree('/invalid')
+                SELECT 'ENGINE = ReplicatedMergeTree(''also invalid'')';
+                /* ENGINE = ReplicatedReplacingMergeTree('/invalid') */
+                ENGINE = ReplicatedMergeTree()
+                """);
+    }
+
+    @Test
     void transformsEveryAnalyticsMigrationWithoutChangingUnrelatedResources() throws Exception {
         try (var managedAccessor = new ManagedClickHouseMigrationResourceAccessor();
                 var originalAccessor = ManagedClickHouseMigrationResourceAccessor.create(false)) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationResourceAccessorTest.java
@@ -1,0 +1,157 @@
+package com.comet.opik.infrastructure.bundle;
+
+import liquibase.Scope;
+import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.resource.Resource;
+import liquibase.resource.ResourceAccessor;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.comet.opik.infrastructure.bundle.LiquibaseBundle.DB_APP_ANALYTICS_MIGRATIONS_FILE_NAME;
+import static com.comet.opik.infrastructure.bundle.LiquibaseBundle.DB_APP_ANALYTICS_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIOException;
+
+class ManagedClickHouseMigrationResourceAccessorTest {
+
+    private static final String ANALYTICS_MIGRATIONS_PATH = "liquibase/db-app-analytics/migrations";
+
+    @Test
+    void transformsReplicatedEngineArgumentsAndPreservesOtherSql() throws IOException {
+        var sql = """
+                --liquibase formatted sql
+                --changeset test:managed-clickhouse
+                CREATE TABLE events (id UUID)
+                ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/opik/events', '{replica}')
+                ORDER BY id;
+
+                CREATE TABLE versions (id UUID, last_updated_at DateTime64(6))
+                ENGINE = ReplicatedReplacingMergeTree(
+                    '/clickhouse/tables/{shard}/opik/versions',
+                    '{replica}',
+                    last_updated_at
+                )
+                ORDER BY (tuple());
+                """;
+
+        assertThat(ManagedClickHouseMigrationResourceAccessor.transform("test.sql", sql)).isEqualTo("""
+                --liquibase formatted sql
+                --changeset test:managed-clickhouse
+                CREATE TABLE events (id UUID)
+                ENGINE = ReplicatedMergeTree()
+                ORDER BY id;
+
+                CREATE TABLE versions (id UUID, last_updated_at DateTime64(6))
+                ENGINE = ReplicatedReplacingMergeTree(last_updated_at)
+                ORDER BY (tuple());
+                """);
+    }
+
+    @Test
+    void leavesAlreadyManagedEngineArgumentsUnchanged() throws IOException {
+        var sql = """
+                ENGINE = ReplicatedMergeTree()
+                ENGINE = ReplicatedReplacingMergeTree(last_updated_at)
+                """;
+
+        assertThat(ManagedClickHouseMigrationResourceAccessor.transform("test.sql", sql)).isEqualTo(sql);
+    }
+
+    @Test
+    void transformsEveryAnalyticsMigrationWithoutChangingUnrelatedResources() throws Exception {
+        try (var managedAccessor = new ManagedClickHouseMigrationResourceAccessor();
+                var originalAccessor = ManagedClickHouseMigrationResourceAccessor.create(false)) {
+            Map<String, String> originals = originalAccessor.search(ANALYTICS_MIGRATIONS_PATH, true).stream()
+                    .filter(resource -> resource.getPath().endsWith(".sql"))
+                    .collect(Collectors.toMap(Resource::getPath, ManagedClickHouseMigrationResourceAccessorTest::read));
+            Map<String, String> transformed = managedAccessor.search(ANALYTICS_MIGRATIONS_PATH, true).stream()
+                    .filter(resource -> resource.getPath().endsWith(".sql"))
+                    .collect(Collectors.toMap(Resource::getPath, ManagedClickHouseMigrationResourceAccessorTest::read));
+
+            assertThat(transformed).hasSameSizeAs(originals);
+            assertThat(transformed.values())
+                    .noneMatch(sql -> sql.contains("/clickhouse/tables/{shard}"))
+                    .noneMatch(sql -> sql.contains("'{replica}'"));
+            originals.forEach((path, original) -> {
+                if (!original.contains("ENGINE = Replicated")) {
+                    assertThat(transformed.get(path)).as(path).isEqualTo(original);
+                }
+            });
+        }
+    }
+
+    @Test
+    void leavesStateDatabaseResourcesUnchanged() throws Exception {
+        var stateMigration = "liquibase/db-app-state/changelog.xml";
+        try (var managedAccessor = new ManagedClickHouseMigrationResourceAccessor()) {
+            var original = getClass().getClassLoader().getResourceAsStream(stateMigration);
+
+            assertThat(original).isNotNull();
+            assertThat(read(managedAccessor.getExisting(stateMigration))).isEqualTo(read(original));
+        }
+    }
+
+    @Test
+    void rejectsUnrecognizedReplicatedEngineArgumentsWithResourceName() {
+        var sql = "ENGINE = ReplicatedMergeTree('/custom/path', '{replica}')";
+
+        assertThatIOException()
+                .isThrownBy(() -> ManagedClickHouseMigrationResourceAccessor.transform("unsafe.sql", sql))
+                .withMessageContaining("unsafe.sql")
+                .withMessageContaining("ReplicatedMergeTree");
+    }
+
+    @Test
+    void bundleUsesStandardClasspathAccessorUnlessManagedStrategyIsSelected() {
+        var defaultBundle = LiquibaseBundle.builder()
+                .name(DB_APP_ANALYTICS_NAME)
+                .migrationsFileName(DB_APP_ANALYTICS_MIGRATIONS_FILE_NAME)
+                .dataSourceFactoryFunction(configuration -> null)
+                .build();
+        var managedBundle = newAnalyticsBundle(ManagedClickHouseMigrationResourceAccessor::new);
+
+        assertThat(defaultBundle.getScopedObjects().get(Scope.Attr.resourceAccessor.name()))
+                .isExactlyInstanceOf(ClassLoaderResourceAccessor.class);
+        assertThat(managedBundle.getScopedObjects().get(Scope.Attr.resourceAccessor.name()))
+                .isExactlyInstanceOf(ManagedClickHouseMigrationResourceAccessor.class);
+    }
+
+    @Test
+    void environmentStrategyIsOptIn() {
+        assertThat(ManagedClickHouseMigrationResourceAccessor.create(false))
+                .isExactlyInstanceOf(ClassLoaderResourceAccessor.class);
+        assertThat(ManagedClickHouseMigrationResourceAccessor.create(true))
+                .isExactlyInstanceOf(ManagedClickHouseMigrationResourceAccessor.class);
+    }
+
+    private LiquibaseBundle newAnalyticsBundle(Supplier<ResourceAccessor> resourceAccessorSupplier) {
+        return LiquibaseBundle.builder()
+                .name(DB_APP_ANALYTICS_NAME)
+                .migrationsFileName(DB_APP_ANALYTICS_MIGRATIONS_FILE_NAME)
+                .dataSourceFactoryFunction(configuration -> null)
+                .resourceAccessorSupplier(resourceAccessorSupplier)
+                .build();
+    }
+
+    private static String read(Resource resource) {
+        try (var inputStream = resource.openInputStream()) {
+            return read(inputStream);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+
+    private static String read(InputStream inputStream) {
+        try (inputStream) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new RuntimeException(exception);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationsIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bundle/ManagedClickHouseMigrationsIntegrationTest.java
@@ -1,0 +1,89 @@
+package com.comet.opik.infrastructure.bundle;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.SQLException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ManagedClickHouseMigrationsIntegrationTest {
+
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeper = ClickHouseContainerUtils.newZookeeperContainer(false, network);
+    private final ClickHouseContainer clickHouse = ClickHouseContainerUtils
+            .newClickHouseContainer(false, network, zookeeper);
+
+    @BeforeAll
+    void setUp() throws SQLException {
+        Startables.deepStart(clickHouse).join();
+        execute("""
+                CREATE DATABASE IF NOT EXISTS opik
+                ENGINE = Replicated('/clickhouse/databases/opik', '{shard}', '{replica}')
+                """);
+    }
+
+    @AfterAll
+    void tearDown() {
+        if (clickHouse.isRunning()) {
+            clickHouse.stop();
+        }
+        if (zookeeper.isRunning()) {
+            zookeeper.stop();
+        }
+        network.close();
+    }
+
+    @Test
+    void runsCompleteManagedChangelogAndRerunsIdempotently() throws SQLException {
+        var accessor = new ManagedClickHouseMigrationResourceAccessor();
+
+        MigrationUtils.runClickhouseDbMigration(clickHouse, accessor);
+        var appliedChangeSets = queryLong("SELECT count() FROM DATABASECHANGELOG");
+
+        assertThat(queryString("""
+                SELECT engine FROM system.tables
+                WHERE database = 'opik' AND name = 'alert_logs'
+                """)).isEqualTo("ReplicatedMergeTree");
+        assertThat(queryString("""
+                SELECT engine FROM system.tables
+                WHERE database = 'opik' AND name = 'comments'
+                """)).isEqualTo("ReplicatedReplacingMergeTree");
+
+        MigrationUtils.runClickhouseDbMigration(clickHouse, new ManagedClickHouseMigrationResourceAccessor());
+        assertThat(queryLong("SELECT count() FROM DATABASECHANGELOG")).isEqualTo(appliedChangeSets);
+    }
+
+    private void execute(String sql) throws SQLException {
+        try (var connection = clickHouse.createConnection(""); var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private String queryString(String sql) throws SQLException {
+        try (var connection = clickHouse.createConnection("");
+                var statement = connection.createStatement();
+                var resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getString(1);
+        }
+    }
+
+    private long queryLong(String sql) throws SQLException {
+        try (var connection = clickHouse.createConnection("");
+                var statement = connection.createStatement();
+                var resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).isTrue();
+            return resultSet.getLong(1);
+        }
+    }
+}

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/kubernetes.mdx
@@ -258,8 +258,9 @@ component:
 ```
 
 This makes Opik omit explicit ZooKeeper paths and replica names from replicated table engines so ClickHouse can use
-the managed service defaults. Keep this setting unchanged for the lifetime of the analytics database: it changes the
-SQL content used to calculate Liquibase checksums.
+the managed service defaults. The setting defaults to disabled when unset. Helm environment values are strings: only
+`"true"` (case-insensitive) enables it; `"false"` or any other value disables it. Keep this setting unchanged for the
+lifetime of the analytics database because it changes the SQL content used to calculate Liquibase checksums.
 
 # Delete your installation 
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/kubernetes.mdx
@@ -247,6 +247,20 @@ clickhouse:
     enabled: false
 ```
 
+For ClickHouse Cloud, OVHcloud, or another provider that creates the analytics database with `ENGINE = Replicated`,
+also enable managed ClickHouse migrations:
+
+```yaml
+component:
+  backend:
+    env:
+      ANALYTICS_DB_MANAGED_CLICKHOUSE: "true"
+```
+
+This makes Opik omit explicit ZooKeeper paths and replica names from replicated table engines so ClickHouse can use
+the managed service defaults. Keep this setting unchanged for the lifetime of the analytics database: it changes the
+SQL content used to calculate Liquibase checksums.
+
 # Delete your installation 
 
 Before deleting opik installation with helm, make sure to remove finalizer on the clickhouse resource:

--- a/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
@@ -259,8 +259,9 @@ component:
 ```
 
 This makes Opik omit explicit ZooKeeper paths and replica names from replicated table engines so ClickHouse can use
-the managed service defaults. Keep this setting unchanged for the lifetime of the analytics database: it changes the
-SQL content used to calculate Liquibase checksums.
+the managed service defaults. The setting defaults to disabled when unset. Helm environment values are strings: only
+`"true"` (case-insensitive) enables it; `"false"` or any other value disables it. Keep this setting unchanged for the
+lifetime of the analytics database because it changes the SQL content used to calculate Liquibase checksums.
 
 # Delete your installation 
 

--- a/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/self-host/kubernetes.mdx
@@ -248,6 +248,20 @@ clickhouse:
     enabled: false
 ```
 
+For ClickHouse Cloud, OVHcloud, or another provider that creates the analytics database with `ENGINE = Replicated`,
+also enable managed ClickHouse migrations:
+
+```yaml
+component:
+  backend:
+    env:
+      ANALYTICS_DB_MANAGED_CLICKHOUSE: "true"
+```
+
+This makes Opik omit explicit ZooKeeper paths and replica names from replicated table engines so ClickHouse can use
+the managed service defaults. Keep this setting unchanged for the lifetime of the analytics database: it changes the
+SQL content used to calculate Liquibase checksums.
+
 # Delete your installation 
 
 Before deleting opik installation with helm, make sure to remove finalizer on the clickhouse resource:


### PR DESCRIPTION
## Details

Self-hosted Opik cannot run its analytics migrations against a managed ClickHouse service. Providers like ClickHouse Cloud and OVHcloud create the database with `ENGINE = Replicated`, which rejects the explicit ZooKeeper path and replica name that Opik's `db-app-analytics` migrations pass to `ReplicatedMergeTree` / `ReplicatedReplacingMergeTree`. The install fails at migration time with `Can't create replicated table without ZooKeeper`.

This adds `ManagedClickHouseMigrationResourceAccessor`, a Liquibase `ResourceAccessor` that rewrites analytics migration SQL on read when `ANALYTICS_DB_MANAGED_CLICKHOUSE=true`. It strips the ZooKeeper-path and replica-name arguments from replicated engine declarations while keeping semantic arguments such as `last_updated_at` intact, so the managed service supplies its own defaults.

The rewrite is structural rather than a list of known-bad migrations: it matches the replicated-engine pattern across every file under `liquibase/db-app-analytics/`, so migrations added later are covered without further changes. An argument list it cannot classify safely raises instead of silently emitting altered DDL.

Fixes #4316

## Change checklist

- Opt-in by default: with the flag unset, `create()` returns a plain `ClassLoaderResourceAccessor`, so every byte Liquibase reads is unchanged.
- `LiquibaseBundle` takes the accessor as a strategy; `OpikApplication` wires it into the `dbAnalytics` bundle only. The state database keeps the default accessor.
- Set-once, not a runtime toggle: rewriting SQL content changes Liquibase checksums, so flipping the flag on an existing analytics database would invalidate them. This is called out in the docs change.
- No existing migration file is edited, and nothing outside `db-app-analytics` is touched.

## Issues

- Resolves #4316

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: AI coding assistant
- Model(s): a general-purpose code model (specific vendor and model withheld under my contributor policy)
- Scope: implementation and tests, written from a plan I wrote after reading `LiquibaseBundle`, `OpikApplication`, the `db-app-analytics` migrations, and issue #4316.
- Human verification: I read the full diff line by line, checked that the disabled path is byte-identical to current behavior, and confirmed the checksum caveat is documented before opening this PR.

## Testing

- `ManagedClickHouseMigrationResourceAccessorTest` (unit): engine rewriting for `ReplicatedMergeTree` and `ReplicatedReplacingMergeTree`, preservation of the `last_updated_at` argument, disabled-flag passthrough, non-analytics paths left untouched, and the raise-on-unclassifiable-arguments case.
- `ManagedClickHouseMigrationsIntegrationTest`: runs the analytics migration set through the accessor and asserts the rendered DDL carries no ZooKeeper path or replica name.
- `MigrationUtils` gained a small hook so integration tests can select the accessor.

I could not execute the Java suite in this workspace (no local JDK/Maven for this project), so CI is the authority on the full run.

## Documentation

`self-host/kubernetes.mdx` (both `docs` and `docs-v2`) gains a short section naming the managed providers this applies to, the `ANALYTICS_DB_MANAGED_CLICKHOUSE` env var, and the set-once checksum caveat. It sits directly beside the existing `NO_ZOOKEEPER` troubleshooting note, which is where someone hitting this lands.

AI was used for assistance.
