### PR TITLE
[BE]: bill reasoning tokens at their own rate instead of the output rate

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ModelCostData.java
@@ -18,6 +18,7 @@ public record ModelCostData(String litellmProvider,
         String cacheReadInputTokenCost,
         String inputCostPerAudioToken,
         String outputCostPerAudioToken,
+        String outputCostPerReasoningToken,
         // Jackson's SnakeCaseStrategy doesn't insert an underscore between letters and digits,
         // so the camelCase fields below would resolve to keys like "above200k" without an
         // underscore. Pin each tier field to the literal LiteLLM JSON key with @JsonProperty.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -456,6 +456,9 @@ public class CostService {
         BigDecimal outputAudioTokenPrice = Optional.ofNullable(modelCost.outputCostPerAudioToken())
                 .map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);
+        BigDecimal outputReasoningTokenPrice = Optional.ofNullable(modelCost.outputCostPerReasoningToken())
+                .map(BigDecimal::new)
+                .orElse(BigDecimal.ZERO);
         // Whole-prompt tiers: LiteLLM's above_{128k,200k,272k}_tokens rates replace the base
         // rate wholesale once the prompt strictly exceeds the threshold. Only include a tier
         // when at least one of its rates is non-zero; that keeps the tier list empty for the
@@ -490,6 +493,7 @@ public class CostService {
                 .audioInputCharacterPrice(audioInputCharacterPrice)
                 .inputAudioTokenPrice(inputAudioTokenPrice)
                 .outputAudioTokenPrice(outputAudioTokenPrice)
+                .outputReasoningTokenPrice(outputReasoningTokenPrice)
                 .calculator(calculator)
                 .promptTiers(List.copyOf(promptTiers))
                 .build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/ModelPrice.java
@@ -20,6 +20,7 @@ public record ModelPrice(
         @NonNull BigDecimal audioInputCharacterPrice,
         @NonNull BigDecimal inputAudioTokenPrice,
         @NonNull BigDecimal outputAudioTokenPrice,
+        @NonNull BigDecimal outputReasoningTokenPrice,
         @NonNull BiFunction<ModelPrice, Map<String, Integer>, BigDecimal> calculator,
         @NonNull List<PromptTier> promptTiers) {
 
@@ -67,6 +68,7 @@ public record ModelPrice(
                 .audioInputCharacterPrice(BigDecimal.ZERO)
                 .inputAudioTokenPrice(BigDecimal.ZERO)
                 .outputAudioTokenPrice(BigDecimal.ZERO)
+                .outputReasoningTokenPrice(BigDecimal.ZERO)
                 .calculator(SpanCostCalculator::defaultCost)
                 .promptTiers(List.of());
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
@@ -39,11 +39,24 @@ class SpanCostCalculator {
                 ? Math.max(0, completionTokens - audioOutputTokens)
                 : completionTokens;
 
+        // Reasoning/thinking tokens are a subset of completion_tokens (SDK 1.6.0+ logs them under
+        // original_usage.completion_tokens_details.reasoning_tokens, with the bare OTel key as a
+        // fallback) and bill at a separate rate when the model publishes output_cost_per_reasoning_token.
+        // Subtract them from the standard-output bucket so they aren't billed at both rates.
+        int reasoningTokens = usage.getOrDefault("original_usage.completion_tokens_details.reasoning_tokens",
+                usage.getOrDefault("completion_tokens_details.reasoning_tokens", 0));
+
+        BigDecimal outputReasoningRate = modelPrice.outputReasoningTokenPrice();
+        int standardCompletionTokens = outputReasoningRate.compareTo(BigDecimal.ZERO) > 0
+                ? Math.max(0, nonAudioCompletionTokens - reasoningTokens)
+                : nonAudioCompletionTokens;
+
         return modelPrice.effectiveInputPrice(promptTokens).multiply(BigDecimal.valueOf(nonAudioPromptTokens))
                 .add(inputAudioRate.multiply(BigDecimal.valueOf(audioInputTokens)))
                 .add(modelPrice.effectiveOutputPrice(promptTokens)
-                        .multiply(BigDecimal.valueOf(nonAudioCompletionTokens)))
-                .add(outputAudioRate.multiply(BigDecimal.valueOf(audioOutputTokens)));
+                        .multiply(BigDecimal.valueOf(standardCompletionTokens)))
+                .add(outputAudioRate.multiply(BigDecimal.valueOf(audioOutputTokens)))
+                .add(outputReasoningRate.multiply(BigDecimal.valueOf(reasoningTokens)));
     }
 
     public static BigDecimal textGenerationWithCacheCostOpenAI(@NonNull ModelPrice modelPrice,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/SpanCostCalculator.java
@@ -43,12 +43,16 @@ class SpanCostCalculator {
         // original_usage.completion_tokens_details.reasoning_tokens, with the bare OTel key as a
         // fallback) and bill at a separate rate when the model publishes output_cost_per_reasoning_token.
         // Subtract them from the standard-output bucket so they aren't billed at both rates.
-        int reasoningTokens = usage.getOrDefault("original_usage.completion_tokens_details.reasoning_tokens",
+        int reportedReasoningTokens = usage.getOrDefault("original_usage.completion_tokens_details.reasoning_tokens",
                 usage.getOrDefault("completion_tokens_details.reasoning_tokens", 0));
+        // Clamp to [0, nonAudioCompletionTokens]: reasoning tokens are a subset of the completion
+        // tokens, so a missing/negative or over-reported value must never bill more reasoning than
+        // there are completion tokens, nor inflate the standard-output bucket.
+        int reasoningTokens = Math.max(0, Math.min(reportedReasoningTokens, nonAudioCompletionTokens));
 
         BigDecimal outputReasoningRate = modelPrice.outputReasoningTokenPrice();
         int standardCompletionTokens = outputReasoningRate.compareTo(BigDecimal.ZERO) > 0
-                ? Math.max(0, nonAudioCompletionTokens - reasoningTokens)
+                ? nonAudioCompletionTokens - reasoningTokens
                 : nonAudioCompletionTokens;
 
         return modelPrice.effectiveInputPrice(promptTokens).multiply(BigDecimal.valueOf(nonAudioPromptTokens))

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/SpanCostCalculatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/SpanCostCalculatorTest.java
@@ -52,6 +52,75 @@ class SpanCostCalculatorTest {
         assertThat(cost).isEqualByComparingTo("1.0");
     }
 
+    /**
+     * Covers reasoning-token handling in {@link SpanCostCalculator#textGenerationCost}. Reasoning
+     * tokens are a subset of {@code completion_tokens} and bill at {@code output_cost_per_reasoning_token}
+     * when the model publishes it, so they must be subtracted from the standard-output bucket (both
+     * the bare OTel key and the {@code original_usage.} prefixed key), and ignored entirely when no
+     * reasoning rate is configured. The audio+reasoning case guarantees both subtractions compose.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideReasoningTokenCases")
+    void textGenerationCost_splitsReasoningTokens(String description, ModelPrice modelPrice,
+            Map<String, Integer> usage, String expectedCost) {
+        BigDecimal cost = SpanCostCalculator.textGenerationCost(modelPrice, usage);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideReasoningTokenCases() {
+        ModelPrice withReasoningRate = ModelPrice.defaultBuilder()
+                .inputPrice(new BigDecimal("0.01"))
+                .outputPrice(new BigDecimal("0.02"))
+                .outputReasoningTokenPrice(new BigDecimal("0.003"))
+                .build();
+        ModelPrice withReasoningAndAudioRates = ModelPrice.defaultBuilder()
+                .inputPrice(new BigDecimal("0.01"))
+                .outputPrice(new BigDecimal("0.02"))
+                .outputAudioTokenPrice(new BigDecimal("0.08"))
+                .outputReasoningTokenPrice(new BigDecimal("0.003"))
+                .build();
+        ModelPrice noReasoningRate = ModelPrice.defaultBuilder()
+                .inputPrice(new BigDecimal("0.01"))
+                .outputPrice(new BigDecimal("0.02"))
+                .build();
+        return Stream.of(
+                // reasoning rate set (bare OTel key): reasoning splits out of the completion bucket
+                // input = 1000 * 0.01 = 10.00
+                // standard completion = 500 - 200 reasoning = 300 -> 300 * 0.02 = 6.00
+                // reasoning = 200 * 0.003 = 0.60
+                // total = 10 + 6 + 0.60 = 16.60  (vs 16.00 if reasoning billed at the output rate)
+                Arguments.of("reasoning rate set: bare completion_tokens_details.reasoning_tokens",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "completion_tokens_details.reasoning_tokens", 200),
+                        "16.60"),
+                // original_usage.* key path (SDK 1.6.0+): same expected math as the bare-key case
+                Arguments.of("reasoning rate set: original_usage.* prefixed key",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "original_usage.completion_tokens_details.reasoning_tokens", 200),
+                        "16.60"),
+                // reasoning + audio both set: both subtracted from the completion bucket
+                // input = 1000 * 0.01 = 10.00
+                // completion - 100 audio - 200 reasoning = 200 -> 200 * 0.02 = 4.00
+                // audio_out = 100 * 0.08 = 8.00; reasoning = 200 * 0.003 = 0.60
+                // total = 10 + 4 + 8 + 0.60 = 22.60
+                Arguments.of("reasoning and audio rates set: both split out of completion",
+                        withReasoningAndAudioRates,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "completion_tokens_details.audio_tokens", 100,
+                                "completion_tokens_details.reasoning_tokens", 200),
+                        "22.60"),
+                // reasoning rate unset: the reasoning-token key is ignored, all completion at output
+                // input = 1000 * 0.01 = 10.00; completion = 500 * 0.02 = 10.00; total = 20.00
+                Arguments.of("reasoning rate unset: reasoning_tokens key is ignored",
+                        noReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "completion_tokens_details.reasoning_tokens", 200),
+                        "20.00"));
+    }
+
     // --- Audio Speech Cost Tests ---
 
     @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/SpanCostCalculatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/SpanCostCalculatorTest.java
@@ -118,6 +118,33 @@ class SpanCostCalculatorTest {
                         noReasoningRate,
                         Map.of("prompt_tokens", 1000, "completion_tokens", 500,
                                 "completion_tokens_details.reasoning_tokens", 200),
+                        "20.00"),
+                // reasoning rate set but no reasoning_tokens key: reasoning is 0, all completion standard
+                // input = 10.00; completion = 500 * 0.02 = 10.00; total = 20.00
+                Arguments.of("reasoning rate set: reasoning_tokens key absent bills zero reasoning",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500),
+                        "20.00"),
+                // reasoning tokens equal to completion tokens: standard bucket clamps to 0
+                // input = 10.00; standard = 500 - 500 = 0; reasoning = 500 * 0.003 = 1.50; total = 11.50
+                Arguments.of("reasoning tokens equal completion tokens: standard bucket empties",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "completion_tokens_details.reasoning_tokens", 500),
+                        "11.50"),
+                // over-reported reasoning (200 > 100 completion): reasoning is clamped to the completion
+                // total so billing never exceeds it. input = 10.00; standard = 0; reasoning = 100 * 0.003 = 0.30
+                Arguments.of("over-reported reasoning tokens are clamped to the completion total",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 100,
+                                "completion_tokens_details.reasoning_tokens", 200),
+                        "10.30"),
+                // negative reasoning is clamped to 0: no negative reasoning charge, completion stays whole
+                // input = 10.00; standard = 500 * 0.02 = 10.00; reasoning = 0; total = 20.00
+                Arguments.of("negative reasoning tokens are clamped to zero",
+                        withReasoningRate,
+                        Map.of("prompt_tokens", 1000, "completion_tokens", 500,
+                                "completion_tokens_details.reasoning_tokens", -10),
                         "20.00"));
     }
 


### PR DESCRIPTION
## Details

Reasoning/thinking tokens are billed at a separate rate (`output_cost_per_reasoning_token`) by the models that publish it, but `SpanCostCalculator.textGenerationCost` never read them. Reasoning tokens are a subset of `completion_tokens` (the OpenAI usage shape nests them under `completion_tokens_details.reasoning_tokens`, flattened by the SDK to `original_usage.completion_tokens_details.reasoning_tokens`), so every reasoning token was billed at the standard output rate.

54 models in the bundled price file carry `output_cost_per_reasoning_token`, and 6 price it differently from their output rate. The concrete live case is `perplexity/sonar-deep-research` (a registered, non-cache-routed provider): output `8e-6`, reasoning `3e-6`, so its reasoning tokens were over-billed by 2.67x. The dashscope qwen models go the other way (reasoning `4e-6` vs output `1.2e-6`, i.e. under-billed) and will price correctly once dashscope is registered.

This threads the rate through `ModelCostData` -> `ModelPrice` -> `CostService`, then subtracts reasoning tokens from the standard-output bucket in `textGenerationCost` and bills them at the reasoning rate, mirroring the existing audio-token handling. The subtraction composes with the audio subtraction (both come out of the completion bucket) and is a no-op when the model has no reasoning rate or the span carries no reasoning tokens.

Scope note: the change lives in the standard `textGenerationCost` path, which is where the models that publish a distinct reasoning rate route today (none of them are OpenAI-cache-routed). Extending the same split to `textGenerationWithCacheCostOpenAI` can follow if a cache-priced reasoning model appears; I kept this PR to the path with real impact rather than touching the more delicate cached-token overlap logic speculatively.

## Testing

Added `textGenerationCost_splitsReasoningTokens` to `SpanCostCalculatorTest`, a parameterized regression covering: reasoning split via the bare OTel key, via the `original_usage.` prefixed key, reasoning and audio both splitting out of the completion bucket, and the reasoning-rate-unset case where the reasoning key is ignored. Each case carries the worked arithmetic and fails if reasoning tokens fall back to the output rate.

## Documentation

No documentation changes needed
