### PR TITLE
[OPIK-7672] test: add visual regression tests for Configuration page

### DIFF
--- a/.agents/skills/writing-visual-tests/SKILL.md
+++ b/.agents/skills/writing-visual-tests/SKILL.md
@@ -122,6 +122,8 @@ docker ps --format '{{.Names}}\t{{.Status}}'   # look for opik-opik-frontend-1, 
 
 If containers are already up (healthy, running), leave them alone — don't `--stop`/`--clean`/restart something a teammate or another task left running. Only run `./opik.sh` (no flags) to start what's missing.
 
+**A rebuilt stack is not a fresh one.** `./opik.sh --build` rebuilds images but reuses existing Docker volumes (MySQL, ClickHouse, …) unless you explicitly wipe them — so a container that just restarted can still be serving months of accumulated local data: projects, feedback definitions, environments, AI provider keys, whatever previous sessions (yours or a teammate's) left behind. If your test's scope includes a **default** or **empty** state — anything you'd normally get "for free" on a brand-new workspace — don't trust what a long-lived instance currently shows. See "Know your defaults before you seed or delete" below before writing any seed/cleanup code against it. If a genuinely fresh stack (fresh volumes) is feasible and not disruptive to concurrent work, prefer it for this kind of test; if not, fall back to reasoning from the Liquibase migrations directly rather than from the current DB contents.
+
 Start the test helper service (check port 5555 is free first):
 
 ```bash
@@ -280,6 +282,23 @@ Follow the existing pattern in `test-helper-service/routes/*.py`: a Flask bluepr
   ```
 - Attachments: resolve paths via the existing `resolve_attachment_path()` helper (relative to `tests_end_to_end/`), and check in a small fixture file under `visual-tests/fixtures/` if one doesn't already exist for your case.
 
+## Know your defaults before you seed or delete
+
+Before you write a test that asserts an "empty" or "default" state, find out what a **genuinely fresh** workspace actually contains for that entity — don't infer it from what a long-lived local instance currently shows, and don't assume "I deleted it and now it's empty" proves the state is reachable elsewhere.
+
+Backend migrations can seed real per-workspace defaults that are visually indistinguishable from leftover test/dev artifacts:
+
+```bash
+grep -rl "INSERT" apps/opik-backend/src/main/resources/liquibase/**/*.sql | xargs grep -l "<table_name>"
+```
+
+What you find splits into two cases, and they need different handling:
+
+- **Hard-protected default (backend blocks deletion).** Some seeded rows are permanently undeletable by design — e.g. the "User feedback" feedback definition, guarded in `FeedbackDefinitionService.java` (`containsNameByIds(... USER_FEEDBACK)` → 409 on delete). If you hit a 409 trying to clear one, that "empty" screenshot is **not reachable** on any real Opik instance. Don't chase it by deleting whatever it's referencing (e.g. cascading into trace feedback scores to free it up) — drop that screenshot, tell the user why, and note the gap in the PR description. Confirm this with the user before dropping it; don't decide unilaterally.
+- **Deletable-but-still-a-default.** Other rows are seeded the same way (a migration backfills them for every workspace) but have no delete guard — e.g. `environments` gets `development`/`staging`/`production` from a real migration (`...seed_default_environments.sql`), not from anyone clicking around. Deleting these locally only fixes *your* machine. If your test's cleanup routine (`global-setup.ts`/`global-teardown.ts`) doesn't also delete these **known default names** on every run, the test only passes on the instance you personally vandalized — it fails on a teammate's clone, a fresh volume, or CI, either by rendering extra rows in a populated screenshot or by never reaching the empty state at all.
+
+Before deleting anything on a shared/long-lived local instance to "get to empty," ask whether it's a real default (migration-seeded, potentially relied on elsewhere) or actual scratch data (e.g. an old e2e run's leftover config) — check for the entity's name in `tests_end_to_end/e2e/**` seeding helpers too, since some things that *look* like defaults (e.g. a lone "openai" AI provider key on an otherwise-default instance) are really just residue from a different test suite (`ensureProviderConfigured`) rather than anything the backend seeds. If deleting something that turns out to matter beyond your own session (shared instance, other suites depending on it), stop and confirm with the user first rather than deleting and hoping it doesn't matter.
+
 ## Waiting: for content, not just structure
 
 `waitForReady()` methods should wait for the *specific value* you seeded to be visible (e.g. a known input string), not just a generic loading state. Many Opik tables don't render a "Name" column by default, so `waitFor({ hasText: entityName })` can time out even though the row is there — match on whatever text is actually visible in the default column set (e.g. the input/output preview), not the entity's name.
@@ -326,3 +345,5 @@ If a test in a `describe` block fails, Playwright restarts the worker process be
 | "I'll add my new span/row to the trace an earlier test in this file already screenshots" | Isolating new entities within a reused project — extending a shared entity shifts what an already-baselined screenshot in the same file renders (extra tree row, changed count), breaking it. Seed a new, separate entity instead. |
 | "I'll wrap this panel in `BasePage`" | The panel exception — a non-route panel takes just `Page` + a `root` testid locator, not the full `BasePage` constructor. |
 | "I stopped the test-helper-service, I'm done" | The rest of the cleanup checklist — config restore, a non-`SKIP_TEARDOWN` final run (server-side project deletion), and the local report/log directories (`test-results/`, `visual-report/`, `allure-results/`, `screenshots/comparison/`). |
+| "I deleted the leftover rows, now the tab is empty, ship it" | Checking whether what you deleted was a real per-workspace default (migration-seeded, e.g. `environments`' `development`/`staging`/`production`) rather than test residue — if it's a real default, your cleanup routine must delete it by name on *every* run, or the empty state only exists on the one instance you manually cleared. |
+| "The rebuild finished, the stack is fresh" | `--build` rebuilds images, not volumes — a "fresh" container can still be serving months of accumulated local data. Don't infer default/empty state from a long-lived instance's current contents; check the Liquibase migrations. |

--- a/.agents/skills/writing-visual-tests/SKILL.md
+++ b/.agents/skills/writing-visual-tests/SKILL.md
@@ -180,7 +180,7 @@ rm -rf test-results screenshots/comparison visual-report allure-results
 - On a fresh clone, or after `git clean`, **no baselines exist at all** — every screenshot name in every spec needs generating before you can run a compare pass.
 - Adding a *new* screenshot name always needs a fresh baseline, regardless of whether other baselines in the same directory already exist from a previous session.
 
-**Always (re)generate baselines for whatever you touched** before judging a compare run — via `--update-snapshots` (see the loop below). Don't assume "the baseline is already there"; check, or just regenerate, it's cheap:
+**Always (re)generate baselines for the whole suite**, not just the spec you touched, before judging a compare run — via `--update-snapshots` (see the loop below). Don't assume "the baseline is already there"; check, or just regenerate, it's cheap:
 
 ```bash
 ls tests_end_to_end/visual-tests/screenshots/baseline/ | grep <your-prefix>
@@ -194,23 +194,23 @@ Regenerate whenever any of these change, not just on first add: the screenshot n
 2. **Seed data.** Add a `test-helper-service` route if no existing one produces the shape you need (see "Adding a seed endpoint" below), plus a `TestHelperClient` method.
 3. **Page object(s).** Follow the pattern above exactly; reuse an existing page object if the page already has one.
 4. **Spec.** One `test()` per screenshot, unique names (see "Unique screenshot names").
-5. **Generate/refresh the baseline** — every time, whether or not one already exists (see "Baselines are local and gitignored" above):
+5. **Generate/refresh baselines for the whole suite** — every time, whether or not baselines already exist (see "Baselines are local and gitignored" above). Run **all** spec files, not just the one you touched: adding or changing a test can shift shared page chrome, and stale baselines in untouched files are otherwise only caught by accident.
    ```bash
    cd tests_end_to_end/visual-tests
-   SKIP_TEARDOWN=1 OPIK_BASE_URL=http://localhost:5173 npx playwright test tests/<name>.spec.ts --update-snapshots --reporter=list
+   SKIP_TEARDOWN=1 OPIK_BASE_URL=http://localhost:5173 npx playwright test --update-snapshots --reporter=list
    ```
-   `SKIP_TEARDOWN=1` keeps the seeded project alive for a fast next run; the plain `npx playwright test` invocation still always cleans and recreates it at the *start* (global-setup), so each run starts from a known state.
-6. **Stress-test for stability — do not skip this.** Run the compare pass (no `--update-snapshots`) several times in a row:
+   `SKIP_TEARDOWN=1` keeps the seeded projects alive for a fast next run; the plain `npx playwright test` invocation still always cleans and recreates them at the *start* (global-setup), so each run starts from a known state. If the full-suite run surfaces failures in files you didn't touch, don't reflexively blame your change — check whether those baselines simply predate a recent, unrelated app change (compare `ls -la screenshots/baseline/` timestamps against recent frontend commits) before deciding whether to regenerate them or investigate further; confirm with the user before regenerating baselines outside the scope of your own change.
+6. **Stress-test for stability — do not skip this.** Run the full-suite compare pass (no `--update-snapshots`) 3 times in a row:
    ```bash
-   for i in 1 2 3 4 5; do
+   for i in 1 2 3; do
      echo "=== Run $i ==="
-     SKIP_TEARDOWN=1 OPIK_BASE_URL=http://localhost:5173 npx playwright test tests/<name>.spec.ts --reporter=list
+     SKIP_TEARDOWN=1 OPIK_BASE_URL=http://localhost:5173 npx playwright test --reporter=list
    done
    ```
    A single green run proves nothing — real timestamps, real durations, and font/layout jitter only show up over several runs. If anything fails, open the `*-diff.png` attachment under `test-results/` before touching anything — it tells you exactly which pixels moved. Don't guess. If you change the spec, masks, or seed data in response, go back to step 5 and regenerate the baseline before stress-testing again — a stale baseline will just fail for a different, misleading reason.
    > macOS gotcha: `timeout` is not a built-in command (no coreutils by default) — a loop like `timeout 60 npx playwright test ...` silently no-ops. Don't wrap runs in `timeout`.
-   > Shell-tool gotcha: 5 sequential runs of a multi-test spec easily exceed a shell tool's default ~2-minute timeout, cutting the loop off mid-run. That's a harness timeout, not a test failure — don't read it as one. Pass an explicit longer timeout for the whole loop (e.g. 5+ minutes), or split into separate invocations and resume numbering (`for i in 3 4 5; do ...`) if one gets cut off.
-7. **Final full run, then work through the "Cleanup checklist" above** — one run *without* `SKIP_TEARDOWN` first (so `global-teardown.ts` actually deletes the seeded project server-side), then every item in the checklist. Config restore and stopping `test-helper-service` are only two of several things left behind.
+   > Shell-tool gotcha: 3 sequential runs of the full suite easily exceed a shell tool's default ~2-minute timeout, cutting the loop off mid-run. That's a harness timeout, not a test failure — don't read it as one. Pass an explicit longer timeout for the whole loop (e.g. 5+ minutes), or split into separate invocations and resume numbering (`for i in 2 3; do ...`) if one gets cut off.
+7. **Final full run, then work through the "Cleanup checklist" above** — one run *without* `SKIP_TEARDOWN` first (so `global-teardown.ts` actually deletes the seeded projects server-side), then every item in the checklist. Config restore and stopping `test-helper-service` are only two of several things left behind.
 
 ## Unique screenshot names
 

--- a/tests_end_to_end/test-helper-service/app.py
+++ b/tests_end_to_end/test-helper-service/app.py
@@ -20,6 +20,8 @@ from routes.threads import threads_bp
 from routes.feedback_scores import feedback_scores_bp
 from routes.experiments import experiments_bp
 from routes.prompts import prompts_bp
+from routes.environments import environments_bp
+from routes.ai_providers import ai_providers_bp
 
 
 def authenticate_if_needed():
@@ -105,6 +107,8 @@ app.register_blueprint(threads_bp, url_prefix="/api/threads")
 app.register_blueprint(feedback_scores_bp, url_prefix="/api/feedback-scores")
 app.register_blueprint(experiments_bp, url_prefix="/api/experiments")
 app.register_blueprint(prompts_bp, url_prefix="/api/prompts")
+app.register_blueprint(environments_bp, url_prefix="/api/environments")
+app.register_blueprint(ai_providers_bp, url_prefix="/api/ai-providers")
 
 
 @app.route("/health", methods=["GET"])

--- a/tests_end_to_end/test-helper-service/routes/ai_providers.py
+++ b/tests_end_to_end/test-helper-service/routes/ai_providers.py
@@ -1,0 +1,81 @@
+"""AI provider (LLM provider API key) endpoints for test helper service"""
+
+from flask import Blueprint, request, abort
+from werkzeug.exceptions import HTTPException
+from .utils import (
+    get_opik_api_client,
+    build_error_response,
+    success_response,
+    validate_required_fields,
+)
+
+ai_providers_bp = Blueprint("ai_providers", __name__)
+
+
+@ai_providers_bp.errorhandler(400)
+def bad_request(exception: HTTPException):
+    return build_error_response(exception, 400)
+
+
+@ai_providers_bp.errorhandler(404)
+def not_found(exception: HTTPException):
+    return build_error_response(exception, 404)
+
+
+@ai_providers_bp.errorhandler(500)
+def internal_server_error(exception: HTTPException):
+    return build_error_response(exception, 500)
+
+
+@ai_providers_bp.route("/create-provider-api-key", methods=["POST"])
+def create_provider_api_key():
+    data = request.get_json()
+    validate_required_fields(data, ["provider", "api_key"])
+
+    provider = data["provider"]
+    client = get_opik_api_client()
+
+    kwargs = {}
+    if data.get("name"):
+        kwargs["name"] = data["name"]
+    if data.get("provider_name"):
+        kwargs["provider_name"] = data["provider_name"]
+
+    client.llm_provider_key.store_llm_provider_api_key(
+        provider=provider, api_key=data["api_key"], **kwargs
+    )
+
+    keys = client.llm_provider_key.find_llm_provider_keys()
+    matches = [key for key in (keys.content or []) if key.provider == provider]
+    if matches:
+        created = matches[0]
+        return success_response({"id": created.id, "provider": created.provider})
+
+    abort(500, "Failed to retrieve created provider API key")
+
+
+@ai_providers_bp.route("/find-provider-api-keys", methods=["GET"])
+def find_provider_api_keys():
+    client = get_opik_api_client()
+    keys = client.llm_provider_key.find_llm_provider_keys()
+    return success_response(
+        {
+            "providers": [
+                {"id": key.id, "provider": key.provider}
+                for key in (keys.content or [])
+            ]
+        }
+    )
+
+
+@ai_providers_bp.route("/delete-provider-api-key", methods=["DELETE"])
+def delete_provider_api_key():
+    data = request.get_json()
+    validate_required_fields(data, ["id"])
+
+    key_id = data["id"]
+    client = get_opik_api_client()
+
+    client.llm_provider_key.delete_llm_provider_api_keys_batch(ids=[key_id])
+
+    return success_response({"id": key_id})

--- a/tests_end_to_end/test-helper-service/routes/environments.py
+++ b/tests_end_to_end/test-helper-service/routes/environments.py
@@ -1,6 +1,7 @@
 """Environment-related endpoints for test helper service"""
 
-from flask import Blueprint, request, abort
+from flask import Blueprint, request
+from opik.id_helpers import generate_id
 from werkzeug.exceptions import HTTPException
 from .utils import (
     get_opik_api_client,
@@ -35,21 +36,16 @@ def create_environment():
     name = data["name"]
     client = get_opik_api_client()
 
+    environment_id = generate_id()
     kwargs = {}
     if data.get("description"):
         kwargs["description"] = data["description"]
     if data.get("color"):
         kwargs["color"] = data["color"]
 
-    client.environments.create_environment(name=name, **kwargs)
+    client.environments.create_environment(id=environment_id, name=name, **kwargs)
 
-    environments = client.environments.find_environments()
-    matches = [env for env in (environments.content or []) if env.name == name]
-    if matches:
-        created = matches[0]
-        return success_response({"id": created.id, "name": created.name})
-
-    abort(500, "Failed to retrieve created environment")
+    return success_response({"id": environment_id, "name": name})
 
 
 @environments_bp.route("/find-environments", methods=["GET"])

--- a/tests_end_to_end/test-helper-service/routes/environments.py
+++ b/tests_end_to_end/test-helper-service/routes/environments.py
@@ -1,0 +1,79 @@
+"""Environment-related endpoints for test helper service"""
+
+from flask import Blueprint, request, abort
+from werkzeug.exceptions import HTTPException
+from .utils import (
+    get_opik_api_client,
+    build_error_response,
+    success_response,
+    validate_required_fields,
+)
+
+environments_bp = Blueprint("environments", __name__)
+
+
+@environments_bp.errorhandler(400)
+def bad_request(exception: HTTPException):
+    return build_error_response(exception, 400)
+
+
+@environments_bp.errorhandler(404)
+def not_found(exception: HTTPException):
+    return build_error_response(exception, 404)
+
+
+@environments_bp.errorhandler(500)
+def internal_server_error(exception: HTTPException):
+    return build_error_response(exception, 500)
+
+
+@environments_bp.route("/create-environment", methods=["POST"])
+def create_environment():
+    data = request.get_json()
+    validate_required_fields(data, ["name"])
+
+    name = data["name"]
+    client = get_opik_api_client()
+
+    kwargs = {}
+    if data.get("description"):
+        kwargs["description"] = data["description"]
+    if data.get("color"):
+        kwargs["color"] = data["color"]
+
+    client.environments.create_environment(name=name, **kwargs)
+
+    environments = client.environments.find_environments()
+    matches = [env for env in (environments.content or []) if env.name == name]
+    if matches:
+        created = matches[0]
+        return success_response({"id": created.id, "name": created.name})
+
+    abort(500, "Failed to retrieve created environment")
+
+
+@environments_bp.route("/find-environments", methods=["GET"])
+def find_environments():
+    client = get_opik_api_client()
+    environments = client.environments.find_environments()
+    return success_response(
+        {
+            "environments": [
+                {"id": env.id, "name": env.name}
+                for env in (environments.content or [])
+            ]
+        }
+    )
+
+
+@environments_bp.route("/delete-environment", methods=["DELETE"])
+def delete_environment():
+    data = request.get_json()
+    validate_required_fields(data, ["id"])
+
+    environment_id = data["id"]
+    client = get_opik_api_client()
+
+    client.environments.delete_environments_batch(ids=[environment_id])
+
+    return success_response({"id": environment_id})

--- a/tests_end_to_end/test-helper-service/routes/feedback_scores.py
+++ b/tests_end_to_end/test-helper-service/routes/feedback_scores.py
@@ -87,7 +87,7 @@ def get_feedback_definition():
             "id": definition.id,
             "name": definition.name,
             "type": definition.type,
-            "details": definition.details,
+            "details": definition.details.dict() if definition.details else None,
         }
     )
 

--- a/tests_end_to_end/visual-tests/global-setup.ts
+++ b/tests_end_to_end/visual-tests/global-setup.ts
@@ -13,6 +13,18 @@ const EMPTY_PROJECT_NAME = 'visual-empty-project';
 const SIDEBAR_PROJECT_NAME = 'visual-sidebar-project';
 const DATASET_NAME = 'visual-dataset';
 const TEST_SUITE_NAME = 'visual-testsuite';
+const FEEDBACK_DEF_NAMES = ['visual-config-quality', 'visual-config-sentiment'];
+// 'development'/'staging'/'production' are seeded by Liquibase for every workspace
+// (migration 000066_seed_default_environments.sql) — deletable, but present on any
+// fresh instance, so they must be cleared too or the environments tab is never empty.
+const ENVIRONMENT_NAMES = [
+  'visual-config-env-staging',
+  'visual-config-env-production',
+  'development',
+  'staging',
+  'production',
+];
+const AI_PROVIDERS = ['openai', 'anthropic'];
 
 async function globalSetup(_config: FullConfig) {
   const envConfig = getEnvironmentConfig();
@@ -77,6 +89,29 @@ async function globalSetup(_config: FullConfig) {
   try {
     await client.deleteProject(SIDEBAR_PROJECT_NAME);
     await client.waitForProjectDeleted(SIDEBAR_PROJECT_NAME, 30);
+  } catch { /* ignore */ }
+
+  for (const name of FEEDBACK_DEF_NAMES) {
+    try {
+      const definition = await client.getFeedbackDefinition(name);
+      await client.deleteFeedbackDefinition(definition.id);
+    } catch { /* ignore */ }
+  }
+  try {
+    const environments = await client.findEnvironments();
+    for (const env of environments) {
+      if (ENVIRONMENT_NAMES.includes(env.name)) {
+        await client.deleteEnvironment(env.id);
+      }
+    }
+  } catch { /* ignore */ }
+  try {
+    const providerKeys = await client.findProviderApiKeys();
+    for (const key of providerKeys) {
+      if (AI_PROVIDERS.includes(key.provider)) {
+        await client.deleteProviderApiKey(key.id);
+      }
+    }
   } catch { /* ignore */ }
 
   console.log('Creating projects...');

--- a/tests_end_to_end/visual-tests/global-teardown.ts
+++ b/tests_end_to_end/visual-tests/global-teardown.ts
@@ -7,6 +7,18 @@ const EMPTY_PROJECT_NAME = 'visual-empty-project';
 const SIDEBAR_PROJECT_NAME = 'visual-sidebar-project';
 const DATASET_NAME = 'visual-dataset';
 const TEST_SUITE_NAME = 'visual-testsuite';
+const FEEDBACK_DEF_NAMES = ['visual-config-quality', 'visual-config-sentiment'];
+// 'development'/'staging'/'production' are seeded by Liquibase for every workspace
+// (migration 000066_seed_default_environments.sql) — deletable, but present on any
+// fresh instance, so they must be cleared too or the environments tab is never empty.
+const ENVIRONMENT_NAMES = [
+  'visual-config-env-staging',
+  'visual-config-env-production',
+  'development',
+  'staging',
+  'production',
+];
+const AI_PROVIDERS = ['openai', 'anthropic'];
 
 const STATE_FILE = path.join(__dirname, '.test-state.json');
 
@@ -31,6 +43,29 @@ async function globalTeardown() {
   try { await client.deleteProject(PROJECT_NAME); } catch { /* ignore */ }
   try { await client.deleteProject(EMPTY_PROJECT_NAME); } catch { /* ignore */ }
   try { await client.deleteProject(SIDEBAR_PROJECT_NAME); } catch { /* ignore */ }
+
+  for (const name of FEEDBACK_DEF_NAMES) {
+    try {
+      const definition = await client.getFeedbackDefinition(name);
+      await client.deleteFeedbackDefinition(definition.id);
+    } catch { /* ignore */ }
+  }
+  try {
+    const environments = await client.findEnvironments();
+    for (const env of environments) {
+      if (ENVIRONMENT_NAMES.includes(env.name)) {
+        await client.deleteEnvironment(env.id);
+      }
+    }
+  } catch { /* ignore */ }
+  try {
+    const providerKeys = await client.findProviderApiKeys();
+    for (const key of providerKeys) {
+      if (AI_PROVIDERS.includes(key.provider)) {
+        await client.deleteProviderApiKey(key.id);
+      }
+    }
+  } catch { /* ignore */ }
 }
 
 export default globalTeardown;

--- a/tests_end_to_end/visual-tests/helpers/test-helper-client.ts
+++ b/tests_end_to_end/visual-tests/helpers/test-helper-client.ts
@@ -67,6 +67,16 @@ export interface Experiment {
   dataset_name?: string;
 }
 
+export interface Environment {
+  id: string;
+  name: string;
+}
+
+export interface ProviderApiKey {
+  id: string;
+  provider: string;
+}
+
 export interface Prompt {
   name: string;
   prompt: string;
@@ -800,6 +810,80 @@ export class TestHelperClient {
       });
     } catch (error) {
       throw this.handleError(error, 'Failed to delete feedback definition');
+    }
+  }
+
+  // Environment methods
+  async createEnvironment(
+    name: string,
+    options?: { description?: string; color?: string }
+  ): Promise<Environment> {
+    try {
+      const response = await this.client.post('/api/environments/create-environment', {
+        name,
+        ...options,
+      });
+
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error, 'Failed to create environment');
+    }
+  }
+
+  async findEnvironments(): Promise<Environment[]> {
+    try {
+      const response = await this.client.get('/api/environments/find-environments');
+      return response.data.environments;
+    } catch (error) {
+      throw this.handleError(error, 'Failed to find environments');
+    }
+  }
+
+  async deleteEnvironment(id: string): Promise<void> {
+    try {
+      await this.client.delete('/api/environments/delete-environment', {
+        data: { id },
+      });
+    } catch (error) {
+      throw this.handleError(error, 'Failed to delete environment');
+    }
+  }
+
+  // AI provider methods
+  async createProviderApiKey(
+    provider: string,
+    apiKey: string,
+    options?: { name?: string; provider_name?: string }
+  ): Promise<ProviderApiKey> {
+    try {
+      const response = await this.client.post('/api/ai-providers/create-provider-api-key', {
+        provider,
+        api_key: apiKey,
+        ...options,
+      });
+
+      return response.data;
+    } catch (error) {
+      throw this.handleError(error, 'Failed to create provider API key');
+    }
+  }
+
+  async findProviderApiKeys(): Promise<ProviderApiKey[]> {
+    try {
+      const response = await this.client.get('/api/ai-providers/find-provider-api-keys');
+      return response.data.providers;
+    } catch (error) {
+      throw this.handleError(error, 'Failed to find provider API keys');
+    }
+  }
+
+  async deleteProviderApiKey(id: string): Promise<void> {
+    try {
+      await this.client.delete('/api/ai-providers/delete-provider-api-key', {
+        data: { id },
+      });
+    } catch (error) {
+      throw this.handleError(error, 'Failed to delete provider API key');
     }
   }
 

--- a/tests_end_to_end/visual-tests/page-objects/configuration.page.ts
+++ b/tests_end_to_end/visual-tests/page-objects/configuration.page.ts
@@ -1,0 +1,43 @@
+import { Page } from '@playwright/test';
+import { BasePage } from './base.page';
+
+export type ConfigurationTab = 'feedback-definitions' | 'environments' | 'ai-provider' | 'workspace-preferences';
+
+export class ConfigurationPage extends BasePage {
+  constructor(page: Page, baseUrl: string, workspace: string) {
+    super(page, baseUrl, workspace);
+  }
+
+  async goto(tab: ConfigurationTab): Promise<void> {
+    await this.page.goto(this.url(`configuration?tab=${tab}`));
+    await this.page.waitForLoadState('load');
+    await this.dismissWelcomeDialogIfPresent();
+  }
+
+  async waitForFeedbackDefinitionsReady(expectedCellText: string): Promise<void> {
+    await this.page.getByRole('heading', { name: 'Feedback definitions', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.locator('td').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async waitForEnvironmentsReady(expectedCellText: string): Promise<void> {
+    await this.page.getByRole('heading', { name: 'Environments', exact: true }).waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.locator('td').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async waitForEnvironmentsEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: 'No environments yet', exact: true }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+
+  async waitForAiProvidersReady(expectedCellText: string): Promise<void> {
+    await this.page.getByTestId('ai-providers-tabpanel').waitFor({ state: 'visible', timeout: 10000 });
+    await this.page.locator('[data-testid="ai-provider-row-cell"]').filter({ hasText: expectedCellText }).first().waitFor({ state: 'visible', timeout: 10000 });
+  }
+
+  async waitForAiProvidersEmpty(): Promise<void> {
+    await this.page.getByRole('heading', { name: 'No AI providers yet', exact: true }).waitFor({ state: 'visible', timeout: 20000 });
+  }
+
+  async waitForWorkspacePreferencesReady(): Promise<void> {
+    await this.page.locator('td').filter({ hasText: 'Thread online scoring rule cooldown period' }).waitFor({ state: 'visible', timeout: 10000 });
+  }
+}

--- a/tests_end_to_end/visual-tests/tests/configuration.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/configuration.spec.ts
@@ -1,0 +1,89 @@
+import { test } from '@playwright/test';
+import { getEnvironmentConfig } from '../config/env.config';
+import { TestHelperClient } from '../helpers/test-helper-client';
+import { ConfigurationPage } from '../page-objects/configuration.page';
+import { screenshot, tableMasks } from './utils/screenshot';
+
+const FEEDBACK_DEF_QUALITY = 'visual-config-quality';
+const FEEDBACK_DEF_SENTIMENT = 'visual-config-sentiment';
+const ENV_STAGING = 'visual-config-env-staging';
+const ENV_PRODUCTION = 'visual-config-env-production';
+
+test.setTimeout(300000);
+
+test.describe('Visual Comparison - Configuration', () => {
+  const { baseUrl, workspace } = getEnvironmentConfig().getConfig();
+
+  test.beforeAll(async () => {
+    const client = new TestHelperClient();
+
+    await client.createFeedbackDefinition(FEEDBACK_DEF_QUALITY, 'numerical', { min: 0, max: 1 });
+    await client.createFeedbackDefinition(FEEDBACK_DEF_SENTIMENT, 'categorical', {
+      categories: { positive: 1, negative: 0 },
+    });
+
+    await client.createEnvironment(ENV_STAGING, { description: 'Staging deployment', color: '#5A6ACF' });
+    await client.createEnvironment(ENV_PRODUCTION, { description: 'Production deployment', color: '#DB5A5A' });
+
+    await client.createProviderApiKey('openai', 'sk-visual-test-fake-key-openai');
+    await client.createProviderApiKey('anthropic', 'sk-visual-test-fake-key-anthropic');
+  });
+
+  test.afterAll(async () => {
+    // Configuration entities are workspace-level, not project-scoped, so they'd
+    // otherwise leak into empty-states.spec.ts's environments/AI-providers empty
+    // assertions, which run in the same workspace right after this file.
+    const client = new TestHelperClient();
+
+    for (const name of [FEEDBACK_DEF_QUALITY, FEEDBACK_DEF_SENTIMENT]) {
+      try {
+        const definition = await client.getFeedbackDefinition(name);
+        await client.deleteFeedbackDefinition(definition.id);
+      } catch { /* ignore */ }
+    }
+    try {
+      const environments = await client.findEnvironments();
+      for (const env of environments) {
+        if ([ENV_STAGING, ENV_PRODUCTION].includes(env.name)) {
+          await client.deleteEnvironment(env.id);
+        }
+      }
+    } catch { /* ignore */ }
+    try {
+      const providerKeys = await client.findProviderApiKeys();
+      for (const key of providerKeys) {
+        if (['openai', 'anthropic'].includes(key.provider)) {
+          await client.deleteProviderApiKey(key.id);
+        }
+      }
+    } catch { /* ignore */ }
+  });
+
+  test('C01: Configuration - Feedback definitions', { tag: ['@vcap:configuration.config-feedback-definitions'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('feedback-definitions');
+    await configurationPage.waitForFeedbackDefinitionsReady(FEEDBACK_DEF_QUALITY);
+    await screenshot(page, 'C01-config-feedback-definitions', tableMasks(page));
+  });
+
+  test('C02: Configuration - Environments', { tag: ['@vcap:configuration.config-environments'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('environments');
+    await configurationPage.waitForEnvironmentsReady(ENV_STAGING);
+    await screenshot(page, 'C02-config-environments', tableMasks(page));
+  });
+
+  test('C03: Configuration - AI providers', { tag: ['@vcap:configuration.config-ai-providers'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('ai-provider');
+    await configurationPage.waitForAiProvidersReady('OpenAI');
+    await screenshot(page, 'C03-config-ai-providers', tableMasks(page));
+  });
+
+  test('C04: Configuration - Workspace preferences', { tag: ['@vcap:configuration.config-workspace-prefs'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('workspace-preferences');
+    await configurationPage.waitForWorkspacePreferencesReady();
+    await screenshot(page, 'C04-config-workspace-prefs');
+  });
+});

--- a/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
+++ b/tests_end_to_end/visual-tests/tests/empty-states.spec.ts
@@ -12,6 +12,7 @@ import { OptimizationsPage } from '../page-objects/optimizations.page';
 import { AnnotationQueuesPage } from '../page-objects/annotation-queues.page';
 import { OnlineEvaluationPage } from '../page-objects/online-evaluation.page';
 import { AlertsPage } from '../page-objects/alerts.page';
+import { ConfigurationPage } from '../page-objects/configuration.page';
 import { screenshot } from './utils/screenshot';
 
 test.setTimeout(300000);
@@ -114,5 +115,19 @@ test.describe('Visual Comparison - Empty States', () => {
     await alertsPage.goto(projectId);
     await alertsPage.waitForEmpty();
     await screenshot(page, 'E12-alerts-empty');
+  });
+
+  test('E13: Configuration - Environments empty state', { tag: ['@vcap:configuration.config-environments-empty'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('environments');
+    await configurationPage.waitForEnvironmentsEmpty();
+    await screenshot(page, 'E13-config-environments-empty');
+  });
+
+  test('E14: Configuration - AI providers empty state', { tag: ['@vcap:configuration.config-ai-providers-empty'] }, async ({ page }) => {
+    const configurationPage = new ConfigurationPage(page, baseUrl, workspace);
+    await configurationPage.goto('ai-provider');
+    await configurationPage.waitForAiProvidersEmpty();
+    await screenshot(page, 'E14-config-ai-providers-empty');
   });
 });


### PR DESCRIPTION
## Details
Adds visual regression coverage for the Configuration page (per `tests_end_to_end/coverage/taxonomy.yaml`), which previously had zero screenshot coverage across its tabs. Covers the default state of Feedback definitions, Environments, AI providers, and Workspace preferences, plus the empty states for Environments and AI providers. New test-helper-service endpoints (`environments.py`, `ai_providers.py`) support seeding/cleanup of environments and provider API keys for these tests.

Not included in this PR: the Feedback definitions empty state (`config-feedback-def-empty`) is still uncovered and left for a follow-up.

`environments.py`'s `create_environment` now generates the environment id client-side (UUIDv7, via `opik.id_helpers.generate_id()`) and passes it into `client.environments.create_environment(id=...)`, instead of re-querying `find_environments()` by name afterward — addresses PR review feedback that the name-based lookup could return the wrong environment's id if names collide.

Also updates the `writing-visual-tests` skill doc:
- Guidance on not trusting a long-lived/rebuilt local stack's current data for "default"/"empty" state assertions — a rebuild reuses existing Docker volumes, and some seeded rows (e.g. environments' `development`/`staging`/`production`) are real per-workspace defaults from Liquibase migrations rather than test residue, while others are hard-protected and undeletable by design.
- Baseline-regeneration guidance now scopes to the whole suite (not just the touched spec) when adding/changing a test, since shared page chrome can shift other specs' baselines.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7672

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation
- Human verification: code review

## Testing
Ran locally against the visual-tests suite:
- `npx tsc --noEmit -p tests_end_to_end/visual-tests/tsconfig.json` — passes
- `python3 -m py_compile` on the new/changed test-helper-service routes — passes

New specs added:
- `configuration.spec.ts`: C01 (Feedback definitions), C02 (Environments), C03 (AI providers), C04 (Workspace preferences)
- `empty-states.spec.ts`: E13 (Environments empty), E14 (AI providers empty)

Baseline screenshots for the new tests exist locally under `tests_end_to_end/visual-tests/screenshots/baseline/` (gitignored, not part of this diff).

## Documentation
Updated `.agents/skills/writing-visual-tests/SKILL.md`: clean-environment caveat for rebuilt-but-not-fresh stacks, a new "Know your defaults before you seed or delete" section, two lessons-learned table entries, and revised baseline-regeneration/stress-test instructions to run the whole suite rather than a single spec.


