### PR TITLE
[OPIK-7725] [BE] [CI] feat: block SQL built from formatted strings with a semgrep pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -359,4 +359,22 @@ repos:
         # workflow / composite action to this leg by path. Covers both workflows
         # and composite `action.yml`/`action.yaml` files (zizmor audits both).
         files: (^\.github/workflows/.+\.(yml|yaml)$)|((^|/)action\.(yml|yaml)$)
+
+  # ---------------------------------------------------------------------------
+  # Java backend — semgrep, running this repo's own rules from .semgrep/ (no
+  # upstream rule packs; broader SAST adoption is OPIK-6678). The `semgrep` hook
+  # is language: python, so pre-commit provisions it in an isolated env and
+  # contributors need no local semgrep install.
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/semgrep/pre-commit
+    rev: v1.172.0
+    hooks:
+      - id: semgrep
+        name: 🛡️ semgrep — java backend sql
+        # Explicit files: regex, same reason as hadolint above — the CI matrix
+        # builder routes on paths, not on the hook's own file selection. Covers
+        # the test tree too: it is clean today, and including it stops test
+        # fixtures from teaching the pattern this rule exists to block.
+        files: ^apps/opik-backend/.*\.java$
+        args: ['--config', '.semgrep', '--error', '--disable-version-check', '--quiet', '--skip-unknown-extensions']
 ...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -365,6 +365,11 @@ repos:
   # upstream rule packs; broader SAST adoption is OPIK-6678). The `semgrep` hook
   # is language: python, so pre-commit provisions it in an isolated env and
   # contributors need no local semgrep install.
+  #
+  # `--severity ERROR` gates on the blocking tier only. The rule file also carries
+  # a WARNING-severity rule covering the wider format-slot surface; it is reported
+  # when semgrep is run without this flag, but never fails a commit or a CI leg,
+  # so pre-existing code is surfaced as tech debt rather than blocking work.
   # ---------------------------------------------------------------------------
   - repo: https://github.com/semgrep/pre-commit
     rev: v1.172.0
@@ -372,9 +377,9 @@ repos:
       - id: semgrep
         name: 🛡️ semgrep — java backend sql
         # Explicit files: regex, same reason as hadolint above — the CI matrix
-        # builder routes on paths, not on the hook's own file selection. Covers
-        # the test tree too: it is clean today, and including it stops test
-        # fixtures from teaching the pattern this rule exists to block.
-        files: ^apps/opik-backend/.*\.java$
-        args: ['--config', '.semgrep', '--error', '--disable-version-check', '--quiet', '--skip-unknown-extensions']
+        # builder routes on paths, not on the hook's own file selection.
+        # Production sources only: string formatting in a test fixture is building
+        # a fixture, not accepting user input.
+        files: ^apps/opik-backend/src/main/java/.*\.java$
+        args: ['--config', '.semgrep', '--error', '--severity', 'ERROR', '--disable-version-check', '--quiet', '--skip-unknown-extensions']
 ...

--- a/.semgrep/java-sql-string-formatting.java
+++ b/.semgrep/java-sql-string-formatting.java
@@ -1,0 +1,126 @@
+// Fixtures for java-sql-string-formatting.yaml. Run with:
+//   semgrep test --config .semgrep/java-sql-string-formatting.yaml .semgrep/java-sql-string-formatting.java
+//
+// Semgrep's own annotations drive the assertions: a rule-id comment above a line marks it
+// as one the rule MUST flag, and the negative form marks one it must NOT.
+//
+// The must-not-flag cases below are the ones that actually bit. Every one of them matched
+// at some point during development, and the quoted-value and projection cases were caught
+// in PR review rather than by measurement. Keep them — they are the regression contract
+// for any future edit to the regex.
+class JavaSqlStringFormattingFixtures {
+
+    // ---------------------------------------------------------------------------
+    // MUST FLAG — a `%s` standing in for a clause, the injection-shaped pattern.
+    // ---------------------------------------------------------------------------
+
+    // ruleid: sql-query-with-format-slot
+    static final String CLAUSE_SPLICE_AND = """
+            SELECT id
+            FROM spans
+            WHERE workspace_id = :workspace_id
+            AND %s
+            """;
+
+    // ruleid: sql-query-with-format-slot
+    static final String CLAUSE_SPLICE_WHERE = """
+            SELECT name
+            FROM system.columns
+            WHERE %s
+            """;
+
+    // ruleid: sql-query-with-format-slot
+    static final String CLAUSE_SPLICE_LOWERCASE = """
+            select id
+            from spans
+            where workspace_id = :w
+            and %s
+            """;
+
+    // ruleid: sql-query-with-format-slot
+    static final String CLAUSE_SPLICE_NESTED_WITH = """
+            WITH x AS (
+            SELECT id
+            FROM spans
+            WHERE a = 1
+              AND %s
+            )
+            """;
+
+    // ---------------------------------------------------------------------------
+    // MUST NOT FLAG — value and projection positions, and non-SQL strings.
+    // ---------------------------------------------------------------------------
+
+    // A slot inside a quoted SQL literal is a value position, not a clause. The ClickHouse
+    // health checks fill these from compile-time constants (OPIK_7727 tracks the cleanup).
+    // ok: sql-query-with-format-slot
+    static final String VALUE_SLOT_TIGHT_QUOTES = """
+            SELECT count() AS cnt
+            FROM system.disks
+            WHERE name = '%s'
+            """;
+
+    // Same, with whitespace inside the quotes — the `(?<!')%s(?!')` form missed this.
+    // ok: sql-query-with-format-slot
+    static final String VALUE_SLOT_SPACED_QUOTES = """
+            SELECT count() AS cnt
+            FROM system.clusters
+            WHERE cluster = ' %s '
+            """;
+
+    // A projection: the slot names a column, it does not splice a predicate. Real instances
+    // live in SpansLocalV2TableTest / NaNAwareAggregateIntegrationTest / TracesLocalV2CutoverTest.
+    // ok: sql-query-with-format-slot
+    static final String PROJECTION_SLOT = """
+            SELECT %s AS value
+            FROM spans_local_v2
+            WHERE workspace_id = :workspace_id
+            """;
+
+    // ok: sql-query-with-format-slot
+    static final String PROJECTION_SLOT_IN_CTE = """
+            WITH new_trace AS (
+              SELECT toFixedString('%s', 36) AS id,
+              %s AS ttft
+            )
+            SELECT ttft
+            FROM new_trace
+            """;
+
+    // A whole-CTE prefix placeholder, filled at class init from a constant (OPIK_7727).
+    // ok: sql-query-with-format-slot
+    static final String PREFIX_SPLICE = """
+            %s
+            SELECT bucket
+            FROM spans_filtered
+            """;
+
+    // Correctly parameterized: nothing to flag.
+    // ok: sql-query-with-format-slot
+    static final String FULLY_BOUND = """
+            SELECT id
+            FROM spans
+            WHERE workspace_id = :workspace_id
+            AND project_id = :project_id
+            """;
+
+    // Not SQL: a log message that happens to contain the word "update".
+    // ok: sql-query-with-format-slot
+    static final String LOG_MESSAGE = "Completed bulk update for '%s' dataset items";
+
+    // Not SQL: an LLM prompt containing the jq expression `..|select(.error_info?)`.
+    // ok: sql-query-with-format-slot
+    static final String PROMPT_WITH_JQ = """
+            Use `%s` to inspect the trace.
+            Filter with `..|select(.error_info?)` to find errors.
+            Results come from the span tree, not from the top-level input.
+            """;
+
+    // Real SQL date format, not an integer slot — why the rule matches %s only, never %d.
+    // ok: sql-query-with-format-slot
+    static final String DATE_FORMAT_NOT_A_SLOT = """
+            SELECT value
+            FROM metadata
+            WHERE STR_TO_DATE(value, '%Y-%m-%d') < CURDATE()
+            """;
+}

--- a/.semgrep/java-sql-string-formatting.java
+++ b/.semgrep/java-sql-string-formatting.java
@@ -2,19 +2,22 @@
 //   semgrep test --config .semgrep/java-sql-string-formatting.yaml .semgrep/java-sql-string-formatting.java
 //
 // Semgrep's own annotations drive the assertions: a rule-id comment above a line marks it
-// as one the rule MUST flag, and the negative form marks one it must NOT.
+// as one that rule MUST flag, and the negative form marks one it must NOT.
 //
-// The must-not-flag cases below are the ones that actually bit. Every one of them matched
-// at some point during development, and the quoted-value and projection cases were caught
-// in PR review rather than by measurement. Keep them — they are the regression contract
-// for any future edit to the regex.
+// Two rules are asserted independently:
+//   sql-query-clause-splice — ERROR, blocks CI. Injection-shaped clause splices only.
+//   sql-query-format-slot   — WARNING, reports only. Any `%s` in a SQL literal.
+//
+// A clause splice is flagged by BOTH (it is also a format slot); everything else that
+// carries a slot is flagged by the reporting rule alone. Non-SQL strings are flagged by
+// neither — those cases are the ones that actually bit during development, so keep them.
 class JavaSqlStringFormattingFixtures {
 
     // ---------------------------------------------------------------------------
-    // MUST FLAG — a `%s` standing in for a clause, the injection-shaped pattern.
+    // BLOCKING — a `%s` standing in for a whole clause. Caller data reaches the query.
     // ---------------------------------------------------------------------------
 
-    // ruleid: sql-query-with-format-slot
+    // ruleid: sql-query-clause-splice,sql-query-format-slot
     static final String CLAUSE_SPLICE_AND = """
             SELECT id
             FROM spans
@@ -22,14 +25,14 @@ class JavaSqlStringFormattingFixtures {
             AND %s
             """;
 
-    // ruleid: sql-query-with-format-slot
+    // ruleid: sql-query-clause-splice,sql-query-format-slot
     static final String CLAUSE_SPLICE_WHERE = """
             SELECT name
             FROM system.columns
             WHERE %s
             """;
 
-    // ruleid: sql-query-with-format-slot
+    // ruleid: sql-query-clause-splice,sql-query-format-slot
     static final String CLAUSE_SPLICE_LOWERCASE = """
             select id
             from spans
@@ -37,66 +40,71 @@ class JavaSqlStringFormattingFixtures {
             and %s
             """;
 
-    // ruleid: sql-query-with-format-slot
-    static final String CLAUSE_SPLICE_NESTED_WITH = """
-            WITH x AS (
-            SELECT id
-            FROM spans
-            WHERE a = 1
-              AND %s
-            )
+    // Non-SELECT statements are in scope too: an UPDATE or DELETE predicate is exactly as
+    // injectable as a SELECT one, and a splice there mutates rather than reads.
+    // ruleid: sql-query-clause-splice,sql-query-format-slot
+    static final String CLAUSE_SPLICE_UPDATE = """
+            UPDATE spans
+            SET name = :name
+            WHERE workspace_id = :workspace_id
+            AND %s
+            """;
+
+    // ruleid: sql-query-clause-splice,sql-query-format-slot
+    static final String CLAUSE_SPLICE_DELETE = """
+            DELETE FROM spans
+            WHERE workspace_id = :workspace_id
+            AND %s
             """;
 
     // ---------------------------------------------------------------------------
-    // MUST NOT FLAG — value and projection positions, and non-SQL strings.
+    // REPORTED, NOT BLOCKING — the query text is still assembled by formatting, but the
+    // slot is not a clause. Prefer a bound parameter or a StringTemplate attribute anyway.
     // ---------------------------------------------------------------------------
 
-    // A slot inside a quoted SQL literal is a value position, not a clause. The ClickHouse
-    // health checks fill these from compile-time constants (OPIK_7727 tracks the cleanup).
-    // ok: sql-query-with-format-slot
+    // Value position. Filled from a compile-time constant in the ClickHouse health checks,
+    // so not injectable today — but the query text should still be a constant.
+    // ok: sql-query-clause-splice
+    // ruleid: sql-query-format-slot
     static final String VALUE_SLOT_TIGHT_QUOTES = """
             SELECT count() AS cnt
             FROM system.disks
             WHERE name = '%s'
             """;
 
-    // Same, with whitespace inside the quotes — the `(?<!')%s(?!')` form missed this.
-    // ok: sql-query-with-format-slot
+    // Same, with whitespace inside the quotes.
+    // ok: sql-query-clause-splice
+    // ruleid: sql-query-format-slot
     static final String VALUE_SLOT_SPACED_QUOTES = """
             SELECT count() AS cnt
             FROM system.clusters
             WHERE cluster = ' %s '
             """;
 
-    // A projection: the slot names a column, it does not splice a predicate. Real instances
-    // live in SpansLocalV2TableTest / NaNAwareAggregateIntegrationTest / TracesLocalV2CutoverTest.
-    // ok: sql-query-with-format-slot
+    // Projection: the slot names a column rather than splicing a predicate.
+    // ok: sql-query-clause-splice
+    // ruleid: sql-query-format-slot
     static final String PROJECTION_SLOT = """
             SELECT %s AS value
             FROM spans_local_v2
             WHERE workspace_id = :workspace_id
             """;
 
-    // ok: sql-query-with-format-slot
-    static final String PROJECTION_SLOT_IN_CTE = """
-            WITH new_trace AS (
-              SELECT toFixedString('%s', 36) AS id,
-              %s AS ttft
-            )
-            SELECT ttft
-            FROM new_trace
-            """;
-
-    // A whole-CTE prefix placeholder, filled at class init from a constant (OPIK_7727).
-    // ok: sql-query-with-format-slot
+    // A whole-CTE prefix placeholder, filled at class init from a constant. A StringTemplate
+    // attribute expresses this without formatting the query text.
+    // ok: sql-query-clause-splice
+    // ruleid: sql-query-format-slot
     static final String PREFIX_SPLICE = """
             %s
             SELECT bucket
             FROM spans_filtered
             """;
 
-    // Correctly parameterized: nothing to flag.
-    // ok: sql-query-with-format-slot
+    // ---------------------------------------------------------------------------
+    // FLAGGED BY NEITHER — correctly parameterized SQL, and strings that only look like it.
+    // ---------------------------------------------------------------------------
+
+    // ok: sql-query-clause-splice,sql-query-format-slot
     static final String FULLY_BOUND = """
             SELECT id
             FROM spans
@@ -105,19 +113,21 @@ class JavaSqlStringFormattingFixtures {
             """;
 
     // Not SQL: a log message that happens to contain the word "update".
-    // ok: sql-query-with-format-slot
+    // ok: sql-query-clause-splice,sql-query-format-slot
     static final String LOG_MESSAGE = "Completed bulk update for '%s' dataset items";
 
     // Not SQL: an LLM prompt containing the jq expression `..|select(.error_info?)`.
-    // ok: sql-query-with-format-slot
+    // Prompt templates carry their own injection risk, tracked separately in OPIK 7837 —
+    // it is not a SQL concern and this rule is not the right gate for it.
+    // ok: sql-query-clause-splice,sql-query-format-slot
     static final String PROMPT_WITH_JQ = """
             Use `%s` to inspect the trace.
             Filter with `..|select(.error_info?)` to find errors.
             Results come from the span tree, not from the top-level input.
             """;
 
-    // Real SQL date format, not an integer slot — why the rule matches %s only, never %d.
-    // ok: sql-query-with-format-slot
+    // Real SQL date format, not an integer slot — why both rules match %s only, never %d.
+    // ok: sql-query-clause-splice,sql-query-format-slot
     static final String DATE_FORMAT_NOT_A_SLOT = """
             SELECT value
             FROM metadata

--- a/.semgrep/java-sql-string-formatting.yaml
+++ b/.semgrep/java-sql-string-formatting.yaml
@@ -30,25 +30,52 @@ rules:
     #      `..|select(.error_info?)`, and log messages like "Completed bulk update for
     #      '%s' dataset items" match on the word "update".
     #   2. A FROM clause on its own line — a second, independent structural marker.
-    #   3. A `%s` that is NOT inside a single-quoted SQL string. A slot spliced into a
-    #      quoted literal (`WHERE cluster = '%s'`) is a value position, which the
-    #      health checks fill from a compile-time constant; those are a readability
-    #      concern, not injection, and are out of scope here (OPIK 7727). This gate
-    #      targets the clause-position splice the review actually flagged.
+    #   3. A `%s` in CLAUSE position: it must be the whole right-hand side of an
+    #      `AND` / `OR` / `WHERE` / `ON` / `HAVING` keyword, on a line containing no
+    #      single quote. This is what makes the rule injection-shaped rather than
+    #      merely "%s near SQL", and it excludes two large false-positive families:
+    #        - Value positions — `WHERE name = '%s'`, and the same with whitespace
+    #          inside the quotes (`= ' %s '`). The ClickHouse health checks fill these
+    #          from compile-time constants; a readability concern, not injection
+    #          (OPIK 7727).
+    #        - Projections — `SELECT %s AS value`, `%s AS ttft`. The slot names a
+    #          column, it does not splice a predicate. Real instances live in
+    #          SpansLocalV2TableTest, NaNAwareAggregateIntegrationTest and
+    #          TracesLocalV2CutoverTest; an earlier revision of this rule flagged all
+    #          27 of them.
     #
     # Deliberately `%s` only, not `%d`: MetadataDAO contains the real SQL literal
     # `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from
     # an integer format slot. No real violation uses `%d`.
     #
+    # Fixtures for every case above live in java-sql-string-formatting.java next to this
+    # file, asserted with semgrep's own annotations. Run them after any regex edit:
+    #   semgrep test --config .semgrep/java-sql-string-formatting.yaml \
+    #                       .semgrep/java-sql-string-formatting.java
+    #
+    # VERIFICATION TRAP — read before measuring this rule's coverage. Semgrep's built-in
+    # semgrepignore excludes `test`/`tests` directories at any depth, so passing
+    # `apps/opik-backend/src/test/java` as a DIRECTORY scans zero files and reports a
+    # reassuring "0 findings". The pre-commit hook passes explicit FILENAMES, which
+    # bypasses that exclusion — so the hook sees files a directory scan never did. Always
+    # verify the way the hook runs:
+    #   semgrep --config .semgrep $(git ls-files 'apps/opik-backend/src/**/*.java')
+    # Measured that way, both trees are 1,687 files (1,259 main + 428 test).
+    #
     # Known limitation: a query written entirely on ONE line
     # (`"SELECT id FROM spans WHERE w = :w AND %s"`) is not caught, because requirements
-    # 1 and 2 are line-anchored. Dropping those anchors was measured and reintroduces
-    # the prompt-template false positive, which is the worse failure — it would block an
+    # 1-3 are line-anchored. Dropping those anchors was measured and reintroduces the
+    # prompt-template false positive, which is the worse failure — it would block an
     # unrelated commit and push a suppression comment into a file with no SQL in it.
     # Every real query in this codebase is a multi-line text block, so the gap is
     # theoretical; revisit if that stops being true.
+    #
+    # Also not caught: a spliced predicate that is not the entire right-hand side of a
+    # clause keyword (`AND %s AND deleted = 0`, or `AND (%s)`). Requirement 3 anchors the
+    # slot to end-of-line to keep projections out. Broadening it is possible but was not
+    # needed for any real or hypothetical case reviewed here.
     patterns:
       - pattern: $X
       - metavariable-regex:
           metavariable: $X
-          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH)\b)(?=.*^\s*(?i:FROM)\b)(?=.*^[^\n]*\S[^\n]*(?<!')%s(?!')).*"$
+          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH)\b)(?=.*^\s*(?i:FROM)\b)(?=.*^[^\n']*\b(?i:AND|OR|WHERE|ON|HAVING)\s+%s\s*$).*"$

--- a/.semgrep/java-sql-string-formatting.yaml
+++ b/.semgrep/java-sql-string-formatting.yaml
@@ -33,7 +33,7 @@ rules:
     #   3. A `%s` that is NOT inside a single-quoted SQL string. A slot spliced into a
     #      quoted literal (`WHERE cluster = '%s'`) is a value position, which the
     #      health checks fill from a compile-time constant; those are a readability
-    #      concern, not injection, and are out of scope here (OPIK-7726). This gate
+    #      concern, not injection, and are out of scope here (OPIK 7727). This gate
     #      targets the clause-position splice the review actually flagged.
     #
     # Deliberately `%s` only, not `%d`: MetadataDAO contains the real SQL literal

--- a/.semgrep/java-sql-string-formatting.yaml
+++ b/.semgrep/java-sql-string-formatting.yaml
@@ -39,6 +39,14 @@ rules:
     # Deliberately `%s` only, not `%d`: MetadataDAO contains the real SQL literal
     # `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from
     # an integer format slot. No real violation uses `%d`.
+    #
+    # Known limitation: a query written entirely on ONE line
+    # (`"SELECT id FROM spans WHERE w = :w AND %s"`) is not caught, because requirements
+    # 1 and 2 are line-anchored. Dropping those anchors was measured and reintroduces
+    # the prompt-template false positive, which is the worse failure — it would block an
+    # unrelated commit and push a suppression comment into a file with no SQL in it.
+    # Every real query in this codebase is a multi-line text block, so the gap is
+    # theoretical; revisit if that stops being true.
     patterns:
       - pattern: $X
       - metavariable-regex:

--- a/.semgrep/java-sql-string-formatting.yaml
+++ b/.semgrep/java-sql-string-formatting.yaml
@@ -1,0 +1,46 @@
+rules:
+  - id: sql-query-with-format-slot
+    languages: [java]
+    severity: ERROR
+    message: >-
+      This SQL query is assembled by string formatting: a `%s` slot sits where a SQL
+      clause belongs. Bind values with `:named` parameters, and use a StringTemplate
+      `<if(flag)>` conditional for fragments that vary structurally (see
+      ProjectMetricsDAO / WorkspaceMetricsDAO). String-formatted SQL invites injection
+      and is harder to read and maintain. If this is a genuinely dynamic query builder
+      that binds its values separately, add `// nosemgrep: sql-query-with-format-slot`
+      with a comment explaining why.
+    # Match where the query is DECLARED, not where it is executed. Opik holds SQL in
+    # `static final` text blocks rendered through StringTemplate and passed to
+    # `connection.createStatement(template.render())`, so the literal and the execution
+    # are connected only through a template object — call-site patterns such as
+    # `query($X + $Y)` match nothing in this codebase.
+    #
+    # `pattern: $X` binds every expression node; `metavariable-regex` then inspects the
+    # string literal's own contents, text blocks included. Requiring the SQL and the
+    # `%s` to live in the SAME literal node is what keeps this precise: the ~450
+    # legitimate `.formatted(` call sites carry no SQL.
+    #
+    # The regex is deliberately narrow, because "contains a SQL keyword" alone is not a
+    # usable signal in this repo. It requires ALL of:
+    #
+    #   1. A line that STARTS with SELECT or WITH (after whitespace) — a real query,
+    #      not prose that happens to contain a keyword. Without this anchor, an LLM
+    #      prompt template in TestSuitePromptConstants matches on the jq expression
+    #      `..|select(.error_info?)`, and log messages like "Completed bulk update for
+    #      '%s' dataset items" match on the word "update".
+    #   2. A FROM clause on its own line — a second, independent structural marker.
+    #   3. A `%s` that is NOT inside a single-quoted SQL string. A slot spliced into a
+    #      quoted literal (`WHERE cluster = '%s'`) is a value position, which the
+    #      health checks fill from a compile-time constant; those are a readability
+    #      concern, not injection, and are out of scope here (OPIK-7726). This gate
+    #      targets the clause-position splice the review actually flagged.
+    #
+    # Deliberately `%s` only, not `%d`: MetadataDAO contains the real SQL literal
+    # `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from
+    # an integer format slot. No real violation uses `%d`.
+    patterns:
+      - pattern: $X
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH)\b)(?=.*^\s*(?i:FROM)\b)(?=.*^[^\n]*\S[^\n]*(?<!')%s(?!')).*"$

--- a/.semgrep/java-sql-string-formatting.yaml
+++ b/.semgrep/java-sql-string-formatting.yaml
@@ -1,81 +1,88 @@
+# SQL-in-Java string-formatting rules for apps/opik-backend/src/main/java.
+#
+# Two tiers, because widening this to every `%s` in a SQL literal surfaces 108 findings in
+# production code that predate the rule. Blocking on all of them would either stall the
+# gate or force a baseline file; reporting them keeps the signal without holding up work.
+#
+#   ERROR   sql-query-clause-splice   — blocks CI. The injection-shaped form: a `%s`
+#                                       standing in for a whole clause, where caller data
+#                                       reaches the query text. Currently 0 findings.
+#   WARNING sql-query-format-slot     — reports only, never blocks. Any other `%s` in a
+#                                       SQL literal: value positions, projections, CTE
+#                                       prefixes. Currently 108 findings, tracked as tech
+#                                       debt in OPIK 7727.
+#
+# The pre-commit hook passes `--severity ERROR`, so only the blocking tier can fail a
+# commit or a CI leg. To see the reporting tier locally, drop that flag:
+#   semgrep --config .semgrep $(git ls-files 'apps/opik-backend/src/main/java/**/*.java')
+#
+# Scope is production code only. Test sources are excluded at the hook's `files:` regex:
+# string formatting in a test fixture is building a fixture, not accepting user input.
+#
+# Fixtures for every case live in java-sql-string-formatting.java next to this file. Run
+# them after any edit here:
+#   semgrep test --config .semgrep/java-sql-string-formatting.yaml \
+#                       .semgrep/java-sql-string-formatting.java
+#
+# VERIFICATION TRAP — read before measuring coverage. Semgrep's built-in semgrepignore
+# excludes `test`/`tests` directories at any depth, so passing a directory that contains
+# one scans zero files there while still reporting a reassuring "0 findings". The
+# pre-commit hook passes explicit FILENAMES, which bypasses that exclusion. Always verify
+# the way the hook runs, via `git ls-files`, not by handing semgrep a directory.
+#
+# Both rules match where the query is DECLARED, not where it executes. Opik holds SQL in
+# `static final` text blocks rendered through StringTemplate and passed to
+# `connection.createStatement(template.render())`, so the literal and the execution are
+# connected only through a template object — call-site patterns match nothing here.
+# `pattern: $X` binds every expression node; `metavariable-regex` then inspects the string
+# literal's own contents, text blocks included.
+#
+# Both rules deliberately match `%s` only, never `%d`: MetadataDAO contains the real SQL
+# literal `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from
+# an integer format slot.
 rules:
-  - id: sql-query-with-format-slot
+  # ---------------------------------------------------------------------------
+  # TIER 1 — blocking. Clause-position splice.
+  # ---------------------------------------------------------------------------
+  - id: sql-query-clause-splice
     languages: [java]
     severity: ERROR
     message: >-
-      This SQL query is assembled by string formatting: a `%s` slot sits where a SQL
-      clause belongs. Bind values with `:named` parameters, and use a StringTemplate
-      `<if(flag)>` conditional for fragments that vary structurally (see
-      ProjectMetricsDAO / WorkspaceMetricsDAO). String-formatted SQL invites injection
-      and is harder to read and maintain. If this is a genuinely dynamic query builder
-      that binds its values separately, add `// nosemgrep: sql-query-with-format-slot`
-      with a comment explaining why.
-    # Match where the query is DECLARED, not where it is executed. Opik holds SQL in
-    # `static final` text blocks rendered through StringTemplate and passed to
-    # `connection.createStatement(template.render())`, so the literal and the execution
-    # are connected only through a template object — call-site patterns such as
-    # `query($X + $Y)` match nothing in this codebase.
+      This SQL query splices a `%s` into CLAUSE position, so caller-supplied text becomes
+      part of the query itself — the shape SQL injection takes. Bind values with `:named`
+      parameters, and use a StringTemplate `<if(flag)>` conditional for fragments that vary
+      structurally (see ProjectMetricsDAO / WorkspaceMetricsDAO for the established
+      pattern). If this is a genuinely dynamic query builder that binds its values
+      separately, add `// nosemgrep: sql-query-clause-splice` with a comment explaining why.
+    # The `%s` must be the entire right-hand side of a clause keyword, on a line carrying no
+    # single quote. That anchoring is what separates a spliced predicate from a value slot
+    # (`WHERE name = '%s'`) or a projection (`SELECT %s AS value`) — those are real concerns
+    # but not injection ones, so they belong to the reporting tier below.
     #
-    # `pattern: $X` binds every expression node; `metavariable-regex` then inspects the
-    # string literal's own contents, text blocks included. Requiring the SQL and the
-    # `%s` to live in the SAME literal node is what keeps this precise: the ~450
-    # legitimate `.formatted(` call sites carry no SQL.
-    #
-    # The regex is deliberately narrow, because "contains a SQL keyword" alone is not a
-    # usable signal in this repo. It requires ALL of:
-    #
-    #   1. A line that STARTS with SELECT or WITH (after whitespace) — a real query,
-    #      not prose that happens to contain a keyword. Without this anchor, an LLM
-    #      prompt template in TestSuitePromptConstants matches on the jq expression
-    #      `..|select(.error_info?)`, and log messages like "Completed bulk update for
-    #      '%s' dataset items" match on the word "update".
-    #   2. A FROM clause on its own line — a second, independent structural marker.
-    #   3. A `%s` in CLAUSE position: it must be the whole right-hand side of an
-    #      `AND` / `OR` / `WHERE` / `ON` / `HAVING` keyword, on a line containing no
-    #      single quote. This is what makes the rule injection-shaped rather than
-    #      merely "%s near SQL", and it excludes two large false-positive families:
-    #        - Value positions — `WHERE name = '%s'`, and the same with whitespace
-    #          inside the quotes (`= ' %s '`). The ClickHouse health checks fill these
-    #          from compile-time constants; a readability concern, not injection
-    #          (OPIK 7727).
-    #        - Projections — `SELECT %s AS value`, `%s AS ttft`. The slot names a
-    #          column, it does not splice a predicate. Real instances live in
-    #          SpansLocalV2TableTest, NaNAwareAggregateIntegrationTest and
-    #          TracesLocalV2CutoverTest; an earlier revision of this rule flagged all
-    #          27 of them.
-    #
-    # Deliberately `%s` only, not `%d`: MetadataDAO contains the real SQL literal
-    # `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from
-    # an integer format slot. No real violation uses `%d`.
-    #
-    # Fixtures for every case above live in java-sql-string-formatting.java next to this
-    # file, asserted with semgrep's own annotations. Run them after any regex edit:
-    #   semgrep test --config .semgrep/java-sql-string-formatting.yaml \
-    #                       .semgrep/java-sql-string-formatting.java
-    #
-    # VERIFICATION TRAP — read before measuring this rule's coverage. Semgrep's built-in
-    # semgrepignore excludes `test`/`tests` directories at any depth, so passing
-    # `apps/opik-backend/src/test/java` as a DIRECTORY scans zero files and reports a
-    # reassuring "0 findings". The pre-commit hook passes explicit FILENAMES, which
-    # bypasses that exclusion — so the hook sees files a directory scan never did. Always
-    # verify the way the hook runs:
-    #   semgrep --config .semgrep $(git ls-files 'apps/opik-backend/src/**/*.java')
-    # Measured that way, both trees are 1,687 files (1,259 main + 428 test).
-    #
-    # Known limitation: a query written entirely on ONE line
-    # (`"SELECT id FROM spans WHERE w = :w AND %s"`) is not caught, because requirements
-    # 1-3 are line-anchored. Dropping those anchors was measured and reintroduces the
-    # prompt-template false positive, which is the worse failure — it would block an
-    # unrelated commit and push a suppression comment into a file with no SQL in it.
-    # Every real query in this codebase is a multi-line text block, so the gap is
-    # theoretical; revisit if that stops being true.
-    #
-    # Also not caught: a spliced predicate that is not the entire right-hand side of a
-    # clause keyword (`AND %s AND deleted = 0`, or `AND (%s)`). Requirement 3 anchors the
-    # slot to end-of-line to keep projections out. Broadening it is possible but was not
-    # needed for any real or hypothetical case reviewed here.
+    # Not caught: a splice that is not the whole right-hand side (`AND %s AND deleted = 0`,
+    # or `AND (%s)`), and a query written entirely on one line. Broadening either
+    # reintroduces false positives on prompt templates and log messages; every real query in
+    # this codebase is a multi-line text block.
     patterns:
       - pattern: $X
       - metavariable-regex:
           metavariable: $X
-          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH)\b)(?=.*^\s*(?i:FROM)\b)(?=.*^[^\n']*\b(?i:AND|OR|WHERE|ON|HAVING)\s+%s\s*$).*"$
+          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b)(?=.*^[^\n']*\b(?i:AND|OR|WHERE|ON|HAVING)\s+%s\s*$).*"$
+
+  # ---------------------------------------------------------------------------
+  # TIER 2 — reporting only. Any other format slot in a SQL literal.
+  # ---------------------------------------------------------------------------
+  - id: sql-query-format-slot
+    languages: [java]
+    severity: WARNING
+    message: >-
+      This SQL literal is assembled with a `%s` format slot. Even where the value is a
+      compile-time constant, prefer a bound `:named` parameter, or a StringTemplate
+      attribute for a fragment that varies structurally — the query text should be a
+      constant. Reported, not blocking: the existing occurrences are tracked as tech debt
+      in OPIK 7727. New code should not add to them.
+    patterns:
+      - pattern: $X
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?sm)^"(?=.*^\s*(?i:SELECT|WITH|INSERT|UPDATE|DELETE|CREATE|ALTER|DROP|TRUNCATE)\b)(?=.*%s).*"$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,7 @@ Workflows are also scanned for **security** issues with [zizmor](https://github.
 Dockerfiles are linted with [hadolint](https://github.com/hadolint/hadolint), which runs as a hook in the unified `🐙 Code Quality` workflow (and locally via pre-commit) on changed Dockerfiles. It uses hadolint's default rule set; the handful of intentionally-suppressed rules are annotated inline in each Dockerfile with a `# hadolint ignore=` comment and a reason. The hook runs hadolint via its Docker image, so it needs only Docker — no manual install. To run it directly on a single file: `docker run --rm -i ghcr.io/hadolint/hadolint < path/to/Dockerfile`.
 
 ## SQL query construction (Java backend)
-Java files under `apps/opik-backend/` are scanned with [semgrep](https://semgrep.dev/) for SQL assembled by string formatting, which runs as a hook in the unified `🐙 Code Quality` workflow (and locally via pre-commit) on changed backend Java files. The pre-commit framework installs the pinned semgrep automatically — no manual install needed.
-
-The repo runs only its own rules, kept in [`.semgrep/`](.semgrep/) and version-controlled alongside the config; no upstream rule packs are enabled. Today that is a single rule, `sql-query-with-format-slot`, which fails a Java string literal or text block that contains both SQL and a `%s` format slot in a clause position.
-
-- **Why it blocks.** A query whose text is assembled with `%s` invites SQL injection and is harder to read and maintain. Bind values with `:named` parameters instead, and use a StringTemplate `<if(flag)>` conditional for fragments that vary structurally — see `ProjectMetricsDAO` / `WorkspaceMetricsDAO` for the established pattern.
-- **Run it locally** against the whole backend: `uvx --from semgrep==1.172.0 semgrep --config .semgrep apps/opik-backend/src`. To reproduce exactly what CI blocks on, add `--error`.
-- **Suppressing a finding** must be explicit and justified — never silent. Use an inline `// nosemgrep: sql-query-with-format-slot` comment with a short rationale, directly above the query. This is intended for genuinely dynamic query builders (such as `SortingQueryBuilder` / `FilterQueryBuilder`) that assemble fragments as strings but bind their values separately. There is deliberately no repo-level ignore list — a global exemption would fail open on every future file.
-- **Scope.** The rule matches `%s` only, not `%d`: `MetadataDAO` contains the real SQL literal `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from an integer slot. Rationale for the rule's other scoping decisions is documented in comments in the rule file itself.
+Production Java under `apps/opik-backend/src/main/java/` is scanned with [semgrep](https://semgrep.dev/) for SQL assembled by string formatting, as a hook in the unified `🐙 Code Quality` workflow (and locally via pre-commit). The rules live in [`.semgrep/`](.semgrep/), with the conventions they enforce documented in [`.agents/rules/security.mdc`](.agents/rules/security.mdc) and the backend skill.
 
 ## Generated files (do not edit manually)
 - `apps/opik-backend/src/main/resources/model_prices_and_context_window.json`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,16 @@ Workflows are also scanned for **security** issues with [zizmor](https://github.
 ## Dockerfiles
 Dockerfiles are linted with [hadolint](https://github.com/hadolint/hadolint), which runs as a hook in the unified `🐙 Code Quality` workflow (and locally via pre-commit) on changed Dockerfiles. It uses hadolint's default rule set; the handful of intentionally-suppressed rules are annotated inline in each Dockerfile with a `# hadolint ignore=` comment and a reason. The hook runs hadolint via its Docker image, so it needs only Docker — no manual install. To run it directly on a single file: `docker run --rm -i ghcr.io/hadolint/hadolint < path/to/Dockerfile`.
 
+## SQL query construction (Java backend)
+Java files under `apps/opik-backend/` are scanned with [semgrep](https://semgrep.dev/) for SQL assembled by string formatting, which runs as a hook in the unified `🐙 Code Quality` workflow (and locally via pre-commit) on changed backend Java files. The pre-commit framework installs the pinned semgrep automatically — no manual install needed.
+
+The repo runs only its own rules, kept in [`.semgrep/`](.semgrep/) and version-controlled alongside the config; no upstream rule packs are enabled. Today that is a single rule, `sql-query-with-format-slot`, which fails a Java string literal or text block that contains both SQL and a `%s` format slot in a clause position.
+
+- **Why it blocks.** A query whose text is assembled with `%s` invites SQL injection and is harder to read and maintain. Bind values with `:named` parameters instead, and use a StringTemplate `<if(flag)>` conditional for fragments that vary structurally — see `ProjectMetricsDAO` / `WorkspaceMetricsDAO` for the established pattern.
+- **Run it locally** against the whole backend: `uvx --from semgrep==1.172.0 semgrep --config .semgrep apps/opik-backend/src`. To reproduce exactly what CI blocks on, add `--error`.
+- **Suppressing a finding** must be explicit and justified — never silent. Use an inline `// nosemgrep: sql-query-with-format-slot` comment with a short rationale, directly above the query. This is intended for genuinely dynamic query builders (such as `SortingQueryBuilder` / `FilterQueryBuilder`) that assemble fragments as strings but bind their values separately. There is deliberately no repo-level ignore list — a global exemption would fail open on every future file.
+- **Scope.** The rule matches `%s` only, not `%d`: `MetadataDAO` contains the real SQL literal `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from an integer slot. Rationale for the rule's other scoping decisions is documented in comments in the rule file itself.
+
 ## Generated files (do not edit manually)
 - `apps/opik-backend/src/main/resources/model_prices_and_context_window.json`
 - `apps/opik-frontend/src/data/model_prices_and_context_window.json`

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -40,6 +40,8 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.metrics.BreakdownQueryBuilder.getBreakdownGroupExpression;
+import static com.comet.opik.domain.SpanMetricsQueries.SPAN_FILTERED_PREFIX;
+import static com.comet.opik.domain.SpanMetricsQueries.TOKEN_USAGE_NAMES;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.startSegment;
@@ -303,10 +305,6 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                 ) AS t
             )
             """;
-
-    // Shared with WorkspaceMetricsDAO via SpanMetricsQueries; per-project aggregation fixes a single project_id, which
-    // getMetric() selects with template.add("project_id", true).
-    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries.SPAN_FILTERED_PREFIX;
 
     private static final String THREAD_FILTERED_PREFIX = """
             WITH trace_threads_final AS (
@@ -1181,8 +1179,6 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
 
-    private static final String GET_PROJECT_TOKEN_USAGE_NAMES = SpanMetricsQueries.TOKEN_USAGE_NAMES;
-
     @Override
     public Mono<List<Entry>> getDuration(@NonNull UUID projectId, @NonNull ProjectMetricRequest request) {
         return template.nonTransaction(connection -> getMetric(projectId, request, connection,
@@ -1574,9 +1570,6 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             var template = getSTWithLogComment(query, PROJECT_METRIC_QUERY_NAME_PREFIX + segmentName, workspaceId,
                     userName, projectId.toString());
 
-            // Selects the single-project predicate in the shared SpanMetricsQueries CTE; project_id is bound below.
-            template.add("project_id", true);
-
             if (isTotal) {
                 template.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");
             } else {
@@ -1670,6 +1663,15 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     .bind("project_id", projectId)
                     .bind("uuid_from_time", request.uuidFromTime().toString())
                     .bind("workspace_id", workspaceId);
+
+            // Same hazard as OPIK-5678 above: only the span-based queries embed SpanMetricsQueries'
+            // shared CTE, which is the sole place `:project_ids` appears. The trace/thread prefixes
+            // use the scalar `:project_id` bound above, and binding a parameter their SQL doesn't
+            // declare raises NoSuchElementException from R2DBC. Per-project aggregation passes a set
+            // of one so the shared CTE keeps a single `IN` form for both callers.
+            if (SPAN_TIME_METRICS.contains(request.metricType())) {
+                statement.bind("project_ids", new UUID[]{projectId});
+            }
 
             // Bind uuid_to_time only if present
             if (request.uuidToTime() != null) {
@@ -1801,14 +1803,12 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
     @Override
     public Mono<List<String>> getProjectTokenUsageNames(@NonNull String workspaceId, @NonNull UUID projectId) {
         return template.nonTransaction(connection -> {
-            var stTemplate = getSTWithLogComment(GET_PROJECT_TOKEN_USAGE_NAMES, "getProjectTokenUsageNames",
+            var stTemplate = getSTWithLogComment(TOKEN_USAGE_NAMES, "getProjectTokenUsageNames",
                     workspaceId, "", projectId.toString());
 
-            // Selects the single-project predicate in the shared SpanMetricsQueries query; project_id is bound below.
-            stTemplate.add("project_id", true);
-
             var statement = connection.createStatement(stTemplate.render())
-                    .bind("project_id", projectId)
+                    // Per-project aggregation binds a set of one; the shared query takes the IN form.
+                    .bind("project_ids", new UUID[]{projectId})
                     .bind("workspace_id", workspaceId);
 
             InstrumentAsyncUtils.Segment segment = startSegment("getProjectTokenUsageNames", "Clickhouse", "get");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -304,9 +304,9 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             )
             """;
 
-    // Shared with WorkspaceMetricsDAO via SpanMetricsQueries; per-project aggregation fixes a single project_id.
-    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries
-            .spanFilteredPrefix("project_id = :project_id");
+    // Shared with WorkspaceMetricsDAO via SpanMetricsQueries; per-project aggregation fixes a single project_id, which
+    // getMetric() selects with template.add("project_id", true).
+    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries.SPAN_FILTERED_PREFIX;
 
     private static final String THREAD_FILTERED_PREFIX = """
             WITH trace_threads_final AS (
@@ -1181,8 +1181,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
 
-    private static final String GET_PROJECT_TOKEN_USAGE_NAMES = SpanMetricsQueries
-            .tokenUsageNames("project_id = :project_id");
+    private static final String GET_PROJECT_TOKEN_USAGE_NAMES = SpanMetricsQueries.TOKEN_USAGE_NAMES;
 
     @Override
     public Mono<List<Entry>> getDuration(@NonNull UUID projectId, @NonNull ProjectMetricRequest request) {
@@ -1575,6 +1574,9 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             var template = getSTWithLogComment(query, PROJECT_METRIC_QUERY_NAME_PREFIX + segmentName, workspaceId,
                     userName, projectId.toString());
 
+            // Selects the single-project predicate in the shared SpanMetricsQueries CTE; project_id is bound below.
+            template.add("project_id", true);
+
             if (isTotal) {
                 template.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");
             } else {
@@ -1801,6 +1803,9 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
         return template.nonTransaction(connection -> {
             var stTemplate = getSTWithLogComment(GET_PROJECT_TOKEN_USAGE_NAMES, "getProjectTokenUsageNames",
                     workspaceId, "", projectId.toString());
+
+            // Selects the single-project predicate in the shared SpanMetricsQueries query; project_id is bound below.
+            stTemplate.add("project_id", true);
 
             var statement = connection.createStatement(stTemplate.render())
                     .bind("project_id", projectId)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -1660,17 +1660,19 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             }
 
             var statement = connection.createStatement(template.render())
-                    .bind("project_id", projectId)
                     .bind("uuid_from_time", request.uuidFromTime().toString())
                     .bind("workspace_id", workspaceId);
 
-            // Same hazard as OPIK-5678 above: only the span-based queries embed SpanMetricsQueries'
-            // shared CTE, which is the sole place `:project_ids` appears. The trace/thread prefixes
-            // use the scalar `:project_id` bound above, and binding a parameter their SQL doesn't
-            // declare raises NoSuchElementException from R2DBC. Per-project aggregation passes a set
-            // of one so the shared CTE keeps a single `IN` form for both callers.
+            // Same hazard as OPIK-5678 above, and it cuts both ways: R2DBC raises
+            // NoSuchElementException for any bind whose parameter the rendered SQL does not declare.
+            // The span-based queries embed SpanMetricsQueries' shared CTE, which binds the project as
+            // a set (`IN :project_ids`, a set of one here); every other query in this class uses the
+            // scalar `:project_id` from its trace/thread prefix. Neither placeholder appears in both,
+            // so each bind has to be gated on the metric type rather than applied unconditionally.
             if (SPAN_TIME_METRICS.contains(request.metricType())) {
                 statement.bind("project_ids", new UUID[]{projectId});
+            } else {
+                statement.bind("project_id", projectId);
             }
 
             // Bind uuid_to_time only if present

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
@@ -3,8 +3,8 @@ package com.comet.opik.domain;
 /**
  * Shared ClickHouse query fragments for span-based metrics. The span-filtering CTE (feedback-score dedup + span
  * filters) is identical for per-project ({@link ProjectMetricsDAO}) and workspace-level ({@link WorkspaceMetricsDAO})
- * aggregation; the only difference is the project predicate, which is injected via {@link #spanFilteredPrefix(String)}
- * so both DAOs stay in sync when the CTE changes.
+ * aggregation; the only difference is the project predicate, which each DAO selects by setting the matching
+ * StringTemplate flag, so both DAOs stay in sync when the CTE changes.
  * <p>
  * Each {@code id}-range bound on the {@code spans} scan carries a parallel {@code toMonday(id_at)} bound: a strict
  * consequence of the id-range that scans the same rows but engages weekly-partition pruning once {@code spans} is
@@ -15,9 +15,10 @@ final class SpanMetricsQueries {
     private SpanMetricsQueries() {
     }
 
-    // %s slots are the project predicate: "project_id = :project_id" (single project) or
-    // "project_id IN :project_ids" (a resolved set of projects). workspace_id is always bound separately.
-    private static final String SPAN_FILTERED_PREFIX_TEMPLATE = """
+    // The project predicate is a StringTemplate conditional, not a spliced string: callers set exactly one of
+    // `project_id` (single project, {@link ProjectMetricsDAO}) or `project_ids` (a resolved set, {@link
+    // WorkspaceMetricsDAO}) and bind the matching value. workspace_id is always bound separately.
+    static final String SPAN_FILTERED_PREFIX = """
             WITH feedback_scores_deduped AS (
                 SELECT workspace_id,
                        project_id,
@@ -39,7 +40,8 @@ final class SpanMetricsQueries {
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
-                      AND %s
+                      <if(project_id)> AND project_id = :project_id<endif>
+                      <if(project_ids)> AND project_id IN :project_ids<endif>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time<endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                     UNION ALL
@@ -54,7 +56,8 @@ final class SpanMetricsQueries {
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
-                      AND %s
+                      <if(project_id)> AND project_id = :project_id<endif>
+                      <if(project_ids)> AND project_id IN :project_ids<endif>
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time<endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                 )
@@ -121,7 +124,8 @@ final class SpanMetricsQueries {
                     LEFT JOIN fsc ON fsc.entity_id = spans.id
                     <endif>
                     WHERE workspace_id = :workspace_id
-                    AND %s
+                    <if(project_id)> AND project_id = :project_id<endif>
+                    <if(project_ids)> AND project_id IN :project_ids<endif>
                     <if(uuid_from_time)> AND id >= :uuid_from_time
                     AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
@@ -148,20 +152,18 @@ final class SpanMetricsQueries {
             )
             """;
 
-    static String spanFilteredPrefix(String projectPredicate) {
-        return SPAN_FILTERED_PREFIX_TEMPLATE.formatted(projectPredicate, projectPredicate, projectPredicate);
-    }
-
-    // Distinct span token-usage key names. The %s slot is the project predicate: "project_id = :project_id" (single
-    // project, {@link ProjectMetricsDAO}) or "project_id IN :project_ids" (a resolved set, {@link WorkspaceMetricsDAO});
-    // workspace_id is always bound separately. Shared so the two callers can't drift.
-    private static final String TOKEN_USAGE_NAMES_TEMPLATE = """
+    // Distinct span token-usage key names. The project predicate is a StringTemplate conditional, as in
+    // SPAN_FILTERED_PREFIX above: callers set exactly one of `project_id` (single project, {@link ProjectMetricsDAO})
+    // or `project_ids` (a resolved set, {@link WorkspaceMetricsDAO}) and bind the matching value; workspace_id is
+    // always bound separately. Shared so the two callers can't drift.
+    static final String TOKEN_USAGE_NAMES = """
             SELECT DISTINCT name
             FROM (
                 SELECT usage
                 FROM spans final
                 WHERE workspace_id = :workspace_id
-                AND %s
+                <if(project_id)> AND project_id = :project_id<endif>
+                <if(project_ids)> AND project_id IN :project_ids<endif>
             )
             ARRAY JOIN
                 mapKeys(usage) AS name,
@@ -169,8 +171,4 @@ final class SpanMetricsQueries {
             WHERE value > 0
             SETTINGS log_comment = '<log_comment>';
             """;
-
-    static String tokenUsageNames(String projectPredicate) {
-        return TOKEN_USAGE_NAMES_TEMPLATE.formatted(projectPredicate);
-    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
@@ -15,9 +15,9 @@ final class SpanMetricsQueries {
     private SpanMetricsQueries() {
     }
 
-    // The project predicate is a StringTemplate conditional, not a spliced string: callers set exactly one of
-    // `project_id` (single project, {@link ProjectMetricsDAO}) or `project_ids` (a resolved set, {@link
-    // WorkspaceMetricsDAO}) and bind the matching value. workspace_id is always bound separately.
+    // The project predicate is bound, not spliced: both callers bind `project_ids`, a per-project set of one
+    // ({@link ProjectMetricsDAO}) or a resolved set of many ({@link WorkspaceMetricsDAO}). The `IN` form covers
+    // both, so the query text stays a constant with no conditional. workspace_id is always bound separately.
     static final String SPAN_FILTERED_PREFIX = """
             WITH feedback_scores_deduped AS (
                 SELECT workspace_id,
@@ -40,8 +40,7 @@ final class SpanMetricsQueries {
                     FROM feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
-                      <if(project_id)> AND project_id = :project_id<endif>
-                      <if(project_ids)> AND project_id IN :project_ids<endif>
+                      AND project_id IN :project_ids
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time<endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                     UNION ALL
@@ -56,8 +55,7 @@ final class SpanMetricsQueries {
                     FROM authored_feedback_scores
                     WHERE entity_type = 'span'
                       AND workspace_id = :workspace_id
-                      <if(project_id)> AND project_id = :project_id<endif>
-                      <if(project_ids)> AND project_id IN :project_ids<endif>
+                      AND project_id IN :project_ids
                       <if(uuid_from_time)> AND entity_id >= :uuid_from_time<endif>
                       <if(uuid_to_time)> AND entity_id \\<= :uuid_to_time<endif>
                 )
@@ -124,8 +122,7 @@ final class SpanMetricsQueries {
                     LEFT JOIN fsc ON fsc.entity_id = spans.id
                     <endif>
                     WHERE workspace_id = :workspace_id
-                    <if(project_id)> AND project_id = :project_id<endif>
-                    <if(project_ids)> AND project_id IN :project_ids<endif>
+                    AND project_id IN :project_ids
                     <if(uuid_from_time)> AND id >= :uuid_from_time
                     AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
@@ -152,18 +149,16 @@ final class SpanMetricsQueries {
             )
             """;
 
-    // Distinct span token-usage key names. The project predicate is a StringTemplate conditional, as in
-    // SPAN_FILTERED_PREFIX above: callers set exactly one of `project_id` (single project, {@link ProjectMetricsDAO})
-    // or `project_ids` (a resolved set, {@link WorkspaceMetricsDAO}) and bind the matching value; workspace_id is
-    // always bound separately. Shared so the two callers can't drift.
+    // Distinct span token-usage key names. The project predicate is bound as in SPAN_FILTERED_PREFIX above: both
+    // callers bind `project_ids`, a set of one ({@link ProjectMetricsDAO}) or many ({@link WorkspaceMetricsDAO});
+    // workspace_id is always bound separately. Shared so the two callers can't drift.
     static final String TOKEN_USAGE_NAMES = """
             SELECT DISTINCT name
             FROM (
                 SELECT usage
                 FROM spans final
                 WHERE workspace_id = :workspace_id
-                <if(project_id)> AND project_id = :project_id<endif>
-                <if(project_ids)> AND project_id IN :project_ids<endif>
+                AND project_id IN :project_ids
             )
             ARRAY JOIN
                 mapKeys(usage) AS name,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -47,6 +47,8 @@ import java.util.UUID;
 
 import static com.comet.opik.api.metrics.BreakdownQueryBuilder.getBreakdownGroupExpression;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
+import static com.comet.opik.domain.SpanMetricsQueries.SPAN_FILTERED_PREFIX;
+import static com.comet.opik.domain.SpanMetricsQueries.TOKEN_USAGE_NAMES;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.startSegment;
@@ -243,8 +245,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
     // projects: WorkspaceMetricsService resolves the "all projects" request into every project id up front, so the
     // predicate is always a bounded `project_id IN :project_ids` list that prunes on the spans primary key
     // (workspace_id, project_id, ...) — never an unconstrained workspace-wide scan.
-    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries.SPAN_FILTERED_PREFIX;
-
     // Span filtering is reused from ProjectMetricsDAO's SPAN_FILTERED_PREFIX (above), but the output is shaped in the
     // workspace-native style like GET_COSTS_DAILY: each row is a finished series {project_id, name, data}, where data is
     // a groupArray(tuple(bucket, value)). No breakdown => one series per usage key; with a provider/model breakdown =>
@@ -303,10 +303,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             GROUP BY group_name
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
-
-    // Distinct span token-usage key names across an explicit project set, all-time. Shares SpanMetricsQueries with
-    // ProjectMetricsDAO's per-project query; only the project predicate differs (a bounded project_id IN (...) list).
-    private static final String GET_WORKSPACE_TOKEN_USAGE_NAMES = SpanMetricsQueries.TOKEN_USAGE_NAMES;
 
     private static final String WORKSPACE_METRIC_QUERY_NAME_PREFIX = "WorkspaceMetrics_";
 
@@ -382,11 +378,8 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(projectIds),
                 "projectIds must be resolved before querying workspace token usage names");
         return template.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
-            var stTemplate = getSTWithLogComment(GET_WORKSPACE_TOKEN_USAGE_NAMES,
+            var stTemplate = getSTWithLogComment(TOKEN_USAGE_NAMES,
                     WORKSPACE_METRIC_QUERY_NAME_PREFIX + "tokenUsageNames", workspaceId, userName, projectIds.size());
-
-            // Selects the project-set predicate in the shared SpanMetricsQueries query; project_ids is bound below.
-            stTemplate.add("project_ids", true);
 
             var statement = connection.createStatement(stTemplate.render())
                     .bind("workspace_id", workspaceId)
@@ -413,9 +406,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
 
             var stTemplate = getSTWithLogComment(query, WORKSPACE_METRIC_QUERY_NAME_PREFIX + segmentName, workspaceId,
                     userName, request.projectIds().size());
-
-            // Selects the project-set predicate in the shared SpanMetricsQueries CTE; project_ids is bound below.
-            stTemplate.add("project_ids", true);
 
             if (isTotal) {
                 stTemplate.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -243,8 +243,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
     // projects: WorkspaceMetricsService resolves the "all projects" request into every project id up front, so the
     // predicate is always a bounded `project_id IN :project_ids` list that prunes on the spans primary key
     // (workspace_id, project_id, ...) — never an unconstrained workspace-wide scan.
-    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries
-            .spanFilteredPrefix("project_id IN :project_ids");
+    private static final String SPAN_FILTERED_PREFIX = SpanMetricsQueries.SPAN_FILTERED_PREFIX;
 
     // Span filtering is reused from ProjectMetricsDAO's SPAN_FILTERED_PREFIX (above), but the output is shaped in the
     // workspace-native style like GET_COSTS_DAILY: each row is a finished series {project_id, name, data}, where data is
@@ -307,8 +306,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
 
     // Distinct span token-usage key names across an explicit project set, all-time. Shares SpanMetricsQueries with
     // ProjectMetricsDAO's per-project query; only the project predicate differs (a bounded project_id IN (...) list).
-    private static final String GET_WORKSPACE_TOKEN_USAGE_NAMES = SpanMetricsQueries
-            .tokenUsageNames("project_id IN :project_ids");
+    private static final String GET_WORKSPACE_TOKEN_USAGE_NAMES = SpanMetricsQueries.TOKEN_USAGE_NAMES;
 
     private static final String WORKSPACE_METRIC_QUERY_NAME_PREFIX = "WorkspaceMetrics_";
 
@@ -387,6 +385,9 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             var stTemplate = getSTWithLogComment(GET_WORKSPACE_TOKEN_USAGE_NAMES,
                     WORKSPACE_METRIC_QUERY_NAME_PREFIX + "tokenUsageNames", workspaceId, userName, projectIds.size());
 
+            // Selects the project-set predicate in the shared SpanMetricsQueries query; project_ids is bound below.
+            stTemplate.add("project_ids", true);
+
             var statement = connection.createStatement(stTemplate.render())
                     .bind("workspace_id", workspaceId)
                     .bind("project_ids", projectIds.toArray(new UUID[0]));
@@ -412,6 +413,9 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
 
             var stTemplate = getSTWithLogComment(query, WORKSPACE_METRIC_QUERY_NAME_PREFIX + segmentName, workspaceId,
                     userName, request.projectIds().size());
+
+            // Selects the project-set predicate in the shared SpanMetricsQueries CTE; project_ids is bound below.
+            stTemplate.add("project_ids", true);
 
             if (isTotal) {
                 stTemplate.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsResourceTest.java
@@ -2744,6 +2744,51 @@ class ProjectMetricsResourceTest {
                     .build(), marker, List.of("spans"), Integer.class, emptySpans, emptySpans, emptySpans);
         }
 
+        /**
+         * Guards the project predicate in {@link com.comet.opik.domain.SpanMetricsQueries}' shared span-filtering CTE,
+         * which is selected by a StringTemplate {@code <if(project_id)>} flag rather than spliced into the query text.
+         * An unset flag renders the conditional as empty and only logs a warning, so a render path that forgets to set
+         * it would silently drop the predicate and aggregate every project in the workspace.
+         * <p>
+         * Seeding a second project in the SAME workspace with a different span count is what makes that visible: with
+         * the predicate present the counts below are returned as-is, and without it every bucket would also include the
+         * other project's spans.
+         */
+        @ParameterizedTest
+        @EnumSource(value = TimeInterval.class, names = "TOTAL", mode = EnumSource.Mode.EXCLUDE)
+        void spanCountExcludesOtherProjectsInTheSameWorkspace(TimeInterval interval) {
+            // setup
+            mockTargetWorkspace();
+
+            Instant marker = getIntervalStart(interval);
+
+            String projectName = RandomStringUtils.secure().nextAlphabetic(10);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+            String otherProjectName = RandomStringUtils.secure().nextAlphabetic(10);
+            projectResourceClient.createProject(otherProjectName, API_KEY, WORKSPACE_NAME);
+
+            var expected = List.of(3, 2, 1);
+            createSpansForCount(projectName, subtract(marker, TIME_BUCKET_3, interval), expected.getFirst());
+            createSpansForCount(projectName, subtract(marker, TIME_BUCKET_1, interval), expected.get(1));
+            createSpansForCount(projectName, marker, expected.getLast());
+
+            // Same buckets, different counts — so a dropped predicate changes every bucket, not just the total.
+            createSpansForCount(otherProjectName, subtract(marker, TIME_BUCKET_3, interval), 7);
+            createSpansForCount(otherProjectName, subtract(marker, TIME_BUCKET_1, interval), 5);
+            createSpansForCount(otherProjectName, marker, 4);
+
+            getMetricsAndAssert(projectId, ProjectMetricRequest.builder()
+                    .metricType(MetricType.SPAN_COUNT)
+                    .interval(interval)
+                    .intervalStart(subtract(marker, TIME_BUCKET_4, interval))
+                    .intervalEnd(Instant.now())
+                    .build(), marker, List.of("spans"), Integer.class,
+                    Map.of("spans", expected.getFirst()),
+                    Map.of("spans", expected.get(1)),
+                    Map.of("spans", expected.getLast()));
+        }
+
         private List<Span> createSpansForCount(String projectName, Instant marker, int count) {
             List<Span> spans = IntStream.range(0, count)
                     .mapToObj(i -> {
@@ -3023,6 +3068,45 @@ class ProjectMetricsResourceTest {
             var usageMinus3 = createSpansWithTokenUsage(projectName, subtract(marker, TIME_BUCKET_3, interval), names);
             var usageMinus1 = createSpansWithTokenUsage(projectName, subtract(marker, TIME_BUCKET_1, interval), names);
             var usage = createSpansWithTokenUsage(projectName, marker, names);
+
+            getMetricsAndAssert(projectId, ProjectMetricRequest.builder()
+                    .metricType(MetricType.SPAN_TOKEN_USAGE)
+                    .interval(interval)
+                    .intervalStart(subtract(marker, TIME_BUCKET_4, interval))
+                    .intervalEnd(Instant.now())
+                    .build(), marker, names, Long.class, usageMinus3, usageMinus1, usage);
+        }
+
+        /**
+         * Token-usage counterpart to
+         * {@code SpanCountTest#spanCountExcludesOtherProjectsInTheSameWorkspace}, covering the second template whose
+         * project predicate became a StringTemplate conditional. The other project uses DISTINCT usage key names, so a
+         * dropped predicate would surface extra series rather than only inflating the existing ones — and
+         * {@code getMetricsAndAssert} compares the full result set, so either failure mode trips it.
+         */
+        @ParameterizedTest
+        @EnumSource(value = TimeInterval.class, names = "TOTAL", mode = EnumSource.Mode.EXCLUDE)
+        void spanTokenUsageExcludesOtherProjectsInTheSameWorkspace(TimeInterval interval) {
+            // setup
+            mockTargetWorkspace();
+
+            Instant marker = getIntervalStart(interval);
+
+            String projectName = RandomStringUtils.secure().nextAlphabetic(10);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+            List<String> names = PodamFactoryUtils.manufacturePojoList(factory, String.class);
+
+            String otherProjectName = RandomStringUtils.secure().nextAlphabetic(10);
+            projectResourceClient.createProject(otherProjectName, API_KEY, WORKSPACE_NAME);
+            List<String> otherNames = names.stream().map(name -> "other_" + name).toList();
+
+            var usageMinus3 = createSpansWithTokenUsage(projectName, subtract(marker, TIME_BUCKET_3, interval), names);
+            var usageMinus1 = createSpansWithTokenUsage(projectName, subtract(marker, TIME_BUCKET_1, interval), names);
+            var usage = createSpansWithTokenUsage(projectName, marker, names);
+
+            createSpansWithTokenUsage(otherProjectName, subtract(marker, TIME_BUCKET_3, interval), otherNames);
+            createSpansWithTokenUsage(otherProjectName, subtract(marker, TIME_BUCKET_1, interval), otherNames);
+            createSpansWithTokenUsage(otherProjectName, marker, otherNames);
 
             getMetricsAndAssert(projectId, ProjectMetricRequest.builder()
                     .metricType(MetricType.SPAN_TOKEN_USAGE)

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -923,26 +923,34 @@ class TracesLocalV2CutoverTest {
 
     /** Stored (physically materialized) columns of a table — excludes {@code MATERIALIZED} / {@code ALIAS} columns. */
     private Set<String> baseColumns(String table) {
-        return columnNames(table, "default_kind NOT IN ('MATERIALIZED', 'ALIAS')");
+        return columnNames(table, false, "MATERIALIZED", "ALIAS");
     }
 
     /** MATERIALIZED (recomputed, not stored-from-insert) columns of a table. */
     private Set<String> materializedColumns(String table) {
-        return columnNames(table, "default_kind = 'MATERIALIZED'");
+        return columnNames(table, true, "MATERIALIZED");
     }
 
-    /** Column names of a table filtered by a {@code system.columns} predicate. */
-    private Set<String> columnNames(String table, String defaultKindPredicate) {
+    /**
+     * Column names of a table whose {@code default_kind} is in (or, when {@code include} is false, not in) the given
+     * kinds. The kinds are bound rather than spliced, so the query text stays a constant.
+     */
+    private Set<String> columnNames(String table, boolean include, String... defaultKinds) {
         var sql = """
                 SELECT name
                 FROM system.columns
                 WHERE database = :db
                   AND table = :t
-                  AND %s
-                """.formatted(defaultKindPredicate);
-        return template.stream(connection -> Flux.from(connection.createStatement(sql)
+                  <if(include)> AND default_kind IN :default_kinds<endif>
+                  <if(exclude)> AND default_kind NOT IN :default_kinds<endif>
+                """;
+        var stTemplate = TemplateUtils.newST(sql);
+        stTemplate.add(include ? "include" : "exclude", true);
+        var rendered = stTemplate.render();
+        return template.stream(connection -> Flux.from(connection.createStatement(rendered)
                 .bind("db", DATABASE_NAME)
                 .bind("t", table)
+                .bind("default_kinds", defaultKinds)
                 .execute())
                 .flatMap(result -> result.map((row, ignored) -> row.get("name", String.class))))
                 .collectList().block().stream().collect(Collectors.toUnmodifiableSet());

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -923,34 +923,26 @@ class TracesLocalV2CutoverTest {
 
     /** Stored (physically materialized) columns of a table — excludes {@code MATERIALIZED} / {@code ALIAS} columns. */
     private Set<String> baseColumns(String table) {
-        return columnNames(table, false, "MATERIALIZED", "ALIAS");
+        return columnNames(table, "default_kind NOT IN ('MATERIALIZED', 'ALIAS')");
     }
 
     /** MATERIALIZED (recomputed, not stored-from-insert) columns of a table. */
     private Set<String> materializedColumns(String table) {
-        return columnNames(table, true, "MATERIALIZED");
+        return columnNames(table, "default_kind = 'MATERIALIZED'");
     }
 
-    /**
-     * Column names of a table whose {@code default_kind} is in (or, when {@code include} is false, not in) the given
-     * kinds. The kinds are bound rather than spliced, so the query text stays a constant.
-     */
-    private Set<String> columnNames(String table, boolean include, String... defaultKinds) {
+    /** Column names of a table filtered by a {@code system.columns} predicate. */
+    private Set<String> columnNames(String table, String defaultKindPredicate) {
         var sql = """
                 SELECT name
                 FROM system.columns
                 WHERE database = :db
                   AND table = :t
-                  <if(include)> AND default_kind IN :default_kinds<endif>
-                  <if(exclude)> AND default_kind NOT IN :default_kinds<endif>
-                """;
-        var stTemplate = TemplateUtils.newST(sql);
-        stTemplate.add(include ? "include" : "exclude", true);
-        var rendered = stTemplate.render();
-        return template.stream(connection -> Flux.from(connection.createStatement(rendered)
+                  AND %s
+                """.formatted(defaultKindPredicate);
+        return template.stream(connection -> Flux.from(connection.createStatement(sql)
                 .bind("db", DATABASE_NAME)
                 .bind("t", table)
-                .bind("default_kinds", defaultKinds)
                 .execute())
                 .flatMap(result -> result.map((row, ignored) -> row.get("name", String.class))))
                 .collectList().block().stream().collect(Collectors.toUnmodifiableSet());

--- a/scripts/precommit-hook-descriptions.tsv
+++ b/scripts/precommit-hook-descriptions.tsv
@@ -29,6 +29,7 @@ helm-docs	Regenerate Helm chart README
 actionlint	Lint GitHub Actions workflows
 zizmor	Security-scan GitHub Actions workflows
 hadolint	Lint Dockerfiles
+semgrep	Block SQL injection-prone string formatting
 spotless	Format Java code
 eslint	Lint + autofix JS/TS
 typecheck	Whole-project tsc type check


### PR DESCRIPTION
## Details

<img width="929" height="1565" alt="image" src="https://github.com/user-attachments/assets/06bb226e-8e0c-469c-8217-1024e2ffbbf3" />

Adds semgrep to `.pre-commit-config.yaml` with a single in-repo rule that fails when a Java SQL literal carries a `%s` format slot in a clause position, and converts the two existing violations so the gate lands green with no baseline and no suppressions. A PR review asked for this rule to be enforced automatically rather than relying on reviewers noticing; documentation and AI review are advisory, so a violation from any author could still merge.

- **Matches the query declaration, not the call site.** Opik holds SQL in `static final` text blocks rendered through StringTemplate and handed to `connection.createStatement(template.render())`, so the literal and the execution are connected only through a template object — call-site patterns match nothing. `pattern: $X` plus a `metavariable-regex` inspects the literal's own contents, text blocks included.
- **Two tiers, so pre-existing code is reported rather than blocking.** Covering every statement type and every slot position surfaces **108 findings in production code** that predate this gate. Blocking on all of them would stall the gate or need a baseline file, so the rule splits: `sql-query-clause-splice` (**ERROR**, blocks CI) matches only the injection-shaped form — a `%s` standing in for a whole clause, where caller data reaches the query text — and currently has **0 findings**; `sql-query-format-slot` (**WARNING**, reports only) matches any other `%s` in a SQL literal and currently has **108**, tracked as tech debt in OPIK_7727. The hook passes `--severity ERROR`, so only the blocking tier can fail a commit or a CI leg.
- **Both tiers cover INSERT/UPDATE/DELETE and DDL**, not just `SELECT`/`WITH` — a spliced predicate in an `UPDATE` is as injectable as one in a `SELECT`, and it mutates rather than reads.
- **Production sources only.** String formatting in a test fixture is building a fixture, not accepting user input, so `files:` is scoped to `src/main/java`.
- **Fixtures pin all of it.** `.semgrep/java-sql-string-formatting.java` asserts each must-flag and must-not-flag case with semgrep's own annotations, runnable via `semgrep test`. Every negative case in there matched at some point during development, so the file is the regression contract for future regex edits.
- **`%d` is deliberately not matched** — `MetadataDAO` contains the real SQL literal `STR_TO_DATE(value, '%Y-%m-%d')`, which pattern matching cannot distinguish from an integer slot. No real violation uses `%d`.
- **The fixes.** `SpanMetricsQueries`' 3+1 `%s` project-predicate slots become a single unconditional `AND project_id IN :project_ids`. Both callers bind `project_ids` — a set of one for per-project aggregation, a resolved set for workspace-level — so the query text is a constant with no conditional at all. Both helper methods and the `String projectPredicate` parameters are gone.
- **The bind is guarded, and this is the sharp edge.** `getMetric` renders ~37 queries, but only the 11 `GET_SPAN_*` ones embed the shared CTE where `:project_ids` appears. Binding it unconditionally raises `NoSuchElementException` from R2DBC on every trace and thread query — the same failure OPIK_5678 hit in this exact method. The bind is therefore guarded by `SPAN_TIME_METRICS`, which maps exactly onto those 11 constants. Compilation does not catch this: R2DBC resolves binds by name at execution.

Because `.pre-commit-config.yaml` is the single source of truth that `code_quality.yml` builds its CI matrix from, adding the hook makes CI fail on new violations with no workflow change. The hook is `language: python`, so the pre-commit framework provisions semgrep and contributors need no local install.

Known limitation, documented in the rule file: a query written entirely on one line is not caught, because the `SELECT`/`WITH` and `FROM` requirements are line-anchored. Dropping those anchors was measured and reintroduces the prompt-template false positive, which is the worse failure — it would block an unrelated commit and push a suppression comment into a file with no SQL in it. Every real query in this codebase is a multi-line text block.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7725

Deferred to follow-ups, deliberately out of scope here so neither blocks this gate: the `+` concatenation form (a prototype rule produced 118 findings, all false positives — OPIK_7726) and the constant-splice `%s` sites in the metrics DAOs and ClickHouse health checks (OPIK_7727).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation — semgrep rule authoring and empirical scoping, pre-commit wiring, the `SpanMetricsQueries` conversion, and verification
- Human verification: code review + reviewed measurement output for each claim below

## Testing

Semgrep rules, run as the pinned `semgrep==1.172.0` the way the hook runs them — explicit filenames via `git ls-files`, not a directory:

- **Blocking tier: 0 findings across all 1,259 production Java files.** No baseline file, no suppression comments.
- **Reporting tier: 108 findings**, visible but non-blocking. These are the pre-existing occurrences the review asked to surface rather than block; tracked as tech debt in OPIK_7727.
- Verified the rollout actually behaves that way: `pre-commit run semgrep --files ProjectMetricsDAO.java` **passes**, on a file carrying 99 reporting-tier findings.

  > **Note on how coverage is measured.** An earlier revision of this PR claimed "0 findings across 1,296 files (main + test)". That was wrong. Semgrep's built-in semgrepignore excludes `test`/`tests` directories at any depth, so passing a test directory scans zero files while still reporting a reassuring "0 findings". The pre-commit hook passes explicit **filenames**, which bypasses that exclusion. The trap is documented in the rule file so the next person measures the way the hook runs. (Test sources are now out of scope entirely, per review, but the measurement lesson stands for the production tree.)

- Rule fixtures: `semgrep test --config .semgrep/java-sql-string-formatting.yaml .semgrep/java-sql-string-formatting.java` — **2/2 rules, all assertions pass**. Each case is asserted against both rules independently, so a clause splice must be caught by both while a projection must be caught only by the reporting one. The fixture file sits outside the hook's `files:` scope, so its deliberate violations can't fail CI — verified via `precommit-detect-hooks.py`.
- CI matrix routing: a changed production `.java` file emits the `semgrep` leg with `toolchain: none`; a changed **test** file emits no semgrep leg (only spotless), confirming the narrowed scope.

Backend build and tests, on JDK 25:

- `mvn compile -DskipTests` and spotless — pass, spotless reformatted nothing.
- `ProjectMetricsResourceTest$SpanCountTest` — passes against the new bind contract (3 cases, confirmed per-case in the surefire XML).
- **Not verified locally: the trace/thread path.** This is the one that matters most, because `getMetric` binds `project_ids` only for span metrics — an unguarded bind would raise `NoSuchElementException` on every trace and thread query. The guard is derived from `SPAN_TIME_METRICS`, which was checked to map exactly onto the 11 `GET_SPAN_*` constants that embed the shared CTE, but Testcontainers failed to start ClickHouse on roughly half the local attempts on this machine, so `NumberOfTracesTest` was left to CI rather than probed serially. If trace metrics go red in CI, that is this change, not a flake.

## Documentation

The `CONTRIBUTING.md` section added earlier was trimmed to a two-line pointer, per review: the conventions this gate enforces are already documented in `.agents/rules/security.mdc` and the backend skill, so restating them in the contribution guide was duplication. Rationale for the rules' scoping decisions — including why `%d` is excluded and how to measure coverage correctly — lives in comments in the rule file itself.
