### PR TITLE
[OPIK-7749] [DOCS] fix: do not move Jira to "In Review" while the PR is still a draft

### DIFF
--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -249,9 +249,9 @@ Before creating the PR, validate the generated title and body against the same r
 - **Transition status — only when the PR is ready for review**: If branch key is `OPIK-<number>` **and** `isDraft` is `false`, change ticket status to "In Review".
   - **Verify transition**: Confirm status was updated successfully
   - **If transition fails**: Show error details but continue
-- **If the PR is a draft**: Do **not** transition. Leave the ticket in its current status (typically "In Progress") and tell the user the transition was deliberately skipped, why, and how to unblock it:
+- **If the PR is a draft**: Do **not** transition. Leave the ticket in whatever status it is already in and tell the user the transition was deliberately skipped, why, and how to unblock it. Name the real status from the ticket fetched above — do not assume "In Progress", since the ticket may still be in "To Do" or anything else:
 
-  > Jira status left at "In Progress" — the PR is still a draft. Moving it to "In Review" now would tell anyone watching the board that a PR is waiting on them. Mark the PR ready for review (`gh pr ready`), then move the ticket to "In Review".
+  > Jira status left at "<current status>" — the PR is still a draft. Moving it to "In Review" now would tell anyone watching the board that a PR is waiting on them. Mark the PR ready for review (`gh pr ready`), then move the ticket to "In Review".
 
   A ticket already sitting in "In Review" is left alone rather than moved backwards — a stale forward signal is less disruptive than a status that flaps. Mention it so the user can correct it by hand if the PR went back to draft.
 - **Post progress summary**: For OPIK branches, add a progress comment directly to Jira using `addCommentToJiraIssue` with the standard 2-section format. This is independent of the transition above — post it whether or not the status changed, including on the draft path:
@@ -271,7 +271,7 @@ Before creating the PR, validate the generated title and body against the same r
   - ✅ PR template pre-filled
   - ✅ PR title and description pass pr-lint validation
   - ✅ GitHub PR created successfully
-  - ✅ Jira ticket status updated to "In Review" — or ⏸️ **skipped, PR is still a draft** (for OPIK branches). Report the skip as its own explicit line; an omitted ✅ reads as a failure rather than as intent.
+  - ✅ Jira ticket status updated to "In Review" — or ⏸️ **skipped, PR is still a draft; status left at "<current status>"** (for OPIK branches). Report the skip as its own explicit line, naming the ticket's real status rather than an assumed one; an omitted ✅ reads as a failure rather than as intent.
   - ✅ Progress documented in Jira (for OPIK branches)
 - **Show summary**: Display PR URL and Jira ticket status (if applicable)
 - **Next steps**: Provide guidance on PR review process

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -17,7 +17,7 @@ This workflow will:
 - Pre-fill PR template with extracted information
 - Validate PR title and description against pr-lint rules before submission
 - Create GitHub draft PR using GitHub CLI (fallback to GitHub MCP only when CLI is unavailable)
-- Update Jira ticket status to "In Review" (for OPIK branches)
+- Update Jira ticket status to "In Review" (for OPIK branches, and only once the PR is no longer a draft)
 - Document progress directly in Jira for OPIK branches using the same analysis logic as `share-progress-in-jira`
 
 ---
@@ -238,10 +238,23 @@ Before creating the PR, validate the generated title and body against the same r
 ### 10. Update Jira Status
 
 - **Fetch Jira ticket**: For `OPIK-<number>` branches, use Jira MCP to get ticket details
-- **Transition status**: If branch key is `OPIK-<number>`, change ticket status to "In Review"
-- **Verify transition**: Confirm status was updated successfully (for OPIK branches)
-- **If transition fails**: Show error details but continue
-- **Post progress summary**: For OPIK branches, after successful status update, add a progress comment directly to Jira using `addCommentToJiraIssue` with the standard 2-section format:
+- **Read the PR's actual draft state**: Query the PR itself — do not infer it from the flags passed in step 9:
+
+  ```bash
+  gh pr view --json isDraft,url --jq '.isDraft'
+  ```
+
+  Step 9 creates the PR as a draft by default, so on the normal happy path this returns `true`.
+
+- **Transition status — only when the PR is ready for review**: If branch key is `OPIK-<number>` **and** `isDraft` is `false`, change ticket status to "In Review".
+  - **Verify transition**: Confirm status was updated successfully
+  - **If transition fails**: Show error details but continue
+- **If the PR is a draft**: Do **not** transition. Leave the ticket in its current status (typically "In Progress") and tell the user the transition was deliberately skipped, why, and how to unblock it:
+
+  > Jira status left at "In Progress" — the PR is still a draft. Moving it to "In Review" now would tell anyone watching the board that a PR is waiting on them. Mark the PR ready for review (`gh pr ready`), then move the ticket to "In Review".
+
+  A ticket already sitting in "In Review" is left alone rather than moved backwards — a stale forward signal is less disruptive than a status that flaps. Mention it so the user can correct it by hand if the PR went back to draft.
+- **Post progress summary**: For OPIK branches, add a progress comment directly to Jira using `addCommentToJiraIssue` with the standard 2-section format. This is independent of the transition above — post it whether or not the status changed, including on the draft path:
   - **Release Notes**: User-facing changes for Product Managers, including feature toggle changes (or "No user-facing changes were made in this ticket" if none)
   - **Docs**: Developer-focused technical details and implementation notes
 - **No Jira branch key**: If branch key is `issue-<number>` or `NA`, skip Jira transition/comment and continue.
@@ -258,7 +271,7 @@ Before creating the PR, validate the generated title and body against the same r
   - ✅ PR template pre-filled
   - ✅ PR title and description pass pr-lint validation
   - ✅ GitHub PR created successfully
-  - ✅ Jira ticket status updated to "In Review" (for OPIK branches)
+  - ✅ Jira ticket status updated to "In Review" — or ⏸️ **skipped, PR is still a draft** (for OPIK branches). Report the skip as its own explicit line; an omitted ✅ reads as a failure rather than as intent.
   - ✅ Progress documented in Jira (for OPIK branches)
 - **Show summary**: Display PR URL and Jira ticket status (if applicable)
 - **Next steps**: Provide guidance on PR review process
@@ -310,6 +323,7 @@ Before creating the PR, validate the generated title and body against the same r
 
 ### **Jira Status Update Failures**
 
+- Status intentionally unchanged: If the PR is still a draft, the "In Review" transition is skipped by design — this is not a failure. Run `gh pr ready`, then move the ticket.
 - Transition not allowed: Check workflow permissions
 - Ticket not found: Verify ticket exists and is accessible
 - Network issues: Verify connectivity to Atlassian services
@@ -335,7 +349,7 @@ The command is successful when:
 8. ✅ PR template is pre-filled with meaningful content
 9. ✅ PR title and description pass pr-lint validation before submission
 10. ✅ GitHub PR is created successfully
-11. ✅ Jira ticket status is updated to "In Review" (for OPIK branches)
+11. ✅ Jira ticket status is updated to "In Review" when the PR is ready for review, or deliberately left unchanged (with the reason reported) while the PR is a draft — for OPIK branches
 12. ✅ Progress is documented in Jira (via direct MCP call, for OPIK branches)
 13. ✅ All operations complete with clear feedback
 


### PR DESCRIPTION
## Details

<img width="1063" height="1446" alt="image" src="https://github.com/user-attachments/assets/c840fef4-eb5e-4621-b2ea-0be8ce500801" />

`/comet:create-pr` creates the PR as a draft (step 9 runs `gh pr create --draft`) and then transitioned the Jira ticket to "In Review" unconditionally (step 10). Because the happy path always produces a draft, every invocation signalled "a PR is waiting for review" to anyone watching the Jira board while the work was in fact still in progress. Step 10 now reads the PR's real draft state and only transitions when the PR is actually ready.

- Draft state comes from the PR itself (`gh pr view --json isDraft`), not from the flags step 9 passed — so the gate stays correct if a PR is created ready, or marked ready later in the same run.
- On the draft path the ticket status is left alone and the skip is reported with its reason plus the unblock action (`gh pr ready`).
- The Jira progress comment is now decoupled from the transition. It previously posted "after successful status update", so gating the transition alone would have silently dropped the comment for draft PRs; it now posts either way.
- A ticket already sitting in "In Review" is left alone rather than moved backwards, and the situation is surfaced instead — a stale forward signal is less disruptive than a status that flaps.
- The overview line, completion summary, success criterion #11, and the Jira-failure troubleshooting list were all updated so the command's self-documentation agrees with the new behavior.

Review follow-up (`dc0072c1d5`): the skip message originally hard-coded `Jira status left at "In Progress"` even though step 10 fetches the ticket and already knows its status. Not hypothetical — OPIK-7749 was in `To Do` when this flow first ran, so the message named a status the ticket was never in. Both the quoted message and the completion-summary skip line now interpolate the fetched status, and the "typically In Progress" assumption is gone.

Audit (the ticket asked for the broader sweep): `create-pr.md` is the only command that transitions to "In Review". `create-jira-ticket.md` (→ To Do) and `work-on-jira-ticket.md` (→ In Progress) do not follow a PR operation and are unchanged.

Note on scope: `.agents/` is the single source of truth here. The `.claude/` copy is gitignored and generated by a plain `cp` in `make claude`, so it is regenerated rather than edited — one acceptance criterion on the ticket assumed the two were parallel source files and has been corrected there.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7749

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: code review + manual verification of the `gh` commands against live PRs

## Testing

This change is to an agent command definition (markdown), so there is no compiled code path to unit-test. Verification was of the commands the new step documents, plus the repo gate:

- `pre-commit run --files .agents/commands/comet/create-pr.md` — passes (exit 0). No hook targets `.agents/**` markdown, so every hook reports "no files to check"; the language suites (Maven / frontend / SDK) do not apply to this diff.
- Verified the documented draft-state query returns the right answer on real PRs, rather than assuming the field name:
  - `gh pr list --repo comet-ml/opik --draft --json number,isDraft` → `isDraft: true` on genuine drafts (#7726, #7706)
  - same query filtered to ready PRs → `isDraft: false` (#7728, #7727)
- Confirmed `gh pr ready` exists and is the correct unblock command quoted in the skip message (`gh pr ready --help`).
- Confirmed the regenerated local `.claude/` copy picks up the change (`make claude`, then grep for `isDraft`), and that `git status` keeps the gitignored copy out of the commit.

After the review fix (`dc0072c1d5`): re-ran `pre-commit` (exit 0), re-ran `make claude` and confirmed the regenerated local copy picks up the interpolation, and grepped the file to confirm no hard-coded `"In Progress"` status remains.

Not run: no E2E or integration suites — this diff changes no application code.

Scenario note: this PR is itself the end-to-end case. It was opened as a draft, and per the new behavior the Jira ticket was deliberately **not** moved to "In Review".

## Documentation

N/A — the changed file is itself the command's documentation; no separate docs page describes this behavior.
