### PR TITLE
[OPIK-7534] Declare release-surface scope in the QA taxonomy

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -151,9 +151,25 @@ rules:
   # What counts as PRODUCT SURFACE when attributing a release's changed files to
   # areas (consumed by the release-coverage skill in comet-ml/qa-plugin).
   # Declared here rather than in tooling because both lists are scope decisions
-  # this file already owns. Note the path->area mapping ITSELF is not here: it is
-  # derived from router.tsx joined with the `routes:` on each area below, so it
-  # follows a page rename automatically and is never hand-maintained.
+  # this file already owns.
+  #
+  # The path->area mapping ITSELF is not here: it is derived by joining the V2
+  # router tree (routes resolved transitively through getParentRoute) with the
+  # `routes:` on each area below, so it follows a page rename automatically and
+  # is never hand-maintained.
+  #
+  # That join is NOT literal string equality — the two spellings diverge by
+  # design, and the resolver normalises both sides before comparing:
+  #   * `$param` -> `*`, so this file's `/annotation-queues/$id` matches the
+  #     router's `.../annotation-queues/$annotationQueueId`
+  #   * the query string is DROPPED, which is what lets one component serve two
+  #     areas: `/logs?type=traces` and `/logs?type=threads` are one route
+  #     (LogsPage) and two areas (traces, threads)
+  #   * the `/opik` basepath is stripped
+  #   * comparison is suffix-based, so a route written relative to a project
+  #     matches the router's workspace-prefixed form
+  # Measured against main: all 18 areas join to at least one component, and no
+  # component resolves to more than two areas.
   release_surface:
     # Never product surface. A change confined to these is not a coverage gap;
     # counting them manufactures gaps and buries the real ones.
@@ -170,16 +186,33 @@ rules:
       - README.md
       - .gitignore
       - Makefile
-    # Real product surface this taxonomy deliberately does NOT enumerate — it
-    # covers 18 UI areas. Changes here are reported by name with coverage stated
-    # as *unknown*, never as zero, and never mapped to a UI area.
+    # Real product surface this taxonomy does not enumerate AS ITS OWN AREA — it
+    # covers 18 UI areas. Changes here are reported by name, never mapped to a UI
+    # area, and never scored as zero.
+    #
+    # "Not enumerated" is not the same as "not exercised". The e2e estate drives
+    # the SDKs and the API heavily as fixtures — 11 specs use the SDK or the
+    # backend client, and five capabilities are explicitly SDK-shaped
+    # (datasets.create-dataset-sdk, datasets.sdk-round-trip,
+    # test-suites.create-suite-sdk, test-suites.run-suite-sdk,
+    # prompts.sdk-seeded-visible), all covered. What is untracked is each of
+    # these as a product surface in ITS OWN RIGHT: SDK ergonomics and options
+    # (num_threads, retries, error handling), REST contract details, and
+    # deployment behaviour. Report those as **coverage not measured here**, and
+    # say what the estate does exercise incidentally rather than implying zero.
     untracked:
       - prefix: sdks/python
         label: Python SDK
       - prefix: sdks/typescript
         label: TypeScript SDK
       - prefix: apps/opik-backend/
-        label: Backend (API / internal)
+        label: Backend (Java API / internal)
+      - prefix: apps/opik-python-backend/
+        label: Python backend
+      - prefix: apps/opik-guardrails-backend/
+        label: Guardrails backend
+      - prefix: apps/opik-sandbox-executor-python/
+        label: Sandbox executor
       - prefix: deployment/
         label: Deployment / Helm
   # Tag-lint enforcement. All three are hard CI failures, not warnings.

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -148,6 +148,40 @@ rules:
   cloud_only_separate_view: true
   # Report one % per dimension per area. Never a blended figure.
   report_per_dimension: true
+  # What counts as PRODUCT SURFACE when attributing a release's changed files to
+  # areas (consumed by the release-coverage skill in comet-ml/qa-plugin).
+  # Declared here rather than in tooling because both lists are scope decisions
+  # this file already owns. Note the path->area mapping ITSELF is not here: it is
+  # derived from router.tsx joined with the `routes:` on each area below, so it
+  # follows a page rename automatically and is never hand-maintained.
+  release_surface:
+    # Never product surface. A change confined to these is not a coverage gap;
+    # counting them manufactures gaps and buries the real ones.
+    not_surface:
+      - .github/
+      - tests_end_to_end/
+      - .agents/
+      - apps/opik-documentation/
+      - sdks/code_generation/
+      - scripts/
+      - version.txt
+      - .pre-commit-config.yaml
+      - CONTRIBUTING.md
+      - README.md
+      - .gitignore
+      - Makefile
+    # Real product surface this taxonomy deliberately does NOT enumerate — it
+    # covers 18 UI areas. Changes here are reported by name with coverage stated
+    # as *unknown*, never as zero, and never mapped to a UI area.
+    untracked:
+      - prefix: sdks/python
+        label: Python SDK
+      - prefix: sdks/typescript
+        label: TypeScript SDK
+      - prefix: apps/opik-backend/
+        label: Backend (API / internal)
+      - prefix: deployment/
+        label: Deployment / Helm
   # Tag-lint enforcement. All three are hard CI failures, not warnings.
   enforce:
     # every non-exempt e2e spec declares exactly one tier and one @area:


### PR DESCRIPTION
## Details

Adds a `rules.release_surface` block to `tests_end_to_end/coverage/taxonomy.yaml` declaring what counts as product surface when attributing a release's changed files to areas, and which product surface this taxonomy does not enumerate as an area (the SDKs, the four backends, Helm). Consumed by the new `release-coverage` skill in comet-ml/qa-plugin, which decides per-PR whether an existing test covers a change before a release ships.

Both lists are scope decisions this file already owns, so declaring them here means they are reviewed alongside the areas instead of living in tooling constants. No existing field changes, and nothing in the `covered:`/`tier:` derived zone is touched.

- The path→area mapping itself is deliberately **not** here: it is derived by joining the V2 router tree with the `routes:` already on each area, so it follows a page rename automatically and is never hand-maintained.
- The comment documents the normalisation contract that join depends on (`$param` → `*`, query string dropped, `/opik` basepath stripped, suffix comparison) — measured against `main`: all 18 areas join to at least one component, none resolves to more than two.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7534

<!-- Related but NOT resolved here: OPIK_7532 (coverage map), OPIK_7731 (self-hosted release verification), OPIK_7774 (nightly records no version). -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Authored the `rules.release_surface` block and its comments. The two lists were derived from measurement against `main` (enumerating `apps/` children, and joining router routes to `areas[].routes` to confirm all 18 areas resolve), not from assumption.
- Human verification: Andrei Cautisanu reviewed the scope decisions — which prefixes count as product surface, and which surfaces are out of this taxonomy's remit — and directed the design (declare scope here rather than in tooling; derive the mapping rather than hardcode it). Review feedback on the PR caught a genuine omission (only one of four backends declared), verified against the repo and fixed.

## Testing

YAML validity and downstream behaviour, from the consuming tool:

```
python3 -m pytest -q          # 24 passed  (qa-plugin skills/release-coverage)
```

Scenarios validated:
- **Parses and loads** — `load_scope()` reads the block and reports `source: taxonomy` (as opposed to the built-in fallback for older refs).
- **Attribution unchanged** — the same release (`2.2.16..2.2.18`, 16 PRs) produces identical per-PR verdicts before and after moving the lists out of code: same 5 PRs with areas, same areas, same cross-cutting counts.
- **All four backends classified** — a change under `apps/opik-python-backend/`, `apps/opik-guardrails-backend/` or `apps/opik-sandbox-executor-python/` is now labelled backend surface rather than falling through as unclassified. Regression test asserts each.
- **No `apps/` child silently unclassified** — a test walks `apps/` and fails if any child is neither mapped to areas, nor non-surface, nor declared untracked. Guards against a new backend appearing undeclared.
- **Route-join contract** — verified all 18 areas join to a component and none over-matches (>2 areas), which is what the new comment claims.
- **Fallback path** — with the block absent, the tool still runs and reports `source: fallback`, so an older opik ref keeps working and a renamed block surfaces instead of degrading silently.

Not run: no e2e or backend suite, as this change is a comment-and-config addition to a file read only by QA tooling. `helm-docs` was the only pre-commit hook with matching files and it passed.

## Documentation

Self-documenting: the block carries the reasoning inline (why each list exists, what the join normalises, and the measurement behind the claims). `tests_end_to_end/TESTING-TAGS.md` covers tag grammar and is unaffected. The consuming skill's own README and SKILL.md in comet-ml/qa-plugin describe how the block is read.