### PR TITLE
[NA] [HELM] Expose cost-api's version endpoint through the frontend nginx

### DIFF
--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -184,6 +184,37 @@ data:
             {{ $k }}{{- if eq (printf "%v" $v) "true" }} on{{- else if eq (printf "%v" $v) "false" }} off{{- else }} {{ $v }}{{- end }};
         {{- end }}
         }
+
+        # cost-api's build version, so release tooling can read the deployed
+        # cost-api version the same way it reads opik's from
+        # {{ $rootPath }}/api/is-alive/ver.
+        #
+        # `=` makes this an EXACT match: only the version endpoint is reachable,
+        # not the rest of {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/*. The
+        # ai-spend API above stays the only other way in, so cost-api's private
+        # routes still require the platform session cookie.
+        #
+        # The response is public and unauthenticated by design on cost-api's side
+        # ({{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver returns just {"version": "x.y.z"}).
+        location = {{ $rootPath }}{{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver {
+            try_files /dev/null @ai_spend_version;
+        }
+        location @ai_spend_version {
+            # The rewrite carries the target URI, because nginx refuses a
+            # proxy_pass with a URI part inside a named location. Strips the opik
+            # rootPath so the upstream sees its own {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver;
+            # a no-op when rootPath is empty, and `break` stops further rewriting.
+            rewrite ^{{ $rootPath }}{{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver$ {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver break;
+            proxy_pass http://ai-cost-backend;
+            proxy_redirect  off;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        {{- range $k, $v := .Values.component.frontend.upstreamConfig }}
+            {{ $k }}{{- if eq (printf "%v" $v) "true" }} on{{- else if eq (printf "%v" $v) "false" }} off{{- else }} {{ $v }}{{- end }};
+        {{- end }}
+        }
         {{- end }}
 
         location {{ $rootPath }}/api/ {

--- a/deployment/helm_chart/opik/tests/cost_api_version_endpoint_test.yaml
+++ b/deployment/helm_chart/opik/tests/cost_api_version_endpoint_test.yaml
@@ -1,0 +1,97 @@
+suite: cost-api version endpoint (frontend nginx)
+
+# Exercises the Cost Intelligence version endpoint rendered into the frontend
+# nginx ConfigMap (templates/configmap-frontend-nginx.yaml).
+#
+# The endpoint lets release tooling read the deployed cost-api version the same
+# way it reads opik's own from <rootPath>/api/is-alive/ver. It is gated by the
+# existing component.frontend.aiSpendBackend.enabled flag, and is deliberately
+# scoped to an EXACT-match location so none of cost-api's other routes become
+# reachable through it.
+templates:
+  - templates/configmap-frontend-nginx.yaml
+
+documentSelector: &nginx
+  path: metadata.name
+  value: opik-frontend-nginx
+
+tests:
+  - it: exposes nothing when aiSpendBackend is disabled (the default)
+    documentSelector: *nginx
+    asserts:
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: "cost-api"
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: "ai_spend"
+
+  - it: exposes the version endpoint under the rootPath when opik is not standalone
+    set:
+      standalone: false
+      component.frontend.aiSpendBackend.enabled: true
+    documentSelector: *nginx
+    asserts:
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: 'location = /opik/cost-api/ver \{'
+      # The rootPath is stripped so the upstream sees its own /cost-api/ver.
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: 'rewrite \^/opik/cost-api/ver\$ /cost-api/ver break;'
+
+  - it: exposes the version endpoint at the root when opik is standalone
+    set:
+      standalone: true
+      component.frontend.aiSpendBackend.enabled: true
+    documentSelector: *nginx
+    asserts:
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: 'location = /cost-api/ver \{'
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: "location = /opik/cost-api/ver"
+
+  - it: keeps proxy_pass free of a URI part, which nginx rejects in a named location
+    # Regression guard: nginx refuses to load a config where proxy_pass carries a
+    # URI inside `location @name` ("proxy_pass" cannot have URI part in ... named
+    # location), so the target URI must be carried by the rewrite instead. Getting
+    # this wrong takes down the whole frontend nginx, not just this endpoint.
+    set:
+      standalone: false
+      component.frontend.aiSpendBackend.enabled: true
+    documentSelector: *nginx
+    asserts:
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: "proxy_pass http://ai-cost-backend;"
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: "proxy_pass http://ai-cost-backend/"
+
+  - it: does not expose cost-api as a prefix, so only the version endpoint is reachable
+    set:
+      standalone: false
+      component.frontend.aiSpendBackend.enabled: true
+    documentSelector: *nginx
+    asserts:
+      # A bare `location /opik/cost-api` or `location ^~ /opik/cost-api` would
+      # match every cost-api route; only the `=` exact match is allowed.
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: 'location (\^~ )?/opik/cost-api'
+
+  - it: honours a custom costApiRootPath
+    set:
+      standalone: false
+      component.frontend.aiSpendBackend.enabled: true
+      component.frontend.aiSpendBackend.costApiRootPath: /ci
+    documentSelector: *nginx
+    asserts:
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: 'location = /opik/ci/ver \{'
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: 'rewrite \^/opik/ci/ver\$ /ci/ver break;'

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -598,6 +598,13 @@ component:
     # (exact match only, so none of cost-api's other routes become reachable),
     # mirroring opik's own <rootPath>/api/is-alive/ver so release tooling can read
     # the deployed cost-api version.
+    #
+    # Scope of that guarantee: this chart owns the proxy hop only — it forwards
+    # <rootPath>/cost-api/ver to the ai-cost-backend service with the rootPath
+    # stripped. The response is cost-api's own contract, not this chart's: it
+    # serves that path unauthenticated and answers {"version": "<build version>"}.
+    # Nothing here pins that, so if cost-api changes the shape or starts requiring
+    # auth, this location keeps proxying and the consumer sees the new behaviour.
     aiSpendBackend:
       enabled: false
       host: ai-cost-backend

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -593,6 +593,11 @@ component:
     # deployment turns it on the same way on both comet.com (comet-helm) and
     # single-tenant SaaS (comet-ml-helm-chart). rootPath-aware, so it works
     # whether opik is served at the root or under /opik.
+    #
+    # This also exposes cost-api's version endpoint at <rootPath>/cost-api/ver
+    # (exact match only, so none of cost-api's other routes become reachable),
+    # mirroring opik's own <rootPath>/api/is-alive/ver so release tooling can read
+    # the deployed cost-api version.
     aiSpendBackend:
       enabled: false
       host: ai-cost-backend


### PR DESCRIPTION
## Details

Release tooling needs to read the deployed cost-api version the same way it reads Opik's own from `<rootPath>/api/is-alive/ver`, but nothing under `/cost-api` is reachable from outside today: the `aiSpendBackend` block routes only the ai-spend API subset to `ai-cost-backend`, and the `ai-cost-backend` chart's own `/cost-api` ingress is disabled everywhere. This adds a single nginx location for the version endpoint, gated by the existing `aiSpendBackend.enabled` flag so no new switch is introduced and the default stays off.

Scoped deliberately narrowly:

- `location =` is an **exact** match, so only `<rootPath>/cost-api/ver` becomes reachable. cost-api's private routes remain accessible only through the existing ai-spend location, which keeps them behind the platform session cookie. The alternative — enabling the `ai-cost-backend` chart's own ingress — uses `pathType: Prefix` and would have exposed every cost-api route directly via the ALB, bypassing this nginx layer entirely.
- The response is public by design on cost-api's side: `/cost-api/ver` returns only `{"version": "x.y.z"}`.
- The rewrite carries the target URI rather than putting it on `proxy_pass`, because nginx rejects a `proxy_pass` with a URI part inside a named location (`"proxy_pass" cannot have URI part in ... named location`) — the config would have failed to load and taken the frontend nginx with it. Same reason the existing `@ai_spend` location is written that way.

`rootPath`-aware, so the same switch serves both a rootPath deployment and one where Opik is at the root.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

No ticket — follow-up to enable release automation to read the deployed cost-api version.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Full authorship of the diff (nginx location + values.yaml comment) and of the verification described below.
- Human verification: Change requested and directed by @aadereiko, who chose this approach over enabling the chart's own ingress. The commands under Testing were executed and their output inspected before opening this PR; the reviewer is asked to confirm the rendered output independently.

## Testing

Rendered the chart and ran the resulting nginx config through real nginx (`nginx:alpine`, nginx 1.31.3) in both `rootPath` modes. Subchart dependencies aren't vendored locally, so this was done from a copy of the chart with the `dependencies:` block stripped — the frontend nginx configmap doesn't depend on any subchart.

```
helm template t . --set standalone=false --set component.frontend.aiSpendBackend.enabled=true
helm template t . --set standalone=true  --set component.frontend.aiSpendBackend.enabled=true
docker run --rm -v .../nginx.conf:/etc/nginx/nginx.conf:ro \
                -v .../default.conf:/etc/nginx/conf.d/default.conf:ro nginx:alpine nginx -t
```

Rendered output:

| mode | rendered location | rewrite | `nginx -t` |
|---|---|---|---|
| `standalone=false` | `location = /opik/cost-api/ver` | `^/opik/cost-api/ver$ → /cost-api/ver` | successful |
| `standalone=true` | `location = /cost-api/ver` | no-op (source == target) | successful |
| flag off (default) | *nothing rendered* — zero `cost-api` / `ai_spend` matches | — | — |

For the `nginx -t` runs, upstream hostnames were pointed at localhost and the pre-existing OpenTelemetry directives / `$otel_trace_id` were neutralised, since that module isn't present in the stock image — neither is related to this change.

Then functionally, with nginx proxying to a stub cost-api on a Docker network (`--network-alias ai-cost-backend`) that serves `/cost-api/ver`:

| request | result |
|---|---|
| `GET /opik/cost-api/ver` | `{"version": "0.1.34"}`, `application/json` — proxied to cost-api |
| `GET /opik/cost-api/ping` | falls through to the static/SPA handler; **does not** reach cost-api |
| `GET /opik/cost-api/v1/private/ai-spend/summary` | falls through to the static/SPA handler; **does not** reach cost-api |
| `GET /cost-api/ver` (no rootPath) | 404 |

Note on the containment rows: those two paths return HTTP **200**, so a status-code-only check looks like a leak. The response *bodies* are the SPA fallback's HTML, not cost-api's JSON — that's what confirms only `/ver` is proxied.

### Automated tests

`deployment/helm_chart/opik/tests/cost_api_version_endpoint_test.yaml` — six helm-unittest cases, in the same style as the existing `csp_header_test.yaml` which already asserts against this ConfigMap:

- renders nothing when `aiSpendBackend` is disabled (the default)
- exposes `/opik/cost-api/ver` with the rootPath-stripping rewrite when not standalone
- exposes `/cost-api/ver`, and not the `/opik` variant, when standalone
- keeps `proxy_pass` free of a URI part
- never emits a prefix or `^~` location for cost-api, so only the exact version path is reachable
- honours a custom `costApiRootPath`

```
cd deployment/helm_chart/opik && helm unittest .
# 67 tests across 11 suites pass
```

I confirmed the suite genuinely fails on a regression rather than passing vacuously: reintroducing the `proxy_pass`-with-URI bug in the template made the run fail on both the missing rewrite and the reappearing URI, and it passed again once reverted.

Not run: no deployment to a live environment.

## Documentation

`values.yaml` comment for `aiSpendBackend` updated to record that the version endpoint is exposed and that it is an exact match only.
