### PR TITLE
[NA] [INFRA] fix: pass github.actor via env in qa_coverage_reconcile (zizmor template-injection)

### DIFF
--- a/.github/workflows/qa_coverage_reconcile.yml
+++ b/.github/workflows/qa_coverage_reconcile.yml
@@ -103,10 +103,12 @@ jobs:
 
       - name: Commit
         if: steps.check_changes.outputs.has_changes == 'true'
+        env:
+          ACTOR: ${{ github.actor }}
         run: |
           set -ex
           git config --local user.email "github-actions@comet.com"
-          git config --local user.name "Github Actions (${{ github.actor }})"
+          git config --local user.name "Github Actions (${ACTOR})"
           git add tests_end_to_end/coverage/taxonomy.yaml
           git commit -m "[OPIK-7532] [QA] chore: reconcile coverage taxonomy with spec tags"
 


### PR DESCRIPTION
## Details

<img width="1024" height="1395" alt="image" src="https://github.com/user-attachments/assets/744427c3-fe9e-4bd3-aea8-f041ffa92a1b" />

Fixes the single high-severity zizmor `template-injection` finding in `.github/workflows/qa_coverage_reconcile.yml`.

`${{ github.actor }}` interpolated directly into a `run:` block is expanded into the script *text* before the shell ever sees it, so an attacker-controlled actor name can inject shell code. Passing it through `env:` makes it an ordinary shell variable instead:

```yaml
      - name: Commit
        if: steps.check_changes.outputs.has_changes == 'true'
        env:
          ACTOR: ${{ github.actor }}
        run: |
          set -ex
          git config --local user.email "github-actions@comet.com"
          git config --local user.name "Github Actions (${ACTOR})"
```

This matches the pattern already used in `sdks_generate_openapi_spec_and_fern_code.yml`.

### Why this surfaced now

The violation is **pre-existing and unrelated to any current work** — it landed with PR #7678 on 2026-07-30, five days *before* the zizmor hook itself landed (PR #7546, 2026-08-04). I confirmed there is no zizmor check-run at all on #7678's merge commit, and `.pre-commit-config.yaml` at that commit contains no `zizmor` entry.

`actionlint` would never have caught it either, and that's by design — per the config comment, actionlint asks "will this YAML run?" while zizmor asks "if it runs, can it be exploited?". The expression is perfectly valid YAML that runs fine; it's only a *security* problem.

Because the hook lints only *changed files*, nothing tripped it until dependabot's `setup-node` bump (#7740) touched this file — which is what turned that PR's zizmor leg red.

### Scope

Workflows-side, this was the only high finding; `.github/workflows/**` now reports **0**. A repo-wide sweep including `.github/actions/**` found 9 further high findings in two composite actions, which are untouched here and filed as OPIK-7754 (escalation for OPIK_6366). Verified as not already covered by OPIK_7413, OPIK_7720, or OPIK_6669.

## Change checklist

- [x] Single-file, behavior-preserving change — the resulting git author name is byte-identical
- [x] Follows an existing in-repo pattern rather than inventing one
- [x] No new dependencies, no config/rule changes; the gate stays strict

## Issues

N/A — no ticket; drive-by CI-gate unblock. Follow-up work tracked in OPIK-7754.

## Testing

Ran both affected gates locally exactly as CI invokes them:

```
uvx pre-commit run zizmor    --files .github/workflows/qa_coverage_reconcile.yml   → Passed
uvx pre-commit run actionlint --files .github/workflows/qa_coverage_reconcile.yml  → Passed
```

Repo-wide, at the gate's own severity:

```
zizmor --offline --min-severity high --persona regular --no-progress .github/workflows/
→ 0 high   (was 1)
```

No runtime behavior change: `git config --local user.name` receives the same string as before, so the reconcile job's commits are unaffected.

## Documentation

None needed — no user-facing or developer-facing surface changes.