### PR TITLE
[BE]: register hyperbolic as a canonical provider so Hyperbolic model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -53,7 +53,8 @@ public class CostService {
             Map.entry("meta", "meta"),
             Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
-            Map.entry("sambanova", "sambanova"));
+            Map.entry("sambanova", "sambanova"),
+            Map.entry("hyperbolic", "hyperbolic"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -955,4 +955,21 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers registering {@code hyperbolic} as a canonical provider so that the 16 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "hyperbolic"} are no longer silently dropped at load time. No Hyperbolic
+     * model publishes cache rates today, so all Hyperbolic requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesHyperbolicModels() {
+        // hyperbolic/Qwen/QwQ-32B: input 2e-07, output 2e-07
+        // 1000 * 2e-07 + 200 * 2e-07 = 0.00024
+        BigDecimal cost = CostService.calculateCost("hyperbolic/Qwen/QwQ-32B", "hyperbolic",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.00024");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values present in `model_prices_and_context_window.json`. Any model whose `litellm_provider` is not in that map has its price dropped at load time (`buildModelPrice` returns null), so its spans are billed at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

`hyperbolic` is one such provider: the bundled price file carries 16 non-zero-cost Hyperbolic entries (Qwen, DeepSeek, Llama and more served on Hyperbolic) that currently never load. This registers `hyperbolic` as a canonical provider so those prices resolve. No Hyperbolic model publishes cache rates today, so requests route through the standard `textGenerationCost` path; no cache calculator entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added `calculateCostHandlesHyperbolicModels` asserting a representative Hyperbolic model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
