### PR TITLE
[OPIK-7771] [BE] perf: dedup trace-stats spans_data with FINAL

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -2232,13 +2232,11 @@ class TraceDAOImpl implements TraceDAO {
                     type,
                     workspace_id,
                     project_id
-                FROM spans
+                FROM spans FINAL
                 WHERE workspace_id = :workspace_id
                 AND project_id IN :project_ids
                 <if(uuid_from_time)> AND trace_id >= :uuid_from_time <endif>
                 <if(uuid_to_time)> AND trace_id \\<= :uuid_to_time <endif>
-                ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC
-                LIMIT 1 BY id
              ), spans_agg AS (
                 SELECT
                     trace_id,


### PR DESCRIPTION
## Details

`spans_data` in `SELECT_TRACES_SPANS_STATS` deduplicated spans with `ORDER BY (workspace_id, project_id, trace_id, parent_span_id, id) DESC, last_updated_at DESC` + `LIMIT 1 BY id`; because `id` is not the leading sort column ClickHouse cannot stream that, so it plans a full blocking sort of every span row in the requested projects and drags the wide `usage` map through it. This switches the CTE to `FROM spans FINAL`, which merges in sort-key order instead — exactly what the sibling `SELECT_FEEDBACK_SCORES_STATS` already does for the identical CTE.

- `EXPLAIN indexes=1` on a real production query shows `Sorting (Sorting for ORDER BY)` → `LimitBy` → `Aggregating` over the spans read, with no part pruning (`spans` is unpartitioned and the projects-list caller passes no time bound, so it is the whole project history).
- Both entrypoints render this template, so it covers `get_trace_stats_traces_spans` (single project) and `get_trace_stats_traces_spans_by_project_ids` (projects list).
- Behaviour note: `FINAL` dedups by the full sort key, `LIMIT 1 BY id` by `id` alone. They differ only for span ids that exist under two `parent_span_id` values (~1.8% of span ids over a 24h production window, concentrated in a minority of workspaces, caused by `SpanDAO`'s upsert falling through its key guard when the first write stored an empty parent). Verified against production, the only output field that changes is `span_count_avg`; `migrations/000115_create_spans_local_v2_table.sql` already drops `parent_span_id` from the sort key to remove the cause.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7771

<!-- No GitHub issue; found while profiling slow ClickHouse queries in production. Related but NOT resolved here: the projects-list span-score inversion shipped in #7684 under OPIK_7331, which fixes a different query (`get_trace_stats_feedback_scores`) in the same DAO. -->

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5 (`claude-opus-5`, 1M context)
  - Scope: Whole change authored by the agent — production query-log profiling and `EXPLAIN` analysis, the one-line SQL change, the local benchmark harness, the production A/B replay, and this PR description.
  - Human verification: The human directed the investigation, ruled on the `parent_span_id` divergence being a separate write-path bug rather than a blocker, and instructed the commit and PR. Test runs and benchmarks were executed and their output read by the agent. **The diff itself has not yet been reviewed line by line by a human — that review is still owed before merge.**

## Testing

Commands run, from `apps/opik-backend`:

- `mvn test -Dtest="ProjectsResourceTest,GetTracesByProjectResourceTest"` → **1864 tests, 0 failures, 0 errors**
- `mvn test -Dtest="ProjectsResourceTest,GetTracesByProjectResourceTest,GuardrailsResourceTest"` (earlier run, pre-merge) → 1864 pass
- `mvn spotless:check` → exit 0
- `mvn compile -DskipTests` → exit 0

Scenarios validated:

- **Coverage of the touched path.** `ProjectsResourceTest` covers the `has_legacy_scores` flip, the legacy `feedback_scores` UNION path and the `source` filter this query actually carries in production; `GetTracesByProjectResourceTest` + `GuardrailsResourceTest` cover the shared single-project stats path (`guardrails_agg`, annotation queues, feedback-score filters).
- **Production A/B.** Real queries captured from `system.query_log` and replayed unmodified against their own workspaces (several distinct workspaces, both entrypoints), each variant twice, best-of compared, restricted to completed runs (`type = 2` — `type > 1` includes aborted rows and silently poisons the comparison). Speedups: **2.64x**, **1.98x**, **1.71x**, **1.47x**, and one **0.83x regression**. `FINAL` carries fixed per-part merge overhead, so it wins on expensive reads and mildly loses on cheap ones; this endpoint's cost is concentrated in the slow tail. One larger query is absent because both variants exceed the read quota of the read-only account used for the replay, so it was excluded symmetrically.
- **Result equality on production data.** Field-by-field comparison of old vs new output: `trace_count`, `thread_count`, `duration` quantiles, input/output/metadata/tags counts, every `usage` key, `usage_sum`, `total_estimated_cost_avg`/`_sum`, `guardrails_failed_count`, `error_count` and `llm_span_count_avg` all byte-identical; only `span_count_avg` moves, because the duplicate row is a skeleton carrying no usage, no cost, and never `type = 'llm'`. The projects-list endpoint does not expose span counts at all.
- **Local benchmark**, synthetic dataset built from the production `spans` schema (8.48M rows, 800k traces, ~10.6 spans/trace, duplicate versions seeded, merges stopped), 12 threads: at 34 parts 4817 ms → 712 ms best (5833 → 1146 median); at 1112 parts 4698 → 1669 best (6084 → 2255 median); dedup in isolation 3727 ms → 334 ms. Results identical at both part counts, checked with a fingerprint over each id's *chosen version* so picking the wrong row would be caught. Peak memory is roughly neutral — the sort was the CPU cost, not the memory cost.
- **Alternatives rejected after measuring:** a flat `ORDER BY` column list (no gain, still plans a full sort) and `argMax` + `GROUP BY` on the sort key (far worse — hash aggregation over one group per span).

Environment: local process mode, macOS; ClickHouse benchmarks in throwaway Docker containers on `clickhouse/clickhouse-server:26.3.16.16-alpine` (matching the version `ClickHouseContainerUtils` pins), all torn down afterwards.

## Documentation

No documentation update needed — internal DAO query change with no API, schema, or SDK surface.
