### PR TITLE
[NA] [HELM] Discard the query string on the cost-api version proxy

### DIFF
--- a/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-frontend-nginx.yaml
@@ -204,7 +204,14 @@ data:
             # proxy_pass with a URI part inside a named location. Strips the opik
             # rootPath so the upstream sees its own {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver;
             # a no-op when rootPath is empty, and `break` stops further rewriting.
-            rewrite ^{{ $rootPath }}{{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver$ {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver break;
+            #
+            # The trailing `?` DISCARDS the caller's query string. Without it nginx
+            # appends the original query to the rewritten URI, so the upstream would
+            # receive /cost-api/ver?<anything the caller sent>. This endpoint takes
+            # no parameters, so the proxied request is now query-free regardless of
+            # what the caller appends, rather than relying on the upstream ignoring
+            # unknown arguments.
+            rewrite ^{{ $rootPath }}{{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver$ {{ .Values.component.frontend.aiSpendBackend.costApiRootPath }}/ver? break;
             proxy_pass http://ai-cost-backend;
             proxy_redirect  off;
             proxy_set_header Host $host;

--- a/deployment/helm_chart/opik/tests/cost_api_version_endpoint_test.yaml
+++ b/deployment/helm_chart/opik/tests/cost_api_version_endpoint_test.yaml
@@ -38,7 +38,7 @@ tests:
       # The rootPath is stripped so the upstream sees its own /cost-api/ver.
       - matchRegex:
           path: data["default.conf.template"]
-          pattern: 'rewrite \^/opik/cost-api/ver\$ /cost-api/ver break;'
+          pattern: 'rewrite \^/opik/cost-api/ver\$ /cost-api/ver\? break;'
 
   - it: exposes the version endpoint at the root when opik is standalone
     set:
@@ -94,4 +94,21 @@ tests:
           pattern: 'location = /opik/ci/ver \{'
       - matchRegex:
           path: data["default.conf.template"]
-          pattern: 'rewrite \^/opik/ci/ver\$ /ci/ver break;'
+          pattern: 'rewrite \^/opik/ci/ver\$ /ci/ver\? break;'
+
+  - it: discards the caller's query string on the way to the upstream
+    # Regression guard: without the trailing `?` nginx APPENDS the original query
+    # to the rewritten URI, so the upstream receives /cost-api/ver?<caller input>.
+    # The endpoint takes no parameters, so the proxied request must be query-free
+    # rather than depending on the upstream ignoring unknown arguments.
+    set:
+      standalone: false
+      component.frontend.aiSpendBackend.enabled: true
+    documentSelector: *nginx
+    asserts:
+      - matchRegex:
+          path: data["default.conf.template"]
+          pattern: '/cost-api/ver\? break;'
+      - notMatchRegex:
+          path: data["default.conf.template"]
+          pattern: '/cost-api/ver break;'


### PR DESCRIPTION
## Details

Review follow-up on #7728. The version-endpoint rewrite had no trailing `?`, so nginx appended the caller's query string to the rewritten URI and the upstream received `/cost-api/ver?<whatever the caller sent>`. Adding `?` makes the proxied request query-free.

**No impact today.** cost-api's `ver()` declares no parameters, so FastAPI ignores unknown arguments and the response is byte-identical — I confirmed that against a live environment (`?foo=bar`, `?version=evil`, `?a=1&a=2`, `?%00=x` all return `200 {"version":"0.1.28"}`). The reason to fix it anyway is that the guarantee belongs in nginx rather than in the upstream's leniency: if that handler ever gains a query parameter, the behaviour would change silently.

**The path was never at risk.** `location =` is an exact match, so only the query string ever varied — the proxied path is always `/cost-api/ver`.

Note the neighbouring `@ai_spend` location intentionally keeps its query string, since the ai-spend API takes real query parameters. Only this fixed-response endpoint discards it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

No ticket — review follow-up on #7728.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Full authorship of the diff (one-character template change plus test updates) and of the verification below.
- Human verification: Raised by the automated reviewer on comet-ml/comet-helm#1286 and triaged with @aadereiko, who asked for the fix. The commands below were executed and their output inspected before opening this PR.

## Testing

Verified with real nginx (`nginx:alpine`) proxying to a stub that echoes back the URI it received, using the chart's own rendered output:

| request | before | after |
|---|---|---|
| `/opik/cost-api/ver` | `/cost-api/ver` | `/cost-api/ver` |
| `/opik/cost-api/ver?foo=bar` | `/cost-api/ver?foo=bar` | `/cost-api/ver` |
| `/opik/cost-api/ver?a=1&b=2` | `/cost-api/ver?a=1&b=2` | `/cost-api/ver` |
| `/opik/cost-api/ver?x=%2Fetc%2Fpasswd` | `/cost-api/ver?x=%2Fetc%2Fpasswd` | `/cost-api/ver` |

`nginx -t` passes on the rendered config in both rootPath modes (`standalone=false` and `standalone=true`).

### Automated tests

`tests/cost_api_version_endpoint_test.yaml` — **the existing suite caught this change as designed.** The two rewrite assertions failed until updated to expect the `?`, which is the regression guard working. I also added a dedicated case asserting the trailing `?` is present *and* that the query-preserving form is absent, so it cannot be dropped again.

```
cd deployment/helm_chart/opik && helm unittest .
# 68 tests across 11 suites pass
```

Not run: no deployment to a live environment with this change (it is not yet in a published chart).

## Documentation

Template comment explains why the `?` is there and what happens without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
