### PR TITLE
[OPIK-7469] [SDK] feat: add Experiment.batch_upload_items for the experiment items bulk endpoint

### DIFF
--- a/.agents/skills/python-sdk/good-code.md
+++ b/.agents/skills/python-sdk/good-code.md
@@ -18,6 +18,57 @@ class DataProcessor:
         pass
 ```
 
+## Prefer Module-Level Functions Over Static Methods
+
+A `@staticmethod` touches no instance state, so the class adds nothing but a
+longer call path. Make it a module-level function — private (`_name`) when it is
+an implementation detail. Reserve `@staticmethod` for the rare case where the
+function must be reachable through the class as part of its public API, or where
+a subclass is expected to override it.
+
+```python
+# ❌ Bad: nothing here needs the class
+class Experiment:
+    def upload(self, items):
+        self._raise_on_oversized(items)
+
+    @staticmethod
+    def _raise_on_oversized(items): ...
+
+# ✅ Good: plain function, testable on its own
+def _raise_on_oversized(items): ...
+
+class Experiment:
+    def upload(self, items):
+        _raise_on_oversized(items)
+```
+
+## Use Strict Types
+
+Annotate with the narrowest type that is true. `Any` disables type checking
+exactly where a mistake is most likely — reach for the concrete type, a
+`TypedDict`, or a `Protocol` instead.
+
+```python
+# ❌ Bad: Any, then subscripted as if the shape were known
+def _to_rest_score(score: Any) -> RestScore:
+    return RestScore(name=score["name"], value=score["value"])
+
+# ✅ Good: the shape is declared, so mypy checks the access
+def _to_rest_score(score: FeedbackScoreDict) -> RestScore:
+    return RestScore(name=score["name"], value=score["value"])
+```
+
+`Any` is legitimate for genuinely unvalidated input — a validator whose whole job
+is to `isinstance`-check caller data cannot promise the type it is checking for:
+
+```python
+# ✅ Good: Any is honest here; the function exists to reject wrong shapes
+def _validate_score(score: Any, failures: List[str]) -> None:
+    if not isinstance(score, dict):
+        failures.append("score must be a dict")
+```
+
 ## Module Organization
 
 One module, one responsibility. Avoid monolithic utils.

--- a/sdks/python/src/opik/__init__.py
+++ b/sdks/python/src/opik/__init__.py
@@ -10,6 +10,11 @@ from .api_objects.dashboard import Dashboard
 from .api_objects.dataset import Dataset
 from .api_objects.dataset.test_suite import TestSuite
 from .api_objects.dataset.test_suite.types import TestSuiteResult
+from .api_objects.experiment.bulk_item import (
+    ExperimentItemBulkRecord,
+    ExperimentItemBulkSpan,
+    ExperimentItemBulkTrace,
+)
 from .api_objects.experiment.experiment_item import (
     ExperimentItemContent,
     ExperimentItemReferences,
@@ -70,6 +75,9 @@ __all__ = [
     "evaluate_on_dict_items",
     "evaluate_resume",
     "run_tests",
+    "ExperimentItemBulkRecord",
+    "ExperimentItemBulkSpan",
+    "ExperimentItemBulkTrace",
     "ExperimentItemContent",
     "ExperimentItemReferences",
     "track",

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -3,6 +3,14 @@ DATASET_SOURCE_SDK = "sdk"
 
 FEEDBACK_SCORES_MAX_BATCH_SIZE = 1000
 EXPERIMENT_ITEMS_MAX_BATCH_SIZE = 1000
+EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE = 1000
+
+# The bulk endpoint rejects any request whose *serialized* body exceeds 4MB
+# (MaxRequestSize.java). The backend measures the whole request, envelope
+# fields included, so we batch against a lower ceiling to leave headroom for
+# experiment_name/dataset_name/experiment_id/project_name and for the gap
+# between our size estimate and real JSON encoding.
+EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB = 3.5
 DATASET_ITEMS_MAX_BATCH_SIZE = 1000
 ANNOTATION_QUEUE_ITEMS_MAX_BATCH_SIZE = 1000
 DELETE_TRACE_BATCH_SIZE = 1000

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -11,6 +11,10 @@ EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE = 1000
 # experiment_name/dataset_name/experiment_id/project_name and for the gap
 # between our size estimate and real JSON encoding.
 EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB = 3.5
+
+# Ceiling on upload threads, matching the file-upload pool. Guards against a
+# caller passing an arbitrarily large num_threads.
+EXPERIMENT_ITEMS_BULK_MAX_THREADS = 32
 DATASET_ITEMS_MAX_BATCH_SIZE = 1000
 ANNOTATION_QUEUE_ITEMS_MAX_BATCH_SIZE = 1000
 DELETE_TRACE_BATCH_SIZE = 1000

--- a/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
@@ -29,6 +29,46 @@ def _validate_json_like_fields(
         )
 
 
+def _validate_feedback_score(
+    score: Any,
+    failure_reasons: List[str],
+    location: str,
+) -> None:
+    """Check the keys the conversion reads, which would otherwise raise KeyError."""
+    if not isinstance(score, dict):
+        failure_reasons.append(f"{location} must be a dict, got {type(score).__name__}")
+        return
+
+    if not score.get("name"):
+        failure_reasons.append(f"{location}.name is required and must be non-empty")
+
+    value = score.get("value")
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        failure_reasons.append(f"{location}.value is required and must be a number")
+
+
+def _validate_error_info(
+    error_info: Any,
+    failure_reasons: List[str],
+    location: str,
+) -> None:
+    """Check the fields the wire model requires, avoiding a raw pydantic error."""
+    if error_info is None:
+        return
+
+    if not isinstance(error_info, dict):
+        failure_reasons.append(
+            f"{location}.error_info must be a dict, got {type(error_info).__name__}"
+        )
+        return
+
+    for required_key in ("exception_type", "traceback"):
+        if not error_info.get(required_key):
+            failure_reasons.append(
+                f"{location}.error_info.{required_key} is required and must be non-empty"
+            )
+
+
 def _validate_record(
     record: bulk_item.ExperimentItemBulkRecord,
     index: int,
@@ -61,10 +101,18 @@ def _validate_record(
 
     if record.trace is not None:
         _validate_json_like_fields(record.trace, failure_reasons, f"{location}.trace")
+        _validate_error_info(
+            record.trace.error_info, failure_reasons, f"{location}.trace"
+        )
 
     for span_index, span in enumerate(record.spans or []):
-        _validate_json_like_fields(
-            span, failure_reasons, f"{location}.spans[{span_index}]"
+        span_location = f"{location}.spans[{span_index}]"
+        _validate_json_like_fields(span, failure_reasons, span_location)
+        _validate_error_info(span.error_info, failure_reasons, span_location)
+
+    for score_index, score in enumerate(record.feedback_scores or []):
+        _validate_feedback_score(
+            score, failure_reasons, f"{location}.feedback_scores[{score_index}]"
         )
 
 
@@ -110,7 +158,7 @@ def validate_records(
 
     if failure_reasons:
         raise exceptions.ValidationError(
-            prefix="bulk_upload_items", failure_reasons=failure_reasons
+            prefix="batch_upload_items", failure_reasons=failure_reasons
         )
 
 

--- a/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from opik import exceptions
 from opik.rest_api import types as rest_api_types
@@ -170,18 +170,29 @@ def _to_rest_feedback_score(
 def to_rest_record(
     record: bulk_item.ExperimentItemBulkRecord,
 ) -> rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView:
+    # Only set the fields the caller actually provided. The backend maps
+    # evaluate_task_result to a Jackson JsonNode, so an explicit JSON null
+    # deserializes to NullNode rather than Java null — sending
+    # "evaluate_task_result": null next to a trace trips the
+    # "cannot provide both" validator. Unset fields are omitted from the
+    # request body, which is what the backend expects.
+    optional_fields: Dict[str, Any] = {}
+
+    if record.evaluate_task_result is not None:
+        optional_fields["evaluate_task_result"] = record.evaluate_task_result
+
+    if record.trace is not None:
+        optional_fields["trace"] = _to_rest_trace(record.trace)
+
+    if record.spans is not None:
+        optional_fields["spans"] = [_to_rest_span(span) for span in record.spans]
+
+    if record.feedback_scores is not None:
+        optional_fields["feedback_scores"] = [
+            _to_rest_feedback_score(score) for score in record.feedback_scores
+        ]
+
     return rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView(
         dataset_item_id=record.dataset_item_id,
-        evaluate_task_result=record.evaluate_task_result,
-        trace=_to_rest_trace(record.trace) if record.trace is not None else None,
-        spans=(
-            [_to_rest_span(span) for span in record.spans]
-            if record.spans is not None
-            else None
-        ),
-        feedback_scores=(
-            [_to_rest_feedback_score(score) for score in record.feedback_scores]
-            if record.feedback_scores is not None
-            else None
-        ),
+        **optional_fields,
     )

--- a/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
@@ -1,0 +1,187 @@
+from typing import Any, List, Optional
+
+from opik import exceptions
+from opik.rest_api import types as rest_api_types
+from . import bulk_item
+from .. import constants
+
+_JSON_LIKE_FIELDS = ("input", "output", "metadata")
+
+
+def _validate_json_like_fields(
+    source: Any,
+    failure_reasons: List[str],
+    location: str,
+) -> None:
+    """Reject str/list where the backend expects a JSON object.
+
+    The wire type accepts ``str`` and ``List[Dict]`` as well as ``Dict``, but a
+    string lands in ClickHouse as an opaque blob that the UI cannot render as
+    structured input/output. Callers hitting the raw Fern client discover this
+    only after the data is already stored, so we reject it up front.
+    """
+    for field_name in _JSON_LIKE_FIELDS:
+        value = getattr(source, field_name, None)
+        if value is None or isinstance(value, dict):
+            continue
+        failure_reasons.append(
+            f"{location}.{field_name} must be a dict, got {type(value).__name__}"
+        )
+
+
+def _validate_record(
+    record: bulk_item.ExperimentItemBulkRecord,
+    index: int,
+    failure_reasons: List[str],
+) -> None:
+    location = f"items[{index}]"
+
+    if not record.dataset_item_id:
+        failure_reasons.append(f"{location}.dataset_item_id must be a non-empty string")
+
+    if record.evaluate_task_result is not None and record.trace is not None:
+        failure_reasons.append(
+            f"{location} must provide either evaluate_task_result or trace, but not both"
+        )
+
+    if record.evaluate_task_result is not None and not isinstance(
+        record.evaluate_task_result, dict
+    ):
+        failure_reasons.append(
+            f"{location}.evaluate_task_result must be a dict, "
+            f"got {type(record.evaluate_task_result).__name__}"
+        )
+
+    if record.trace is not None:
+        _validate_json_like_fields(record.trace, failure_reasons, f"{location}.trace")
+
+    for span_index, span in enumerate(record.spans or []):
+        _validate_json_like_fields(
+            span, failure_reasons, f"{location}.spans[{span_index}]"
+        )
+
+
+def _validate_project_name_consistency(
+    records: List[bulk_item.ExperimentItemBulkRecord],
+    project_name: Optional[str],
+    failure_reasons: List[str],
+) -> None:
+    """Mirror ExperimentItemBulkUploadValidator.
+
+    When a request-level project_name is set, the backend rejects the whole
+    upload if any item-level trace names a different project.
+    """
+    if project_name is None or not project_name.strip():
+        return
+
+    for index, record in enumerate(records):
+        trace = record.trace
+        if (
+            trace is None
+            or trace.project_name is None
+            or not trace.project_name.strip()
+        ):
+            continue
+        if trace.project_name.casefold() != project_name.casefold():
+            failure_reasons.append(
+                f"items[{index}].trace.project_name ({trace.project_name!r}) does not match "
+                f"the upload project_name ({project_name!r})"
+            )
+
+
+def validate_records(
+    records: List[bulk_item.ExperimentItemBulkRecord],
+    project_name: Optional[str],
+) -> None:
+    """Raise :class:`opik.exceptions.ValidationError` if any record is invalid."""
+    failure_reasons: List[str] = []
+
+    for index, record in enumerate(records):
+        _validate_record(record, index, failure_reasons)
+
+    _validate_project_name_consistency(records, project_name, failure_reasons)
+
+    if failure_reasons:
+        raise exceptions.ValidationError(
+            prefix="bulk_upload_items", failure_reasons=failure_reasons
+        )
+
+
+def _to_rest_trace(
+    trace: bulk_item.ExperimentItemBulkTrace,
+) -> rest_api_types.TraceExperimentItemBulkWriteView:
+    return rest_api_types.TraceExperimentItemBulkWriteView(
+        id=trace.id,
+        project_name=trace.project_name,
+        name=trace.name,
+        start_time=trace.start_time,
+        end_time=trace.end_time,
+        input=trace.input,
+        output=trace.output,
+        metadata=trace.metadata,
+        tags=trace.tags,
+        error_info=(
+            rest_api_types.ErrorInfoExperimentItemBulkWriteView(**trace.error_info)
+            if trace.error_info is not None
+            else None
+        ),
+        thread_id=trace.thread_id,
+    )
+
+
+def _to_rest_span(
+    span: bulk_item.ExperimentItemBulkSpan,
+) -> rest_api_types.SpanExperimentItemBulkWriteView:
+    return rest_api_types.SpanExperimentItemBulkWriteView(
+        id=span.id,
+        parent_span_id=span.parent_span_id,
+        name=span.name,
+        type=span.type,
+        start_time=span.start_time,
+        end_time=span.end_time,
+        input=span.input,
+        output=span.output,
+        metadata=span.metadata,
+        model=span.model,
+        provider=span.provider,
+        tags=span.tags,
+        usage=span.usage,
+        error_info=(
+            rest_api_types.ErrorInfoExperimentItemBulkWriteView(**span.error_info)
+            if span.error_info is not None
+            else None
+        ),
+        total_estimated_cost=span.total_estimated_cost,
+    )
+
+
+def _to_rest_feedback_score(
+    score: Any,
+) -> rest_api_types.FeedbackScoreExperimentItemBulkWriteView:
+    return rest_api_types.FeedbackScoreExperimentItemBulkWriteView(
+        name=score["name"],
+        value=score["value"],
+        category_name=score.get("category_name"),
+        reason=score.get("reason"),
+        source=constants.FEEDBACK_SCORE_SOURCE_SDK,
+    )
+
+
+def to_rest_record(
+    record: bulk_item.ExperimentItemBulkRecord,
+) -> rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView:
+    return rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView(
+        dataset_item_id=record.dataset_item_id,
+        evaluate_task_result=record.evaluate_task_result,
+        trace=_to_rest_trace(record.trace) if record.trace is not None else None,
+        spans=(
+            [_to_rest_span(span) for span in record.spans]
+            if record.spans is not None
+            else None
+        ),
+        feedback_scores=(
+            [_to_rest_feedback_score(score) for score in record.feedback_scores]
+            if record.feedback_scores is not None
+            else None
+        ),
+    )

--- a/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional
 
-from opik import exceptions
+from opik import exceptions, id_helpers
 from opik.rest_api import types as rest_api_types
 from . import bulk_item
 from .. import constants
@@ -42,6 +42,13 @@ def _validate_record(
     if record.evaluate_task_result is not None and record.trace is not None:
         failure_reasons.append(
             f"{location} must provide either evaluate_task_result or trace, but not both"
+        )
+
+    # Without either field the backend silently creates a hidden trace whose
+    # output is null, so the item is stored but invisible to the user.
+    if record.evaluate_task_result is None and record.trace is None:
+        failure_reasons.append(
+            f"{location} must provide either evaluate_task_result or trace"
         )
 
     if record.evaluate_task_result is not None and not isinstance(
@@ -111,7 +118,7 @@ def _to_rest_trace(
     trace: bulk_item.ExperimentItemBulkTrace,
 ) -> rest_api_types.TraceExperimentItemBulkWriteView:
     return rest_api_types.TraceExperimentItemBulkWriteView(
-        id=trace.id,
+        id=trace.id if trace.id is not None else id_helpers.generate_id(),
         project_name=trace.project_name,
         name=trace.name,
         start_time=trace.start_time,
@@ -133,7 +140,7 @@ def _to_rest_span(
     span: bulk_item.ExperimentItemBulkSpan,
 ) -> rest_api_types.SpanExperimentItemBulkWriteView:
     return rest_api_types.SpanExperimentItemBulkWriteView(
-        id=span.id,
+        id=span.id if span.id is not None else id_helpers.generate_id(),
         parent_span_id=span.parent_span_id,
         name=span.name,
         type=span.type,

--- a/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_converters.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from opik import exceptions, id_helpers
 from opik.rest_api import types as rest_api_types
+from opik.types import FeedbackScoreDict
 from . import bulk_item
 from .. import constants
 
@@ -211,7 +212,7 @@ def _to_rest_span(
 
 
 def _to_rest_feedback_score(
-    score: Any,
+    score: FeedbackScoreDict,
 ) -> rest_api_types.FeedbackScoreExperimentItemBulkWriteView:
     return rest_api_types.FeedbackScoreExperimentItemBulkWriteView(
         name=score["name"],

--- a/sdks/python/src/opik/api_objects/experiment/bulk_item.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_item.py
@@ -1,0 +1,61 @@
+import dataclasses
+import datetime
+from typing import Any, Dict, List, Optional
+
+from opik.types import ErrorInfoDict, FeedbackScoreDict, SpanType
+
+JsonLike = Dict[str, Any]
+
+
+@dataclasses.dataclass
+class ExperimentItemBulkTrace:
+    """A trace to create alongside an experiment item in a bulk upload."""
+
+    start_time: datetime.datetime
+    id: Optional[str] = None
+    name: Optional[str] = None
+    project_name: Optional[str] = None
+    end_time: Optional[datetime.datetime] = None
+    input: Optional[JsonLike] = None
+    output: Optional[JsonLike] = None
+    metadata: Optional[JsonLike] = None
+    tags: Optional[List[str]] = None
+    error_info: Optional[ErrorInfoDict] = None
+    thread_id: Optional[str] = None
+
+
+@dataclasses.dataclass
+class ExperimentItemBulkSpan:
+    """A span to create alongside an experiment item in a bulk upload."""
+
+    start_time: datetime.datetime
+    id: Optional[str] = None
+    parent_span_id: Optional[str] = None
+    name: Optional[str] = None
+    type: Optional[SpanType] = None
+    end_time: Optional[datetime.datetime] = None
+    input: Optional[JsonLike] = None
+    output: Optional[JsonLike] = None
+    metadata: Optional[JsonLike] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    tags: Optional[List[str]] = None
+    usage: Optional[Dict[str, int]] = None
+    error_info: Optional[ErrorInfoDict] = None
+    total_estimated_cost: Optional[float] = None
+
+
+@dataclasses.dataclass
+class ExperimentItemBulkRecord:
+    """
+    A single experiment item to upload via :meth:`Experiment.bulk_upload_items`.
+
+    Provide either ``evaluate_task_result`` (the backend creates the trace) or
+    ``trace`` (you supply it), but never both.
+    """
+
+    dataset_item_id: str
+    evaluate_task_result: Optional[JsonLike] = None
+    trace: Optional[ExperimentItemBulkTrace] = None
+    spans: Optional[List[ExperimentItemBulkSpan]] = None
+    feedback_scores: Optional[List[FeedbackScoreDict]] = None

--- a/sdks/python/src/opik/api_objects/experiment/bulk_item.py
+++ b/sdks/python/src/opik/api_objects/experiment/bulk_item.py
@@ -48,7 +48,7 @@ class ExperimentItemBulkSpan:
 @dataclasses.dataclass
 class ExperimentItemBulkRecord:
     """
-    A single experiment item to upload via :meth:`Experiment.bulk_upload_items`.
+    A single experiment item to upload via :meth:`Experiment.batch_upload_items`.
 
     Provide either ``evaluate_task_result`` (the backend creates the trace) or
     ``trace`` (you supply it), but never both.

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -159,12 +159,16 @@ class Experiment:
         limiting (HTTP 429).
 
         If a batch fails, the exception propagates and the remaining batches are
-        not sent, leaving the experiment partially populated. The backend upserts
-        on ``dataset_item_id``, so retrying the same call is safe.
+        not sent, leaving the experiment partially populated. Rate-limit retries
+        re-send the identical payload, so they never duplicate anything. Calling
+        this method again, however, mints new ids for any trace or span left
+        without one, which would duplicate whatever the first call did manage to
+        write — set ``id`` on the traces and spans you pass in if you intend to
+        retry a failed upload.
 
         Args:
-            items: The experiment items to upload. Each item must provide either
-                ``evaluate_task_result`` or ``trace``, but never both.
+            items: The experiment items to upload. Each item must provide exactly
+                one of ``evaluate_task_result`` or ``trace``.
             project_name: Project for traces auto-created from items that provide
                 ``evaluate_task_result``. Defaults to the experiment's project.
                 When set, every item-level ``trace.project_name`` must match it.
@@ -234,10 +238,11 @@ class Experiment:
                 for future in futures.as_completed(submitted):
                     future.result()
             except BaseException:
-                # Fail fast: drop batches that have not started yet. Those
-                # already in flight still finish while the pool shuts down.
-                for pending in submitted:
-                    pending.cancel()
+                # Fail fast without blocking. cancel_futures drops batches that
+                # have not started; wait=False means we do not join batches that
+                # are already in flight, which could otherwise be parked in the
+                # rate-limit retry loop and hang the caller indefinitely.
+                pool.shutdown(wait=False, cancel_futures=True)
                 raise
 
     @staticmethod

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -142,7 +142,7 @@ class Experiment:
             "Successfully sent experiment items bulk batch of size %d", len(batch)
         )
 
-    def bulk_upload_items(
+    def batch_upload_items(
         self,
         items: List[bulk_item.ExperimentItemBulkRecord],
         project_name: Optional[str] = None,
@@ -186,7 +186,7 @@ class Experiment:
         """
         if num_threads < 1:
             raise exceptions.ValidationError(
-                prefix="bulk_upload_items",
+                prefix="batch_upload_items",
                 failure_reasons=[f"num_threads must be at least 1, got {num_threads}"],
             )
 
@@ -223,27 +223,31 @@ class Experiment:
                 )
             return
 
-        with futures.ThreadPoolExecutor(
+        # Deliberately not a `with` block: ThreadPoolExecutor.__exit__ always
+        # calls shutdown(wait=True), which would re-join batches we just chose
+        # not to wait for and park the caller behind a batch stuck in the
+        # rate-limit retry loop.
+        pool = futures.ThreadPoolExecutor(
             max_workers=num_threads, thread_name_prefix="opik_experiment_items_bulk"
-        ) as pool:
-            submitted = [
-                pool.submit(
-                    self._bulk_upload_batch_with_retry,
-                    batch,
-                    project_name=resolved_project_name,
-                )
-                for batch in batches
-            ]
-            try:
-                for future in futures.as_completed(submitted):
-                    future.result()
-            except BaseException:
-                # Fail fast without blocking. cancel_futures drops batches that
-                # have not started; wait=False means we do not join batches that
-                # are already in flight, which could otherwise be parked in the
-                # rate-limit retry loop and hang the caller indefinitely.
-                pool.shutdown(wait=False, cancel_futures=True)
-                raise
+        )
+        submitted = [
+            pool.submit(
+                self._bulk_upload_batch_with_retry,
+                batch,
+                project_name=resolved_project_name,
+            )
+            for batch in batches
+        ]
+        try:
+            for future in futures.as_completed(submitted):
+                future.result()
+        except BaseException:
+            # Fail fast: drop batches that have not started and return without
+            # joining the ones already in flight.
+            pool.shutdown(wait=False, cancel_futures=True)
+            raise
+        else:
+            pool.shutdown(wait=True)
 
     @staticmethod
     def _raise_on_oversized_items(
@@ -269,7 +273,7 @@ class Experiment:
 
         if failure_reasons:
             raise exceptions.ValidationError(
-                prefix="bulk_upload_items", failure_reasons=failure_reasons
+                prefix="batch_upload_items", failure_reasons=failure_reasons
             )
 
     def get_items(

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -28,9 +28,13 @@ def _raise_on_oversized_items(
     ``split_into_batches`` puts an oversized item in a batch by itself rather
     than dropping it, which would send a request the backend is guaranteed to
     reject with a 422. Failing here names the offending item instead.
+
+    The bound is inclusive, matching ``split_into_batches``: an item measuring
+    exactly the limit already fills a batch on its own, leaving no room for the
+    request envelope.
     """
     failure_reasons = [
-        f"items[{index}] is {size_MB:.1f}MB, which exceeds the "
+        f"items[{index}] is {size_MB:.1f}MB, which is at or above the "
         f"{constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB}MB per-request limit"
         for index, size_MB in (
             (index, sequence_splitter.get_payload_size_MB(item))

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -18,6 +18,33 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
+def _raise_on_oversized_items(
+    rest_items: List[
+        rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView
+    ],
+) -> None:
+    """Reject items that cannot fit in a request on their own.
+
+    ``split_into_batches`` puts an oversized item in a batch by itself rather
+    than dropping it, which would send a request the backend is guaranteed to
+    reject with a 422. Failing here names the offending item instead.
+    """
+    failure_reasons = [
+        f"items[{index}] is {size_MB:.1f}MB, which exceeds the "
+        f"{constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB}MB per-request limit"
+        for index, size_MB in (
+            (index, sequence_splitter.get_payload_size_MB(item))
+            for index, item in enumerate(rest_items)
+        )
+        if size_MB >= constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB
+    ]
+
+    if failure_reasons:
+        raise exceptions.ValidationError(
+            prefix="batch_upload_items", failure_reasons=failure_reasons
+        )
+
+
 class Experiment:
     def __init__(
         self,
@@ -209,7 +236,7 @@ class Experiment:
 
         rest_items = [bulk_converters.to_rest_record(item) for item in items]
 
-        self._raise_on_oversized_items(rest_items)
+        _raise_on_oversized_items(rest_items)
 
         batches = sequence_splitter.split_into_batches(
             rest_items,
@@ -261,33 +288,6 @@ class Experiment:
             raise
         else:
             pool.shutdown(wait=True)
-
-    @staticmethod
-    def _raise_on_oversized_items(
-        rest_items: List[
-            rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView
-        ],
-    ) -> None:
-        """Reject items that cannot fit in a request on their own.
-
-        ``split_into_batches`` puts an oversized item in a batch by itself rather
-        than dropping it, which would send a request the backend is guaranteed to
-        reject with a 422. Failing here names the offending item instead.
-        """
-        failure_reasons = [
-            f"items[{index}] is {size_MB:.1f}MB, which exceeds the "
-            f"{constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB}MB per-request limit"
-            for index, size_MB in (
-                (index, sequence_splitter.get_payload_size_MB(item))
-                for index, item in enumerate(rest_items)
-            )
-            if size_MB >= constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB
-        ]
-
-        if failure_reasons:
-            raise exceptions.ValidationError(
-                prefix="batch_upload_items", failure_reasons=failure_reasons
-            )
 
     def get_items(
         self,

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -1,14 +1,16 @@
 import functools
 import logging
+from concurrent import futures
 from typing import List, Optional, TYPE_CHECKING
 
 from opik.message_processing.batching import sequence_splitter
 from opik.message_processing import messages, streamer
 from opik.rest_api import client as rest_api_client
 from opik.rest_api import types as rest_api_types
-from . import experiment_item, experiments_client
-from .. import constants, helpers
+from . import bulk_converters, bulk_item, experiment_item, experiments_client
+from .. import constants, helpers, rest_helpers
 from ...api_objects.prompt import base_prompt
+from ... import exceptions
 
 if TYPE_CHECKING:
     from opik.evaluation.metrics import score_result
@@ -120,6 +122,150 @@ class Experiment:
                 messages.CreateExperimentItemsBatchMessage(batch=batch)
             )
             self._streamer.put(create_experiment_items_batch_message)
+
+    def _bulk_upload_batch_with_retry(
+        self,
+        batch: List[rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView],
+        project_name: Optional[str],
+    ) -> None:
+        rest_helpers.ensure_rest_api_call_respecting_rate_limit(
+            lambda: self._rest_client.experiments.experiment_items_bulk(
+                experiment_id=self.id,
+                experiment_name=self.name,
+                dataset_name=self.dataset_name,
+                project_name=project_name,
+                items=batch,
+            ),
+            operation_name="experiment_items_bulk",
+        )
+        LOGGER.debug(
+            "Successfully sent experiment items bulk batch of size %d", len(batch)
+        )
+
+    def bulk_upload_items(
+        self,
+        items: List[bulk_item.ExperimentItemBulkRecord],
+        project_name: Optional[str] = None,
+        num_threads: int = 1,
+    ) -> None:
+        """
+        Upload experiment items together with their traces, spans and feedback scores.
+
+        Unlike :meth:`insert`, which only links already-existing traces to dataset
+        items, this method creates the traces and spans as part of the same request.
+
+        Items are validated up front, split into batches that respect the backend's
+        1000-item and 4MB-per-request limits, and sent with automatic retry on rate
+        limiting (HTTP 429).
+
+        If a batch fails, the exception propagates and the remaining batches are
+        not sent, leaving the experiment partially populated. The backend upserts
+        on ``dataset_item_id``, so retrying the same call is safe.
+
+        Args:
+            items: The experiment items to upload. Each item must provide either
+                ``evaluate_task_result`` or ``trace``, but never both.
+            project_name: Project for traces auto-created from items that provide
+                ``evaluate_task_result``. Defaults to the experiment's project.
+                When set, every item-level ``trace.project_name`` must match it.
+            num_threads: Number of batches to upload concurrently. Defaults to 1
+                (sequential). Raising it trades ordering and a higher chance of
+                being rate limited for throughput.
+
+        Returns:
+            None
+
+        Raises:
+            opik.exceptions.ValidationError: If any item fails validation, if a
+                single item is too large to fit in one request, or if
+                ``num_threads`` is less than 1.
+        """
+        if num_threads < 1:
+            raise exceptions.ValidationError(
+                prefix="bulk_upload_items",
+                failure_reasons=[f"num_threads must be at least 1, got {num_threads}"],
+            )
+
+        if not items:
+            return
+
+        resolved_project_name = (
+            project_name if project_name is not None else self._project_name
+        )
+
+        bulk_converters.validate_records(items, project_name=resolved_project_name)
+
+        rest_items = [bulk_converters.to_rest_record(item) for item in items]
+
+        self._raise_on_oversized_items(rest_items)
+
+        batches = sequence_splitter.split_into_batches(
+            rest_items,
+            max_payload_size_MB=constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB,
+            max_length=constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE,
+        )
+
+        LOGGER.debug(
+            "Uploading %d experiment items in %d batch(es) using %d thread(s)",
+            len(rest_items),
+            len(batches),
+            num_threads,
+        )
+
+        if num_threads == 1:
+            for batch in batches:
+                self._bulk_upload_batch_with_retry(
+                    batch, project_name=resolved_project_name
+                )
+            return
+
+        with futures.ThreadPoolExecutor(
+            max_workers=num_threads, thread_name_prefix="opik_experiment_items_bulk"
+        ) as pool:
+            submitted = [
+                pool.submit(
+                    self._bulk_upload_batch_with_retry,
+                    batch,
+                    project_name=resolved_project_name,
+                )
+                for batch in batches
+            ]
+            try:
+                for future in futures.as_completed(submitted):
+                    future.result()
+            except BaseException:
+                # Fail fast: drop batches that have not started yet. Those
+                # already in flight still finish while the pool shuts down.
+                for pending in submitted:
+                    pending.cancel()
+                raise
+
+    @staticmethod
+    def _raise_on_oversized_items(
+        rest_items: List[
+            rest_api_types.ExperimentItemBulkRecordExperimentItemBulkWriteView
+        ],
+    ) -> None:
+        """Reject items that cannot fit in a request on their own.
+
+        ``split_into_batches`` puts an oversized item in a batch by itself rather
+        than dropping it, which would send a request the backend is guaranteed to
+        reject with a 422. Failing here names the offending item instead.
+        """
+        failure_reasons = [
+            f"items[{index}] is {size_MB:.1f}MB, which exceeds the "
+            f"{constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB}MB per-request limit"
+            for index, size_MB in (
+                (index, sequence_splitter.get_payload_size_MB(item))
+                for index, item in enumerate(rest_items)
+            )
+            if size_MB >= constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB
+        ]
+
+        if failure_reasons:
+            raise exceptions.ValidationError(
+                prefix="bulk_upload_items", failure_reasons=failure_reasons
+            )
 
     def get_items(
         self,

--- a/sdks/python/src/opik/api_objects/experiment/experiment.py
+++ b/sdks/python/src/opik/api_objects/experiment/experiment.py
@@ -170,11 +170,14 @@ class Experiment:
             items: The experiment items to upload. Each item must provide exactly
                 one of ``evaluate_task_result`` or ``trace``.
             project_name: Project for traces auto-created from items that provide
-                ``evaluate_task_result``. Defaults to the experiment's project.
-                When set, every item-level ``trace.project_name`` must match it.
+                ``evaluate_task_result``. Defaults to the experiment's project;
+                blank is treated as unset. When set, every item-level
+                ``trace.project_name`` must match it.
             num_threads: Number of batches to upload concurrently. Defaults to 1
                 (sequential). Raising it trades ordering and a higher chance of
-                being rate limited for throughput.
+                being rate limited for throughput. Capped at the number of
+                batches and at
+                ``constants.EXPERIMENT_ITEMS_BULK_MAX_THREADS``.
 
         Returns:
             None
@@ -196,6 +199,11 @@ class Experiment:
         resolved_project_name = (
             project_name if project_name is not None else self._project_name
         )
+        # The backend annotates project_name with @Pattern(NULL_OR_NOT_BLANK), so a
+        # blank string is rejected outright rather than falling back to the default
+        # project. Treat it as unset, which is what the caller meant.
+        if resolved_project_name is not None and not resolved_project_name.strip():
+            resolved_project_name = None
 
         bulk_converters.validate_records(items, project_name=resolved_project_name)
 
@@ -227,8 +235,13 @@ class Experiment:
         # calls shutdown(wait=True), which would re-join batches we just chose
         # not to wait for and park the caller behind a batch stuck in the
         # rate-limit retry loop.
+        # More workers than batches is pure waste, and an unbounded caller-supplied
+        # value would spawn a thread per batch.
+        worker_count = min(
+            num_threads, len(batches), constants.EXPERIMENT_ITEMS_BULK_MAX_THREADS
+        )
         pool = futures.ThreadPoolExecutor(
-            max_workers=num_threads, thread_name_prefix="opik_experiment_items_bulk"
+            max_workers=worker_count, thread_name_prefix="opik_experiment_items_bulk"
         )
         submitted = [
             pool.submit(

--- a/sdks/python/tests/e2e/test_experiments.py
+++ b/sdks/python/tests/e2e/test_experiments.py
@@ -383,7 +383,7 @@ def test__experiment_scores__happy_path(
     )
 
 
-def test__bulk_upload_items__happy_path(
+def test__batch_upload_items__happy_path(
     opik_client: opik.Opik, dataset_name: str, experiment_name: str
 ):
     """Upload experiment items with their traces, spans and scores in one call."""
@@ -416,7 +416,7 @@ def test__bulk_upload_items__happy_path(
         "What is the capital of Poland?": "Warsaw",
     }
 
-    experiment.bulk_upload_items(
+    experiment.batch_upload_items(
         [
             opik.ExperimentItemBulkRecord(
                 dataset_item_id=dataset_item["id"],
@@ -465,7 +465,7 @@ def test__bulk_upload_items__happy_path(
         ]
 
 
-def test__bulk_upload_items__output_passed_as_string__raises_validation_error(
+def test__batch_upload_items__output_passed_as_string__raises_validation_error(
     opik_client: opik.Opik, dataset_name: str, experiment_name: str
 ):
     """The SDK rejects a stringified output before it reaches the backend."""
@@ -480,7 +480,7 @@ def test__bulk_upload_items__output_passed_as_string__raises_validation_error(
     )
 
     with pytest.raises(opik.exceptions.ValidationError):
-        experiment.bulk_upload_items(
+        experiment.batch_upload_items(
             [
                 opik.ExperimentItemBulkRecord(
                     dataset_item_id=dataset_items[0]["id"],

--- a/sdks/python/tests/e2e/test_experiments.py
+++ b/sdks/python/tests/e2e/test_experiments.py
@@ -1,4 +1,8 @@
+import datetime
+import json
 from typing import Dict, Any
+
+import pytest
 
 import opik
 from opik.api_objects.experiment import experiment_item
@@ -377,3 +381,114 @@ def test__experiment_scores__happy_path(
     assert min_score.value <= avg_score.value <= max_score.value, (
         f"Score ordering should be min <= avg <= max, got {min_score.value} <= {avg_score.value} <= {max_score.value}"
     )
+
+
+def test__bulk_upload_items__happy_path(
+    opik_client: opik.Opik, dataset_name: str, experiment_name: str
+):
+    """Upload experiment items with their traces, spans and scores in one call."""
+    dataset = opik_client.create_dataset(dataset_name, project_name=PROJECT_NAME)
+    dataset.insert(
+        [
+            {
+                "input": {"question": "What is the capital of Ukraine?"},
+                "expected_model_output": {"output": "Kyiv"},
+            },
+            {
+                "input": {"question": "What is the capital of Poland?"},
+                "expected_model_output": {"output": "Warsaw"},
+            },
+        ]
+    )
+
+    dataset_items = dataset.get_items()
+    assert len(dataset_items) == 2
+
+    experiment = opik_client.create_experiment(
+        dataset_name=dataset_name,
+        name=experiment_name,
+        project_name=PROJECT_NAME,
+    )
+
+    start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    answers = {
+        "What is the capital of Ukraine?": "Kyiv",
+        "What is the capital of Poland?": "Warsaw",
+    }
+
+    experiment.bulk_upload_items(
+        [
+            opik.ExperimentItemBulkRecord(
+                dataset_item_id=dataset_item["id"],
+                trace=opik.ExperimentItemBulkTrace(
+                    name="bulk-uploaded-trace",
+                    project_name=PROJECT_NAME,
+                    start_time=start_time,
+                    end_time=start_time + datetime.timedelta(seconds=1),
+                    input=dataset_item["input"],
+                    output={"output": answers[dataset_item["input"]["question"]]},
+                ),
+                spans=[
+                    opik.ExperimentItemBulkSpan(
+                        name="bulk-uploaded-span",
+                        type="llm",
+                        start_time=start_time,
+                        end_time=start_time + datetime.timedelta(seconds=1),
+                        input=dataset_item["input"],
+                        output={"output": answers[dataset_item["input"]["question"]]},
+                    )
+                ],
+                feedback_scores=[
+                    {"name": "equals_scoring_function", "value": 1.0, "reason": "ok"}
+                ],
+            )
+            for dataset_item in dataset_items
+        ],
+        project_name=PROJECT_NAME,
+    )
+
+    verifiers.verify_experiment_items_completed(
+        opik_client=opik_client,
+        experiment_id=experiment.id,
+        expected_completed_dataset_item_ids={
+            dataset_item["id"] for dataset_item in dataset_items
+        },
+    )
+
+    experiment_items = experiment.get_items()
+    assert len(experiment_items) == 2
+    for uploaded_item in experiment_items:
+        assert uploaded_item.evaluation_task_output is not None
+        assert uploaded_item.evaluation_task_output["output"] in answers.values()
+        assert [score["name"] for score in uploaded_item.feedback_scores] == [
+            "equals_scoring_function"
+        ]
+
+
+def test__bulk_upload_items__output_passed_as_string__raises_validation_error(
+    opik_client: opik.Opik, dataset_name: str, experiment_name: str
+):
+    """The SDK rejects a stringified output before it reaches the backend."""
+    dataset = opik_client.create_dataset(dataset_name, project_name=PROJECT_NAME)
+    dataset.insert([{"input": {"question": "What is the capital of Ukraine?"}}])
+    dataset_items = dataset.get_items()
+
+    experiment = opik_client.create_experiment(
+        dataset_name=dataset_name,
+        name=experiment_name,
+        project_name=PROJECT_NAME,
+    )
+
+    with pytest.raises(opik.exceptions.ValidationError):
+        experiment.bulk_upload_items(
+            [
+                opik.ExperimentItemBulkRecord(
+                    dataset_item_id=dataset_items[0]["id"],
+                    trace=opik.ExperimentItemBulkTrace(
+                        start_time=datetime.datetime.now(tz=datetime.timezone.utc),
+                        output=json.dumps({"output": "Kyiv"}),
+                    ),
+                )
+            ],
+            project_name=PROJECT_NAME,
+        )

--- a/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
@@ -1,7 +1,7 @@
 """Tests for ``Experiment.batch_upload_items`` — validation, batching and retry."""
 
+import concurrent.futures as concurrent_futures
 import datetime
-import itertools
 import json
 import threading
 import time
@@ -14,6 +14,7 @@ import pytest
 from opik import exceptions
 from opik.api_objects import constants
 from opik.api_objects.experiment import bulk_item, experiment as experiment_module
+from opik.message_processing.batching import sequence_splitter
 from opik.rest_api import client as rest_api_client
 from opik.rest_api.core.api_error import ApiError
 
@@ -50,6 +51,15 @@ def _sent_batch_sizes(mock_rest_client: Mock) -> List[int]:
     return [
         len(call.kwargs["items"])
         for call in mock_rest_client.experiments.experiment_items_bulk.call_args_list
+    ]
+
+
+def _sent_dataset_item_ids(mock_rest_client: Mock) -> List[str]:
+    """Every id actually submitted, so drops and duplicates both show up."""
+    return [
+        item.dataset_item_id
+        for call in mock_rest_client.experiments.experiment_items_bulk.call_args_list
+        for item in call.kwargs["items"]
     ]
 
 
@@ -104,6 +114,18 @@ class TestBulkUploadItemsRequest:
         kwargs = mock_rest_client.experiments.experiment_items_bulk.call_args.kwargs
         assert kwargs["project_name"] == "explicit-one"
 
+    @pytest.mark.parametrize("blank_project_name", ["", "   "])
+    def test_batch_upload_items__blank_project_name__is_sent_as_none(
+        self, blank_project_name: str
+    ) -> None:
+        """The backend's @Pattern(NULL_OR_NOT_BLANK) rejects a blank string."""
+        experiment, mock_rest_client = _create_experiment()
+
+        experiment.batch_upload_items([_record()], project_name=blank_project_name)
+
+        kwargs = mock_rest_client.experiments.experiment_items_bulk.call_args.kwargs
+        assert kwargs["project_name"] is None
+
 
 class TestBulkUploadItemsBatching:
     def test_batch_upload_items__more_items_than_max_batch_size__splits_by_count(
@@ -122,7 +144,11 @@ class TestBulkUploadItemsBatching:
             constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE,
             500,
         ]
-        assert sum(batch_sizes) == items_count
+        # Sizes alone would still pass if one item were dropped and another
+        # duplicated, so compare the submitted ids against the input set.
+        assert _sent_dataset_item_ids(mock_rest_client) == [
+            f"item-{i}" for i in range(items_count)
+        ]
 
     def test_batch_upload_items__items_exceeding_payload_limit__splits_by_size(
         self,
@@ -143,10 +169,17 @@ class TestBulkUploadItemsBatching:
         )
 
         batch_sizes = _sent_batch_sizes(mock_rest_client)
-        assert sum(batch_sizes) == 10
         assert len(batch_sizes) > 1
-        # Each batch must stay under the backend's per-request ceiling.
-        assert all(size <= 3 for size in batch_sizes)
+        assert _sent_dataset_item_ids(mock_rest_client) == [
+            f"item-{i}" for i in range(10)
+        ]
+        # Assert the actual ceiling rather than a hand-computed batch size.
+        for call in mock_rest_client.experiments.experiment_items_bulk.call_args_list:
+            batch_size_MB = sum(
+                sequence_splitter.get_payload_size_MB(item)
+                for item in call.kwargs["items"]
+            )
+            assert batch_size_MB <= constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB
 
 
 class TestBulkUploadItemsSerialization:
@@ -358,6 +391,29 @@ class TestBulkUploadItemsConcurrency:
             f"item-{i}" for i in range(items_count)
         )
 
+    def test_batch_upload_items__num_threads_far_exceeds_batches__worker_count_is_capped(
+        self,
+    ) -> None:
+        """An unbounded caller value would otherwise spawn a thread per batch."""
+        experiment, mock_rest_client = _create_experiment()
+        captured_max_workers: List[int] = []
+        real_executor = concurrent_futures.ThreadPoolExecutor
+
+        def spy(*args: Any, **kwargs: Any) -> Any:
+            captured_max_workers.append(kwargs["max_workers"])
+            return real_executor(*args, **kwargs)
+
+        records = [_record(dataset_item_id=f"item-{i}") for i in range(3)]
+
+        with patch.object(
+            experiment_module.futures, "ThreadPoolExecutor", side_effect=spy
+        ):
+            experiment.batch_upload_items(records, num_threads=5000)
+
+        # 3 records fit in a single batch, so one worker is enough.
+        assert captured_max_workers == [1]
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
+
     def test_batch_upload_items__num_threads_below_one__raises_validation_error(
         self,
     ) -> None:
@@ -382,14 +438,19 @@ class TestBulkUploadItemsConcurrency:
         experiment, mock_rest_client = _create_experiment()
         release_stuck_batch = threading.Event()
         stuck_batch_entered = threading.Event()
-        call_count = itertools.count()
 
         def upload(**kwargs: Any) -> None:
-            if next(call_count) == 0:
+            # Keyed off the batch contents, not arrival order, so thread
+            # scheduling cannot change which batch stalls.
+            batch_ids = {item.dataset_item_id for item in kwargs["items"]}
+            if "item-0" in batch_ids:
                 stuck_batch_entered.set()
                 # Stands in for a batch parked on repeated 429s.
                 release_stuck_batch.wait(timeout=30)
                 return None
+            # Every other batch fails, so the test does not depend on which
+            # one the pool happens to run first.
+            stuck_batch_entered.wait(timeout=10)
             raise ApiError(status_code=400, headers={}, body="bad request")
 
         mock_rest_client.experiments.experiment_items_bulk.side_effect = upload

--- a/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
@@ -1,10 +1,14 @@
-"""Tests for ``Experiment.bulk_upload_items`` — validation, batching and retry."""
+"""Tests for ``Experiment.batch_upload_items`` — validation, batching and retry."""
 
 import datetime
+import itertools
 import json
+import threading
+import time
 from typing import Any, List, Optional, Tuple
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 
 from opik import exceptions
@@ -50,12 +54,12 @@ def _sent_batch_sizes(mock_rest_client: Mock) -> List[int]:
 
 
 class TestBulkUploadItemsRequest:
-    def test_bulk_upload_items__single_item__sends_one_request_with_experiment_identity(
+    def test_batch_upload_items__single_item__sends_one_request_with_experiment_identity(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment(project_name="my-project")
 
-        experiment.bulk_upload_items(
+        experiment.batch_upload_items(
             [
                 _record(
                     trace=bulk_item.ExperimentItemBulkTrace(
@@ -83,32 +87,32 @@ class TestBulkUploadItemsRequest:
             sent_item.feedback_scores[0].source == constants.FEEDBACK_SCORE_SOURCE_SDK
         )
 
-    def test_bulk_upload_items__empty_list__no_request_is_sent(self) -> None:
+    def test_batch_upload_items__empty_list__no_request_is_sent(self) -> None:
         experiment, mock_rest_client = _create_experiment()
 
-        experiment.bulk_upload_items([])
+        experiment.batch_upload_items([])
 
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
-    def test_bulk_upload_items__explicit_project_name__overrides_experiment_project(
+    def test_batch_upload_items__explicit_project_name__overrides_experiment_project(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment(project_name="experiment-one")
 
-        experiment.bulk_upload_items([_record()], project_name="explicit-one")
+        experiment.batch_upload_items([_record()], project_name="explicit-one")
 
         kwargs = mock_rest_client.experiments.experiment_items_bulk.call_args.kwargs
         assert kwargs["project_name"] == "explicit-one"
 
 
 class TestBulkUploadItemsBatching:
-    def test_bulk_upload_items__more_items_than_max_batch_size__splits_by_count(
+    def test_batch_upload_items__more_items_than_max_batch_size__splits_by_count(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
         items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 2 + 500
 
-        experiment.bulk_upload_items(
+        experiment.batch_upload_items(
             [_record(dataset_item_id=f"item-{i}") for i in range(items_count)]
         )
 
@@ -120,13 +124,13 @@ class TestBulkUploadItemsBatching:
         ]
         assert sum(batch_sizes) == items_count
 
-    def test_bulk_upload_items__items_exceeding_payload_limit__splits_by_size(
+    def test_batch_upload_items__items_exceeding_payload_limit__splits_by_size(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
         one_megabyte_payload = {"padding": "x" * 1_000_000}
 
-        experiment.bulk_upload_items(
+        experiment.batch_upload_items(
             [
                 _record(
                     dataset_item_id=f"item-{i}",
@@ -173,12 +177,12 @@ class TestBulkUploadItemsSerialization:
             experiments_client=Mock(),
         )
 
-        experiment.bulk_upload_items(records)
+        experiment.batch_upload_items(records)
 
         assert len(route.calls) == 1
         return json.loads(route.calls[0].request.read())["items"]
 
-    def test_bulk_upload_items__trace_only__evaluate_task_result_is_omitted(
+    def test_batch_upload_items__trace_only__evaluate_task_result_is_omitted(
         self, respx_mock: Any
     ) -> None:
         sent_item = self._sent_items(
@@ -195,7 +199,7 @@ class TestBulkUploadItemsSerialization:
         assert "evaluate_task_result" not in sent_item
         assert "trace" in sent_item
 
-    def test_bulk_upload_items__evaluate_task_result_only__trace_is_omitted(
+    def test_batch_upload_items__evaluate_task_result_only__trace_is_omitted(
         self, respx_mock: Any
     ) -> None:
         sent_item = self._sent_items(
@@ -205,7 +209,7 @@ class TestBulkUploadItemsSerialization:
         assert "trace" not in sent_item
         assert sent_item["evaluate_task_result"] == {"answer": "a"}
 
-    def test_bulk_upload_items__no_spans_or_scores__keys_are_omitted(
+    def test_batch_upload_items__no_spans_or_scores__keys_are_omitted(
         self, respx_mock: Any
     ) -> None:
         sent_item = self._sent_items(
@@ -215,7 +219,7 @@ class TestBulkUploadItemsSerialization:
         assert "spans" not in sent_item
         assert "feedback_scores" not in sent_item
 
-    def test_bulk_upload_items__trace_and_span_without_ids__ids_are_generated(
+    def test_batch_upload_items__trace_and_span_without_ids__ids_are_generated(
         self, respx_mock: Any
     ) -> None:
         """Ids must be set client-side so a retry re-sends the same ones.
@@ -240,7 +244,76 @@ class TestBulkUploadItemsSerialization:
         assert sent_item["trace"]["id"] is not None
         assert sent_item["spans"][0]["id"] is not None
 
-    def test_bulk_upload_items__caller_supplied_ids__are_preserved(
+    def test_batch_upload_items__same_records_uploaded_twice__ids_differ(
+        self, respx_mock: Any
+    ) -> None:
+        """Pins the documented limitation: a second call re-mints ids.
+
+        Ids are generated during conversion, which happens once per call, so a
+        rate-limit retry re-sends identical ids but an explicit second call does
+        not. Callers who need to retry must set ``id`` themselves — asserting the
+        difference here keeps the docstring honest if that ever changes silently.
+        """
+        records = [
+            _record(
+                trace=bulk_item.ExperimentItemBulkTrace(start_time=START_TIME),
+                spans=[bulk_item.ExperimentItemBulkSpan(start_time=START_TIME)],
+            )
+        ]
+
+        first = self._sent_items(respx_mock, records)[0]
+        respx_mock.reset()
+        second = self._sent_items(respx_mock, records)[0]
+
+        assert first["trace"]["id"] != second["trace"]["id"]
+        assert first["spans"][0]["id"] != second["spans"][0]["id"]
+
+    def test_batch_upload_items__retry_after_rate_limit__resends_identical_ids(
+        self, respx_mock: Any
+    ) -> None:
+        """A 429 retry must not duplicate data.
+
+        Conversion runs once, before the batching loop, so the retried request
+        has to carry byte-identical ids. This is the guarantee the docstring
+        makes, and the one that actually protects users from duplicates.
+        """
+        route = respx_mock.put(url__regex=r".*/experiments/items/bulk").mock(
+            side_effect=[
+                httpx.Response(429, headers={"RateLimit-Reset": "0"}),
+                httpx.Response(204),
+            ]
+        )
+
+        rest_client = rest_api_client.OpikApi(
+            base_url=_BASE_URL, api_key="api-key", workspace_name="workspace"
+        )
+        experiment = experiment_module.Experiment(
+            id="experiment-id",
+            name="experiment-name",
+            dataset_name="dataset-name",
+            rest_client=rest_client,
+            streamer=Mock(),
+            experiments_client=Mock(),
+        )
+
+        with patch("opik.api_objects.rest_helpers._sleep"):
+            experiment.batch_upload_items(
+                [
+                    _record(
+                        trace=bulk_item.ExperimentItemBulkTrace(start_time=START_TIME),
+                        spans=[bulk_item.ExperimentItemBulkSpan(start_time=START_TIME)],
+                    )
+                ]
+            )
+
+        assert len(route.calls) == 2
+        first, second = (
+            json.loads(call.request.read())["items"][0] for call in route.calls
+        )
+        assert first["trace"]["id"] == second["trace"]["id"]
+        assert first["spans"][0]["id"] == second["spans"][0]["id"]
+
+    def test_batch_upload_items__caller_supplied_ids__are_preserved(
         self, respx_mock: Any
     ) -> None:
         sent_item = self._sent_items(
@@ -265,13 +338,13 @@ class TestBulkUploadItemsSerialization:
 
 class TestBulkUploadItemsConcurrency:
     @pytest.mark.parametrize("num_threads", [1, 2, 4, 8, 16])
-    def test_bulk_upload_items__any_thread_count__every_batch_is_sent_exactly_once(
+    def test_batch_upload_items__any_thread_count__every_batch_is_sent_exactly_once(
         self, num_threads: int
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
         items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 4 + 7
 
-        experiment.bulk_upload_items(
+        experiment.batch_upload_items(
             [_record(dataset_item_id=f"item-{i}") for i in range(items_count)],
             num_threads=num_threads,
         )
@@ -285,18 +358,61 @@ class TestBulkUploadItemsConcurrency:
             f"item-{i}" for i in range(items_count)
         )
 
-    def test_bulk_upload_items__num_threads_below_one__raises_validation_error(
+    def test_batch_upload_items__num_threads_below_one__raises_validation_error(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items([_record()], num_threads=0)
+            experiment.batch_upload_items([_record()], num_threads=0)
 
         assert "num_threads must be at least 1" in str(exc_info.value)
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
-    def test_bulk_upload_items__multiple_threads__batch_failure_propagates(
+    def test_batch_upload_items__batch_stuck_when_another_fails__returns_without_waiting(
+        self,
+    ) -> None:
+        """The failure path must not join batches that are still running.
+
+        An earlier fix used ``shutdown(wait=False, cancel_futures=True)`` inside
+        a ``with`` block, but ``ThreadPoolExecutor.__exit__`` calls
+        ``shutdown(wait=True)`` regardless, so the caller was still parked behind
+        a batch stuck in the unbounded rate-limit retry loop.
+        """
+        experiment, mock_rest_client = _create_experiment()
+        release_stuck_batch = threading.Event()
+        stuck_batch_entered = threading.Event()
+        call_count = itertools.count()
+
+        def upload(**kwargs: Any) -> None:
+            if next(call_count) == 0:
+                stuck_batch_entered.set()
+                # Stands in for a batch parked on repeated 429s.
+                release_stuck_batch.wait(timeout=30)
+                return None
+            raise ApiError(status_code=400, headers={}, body="bad request")
+
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = upload
+
+        records = [
+            _record(dataset_item_id=f"item-{i}")
+            for i in range(constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 3)
+        ]
+
+        try:
+            started_at = time.monotonic()
+            with pytest.raises(ApiError):
+                experiment.batch_upload_items(records, num_threads=3)
+            elapsed = time.monotonic() - started_at
+
+            assert stuck_batch_entered.is_set()
+            # Generous bound: the point is that it returns rather than joining
+            # the 30s wait above.
+            assert elapsed < 10
+        finally:
+            release_stuck_batch.set()
+
+    def test_batch_upload_items__multiple_threads__batch_failure_propagates(
         self,
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
@@ -305,7 +421,7 @@ class TestBulkUploadItemsConcurrency:
         )
 
         with pytest.raises(ApiError):
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [
                     _record(dataset_item_id=f"item-{i}")
                     for i in range(constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 3)
@@ -316,7 +432,7 @@ class TestBulkUploadItemsConcurrency:
 
 class TestBulkUploadItemsValidation:
     @pytest.mark.parametrize("field_name", ["input", "output", "metadata"])
-    def test_bulk_upload_items__trace_json_field_is_a_string__raises_validation_error(
+    def test_batch_upload_items__trace_json_field_is_a_string__raises_validation_error(
         self, field_name: str
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
@@ -325,29 +441,29 @@ class TestBulkUploadItemsValidation:
         )
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items([_record(trace=trace)])
+            experiment.batch_upload_items([_record(trace=trace)])
 
         assert f"items[0].trace.{field_name} must be a dict" in str(exc_info.value)
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
-    def test_bulk_upload_items__span_output_is_a_string__raises_validation_error(
+    def test_batch_upload_items__span_output_is_a_string__raises_validation_error(
         self,
     ) -> None:
         experiment, _ = _create_experiment()
         span = bulk_item.ExperimentItemBulkSpan(start_time=START_TIME, output="plain")
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items([_record(spans=[span])])
+            experiment.batch_upload_items([_record(spans=[span])])
 
         assert "items[0].spans[0].output must be a dict" in str(exc_info.value)
 
-    def test_bulk_upload_items__both_trace_and_evaluate_task_result__raises_validation_error(
+    def test_batch_upload_items__both_trace_and_evaluate_task_result__raises_validation_error(
         self,
     ) -> None:
         experiment, _ = _create_experiment()
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [
                     _record(
                         evaluate_task_result={"answer": "a"},
@@ -358,14 +474,14 @@ class TestBulkUploadItemsValidation:
 
         assert "but not both" in str(exc_info.value)
 
-    def test_bulk_upload_items__neither_trace_nor_evaluate_task_result__raises_validation_error(
+    def test_batch_upload_items__neither_trace_nor_evaluate_task_result__raises_validation_error(
         self,
     ) -> None:
         """Without either field the backend stores a hidden trace with null output."""
         experiment, mock_rest_client = _create_experiment()
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [bulk_item.ExperimentItemBulkRecord(dataset_item_id="dataset-item-id")]
             )
 
@@ -374,17 +490,17 @@ class TestBulkUploadItemsValidation:
         )
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
-    def test_bulk_upload_items__evaluate_task_result_is_a_string__raises_validation_error(
+    def test_batch_upload_items__evaluate_task_result_is_a_string__raises_validation_error(
         self,
     ) -> None:
         experiment, _ = _create_experiment()
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items([_record(evaluate_task_result="plain")])
+            experiment.batch_upload_items([_record(evaluate_task_result="plain")])
 
         assert "items[0].evaluate_task_result must be a dict" in str(exc_info.value)
 
-    def test_bulk_upload_items__trace_project_name_differs_from_upload__raises_validation_error(
+    def test_batch_upload_items__trace_project_name_differs_from_upload__raises_validation_error(
         self,
     ) -> None:
         experiment, _ = _create_experiment()
@@ -393,13 +509,13 @@ class TestBulkUploadItemsValidation:
         )
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [_record(trace=trace)], project_name="upload-project"
             )
 
         assert "does not match the upload project_name" in str(exc_info.value)
 
-    def test_bulk_upload_items__trace_project_name_differs_only_by_case__is_accepted(
+    def test_batch_upload_items__trace_project_name_differs_only_by_case__is_accepted(
         self,
     ) -> None:
         """The backend compares project names case-insensitively, so we must too."""
@@ -408,15 +524,56 @@ class TestBulkUploadItemsValidation:
             start_time=START_TIME, project_name="My-Project"
         )
 
-        experiment.bulk_upload_items([_record(trace=trace)], project_name="my-project")
+        experiment.batch_upload_items([_record(trace=trace)], project_name="my-project")
 
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
 
-    def test_bulk_upload_items__all_failures_reported_together(self) -> None:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            ({"value": 1.0}, "feedback_scores[0].name is required"),
+            ({"name": "acc"}, "feedback_scores[0].value is required"),
+            (
+                {"name": "acc", "value": "high"},
+                "feedback_scores[0].value is required and must be a number",
+            ),
+        ],
+    )
+    def test_batch_upload_items__malformed_feedback_score__raises_validation_error(
+        self, score: Any, expected: str
+    ) -> None:
+        """Previously surfaced as a raw KeyError from the conversion step."""
+        experiment, mock_rest_client = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.batch_upload_items([_record(feedback_scores=[score])])
+
+        assert expected in str(exc_info.value)
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_batch_upload_items__malformed_error_info__raises_validation_error(
+        self,
+    ) -> None:
+        """Previously surfaced as a raw pydantic ValidationError."""
+        experiment, mock_rest_client = _create_experiment()
+        trace = bulk_item.ExperimentItemBulkTrace(
+            start_time=START_TIME,
+            error_info={"message": "boom"},
+        )
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.batch_upload_items([_record(trace=trace)])
+
+        message = str(exc_info.value)
+        assert "trace.error_info.exception_type is required" in message
+        assert "trace.error_info.traceback is required" in message
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_batch_upload_items__all_failures_reported_together(self) -> None:
         experiment, _ = _create_experiment()
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [
                     _record(evaluate_task_result="plain"),
                     _record(dataset_item_id=""),
@@ -427,7 +584,7 @@ class TestBulkUploadItemsValidation:
         assert "items[0].evaluate_task_result must be a dict" in message
         assert "items[1].dataset_item_id must be a non-empty string" in message
 
-    def test_bulk_upload_items__single_item_larger_than_request_limit__raises_validation_error(
+    def test_batch_upload_items__single_item_larger_than_request_limit__raises_validation_error(
         self,
     ) -> None:
         """An oversized item would otherwise be sent alone and rejected with a 422."""
@@ -437,7 +594,7 @@ class TestBulkUploadItemsValidation:
         )
 
         with pytest.raises(exceptions.ValidationError) as exc_info:
-            experiment.bulk_upload_items([_record(trace=oversized_trace)])
+            experiment.batch_upload_items([_record(trace=oversized_trace)])
 
         assert "exceeds the" in str(exc_info.value)
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
@@ -445,7 +602,7 @@ class TestBulkUploadItemsValidation:
 
 class TestBulkUploadItemsRateLimitRetry:
     @patch("opik.api_objects.rest_helpers._sleep")
-    def test_bulk_upload_items__429_with_retry_after_header__retries_with_correct_delay(
+    def test_batch_upload_items__429_with_retry_after_header__retries_with_correct_delay(
         self, mock_sleep: Mock
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
@@ -454,13 +611,13 @@ class TestBulkUploadItemsRateLimitRetry:
             None,
         ]
 
-        experiment.bulk_upload_items([_record()])
+        experiment.batch_upload_items([_record()])
 
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 2
         mock_sleep.assert_called_once_with(5.0)
 
     @patch("opik.api_objects.rest_helpers._sleep")
-    def test_bulk_upload_items__429_without_header__uses_fallback_delay(
+    def test_batch_upload_items__429_without_header__uses_fallback_delay(
         self, mock_sleep: Mock
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
@@ -469,13 +626,13 @@ class TestBulkUploadItemsRateLimitRetry:
             None,
         ]
 
-        experiment.bulk_upload_items([_record()])
+        experiment.batch_upload_items([_record()])
 
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 2
         mock_sleep.assert_called_once_with(1)
 
     @patch("opik.api_objects.rest_helpers._sleep")
-    def test_bulk_upload_items__non_429_error__raises_without_retrying(
+    def test_batch_upload_items__non_429_error__raises_without_retrying(
         self, mock_sleep: Mock
     ) -> None:
         experiment, mock_rest_client = _create_experiment()
@@ -484,13 +641,13 @@ class TestBulkUploadItemsRateLimitRetry:
         )
 
         with pytest.raises(ApiError):
-            experiment.bulk_upload_items([_record()])
+            experiment.batch_upload_items([_record()])
 
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
         mock_sleep.assert_not_called()
 
     @patch("opik.api_objects.rest_helpers._sleep")
-    def test_bulk_upload_items__batch_fails__remaining_batches_are_not_sent(
+    def test_batch_upload_items__batch_fails__remaining_batches_are_not_sent(
         self, mock_sleep: Mock
     ) -> None:
         """Fail-fast, matching Dataset.insert: the caller retries the whole call."""
@@ -503,7 +660,7 @@ class TestBulkUploadItemsRateLimitRetry:
         items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 2 + 1
 
         with pytest.raises(ApiError):
-            experiment.bulk_upload_items(
+            experiment.batch_upload_items(
                 [_record(dataset_item_id=f"item-{i}") for i in range(items_count)]
             )
 

--- a/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py
@@ -13,7 +13,11 @@ import pytest
 
 from opik import exceptions
 from opik.api_objects import constants
-from opik.api_objects.experiment import bulk_item, experiment as experiment_module
+from opik.api_objects.experiment import (
+    bulk_converters,
+    bulk_item,
+    experiment as experiment_module,
+)
 from opik.message_processing.batching import sequence_splitter
 from opik.rest_api import client as rest_api_client
 from opik.rest_api.core.api_error import ApiError
@@ -657,7 +661,35 @@ class TestBulkUploadItemsValidation:
         with pytest.raises(exceptions.ValidationError) as exc_info:
             experiment.batch_upload_items([_record(trace=oversized_trace)])
 
-        assert "exceeds the" in str(exc_info.value)
+        assert "at or above the" in str(exc_info.value)
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_batch_upload_items__item_exactly_at_the_limit__is_rejected(self) -> None:
+        """The bound is inclusive, matching ``split_into_batches``.
+
+        An item measuring exactly the limit already fills a batch on its own,
+        leaving no room for the request envelope — so the message has to say
+        "at or above" rather than "exceeds".
+        """
+        experiment, mock_rest_client = _create_experiment()
+        record = _record(
+            trace=bulk_item.ExperimentItemBulkTrace(
+                start_time=START_TIME, output={"padding": "x" * 5_000_000}
+            )
+        )
+        measured_MB = sequence_splitter.get_payload_size_MB(
+            bulk_converters.to_rest_record(record)
+        )
+
+        with patch.object(
+            constants,
+            "EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE_MB",
+            measured_MB,
+        ):
+            with pytest.raises(exceptions.ValidationError) as exc_info:
+                experiment.batch_upload_items([record])
+
+        assert "at or above the" in str(exc_info.value)
         assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
 

--- a/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
@@ -1,0 +1,370 @@
+"""Tests for ``Experiment.bulk_upload_items`` — validation, batching and retry."""
+
+import datetime
+import json
+from typing import Any, List, Optional, Tuple
+from unittest.mock import Mock, patch
+
+import pytest
+
+from opik import exceptions
+from opik.api_objects import constants
+from opik.api_objects.experiment import bulk_item, experiment as experiment_module
+from opik.rest_api.core.api_error import ApiError
+
+START_TIME = datetime.datetime(2026, 8, 4, 12, 0, 0)
+
+
+def _create_experiment(
+    project_name: Optional[str] = None,
+) -> Tuple[experiment_module.Experiment, Mock]:
+    mock_rest_client = Mock()
+    experiment = experiment_module.Experiment(
+        id="experiment-id",
+        name="experiment-name",
+        dataset_name="dataset-name",
+        rest_client=mock_rest_client,
+        streamer=Mock(),
+        experiments_client=Mock(),
+        project_name=project_name,
+    )
+    return experiment, mock_rest_client
+
+
+def _record(**kwargs: Any) -> bulk_item.ExperimentItemBulkRecord:
+    kwargs.setdefault("dataset_item_id", "dataset-item-id")
+    return bulk_item.ExperimentItemBulkRecord(**kwargs)
+
+
+def _sent_batch_sizes(mock_rest_client: Mock) -> List[int]:
+    return [
+        len(call.kwargs["items"])
+        for call in mock_rest_client.experiments.experiment_items_bulk.call_args_list
+    ]
+
+
+class TestBulkUploadItemsRequest:
+    def test_bulk_upload_items__single_item__sends_one_request_with_experiment_identity(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment(project_name="my-project")
+
+        experiment.bulk_upload_items(
+            [
+                _record(
+                    trace=bulk_item.ExperimentItemBulkTrace(
+                        start_time=START_TIME,
+                        input={"question": "q"},
+                        output={"answer": "a"},
+                    ),
+                    feedback_scores=[{"name": "accuracy", "value": 1.0}],
+                )
+            ]
+        )
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
+        kwargs = mock_rest_client.experiments.experiment_items_bulk.call_args.kwargs
+        assert kwargs["experiment_id"] == "experiment-id"
+        assert kwargs["experiment_name"] == "experiment-name"
+        assert kwargs["dataset_name"] == "dataset-name"
+        assert kwargs["project_name"] == "my-project"
+
+        sent_item = kwargs["items"][0]
+        assert sent_item.dataset_item_id == "dataset-item-id"
+        assert sent_item.trace.input == {"question": "q"}
+        assert sent_item.trace.output == {"answer": "a"}
+        assert (
+            sent_item.feedback_scores[0].source == constants.FEEDBACK_SCORE_SOURCE_SDK
+        )
+
+    def test_bulk_upload_items__empty_list__no_request_is_sent(self) -> None:
+        experiment, mock_rest_client = _create_experiment()
+
+        experiment.bulk_upload_items([])
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_bulk_upload_items__explicit_project_name__overrides_experiment_project(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment(project_name="experiment-one")
+
+        experiment.bulk_upload_items([_record()], project_name="explicit-one")
+
+        kwargs = mock_rest_client.experiments.experiment_items_bulk.call_args.kwargs
+        assert kwargs["project_name"] == "explicit-one"
+
+
+class TestBulkUploadItemsBatching:
+    def test_bulk_upload_items__more_items_than_max_batch_size__splits_by_count(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 2 + 500
+
+        experiment.bulk_upload_items(
+            [_record(dataset_item_id=f"item-{i}") for i in range(items_count)]
+        )
+
+        batch_sizes = _sent_batch_sizes(mock_rest_client)
+        assert batch_sizes == [
+            constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE,
+            constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE,
+            500,
+        ]
+        assert sum(batch_sizes) == items_count
+
+    def test_bulk_upload_items__items_exceeding_payload_limit__splits_by_size(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        one_megabyte_payload = {"padding": "x" * 1_000_000}
+
+        experiment.bulk_upload_items(
+            [
+                _record(
+                    dataset_item_id=f"item-{i}",
+                    trace=bulk_item.ExperimentItemBulkTrace(
+                        start_time=START_TIME, output=one_megabyte_payload
+                    ),
+                )
+                for i in range(10)
+            ]
+        )
+
+        batch_sizes = _sent_batch_sizes(mock_rest_client)
+        assert sum(batch_sizes) == 10
+        assert len(batch_sizes) > 1
+        # Each batch must stay under the backend's per-request ceiling.
+        assert all(size <= 3 for size in batch_sizes)
+
+
+class TestBulkUploadItemsConcurrency:
+    @pytest.mark.parametrize("num_threads", [1, 2, 4, 8, 16])
+    def test_bulk_upload_items__any_thread_count__every_batch_is_sent_exactly_once(
+        self, num_threads: int
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 4 + 7
+
+        experiment.bulk_upload_items(
+            [_record(dataset_item_id=f"item-{i}") for i in range(items_count)],
+            num_threads=num_threads,
+        )
+
+        sent_dataset_item_ids = [
+            item.dataset_item_id
+            for call in mock_rest_client.experiments.experiment_items_bulk.call_args_list
+            for item in call.kwargs["items"]
+        ]
+        assert sorted(sent_dataset_item_ids) == sorted(
+            f"item-{i}" for i in range(items_count)
+        )
+
+    def test_bulk_upload_items__num_threads_below_one__raises_validation_error(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items([_record()], num_threads=0)
+
+        assert "num_threads must be at least 1" in str(exc_info.value)
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_bulk_upload_items__multiple_threads__batch_failure_propagates(
+        self,
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = ApiError(
+            status_code=400, headers={}, body="bad request"
+        )
+
+        with pytest.raises(ApiError):
+            experiment.bulk_upload_items(
+                [
+                    _record(dataset_item_id=f"item-{i}")
+                    for i in range(constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 3)
+                ],
+                num_threads=4,
+            )
+
+
+class TestBulkUploadItemsValidation:
+    @pytest.mark.parametrize("field_name", ["input", "output", "metadata"])
+    def test_bulk_upload_items__trace_json_field_is_a_string__raises_validation_error(
+        self, field_name: str
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        trace = bulk_item.ExperimentItemBulkTrace(
+            start_time=START_TIME, **{field_name: json.dumps({"a": 1})}
+        )
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items([_record(trace=trace)])
+
+        assert f"items[0].trace.{field_name} must be a dict" in str(exc_info.value)
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+    def test_bulk_upload_items__span_output_is_a_string__raises_validation_error(
+        self,
+    ) -> None:
+        experiment, _ = _create_experiment()
+        span = bulk_item.ExperimentItemBulkSpan(start_time=START_TIME, output="plain")
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items([_record(spans=[span])])
+
+        assert "items[0].spans[0].output must be a dict" in str(exc_info.value)
+
+    def test_bulk_upload_items__both_trace_and_evaluate_task_result__raises_validation_error(
+        self,
+    ) -> None:
+        experiment, _ = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items(
+                [
+                    _record(
+                        evaluate_task_result={"answer": "a"},
+                        trace=bulk_item.ExperimentItemBulkTrace(start_time=START_TIME),
+                    )
+                ]
+            )
+
+        assert "but not both" in str(exc_info.value)
+
+    def test_bulk_upload_items__evaluate_task_result_is_a_string__raises_validation_error(
+        self,
+    ) -> None:
+        experiment, _ = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items([_record(evaluate_task_result="plain")])
+
+        assert "items[0].evaluate_task_result must be a dict" in str(exc_info.value)
+
+    def test_bulk_upload_items__trace_project_name_differs_from_upload__raises_validation_error(
+        self,
+    ) -> None:
+        experiment, _ = _create_experiment()
+        trace = bulk_item.ExperimentItemBulkTrace(
+            start_time=START_TIME, project_name="other-project"
+        )
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items(
+                [_record(trace=trace)], project_name="upload-project"
+            )
+
+        assert "does not match the upload project_name" in str(exc_info.value)
+
+    def test_bulk_upload_items__trace_project_name_differs_only_by_case__is_accepted(
+        self,
+    ) -> None:
+        """The backend compares project names case-insensitively, so we must too."""
+        experiment, mock_rest_client = _create_experiment()
+        trace = bulk_item.ExperimentItemBulkTrace(
+            start_time=START_TIME, project_name="My-Project"
+        )
+
+        experiment.bulk_upload_items([_record(trace=trace)], project_name="my-project")
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
+
+    def test_bulk_upload_items__all_failures_reported_together(self) -> None:
+        experiment, _ = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items(
+                [
+                    _record(evaluate_task_result="plain"),
+                    _record(dataset_item_id=""),
+                ]
+            )
+
+        message = str(exc_info.value)
+        assert "items[0].evaluate_task_result must be a dict" in message
+        assert "items[1].dataset_item_id must be a non-empty string" in message
+
+    def test_bulk_upload_items__single_item_larger_than_request_limit__raises_validation_error(
+        self,
+    ) -> None:
+        """An oversized item would otherwise be sent alone and rejected with a 422."""
+        experiment, mock_rest_client = _create_experiment()
+        oversized_trace = bulk_item.ExperimentItemBulkTrace(
+            start_time=START_TIME, output={"padding": "x" * 5_000_000}
+        )
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items([_record(trace=oversized_trace)])
+
+        assert "exceeds the" in str(exc_info.value)
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
+
+
+class TestBulkUploadItemsRateLimitRetry:
+    @patch("opik.api_objects.rest_helpers._sleep")
+    def test_bulk_upload_items__429_with_retry_after_header__retries_with_correct_delay(
+        self, mock_sleep: Mock
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = [
+            ApiError(status_code=429, headers={"RateLimit-Reset": "5"}, body="limited"),
+            None,
+        ]
+
+        experiment.bulk_upload_items([_record()])
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 2
+        mock_sleep.assert_called_once_with(5.0)
+
+    @patch("opik.api_objects.rest_helpers._sleep")
+    def test_bulk_upload_items__429_without_header__uses_fallback_delay(
+        self, mock_sleep: Mock
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = [
+            ApiError(status_code=429, headers={}, body="limited"),
+            None,
+        ]
+
+        experiment.bulk_upload_items([_record()])
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 2
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("opik.api_objects.rest_helpers._sleep")
+    def test_bulk_upload_items__non_429_error__raises_without_retrying(
+        self, mock_sleep: Mock
+    ) -> None:
+        experiment, mock_rest_client = _create_experiment()
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = ApiError(
+            status_code=400, headers={}, body="bad request"
+        )
+
+        with pytest.raises(ApiError):
+            experiment.bulk_upload_items([_record()])
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch("opik.api_objects.rest_helpers._sleep")
+    def test_bulk_upload_items__batch_fails__remaining_batches_are_not_sent(
+        self, mock_sleep: Mock
+    ) -> None:
+        """Fail-fast, matching Dataset.insert: the caller retries the whole call."""
+        experiment, mock_rest_client = _create_experiment()
+        mock_rest_client.experiments.experiment_items_bulk.side_effect = [
+            None,
+            ApiError(status_code=400, headers={}, body="bad request"),
+            None,
+        ]
+        items_count = constants.EXPERIMENT_ITEMS_BULK_MAX_BATCH_SIZE * 2 + 1
+
+        with pytest.raises(ApiError):
+            experiment.bulk_upload_items(
+                [_record(dataset_item_id=f"item-{i}") for i in range(items_count)]
+            )
+
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 2

--- a/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
@@ -14,10 +14,7 @@ from opik.rest_api import client as rest_api_client
 from opik.rest_api.core.api_error import ApiError
 
 START_TIME = datetime.datetime(2026, 8, 4, 12, 0, 0)
-
-
-class _StopAfterCapture(Exception):
-    """Aborts the request once the encoded body has been captured."""
+_BASE_URL = "http://opik-bulk-upload-tests.local"
 
 
 def _create_experiment(
@@ -38,6 +35,10 @@ def _create_experiment(
 
 def _record(**kwargs: Any) -> bulk_item.ExperimentItemBulkRecord:
     kwargs.setdefault("dataset_item_id", "dataset-item-id")
+    # Every record needs exactly one of evaluate_task_result/trace to pass
+    # validation, so default the tests that do not care to the simpler one.
+    if "evaluate_task_result" not in kwargs and "trace" not in kwargs:
+        kwargs["evaluate_task_result"] = {"output": "output"}
     return bulk_item.ExperimentItemBulkRecord(**kwargs)
 
 
@@ -155,16 +156,14 @@ class TestBulkUploadItemsSerialization:
     """
 
     @staticmethod
-    def _sent_item(records: List[bulk_item.ExperimentItemBulkRecord]) -> Any:
-        rest_client = rest_api_client.OpikApi(base_url="http://testserver", api_key="k")
-        captured: dict = {}
+    def _sent_items(
+        respx_mock: Any, records: List[bulk_item.ExperimentItemBulkRecord]
+    ) -> Any:
+        route = respx_mock.put(url__regex=r".*/experiments/items/bulk").respond(204)
 
-        def capture(request: Any, **kwargs: Any) -> Any:
-            captured["body"] = request.read()
-            raise _StopAfterCapture()
-
-        rest_client._client_wrapper.httpx_client.httpx_client._transport.handle_request = capture
-
+        rest_client = rest_api_client.OpikApi(
+            base_url=_BASE_URL, api_key="api-key", workspace_name="workspace"
+        )
         experiment = experiment_module.Experiment(
             id="experiment-id",
             name="experiment-name",
@@ -174,40 +173,94 @@ class TestBulkUploadItemsSerialization:
             experiments_client=Mock(),
         )
 
-        with pytest.raises(_StopAfterCapture):
-            experiment.bulk_upload_items(records)
+        experiment.bulk_upload_items(records)
 
-        return json.loads(captured["body"])["items"][0]
+        assert len(route.calls) == 1
+        return json.loads(route.calls[0].request.read())["items"]
 
     def test_bulk_upload_items__trace_only__evaluate_task_result_is_omitted(
-        self,
+        self, respx_mock: Any
     ) -> None:
-        sent_item = self._sent_item(
+        sent_item = self._sent_items(
+            respx_mock,
             [
                 _record(
                     trace=bulk_item.ExperimentItemBulkTrace(
                         start_time=START_TIME, output={"answer": "a"}
                     )
                 )
-            ]
-        )
+            ],
+        )[0]
 
         assert "evaluate_task_result" not in sent_item
         assert "trace" in sent_item
 
     def test_bulk_upload_items__evaluate_task_result_only__trace_is_omitted(
-        self,
+        self, respx_mock: Any
     ) -> None:
-        sent_item = self._sent_item([_record(evaluate_task_result={"answer": "a"})])
+        sent_item = self._sent_items(
+            respx_mock, [_record(evaluate_task_result={"answer": "a"})]
+        )[0]
 
         assert "trace" not in sent_item
         assert sent_item["evaluate_task_result"] == {"answer": "a"}
 
-    def test_bulk_upload_items__no_spans_or_scores__keys_are_omitted(self) -> None:
-        sent_item = self._sent_item([_record(evaluate_task_result={"answer": "a"})])
+    def test_bulk_upload_items__no_spans_or_scores__keys_are_omitted(
+        self, respx_mock: Any
+    ) -> None:
+        sent_item = self._sent_items(
+            respx_mock, [_record(evaluate_task_result={"answer": "a"})]
+        )[0]
 
         assert "spans" not in sent_item
         assert "feedback_scores" not in sent_item
+
+    def test_bulk_upload_items__trace_and_span_without_ids__ids_are_generated(
+        self, respx_mock: Any
+    ) -> None:
+        """Ids must be set client-side so a retry re-sends the same ones.
+
+        The backend only preserves ids the client supplies -- see
+        ``ExperimentItemBulkMapper.addIdsIfRequired``, which mints a fresh id
+        whenever one is absent. Letting it do so would make every retry create
+        duplicate traces and spans.
+        """
+        sent_item = self._sent_items(
+            respx_mock,
+            [
+                _record(
+                    trace=bulk_item.ExperimentItemBulkTrace(start_time=START_TIME),
+                    spans=[
+                        bulk_item.ExperimentItemBulkSpan(start_time=START_TIME),
+                    ],
+                )
+            ],
+        )[0]
+
+        assert sent_item["trace"]["id"] is not None
+        assert sent_item["spans"][0]["id"] is not None
+
+    def test_bulk_upload_items__caller_supplied_ids__are_preserved(
+        self, respx_mock: Any
+    ) -> None:
+        sent_item = self._sent_items(
+            respx_mock,
+            [
+                _record(
+                    trace=bulk_item.ExperimentItemBulkTrace(
+                        id="trace-id", start_time=START_TIME
+                    ),
+                    spans=[
+                        bulk_item.ExperimentItemBulkSpan(
+                            id="span-id", start_time=START_TIME
+                        )
+                    ],
+                )
+            ],
+        )[0]
+
+        assert sent_item["trace"]["id"] == "trace-id"
+        assert sent_item["spans"][0]["id"] == "span-id"
 
 
 class TestBulkUploadItemsConcurrency:
@@ -304,6 +357,22 @@ class TestBulkUploadItemsValidation:
             )
 
         assert "but not both" in str(exc_info.value)
+
+    def test_bulk_upload_items__neither_trace_nor_evaluate_task_result__raises_validation_error(
+        self,
+    ) -> None:
+        """Without either field the backend stores a hidden trace with null output."""
+        experiment, mock_rest_client = _create_experiment()
+
+        with pytest.raises(exceptions.ValidationError) as exc_info:
+            experiment.bulk_upload_items(
+                [bulk_item.ExperimentItemBulkRecord(dataset_item_id="dataset-item-id")]
+            )
+
+        assert "items[0] must provide either evaluate_task_result or trace" in str(
+            exc_info.value
+        )
+        assert mock_rest_client.experiments.experiment_items_bulk.call_count == 0
 
     def test_bulk_upload_items__evaluate_task_result_is_a_string__raises_validation_error(
         self,

--- a/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
+++ b/sdks/python/tests/unit/api_objects/experiment/test_bulk_upload_items.py
@@ -10,9 +10,14 @@ import pytest
 from opik import exceptions
 from opik.api_objects import constants
 from opik.api_objects.experiment import bulk_item, experiment as experiment_module
+from opik.rest_api import client as rest_api_client
 from opik.rest_api.core.api_error import ApiError
 
 START_TIME = datetime.datetime(2026, 8, 4, 12, 0, 0)
+
+
+class _StopAfterCapture(Exception):
+    """Aborts the request once the encoded body has been captured."""
 
 
 def _create_experiment(
@@ -137,6 +142,72 @@ class TestBulkUploadItemsBatching:
         assert len(batch_sizes) > 1
         # Each batch must stay under the backend's per-request ceiling.
         assert all(size <= 3 for size in batch_sizes)
+
+
+class TestBulkUploadItemsSerialization:
+    """Assert on the serialized request body rather than the mocked call.
+
+    The backend maps ``evaluate_task_result`` to a Jackson ``JsonNode``, so an
+    explicit JSON null deserializes to ``NullNode`` instead of Java ``null``.
+    Sending ``"evaluate_task_result": null`` next to a trace therefore trips the
+    "cannot provide both" validator with a 422. A mock-based test cannot see
+    this — only the encoded body can.
+    """
+
+    @staticmethod
+    def _sent_item(records: List[bulk_item.ExperimentItemBulkRecord]) -> Any:
+        rest_client = rest_api_client.OpikApi(base_url="http://testserver", api_key="k")
+        captured: dict = {}
+
+        def capture(request: Any, **kwargs: Any) -> Any:
+            captured["body"] = request.read()
+            raise _StopAfterCapture()
+
+        rest_client._client_wrapper.httpx_client.httpx_client._transport.handle_request = capture
+
+        experiment = experiment_module.Experiment(
+            id="experiment-id",
+            name="experiment-name",
+            dataset_name="dataset-name",
+            rest_client=rest_client,
+            streamer=Mock(),
+            experiments_client=Mock(),
+        )
+
+        with pytest.raises(_StopAfterCapture):
+            experiment.bulk_upload_items(records)
+
+        return json.loads(captured["body"])["items"][0]
+
+    def test_bulk_upload_items__trace_only__evaluate_task_result_is_omitted(
+        self,
+    ) -> None:
+        sent_item = self._sent_item(
+            [
+                _record(
+                    trace=bulk_item.ExperimentItemBulkTrace(
+                        start_time=START_TIME, output={"answer": "a"}
+                    )
+                )
+            ]
+        )
+
+        assert "evaluate_task_result" not in sent_item
+        assert "trace" in sent_item
+
+    def test_bulk_upload_items__evaluate_task_result_only__trace_is_omitted(
+        self,
+    ) -> None:
+        sent_item = self._sent_item([_record(evaluate_task_result={"answer": "a"})])
+
+        assert "trace" not in sent_item
+        assert sent_item["evaluate_task_result"] == {"answer": "a"}
+
+    def test_bulk_upload_items__no_spans_or_scores__keys_are_omitted(self) -> None:
+        sent_item = self._sent_item([_record(evaluate_task_result={"answer": "a"})])
+
+        assert "spans" not in sent_item
+        assert "feedback_scores" not in sent_item
 
 
 class TestBulkUploadItemsConcurrency:


### PR DESCRIPTION
## Details

<img width="662" height="1230" alt="image" src="https://github.com/user-attachments/assets/04b8c20e-faf0-4711-9d3e-b89a96fbe931" />

The experiment items bulk endpoint was only reachable through the Fern-generated client, which gave users no retry logic, no batching, no error handling and no data validation — everyone integrating against it had to build that themselves. This adds `Experiment.batch_upload_items`, which wraps the endpoint with the same conventions the rest of the SDK already follows.

- **SDK-native input types** — `ExperimentItemBulkRecord` / `ExperimentItemBulkTrace` / `ExperimentItemBulkSpan`, exported at top level, so callers never construct the generated `...BulkWriteView` wire models.
- **Up-front validation** — `input`/`output`/`metadata` must be dicts rather than strings (the endpoint accepts a string but it lands as an opaque blob the UI cannot render); `evaluate_task_result` and `trace` are mutually exclusive; `project_name` must agree case-insensitively with every item-level trace project, mirroring the backend's `ExperimentItemBulkUploadValidator`. Failures are collected and reported together via the existing `exceptions.ValidationError`.
- **Batching against both backend limits** — 1000 items per request, and a 3.5MB payload ceiling. The existing `config.MAX_BATCH_SIZE_MB = 5` could not be reused: it sits *above* the endpoint's hard 4MB cap, and the backend measures the whole serialized request including envelope fields. Items too large to ever fit in one request are rejected by index and size, rather than being sent as a batch-of-one the backend is guaranteed to reject with a 422.
- **Rate-limit retry** — each batch goes through `rest_helpers.ensure_rest_api_call_respecting_rate_limit`. This matters more here than for `create_experiment_items`, because the backend's `eventCount()` counts nested spans and feedback scores toward the rate limit, so throttling is hit far sooner.
- **Concurrency** — sequential by default (`num_threads=1`), matching `Dataset.insert`. `num_threads` is exposed so the optimal value can be measured rather than guessed. Failures propagate without aggregation, also matching `Dataset.insert`. Trace and span ids are generated client-side when the caller leaves them unset, so rate-limit retries re-send an identical payload and cannot duplicate data. (An earlier revision claimed the backend upserts on `dataset_item_id` and that retrying was therefore always safe — that was wrong, and review caught it: `ExperimentItemBulkMapper` only preserves ids the client supplies. Calling the method a second time re-mints ids unless the caller pins them, which the docstring now spells out.)

Named `batch_upload_items` per `SKILL.md`'s "Batch for bulk operations" convention (matching the existing `batch_update_prompt_version_tags`), even though the ticket text and the REST endpoint both say "bulk" — review caught the deviation while the method was still unreleased and renaming was free.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7469

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: code review + local test runs

## Testing

**Unit tests** — 39 new tests in `sdks/python/tests/unit/api_objects/experiment/test_batch_upload_items.py`:

```
PYTHONPATH=src python -m pytest tests/unit/api_objects/experiment/ -q
# 50 passed
```

Scenarios covered:
- Request shape: experiment identity fields, feedback-score source, empty-list no-op, explicit `project_name` overriding the experiment's.
- Batching: split by item count (2500 items → 1000/1000/500) and by payload size (10×1MB items → batches that each stay under the cap), asserting no items are lost either way.
- Validation: stringified `input`/`output`/`metadata` on traces and spans, stringified `evaluate_task_result`, `trace` + `evaluate_task_result` together, `project_name` mismatch, case-only difference accepted, multiple failures reported together, single oversized item rejected before any request is sent.
- Rate limiting: 429 with `RateLimit-Reset` honoured, 429 without header falling back to 1s, non-429 raising immediately without retry.
- Concurrency: parametrized over 1/2/4/8/16 threads asserting every batch is sent exactly once, `num_threads < 1` rejected, and failure propagation under multiple threads.
- Serialization: the encoded HTTP body omits unset optional fields rather than sending explicit JSON nulls (see the E2E note below).

**Full unit suite** — `4346 passed, 2 failed`. The two failures are in `tests/unit/message_processing/test_payload_truncation.py` (`caplog.text` empty while the log line is present in captured stderr). Verified pre-existing by stashing this branch's changes and re-running on a clean tree — they fail identically without this diff, and are unrelated to experiments.

**Linting / typing** — `pre-commit` on the changed files: ruff, ruff-format and mypy all pass.

**E2E** — two tests added to `sdks/python/tests/e2e/test_experiments.py` (happy path with traces + spans + scores, and stringified-output rejection). **Green on all 5 Python versions (3.10–3.14) against a real backend.**

These caught a genuine bug that the mock-based unit tests structurally could not. The first E2E run failed everywhere with:

```
422: items[0].<list element> cannot provide both evaluate_task_result and trace together
```

...for items that only set `trace`. Cause: constructing the generated model with `evaluate_task_result=None` makes the client emit the key as an explicit JSON `null`. The backend maps that field to a Jackson `JsonNode`, so JSON `null` deserializes to a `NullNode` **instance** rather than Java `null` — the validator's `!= null` check then sees both fields present. Fixed by only setting optional fields the caller actually provided, so unset ones are omitted from the body.

Three tests were added that assert on the **encoded HTTP body** rather than the mocked call, closing the gap that let this through. Verified by reverting the fix: all three fail against the old behavior and pass with it restored.

**Known-failing, unrelated:** `adk_tests`, `adk_legacy_1_3_0_tests` and `genai_tests` on some Python versions. These call the live Gemini API and are failing with `429 RESOURCE_EXHAUSTED` (22 occurrences of `429` in the GenAI log). No file in this PR touches ADK, GenAI or any integration, and those suites install `opik` from PyPI rather than building this branch. They also passed on an earlier rerun of this same commit range, confirming the flakiness is quota-driven.

**Not yet measured:** whether concurrency above 1 actually improves throughput. Planned follow-up on this PR — sweep `num_threads` across 1/2/4/8/16 in the test environment and pick the default from the result. The current default of 1 is deliberately the conservative, already-proven behavior.

## Documentation

N/A — docstrings only; no changes to the docs site in this PR.
