### PR TITLE
[OPIK-6901] [BE] refactor: reconcile traces cutover tooling with the 7455/7456/7483 follow-ups

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -30,8 +30,9 @@ The **deletion-events bridge** closes it: with `traceDeletionEventsCaptureEnable
 new table before the EXCHANGE. The replay matches the **full key**, not `id` alone — see "Delta and replay correctness".
 
 > **All user-facing trace deletes route through one captured path.** Single delete, batch delete-by-project, and thread
-> deletion all funnel through `TraceService.delete(...)`, which calls `captureDeletions` on both the resolved-project
-> and the unresolved (empty-project) branch — so enabling the flag covers every one. The **only** uncaptured
+> deletion all funnel through `TraceService.delete(...)`, which calls `captureDeletions` for every resolved-project
+> delete — since OPIK-7483 there is no project-less branch (ids that resolve to no project are absent and skipped) — so
+> enabling the flag covers every one. The **only** uncaptured
 > `DELETE FROM traces` is the retention sweep, which is disabled (see the retention note). Any **new** trace-delete path
 > introduced during the migration window must likewise capture, or its deletes would leak across the swap.
 
@@ -99,11 +100,23 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
     column added to one table but not the other fails the build). Re-confirm both are green on the release being
     deployed.
 11. **Fresh backup / snapshot** of the ClickHouse data node.
-12. **Freeze concurrent DDL on `traces` for the window.** Hold any deploy or Liquibase changeset that would `ALTER`,
-    `RENAME`, or otherwise touch `traces` / `traces_local_v2` for the whole backfill→EXCHANGE window — a schema change
-    landing mid-cutover races the swap and can corrupt it. The revamp's own migrations (000096/000101) are already
-    applied; this is about *unrelated* migrations or ad-hoc DDL during the window.
-13. Schedule during off-peak hours.
+12. **Freeze concurrent DDL on `traces` for the window — and through the rollback-eligible soak.** Hold any deploy or
+    Liquibase changeset that would `ALTER`, `RENAME`, or otherwise touch `traces` / `traces_local_v2` for the whole
+    backfill→EXCHANGE window — a schema change landing mid-cutover races the swap and can corrupt it — and keep it frozen
+    until `finalize.sh` commits (see "Point of no return"): a `traces` schema change made *after* the EXCHANGE is lost
+    from the live table on a rollback + finalize. The revamp's own migrations (000096/000101) are already applied; this
+    is about *unrelated* migrations or ad-hoc DDL during the window.
+13. **Deletion bridge holds no empty-`project_id` trace events, and OPIK-7483 is live fleet-wide.** Since OPIK-7483 every
+    trace delete carries its `project_id`, so the cutover replay is full-key only (no workspace-scoped branch). Confirm
+    OPIK-7483 is deployed across the **whole** backend fleet before the window (a straggler pre-7483 backend could emit an
+    empty-`project_id` event the replay would miss), then assert the bridge holds none. `deletion_events_local` is a
+    per-shard local table, so query it cluster-wide:
+    ```sql
+    SELECT count() FROM clusterAllReplicas('{cluster}', <database>.deletion_events_local)
+    WHERE source_table = 'traces' AND project_id = '';
+    ```
+    If non-zero, do NOT proceed: an unexpected row means the replay would miss those deletes — investigate/drain them first.
+14. Schedule during off-peak hours.
 
 ## The sequence
 
@@ -151,10 +164,11 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    ```
    Every EXCHANGE path requires: `--backfill-start` (for the final deletion replay), `--confirm-buffer-raised` (writes in
    the final window survive the swap), and `--confirm-retention-paused` (retention deletes bypass the bridge, so a
-   retention sweep in the window would leak across the swap). Add `--with-wrap --confirm-daos-retargeted` only once the
-   DAOs target `traces_local`.
+   retention sweep in the window would leak across the swap). Add `--with-wrap --confirm-daos-retargeted` only once
+   `databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true` is live across the backend fleet (OPIK-7455), so trace
+   mutations target `traces_local`.
 
-> **HARD PREREQUISITE for the wrap (step 4, part 2): the delete/mutation DAO must target `traces_local` first.** A
+> **HARD PREREQUISITE for the wrap (step 4, part 2): enable `tracesDistributedWrapEnabled` so trace mutations target `traces_local` first (OPIK-7455).** A
 > `Distributed` table supports `SELECT` and `INSERT` but **not** mutations. Verified on ClickHouse 26.3:
 > - `DELETE FROM <distributed>` → `Code 36 BAD_ARGUMENTS: DELETE query is not supported`
 > - `ALTER TABLE <distributed> DELETE` → `Code 48 NOT_IMPLEMENTED: Distributed doesn't support mutations`
@@ -185,7 +199,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it runs the settle
 > gate and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new `cutover_start`).
 > `--confirm-daos-retargeted` is required for **any** wrap (same-run or deferred), since the wrap makes `traces`
-> `Distributed` and breaks the delete/mutation DAOs until they target `traces_local`. To roll the wrap back, use
+> `Distributed` and breaks the delete/mutation DAOs until `tracesDistributedWrapEnabled=true` routes them at `traces_local`. To roll the wrap back, use
 > `rollback.sh --stage C`.
 >
 > The wrap is **gapless per node**: it pre-builds the `Distributed` wrapper under a temp name, then one atomic
@@ -364,28 +378,19 @@ on a large backfill for no gain.
 - The anchor is captured **before** the backfill, not at its end — a cutoff taken at the end would miss writes that
   landed during the backfill itself. The same `backfill_start` bounds the replay window.
 
-**Replay matches on two branches — full key, or `(workspace_id, id)` — mirroring the two delete shapes recorded in the bridge.**
-`TraceService.delete(ids, projectId)` resolves each id's owning project and deletes per project (full key). **Pre-OPIK-7483**,
-ids it could not resolve fell back to a **workspace-scoped** delete (`DELETE … WHERE id IN … AND workspace_id = …` across
-every project), recorded in the bridge with an **empty `project_id`** (`DeletionEventDAO`: "project_id is empty for
-workspace-scoped source tables"). OPIK-7483 removed that fallback, so current `TraceService.delete` always carries
-`project_id` and the empty-project branch now replays **only** legacy bridge rows written before OPIK-7483 (still resident
-under the 2-year TTL). The
-replay mirrors both: full-key events delete by `(workspace_id, project_id, id)` (exact; prunes on the destination primary
-key — correct even though trace ids are not globally unique), and empty-project events delete by `(workspace_id, id)`.
-The second branch is a **mirror, not an over-delete**: the workspace-scoped fallback fires only for ids the resolver
-found no live row for in any project, and the source deletion that it replays already removed every `(workspace_id, id)`
-row.
-Without it, those deletions would **silently leak** across the swap. It is faithful in the common case, with **one known
-residual** (see 000002): because its resurrection guard keys on `(workspace_id, id)` (no project), an id that is live in
-one project shields the delete of the *same reused id* in another — leaving an extra destination row. It needs id reuse
-across projects **plus** a workspace-scoped delete **plus** a resurrection in the window, so it is rare; the `000005`
-`FINAL` fingerprint flags it (`ok=0`) rather than passing silently, and OPIK-7483 retires the arm entirely by making
-deletes always carry `project_id`.
+**Replay matches on the full key `(workspace_id, project_id, id)`.**
+`TraceService.delete(ids, projectId)` resolves each id's owning project(s) and deletes per project under the full key.
+Since **OPIK-7483** there is no project-less path: an id that resolves to no owning project is absent (a delete of a
+non-existent row) and is skipped, so **no deletion event is ever bridged with an empty `project_id`** for
+`source_table='traces'` (a pre-cutover check asserts the bridge holds none — Prerequisites #13). The replay therefore
+carries a single branch: full-key events delete by `(workspace_id, project_id, id)` — exact, prunes on the destination
+primary key, and correct even though trace ids are not globally unique (a reused id deleted in one project leaves its
+copies in other projects untouched). Without this replay, those during-window deletions would **silently leak** across
+the swap.
 
 **Resurrection guard.** A trace can be deleted and then re-created/updated under the **same id** during the window
 (ids are client-supplied; the delete is a mask, and a newer insert wins under `FINAL`). Such an id is bridged as deleted
-but is **live again** on the source, and the backfill/delta already copied its live version. So each replay branch also
+but is **live again** on the source, and the backfill/delta already copied its live version. So the replay also
 requires the id is **not currently live on the source** (`AND (…) NOT IN (SELECT … FROM traces WHERE id IN <deleted ids
 since anchor>)`, mask-honored) before deleting it — otherwise the replay would drop a row that is live on the source,
 silent data loss. This also makes the replay idempotent (it never masks a live-on-source id), so re-running to
@@ -405,6 +410,11 @@ They are **complementary, not alternatives**, and there is **no copy-paste drift
   placeholders for the database, window bounds and block size. It is read by the driver, not run by hand.
 - **`backfill.sh` is the driver (the "how"):** it derives the week range, and for each week reads `000001_...sql`,
   substitutes the placeholders, runs it, reconciles, throttles, and is resumable. It embeds no copy of the INSERT.
+- **Keep the explicit column list in sync.** `000001`'s `INSERT` names each copied column explicitly (parallel `SELECT`,
+  no `SELECT *`), so a column added to `traces` before a cutover is carried across **only if it is also added to this
+  list and to the `traces_local_v2` shadow** (migration 000101, recreated by 000114). This is an incidental per-column
+  edit that rides with the feature DDL; omissions are caught in CI by the schema-parity guard — `cutoverCopiesEveryBaseColumn`
+  pins this list to the live `traces` base columns (OPIK-7772 extends it to a topology-aware CI check).
 
 **Every SQL operation — happy path and every rollback stage — is run by a driver script; no SQL or `.sql` file is ever
 run by hand.** Each `.sql` file is the single source a driver reads:
@@ -551,6 +561,13 @@ backup with `finalize.sh` is the one irreversible step, so gate it on an explici
 - **Soak duration** — keep the parked backup (`traces_pre_cutover_backup` after a successful cutover;
   `traces_post_rollback_backup` after a rollback) for a defined window (recommend ~2 weeks; it fits well inside the
   bridge's 2-year TTL) so any latent read/query regression surfaces while rollback is still an option.
+- **Freeze `traces` schema DDL through the soak** (extends prereq #12 past the EXCHANGE). Rollback restores the **frozen
+  original** `traces`, which carries no post-cutover DDL, so a column/index added to the successor in-window is **lost
+  from the live table** on rollback; finalize's recycle then truncates the parked successor to an empty shadow (its data
+  gone — the empty shadow keeps the added column, drift the next cutover's `cutoverCopiesEveryBaseColumn` guard flags).
+  Do not deploy `traces` schema migrations until the soak ends (finalize committed). Post-finalize the general rule
+  resumes: apply `ADD`/`DROP`/`MODIFY COLUMN` to **both** `traces_local` and the `Distributed` `traces` (see the wrap
+  prerequisite).
 - **Finalize exit criteria** — before retiring the backup: `verify.sh` clean, query p99 within budget over the soak, no
   cutover-related incidents open, and (if the wrap was applied) the retarget flag (`tracesDistributedWrapEnabled`) live
   and healthy across the backend fleet.
@@ -735,13 +752,16 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       on the release, so the cutover copies every base column of `traces` and the two tables' base and materialized
       columns match.
 - [ ] **Fidelity verified** — `verify.sh` passes between source and destination before the EXCHANGE. This gate MUST be a
-      **full compare** (`--sample-mod 1 --weeks-stride 1`, no `--from-week`/`--to-week` narrowing): a cross-project
-      workspace-scoped residual row is a single key, so any sampling (`--sample-mod > 1`), week stride, or week narrowing
-      can hash it out or skip its week and still report `ok=1`. Reserve sampling/ranged runs for follow-up confidence
-      *after* the full gate passes. Re-run `delta_replay.sh` then `verify.sh` until it PASSES: while the buffer holds
-      writes (or, on a rehearsal without it, once traffic is quiescent) the last delta must catch every in-flight write.
-- [ ] **`Distributed` wrap gated on app-readiness** — apply the wrap (step 4, part 2) only when the delete/read DAOs are
-      sharding-aware; otherwise stop after the `EXCHANGE`, since a lightweight `DELETE` against a `Distributed` `traces`
+      **full compare** (`--sample-mod 1 --weeks-stride 1`, no `--from-week`/`--to-week` narrowing): it is the last backstop
+      for a single-row deletion leak — an unexpected empty-`project_id` bridge event the single-branch replay would miss,
+      or any other single-key divergence — and any sampling (`--sample-mod > 1`), week stride, or week narrowing can hash
+      that one row out and still report `ok=1`. Reserve sampling/ranged runs for follow-up confidence *after* the full gate
+      passes. Re-run `delta_replay.sh` then `verify.sh` until it PASSES: while the buffer holds writes (or, on a rehearsal
+      without it, once traffic is quiescent) the last delta must catch every in-flight write.
+- [ ] **`Distributed` wrap gated on the DAO toggle** — apply the wrap (step 4, part 2) only once
+      `databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true` is live across the backend fleet (OPIK-7455), set in
+      lockstep with the wrap so trace mutations target `traces_local`; otherwise stop after the `EXCHANGE`, since a
+      lightweight `DELETE` against a `Distributed` `traces`
       is unsupported and breaks the trace-delete path.
 - [ ] **No query-semantics regression** — FINAL / `LIMIT 1 BY` dedup verified; p99 on the project traces listing page within
       ±10% of the pre-migration baseline.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -224,7 +224,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > - **wrap first**: from the swap until the rolling restart finishes, deletes hit the `Distributed` `traces`
 >   → `Code: 36`. Same blast radius, but it also exposes the cross-node `ON CLUSTER` skew with no buffer.
 >
-> Prefer **toggle first**, have the `--wrap-only` command ready to run the second both pods report ready, and
+> Prefer **toggle first**, have the `--wrap-only` command ready to run the moment every backend instance is up, and
 > keep the window to seconds. Both directions are delete-path-only and fail loudly rather than corrupting
 > anything, which is what makes a short window acceptable — but on a shared environment announce it, and do
 > not leave the toggle `true` without the wrap (or vice versa) for any length of time.
@@ -496,13 +496,13 @@ run by hand.** Each `.sql` file is the single source a driver reads:
 Each driver takes the connection from the `clickhouse-client` env vars `CLICKHOUSE_HOST`, `CLICKHOUSE_USER` and
 `CLICKHOUSE_PASSWORD`, plus `--database` and — when the native port is not 9000 — `--port`.
 
-> **Pass `--host` and `--port` together; the env vars are not enough.** Verified on 26.3:
+> **Pass `--host` and `--port` together; the env vars are not enough.** Verified on `clickhouse-client` 26.3:
 > `CLICKHOUSE_PORT` is **not honored at all** (set it to a bogus value and the client still dials 9000), and
 > `CLICKHOUSE_HOST` is honored **only while no connection flag is given** — so supplying `--port` alone silently reverts
 > the host to `localhost`. Every driver therefore takes `--host` and `--port`; user and password stay in the environment,
-> keeping the password out of `argv`. This matters for any real cutover, because a cluster is normally reached from the
-> ops host through a `kubectl port-forward` or a bastion on a **non-default local port** (9000 is often already taken by
-> a local ClickHouse). Pass the same `--host`/`--port` to every driver in the run.
+> keeping the password out of `argv`. This matters for any real cutover, because a remote cluster is usually reached over
+> a forwarded or tunnelled **non-default local port** (9000 is often already taken by a local ClickHouse). Pass the same
+> `--host`/`--port` to every driver in the run.
 >
 > **The connecting user must be able to set `log_comment`.** Every driver tags its queries with `log_comment` for
 > cutover attribution in `query_log`. A `readonly = 1` profile rejects that outright — `Cannot modify 'log_comment'
@@ -529,7 +529,7 @@ read-only drivers cannot surface a mutation-privilege gap by construction.
 | **wrap** (sharding) | `CREATE TABLE traces_dist … ENGINE = Distributed(…)`, then `RENAME traces → traces_local, traces_dist → traces` | `CREATE TABLE` + `DROP TABLE` on **`traces_dist`** and **`traces_local`** — two names that **do not exist yet**, so a grant set scoped to the cutover's three names will NOT cover the wrap. Plus `SELECT` on `traces_local` (post-wrap reads route through the wrapper to it) and `REMOTE` for the `Distributed` engine. |
 | rollback stage A/B (if in scope) | stage A `TRUNCATE`, reverse replay | `TRUNCATE` on the shadow, and `ALTER UPDATE(_row_exists)` on the **source** (the reverse replay masks rows on the restored original). Withhold unless a rollback is actually planned. |
 | rollback stage C (if the wrap is applied) | 3-way `RENAME` + `DROP` of the ex-wrapper | `CREATE TABLE`/`DROP TABLE` on **`traces_dist_old`** and **`traces_post_rollback_backup`**, `DROP TABLE` on `traces_local`, plus `ALTER UPDATE(_row_exists)` on the restored `traces`. **Decide this before applying the wrap:** without these grants the wrap is a one-way door until another grant change lands. |
-| post-rollback sentinel repair (stage B/C only) | `ALTER TABLE traces UPDATE end_time = NULL …`, same for `ttft` | `ALTER UPDATE(end_time)` and `ALTER UPDATE(ttft)` on **`traces`** — **column privileges the rows above do NOT include.** The reverse replay needs only `ALTER UPDATE(_row_exists)`, so a cutover user scoped to the rollback set gets `ACCESS_DENIED` on the repair that `rollback.sh` prints when it finishes (verified on dev and staging). Either grant these two columns with the rollback grants, or plan to run the repair as a more privileged user. |
+| post-rollback sentinel repair (stage B/C only) | `ALTER TABLE traces UPDATE end_time = NULL …`, same for `ttft` | `ALTER UPDATE(end_time)` and `ALTER UPDATE(ttft)` on **`traces`** — **column privileges the rows above do NOT include.** The reverse replay needs only `ALTER UPDATE(_row_exists)`, so a user scoped to the rollback set gets `ACCESS_DENIED` on the repair `rollback.sh` prints when it finishes. Either grant these two columns with the rollback grants, or plan to run the repair as a more privileged user. |
 | `finalize.sh` (if in scope) | `TRUNCATE` / `DROP TABLE` | `TRUNCATE`, `DROP TABLE`, and `max_table_size_to_drop` override |
 
 **The boundary worth preserving.** For a *forward-only* cutover the user needs `INSERT` on the live source
@@ -685,18 +685,16 @@ complete until they land.
    A bare `MATERIALIZE COLUMN duration` does **not** fix it — it re-evaluates the same expression against the same
    sentinel and reproduces the negative value.
 
-   **Success is `sentinel_end_time` and `sentinel_ttft` reaching `0` — NOT `negative_duration_total`.** Only
-   `negative_from_sentinel` is this repair's business. Rows whose `end_time` genuinely precedes `start_time` are a
-   pre-existing data-quality artifact of the source, faithfully carried by the migration, and they stay negative
-   afterwards. Measured while validating this runbook: the staging original held **8,378** negative durations of which
-   only **6** came from the sentinel, and dev held **3** of which **1** did. Waiting for a total of `0` would look like
-   a failed repair forever.
+   **Success is `sentinel_end_time` and `sentinel_ttft` reaching `0` — not `negative_duration_total`.** A table can
+   also hold rows whose `end_time` genuinely precedes `start_time`. Those are a pre-existing source artifact that the
+   migration carries faithfully, they have nothing to do with the sentinel, and they stay negative. Where any exist,
+   waiting for a negative total of `0` would look like a failed repair forever.
 
-   > **The repair needs privileges the migration user does not have.** It updates `end_time` and `ttft`, whereas the
-   > cutover user is granted only `ALTER UPDATE(_row_exists)` (all the reverse replay needs — see the privileges table).
-   > Run these two statements as a user holding `ALTER UPDATE(end_time)` / `ALTER UPDATE(ttft)` on `traces`, or add
-   > those column grants alongside the rollback grants. Verified on dev and staging: as granted, the cutover user
-   > gets `ACCESS_DENIED` here — so this cannot be pasted into the same session that just ran `rollback.sh`.
+   > **These two statements need column privileges the cutover user may not hold.** They update `end_time` and `ttft`,
+   > while the rollback grant set carries only `ALTER UPDATE(_row_exists)` — all the reverse replay needs. A user
+   > scoped to that set gets `ACCESS_DENIED` here, so the repair cannot simply be pasted into the session that ran
+   > `rollback.sh`. Either grant both columns alongside the rollback grants, or run the repair as a more privileged
+   > user.
 
 **Point of no return.** The `EXCHANGE` is reversible for as long as the parked backup exists (stage B/C). Retiring that
 backup with `finalize.sh` is the one irreversible step, so gate it on an explicit soak:

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -83,10 +83,18 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    flushes, so a shorter client timeout would surface as ingestion errors during the window.
 7. **Schema-state flag wired, with a rollout plan** — `databaseAnalyticsDataModel.traceColumnsNonNullable` (env
    `ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE`, default `false`). The successor's `end_time`/`ttft` are
-   **non-nullable sentinel** columns, so the app must bind epoch/NaN instead of `null` once they are live — a `null`
-   bind is rejected. This flag switches that (writes, reads, filters, sorts); it **must be flipped in lockstep with the
-   EXCHANGE** (see "The final cutover window"). Confirm it is deployable on the target (env passthrough present) and that
-   you have a fleet-wide rollout mechanism (config push or rolling restart) ready.
+   **non-nullable sentinel** columns, so the app must represent an absent value as the epoch/NaN sentinel — not `null` —
+   once they are live. This flag switches that on **both** sides: the write bind, and the read/filter/sort translation
+   back (`epochToNull` on read, `nullIf(end_time, epoch)` in sorts, sentinel logic in the filter builder). It **must be
+   flipped in lockstep with the EXCHANGE** (see "The final cutover window"). Confirm it is deployable on the target (env
+   passthrough present) and that you have a fleet-wide rollout mechanism (config push or rolling restart) ready.
+   > **The failure mode is silent, so plan a positive check — not error-watching.** A `null` bind into the non-nullable
+   > successor is **not** rejected: ClickHouse's `input_format_null_as_default` (default `1`) converts it to the column
+   > DEFAULT, which is exactly the epoch/NaN sentinel. So a stale-`false` instance keeps **writing correctly** and emits
+   > no ingestion error — but it **reads back** an absent `end_time` as `1970-01-01` instead of `null`, and filters/sorts
+   > on absent values use the wrong semantics. Unlike `tracesDistributedWrapEnabled` (fail-loud, see the wrap
+   > prerequisite), a missed or partial rollout here shows up only as wrong data. Verify it positively: write an
+   > in-progress trace (no `end_time`) through the API on each instance and assert it reads back `end_time = null`.
 8. **Confirm Data Retention is disabled** (`RETENTION_ENABLED=false`, the default). If it is ever enabled, see the
    retention note above first.
 9. **Sufficient free disk** — the backfill writes a full second physical copy of `traces`, so node free space must clear
@@ -116,7 +124,18 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
     WHERE source_table = 'traces' AND project_id = '';
     ```
     If non-zero, do NOT proceed: an unexpected row means the replay would miss those deletes — investigate/drain them first.
-14. Schedule during off-peak hours.
+14. **Privilege smoke test — run `delta_replay.sh` once BEFORE the backfill, with `--backfill-start` set to
+    `now()`.** Both statements execute but match nothing (no row has `created_at`/`last_updated_at` in the future, and
+    the bridge holds no events after that instant), so it is a functional no-op against the data — while still proving
+    the migration user can actually perform every kind of statement the cutover needs. Do this on a least-privilege user
+    and you catch grant gaps in seconds instead of mid-window.
+    > This is not hypothetical. On the first real-cluster run the deletion replay failed with
+    > `Code: 497 … necessary to have the grant ALTER UPDATE(_row_exists)`: ClickHouse implements a lightweight `DELETE`
+    > as `ALTER UPDATE _row_exists = 0`, so it authorises it as **`ALTER UPDATE` on that hidden column, not
+    > `ALTER DELETE`**. The read-only drivers (`estimate.sh`, `verify.sh`) cannot surface this — only executing a
+    > mutation can. Grant it **column-scoped** (`ALTER UPDATE(_row_exists)`) so the user can flip the delete mask
+    > without being able to modify any real data column.
+15. Schedule during off-peak hours.
 
 ## The sequence
 
@@ -143,7 +162,9 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    (reference SQL [`000002_delta_and_deletion_replay.sql`](scripts/db-app-analytics/000002_delta_and_deletion_replay.sql))
    — delta-insert (anchored at `backfill_start`), then **deletion replay**. The replay runs with
    `lightweight_deletes_sync = 2`, so it returns only once the delete mutation has applied on **every** replica.
-   clickhouse-client prints each statement's wall time; record the replay's wall time.
+   The driver passes `--time`, so clickhouse-client prints each statement's wall time in seconds (delta-insert first,
+   deletion replay second) — **record the second value**: the final-delta→EXCHANGE gap must fit inside the buffer hold
+   (Go/No-Go). Without `--time` a bare `--query` prints no timing at all.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/delta_replay.sh --database opik --backfill-start '<ts>'
    ```
@@ -193,6 +214,20 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > `MergeTree` where deletes still work — which is why the wrap is **opt-in** (`--with-wrap`) and the default stops after
 > the EXCHANGE. Defer the
 > wrap until the retarget flag is wired into the deploy. The wrap is the sharding-readiness layer, not the cutover.
+>
+> **"In lockstep" cannot mean simultaneous — plan for a short fail-loud delete window.** The toggle is a
+> config push plus a rolling restart; the wrap is a DDL statement. They cannot land at the same instant, so
+> one of two windows is unavoidable:
+> - **toggle first** (recommended): from the moment the last backend comes up with `true` until the wrap
+>   completes, every trace delete targets a `traces_local` that does not exist yet →
+>   `Code: 60 UNKNOWN_TABLE`. Reads and writes are unaffected.
+> - **wrap first**: from the swap until the rolling restart finishes, deletes hit the `Distributed` `traces`
+>   → `Code: 36`. Same blast radius, but it also exposes the cross-node `ON CLUSTER` skew with no buffer.
+>
+> Prefer **toggle first**, have the `--wrap-only` command ready to run the second both pods report ready, and
+> keep the window to seconds. Both directions are delete-path-only and fail loudly rather than corrupting
+> anything, which is what makes a short window acceptable — but on a shared environment announce it, and do
+> not leave the toggle `true` without the wrap (or vice versa) for any length of time.
 >
 > **Monitoring consequence of the flip:** `system.parts` only knows `traces_local` post-wrap, so the
 > `opik.clickhouse.partition.*` parts gauges relabel from `table="traces"` to `table="traces_local"`, while the
@@ -255,16 +290,37 @@ bridge row commits after that final replay's read but with `event_time < cutover
 as a size-triggered buffer flush; if delete load is high, quiesce user deletes for the final seconds.
 
 **The `traceColumnsNonNullable` flip (mandatory, and why it goes first).** The successor stores `end_time`/`ttft` as
-non-nullable epoch/NaN sentinels; the app must bind those sentinels — not `null` — the moment that schema is live under
-the name `traces`, or every write of an in-progress trace (no `end_time` yet) is **rejected** by the non-nullable
-column. The flag switches the app to sentinel binds (and sentinel→`null` on read). It is a **config** change rolled out
-across the fleet (not atomic), unlike the metadata-only `EXCHANGE`, so it cannot be flipped at the same instant. Roll it
-out to `true` on **all** instances **before** the `EXCHANGE`: binding the epoch/NaN sentinel into the *still-Nullable*
-source column is valid, and reads translate epoch/`null`→`null` either way, so `true` is write-safe on both schemas —
-this removes any write-rejection window. The copy machinery already tolerates the resulting NULL/epoch mix (backfill
-`coalesce`, verify normalizes both to `0`). The one transient caveat is that "`end_time` is empty"-style **filters** use
-sentinel logic against the still-Nullable table during that short pre-swap window; keep the window short and off-peak.
-On rollback, after swapping the Nullable original back, revert the flag to `false`.
+non-nullable epoch/NaN sentinels, and the flag is what makes the app agree with that representation — sentinel binds on
+write, and sentinel→`null` translation on read, filter and sort. It is a **config** change rolled out across the fleet
+(not atomic), unlike the metadata-only `EXCHANGE`, so it cannot be flipped at the same instant; roll it out to `true` on
+**all** instances **before** the `EXCHANGE`.
+
+*Why before, not after.* Not because writes would break — they would not (see prereq #7: a `null` bind is silently
+converted to the column DEFAULT, which is the sentinel, so writes succeed on either setting). It goes first because the
+**read** side must already speak sentinel the instant the successor is live under the name `traces`: while the flag is
+`false` against the successor, an absent `end_time` reads back as `1970-01-01` rather than `null`, and absent-value
+filters/sorts are wrong. Doing it first is safe because `true` is write-compatible with **both** schemas — binding the
+epoch/NaN sentinel into the *still-Nullable* source column is valid — and the copy machinery tolerates the resulting
+NULL/epoch mix (backfill `coalesce`, verify normalizes both to `0`).
+
+*Two caveats for the pre-swap window, so keep it short and off-peak.* Both affect rows written while the flag is `true`
+and `traces` is still the Nullable original — and note the window does not close at the `EXCHANGE`: on a rollback it
+**reopens** until the flag-revert restart lands on every instance, so the same rows keep accruing then (see "Rolling back
+the `traceColumnsNonNullable` flip").
+
+- "`end_time` is empty"-style **filters** use sentinel logic against the still-Nullable table.
+- **The sentinels persist in the original, and `duration` is computed wrong from them.** An absent value is written as
+  the epoch / `NaN` sentinel instead of `NULL`, against a column whose convention is `NULL`. The blast radius is wider
+  than in-progress traces: the `end_time` arm needs a trace with no `end_time` yet, but the **`ttft` arm hits any trace
+  written without a `ttft`** — the common case. Worse, the original's **`duration`** (a stored `MATERIALIZED` column)
+  guards only `end_time IS NOT NULL` and does not know the epoch sentinel, so a trace with no `end_time` gets a large
+  **negative** duration (≈ `-1.79e12` ms) instead of `NULL`. The successor's expression *does* guard the sentinel, so the
+  copy recomputes it as `NaN` and the **forward path is self-healing**; `verify.sh` is unaffected (it excludes
+  materialized columns by design). But a **stage B/C rollback promotes the frozen original**, making those sentinels and
+  negative durations live again while the healed successor copy is parked and then discarded by `finalize.sh` — so the
+  rollback path must repair them.
+
+On rollback, after swapping the Nullable original back, revert the flag to `false` **and** run that repair.
 
 ## Batching and throttling
 
@@ -437,8 +493,50 @@ run by hand.** Each `.sql` file is the single source a driver reads:
 | rollback | `000004_rollback_stage_{a,b,c}_*.sql` + `000004_rollback_reverse_replay.sql` | `rollback.sh` |
 | finalize — retire the parked backup (drop after cutover / recycle to empty shadow after rollback) | — | `finalize.sh` |
 
-Each driver takes the connection from the standard `clickhouse-client` env vars (`CLICKHOUSE_HOST`, `CLICKHOUSE_PORT`,
-`CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`) and `--database`.
+Each driver takes the connection from the `clickhouse-client` env vars `CLICKHOUSE_HOST`, `CLICKHOUSE_USER` and
+`CLICKHOUSE_PASSWORD`, plus `--database` and — when the native port is not 9000 — `--port`.
+
+> **Pass `--host` and `--port` together; the env vars are not enough.** Verified on 26.3:
+> `CLICKHOUSE_PORT` is **not honored at all** (set it to a bogus value and the client still dials 9000), and
+> `CLICKHOUSE_HOST` is honored **only while no connection flag is given** — so supplying `--port` alone silently reverts
+> the host to `localhost`. Every driver therefore takes `--host` and `--port`; user and password stay in the environment,
+> keeping the password out of `argv`. This matters for any real cutover, because a cluster is normally reached from the
+> ops host through a `kubectl port-forward` or a bastion on a **non-default local port** (9000 is often already taken by
+> a local ClickHouse). Pass the same `--host`/`--port` to every driver in the run.
+>
+> **The connecting user must be able to set `log_comment`.** Every driver tags its queries with `log_comment` for
+> cutover attribution in `query_log`. A `readonly = 1` profile rejects that outright — `Cannot modify 'log_comment'
+> setting in readonly mode` — so such a user cannot run **even the read-only drivers** (`estimate.sh`, `verify.sh`). Use
+> `readonly = 2` for a read-only assessor (it permits `SET` but no writes), and a non-readonly profile for the migration
+> user. This is worth checking before the window: an ops account that can happily run ad-hoc `SELECT`s may still fail
+> every driver on the first query.
+
+### Required privileges (provision these before the window)
+
+The cutover should run as a **dedicated least-privilege user**, not as the app/admin account and not as a
+read-only account. Two of these grants are **not guessable** — they were each found only by executing the
+step against a real cluster, because a local rehearsal running as admin exercises no grant at all and the
+read-only drivers cannot surface a mutation-privilege gap by construction.
+
+| Step | Statement | Privileges ClickHouse actually checks |
+|------|-----------|--------------------------------------|
+| all drivers | any query | able to set `log_comment` → **not** a `readonly = 1` profile (`readonly = 2` for a read-only assessor) |
+| `estimate.sh`, guards, settle gate | `SELECT` on `system.*`, `clusterAllReplicas(...)` | `SELECT ON system.*`, plus `REMOTE` and `CLUSTER` |
+| backfill / delta | `INSERT INTO <shadow> SELECT … FROM <source>` | `SELECT` on source, `INSERT` on shadow |
+| deletion replay | lightweight `DELETE FROM <shadow>` | **`ALTER UPDATE(_row_exists)`** on the shadow — *not* `ALTER DELETE`. A lightweight delete is implemented as `ALTER UPDATE _row_exists = 0`. Grant it **column-scoped** so the user can flip the delete mask without being able to rewrite any real column. |
+| `EXCHANGE` | `EXCHANGE TABLES <source> AND <shadow> ON CLUSTER` | **`INSERT` + `CREATE TABLE` + `DROP TABLE` on BOTH names** — `INSERT` is required even though the swap is metadata-only and moves no rows. |
+| post-swap `RENAME` | `RENAME TABLE <shadow> TO <backup>` | `CREATE TABLE` + `DROP TABLE` (grant `INSERT` on the backup name too, so the rename cannot trip the same check) |
+| **wrap** (sharding) | `CREATE TABLE traces_dist … ENGINE = Distributed(…)`, then `RENAME traces → traces_local, traces_dist → traces` | `CREATE TABLE` + `DROP TABLE` on **`traces_dist`** and **`traces_local`** — two names that **do not exist yet**, so a grant set scoped to the cutover's three names will NOT cover the wrap. Plus `SELECT` on `traces_local` (post-wrap reads route through the wrapper to it) and `REMOTE` for the `Distributed` engine. |
+| rollback stage A/B (if in scope) | stage A `TRUNCATE`, reverse replay | `TRUNCATE` on the shadow, and `ALTER UPDATE(_row_exists)` on the **source** (the reverse replay masks rows on the restored original). Withhold unless a rollback is actually planned. |
+| rollback stage C (if the wrap is applied) | 3-way `RENAME` + `DROP` of the ex-wrapper | `CREATE TABLE`/`DROP TABLE` on **`traces_dist_old`** and **`traces_post_rollback_backup`**, `DROP TABLE` on `traces_local`, plus `ALTER UPDATE(_row_exists)` on the restored `traces`. **Decide this before applying the wrap:** without these grants the wrap is a one-way door until another grant change lands. |
+| post-rollback sentinel repair (stage B/C only) | `ALTER TABLE traces UPDATE end_time = NULL …`, same for `ttft` | `ALTER UPDATE(end_time)` and `ALTER UPDATE(ttft)` on **`traces`** — **column privileges the rows above do NOT include.** The reverse replay needs only `ALTER UPDATE(_row_exists)`, so a cutover user scoped to the rollback set gets `ACCESS_DENIED` on the repair that `rollback.sh` prints when it finishes (verified on dev and staging). Either grant these two columns with the rollback grants, or plan to run the repair as a more privileged user. |
+| `finalize.sh` (if in scope) | `TRUNCATE` / `DROP TABLE` | `TRUNCATE`, `DROP TABLE`, and `max_table_size_to_drop` override |
+
+**The boundary worth preserving.** For a *forward-only* cutover the user needs `INSERT` on the live source
+(forced by `EXCHANGE`) but needs **no `ALTER DELETE`/`ALTER UPDATE` on it and no `TRUNCATE` anywhere** — so
+it cannot delete or modify existing live rows, nor empty a table. The worst it can do to live data is add
+rows. Keep it that way: grant rollback/finalize privileges only when those steps are in scope, as a separate
+reviewed change.
 
 **`clickhouse-client` is an operator prerequisite on the machine that runs these scripts.** Every driver invokes it and
 reads the env above. It is a **client tool on the operator's host**, separate from ClickHouse itself, which the scripts
@@ -555,13 +653,50 @@ statements, so a failure *between* them needs a restart path:
   post-swap `RENAME` did not, the parked original is still under `traces_local_v2` and stage B aborts pointing at the
   one-line `RENAME` that finishes it (`traces_local_v2` → `traces_pre_cutover_backup`); run that, then re-run stage B.
 
-After a stage B or C rollback, `traces` is the Nullable original again — **revert `traceColumnsNonNullable` to `false`
-AND roll-restart every backend instance**. The flag is read from a **startup snapshot** of `OpikConfiguration` (bound via
-`toInstance`), so a config change does **not** take effect until each instance restarts — exactly like the forward
-rollout before the EXCHANGE. Until the restart completes, the app keeps binding sentinels (epoch/NaN) and using
-sentinel-based absent-value logic against the now-Nullable column, mixing sentinel and `null` representations: not a hard
-write failure, but inconsistent absent-value reads/filters/sorts. The rollback is therefore not fully complete until the
-rolling restart lands on the whole fleet.
+**Rolling back the `traceColumnsNonNullable` flip.** After a stage B or C rollback, `traces` is the Nullable original
+again, so the flip has to be undone in two steps — `rollback.sh` prints both when the stage finishes. The rollback is not
+complete until they land.
+
+1. **Revert `traceColumnsNonNullable` to `false` AND roll-restart every backend instance.** The flag is read from a
+   **startup snapshot** of `OpikConfiguration` (bound via `toInstance`), so a config change does **not** take effect until
+   each instance restarts — exactly like the forward rollout before the EXCHANGE. Until the restart completes, the app
+   keeps binding sentinels (epoch/NaN) and using sentinel-based absent-value logic against the now-Nullable column,
+   mixing sentinel and `null` representations: not a hard write failure, but inconsistent absent-value
+   reads/filters/sorts.
+2. **Repair the sentinels written into the original during the pre-swap window** (see the caveats under "The
+   `traceColumnsNonNullable` flip"). Those rows carry `end_time = epoch` / `ttft = NaN` where the original's convention is
+   `NULL`, and — because the original's `duration` expression guards only `end_time IS NOT NULL` — a large **negative**
+   `duration`. The promote made them live again, and the successor's healed copy is discarded by `finalize.sh`, so repair
+   them here. Do this **after** step 1, or in-flight writes keep minting more:
+   ```sql
+   -- how many need repair. Scope the count to the SENTINEL, not to `duration < 0`: a table can hold rows whose
+   -- end_time legitimately precedes start_time, and those are negative for reasons this repair does not address.
+   SELECT countIf(end_time = toDateTime64('1970-01-01 00:00:00', 9)) AS sentinel_end_time,
+          countIf(isNaN(ttft))                                       AS sentinel_ttft,
+          countIf(duration < 0)                                      AS negative_duration_total,
+          countIf(duration < 0 AND end_time = toDateTime64('1970-01-01 00:00:00', 9)) AS negative_from_sentinel
+   FROM <database>.traces;
+   -- restore the original's NULL convention; the mutation rewrites the parts and recomputes `duration`
+   ALTER TABLE <database>.traces ON CLUSTER '{cluster}'
+       UPDATE end_time = NULL WHERE end_time = toDateTime64('1970-01-01 00:00:00', 9) SETTINGS mutations_sync = 2;
+   ALTER TABLE <database>.traces ON CLUSTER '{cluster}'
+       UPDATE ttft = NULL WHERE isNaN(ttft) SETTINGS mutations_sync = 2;
+   ```
+   A bare `MATERIALIZE COLUMN duration` does **not** fix it — it re-evaluates the same expression against the same
+   sentinel and reproduces the negative value.
+
+   **Success is `sentinel_end_time` and `sentinel_ttft` reaching `0` — NOT `negative_duration_total`.** Only
+   `negative_from_sentinel` is this repair's business. Rows whose `end_time` genuinely precedes `start_time` are a
+   pre-existing data-quality artifact of the source, faithfully carried by the migration, and they stay negative
+   afterwards. Measured while validating this runbook: the staging original held **8,378** negative durations of which
+   only **6** came from the sentinel, and dev held **3** of which **1** did. Waiting for a total of `0` would look like
+   a failed repair forever.
+
+   > **The repair needs privileges the migration user does not have.** It updates `end_time` and `ttft`, whereas the
+   > cutover user is granted only `ALTER UPDATE(_row_exists)` (all the reverse replay needs — see the privileges table).
+   > Run these two statements as a user holding `ALTER UPDATE(end_time)` / `ALTER UPDATE(ttft)` on `traces`, or add
+   > those column grants alongside the rollback grants. Verified on dev and staging: as granted, the cutover user
+   > gets `ACCESS_DENIED` here — so this cannot be pasted into the same session that just ran `rollback.sh`.
 
 **Point of no return.** The `EXCHANGE` is reversible for as long as the parked backup exists (stage B/C). Retiring that
 backup with `finalize.sh` is the one irreversible step, so gate it on an explicit soak:
@@ -657,6 +792,21 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 # After the EXCHANGE: `traces` is the successor and the old data is parked as traces_pre_cutover_backup:
 ./scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces
 ```
+
+**Verifying after a rollback.** After a stage B/C rollback the defaults do not apply — `traces_local_v2` no longer
+exists (the successor is parked as `traces_post_rollback_backup`), so a bare `verify.sh --database opik` dies with
+`Code: 60 … Unknown table … traces_local_v2`. The old-schema side is now the restored original and the new-schema side the
+parked successor:
+
+```bash
+./scripts/verify.sh --database opik --old-table traces --new-table traces_post_rollback_backup --to-week N
+```
+
+Expect the **sealed historical weeks to match** and the **current week to mismatch**, by exactly the post-cutover writes
+the rollback discarded (the parked successor holds them; the restored original never did) — so bound the run with
+`--to-week N` at the last sealed week, exactly as for the post-EXCHANGE compare. A mismatch in a *sealed* week would be
+the real signal. Note the divergence is the **opposite** direction from the post-EXCHANGE case: here the *new-table* side
+is the superset.
 
 > **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat.** `traces_pre_cutover_backup` is a
 > **frozen** snapshot as of `cutover_start`, but live `traces` keeps taking writes the instant the buffer drains — so
@@ -757,8 +907,11 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
 - [ ] **Replication settled before the EXCHANGE** — `replication_queue` empty and the deletion-replay mutation
       `is_done` on **all** replicas (`exchange_and_wrap.sh` gates on this; do not `--force` past it in production).
 - [ ] **`traceColumnsNonNullable = true` rolled out to every backend instance before the EXCHANGE** — confirmed live on
-      the whole fleet (else in-progress-trace writes are rejected the instant the non-nullable schema goes live); revert
-      plan to `false` ready for rollback.
+      the whole fleet by a **positive** check, not by the absence of ingestion errors: write an in-progress trace (no
+      `end_time`) through the API and assert it reads back `end_time = null`. A stale-`false` instance still writes
+      correctly (`input_format_null_as_default` converts the `null` bind to the sentinel) and logs nothing — it just
+      serves wrong absent-value reads/filters/sorts. Revert plan to `false` ready for rollback, **plus** the pre-swap
+      sentinel/`duration` repair (see "Rolling back the `traceColumnsNonNullable` flip").
 - [ ] **Schema-parity guards green** — `cutoverCopiesEveryBaseColumn` and `successorMaterializedColumnsMatchSource` pass
       on the release, so the cutover copies every base column of `traces` and the two tables' base and materialized
       columns match.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -177,7 +177,13 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > sweep (`DELETE_FOR_RETENTION` / `deleteForRetentionBounded`) start returning 500 against `traces`. This is prep work
 > that shipped **before** the wrap (OPIK-7455): `TraceDAO` renders its mutation table through a single toggle,
 > `databaseAnalyticsDataModel.tracesDistributedWrapEnabled`. Set it **`true` in lockstep with applying the wrap** so those
-> deletes run against `traces_local`; reads and inserts stay on the Distributed `traces`. While it is `false` (the deploy
+> deletes run against `traces_local`; reads and inserts stay on the Distributed `traces`. The flag is **startup-bound**
+> (read once at boot; no hot-reload), so making it "live across the fleet" means a **completed rolling restart of every
+> backend instance** — there is no readiness endpoint exposing its value, so confirm via the deploy's restart completion
+> or by observing that trace deletes hit the intended table (queries are `log_comment`-tagged). A mismatch is
+> **fail-loud**, not silent: a stale-`false` instance issues `DELETE` against the `Distributed` `traces` (code 36/48), a
+> stale-`true` instance against an absent `traces_local` — both 500 the delete path, so a partial rollout surfaces at
+> once and is recoverable. While it is `false` (the deploy
 > default, and correct while `traces` is still a `MergeTree`) the deletes target `traces` directly. **General rule (splits
 > by kind of change):** row mutations (`DELETE`, `ALTER … DELETE`) and `MATERIALIZE COLUMN` / `ADD INDEX` / `MODIFY TTL`
 > target **`traces_local` only** — the `Distributed` `traces` rejects them (code 36/48), so a slip fails loudly; but
@@ -200,7 +206,9 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > gate and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new `cutover_start`).
 > `--confirm-daos-retargeted` is required for **any** wrap (same-run or deferred), since the wrap makes `traces`
 > `Distributed` and breaks the delete/mutation DAOs until `tracesDistributedWrapEnabled=true` routes them at `traces_local`. To roll the wrap back, use
-> `rollback.sh --stage C`.
+> `rollback.sh --stage C`, then set `tracesDistributedWrapEnabled` back to `false` with the same rolling restart so
+> post-rollback deletes target the `MergeTree` `traces` again — a stale-`true` instance would `DELETE` against the
+> now-absent `traces_local` and 500.
 >
 > The wrap is **gapless per node**: it pre-builds the `Distributed` wrapper under a temp name, then one atomic
 > multi-target `RENAME` rotates the data to `traces_local` and the wrapper into `traces`, so `traces` is never absent on
@@ -713,10 +721,13 @@ Watch these for the whole backfill→EXCHANGE window; wire alerts before startin
   alert on client-side timeouts or ingestion errors, which mean the client timeout is below the buffer.
 - **Query p99** on the project traces listing — the backfill competes for I/O; a sustained regression is an abort signal.
 - **Deletion-capture health** — capture is best-effort and **swallows** errors (so a bridge hiccup never blocks a user's
-  delete), so watch the backend logs for `captureDeletions` failures. A silently-dropped capture would leak a delete;
-  `verify.sh` catches that as a pre-EXCHANGE week mismatch (the row is live on the destination but gone on the source),
-  so it is an early-warning signal, not a silent hole — but treat repeated failures as an abort signal until capture is
-  healthy.
+  delete), so watch the backend logs for `captureDeletions` failures. A silently-dropped capture would leak a delete.
+  `verify.sh` catches that as a pre-EXCHANGE week mismatch (the row is live on the destination but gone on the source)
+  **for any capture failure up to the last pre-EXCHANGE verify** — but a capture that fails in the final
+  `exchange_and_wrap.sh` window (after the last verify, through the swap) is caught by neither `verify.sh` nor the final
+  deletion replay, only by this log-watch. So it is an early-warning signal, not a silent hole: treat repeated failures as
+  an abort signal until capture is healthy, and treat **any** `captureDeletions` failure observed from the last verify
+  through the EXCHANGE as a swap-gating signal.
 
 **Roles.** Name an operator (runs the scripts), an independent observer (watches the dashboards), and the person with
 authority to call a rollback. **Abort thresholds** (decide the numbers up front): free disk below the per-volume alarm,

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -36,7 +36,7 @@
 #                             ClickHouse default); lower it on a memory-constrained data node. Applied to the INSERT.
 #   --divergence P            max tolerated |src-dst|/src per window before aborting. Default 0.0001 (0.01%).
 #   --pause-seconds S         sleep S seconds after each inserted window, to let destination merges catch up and bound
-#                             the part count / IO pressure. Default 0. Recommended 30-60 on the ~4 TB table at peak.
+#                             the part count / IO pressure. Default 0. Recommended 30-60 on a large table at peak.
 #   --min-free-factor F       abort at startup unless node free disk >= F x the current `traces` on-disk size (the
 #                             backfill writes a full second copy). Default 2.0. Pass 0 to skip the check. This is a
 #                             whole-node floor; on tiered storage validate per-volume (hot) headroom separately.
@@ -68,7 +68,7 @@ MAX_INSERT_BLOCK_SIZE=1048576  # rows: SETTINGS max_insert_block_size for the IN
                           # the smaller of this and min_insert_block_size_bytes (256 MB default), which dominates for wide
                           # trace rows; lower it on a memory-constrained node. 1048576 is the ClickHouse default.
 DIVERGENCE="0.0001"       # fraction: max tolerated |src-dst|/src per settled window before aborting (0.01%).
-PAUSE_SECONDS=0           # seconds: sleep after each inserted window so destination merges catch up. 30-60 at ~4 TB peak.
+PAUSE_SECONDS=0           # seconds: sleep after each inserted window so destination merges catch up. 30-60 for a large table at peak.
 MIN_FREE_FACTOR="2.0"     # multiple of the current traces on-disk size that node free space must clear before starting.
 STATE_FILE="./traces_cutover_backfill_start"  # backfill_start is persisted here and reused on resume (keeps one anchor).
 CONFIRM_TIERED_HEADROOM=0 # required when the destination storage_policy is tiered/mismatched (see preflight_capacity).

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -18,11 +18,23 @@
 # Usage:
 #   CLICKHOUSE_HOST=... CLICKHOUSE_PASSWORD=... ./backfill.sh --database opik [options]
 #
-# Connection: passed straight to clickhouse-client via the standard env vars it honors
-# (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD). --database is required.
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
+# --database is required.
 #
 # Options:
 #   --database NAME           analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --dry-run                 print the window plan and per-window source counts; do not INSERT.
 #   --from-week N             start at week offset N (0-based from the anchor Monday). Default 0.
 #   --to-week M               stop after week offset M (inclusive). Default: last week with data.
@@ -46,7 +58,10 @@
 #                             headroom out of band. (No effect on a single-volume/default policy.)
 #   --state-file PATH         file the captured backfill_start is written to and reused from. On resume the ORIGINAL
 #                             anchor is kept; re-minting a later one would miss deletes that fired during the first run
-#                             against already-copied rows. Default ./traces_cutover_backfill_start.
+#                             against already-copied rows. Default ./traces_cutover_backfill_start — note this is
+#                             CWD-RELATIVE, so resuming from a different directory would not find it; pass an absolute
+#                             path for a multi-session cutover. If the anchor is missing while the destination already
+#                             holds rows, the script ABORTS rather than mint a later one (that would leak deletes).
 
 set -euo pipefail
 
@@ -59,6 +74,8 @@ SRC_TABLE="traces"
 DST_TABLE="traces_local_v2"
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 DRY_RUN=0
 FROM_WEEK=0
 TO_WEEK=""
@@ -90,6 +107,8 @@ while [[ $# -gt 0 ]]; do
         --min-free-factor) MIN_FREE_FACTOR="${2:?"$1 requires a value"}"; shift 2 ;;
         --confirm-tiered-headroom) CONFIRM_TIERED_HEADROOM=1; shift ;;
         --state-file) STATE_FILE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -97,6 +116,8 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database is interpolated into the reference SQL; require a plain ClickHouse identifier so it cannot alter the query.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 # --state-file is an operator-owned path read with cat and written with > (both quoted); reject a blank or multi-line
 # value so the single-line anchor round-trips cleanly.
 [[ -n "$STATE_FILE" && "$STATE_FILE" != *$'\n'* ]] || { echo "ERROR: --state-file must be a non-empty single-line path." >&2; exit 2; }
@@ -112,7 +133,7 @@ done
 
 # Every query runs against the analytics database; --query keeps output scriptable (TSV, no formatting).
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:backfill' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:backfill' --query "$1"
 }
 
 log() {
@@ -195,7 +216,7 @@ run_backfill_window() {
     sql="${sql//'${WINDOW_LO}'/$lo}"
     sql="${sql//'${WINDOW_HI}'/$hi}"
     sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
-    clickhouse-client --database "$DATABASE" --multiquery --query "$sql"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 
 # Insert one window whose physical row count is already within the per-statement bound. Reconciliation is dedup-aware
@@ -281,6 +302,17 @@ if [[ "$ROWS" == "0" ]]; then
     exit 0
 fi
 
+# The successor must exist before anything else (runbook prerequisite #2: created empty by migration 000101, recreated by
+# 000114). Checked explicitly so its absence reads as the prerequisite it is, rather than surfacing later as a raw
+# ClickHouse "unknown table" from the capacity probe, the resume check or the first INSERT. Post-cutover the shadow has
+# been renamed away, so this also stops a stray re-run after a completed cutover.
+if [[ -z "$(ch "SELECT name FROM system.tables WHERE database = '$DATABASE' AND name = '$DST_TABLE'")" ]]; then
+    log "ABORT: successor table '$DATABASE.$DST_TABLE' does not exist. It is created empty by Liquibase (migration 000101," >&2
+    log "       recreated by 000114) — confirm those changesets are applied on this instance. If a cutover already" >&2
+    log "       completed, the shadow was renamed away and there is nothing to backfill." >&2
+    exit 1
+fi
+
 preflight_capacity
 
 # backfill_start: the single anchor for BOTH the delta-insert and the deletion replay in step 2. Captured BEFORE the
@@ -295,6 +327,25 @@ if [[ "$DRY_RUN" != "1" ]]; then
         [[ "$BACKFILL_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] || { echo "ERROR: $STATE_FILE does not contain a valid backfill_start timestamp ('YYYY-MM-DD HH:MM:SS[.ffffff]')." >&2; exit 1; }
         log "REUSING backfill_start=$BACKFILL_START from $STATE_FILE (resume: original anchor kept)"
     else
+        # Refuse to mint a FRESH anchor onto a destination that already holds rows. That combination is contradictory:
+        # a genuine first run starts from an empty successor (migration 000101/000114 creates it empty; a stage-A
+        # rollback truncates it back to empty), so a non-empty destination means this is a RESUME whose original anchor
+        # has been lost — most often because --state-file defaults to a CWD-relative path and the resume ran from a
+        # different directory. Minting a later anchor there is silent data loss: deletes that fired between the real
+        # anchor and this one, against rows the earlier run already copied, are seen by neither the delta (bounded by
+        # the anchor) nor the deletion replay (same bound), so they leak live across the EXCHANGE. The pre-EXCHANGE
+        # verify.sh would flag it, but only as a late, hard-to-attribute mismatch after the copy has been redone.
+        DST_ROWS_AT_ANCHOR="$(ch "SELECT count() FROM $DST_TABLE")"
+        if [[ "$DST_ROWS_AT_ANCHOR" != "0" ]]; then
+            log "ABORT: no anchor in '$STATE_FILE', but $DST_TABLE already holds $DST_ROWS_AT_ANCHOR row(s) — this is a RESUME whose" >&2
+            log "       original backfill_start was lost, and minting a fresh (later) anchor would make the delta and the" >&2
+            log "       deletion replay blind to deletes in the gap, leaking them across the EXCHANGE. Recover the original" >&2
+            log "       anchor, then either point --state-file at the file holding it or write it back:" >&2
+            log "         printf '%s' '<original backfill_start>' > '$STATE_FILE'" >&2
+            log "       If it is unrecoverable, restart the copy cleanly instead (discards the partial shadow):" >&2
+            log "         ./rollback.sh --database $DATABASE --stage A" >&2
+            exit 1
+        fi
         BACKFILL_START="$(ch "SELECT toString(now64(6))")"
         printf '%s' "$BACKFILL_START" > "$STATE_FILE"
         log "RECORD backfill_start=$BACKFILL_START  (saved to $STATE_FILE; pass this to step 2: 000002_delta_and_deletion_replay.sql)"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/clickhouse-client-docker.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/clickhouse-client-docker.sh
@@ -12,9 +12,19 @@
 #   CLICKHOUSE_CLIENT_IMAGE        official image to run — match your server's major version. Default:
 #                                  clickhouse/clickhouse-server:26.3.16.16-alpine (the version Opik ships); its bundled
 #                                  clickhouse-client is used via --entrypoint, so there is one trusted image.
-#   CLICKHOUSE_CLIENT_DOCKER_OPTS  extra `docker run` flags. Empty for a remote CLICKHOUSE_HOST (the container dials out);
-#                                  set '--network=host' (or CLICKHOUSE_HOST=host.docker.internal) only when ClickHouse is
-#                                  on the host's own loopback, e.g. a local `opik.sh --port-mapping` run.
+#   CLICKHOUSE_CLIENT_DOCKER_OPTS  extra `docker run` flags. Empty for a remote CLICKHOUSE_HOST (the container dials out).
+#                                  To reach a ClickHouse on the HOST's own loopback there are two cases, and on macOS they
+#                                  are NOT interchangeable:
+#                                    * Linux, or a container publishing its port (e.g. a local `opik.sh --port-mapping`):
+#                                      '--network=host' works.
+#                                    * macOS + `kubectl port-forward` (the normal way to reach a real cluster): use
+#                                        CLICKHOUSE_CLIENT_DOCKER_OPTS=--add-host=host.docker.internal:host-gateway
+#                                        CLICKHOUSE_HOST=host.docker.internal
+#                                      '--network=host' does NOT work here: inside Docker Desktop the "host" network is
+#                                      the Docker VM, not your Mac, so it cannot see a port-forward bound to the Mac's
+#                                      loopback (you get "Connection refused").
+#                                  Remember the port itself must go through the drivers' --port flag — clickhouse-client
+#                                  ignores CLICKHOUSE_PORT.
 set -euo pipefail
 
 IMAGE="${CLICKHOUSE_CLIENT_IMAGE:-clickhouse/clickhouse-server:26.3.16.16-alpine}"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -90,26 +90,19 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- >>> END delta-insert
 
 -- Step 4: Deletion replay — remove from the destination every row that was deleted on the source since backfill_start
--- AND is still deleted there. Two branches, mirroring the product's two delete paths (TraceService.delete): a delete
--- resolves each trace's owning project and deletes per project; ids it cannot resolve fall back to a workspace-scoped
--- delete (TraceDAO DELETE_BY_ID with no project filter). The bridge records the first with the project and the second
--- with an EMPTY project_id (DeletionEventDAO: "project_id is empty for workspace-scoped source tables"). So:
---   * events WITH a project -> match the FULL key (workspace_id, project_id, id). Exact, prunes on the destination
---     primary key, and correct even when an id is reused across projects (ids are not globally unique).
---   * events WITHOUT a project -> match (workspace_id, id). A faithful mirror of the source's workspace-scoped delete.
+-- AND is still deleted there. Single FULL-KEY branch: since OPIK-7483 every trace delete resolves its owning project(s)
+-- and deletes each under the full (workspace_id, project_id, id) key — there is no project-less delete path, so no
+-- deletion event is ever bridged with an empty project_id for source_table='traces' (a pre-cutover prereq asserts the
+-- bridge holds none — see README "Prerequisites"). So the replay matches the FULL key (workspace_id, project_id, id):
+-- exact, prunes on the destination primary key, and correct even when an id is reused across projects (not globally unique).
 -- RESURRECTION GUARD (the `NOT IN traces` arm): a trace can be deleted and then re-created/updated under the same id
 -- during the window (client-supplied ids; the delete is a mask, a newer insert wins under FINAL). Such an id is bridged
 -- as deleted but is LIVE again on the source, and the backfill/delta already copied its live version. Deleting it by key
--- would drop a row that is live on the source — silent data loss. So each branch deletes only ids that are NOT currently
+-- would drop a row that is live on the source — silent data loss. So the replay deletes only ids that are NOT currently
 -- live on the source (mask-honored). The `id IN (deleted_ids since anchor)` bound keeps the deleted-id set tiny
 -- (retention is off, so these are user-scale deletes); `traces` has no id skip index (000088 indexes only
 -- created_at/last_updated_at — id minmax/bloom indexes exist only on traces_local_v2), so this source lookup is a
--- bounded id-filtered read of that tiny set, not a value-indexed prune of the ~4 TB table.
--- KNOWN RESIDUAL (workspace-scoped arm only): its guard keys on (workspace_id, id), so an id live in ONE project shields
--- the deletion of that id's now-deleted copies in OTHER projects (ids are not globally unique). Requires cross-project id
--- reuse + a workspace-scoped delete + a resurrection in the window — rare. The 000005 FINAL fingerprint flags it as an
--- extra destination row (ok=0) rather than passing silently. OPIK-7483 removes the workspace-scoped delete path at the
--- source (deletes always carry project_id), retiring this arm and the residual.
+-- bounded id-filtered read of that tiny set, not a value-indexed prune of the full `traces` table.
 -- allow_nondeterministic_mutations: a lightweight DELETE with cross-table subqueries is flagged nondeterministic, but
 -- deletion_events_local and traces are replicated and identical on every node and the window predicate is fixed, so the
 -- subqueries resolve to the same set on every replica. Idempotent (never masks a live-on-source id, so re-runs converge).
@@ -117,8 +110,9 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- accepted it. The mutation is otherwise asynchronous, so without this the verify step (and the EXCHANGE) could run
 -- against a replica where the mask is not yet applied — a false mismatch, or worse an incomplete cutover.
 -- Uses ${BACKFILL_START}. Retention is disabled everywhere (see step 6), so this is user-scale volume — a single
--- mutation. If it is ever large (e.g. retention enabled), bound each mutation by a partition predicate and loop the
--- weeks, e.g. AND toMonday(id_at) = toDate('<week>').
+-- mutation. If it is ever large (e.g. retention enabled), bound each mutation by a created_at week (the non-wrapping,
+-- minmax-indexed slice backfill.sh uses) and loop the weeks — NOT toMonday(id_at), which wraps far-future/epoch ids
+-- (OPIK-7456) and no longer matches the successor's honest-Date32 partition expression.
 -- length(...) = 36 guards: toFixedString(x, 36) THROWS on a value longer than 36 bytes, which would abort the whole
 -- replay on a single malformed bridge row. For source_table='traces' the ids are 36-char UUIDs, so this is latent — but
 -- a malformed (non-36-char) deleted_id/project_id can't match a real trace id anyway, so skipping it via the length
@@ -142,31 +136,6 @@ WHERE (
         SELECT
             workspace_id,
             project_id,
-            id
-        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
-        WHERE id IN (
-            SELECT toFixedString(deleted_id, 36)
-            FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
-            WHERE source_table = 'traces'
-              AND event_time >= toDateTime64('${BACKFILL_START}', 6)
-              AND length(deleted_id) = 36
-        )
-    )
-)
-OR (
-    (workspace_id, id) IN (
-        SELECT
-            workspace_id,
-            toFixedString(deleted_id, 36)
-        FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
-        WHERE source_table = 'traces'
-          AND event_time >= toDateTime64('${BACKFILL_START}', 6)
-          AND project_id = ''
-          AND length(deleted_id) = 36
-    )
-    AND (workspace_id, id) NOT IN (
-        SELECT
-            workspace_id,
             id
         FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
         WHERE id IN (

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -6,8 +6,9 @@
 -- this file, substitutes the placeholders and runs it — never run this file by hand:
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000'
 -- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where
--- situational awareness matters most — those are config/judgement, not SQL. clickhouse-client prints each statement's
--- elapsed time, which is the replay measurement in step 5.
+-- situational awareness matters most — those are config/judgement, not SQL. The driver invokes clickhouse-client with
+-- --time, so it prints each statement's elapsed seconds to stderr (delta-insert first, deletion replay second); the
+-- second value is the replay measurement in step 5. A bare --query prints no timing, hence the flag.
 
 -- Step 1: BACKFILL_START is the timestamp captured BEFORE the backfill began. backfill.sh prints it at startup
 -- ("RECORD backfill_start=..."); if you ran the backfill manually, use the now64(6) you captured before the first

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
@@ -2,10 +2,12 @@
 -- The gate test TracesLocalV2CutoverTest reimplements this statement inline; keep the two in step (see its Javadoc).
 --
 -- Re-applies the deletes that fired on the successor since cutover_start onto the restored original `traces`, so they do
--- not resurrect. Two branches, like the forward replay in 000002: events with a project match the full key; events from
--- the product's workspace-scoped delete fallback (project_id = '') match (workspace_id, id). Shared by stages B and C
--- (run right after the swap/promote), never on its own. If the set is ever large, bound it with
--- AND toMonday(id_at) = toDate('<week>') and loop the weeks.
+-- not resurrect. Single FULL-KEY branch, like the forward replay in 000002: since OPIK-7483 every delete carries its
+-- project_id (no project-less path), so the replay matches (workspace_id, project_id, id); the post-cutover deletes it
+-- replays come from the live successor, which routes through that same delete path. Shared by stages B and C
+-- (run right after the swap/promote), never on its own. If the set is ever large, bound it by a created_at week and
+-- loop the weeks (NOT toMonday(id_at), which wraps far-future/epoch ids — OPIK-7456; the restored original `traces` is
+-- not weekly-partitioned by it anyway).
 --
 -- Deliberately NO resurrection guard (the `AND ... NOT IN traces` arm the forward replay in 000002 carries). Do NOT add
 -- one here: rollback abandons all post-cutover writes on the successor (they are being discarded) while still honoring
@@ -23,16 +25,6 @@ WHERE (workspace_id, project_id, id) IN (
       AND event_time >= toDateTime64('${CUTOVER_START}', 6)
       AND project_id != ''
       AND length(project_id) = 36
-      AND length(deleted_id) = 36
-)
-OR (workspace_id, id) IN (
-    SELECT
-        workspace_id,
-        toFixedString(deleted_id, 36)
-    FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
-    WHERE source_table = 'traces'
-      AND event_time >= toDateTime64('${CUTOVER_START}', 6)
-      AND project_id = ''
       AND length(deleted_id) = 36
 )
 -- lightweight_deletes_sync = 2: wait for the mutation on every replica so the restored `traces` is consistent

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -186,3 +186,165 @@ WHERE src_hash != dst_hash
 LIMIT 100
 SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- >>> END drill-down
+
+-- >>> BEGIN confirm-keys
+-- For a window the compare reported ok=0: decide whether the difference is REAL, or an artifact of
+-- windowing on created_at under FINAL. Returns one number -- the count of keys that GENUINELY differ.
+--
+-- Why the artifact exists. FINAL collapses ReplacingMergeTree versions only among the parts a query
+-- actually reads, and `created_at` is not in the sorting key, so a created_at predicate can select the
+-- part holding a SUPERSEDED version while excluding the part holding the winner. With no winner in the
+-- read set there is nothing to collapse against, so the stale row is returned as though it were live.
+-- Whether that happens differs between the unpartitioned source and the id_at-partitioned successor
+-- (different part layouts), so one side can surface a superseded row the other does not -- and the window
+-- "mismatches" even though both tables hold byte-identical live data. Observed on staging: one id written
+-- twice, five weeks apart, put its superseded version in an earlier week on the successor only.
+--
+-- Why this re-check is trustworthy. It filters ONLY on (workspace_id, project_id, id) -- the sorting key,
+-- which IS the dedup key. That predicate cannot hide a version from FINAL: every part contributes the
+-- granules holding the key, so FINAL always sees all versions of it and returns the true winner. The
+-- window bounds are used only to pick the candidate keys, never to decide the verdict.
+--
+-- 0  = every differing key has identical live rows on both sides -> superseded-version artifact, not a
+--      data difference (the live row is still compared, and must match, in the week its winner lands in).
+-- >0 = that many keys genuinely differ -> real fidelity failure.
+WITH
+    diff_keys AS (
+        SELECT key
+        FROM (
+            SELECT
+                (workspace_id, project_id, id) AS key,
+                cityHash64(
+            id,
+            workspace_id,
+            toString(project_id),
+            name,
+            toUnixTimestamp64Micro(toDateTime64(start_time, 6)),
+            coalesce(toUnixTimestamp64Micro(toDateTime64(end_time, 6)), toInt64(0)),
+            input,
+            output,
+            metadata,
+            arrayStringConcat(tags, '\x1f'),
+            toUnixTimestamp64Micro(toDateTime64(created_at, 6)),
+            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)),
+            created_by,
+            last_updated_by,
+            error_info,
+            thread_id,
+            toString(visibility_mode),
+            truncation_threshold,
+            input_slim,
+            output_slim,
+            if(ttft IS NULL, 'nan', toString(ttft)),
+            toString(source),
+            toString(environment)) AS src_hash
+            FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE} FINAL
+            WHERE created_at >= toDateTime64('${WINDOW_LO}', 9)
+              AND created_at <  toDateTime64('${WINDOW_HI}', 9)
+              AND cityHash64(id) % ${SAMPLE_MOD} = 0
+        ) AS s
+        FULL OUTER JOIN (
+            SELECT
+                (workspace_id, project_id, id) AS key,
+                cityHash64(
+            id,
+            workspace_id,
+            toString(project_id),
+            name,
+            toUnixTimestamp64Micro(start_time),
+            toUnixTimestamp64Micro(end_time),
+            input,
+            output,
+            metadata,
+            arrayStringConcat(tags, '\x1f'),
+            toUnixTimestamp64Micro(created_at),
+            toUnixTimestamp64Micro(last_updated_at),
+            created_by,
+            last_updated_by,
+            error_info,
+            thread_id,
+            toString(visibility_mode),
+            truncation_threshold,
+            input_slim,
+            output_slim,
+            if(isNaN(ttft), 'nan', toString(ttft)),
+            toString(source),
+            toString(environment)) AS dst_hash
+            FROM ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE} FINAL
+            WHERE created_at >= toDateTime64('${WINDOW_LO}', 6)
+              AND created_at <  toDateTime64('${WINDOW_HI}', 6)
+              AND cityHash64(id) % ${SAMPLE_MOD} = 0
+        ) AS d USING (key)
+        WHERE src_hash != dst_hash OR src_hash IS NULL OR dst_hash IS NULL
+    ),
+    -- Deliberately NOT limited: a verdict drawn from a truncated key set could call a window an artifact
+    -- while an unexamined key held a real difference. A genuinely broken window makes this heavy, which is
+    -- the right trade -- that is the case you want to stop on anyway.
+    src_live AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            cityHash64(
+            id,
+            workspace_id,
+            toString(project_id),
+            name,
+            toUnixTimestamp64Micro(toDateTime64(start_time, 6)),
+            coalesce(toUnixTimestamp64Micro(toDateTime64(end_time, 6)), toInt64(0)),
+            input,
+            output,
+            metadata,
+            arrayStringConcat(tags, '\x1f'),
+            toUnixTimestamp64Micro(toDateTime64(created_at, 6)),
+            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)),
+            created_by,
+            last_updated_by,
+            error_info,
+            thread_id,
+            toString(visibility_mode),
+            truncation_threshold,
+            input_slim,
+            output_slim,
+            if(ttft IS NULL, 'nan', toString(ttft)),
+            toString(source),
+            toString(environment)) AS src_hash
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE} FINAL
+        WHERE (workspace_id, project_id, id) IN (SELECT key FROM diff_keys)
+    ),
+    dst_live AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            cityHash64(
+            id,
+            workspace_id,
+            toString(project_id),
+            name,
+            toUnixTimestamp64Micro(start_time),
+            toUnixTimestamp64Micro(end_time),
+            input,
+            output,
+            metadata,
+            arrayStringConcat(tags, '\x1f'),
+            toUnixTimestamp64Micro(created_at),
+            toUnixTimestamp64Micro(last_updated_at),
+            created_by,
+            last_updated_by,
+            error_info,
+            thread_id,
+            toString(visibility_mode),
+            truncation_threshold,
+            input_slim,
+            output_slim,
+            if(isNaN(ttft), 'nan', toString(ttft)),
+            toString(source),
+            toString(environment)) AS dst_hash
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE} FINAL
+        WHERE (workspace_id, project_id, id) IN (SELECT key FROM diff_keys)
+    )
+SELECT count() AS unresolved
+FROM src_live AS s
+FULL OUTER JOIN dst_live AS d USING (key)
+WHERE src_hash != dst_hash
+   OR src_hash IS NULL
+   OR dst_hash IS NULL
+SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
+-- >>> END confirm-keys

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -195,10 +195,11 @@ SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- actually reads, and `created_at` is not in the sorting key, so a created_at predicate can select the
 -- part holding a SUPERSEDED version while excluding the part holding the winner. With no winner in the
 -- read set there is nothing to collapse against, so the stale row is returned as though it were live.
--- Whether that happens differs between the unpartitioned source and the id_at-partitioned successor
--- (different part layouts), so one side can surface a superseded row the other does not -- and the window
--- "mismatches" even though both tables hold byte-identical live data. Observed on staging: one id written
--- twice, five weeks apart, put its superseded version in an earlier week on the successor only.
+-- Whether that happens depends on part layout, which differs between the unpartitioned source and the
+-- id_at-partitioned successor, so one side can surface a superseded row the other does not -- and the
+-- window "mismatches" even though both tables hold byte-identical live data. Any id written more than
+-- once, far enough apart to land in different created_at weeks, can trigger it; trace ids are
+-- client-supplied, so a re-sent id is ordinary rather than exotic.
 --
 -- Why this re-check is trustworthy. It filters ONLY on (workspace_id, project_id, id) -- the sorting key,
 -- which IS the dedup key. That predicate cannot hide a version from FINAL: every part contributes the

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -5,10 +5,22 @@
 # Reads db-app-analytics/000002_delta_and_deletion_replay.sql (the single source), substitutes the placeholders and runs
 # it. Run it after backfill.sh, then verify.sh, then exchange_and_wrap.sh.
 #
-# Connection: clickhouse-client env vars (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
 #
 # Options:
 #   --database NAME            analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --backfill-start TS        the anchor printed by backfill.sh ("RECORD backfill_start=..."). Required.
 #   --max-insert-block-size N  SETTINGS max_insert_block_size for the delta INSERT. Default 1048576.
 
@@ -18,6 +30,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 BACKFILL_START=""
 MAX_INSERT_BLOCK_SIZE=1048576
 
@@ -26,6 +40,8 @@ while [[ $# -gt 0 ]]; do
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --backfill-start) BACKFILL_START="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -33,6 +49,8 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database and --backfill-start are interpolated into the reference SQL; validate their shapes so neither can alter it.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ -n "$BACKFILL_START" ]] || { echo "ERROR: --backfill-start is required (printed by backfill.sh)" >&2; exit 2; }
 [[ "$BACKFILL_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] || { echo "ERROR: --backfill-start must be 'YYYY-MM-DD HH:MM:SS[.ffffff]'." >&2; exit 2; }
 [[ "$MAX_INSERT_BLOCK_SIZE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-insert-block-size must be a positive integer." >&2; exit 2; }
@@ -45,6 +63,11 @@ sql="$(cat "$SQL_FILE")"
 sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
-clickhouse-client --database "$DATABASE" --multiquery --query "$sql"
+# --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
+# --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
+# the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.
+echo "Statement wall times (seconds, in order: delta-insert, deletion-replay):"
+clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --time --multiquery --query "$sql"
 
-echo "Delta + deletion replay complete. Run verify.sh before the EXCHANGE."
+echo "Delta + deletion replay complete. RECORD the deletion-replay wall time above (the second value) — the"
+echo "final-delta -> EXCHANGE gap must fit inside the buffer hold. Run verify.sh before the EXCHANGE."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
@@ -12,10 +12,22 @@
 # in by --write-cost-factor. For an exact figure, time one real window with backfill.sh and pass its rows/sec via
 # --rows-per-sec.
 #
-# Connection: clickhouse-client env vars (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
 #
 # Options:
 #   --database NAME            analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --max-rows-per-insert R    the value you will pass to backfill.sh; sets how many windows the copy splits into.
 #                              Default 2000000 (matches backfill.sh).
 #   --pause-seconds S          backfill.sh --pause-seconds; added once per window as merge-catch-up idle time. Default 0.
@@ -30,6 +42,8 @@
 set -euo pipefail
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 MAX_ROWS=2000000
 PAUSE_SECONDS=0
 PROBE_ROWS=200000
@@ -44,6 +58,8 @@ while [[ $# -gt 0 ]]; do
         --probe-rows) PROBE_ROWS="${2:?"$1 requires a value"}"; shift 2 ;;
         --write-cost-factor) WRITE_COST_FACTOR="${2:?"$1 requires a value"}"; shift 2 ;;
         --rows-per-sec) ROWS_PER_SEC="${2:?"$1 requires a value"}"; shift 2 ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -51,6 +67,8 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database is interpolated into the probe/size SQL; require a plain ClickHouse identifier so it cannot alter the query.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 # Numeric args flow into the probe/estimate SQL and awk; require sane numeric shapes so none can alter the query.
 [[ "$MAX_ROWS" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-rows-per-insert must be a positive integer." >&2; exit 2; }
 [[ "$PROBE_ROWS" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --probe-rows must be a positive integer." >&2; exit 2; }
@@ -59,7 +77,7 @@ done
 [[ -z "$ROWS_PER_SEC" || "$ROWS_PER_SEC" =~ ^[0-9]+(\.[0-9]+)?$ ]] || { echo "ERROR: --rows-per-sec must be a number." >&2; exit 2; }
 
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:estimate' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:estimate' --query "$1"
 }
 
 # Physical rows to copy (count() honors the deleted-row mask, so masked rows are excluded — as the backfill excludes
@@ -108,7 +126,7 @@ FACTOR_NOTE=""
 if [[ -z "$ROWS_PER_SEC" ]]; then
     PROBE_ACTUAL="$(awk -v a="$PROBE_ROWS" -v b="$TOTAL_ROWS" 'BEGIN { print (a < b) ? a : b }')"
     echo "Probing read throughput with a $PROBE_ACTUAL-row SELECT ... FORMAT Null (no table created)..."
-    ELAPSED="$(clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:estimate' --time --query \
+    ELAPSED="$(clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:estimate' --time --query \
         "SELECT * FROM traces LIMIT $PROBE_ROWS FORMAT Null" 2>&1 1>/dev/null)"
     READ_RPS="$(awk -v r="$PROBE_ACTUAL" -v t="$ELAPSED" 'BEGIN { print (t > 0) ? r / t : 0 }')"
     [[ "$(awk -v v="$READ_RPS" 'BEGIN { print (v > 0) ? 1 : 0 }')" == "1" ]] || {
@@ -117,7 +135,10 @@ if [[ -z "$ROWS_PER_SEC" ]]; then
     }
     ROWS_PER_SEC="$(awk -v r="$READ_RPS" -v f="$WRITE_COST_FACTOR" 'BEGIN { print r / f }')"
     echo "Read throughput: ~$(printf '%.0f' "$READ_RPS") rows/sec ($PROBE_ACTUAL rows in ${ELAPSED}s)."
-    FACTOR_NOTE="  (read ${READ_RPS%.*}/s derated by write-cost-factor ${WRITE_COST_FACTOR})"
+    # Format with printf, not "${READ_RPS%.*}": awk's default OFMT is %.6g, so a fast probe yields
+    # "1.34228e+06" and the parameter expansion strips it to "1" — the note then reads "read 1/s",
+    # which looks like a collapsed cluster rather than 1.3M rows/sec.
+    FACTOR_NOTE="  (read $(printf '%.0f' "$READ_RPS")/s derated by write-cost-factor ${WRITE_COST_FACTOR})"
 fi
 
 # ETA = copy time + total throttle idle. Throttle idle is one --pause-seconds per window (a fresh run inserts every

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
@@ -135,9 +135,9 @@ if [[ -z "$ROWS_PER_SEC" ]]; then
     }
     ROWS_PER_SEC="$(awk -v r="$READ_RPS" -v f="$WRITE_COST_FACTOR" 'BEGIN { print r / f }')"
     echo "Read throughput: ~$(printf '%.0f' "$READ_RPS") rows/sec ($PROBE_ACTUAL rows in ${ELAPSED}s)."
-    # Format with printf, not "${READ_RPS%.*}": awk's default OFMT is %.6g, so a fast probe yields
-    # "1.34228e+06" and the parameter expansion strips it to "1" — the note then reads "read 1/s",
-    # which looks like a collapsed cluster rather than 1.3M rows/sec.
+    # Format with printf, not "${READ_RPS%.*}": awk's default OFMT is %.6g, so any probe above ~1e6 rows/sec
+    # is rendered as "1.34228e+06" and the parameter expansion strips it to "1" — reporting a fast cluster as
+    # "read 1/s". Display only; ROWS_PER_SEC is passed to awk, which parses the exponent form correctly.
     FACTOR_NOTE="  (read $(printf '%.0f' "$READ_RPS")/s derated by write-cost-factor ${WRITE_COST_FACTOR})"
 fi
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -16,10 +16,22 @@
 # so a re-run cannot silently swap the tables back, and a partial EXCHANGE (swap done, post-swap RENAME not) is detected
 # with the command to finish it.
 #
-# Connection: clickhouse-client env vars (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
 #
 # Options:
 #   --database NAME   analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --backfill-start TS  the anchor printed by backfill.sh. REQUIRED for every EXCHANGE path (not --wrap-only): just
 #                     before the swap this runs a final deletion replay from that anchor, so deletes bridged since the
 #                     last delta_replay.sh don't leak live across the EXCHANGE (they'd be covered by neither the forward
@@ -63,6 +75,8 @@ SQL_FILE="$SCRIPT_DIR/db-app-analytics/000003_exchange_and_wrap.sql"
 DELTA_SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 BACKFILL_START=""
 SKIP_WRAP=0
 WITH_WRAP=0
@@ -85,6 +99,8 @@ while [[ $# -gt 0 ]]; do
         --confirm-daos-retargeted) CONFIRM_DAOS_RETARGETED=1; shift ;;
         --confirm-buffer-raised) CONFIRM_BUFFER_RAISED=1; shift ;;
         --confirm-retention-paused) CONFIRM_RETENTION_PAUSED=1; shift ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -92,6 +108,8 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database is interpolated into the reference SQL; require a plain ClickHouse identifier so it cannot alter the query.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ -f "$SQL_FILE" ]] || { echo "ERROR: cannot find $SQL_FILE" >&2; exit 2; }
 [[ -f "$DELTA_SQL_FILE" ]] || { echo "ERROR: cannot find $DELTA_SQL_FILE" >&2; exit 2; }
 # --backfill-start (the anchor printed by backfill.sh) is interpolated into the final deletion replay; validate its shape.
@@ -147,7 +165,7 @@ if [[ "$WRAP_ONLY" != "1" && "$CONFIRM_RETENTION_PAUSED" != "1" ]]; then
 fi
 
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "$1"
 }
 
 # Single scalar (empty string if the object does not exist).
@@ -178,7 +196,7 @@ assert_pre_exchange_topology() {
         if [[ -n "$(traces_engine traces_local_v2)" ]]; then
             echo "ERROR: the EXCHANGE already ran (traces holds the successor schema) but 'traces_local_v2' still exists —" >&2
             echo "       the post-swap RENAME did not complete. Finish it, then continue (e.g. --wrap-only or rollback.sh):" >&2
-            echo "         clickhouse-client --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
+            echo "         clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
         else
             echo "ERROR: the EXCHANGE already ran (traces is the successor; old data parked as traces_pre_cutover_backup)." >&2
             echo "       Do NOT re-run it — a second EXCHANGE would swap the tables back. Apply the deferred wrap with --wrap-only, or roll back with rollback.sh --stage B." >&2
@@ -208,7 +226,7 @@ assert_pre_wrap_topology() {
     if [[ -n "$(traces_engine traces_local_v2)" ]]; then
         echo "ERROR: --wrap-only: 'traces_local_v2' still exists — the post-EXCHANGE RENAME did not complete, so wrapping" >&2
         echo "       now would orphan the old data under the wrong name. Finish the rename first, then re-run --wrap-only:" >&2
-        echo "         clickhouse-client --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
+        echo "         clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
         exit 1
     fi
     if [[ -z "$(traces_engine traces_pre_cutover_backup)" ]]; then
@@ -267,7 +285,11 @@ run_block() {
     local sql
     sql="$(extract "$1")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
-    clickhouse-client --database "$DATABASE" --multiquery --query "$sql"
+    # Each ON CLUSTER DDL in the block emits one row per host (host, port, status, error, hosts_remaining,
+    # hosts_active); status 0 with an empty error means that host applied it. Labelled so the rows are not mistaken for
+    # output of the preceding step (e.g. the final deletion replay).
+    echo "  $1: ON CLUSTER responses per host (host, port, status, error, hosts_remaining, hosts_active):"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 
 # Final deletion replay before the EXCHANGE. delta_replay.sh (step 2) replayed deletes only up to when it ran; cutover_start
@@ -281,7 +303,9 @@ run_final_deletion_replay() {
     sql="$(awk -v begin="-- >>> BEGIN deletion-replay" -v end="-- >>> END deletion-replay" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$DELTA_SQL_FILE")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
     sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap:final_deletion_replay' --multiquery --query "$sql"
+    # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). This replay sits inside
+    # the final-delta -> EXCHANGE gap the buffer hold has to cover, so its wall time is the number to record.
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap:final_deletion_replay' --time --multiquery --query "$sql"
 }
 
 if [[ "$WRAP_ONLY" == "1" ]]; then
@@ -300,7 +324,7 @@ if [[ "$WRAP_ONLY" == "1" ]]; then
     exit 0
 fi
 
-CUTOVER_START="$(clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "SELECT toString(now64(6))")"
+CUTOVER_START="$(clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "SELECT toString(now64(6))")"
 echo "RECORD cutover_start=$CUTOVER_START  (pass to rollback.sh --cutover-start if you roll back after this point)"
 
 echo "Final deletion replay: masking deletes bridged since the last delta_replay so none leak across the swap..."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -8,8 +8,9 @@
 # still holding writes.
 #
 # The wrap is OPT-IN on purpose: a lightweight DELETE against a Distributed table is unsupported, so wrapping `traces`
-# breaks the product's trace-delete / retention paths until those DAOs target `traces_local`. The safe default is to
-# leave `traces` a MergeTree (deletes keep working) and apply the wrap later, once the DAOs are sharding-aware.
+# breaks the product's trace-delete / retention paths unless tracesDistributedWrapEnabled=true (OPIK-7455) routes those
+# mutations at `traces_local`. The safe default is to leave `traces` a MergeTree (deletes keep working) and apply the
+# wrap later, flipping that toggle in lockstep.
 #
 # Guarded like rollback.sh: it asserts the live `traces` topology matches the requested action before touching anything,
 # so a re-run cannot silently swap the tables back, and a partial EXCHANGE (swap done, post-swap RENAME not) is detected
@@ -25,8 +26,9 @@
 #                     replay nor the rollback reverse-replay otherwise).
 #   (default)         run ONLY the EXCHANGE (the data cutover), then stop — leaves `traces` a MergeTree where deletes
 #                     still work. The Distributed wrap is deferred (see above).
-#   --with-wrap       also apply the Distributed wrap in the same run (EXCHANGE + wrap). Use only once the delete/read
-#                     DAOs are sharding-aware. Mutually exclusive with --skip-wrap / --wrap-only.
+#   --with-wrap       also apply the Distributed wrap in the same run (EXCHANGE + wrap). Use only once
+#                     tracesDistributedWrapEnabled=true (OPIK-7455) is live so trace mutations target `traces_local`.
+#                     Mutually exclusive with --skip-wrap / --wrap-only.
 #   --skip-wrap       explicit alias for the default (EXCHANGE only); accepted for clarity and back-compat.
 #   --wrap-only       run ONLY the Distributed wrap on the already-swapped `traces` (no EXCHANGE, no new cutover_start)
 #                     — the deferred second half of a prior EXCHANGE-only run. Mutually exclusive with the above.
@@ -312,7 +314,7 @@ if [[ "$WITH_WRAP" == "1" ]]; then
     echo "Distributed wrap done: 'traces' fronts 'traces_local' via sipHash64(project_id)."
 else
     echo "Distributed wrap deferred (default). Deletes still work on the MergeTree 'traces'. Apply the wrap later with"
-    echo "'--wrap-only --confirm-maintenance --confirm-daos-retargeted' once the delete/read DAOs target traces_local."
+    echo "'--wrap-only --confirm-maintenance --confirm-daos-retargeted' once tracesDistributedWrapEnabled=true is live."
 fi
 
 echo "Restore databaseAnalytics.asyncInsertBusyTimeoutMaxMs to default, verify, and keep traces_pre_cutover_backup for the soak."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
@@ -24,21 +24,37 @@
 # recycle — if `traces_local_v2` already exists (recycle renames the backup INTO that name; a stray shadow means a retry
 # cutover started before the rollback was finalized).
 #
-# Connection: clickhouse-client env vars (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
 #
 # Options:
 #   --database NAME   analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --confirm         actually run the drop/recycle; without it, prints what would happen and exits (dry run).
 
 set -euo pipefail
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 CONFIRM=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --confirm) CONFIRM=1; shift ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -46,9 +62,11 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database is interpolated into the drop/exists SQL; require a plain ClickHouse identifier so it cannot alter the query.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:finalize' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:finalize' --query "$1"
 }
 
 # Cluster-wide detection. finalize is the one irreversible step and production is multi-replica, so a table's presence is

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -271,9 +271,8 @@ if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     echo "     The mutation rewrites the affected parts and recomputes 'duration' from the restored NULL. Success is"
     echo "     'sentinel_end_time' and 'sentinel_ttft' reaching 0 — NOT 'negative_duration_total': rows whose end_time"
     echo "     genuinely precedes start_time are a pre-existing source artifact this repair does not address, and they"
-    echo "     stay negative (staging: 8378 negative, only 6 from the sentinel; dev: 3 and 1). Do step 1 FIRST, or"
-    echo "     in-flight writes keep minting more sentinels."
-    echo "     NOTE: these two statements need ALTER UPDATE(end_time) / ALTER UPDATE(ttft) on 'traces'. This script's own"
-    echo "     credentials very likely lack them — the cutover user is granted only ALTER UPDATE(_row_exists), which is"
-    echo "     all the reverse replay needs — so run the repair as a more privileged user or add those column grants."
+    echo "     stay negative. Do step 1 FIRST, or in-flight writes keep minting more sentinels."
+    echo "     NOTE: these two statements need ALTER UPDATE(end_time) / ALTER UPDATE(ttft) on 'traces'. A user scoped to"
+    echo "     the rollback grant set has only ALTER UPDATE(_row_exists) — all the reverse replay needs — and will get"
+    echo "     ACCESS_DENIED here, so run the repair as a more privileged user or add those two column grants."
 fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -30,7 +30,22 @@
 # backup that finalize.sh later recycles into an empty traces_local_v2); stage A discards the empty traces_local_v2
 # shadow and leaves traces untouched.
 #
-# Connection: clickhouse-client env vars (CLICKHOUSE_HOST, CLICKHOUSE_PORT, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD).
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
+#
+# Options:
+#   --database NAME           analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 
 set -euo pipefail
 
@@ -38,6 +53,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_DIR="$SCRIPT_DIR/db-app-analytics"
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 STAGE=""
 CUTOVER_START=""
 CONFIRM_RETENTION_PAUSED=0
@@ -52,6 +69,8 @@ while [[ $# -gt 0 ]]; do
         --confirm-retention-paused) CONFIRM_RETENTION_PAUSED=1; shift ;;
         --accept-post-cutover-write-loss) ACCEPT_WRITE_LOSS=1; shift ;;
         --reverse-replay-only) REVERSE_REPLAY_ONLY=1; shift ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -59,6 +78,8 @@ done
 [[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
 # --database and --cutover-start are interpolated into the reference SQL; validate their shapes so neither can alter it.
 [[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ -z "$CUTOVER_START" || "$CUTOVER_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] || { echo "ERROR: --cutover-start must be 'YYYY-MM-DD HH:MM:SS[.ffffff]'." >&2; exit 2; }
 # Exactly one of --stage / --reverse-replay-only.
 if [[ "$REVERSE_REPLAY_ONLY" == "1" ]]; then
@@ -91,7 +112,7 @@ if [[ ( "$STAGE" == "B" || "$STAGE" == "C" ) && "$ACCEPT_WRITE_LOSS" != "1" ]]; 
 fi
 
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_rollback' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_rollback' --query "$1"
 }
 
 # Single scalar (or empty string if the object does not exist). Used by the topology guards below.
@@ -139,7 +160,7 @@ assert_topology() {
                     echo "ERROR: 'traces_pre_cutover_backup' not found but 'traces_local_v2' still exists — the forward" >&2
                     echo "       EXCHANGE's post-swap RENAME did not complete, so the parked original is still under" >&2
                     echo "       'traces_local_v2'. Finish that RENAME, then re-run stage B:" >&2
-                    echo "         clickhouse-client --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
+                    echo "         clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
                 else
                     echo "ERROR: 'traces_pre_cutover_backup' (parked original) not found; cannot swap back." >&2
                 fi
@@ -164,7 +185,7 @@ run_file() {
     sql="$(cat "$file")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
     sql="${sql//'${CUTOVER_START}'/$CUTOVER_START}"
-    clickhouse-client --database "$DATABASE" --multiquery --query "$sql"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 
 # Recovery mode: re-apply only the reverse-replay against the current live `traces`, for a stage B/C run whose promote
@@ -230,6 +251,29 @@ esac
 
 if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     echo "Now in the canonical state: traces = original data (live), traces_post_rollback_backup = successor data (parked)."
-    echo "Verify (README 'Verifying the migration'), then run finalize.sh once healthy — it recycles the backup into an"
-    echo "empty traces_local_v2 (restoring the pre-cutover shadow), the one irreversible step."
+    echo "Verify with the POST-ROLLBACK table pair — the verify.sh defaults no longer apply (traces_local_v2 is gone), and"
+    echo "the CURRENT week legitimately mismatches by the post-cutover writes this rollback discarded, so bound it:"
+    echo "  ./verify.sh --database $DATABASE --old-table traces --new-table traces_post_rollback_backup --to-week <last sealed week>"
+    echo "Then run finalize.sh once healthy — it recycles the backup into an empty traces_local_v2 (restoring the"
+    echo "pre-cutover shadow), the one irreversible step."
+    echo
+    echo "NEXT, on the restored original (see README 'Rolling back the traceColumnsNonNullable flip'):"
+    echo "  1. Set databaseAnalyticsDataModel.traceColumnsNonNullable=false and roll-restart every backend instance."
+    echo "     Until that lands, absent end_time/ttft read back as the epoch/NaN sentinel instead of NULL."
+    echo "  2. Repair the epoch/NaN sentinels written into the still-Nullable original while the flag was true. The"
+    echo "     original stores an absent value as NULL, so those rows now read as 'ended at 1970' / 'ttft 0-ish', and"
+    echo "     its MATERIALIZED duration expression — which guards only 'end_time IS NOT NULL', not the sentinel —"
+    echo "     computed a large NEGATIVE duration that the promote made live again. Count, then restore NULL (a"
+    echo "     MATERIALIZE COLUMN alone would NOT fix it: it re-evaluates the same expression on the same sentinel):"
+    echo "       clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"SELECT countIf(end_time = toDateTime64('1970-01-01 00:00:00', 9)) AS sentinel_end_time, countIf(isNaN(ttft)) AS sentinel_ttft, countIf(duration < 0) AS negative_duration_total, countIf(duration < 0 AND end_time = toDateTime64('1970-01-01 00:00:00', 9)) AS negative_from_sentinel FROM $DATABASE.traces\""
+    echo "       clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"ALTER TABLE $DATABASE.traces ON CLUSTER '{cluster}' UPDATE end_time = NULL WHERE end_time = toDateTime64('1970-01-01 00:00:00', 9) SETTINGS mutations_sync = 2\""
+    echo "       clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"ALTER TABLE $DATABASE.traces ON CLUSTER '{cluster}' UPDATE ttft = NULL WHERE isNaN(ttft) SETTINGS mutations_sync = 2\""
+    echo "     The mutation rewrites the affected parts and recomputes 'duration' from the restored NULL. Success is"
+    echo "     'sentinel_end_time' and 'sentinel_ttft' reaching 0 — NOT 'negative_duration_total': rows whose end_time"
+    echo "     genuinely precedes start_time are a pre-existing source artifact this repair does not address, and they"
+    echo "     stay negative (staging: 8378 negative, only 6 from the sentinel; dev: 3 and 1). Do step 1 FIRST, or"
+    echo "     in-flight writes keep minting more sentinels."
+    echo "     NOTE: these two statements need ALTER UPDATE(end_time) / ALTER UPDATE(ttft) on 'traces'. This script's own"
+    echo "     credentials very likely lack them — the cutover user is granted only ALTER UPDATE(_row_exists), which is"
+    echo "     all the reverse replay needs — so run the repair as a more privileged user or add those column grants."
 fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -20,8 +20,22 @@
 #
 # Options:
 #   --database NAME     analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
 #   --old-table NAME    old-schema table (Nullable, nanosecond). Default traces. After the EXCHANGE: traces_pre_cutover_backup.
 #   --new-table NAME    new-schema table (sentinels, microsecond). Default traces_local_v2. After the EXCHANGE: traces.
+#                       After a stage B/C ROLLBACK the defaults do not apply at all — traces_local_v2 no longer exists, so a
+#                       bare run dies with "Unknown table ... traces_local_v2". The old-schema side is the restored original
+#                       (`traces`) and the new-schema side is the parked successor: pass
+#                       `--old-table traces --new-table traces_post_rollback_backup`, and expect the CURRENT week to
+#                       legitimately mismatch by the post-cutover writes the rollback discarded — bound it with --to-week N
+#                       (see README "Verifying after a rollback").
 #   --sample-mod N      compare a deterministic 1/N id sample (same ids on both sides). Default 1 (every row).
 #   --from-week N       start at week offset N (0-based from the anchor Monday). Default 0.
 #   --to-week M         stop after week offset M (inclusive). Default: last week with data.
@@ -34,6 +48,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 VERIFY_SQL="$SCRIPT_DIR/db-app-analytics/000005_verify_migration.sql"
 
 DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 OLD_TABLE="traces"          # old-schema side; becomes traces_pre_cutover_backup after the EXCHANGE (see --old-table)
 NEW_TABLE="traces_local_v2" # new-schema side (the successor being built); becomes traces after the EXCHANGE
 SAMPLE_MOD=1                # 1 = every row; N compares a deterministic 1/N id sample, identical on both sides
@@ -52,6 +68,8 @@ while [[ $# -gt 0 ]]; do
         --to-week) TO_WEEK="${2:?"$1 requires a value"}"; shift 2 ;;
         --weeks-stride) WEEKS_STRIDE="${2:?"$1 requires a value"}"; shift 2 ;;
         --drill-down) DRILL_DOWN=1; shift ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -62,6 +80,8 @@ for _ident in "$DATABASE" "$OLD_TABLE" "$NEW_TABLE"; do
     [[ "$_ident" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database/--old-table/--new-table must be ClickHouse identifiers (letters, digits, underscore): '$_ident'" >&2; exit 2; }
 done
 # Numeric args are interpolated into the reference SQL / week arithmetic; require integer shapes so none can alter it.
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ "$SAMPLE_MOD" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --sample-mod must be a positive integer." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ "$WEEKS_STRIDE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --weeks-stride must be a positive integer." >&2; exit 2; }
@@ -69,7 +89,7 @@ done
 [[ -f "$VERIFY_SQL" ]] || { echo "ERROR: cannot find verify SQL at $VERIFY_SQL" >&2; exit 2; }
 
 ch() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --query "$1"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --query "$1"
 }
 
 log() {
@@ -93,12 +113,19 @@ render_block() {
 
 # Verdict TSV row for one window: src_rows dst_rows src_checksum dst_checksum ok
 compare_window() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block compare "$1" "$2")"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block compare "$1" "$2")"
 }
 
 # Per-key differences for one window (only run on a mismatch, under --drill-down).
 drill_down_window() {
-    clickhouse-client --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block drill-down "$1" "$2")"
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block drill-down "$1" "$2")"
+}
+
+# Count of keys in one window that GENUINELY differ, re-checked on the sorting key so FINAL cannot hide a
+# version (see the confirm-keys block for why a created_at window can surface a superseded row on one side
+# only). 0 means the window's difference is a superseded-version artifact, not a data difference.
+confirm_keys_window() {
+    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block confirm-keys "$1" "$2")"
 }
 
 ROWS="$(ch "SELECT count() FROM $OLD_TABLE")"
@@ -124,6 +151,7 @@ LAST_WEEK="$(ch "SELECT dateDiff('week', toDate('$ANCHOR'), toDate('$HORIZON')) 
 log "Verify: $OLD_TABLE vs $NEW_TABLE | weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE | sample 1/$SAMPLE_MOD"
 
 mismatches=0
+artifacts=0
 checked=0
 for (( week=FROM_WEEK; week<=TO_WEEK; week+=WEEKS_STRIDE )); do
     LO="$(ch "SELECT toString(addWeeks(toDate('$ANCHOR'), $week))") 00:00:00"
@@ -138,13 +166,27 @@ for (( week=FROM_WEEK; week<=TO_WEEK; week+=WEEKS_STRIDE )); do
     if [[ "$ok" == "1" ]]; then
         log "week $week ($LO .. $HI): OK (rows=$src_rows)"
     else
-        mismatches=$((mismatches + 1))
-        log "MISMATCH week $week ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows src_checksum=$src_checksum dst_checksum=$dst_checksum" >&2
-        if [[ "$DRILL_DOWN" == "1" ]]; then
-            log "  differing keys (key, src_hash, dst_hash; NULL = missing on that side):" >&2
-            drill_down_window "$LO" "$HI" >&2
+        # A window difference is not yet a fidelity failure: windowing on created_at under FINAL can surface a
+        # SUPERSEDED version on one side only. Re-check the differing keys on the sorting key, where FINAL
+        # always sees every version, and let that decide. Plain assignment so set -e catches an infra blip
+        # instead of an empty result being read as "artifact" and silently passing a real mismatch.
+        unresolved="$(confirm_keys_window "$LO" "$HI")"
+        [[ "$unresolved" =~ ^[0-9]+$ ]] || {
+            log "FAILED week $week: confirm-keys returned '$unresolved' (expected a count) — treating as a real mismatch." >&2
+            unresolved=-1
+        }
+        if [[ "$unresolved" == "0" ]]; then
+            artifacts=$((artifacts + 1))
+            log "week $week ($LO .. $HI): OK — superseded-version artifact (src_rows=$src_rows dst_rows=$dst_rows); every differing key's live row is identical on both sides"
         else
-            log "  re-run with --drill-down to list the differing keys for this window" >&2
+            mismatches=$((mismatches + 1))
+            log "MISMATCH week $week ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows src_checksum=$src_checksum dst_checksum=$dst_checksum genuinely_differing_keys=$unresolved" >&2
+            if [[ "$DRILL_DOWN" == "1" ]]; then
+                log "  differing keys (key, src_hash, dst_hash; NULL = missing on that side):" >&2
+                drill_down_window "$LO" "$HI" >&2
+            else
+                log "  re-run with --drill-down to list the differing keys for this window" >&2
+            fi
         fi
     fi
 done
@@ -154,4 +196,10 @@ if [[ "$mismatches" != "0" ]]; then
     log "FAILED: $mismatches of $checked windows mismatched." >&2
     exit 1
 fi
-log "PASSED: all $checked windows match (sample 1/$SAMPLE_MOD)."
+if [[ "$artifacts" != "0" ]]; then
+    log "PASSED: all $checked windows match (sample 1/$SAMPLE_MOD); $artifacts window(s) held a superseded-version"
+    log "        artifact only — a key written more than once lands its stale version in an earlier created_at week on"
+    log "        one side. Live data is identical on both sides; nothing to fix (see the confirm-keys block)."
+else
+    log "PASSED: all $checked windows match (sample 1/$SAMPLE_MOD)."
+fi

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -307,9 +305,6 @@ class TracesLocalV2CutoverTest {
         var preExistingDeleted = mintIds(PRE_EXISTING_DELETED_PER_WEEK);
         var retentionDeleted = mintIds(RETENTION_DELETED_PER_WEEK);
         var userDeleted = mintIds(USER_DELETED_PER_WEEK);
-        // Deletes the delete-by-ids path could not resolve to a project — captured in the bridge with an empty
-        // project_id. The replay must still remove them (matched by (workspace_id, id)) or they leak across the swap.
-        var unresolvedDeleted = mintIds(USER_DELETED_PER_WEEK);
         // One id reused across two projects: deleted in projectId, must survive in otherProjectId (full-key replay).
         var reusedInstant = weekInstant(0, 1);
         var reusedId = ID_GENERATOR.generateId(reusedInstant);
@@ -322,7 +317,6 @@ class TracesLocalV2CutoverTest {
         allSeeded.addAll(preExistingDeleted);
         allSeeded.addAll(retentionDeleted);
         allSeeded.addAll(userDeleted);
-        allSeeded.addAll(unresolvedDeleted);
         seedTraces(allSeeded, workspaceId, projectId);
         seedTraces(reused, workspaceId, projectId);
         seedTraces(reused, workspaceId, otherProjectId);
@@ -358,9 +352,6 @@ class TracesLocalV2CutoverTest {
         // User-shape: single-id deletes.
         recordDeletionEvents(idStrings(userDeleted), workspaceId, projectId.toString(), "user_request");
         lightweightDelete(idStrings(userDeleted), workspaceId);
-        // Unresolved-project deletes: captured with an empty project_id (delete-by-ids couldn't resolve the project).
-        recordDeletionEvents(idStrings(unresolvedDeleted), workspaceId, "", "user_request");
-        lightweightDelete(idStrings(unresolvedDeleted), workspaceId);
         // Reused-id delete scoped to projectId only — the copy under otherProjectId must survive.
         recordDeletionEvents(Set.of(reusedId.toString()), workspaceId, projectId.toString(), "user_request");
         lightweightDeleteScoped(Set.of(reusedId.toString()), workspaceId, projectId);
@@ -379,8 +370,7 @@ class TracesLocalV2CutoverTest {
 
         // Negative control — before replay, the during-backfill deletes have leaked onto the destination: still fully
         // alive there, because the delta-insert cannot see a lightweight delete. This is what the bridge exists to fix.
-        // Includes the unresolved (empty-project) deletes, which only the replay's (workspace_id, id) branch catches.
-        var leakedIds = union(union(idStrings(retentionDeleted), idStrings(userDeleted)), idStrings(unresolvedDeleted));
+        var leakedIds = union(idStrings(retentionDeleted), idStrings(userDeleted));
         assertThat(liveCount("traces_local_v2", leakedIds, workspaceId))
                 .as("negative control: without replay, during-backfill deletes leak across the copy")
                 .isEqualTo(leakedIds.size());
@@ -448,9 +438,6 @@ class TracesLocalV2CutoverTest {
         assertThat(liveCount("traces", idStrings(userDeleted), workspaceId))
                 .as("user-shape deletions do not leak across the EXCHANGE")
                 .isZero();
-        assertThat(liveCount("traces", idStrings(unresolvedDeleted), workspaceId))
-                .as("unresolved (empty-project) deletions do not leak across the EXCHANGE")
-                .isZero();
 
         // Full-key replay: the reused id is gone under the deleted project but alive under the other project.
         assertThat(liveCountScoped("traces", Set.of(reusedId.toString()), workspaceId, projectId))
@@ -477,14 +464,15 @@ class TracesLocalV2CutoverTest {
                 .as("reused id still readable under the other project through the Distributed wrapper")
                 .isEqualTo(1L);
 
-        // Rollback (Stage C) — the wrap is reversible without resurrecting post-cutover deletes. A sharding-aware app
-        // deletes on the local table, so simulate a post-wrap delete on `traces_local` and record it in the bridge with
-        // an empty project (the unresolved case), then roll back: drop the Distributed wrapper, promote the parked old
-        // data back to `traces`, and reverse-replay from cutover_start.
+        // Rollback (Stage C) — the wrap is reversible without resurrecting post-cutover deletes. Post-wrap the app's
+        // delete DAO targets `traces_local` (OPIK-7455) and carries the full key (OPIK-7483), so simulate a post-wrap
+        // delete on `traces_local` recorded in the bridge with its project, then roll back: drop the Distributed
+        // wrapper, promote the parked old data back to `traces`, and reverse-replay from cutover_start.
         var postWrapDeleted = Set.of(survivors.getFirst().id().toString());
-        recordDeletionEvents(postWrapDeleted, workspaceId, "", "user_request");
-        execute("DELETE FROM traces_local WHERE workspace_id = :workspace_id AND id IN :ids",
-                statement -> statement.bind("workspace_id", workspaceId).bind("ids", postWrapDeleted));
+        recordDeletionEvents(postWrapDeleted, workspaceId, projectId.toString(), "user_request");
+        execute("DELETE FROM traces_local WHERE workspace_id = :workspace_id AND project_id = :project_id AND id IN :ids",
+                statement -> statement.bind("workspace_id", workspaceId).bind("project_id", projectId.toString())
+                        .bind("ids", postWrapDeleted));
         rollbackAfterWrap(cutoverStart);
 
         assertThat(isDistributed("traces"))
@@ -592,8 +580,8 @@ class TracesLocalV2CutoverTest {
     /**
      * Rollback stage B (000004_rollback_stage_b + reverse_replay): aborting after the EXCHANGE but before the wrap swaps
      * the tables back and reverse-replays, so a delete that landed on the successor after cutover_start does not
-     * resurrect on the restored original. Exercises the reverse-replay's FULL-KEY branch (the comprehensive test covers
-     * the empty-project branch in stage C), and pins reverse-replay idempotence — the contract {@code --reverse-replay-only}
+     * resurrect on the restored original. Exercises the reverse-replay's full-key branch (the only branch since
+     * OPIK-7483), and pins reverse-replay idempotence — the contract {@code --reverse-replay-only}
      * relies on for re-applying an interrupted rollback replay.
      */
     @Test
@@ -740,17 +728,13 @@ class TracesLocalV2CutoverTest {
      * convergence, so a second replay must not change the result — in particular it must not eventually drop the
      * resurrected (live-on-source) rows.
      *
-     * <p>Parameterized over the bridge capture shape so <b>both</b> replay branches carry the guard: a delete captured
-     * WITH its project exercises the full-key branch, one captured with an empty project (the workspace-scoped delete
-     * fallback) exercises the {@code (workspace_id, id)} branch. Both branches must spare a resurrected id.
+     * <p>The full-key replay branch carries the guard: a delete captured WITH its project (the only shape since
+     * OPIK-7483) must spare a resurrected id.
      */
-    @ParameterizedTest(name = "resurrection guard holds on the {0}-project replay branch")
-    @ValueSource(booleans = {true, false})
-    void deleteThenResurrectSurvivesTheReplay(boolean resolvedProject) {
+    @Test
+    void deleteThenResurrectSurvivesTheReplay() {
         var workspaceId = UUID.randomUUID().toString();
         var projectId = ID_GENERATOR.generateId();
-        // Capture shape selects the replay branch: the resolved project (full key) or an empty project (workspace-scoped).
-        var captureProject = resolvedProject ? projectId.toString() : "";
         var survivors = mintIds(SURVIVORS_PER_WEEK);
         var resurrected = mintIds(3); // deleted then re-created under the same id
         var stayDeleted = mintIds(3); // deleted and NOT re-created
@@ -766,9 +750,9 @@ class TracesLocalV2CutoverTest {
         // During the window: delete both cohorts (bridged), then re-create the resurrected cohort under the same ids
         // with a fresh last_updated_at — the newer version wins under FINAL, so they are live again on the source (caught
         // by the delta's last_updated_at arm since their created_at stays historical).
-        recordDeletionEvents(idStrings(resurrected), workspaceId, captureProject, "user_request");
+        recordDeletionEvents(idStrings(resurrected), workspaceId, projectId.toString(), "user_request");
         lightweightDelete(idStrings(resurrected), workspaceId);
-        recordDeletionEvents(idStrings(stayDeleted), workspaceId, captureProject, "user_request");
+        recordDeletionEvents(idStrings(stayDeleted), workspaceId, projectId.toString(), "user_request");
         lightweightDelete(idStrings(stayDeleted), workspaceId);
         // Recreate with a server-clock last_updated_at (a later now64(6), so >= backfillStart) — NOT the JVM clock,
         // whose skew vs the container could put it below backfillStart and make the delta miss the resurrection path.
@@ -790,55 +774,6 @@ class TracesLocalV2CutoverTest {
         assertThat(liveCount("traces_local_v2", idStrings(survivors), workspaceId))
                 .as("untouched survivors are intact")
                 .isEqualTo(survivors.size());
-    }
-
-    /**
-     * The workspace-scoped ({@code project_id = ''}) replay branch must SPARE a live row that shares an {@code id} with
-     * another project. A delete-by-ids fallback that cannot resolve a project is bridged with an empty project and
-     * replayed on the {@code (workspace_id, id)} key; its resurrection guard keys only on {@code (workspace_id, id)}, so
-     * this proves it does not over-delete a cross-project live copy. Complements the single-project
-     * {@link #deleteThenResurrectSurvivesTheReplay} and the full-key reused-id case in
-     * {@link #bufferedCutoverPreservesEveryDeletionAcrossExchange}.
-     */
-    @Test
-    void workspaceScopedReplaySparesLiveCrossProjectRow() {
-        var workspaceId = UUID.randomUUID().toString();
-        var projectA = ID_GENERATOR.generateId();
-        var projectB = ID_GENERATOR.generateId();
-        var reusedInstant = weekInstant(0, 1);
-        var reusedId = ID_GENERATOR.generateId(reusedInstant);
-        var reused = List.of(CategorizedId.builder().id(reusedId).createdAt(reusedInstant).build());
-        // Same id in two projects — ids are not globally unique.
-        seedTraces(reused, workspaceId, projectA);
-        seedTraces(reused, workspaceId, projectB);
-
-        var backfillStart = nowMicros();
-        for (int week = 0; week < SEED_WEEKS; week++) {
-            backfillWeek(week);
-        }
-
-        // Workspace-scoped delete: bridged with an empty project_id (the delete-by-ids fallback). The source LWD is
-        // workspace-scoped, so it removes the id from BOTH projects; then resurrect it in projectB only (a newer version
-        // wins under FINAL), so it is live again on the source in B and caught by the delta's last_updated_at arm.
-        recordDeletionEvents(Set.of(reusedId.toString()), workspaceId, "", "user_request");
-        lightweightDelete(Set.of(reusedId.toString()), workspaceId);
-        // Server-clock last_updated_at (a later now64(6), so >= backfillStart) — NOT the JVM clock, whose skew vs the
-        // container could put it below backfillStart and make the delta's last_updated_at arm miss the resurrection.
-        var resurrectedAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
-        insertRows(reused, workspaceId, projectB, "resurrected", _ -> resurrectedAt);
-
-        deltaInsert(backfillStart);
-        replayDeletions(backfillStart);
-        replayDeletions(backfillStart); // idempotent
-
-        assertThat(liveCountScoped("traces_local_v2", Set.of(reusedId.toString()), workspaceId, projectB))
-                .as("workspace-scoped replay spares the live projectB copy that shares an id with projectA")
-                .isEqualTo(1L);
-        // Known residual (OPIK-7483; the 000005 fingerprint flags it as an extra destination row, ok=0): because the id
-        // is live in B, the (workspace_id, id) guard skips the whole id, so the stale projectA copy is not removed here.
-        assertThat(liveCountScoped("traces_local_v2", Set.of(reusedId.toString()), workspaceId, projectA))
-                .as("documented residual: the stale other-project copy remains until OPIK-7483")
-                .isEqualTo(1L);
     }
 
     /**
@@ -994,12 +929,11 @@ class TracesLocalV2CutoverTest {
 
     /**
      * Reads the bridge for the cutover window and removes the captured deletes from the destination in a single
-     * mutation (mirrors 000002). Two branches, because the delete-by-ids path does not always resolve a trace's project:
-     * events WITH a project match the full key {@code (workspace_id, project_id, id)} (exact; a reused id in another
-     * project is untouched); events captured WITHOUT a project match {@code (workspace_id, id)} — otherwise those
-     * deletions silently leak across the swap. Each branch also requires the id is NOT currently live on the source
-     * (the resurrection guard), so a deleted-then-recreated id is not dropped. Returns the wall time so the runbook can
-     * size it against the buffer window.
+     * mutation (mirrors 000002). Single full-key branch: since OPIK-7483 every trace delete carries its project_id, so
+     * events match the full key {@code (workspace_id, project_id, id)} (exact; a reused id in another project is
+     * untouched) — without this replay those deletions silently leak across the swap. The branch also requires the id is
+     * NOT currently live on the source (the resurrection guard), so a deleted-then-recreated id is not dropped. Returns
+     * the wall time so the runbook can size it against the buffer window.
      */
     private long replayDeletions(String backfillStart) {
         var start = System.nanoTime();
@@ -1026,31 +960,6 @@ class TracesLocalV2CutoverTest {
                         SELECT
                             workspace_id,
                             project_id,
-                            id
-                        FROM traces
-                        WHERE id IN (
-                            SELECT toFixedString(deleted_id, 36)
-                            FROM deletion_events_local
-                            WHERE source_table = 'traces'
-                              AND event_time >= toDateTime64(:backfill_start, 6)
-                              AND length(deleted_id) = 36
-                        )
-                    )
-                )
-                OR (
-                    (workspace_id, id) IN (
-                        SELECT
-                            workspace_id,
-                            toFixedString(deleted_id, 36)
-                        FROM deletion_events_local
-                        WHERE source_table = 'traces'
-                          AND event_time >= toDateTime64(:backfill_start, 6)
-                          AND project_id = ''
-                          AND length(deleted_id) = 36
-                    )
-                    AND (workspace_id, id) NOT IN (
-                        SELECT
-                            workspace_id,
                             id
                         FROM traces
                         WHERE id IN (
@@ -1148,10 +1057,10 @@ class TracesLocalV2CutoverTest {
 
     /**
      * The shared reverse-replay (000004_rollback_reverse_replay): re-apply the deletes captured since
-     * {@code cutoverStart} onto the restored original, so they do not resurrect. Two branches — full key for events with
-     * a project, {@code (workspace_id, id)} for the workspace-scoped (empty-project) fallback. Unlike the forward replay
-     * it carries NO resurrection guard by design: rollback abandons post-cutover writes while honoring post-cutover
-     * deletes, so a bridged id is masked unconditionally (a guard would undo the user's delete). See the .sql header.
+     * {@code cutoverStart} onto the restored original, so they do not resurrect. Single full-key branch — since OPIK-7483
+     * every delete carries its project_id, so the replay matches {@code (workspace_id, project_id, id)}. Unlike the
+     * forward replay it carries NO resurrection guard by design: rollback abandons post-cutover writes while honoring
+     * post-cutover deletes, so a bridged id is masked unconditionally (a guard would undo the user's delete). See the .sql header.
      */
     private void reverseReplay(String cutoverStart) {
         execute("""
@@ -1166,16 +1075,6 @@ class TracesLocalV2CutoverTest {
                       AND event_time >= toDateTime64(:cutover_start, 6)
                       AND project_id != ''
                       AND length(project_id) = 36
-                      AND length(deleted_id) = 36
-                )
-                OR (workspace_id, id) IN (
-                    SELECT
-                        workspace_id,
-                        toFixedString(deleted_id, 36)
-                    FROM deletion_events_local
-                    WHERE source_table = 'traces'
-                      AND event_time >= toDateTime64(:cutover_start, 6)
-                      AND project_id = ''
                       AND length(deleted_id) = 36
                 )
                 SETTINGS allow_nondeterministic_mutations = 1,
@@ -1339,9 +1238,8 @@ class TracesLocalV2CutoverTest {
     }
 
     /**
-     * Batch INSERT into the bridge, mirroring {@code DeletionEventDAO}'s write shape. {@code projectId} is a string so a
-     * caller can pass {@code ""} to reproduce an unresolved delete (the delete-by-ids path records an empty project when
-     * it cannot resolve a trace's project).
+     * Batch INSERT into the bridge, mirroring {@code DeletionEventDAO}'s write shape. {@code projectId} is the real
+     * owning project of each deleted trace — since OPIK-7483 every trace delete carries it (no project-less events).
      */
     private void recordDeletionEvents(Set<String> ids, String workspaceId, String projectId, String reason) {
         var idList = List.copyOf(ids);

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -43,6 +43,28 @@ export CLICKHOUSE_CLIENT_DOCKER_OPTS=--network=host   # (b) only: reach the host
 ClickHouse connection defaults (user/password/db all `opik`, host `localhost:8123`) match `--port-mapping`; override via
 `OPIK_CH_HOST` / `OPIK_CH_PORT` / `OPIK_CH_USER` / `OPIK_CH_PASSWORD` / `OPIK_CH_DATABASE` if yours differ.
 
+### Changing backend config mid-rehearsal
+
+The runbook's operator-owned steps are **backend config plus a restart** (raise/restore the async-insert buffer, flip
+`traceColumnsNonNullable`, flip `tracesDistributedWrapEnabled`). These flags are read from a startup snapshot, so a
+restart is required — `opik.sh` has no flag for them. Recreate just the backend, keeping the rest of the stack up. Note
+`opik.sh` runs under compose project **`opik-opik`** (containers are `opik-opik-*`), so pass `-p opik-opik` or you will
+silently create a second, parallel project:
+
+```bash
+recreate_backend() {   # exports must be set by the caller; unset a var to return it to its default
+  docker compose -p opik-opik \
+    -f deployment/docker-compose/docker-compose.yaml \
+    -f deployment/docker-compose/docker-compose.override.yaml \
+    --profile opik up -d --no-deps backend
+  until [ "$(docker inspect -f '{{.State.Health.Status}}' opik-opik-backend-1)" = healthy ]; do sleep 3; done
+  docker exec opik-opik-backend-1 env | grep -E 'ANALYTICS_DB_DATA_MODEL_TRACE|ASYNC_INSERT_BUSY_TIMEOUT_MAX' | sort
+}
+```
+
+Always re-read the env out of the container afterwards (as above) to confirm the flag actually took — that is the only
+check available for `traceColumnsNonNullable`, whose failure mode is silent (see the runbook's prereq #7).
+
 ## End-to-end rehearsal
 
 Every migration step runs through a driver script in the runbook's `scripts/` — no SQL is run by hand.
@@ -57,15 +79,22 @@ export CLICKHOUSE_HOST=localhost CLICKHOUSE_USER=opik CLICKHOUSE_PASSWORD=opik
 # 2. (Optional) Estimate the backfill ETA for a given config.
 $RUNBOOK/scripts/estimate.sh --database opik --max-rows-per-insert 400 --pause-seconds 1
 
-# 3. Generate concurrent write + delete traffic for the duration of the cutover (two more terminals). The overlap
-#    naturally produces delete-then-resurrect ids (a delete followed by an update to the same id) — the replay's
-#    resurrection guard keeps those live on the destination.
+# 3. Generate concurrent write + delete traffic for the duration of the cutover (two more terminals).
+#    --resurrect-ratio is REQUIRED to exercise the replay's resurrection guard (delete then re-create under the same
+#    id). Do NOT expect the write/delete overlap to produce that by chance: live_traffic.py only updates ids from its
+#    own recent-creates buffer, and a 5-minute 5-tps/3-tps run has been observed to yield ZERO resurrections — leaving
+#    the one silent-data-loss path in the replay completely unexercised. delete_traffic.py warns if it resurrected none.
+#    Let the delete traffic run PAST the end of the backfill: a delete of an already-copied row is the leak the bridge
+#    exists to close, whereas a delete before its row is copied is simply never copied (mask-honored INSERT).
 #    NOTE: --bad-ids rows are ordinary deletable traces, so on a small dataset the delete traffic may remove them all
 #    before the cutover (they are then bridged + replayed like any delete — 0 leak — a valid path, but the far-future
-#    partition won't appear on the successor). To exercise the far-future-partition path specifically, seed with
-#    --bad-ids and run the backfill WITHOUT the delete traffic.
-python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 5 --duration 150 --update-ratio 0.4
-python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 3 --duration 150   # deletes existing (already-backfilled) traces
+#    partition won't appear on the successor). Simplest fix: seed the --bad-ids rows into their OWN project that the
+#    delete traffic does not target (delete_traffic.py takes --project), or run the backfill without delete traffic.
+#    --in-progress-ratio is likewise REQUIRED to exercise the pre-swap window's sentinel / negative-duration caveat:
+#    without it every trace is ended, so no trace is ever written with an absent end_time and the caveat (plus its
+#    rollback repair) produces ZERO affected rows. live_traffic.py warns if it left none in progress.
+python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 5 --duration 150 --update-ratio 0.4 --in-progress-ratio 0.15
+python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 3 --duration 150 --resurrect-ratio 0.05
 
 # 4. Backfill (small --max-rows-per-insert exercises the adaptive sub-window splitting on modest data). Record the
 #    backfill_start it prints.
@@ -80,22 +109,53 @@ $RUNBOOK/scripts/verify.sh --database opik            # add --drill-down to list
 #    re-run delta_replay.sh then verify.sh until it reports "PASSED: all N windows match" (convergence). In production
 #    the buffer holds writes during the cutover window instead.
 
-# 7. EXCHANGE (the data cutover; leaves traces a MergeTree so the backend's deletes keep working). It also renames the
-#    displaced old data to traces_pre_cutover_backup. --skip-wrap defers the sharding-ready Distributed wrap, which
-#    requires the delete DAO to target traces_local first. Pass the backfill_start from step 4. The two --confirm gates
-#    are operator assertions that hold trivially in this local rehearsal: --confirm-buffer-raised (there is no async
-#    buffer locally — just make sure the traffic scripts have stopped before the swap) and --confirm-retention-paused
-#    (retention is disabled by default). --backfill-start drives the final deletion replay run just before the swap.
+# 7. MANDATORY CONFIG STEP, and the one most easily skipped in a rehearsal: roll out traceColumnsNonNullable=true
+#    BEFORE the EXCHANGE (runbook "The final cutover window"), and raise the buffer ceiling so the --confirm-buffer-raised
+#    assertion is truthful rather than vacuous. Use recreate_backend() from "Changing backend config mid-rehearsal" above.
+#    Skipping this leaves the whole read-side half of the flag unexercised — and its failure mode is SILENT (writes still
+#    succeed either way; absent end_time just reads back as 1970-01-01 instead of null).
+export ANALYTICS_DB_DATA_MODEL_TRACE_DELETION_EVENTS_CAPTURE_ENABLED=true \
+       ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE=true \
+       ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS=10000
+recreate_backend
+#    Positive check (the only real one): an in-progress trace must read back end_time = None. Writing one now, while
+#    `traces` is still the Nullable original, is also what exercises the pre-swap window's two documented caveats.
+
+# 8. Final delta + replay (the last write-facing step), then the EXCHANGE immediately after. The EXCHANGE is the data
+#    cutover and leaves traces a MergeTree so the backend's deletes keep working; it also renames the displaced old data
+#    to traces_pre_cutover_backup. --skip-wrap defers the sharding-ready Distributed wrap (step 10).
+#    --confirm-retention-paused holds trivially here (retention is disabled by default).
+$RUNBOOK/scripts/delta_replay.sh --database opik --backfill-start '<backfill_start>'
 $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfill_start>' \
     --confirm-buffer-raised --confirm-retention-paused --skip-wrap
-$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces   # post-swap fidelity
+#    Record the cutover_start it prints. Run the post-swap compare NOW, before writes resume — afterwards the current
+#    week legitimately diverges (live is a superset of the frozen backup), so bound it with --to-week N instead.
+$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces
+
+# 9. Restore the buffer ceiling (unset the env var and recreate_backend), keeping traceColumnsNonNullable=true and
+#    deletion capture ON — capture must stay live through the soak, since the rollback reverse-replay reads the bridge.
+unset ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS; recreate_backend
+
+# 10. OPTIONAL — the deferred Distributed wrap. Flip tracesDistributedWrapEnabled=true FIRST (it retargets trace
+#     mutations at traces_local) and re-raise the buffer for --confirm-maintenance. A mismatch here IS fail-loud: with
+#     the flag true before the wrap exists, deletes 500 with "Code: 60 ... Table opik.traces_local does not exist" —
+#     worth triggering once, to see it. After the wrap, `DELETE FROM opik.traces` returns "Code: 36 DELETE query is not
+#     supported", and system.parts relabels from traces to traces_local.
+export ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=true \
+       ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS=10000
+recreate_backend
+$RUNBOOK/scripts/exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted
+unset ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS; recreate_backend
 ```
 
 **Resetting between iterations depends on how far the last run got.** If you have **not** completed the `EXCHANGE`
 (iterating on backfill/delta/verify), truncate **all three** tables and re-seed: `TRUNCATE TABLE traces`,
 `TRUNCATE TABLE traces_local_v2`, `TRUNCATE TABLE deletion_events_local`. Also delete the persisted anchor
 (`rm -f traces_cutover_backfill_start`) so the next `backfill.sh` captures a fresh `backfill_start` instead of reusing
-the prior run's. Truncate the bridge and re-seed the source too, not just the shadow — a prior run leaves stale delete
+the prior run's. Delete it **only together with truncating `traces_local_v2`** — `backfill.sh` now aborts if the anchor
+is missing while the destination still holds rows, because that combination means a resume whose original anchor was
+lost, and minting a later one would leak deletes. (The default `--state-file` is CWD-relative, so also run the driver
+from the same directory each time, or pass an absolute path.) Truncate the bridge and re-seed the source too, not just the shadow — a prior run leaves stale delete
 events (and rows deleted-then-recreated in the previous window) behind, and a new run whose `backfill_start` is *after*
 those events will neither copy nor replay them, so `verify.sh` reports a spurious mismatch. A real cutover has no such
 residue: `backfill_start` is captured once, before any migration-window activity, so every relevant delete is covered
@@ -124,15 +184,23 @@ Pass the `cutover_start` that `exchange_and_wrap.sh` printed.
 # Stage A — forward run stopped before the EXCHANGE: discards the shadow; live `traces` is untouched.
 $RUNBOOK/scripts/rollback.sh --database opik --stage A
 
-# Stage B — after the EXCHANGE, before the wrap. Generate post-cutover deletes first (traces is still a MergeTree):
-python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 4 --duration 30
+# Stage B — after the EXCHANGE, before the wrap. Generate post-cutover activity first, so the rollback has something to
+# reverse. --resurrect-ratio matters here too, but for the OPPOSITE reason to the forward replay: a post-cutover
+# delete-then-recreate must end up MASKED on the restored original (the reverse replay deliberately carries no
+# resurrection guard — rollback discards post-cutover writes while honoring post-cutover deletes).
+python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 4 --duration 45 --resurrect-ratio 0.25
+python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 4 --duration 30   # -> the discarded writes
 $RUNBOOK/scripts/rollback.sh --database opik --stage B --cutover-start '<cutover_start>' \
     --confirm-retention-paused --accept-post-cutover-write-loss
 
-# Stage C — after the wrap. Issue the post-cutover deletes BEFORE applying the wrap (a Distributed `traces` rejects
-# DELETEs), then roll back:
+# Stage C — after the wrap. The post-cutover deletes can be issued AFTER the wrap: with
+# tracesDistributedWrapEnabled=true (which the wrap requires anyway) TraceDAO targets `traces_local`, so the product's
+# delete path keeps working — only a DIRECT `DELETE FROM traces` against the Distributed wrapper is rejected (code 36).
+python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 4 --duration 45 --resurrect-ratio 0.25
 $RUNBOOK/scripts/rollback.sh --database opik --stage C --cutover-start '<cutover_start>' \
     --confirm-retention-paused --accept-post-cutover-write-loss
+# Worth triggering once: leave the toggle true after stage C and try a delete — it fails loudly with
+# "Code: 60 ... Table opik.traces_local does not exist", the documented inverse mismatch. Then set it false + restart.
 
 # If a stage B/C run's reverse-replay was interrupted, re-apply just it (idempotent):
 $RUNBOOK/scripts/rollback.sh --database opik --reverse-replay-only --cutover-start '<cutover_start>' \
@@ -143,6 +211,29 @@ Check afterwards that no post-cutover-deleted id is live again on the restored `
 that the estate is canonical (`traces` = original; for B/C the successor is parked as `traces_post_rollback_backup`,
 while stage A just empties the `traces_local_v2` shadow). A rollback leaves `traces` as the Nullable original, so
 re-seeding for the next iteration works without a fresh volume.
+
+To verify a rollback, use the **post-rollback table pair** — the `verify.sh` defaults do not apply (`traces_local_v2` is
+gone, so a bare run dies with `Unknown table … traces_local_v2`) — and bound it to the sealed weeks, because the current
+week legitimately diverges by the post-cutover writes the rollback discarded:
+
+```bash
+$RUNBOOK/scripts/verify.sh --database opik --old-table traces --new-table traces_post_rollback_backup --to-week N
+```
+
+**Chaining the stages.** Only stage A leaves you able to retry immediately (it truncates the shadow and leaves `traces`
+untouched — a re-run of `backfill.sh` reuses the original anchor from the state file). Stages B/C consume the shadow: they
+park the successor as `traces_post_rollback_backup` and leave **no** `traces_local_v2`, so retrying the cutover for the
+next stage needs `finalize.sh --confirm` to recycle that backup back into an empty shadow — the irreversible step — or a
+fresh volume. So rehearsing all three stages takes one recycle (or reset) between B and C.
+
+**Then finish the config half of the rollback** — `rollback.sh` prints both steps, and stage B/C is not complete without
+them (runbook: "Rolling back the `traceColumnsNonNullable` flip"). Set `traceColumnsNonNullable=false` and
+`recreate_backend`; then repair the epoch/NaN sentinels the pre-swap window wrote into the original, which the promote
+made live again — including its large **negative** `duration`, which `verify.sh` cannot see (materialized columns are
+excluded from the fingerprint) and which a `MATERIALIZE COLUMN` does **not** fix. Confirming `countIf(duration < 0)`
+goes from non-zero to `0` across that repair is the point of rehearsing it. After the wrap, also flip
+`tracesDistributedWrapEnabled` back to `false` before traffic resumes, or deletes 500 against the now-parked
+`traces_local`.
 
 ## Committing
 

--- a/tests_load/tests/traces-local-v2-cutover/delete_traffic.py
+++ b/tests_load/tests/traces-local-v2-cutover/delete_traffic.py
@@ -7,6 +7,13 @@ deletion-events bridge and must be replayed onto the destination — otherwise i
 It pulls a pool of existing trace ids via search and deletes them at the target rate, refilling as it drains. Run it
 during or after the backfill so the traces it deletes have already been copied — that is the leak the bridge prevents.
 
+`--resurrect-ratio` additionally re-creates a share of the just-deleted ids through the normal ingestion API, which is
+the only way to exercise the forward replay's RESURRECTION GUARD: such an id is bridged as deleted (event_time >=
+backfill_start) yet is live again on the source, so the replay must NOT mask it on the destination — a naive
+replay-by-key would drop a live row, silent data loss. Do not rely on the write/delete overlap to produce this by
+chance: `live_traffic.py` only ever updates ids from its own recent-creates buffer, so a rehearsal can easily see ZERO
+resurrections and leave the guard unexercised. Set it explicitly (e.g. `--resurrect-ratio 0.05`) when rehearsing.
+
 This is a best-effort TRAFFIC GENERATOR (deletes newest-first for the run's --duration), NOT a guaranteed full-drain:
 search returns the newest page, so during delete-mask visibility lag a refill can transiently return only ids already
 in `seen`/`pool`; the loop tolerates a few such empty refills (EMPTY_REFILL_LIMIT) before concluding the project is
@@ -15,6 +22,7 @@ drained. It does not assert every trace was deleted — its job is to exercise t
 Prerequisites: `OPIK_URL_OVERRIDE` pointing at the local install. Run `python delete_traffic.py --help` for options.
 """
 
+import random
 import signal
 import time
 
@@ -31,6 +39,12 @@ EMPTY_REFILL_LIMIT = 5
 # Newest-page size to pull per refill. Larger reaches past the just-deleted (still-visible) top ids to undeleted ones
 # during mask lag, so the run keeps finding work instead of stopping early.
 REFILL_FETCH = 2000
+# Seconds to wait after a delete before re-creating that id under --resurrect-ratio. A lightweight DELETE is an ASYNC
+# mutation: its mask applies to every row matching the predicate in the parts it sweeps, so an id re-created before the
+# mutation lands gets masked along with the original and never becomes live — the resurrection silently does not happen.
+# Measured locally: re-creating immediately left only ~40% of attempts actually live. Deferring past the mutation makes
+# the resurrection real, and costs nothing since the ids are queued rather than slept on (the delete rate is unaffected).
+RESURRECT_SETTLE_SECONDS = 3.0
 
 
 def _handle_sigint(_signum, _frame):
@@ -53,18 +67,38 @@ def _fetch_ids(client, project, want, exclude):
 @click.option("--tps", default=2.0, help="Target deletes per second.")
 @click.option("--duration", default=120, help="How long to run, in seconds (0 = until Ctrl-C).")
 @click.option("--batch", default=1, help="Trace ids per delete call.")
-def main(project, tps, duration, batch):
+@click.option("--resurrect-ratio", default=0.0,
+              help="Fraction of deleted ids to re-create under the SAME id via the ingestion API, exercising the "
+                   "replay's resurrection guard. 0 disables. Try 0.05 when rehearsing the cutover.")
+def main(project, tps, duration, batch, resurrect_ratio):
     signal.signal(signal.SIGINT, _handle_sigint)
     client = make_opik_client()
     interval = batch / tps if tps > 0 else 0.0
 
     seen: set[str] = set()
     pool: list[str] = []
+    # (ready_at, trace_id) queued for re-creation once the delete mutation has had RESURRECT_SETTLE_SECONDS to land.
+    pending_resurrect: list[tuple[float, str]] = []
     deleted = 0
+    resurrected = 0
     empty_refills = 0
     started = time.time()
-    LOGGER.info("delete traffic: project='%s' tps=%.2f batch=%d duration=%ss (Ctrl-C to stop)",
-                project, tps, batch, duration or "∞")
+
+    def flush_resurrections(force=False):
+        """Re-create every queued id whose delete has settled (all of them when force)."""
+        nonlocal resurrected
+        due = [tid for ready_at, tid in pending_resurrect if force or time.time() >= ready_at]
+        if not due:
+            return
+        pending_resurrect[:] = [(r, t) for r, t in pending_resurrect if t not in set(due)]
+        for trace_id in due:
+            # Same id, through the normal ingestion path: bridged as deleted, yet live again on the source.
+            client.trace(id=trace_id, name="resurrected-trace", project_name=project,
+                         input={"resurrected": True}, output={"resurrected": True}).end()
+            resurrected += 1
+
+    LOGGER.info("delete traffic: project='%s' tps=%.2f batch=%d duration=%ss resurrect-ratio=%.3f (Ctrl-C to stop)",
+                project, tps, batch, duration or "∞", resurrect_ratio)
 
     while not _stop and (duration == 0 or time.time() - started < duration):
         tick = time.time()
@@ -91,15 +125,34 @@ def main(project, tps, duration, batch):
         seen.update(ids)
         client.rest_client.traces.delete_traces(ids=ids)
         deleted += len(ids)
+        # Queue a share of the just-deleted ids for re-creation under the SAME id, once their delete mutation has
+        # settled. Such an id is bridged as deleted but live again on the source — the case the replay's resurrection
+        # guard must survive. They stay in `seen`, so a later refill never queues them for deletion again.
+        if resurrect_ratio > 0:
+            for trace_id in ids:
+                if random.random() < resurrect_ratio:
+                    pending_resurrect.append((time.time() + RESURRECT_SETTLE_SECONDS, trace_id))
+        flush_resurrections()
         if deleted % 50 == 0:
-            LOGGER.info("deleted %d traces", deleted)
+            LOGGER.info("deleted %d traces (resurrected %d)", deleted, resurrected)
         sleep = interval - (time.time() - tick)
         if sleep > 0:
             time.sleep(sleep)
 
+    # Drain the queue: wait out the settle window for the last deletes, then re-create the remainder.
+    if pending_resurrect:
+        time.sleep(RESURRECT_SETTLE_SECONDS)
+        flush_resurrections(force=True)
+    client.flush()  # the resurrections go through the batching ingest path, so flush before reporting
     elapsed = time.time() - started
-    LOGGER.info("done: deleted=%d in %.1fs (%.2f deletes/s effective)",
-                deleted, elapsed, deleted / elapsed if elapsed else 0)
+    LOGGER.info("done: deleted=%d resurrected=%d in %.1fs (%.2f deletes/s effective)",
+                deleted, resurrected, elapsed, deleted / elapsed if elapsed else 0)
+    if resurrect_ratio > 0 and resurrected == 0:
+        LOGGER.warning("resurrect-ratio was set but nothing was resurrected — the replay's resurrection guard is "
+                       "UNEXERCISED by this run. Raise --resurrect-ratio or --duration.")
+    elif resurrected:
+        LOGGER.info("Confirm the resurrections are live on the SOURCE before the replay runs — an id bridged as deleted "
+                    "yet live again is exactly what the guard must not mask on the destination.")
 
 
 if __name__ == "__main__":

--- a/tests_load/tests/traces-local-v2-cutover/delete_traffic.py
+++ b/tests_load/tests/traces-local-v2-cutover/delete_traffic.py
@@ -42,8 +42,8 @@ REFILL_FETCH = 2000
 # Seconds to wait after a delete before re-creating that id under --resurrect-ratio. A lightweight DELETE is an ASYNC
 # mutation: its mask applies to every row matching the predicate in the parts it sweeps, so an id re-created before the
 # mutation lands gets masked along with the original and never becomes live — the resurrection silently does not happen.
-# Measured locally: re-creating immediately left only ~40% of attempts actually live. Deferring past the mutation makes
-# the resurrection real, and costs nothing since the ids are queued rather than slept on (the delete rate is unaffected).
+# Re-creating immediately therefore loses most attempts, silently leaving the guard unexercised. Deferring past the
+# mutation makes the resurrection real, and costs nothing: ids are queued rather than slept on, so the delete rate holds.
 RESURRECT_SETTLE_SECONDS = 3.0
 
 

--- a/tests_load/tests/traces-local-v2-cutover/live_traffic.py
+++ b/tests_load/tests/traces-local-v2-cutover/live_traffic.py
@@ -4,6 +4,13 @@ Run it alongside the cutover so the delta-insert has fresh rows to catch. These 
 `created_at` is the current week; a share of them are logged as updates to an already-seen trace (a second `end()` with
 new content) to exercise the version-bump path the delta relies on.
 
+`--in-progress-ratio` leaves a share of them UNENDED (no `end_time`, no `ttft`). That is the only way to reproduce the
+pre-swap window's sentinel caveat: while `traceColumnsNonNullable=true` and `traces` is still the Nullable original, an
+absent value is written as the epoch/NaN sentinel instead of NULL, and the original's MATERIALIZED `duration` — which
+guards only `end_time IS NOT NULL` — turns that into a large NEGATIVE duration that a stage B/C rollback makes live again
+(see the runbook's "The `traceColumnsNonNullable` flip"). Without this option every trace is ended, so a rehearsal
+produces ZERO affected rows and the caveat plus its rollback repair go untested.
+
 Prerequisites: `OPIK_URL_OVERRIDE` pointing at the local install. Run `python live_traffic.py --help` for options.
 """
 
@@ -34,13 +41,17 @@ def _text(n: int) -> str:
 @click.option("--tps", default=5.0, help="Target traces per second.")
 @click.option("--duration", default=120, help="How long to run, in seconds (0 = until Ctrl-C).")
 @click.option("--update-ratio", default=0.2, help="Fraction of ticks that update a prior trace instead of creating one.")
-def main(project, tps, duration, update_ratio):
+@click.option("--in-progress-ratio", default=0.0,
+              help="Fraction of created traces left UNENDED (no end_time/ttft), reproducing the pre-swap window's "
+                   "epoch/NaN sentinel + negative-duration caveat. 0 disables. Try 0.15 when rehearsing the cutover.")
+def main(project, tps, duration, update_ratio, in_progress_ratio):
     signal.signal(signal.SIGINT, _handle_sigint)
     client = make_opik_client()
     interval = 1.0 / tps if tps > 0 else 0.0
 
     created = 0
     updated = 0
+    in_progress = 0
     recent_ids: list[str] = []
     started = time.time()
     LOGGER.info("live traffic: project='%s' tps=%.2f duration=%ss (Ctrl-C to stop)", project, tps, duration or "∞")
@@ -54,17 +65,23 @@ def main(project, tps, duration, update_ratio):
             client.trace(id=trace_id, project_name=project, output={"update": _text(120)}).end()
             updated += 1
         else:
+            leave_in_progress = in_progress_ratio > 0 and random.random() < in_progress_ratio
             trace = client.trace(
-                name="live-trace",
+                name="live-trace-in-progress" if leave_in_progress else "live-trace",
                 project_name=project,
                 start_time=utcnow(),
                 input={"prompt": _text(160)},
-                output={"completion": _text(160)},
+                **({} if leave_in_progress else {"output": {"completion": _text(160)}}),
             )
-            trace.end()
-            recent_ids.append(trace.id)
-            if len(recent_ids) > 500:
-                recent_ids.pop(0)
+            if leave_in_progress:
+                # Deliberately NOT ended: no end_time and no ttft, so the write carries an absent value. Do not add it
+                # to recent_ids either — an update would end it and defeat the point.
+                in_progress += 1
+            else:
+                trace.end()
+                recent_ids.append(trace.id)
+                if len(recent_ids) > 500:
+                    recent_ids.pop(0)
             created += 1
 
         if (created + updated) % 50 == 0:
@@ -75,8 +92,11 @@ def main(project, tps, duration, update_ratio):
 
     client.flush()
     elapsed = time.time() - started
-    LOGGER.info("done: created=%d updated=%d in %.1fs (%.2f traces/s effective)",
-                created, updated, elapsed, (created + updated) / elapsed if elapsed else 0)
+    LOGGER.info("done: created=%d (of which %d left in-progress) updated=%d in %.1fs (%.2f traces/s effective)",
+                created, in_progress, updated, elapsed, (created + updated) / elapsed if elapsed else 0)
+    if in_progress_ratio > 0 and in_progress == 0:
+        LOGGER.warning("in-progress-ratio was set but every trace was ended — the pre-swap sentinel / negative-duration "
+                       "caveat is UNEXERCISED. Raise --in-progress-ratio or --duration.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Details

The buffered `traces` cutover tooling (drivers, reference SQL, runbook, and its gate test) was authored before three follow-ups changed the schema, the delete path, and the wrap prerequisite underneath it. This PR reconciles the tooling with all three, plus two runbook rules from the schema-drift spike. No functional tooling or rollback behavior changes beyond the replay-branch removal below.

- **OPIK-7483 (project-less trace deletes eliminated):** every delete now resolves its owning project(s) and deletes under the full `(workspace_id, project_id, id)` key, so the product can no longer bridge an empty-`project_id` trace deletion event. The forward and reverse replays drop the vestigial workspace-scoped `(workspace_id, id)` branch, leaving a single full-key branch — dead code that also preserved a real correctness wart (a reused id live in one project shielded that id's deleted copies in other projects) and forced `verify.sh`'s full-compare-only gate. A pre-cutover prerequisite now asserts the bridge holds no project-less trace events.
- **OPIK-7456 (`id_at` DateTime64 + honest Date32 weekly partition, migration 000114):** the "bound a large mutation by `toMonday(id_at)`" guidance in the replay SQL is now the wrong partition expression and re-introduces the wrap footgun 000114 fixes; it is replaced with a `created_at`-week bound (the non-wrapping, minmax-indexed slice the backfill uses).
- **OPIK-7455 (mutation DAOs retargeted behind the `tracesDistributedWrapEnabled` toggle):** the residual "delete/read DAOs are sharding-aware" wording in the runbook and `exchange_and_wrap.sh` is reworded to the shipped toggle ("read" was wrong — reads stay on the Distributed table).
- **Runbook rules (schema-drift spike, doc-only):** freeze `traces` schema DDL through the rollback-eligible soak, and keep the backfill's explicit column list in sync when a `traces` column is added (CI-caught by `cutoverCopiesEveryBaseColumn`).
- `DeletionEventDAO`'s generic empty-project affordance is untouched (shared infra for other source tables); only the traces replay consumers drop the branch.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-6901

Reconciles the tooling with the already-merged follow-ups OPIK_7455, OPIK_7456, and OPIK_7483 (referenced, not resolved here).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.8
- Scope: full implementation
- Human verification: code review + end-to-end cutover/rollback rehearsal on local Docker

## Testing

- Gate test `TracesLocalV2CutoverTest` (JUnit + TestContainers, reimplements the cutover/rollback SQL inline and kept in step with the reference `.sql`): 9/9 green against the real migrations, including 000114.
- Forward cutover and all three rollback stages (pre-EXCHANGE, post-EXCHANGE, post-wrap) rehearsed end-to-end on local Docker using only the automation scripts, against the current backend (000114 schema, OPIK-7483 full-key deletes), with simulated existing data plus parallel writes/deletes: the bridge held full-key-only events, the single-branch replay produced 0 leaks / 0 resurrections, and each finalize recycled to a pristine 000114 shadow.

## Documentation

Runbook (`README.md`) and the reference SQL comments updated in lockstep with the code: single full-key replay narrative, the two new pre-cutover/soak rules, and the `tracesDistributedWrapEnabled` wording. This tooling is an internal operator runbook; no public product documentation is affected.
