### PR TITLE
[BE]: register lambda_ai as a canonical provider so Lambda model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -53,7 +53,8 @@ public class CostService {
             Map.entry("meta", "meta"),
             Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
-            Map.entry("sambanova", "sambanova"));
+            Map.entry("sambanova", "sambanova"),
+            Map.entry("lambda_ai", "lambda_ai"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -955,4 +955,21 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers registering {@code lambda_ai} as a canonical provider so that the 20 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "lambda_ai"} are no longer silently dropped at load time. No Lambda
+     * model publishes cache rates today, so all Lambda requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesLambdaModels() {
+        // lambda_ai/lfm-7b: input 2.5e-08, output 4e-08
+        // 1000 * 2.5e-08 + 200 * 4e-08 = 0.000033
+        BigDecimal cost = CostService.calculateCost("lambda_ai/lfm-7b", "lambda_ai",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.000033");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values in `model_prices_and_context_window.json`. Models whose provider is missing from that map have their price dropped at load time (`buildModelPrice` returns null), so their spans bill at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

`lambda_ai` is one such provider: the bundled price file carries 20 non-zero-cost Lambda entries (the Liquid `lfm` models, DeepSeek, Llama, Qwen and more served on the Lambda Inference API) that never load today. This registers `lambda_ai` as a canonical provider so those prices resolve. No Lambda model publishes cache rates today, so requests route through the standard `textGenerationCost` path; no cache calculator entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added `calculateCostHandlesLambdaModels` asserting a representative Lambda model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
