### PR TITLE
[OPIK-7685] [BE] Align TestContainers ClickHouse config with compose/Helm cluster definition

### DIFF
--- a/apps/opik-backend/src/test/resources/clickhouse.xml
+++ b/apps/opik-backend/src/test/resources/clickhouse.xml
@@ -26,6 +26,7 @@
     <remote_servers>
         <cluster>
         <shard>
+            <internal_replication>true</internal_replication>
             <replica>
             <host>clickhouse</host>
             <port>9000</port>


### PR DESCRIPTION
## Summary

Align the TestContainers ClickHouse test configuration with Helm and Docker Compose definitions by adding `<internal_replication>true</internal_replication>` to the `remote_servers` shard.

This ensures all three cluster definitions (Helm, Docker Compose, TestContainers) agree on the `internal_replication` setting, as required by the review comment in PR #7675.

## Details

The ClickHouse cluster is currently defined in three places:
1. **Helm** — `deployment/helm_chart/opik/templates/clickhouseinstallation.yaml`: sets `layout.shards[].internalReplication: true`
2. **Docker Compose** — `deployment/docker-compose/clickhouse_config/additional_config.xml`: includes `<internal_replication>true</internal_replication>`
3. **TestContainers** — `apps/opik-backend/src/test/resources/clickhouse.xml`: was missing the `internal_replication` setting

This PR brings the TestContainers configuration into alignment with the other two. The file header correctly states it "Mirrors deployment/docker-compose/clickhouse_config/additional_config.xml", so this fix makes that claim accurate.

The change is functionally inert in tests since the container is a single node with one replica, and `internal_replication` only affects how Distributed tables route inserts across replicas within a shard. However, keeping configurations consistent prevents future confusion and ensures the test environment accurately represents the production setup.

## Change checklist

- [x] Code changes are complete and tested
- [x] Backend test suite passes (HealthCheckIntegrationTest: 11 tests, 0 failures)
- [x] No breaking changes introduced
- [x] Change is minimal and focused on the stated objective

## Issues

Closes #OPIK-7685

Related to:
- Parent epic: OPIK-6874
- Original PR review: https://github.com/comet-ml/opik/pull/7675#discussion_r3688895810
- Follow-up documentation: PR #7752 (OPIK-7687)

## Documentation

No documentation changes required in this PR. Scope clarification is handled in OPIK-7687.