### PR TITLE
[BE]: register baseten as a canonical provider so Baseten model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -53,7 +53,8 @@ public class CostService {
             Map.entry("meta", "meta"),
             Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
-            Map.entry("sambanova", "sambanova"));
+            Map.entry("sambanova", "sambanova"),
+            Map.entry("baseten", "baseten"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -955,4 +955,21 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers registering {@code baseten} as a canonical provider so that the 11 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "baseten"} are no longer silently dropped at load time. No Baseten
+     * model publishes cache rates today, so all Baseten requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesBasetenModels() {
+        // baseten/zai-org/GLM-5: input 9.5e-07, output 3.15e-06
+        // 1000 * 9.5e-07 + 200 * 3.15e-06 = 0.00158
+        BigDecimal cost = CostService.calculateCost("baseten/zai-org/GLM-5", "baseten",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.00158");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values in `model_prices_and_context_window.json`. Models whose provider is missing from that map have their price dropped at load time (`buildModelPrice` returns null), so their spans bill at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

`baseten` is one such provider: the bundled price file carries 11 non-zero-cost Baseten entries (GLM, DeepSeek, Llama and more served on Baseten Model APIs) that never load today. This registers `baseten` as a canonical provider so those prices resolve. No Baseten model publishes cache rates today, so requests route through the standard `textGenerationCost` path; no cache calculator entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added `calculateCostHandlesBasetenModels` asserting a representative Baseten model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
