### PR TITLE
[OPIK-7806] [QA] fix: harden model-picker and providers-table interactions in E2E POMs

### DIFF
--- a/tests_end_to_end/e2e/pom/configuration.page.ts
+++ b/tests_end_to_end/e2e/pom/configuration.page.ts
@@ -65,13 +65,7 @@ export class ConfigurationPage {
    * caller's idempotency check would fail. Wait for the table to settle first.
    */
   async listConfiguredProviders(): Promise<string[]> {
-    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
-    const firstRowCell = this.page.getByTestId('ai-provider-row-cell').first();
-    const emptyState = tabpanel.getByText('No AI providers yet');
-    await Promise.race([
-      firstRowCell.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
-      emptyState.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
-    ]);
+    await this.waitForProvidersTableSettled();
     const cells = this.page.getByTestId('ai-provider-row-cell');
     const count = await cells.count();
     const providers: string[] = [];
@@ -210,18 +204,33 @@ export class ConfigurationPage {
   }
 
   /**
+   * Block until the providers table has resolved into either a populated or an
+   * empty state. Counting rows before this settles reports zero for a populated
+   * table, which makes callers re-add a provider that already exists — and that
+   * redundant write invalidates the provider-key query right as dependent pages
+   * (Playground, Online evaluation) are opening their model pickers.
+   */
+  private async waitForProvidersTableSettled(): Promise<void> {
+    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
+    const firstRowCell = this.page.getByTestId('ai-provider-row-cell').first();
+    const emptyState = tabpanel.getByText('No AI providers yet');
+    await expect
+      .poll(
+        async () =>
+          (await firstRowCell.isVisible().catch(() => false)) ||
+          (await emptyState.isVisible().catch(() => false)),
+        { timeout: 30_000, intervals: [100, 250, 500] },
+      )
+      .toBe(true);
+  }
+
+  /**
    * Idempotency check for Custom providers — a Custom row is identified by
    * (data-provider=custom-llm, name cell text === providerName). The first
    * cell in each row contains the provider_name.
    */
   private async hasCustomProvider(providerName: string): Promise<boolean> {
-    const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
-    const firstRowCell = this.page.getByTestId('ai-provider-row-cell').first();
-    const emptyState = tabpanel.getByText('No AI providers yet');
-    await Promise.race([
-      firstRowCell.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
-      emptyState.waitFor({ state: 'visible', timeout: 10_000 }).catch(() => undefined),
-    ]);
+    await this.waitForProvidersTableSettled();
     const customCells = this.page
       .getByTestId('ai-provider-row-cell')
       .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`));

--- a/tests_end_to_end/e2e/pom/online-evaluation.page.ts
+++ b/tests_end_to_end/e2e/pom/online-evaluation.page.ts
@@ -1,4 +1,5 @@
 import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
 export interface CreateRuleDialogLLMJudgeFields {
@@ -125,10 +126,22 @@ export class OnlineEvaluationPage {
     const modelCombobox = d.getByRole('combobox').filter({
       hasText: /Select an LLM model|claude|gpt|Claude|GPT/i,
     });
-    await modelCombobox.click();
     const listbox = this.page.getByRole('listbox');
-    await listbox.getByPlaceholder('Search model').fill(fields.modelDisplayName);
-    await listbox.getByRole('option', { name: fields.modelDisplayName }).first().click();
+    await expect(async () => {
+      await modelCombobox.click();
+      await expect(listbox).toBeVisible({ timeout: 2_000 });
+    }).toPass({ timeout: 15_000 });
+
+    // The option list remounts when the model/provider-key queries resolve, so
+    // an option can detach between resolving and being clicked. Re-filter and
+    // re-click until the combobox reflects the selection.
+    await expect(async () => {
+      await listbox.getByPlaceholder('Search model').fill(fields.modelDisplayName);
+      const option = listbox.getByRole('option', { name: fields.modelDisplayName });
+      await expect(option.first()).toBeVisible({ timeout: 2_000 });
+      await option.first().click({ timeout: 2_000 });
+      await expect(modelCombobox).toContainText(fields.modelDisplayName, { timeout: 2_000 });
+    }).toPass({ timeout: 30_000 });
 
     // Change the output variable-mapping from default `output` to `output.output`
     // so the engine extracts the bare string (per the JsonPath semantics in

--- a/tests_end_to_end/e2e/pom/optimization-studio.page.ts
+++ b/tests_end_to_end/e2e/pom/optimization-studio.page.ts
@@ -122,9 +122,17 @@ export class OptimizationStudioPage {
         await this.modelCombobox().click();
         await expect(search).toBeVisible({ timeout: 2_000 });
       }).toPass({ timeout: 15_000 });
-      await search.fill(displayName);
-      await this.page.getByRole('option', { name: displayName }).click();
-      await expect(this.modelCombobox()).toContainText(displayName);
+
+      // The option list remounts when the model/provider-key queries resolve, so
+      // an option can detach between resolving and being clicked. Re-filter and
+      // re-click until the combobox reflects the selection.
+      await expect(async () => {
+        await search.fill(displayName);
+        const option = this.page.getByRole('option', { name: displayName });
+        await expect(option.first()).toBeVisible({ timeout: 2_000 });
+        await option.first().click({ timeout: 2_000 });
+        await expect(this.modelCombobox()).toContainText(displayName, { timeout: 2_000 });
+      }).toPass({ timeout: 30_000 });
     });
   }
 

--- a/tests_end_to_end/e2e/pom/playground.page.ts
+++ b/tests_end_to_end/e2e/pom/playground.page.ts
@@ -476,8 +476,19 @@ export class PlaygroundPage {
       await this.modelPicker(index).click();
       await expect(listbox).toBeVisible({ timeout: 2_000 });
     }).toPass({ timeout: 15_000 });
-    await listbox.getByPlaceholder('Search model').fill(modelDisplayName);
-    await listbox.getByRole('option', { name: modelDisplayName, exact: true }).first().click();
+
+    // The option list remounts when /llm/models or /provider-keys resolves, and
+    // the suite configures a provider immediately before opening the Playground —
+    // so the dropdown routinely opens inside that refetch window and options are
+    // detached mid-click. Re-filter and re-click until the popover actually
+    // closes, which is the only reliable signal the selection registered.
+    await expect(async () => {
+      await listbox.getByPlaceholder('Search model').fill(modelDisplayName);
+      const option = listbox.getByRole('option', { name: modelDisplayName, exact: true });
+      await expect(option.first()).toBeVisible({ timeout: 2_000 });
+      await option.first().click({ timeout: 2_000 });
+      await expect(listbox).toBeHidden({ timeout: 2_000 });
+    }).toPass({ timeout: 30_000 });
   }
 
   private async fillMessageBody(messageRow: Locator, text: string): Promise<void> {


### PR DESCRIPTION
## Details

The LLM model option list is rebuilt when two React Query fetches resolve — `useLlmModels` (`/v1/private/llm/models`, `retry: 3` with backoff up to 10s) and `useProviderKeys` (`staleTime: 1000`). The E2E suite configures a provider immediately before opening the Playground, so the dropdown routinely opens inside that invalidation window and options detach mid-click, producing the `element is not stable` → `element was detached from the DOM` failure seen on stsaas runs.

- Wrap the search + option click in `toPass` across all three POMs that drive the picker (playground, optimization-studio, online-evaluation), each confirming the selection actually registered rather than that the click merely landed.
- Fix `ConfigurationPage`: both provider-table reads raced a row locator against the empty-state locator with `Promise.race`, each branch swallowing its own timeout. When neither settled within 10s the race resolved silently and counted zero rows — reporting "no providers" for a populated table, causing a redundant provider write that triggers the very refetch above. Both copies now share a `waitForProvidersTableSettled()` that fails loudly.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7806

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Failure investigation (Allure launch 92759 + trace analysis), root-cause diagnosis, and all four POM edits.
- Human verification: Author reviewed the diagnosis and approved the changes; local test runs and their limitations are reported verbatim below.

## Testing

Commands run from `tests_end_to_end/e2e/` against a local OSS stack (`OPIK_DEPLOYMENT=oss`, `OPIK_BASE_URL=http://localhost:5173`):

```
npx tsc --noEmit
npx playwright test tests/playground/playground-smoke.spec.ts --workers=1
npx playwright test tests/optimization-studio/optimization-studio.spec.ts --grep "new-run form renders" --workers=1
npx playwright test tests/online-evaluation/online-evaluation-smoke.spec.ts --workers=1
```

- `npx tsc --noEmit` clean.
- `playground-smoke` passes. Verified via the JSON reporter that it genuinely executes (`configure variant 0` runs) rather than skipping on the LLM key gate — a skip would otherwise read as a false green.
- `optimization-studio` form-validation test passes; it asserts the Optimize button enables, which only happens if the model was actually selected.
- `online-evaluation-smoke` both tests pass, including the LLM-judge test that creates a rule and waits for real judge scores.

**Not verified:** the original CI failure could not be reproduced locally. Three repro designs were attempted (fixed delays, fail-then-retry to exercise the `retry: 3` backoff, and a gated release mid-interaction); the interception fired and the retry happened, but the unfixed code passed all of them. The fix therefore rests on the diagnosis (error signature, the documented retry/staleTime behaviour, and the provider write immediately preceding the Playground) rather than on a local red-to-green transition. The changes are strictly more defensive than what they replace.

**Known remaining issue, not fixed here:** the playground spec also fails intermittently with `page.waitForResponse: Timeout 120000ms exceeded` on the experiment-creation POST. A captured trace shows the run never executes (`wait for 3 run(s) to complete` returns in 0.0s), so the 120s wait times out later and misleadingly blames that line. The `configuration.page.ts` fix is a contributing cause but not a complete cure — the failure rate fluctuated independently of the change (2/5 failures when spaced out, 4 consecutive failures in a tight loop, then 4 consecutive passes). Ruled out: provider key overwrite (timestamps unchanged) and LLM rate-limiting/errors (no chat-completion errors in backend logs). Next step is capturing a failing run with network recording enabled; this is called out in OPIK-7806 and should be tracked separately.

## Documentation

No documentation changes — test-infrastructure only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)