### PR TITLE
[OPIK-7798] [BE] Retry Python UDF evaluation on transient NoHttpResponseException

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
@@ -4,6 +4,7 @@ import jakarta.ws.rs.ProcessingException;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.NoHttpResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
@@ -95,10 +96,14 @@ public class RetryUtils {
 
     private static boolean isRetriableException(Throwable throwable) {
         return switch (throwable) {
+            // Network and timeout transient errors
             case SocketException ex -> true;
             case TimeoutException ex -> true;
             case InterruptedIOException ex -> true;
+            // HTTP client transient errors (server closes connection, temporary unavailability)
+            case NoHttpResponseException ex -> true;
             case RetryableHttpException ex -> true;
+            // Wrapped exceptions: check cause recursively for transient errors
             case ProcessingException ex -> {
                 var cause = ex.getCause();
                 yield cause != null && isRetriableException(cause);

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/RetryUtils.java
@@ -4,7 +4,7 @@ import jakarta.ws.rs.ProcessingException;
 import lombok.Getter;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.NoHttpResponseException;
+import org.apache.hc.core5.http.NoHttpResponseException;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -254,6 +254,43 @@ class PythonEvaluatorServiceTest {
         }
 
         @Test
+        void evaluate__whenNoHttpResponseException__shouldRetryAndEventuallySucceed() {
+            // Given
+            var code = "def evaluate(input, output): return 1.0";
+            var data = Map.<String, Object>of("input", "test input", "output", "test output");
+            var expectedScores = List.of(podamFactory.manufacturePojo(PythonScoreResult.class));
+            var pythonResponse = PythonEvaluatorResponse.builder()
+                    .scores(expectedScores)
+                    .build();
+
+            // Setup HTTP call chain
+            setupHttpCallChain();
+
+            // Create immutable response for success case
+            Response successResponse = createMockResponse(Status.OK, pythonResponse);
+
+            // First call throws NoHttpResponseException (server closes connection before responding),
+            // 2nd call succeeds
+            doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.failed(new ProcessingException("The target server failed to respond",
+                        new org.apache.http.NoHttpResponseException("The target server failed to respond")));
+                return null;
+            }).doAnswer(invocation -> {
+                InvocationCallback<Response> callback = invocation.getArgument(1);
+                callback.completed(successResponse);
+                return null;
+            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+
+            // When
+            var actualScores = pythonEvaluatorService.evaluate(code, data).block();
+
+            // Then
+            assertThat(actualScores).isEqualTo(expectedScores);
+            verify(asyncInvoker, times(2)).post(any(Entity.class), any(InvocationCallback.class));
+        }
+
+        @Test
         void evaluate__whenMaxRetriesExceeded__shouldThrowException() {
             // Given
             var code = "def evaluate(input, output): return 1.0";

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -274,7 +274,7 @@ class PythonEvaluatorServiceTest {
             doAnswer(invocation -> {
                 InvocationCallback<Response> callback = invocation.getArgument(1);
                 callback.failed(new ProcessingException("The target server failed to respond",
-                        new org.apache.http.NoHttpResponseException("The target server failed to respond")));
+                        new org.apache.hc.core5.http.NoHttpResponseException("The target server failed to respond")));
                 return null;
             }).doAnswer(invocation -> {
                 InvocationCallback<Response> callback = invocation.getArgument(1);


### PR DESCRIPTION
## Summary
Python UDF evaluation (span, trace, and trace-thread level) fails on transient `NoHttpResponseException` from the HTTP client when python-backend closes connection before responding. The exception was not recognized as retryable, causing immediate failure instead of automatic retry with backoff.

This fix adds explicit handling for the transient connection error, enabling proper retry behavior for python-backend connectivity issues.

## Details

### Root Cause
- **When it happens**: HTTP client connects to python-backend but server closes connection before sending response (transient condition)
- **What throws it**: HttpClient 5 throws `org.apache.hc.core5.http.NoHttpResponseException` wrapped in `ProcessingException` by Jersey
- **Why it fails**: `RetryUtils.isRetriableException()` doesn't recognize this exception type
- **Gap**: Retry logic only checked for `SocketException`, `TimeoutException`, `InterruptedIOException` — missing HTTP client transient errors

### Changes
1. **RetryUtils.java**
   - Add import: `org.apache.hc.core5.http.NoHttpResponseException` (HttpClient 5)
   - Add case to switch: `case NoHttpResponseException ex -> true;`
   - Group exception cases with comments for clarity

2. **PythonEvaluatorServiceTest.java**
   - Add test: `evaluate__whenNoHttpResponseException__shouldRetryAndEventuallySucceed()`
   - Verifies automatic retry on connection failures with HttpClient 5 exception

### Why HttpClient 5 vs HttpClient 4
- Project uses `httpclient5` (org.apache.hc.core5), not httpclient 4
- Exception comes from `org.apache.hc.core5.http.NoHttpResponseException`
- This is what gets wrapped in `ProcessingException` at runtime

### Impact
**Affected Paths:**
- `span_user_defined_metric_python` → Redis stream `SPAN_USER_DEFINED_METRIC_PYTHON`
- `user_defined_metric_python` → Redis stream `USER_DEFINED_METRIC_PYTHON`
- `trace_thread_user_defined_metric_python` → Redis stream `TRACE_THREAD_USER_DEFINED_METRIC_PYTHON`

**Behavior Before:** Transient python-backend connectivity issues → immediate failure

**Behavior After:** Transient python-backend connectivity issues → automatic retry (up to 4 attempts with exponential backoff)

## Testing

### Test Cases Added
- `evaluate__whenNoHttpResponseException__shouldRetryAndEventuallySucceed()` - Verifies NoHttpResponseException wrapped in ProcessingException triggers retry with backoff

### Test Results
- ✅ Unit tests pass: 20/20 in PythonEvaluatorServiceTest
- ✅ New test case verifies automatic retry on connection failures
- ✅ Existing retry tests still pass (503/504, SocketTimeoutException, non-retryable cases)
- ✅ No regressions in related tests

### Test Scenarios Covered
- ProcessingException with NoHttpResponseException (HttpClient 5): Retried ✓
- HTTP 503/504: Already tested and still passing ✓
- SocketTimeoutException: Already tested and still passing ✓
- HTTP 400 BadRequest: Not retried (correct) ✓
- Empty response (HTTP 200 + null scores): Not retried (correct) ✓

## Change checklist

- [x] Code follows project conventions
- [x] All tests pass (20/20)
- [x] New test case added and passing
- [x] No breaking changes
- [x] Commit message follows format
- [x] Branch naming follows conventions
- [x] Uses correct HttpClient 5 exception class (org.apache.hc.core5.http)

## Issues

Resolves OPIK-7798

## Documentation

No documentation changes needed. This is an internal retry logic fix that doesn't affect public APIs or user-facing behavior.

🤖 Generated with Claude Code