### PR TITLE
[NA] [DOCS] docs: add cipx/Cost Intelligence OSS comment hygiene rule

### DIFF
--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -175,7 +175,7 @@ Follow `.agents/rules/oss-comment-hygiene.mdc`.
 
 No match on text **and** enclosing identity → **continue silently**. Do not judge, trim, or mention ordinary Opik comments.
 
-**When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, agent/client/proxy wire-path essays (any coding agent or IDE client), private-repo links, sister-service billing narratives. Reference pattern: verbose `cipx_*` comments on `comet-ml/opik#7725`. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
+**When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, agent/client/proxy wire-path essays (any coding agent or IDE client), private-repo links, sister-service billing narratives. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
 
 ---
 

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -175,7 +175,7 @@ Follow `.agents/rules/oss-comment-hygiene.mdc`.
 
 No match on text **and** enclosing identity → **continue silently**. Do not judge, trim, or mention ordinary Opik comments.
 
-**When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, Claude Code / proxy wire-path essays, private-repo links, sister-service billing narratives. Reference pattern: verbose `cipx_*` comments on `comet-ml/opik#7725`. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
+**When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, agent/client/proxy wire-path essays (any coding agent or IDE client), private-repo links, sister-service billing narratives. Reference pattern: verbose `cipx_*` comments on `comet-ml/opik#7725`. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
 
 ---
 

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -168,14 +168,12 @@ This workflow will:
 
 Follow `.agents/rules/oss-comment-hygiene.mdc`.
 
-**Gate first.** Scan `git diff origin/main...HEAD` for **added or expanded** comments (`//`, `/* */`, `#`, `--`, docstrings/Javadocs). The rule applies **only** if the comment text (or a clear compound in it) matches one of these private-project namings (case-insensitive):
+**Gate first.** Scan `git diff origin/main...HEAD` for **added or expanded** comments (`//`, `/* */`, `#`, `--`, docstrings/Javadocs). The rule applies if **either**:
 
-- `cipx`
-- `cost intelligence` / `cost-intelligence` / `CostIntelligence`
-- `ai-cost` / `ai-spend` / `AI-Spend`
-- `cost-intelligence-proxy` (incl. `-internal`)
+1. **Comment text** matches a private-project naming (case-insensitive): `cipx`, `cost intelligence` / `cost-intelligence` / `CostIntelligence`, `ai-cost` / `ai-spend` / `AI-Spend`, `cost-intelligence-proxy` (incl. `-internal`), **or**
+2. **Enclosing identity** matches those namings — file path/name, type/class, method, field, parameter, or local variable (e.g. comment inside `CipxSpendDAO` / on `getCipxSpend` / next to a `cipxSpan` param), even when the comment text has no keyword
 
-No match anywhere in added/expanded comments → **continue silently**. Do not judge, trim, or mention ordinary Opik comments.
+No match on text **and** enclosing identity → **continue silently**. Do not judge, trim, or mention ordinary Opik comments.
 
 **When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, Claude Code / proxy wire-path essays, private-repo links, sister-service billing narratives. Reference pattern: verbose `cipx_*` comments on `comet-ml/opik#7725`. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
 

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -14,6 +14,7 @@ This workflow will:
 - Extract branch ticket key (`OPIK-<number>`, `issue-<number>`, or `NA`)
 - Check for pending changes and remote branch status
 - Run quality checks to ensure code quality
+- Flag verbose cipx / Cost Intelligence / ai-cost comments only (see `.agents/rules/oss-comment-hygiene.mdc`)
 - Pre-fill PR template with extracted information
 - Validate PR title and description against pr-lint rules before submission
 - Create GitHub draft PR using GitHub CLI (fallback to GitHub MCP only when CLI is unavailable)
@@ -160,6 +161,23 @@ This workflow will:
 - **Check feature toggles**: Specifically analyze configuration files for added/removed feature toggles
 - **Extract commit history**: Review commit messages for context
 - **Generate summary**: Create meaningful description of what was implemented
+
+---
+
+### 6b. OSS Comment Hygiene — cipx / Cost Intelligence only (attention)
+
+Follow `.agents/rules/oss-comment-hygiene.mdc`.
+
+**Gate first.** Scan `git diff origin/main...HEAD` for **added or expanded** comments (`//`, `/* */`, `#`, `--`, docstrings/Javadocs). The rule applies **only** if the comment text (or a clear compound in it) matches one of these private-project namings (case-insensitive):
+
+- `cipx`
+- `cost intelligence` / `cost-intelligence` / `CostIntelligence`
+- `ai-cost` / `ai-spend` / `AI-Spend`
+- `cost-intelligence-proxy` (incl. `-internal`)
+
+No match anywhere in added/expanded comments → **continue silently**. Do not judge, trim, or mention ordinary Opik comments.
+
+**When the gate matches:** flag comments that are more than minimal for public Opik — private pricing, prod stats, Claude Code / proxy wire-path essays, private-repo links, sister-service billing narratives. Reference pattern: verbose `cipx_*` comments on `comet-ml/opik#7725`. Show file paths / hunks; continue. Do not block. Do not rewrite unless asked.
 
 ---
 

--- a/.agents/rules/oss-comment-hygiene.mdc
+++ b/.agents/rules/oss-comment-hygiene.mdc
@@ -1,21 +1,26 @@
 ---
-description: Keep cipx / Cost Intelligence / ai-cost comments minimal in Opik OSS. Use when creating or reviewing PRs that touch those names, or when running create-pr. Does not apply to ordinary Opik comments.
+description: Keep cipx / Cost Intelligence / ai-cost comments minimal in Opik OSS. Use when creating or reviewing PRs that touch those names (in comment text or enclosing identifiers), or when running create-pr. Does not apply to ordinary Opik comments.
 alwaysApply: false
 ---
 # OSS Comment Hygiene — cipx / Cost Intelligence only
 
 Opik is public OSS. Comments that document the private **cipx / Cost Intelligence / ai-cost** stack must stay minimal. This rule does **not** apply to ordinary Opik comments.
 
-## When this rule applies (gate)
+## Name patterns (case-insensitive)
 
-Apply **only** when a new or expanded comment (or the PR description text about the change) mentions one of these private-project namings (case-insensitive), including compounds:
-
-- `cipx` (e.g. `cipx_spends`, `CipxSpend`, `metadata.cipx`)
+- `cipx` (e.g. `cipx_spends`, `CipxSpend`, `CipxSpendDAO`, `metadata.cipx`)
 - `cost intelligence` / `cost-intelligence` / `CostIntelligence`
 - `ai-cost` / `ai-spend` / `AI-Spend`
 - `cost-intelligence-proxy` / `cost-intelligence-proxy-internal`
 
-No match → **do nothing**. Do not ask to trim unrelated Opik comments.
+## When this rule applies (gate)
+
+Apply when a **new or expanded** comment is in scope because **either**:
+
+1. **Comment text** mentions a name pattern above, **or**
+2. **Enclosing identity** matches a name pattern — file path/name, type/class, method, field, parameter, or local variable (e.g. a Javadoc on a field inside `CipxSpendDAO`, or a `//` above `getCipxSpend(...)`, even if the comment itself has no keyword)
+
+No match on text **and** enclosing identity → **do nothing**. Do not ask to trim unrelated Opik comments.
 
 ## What “minimal” means when the gate matches
 

--- a/.agents/rules/oss-comment-hygiene.mdc
+++ b/.agents/rules/oss-comment-hygiene.mdc
@@ -1,0 +1,28 @@
+---
+description: Keep cipx / Cost Intelligence / ai-cost comments minimal in Opik OSS. Use when creating or reviewing PRs that touch those names, or when running create-pr. Does not apply to ordinary Opik comments.
+alwaysApply: false
+---
+# OSS Comment Hygiene — cipx / Cost Intelligence only
+
+Opik is public OSS. Comments that document the private **cipx / Cost Intelligence / ai-cost** stack must stay minimal. This rule does **not** apply to ordinary Opik comments.
+
+## When this rule applies (gate)
+
+Apply **only** when a new or expanded comment (or the PR description text about the change) mentions one of these private-project namings (case-insensitive), including compounds:
+
+- `cipx` (e.g. `cipx_spends`, `CipxSpend`, `metadata.cipx`)
+- `cost intelligence` / `cost-intelligence` / `CostIntelligence`
+- `ai-cost` / `ai-spend` / `AI-Spend`
+- `cost-intelligence-proxy` / `cost-intelligence-proxy-internal`
+
+No match → **do nothing**. Do not ask to trim unrelated Opik comments.
+
+## What “minimal” means when the gate matches
+
+Flag (attention only) if the comment goes beyond what the public Opik code needs — e.g. private pricing tables, prod traffic stats, Claude Code / proxy wire-path narratives, private-repo cross-links, or how sister services bill. Prefer a short public fact (`speed` from `cipx.call.config`; `''` = default) over a private-product essay.
+
+Canonical bad pattern: long migration/DAO comments like those reviewed on `comet-ml/opik#7725` (fast-mode / `cipx_*` persistence).
+
+## Attention only
+
+Warn the author before merge. Do not block. Do not rewrite unless asked.

--- a/.agents/rules/oss-comment-hygiene.mdc
+++ b/.agents/rules/oss-comment-hygiene.mdc
@@ -26,8 +26,6 @@ No match on text **and** enclosing identity → **do nothing**. Do not ask to tr
 
 Flag (attention only) if the comment goes beyond what the public Opik code needs — e.g. private pricing tables, prod traffic stats, agent/client/proxy wire-path narratives (any coding agent or IDE client), private-repo cross-links, or how sister services bill. Prefer a short public fact (`speed` from `cipx.call.config`; `''` = default) over a private-product essay.
 
-Canonical bad pattern: long migration/DAO comments like those reviewed on `comet-ml/opik#7725` (fast-mode / `cipx_*` persistence).
-
 ## Attention only
 
 Warn the author before merge. Do not block. Do not rewrite unless asked.

--- a/.agents/rules/oss-comment-hygiene.mdc
+++ b/.agents/rules/oss-comment-hygiene.mdc
@@ -24,7 +24,7 @@ No match on text **and** enclosing identity → **do nothing**. Do not ask to tr
 
 ## What “minimal” means when the gate matches
 
-Flag (attention only) if the comment goes beyond what the public Opik code needs — e.g. private pricing tables, prod traffic stats, Claude Code / proxy wire-path narratives, private-repo cross-links, or how sister services bill. Prefer a short public fact (`speed` from `cipx.call.config`; `''` = default) over a private-product essay.
+Flag (attention only) if the comment goes beyond what the public Opik code needs — e.g. private pricing tables, prod traffic stats, agent/client/proxy wire-path narratives (any coding agent or IDE client), private-repo cross-links, or how sister services bill. Prefer a short public fact (`speed` from `cipx.call.config`; `''` = default) over a private-product essay.
 
 Canonical bad pattern: long migration/DAO comments like those reviewed on `comet-ml/opik#7725` (fast-mode / `cipx_*` persistence).
 


### PR DESCRIPTION
## Details

Adds an agent rule and a create-pr attention step so comments about the cipx / Cost Intelligence / ai-cost stack stay minimal in this public repo. The check is name-gated: if added comments do not mention those identifiers, ordinary Opik comments are left alone. Attention only — no block, no auto-rewrite.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Cursor
- Model(s): Cursor Grok 4.5
- Scope: agent rule + create-pr step
- Human verification: author will review locally before merge

## Testing

N/A — documentation / agent-config only. Manual review of `.agents/rules/oss-comment-hygiene.mdc` and create-pr Step 6b.

## Documentation

N/A — agent guidance under `.agents/`, not product docs.


Made with [Cursor](https://cursor.com)