### PR TITLE
[OPIK-7728] [QA] fix: scope studio prompt editors to their message role

### DIFF
--- a/tests_end_to_end/e2e/pom/optimization-studio.page.ts
+++ b/tests_end_to_end/e2e/pom/optimization-studio.page.ts
@@ -9,6 +9,12 @@ export interface StudioRunConfig {
   datasetName: string;
   /** User-message prompt content; keep the dataset variable, e.g. `{{text}}`. */
   prompt: string;
+  /**
+   * System-message content — the instruction the optimizer rewrites. Required
+   * because the form seeds a system card and rejects submit while it is empty;
+   * see `setSystemPrompt`.
+   */
+  systemPrompt: string;
   /** Model display name as shown in the picker (e.g. "Claude Haiku 4.5"). */
   modelDisplayName: string;
   /** Equals-metric reference key — the dataset field holding the gold label. */
@@ -51,7 +57,12 @@ export class OptimizationStudioPage {
   /** Assert the form's core sections render with the expected defaults. */
   async assertFormRenders(opts: { optimizer?: string; metric?: string } = {}): Promise<void> {
     return test.step('Assert the studio form renders its sections', async () => {
-      await expect(this.promptEditor()).toBeVisible();
+      // A new run seeds two message cards — instructions in the system message
+      // (the only role the run makes optimizable) and template variables in the
+      // user message. Assert both, so a regression back to a single seeded card
+      // fails here rather than surfacing as a stuck submit later.
+      await expect(this.promptEditor('system')).toBeVisible();
+      await expect(this.promptEditor('user')).toBeVisible();
       await expect(this.modelCombobox()).toBeVisible();
       await expect(this.datasetPickerButton()).toBeVisible();
       await expect(
@@ -78,11 +89,28 @@ export class OptimizationStudioPage {
 
   async setUserPrompt(content: string): Promise<void> {
     return test.step('Type the user-message prompt', async () => {
-      const editor = this.promptEditor();
-      await editor.click();
-      await editor.fill(content);
-      await expect(editor).toContainText(content);
+      await this.fillMessage('user', content);
     });
+  }
+
+  /**
+   * Fill the system message. The form seeds an empty system card alongside the
+   * user one and its schema requires every message to be non-empty, so a run
+   * that leaves this blank never submits — the Optimize button goes enabled
+   * (its disabled gate doesn't cover message content) but validation rejects
+   * the submit, so the panel simply stays open.
+   */
+  async setSystemPrompt(content: string): Promise<void> {
+    return test.step('Type the system-message prompt', async () => {
+      await this.fillMessage('system', content);
+    });
+  }
+
+  private async fillMessage(role: 'system' | 'user', content: string): Promise<void> {
+    const editor = this.promptEditor(role);
+    await editor.click();
+    await editor.fill(content);
+    await expect(editor).toContainText(content);
   }
 
   async selectModel(displayName: string): Promise<void> {
@@ -122,7 +150,22 @@ export class OptimizationStudioPage {
     return test.step('Start the optimization run', async () => {
       await expect(this.optimizeButton()).toBeEnabled();
       await this.optimizeButton().click();
-      await this.page.waitForURL(/\/optimizations\/[0-9a-f-]+$/);
+      // The button's disabled gate doesn't cover message content, so an empty
+      // message card lets the click through and validation silently rejects the
+      // submit — the panel just stays open. Surface that as the actual cause
+      // instead of an unexplained navigation timeout.
+      try {
+        await this.page.waitForURL(/\/optimizations\/[0-9a-f-]+$/);
+      } catch (error) {
+        const validationError = this.newRunPanel().getByText('Message is required').first();
+        if (await validationError.isVisible().catch(() => false)) {
+          throw new Error(
+            'Submit was rejected: a message card is empty ("Message is required"). ' +
+              'The form seeds system + user messages and requires content in both.',
+          );
+        }
+        throw error;
+      }
       const match = this.page.url().match(/\/optimizations\/([0-9a-f-]+)$/);
       if (!match) {
         throw new Error(`Could not extract optimization id from URL: ${this.page.url()}`);
@@ -135,6 +178,7 @@ export class OptimizationStudioPage {
   async configureAndStart(config: StudioRunConfig): Promise<string> {
     return test.step('Configure and start an optimization run', async () => {
       await this.selectDataset(config.datasetName);
+      await this.setSystemPrompt(config.systemPrompt);
       await this.setUserPrompt(config.prompt);
       await this.selectModel(config.modelDisplayName);
       if (config.optimizer && config.optimizer !== 'GEPA optimizer') {
@@ -212,8 +256,18 @@ export class OptimizationStudioPage {
     return this.page.locator('[data-testid="new-optimization-run-sidebar"]');
   }
 
-  private promptEditor(): Locator {
-    return this.page.locator('[data-testid="playground-message-editor"] .cm-content');
+  /**
+   * The message editor for a given role. The form seeds one card per message
+   * (system + user), and each card renders its own `playground-message-editor`,
+   * so an unscoped testid matches every editor on the page. Scope to the panel
+   * and to the card's `data-role` — the row testid plus `data-role` is the
+   * stable per-message hook, and the same pattern is used by the prompts POMs.
+   */
+  private promptEditor(role: 'system' | 'user'): Locator {
+    return this.newRunPanel()
+      .locator(`[data-testid="playground-message-row"][data-role="${role}"]`)
+      .getByTestId('playground-message-editor')
+      .locator('.cm-content');
   }
 
   private optimizeButton(): Locator {

--- a/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
+++ b/tests_end_to_end/e2e/tests/optimization-studio/optimization-studio.spec.ts
@@ -16,7 +16,15 @@ const SENTIMENT_ITEMS = [
   { text: 'Boring and poorly acted, I walked out.', label: 'negative' },
 ];
 
-const PROMPT = 'Classify the sentiment of this movie review as exactly "positive" or "negative": {{text}}';
+/**
+ * The form seeds a system + user message and requires content in both. Split the
+ * prompt the way the product intends: the instruction goes in the system message
+ * (the role the optimizer rewrites) and the dataset variable stays in the user
+ * message, so the optimizer can never rewrite away `{{text}}`.
+ */
+const SYSTEM_PROMPT =
+  'Classify the sentiment of the movie review as exactly "positive" or "negative". Reply with the single word only.';
+const PROMPT = '{{text}}';
 
 type SdkClient = Parameters<Parameters<typeof test>[2]>[0]['sdkClient'];
 
@@ -60,6 +68,7 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
     await test.step('Optimize enables once model + dataset + prompt + reference key are set', async () => {
       await studio.selectModel(modelDisplayName);
       await studio.selectDataset(dataset.name);
+      await studio.setSystemPrompt(SYSTEM_PROMPT);
       await studio.setUserPrompt(PROMPT);
       await studio.setReferenceKey('label');
       await expect(page.getByRole('button', { name: 'Optimize prompt' })).toBeEnabled();
@@ -96,6 +105,7 @@ test.describe('Optimization Studio — core', { tag: ['@t2-cuj', '@t1-stsaas', '
       await studio.assertFormRenders();
       return studio.configureAndStart({
         datasetName,
+        systemPrompt: SYSTEM_PROMPT,
         prompt: PROMPT,
         modelDisplayName,
         referenceKey: 'label',
@@ -199,6 +209,7 @@ test.describe('Optimization Studio — variant', { tag: ['@t2-cuj', '@t1-stsaas'
       await studio.gotoNew();
       return studio.configureAndStart({
         datasetName,
+        systemPrompt: SYSTEM_PROMPT,
         prompt: PROMPT,
         modelDisplayName,
         referenceKey: 'label',


### PR DESCRIPTION
## Details

All three `optimization-studio` E2E tests went red because the v2 new-run form now seeds **system + user** messages instead of a lone user message (product change OPIK_7510, #7656). Each message card renders its own `playground-message-editor`, so the POM's unscoped selector matched two editors and failed on a strict-mode violation. This scopes the editor to the panel and the card's `data-role`, mirroring the pattern already used by `prompts.page.ts`.

Fixing the selector alone was not enough. The schema's `superRefine` requires every message to be non-empty, while the Optimize button's `disabled` gate does not cover message content — so a run that filled only the user card would go enabled, submit, get rejected by validation, and time out on navigation with no stated cause. Both cards are now filled, and that failure mode reports the actual reason.

- The spec's prompt is split the way the product intends: instruction in the system message (the role the optimizer rewrites), `{{text}}` alone in the user message, so the optimizer cannot rewrite away the dataset variable.
- `assertFormRenders` asserts **both** editors, so a regression back to a single seeded card fails there rather than as a stuck submit later.
- No product code changed; no new `data-testid` needed.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7728

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Failure diagnosis from the TestOps launch, root-cause attribution to the product commit, the POM/spec fix, local verification, and this description.
- Human verification: @andreic reviewed the diagnosis and the diff.

## Testing

Ran from `tests_end_to_end/e2e/`:

```
OPIK_DEPLOYMENT=oss OPIK_BASE_URL=http://localhost:5174 \
npx playwright test tests/optimization-studio/optimization-studio.spec.ts --reporter=list --workers=1
```

**Result: 3 passed (1.1m).** Both run tests executed real GEPA and Hierarchical Reflective optimizations end-to-end (~26s each). `npx tsc --noEmit` clean; `pre-commit` on the changed files exits 0.

**Environment — why the default local stack could not verify this.** The local `opik.sh` stack runs image `2.2.9`, which predates the change and still seeds a single message, so a green run there would have proven nothing. The frontend was served from source (Vite, `:5174`) against the running dockerized backend, with the backend's `8080` bridged to the host since compose does not publish it.

**Confirmed the fix does real work.** Stashing it and re-running on the same stack reproduces the exact CI error (`strict mode violation: ... resolved to 2 elements`), so the reproduction is faithful rather than a weak-assertion pass.

**Not run locally:** the MinIO presigned-logs download assertion in the GEPA test, which is skipped on local OSS by design (the presign uses the internal `minio:9000` host, unreachable from the runner). It runs on cloud / self-hosted / stsaas targets.

## Documentation

None — test-only change.
