### PR TITLE
[OPIK-7699] [FE] Resolve one workspace by name instead of downloading the organization

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/BillingLink.tsx
+++ b/apps/opik-frontend/src/plugins/comet/BillingLink.tsx
@@ -1,18 +1,10 @@
 import { useActiveWorkspaceName } from "@/store/AppStore";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
-import useUser from "@/plugins/comet/useUser";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import { buildUrl } from "@/plugins/comet/utils";
 
 const BillingLink = () => {
   const activeWorkspaceName = useActiveWorkspaceName();
-  const { data: user } = useUser();
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
-
-  const workspace = allWorkspaces?.find(
-    (w) => w.workspaceName === activeWorkspaceName,
-  );
+  const workspace = useWorkspace(activeWorkspaceName);
 
   if (!workspace?.organizationId) return null;
 

--- a/apps/opik-frontend/src/plugins/comet/GetStartedPage.tsx
+++ b/apps/opik-frontend/src/plugins/comet/GetStartedPage.tsx
@@ -1,7 +1,7 @@
 import V1NewQuickstart from "@/v1/pages/GetStartedPage/NewQuickstart";
 import useUser from "./useUser";
 import useOrganizations from "@/plugins/comet/useOrganizations";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import { ORGANIZATION_PLAN_ENTERPRISE } from "./types";
 import useAppStore from "@/store/AppStore";
 
@@ -12,15 +12,9 @@ const GetStartedPage = () => {
   const { data: organizations } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
+  const currentWorkspace = useWorkspace(workspaceName);
 
   if (!user) return;
-
-  const currentWorkspace = allWorkspaces?.find(
-    (workspace) => workspace.workspaceName === workspaceName,
-  );
 
   const currentOrganization = organizations?.find((org) => {
     return org.id === currentWorkspace?.organizationId;

--- a/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
+++ b/apps/opik-frontend/src/plugins/comet/InviteUsersForm.tsx
@@ -14,8 +14,7 @@ import {
   FormMessage,
 } from "@/ui/form";
 import { useOpikWorkspaceName } from "@/store/AppStore";
-import useUser from "@/plugins/comet/useUser";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import { useInviteUsersMutation } from "@/plugins/comet/api/useInviteMembersMutation";
 
 const USERNAME_MIN_LENGTH = 3;
@@ -60,10 +59,7 @@ type InviteUsersFormData = z.infer<typeof inviteUsersSchema>;
 
 const InviteUsersForm = () => {
   const workspaceName = useOpikWorkspaceName();
-  const { data: user } = useUser();
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
+  const workspace = useWorkspace(workspaceName);
 
   const form = useForm<InviteUsersFormData>({
     resolver: zodResolver(inviteUsersSchema),
@@ -78,9 +74,6 @@ const InviteUsersForm = () => {
       .map((t) => t.trim())
       .filter(Boolean);
 
-    const workspace = allWorkspaces?.find(
-      (w) => w.workspaceName === workspaceName,
-    );
     if (!workspace) {
       return;
     }

--- a/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
+++ b/apps/opik-frontend/src/plugins/comet/RetentionBanner.tsx
@@ -10,7 +10,7 @@ import useUser from "@/plugins/comet/useUser";
 import { Button } from "@/ui/button";
 import useOrganizations from "@/plugins/comet/useOrganizations";
 import { ORGANIZATION_ROLE_TYPE } from "@/plugins/comet/types";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import { buildUrl } from "@/plugins/comet/utils";
 import useOrganizationMembers from "@/plugins/comet/api/useOrganizationMembers";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
@@ -33,13 +33,7 @@ const RetentionBanner = ({ onChangeHeight }: RetentionBannerProps) => {
     { enabled: !!activeWorkspaceName && !!user?.loggedIn },
   );
 
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
-
-  const workspace = allWorkspaces?.find(
-    (workspace) => workspace.workspaceName === activeWorkspaceName,
-  );
+  const workspace = useWorkspace(activeWorkspaceName);
 
   const { data: organizations } = useOrganizations({
     enabled: !!user?.loggedIn,

--- a/apps/opik-frontend/src/plugins/comet/UpgradeButton.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UpgradeButton.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/ui/button";
 import useAppStore from "@/store/AppStore";
 import useUser from "@/plugins/comet/useUser";
 import useOrganizations from "@/plugins/comet/useOrganizations";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import {
   ORGANIZATION_PLAN_ENTERPRISE,
   ORGANIZATION_ROLE_TYPE,
@@ -24,17 +24,11 @@ const UpgradeButton: React.FC = () => {
   const { data: organizations } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
+  const workspace = useWorkspace(workspaceName);
 
-  if (!user?.loggedIn || !organizations || !allWorkspaces) {
+  if (!user?.loggedIn || !organizations) {
     return null;
   }
-
-  const workspace = allWorkspaces.find(
-    (ws) => ws.workspaceName === workspaceName,
-  );
 
   const organization = organizations.find(
     (org) => org.id === workspace?.organizationId,

--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -49,7 +49,7 @@ import useUser from "./useUser";
 import useUserPermissions from "./useUserPermissions";
 import { buildUrl } from "./utils";
 
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import InviteUsersPopover from "@/plugins/comet/InviteUsersPopover";
 import useUserPermission from "@/plugins/comet/useUserPermission";
 import UserMenuAppLinks from "@/plugins/comet/UserMenuAppLinks";
@@ -69,13 +69,7 @@ const UserMenu = () => {
     enabled: !!user?.loggedIn,
   });
 
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
-
-  const workspace = allWorkspaces?.find(
-    (workspace) => workspace.workspaceName === workspaceName,
-  );
+  const workspace = useWorkspace(workspaceName);
 
   const { data: userPermissions } = useUserPermissions(
     {
@@ -100,8 +94,7 @@ const UserMenu = () => {
     !user.loggedIn ||
     isLoading ||
     !organizations ||
-    !userPermissions ||
-    !allWorkspaces
+    !userPermissions
   ) {
     return null;
   }

--- a/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
+++ b/apps/opik-frontend/src/plugins/comet/WorkspacePreloader.tsx
@@ -12,7 +12,8 @@ import Loader from "@/shared/Loader/Loader";
 import { Button } from "@/ui/button";
 import { DEFAULT_WORKSPACE_NAME } from "@/constants/user";
 import { isLandingRoute } from "@/lib/landingRoutes";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useLandingWorkspace from "@/plugins/comet/useLandingWorkspace";
+import useWorkspaceByName from "@/plugins/comet/useWorkspaceByName";
 import useAppStore, { useSetAppUser } from "@/store/AppStore";
 import { usePostHog } from "posthog-js/react";
 import Logo from "@/shared/Logo/Logo";
@@ -67,10 +68,6 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
   const setAppUser = useSetAppUser();
   const { data: user, isLoading } = useUser();
 
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
-
   const { data: organizations } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
@@ -80,6 +77,43 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     strict: false,
     select: (params) => params["workspaceName"],
   });
+
+  // Point reads instead of the whole organization: the workspace named in the URL, and -- only if
+  // that one turns out not to be visible -- the user's own default workspace to fall back to. Its
+  // name comes from the user payload, so neither lookup needs a list (OPIK-7699).
+  const {
+    data: urlWorkspace,
+    isPending: isUrlWorkspacePending,
+    isError: isUrlWorkspaceError,
+  } = useWorkspaceByName(
+    { workspaceName: workspaceNameFromURL ?? "" },
+    { enabled: !!user?.loggedIn && !!workspaceNameFromURL },
+  );
+  const needsFallbackWorkspace =
+    !!user?.loggedIn && (!workspaceNameFromURL || urlWorkspace === null);
+  const {
+    data: userDefaultWorkspace,
+    isPending: isDefaultWorkspacePending,
+    isError: isDefaultWorkspaceError,
+  } = useWorkspaceByName(
+    { workspaceName: user?.defaultWorkspace ?? "" },
+    { enabled: needsFallbackWorkspace && !!user?.defaultWorkspace },
+  );
+  // Last resort, for a user whose default workspace no longer resolves: ask the backend where they
+  // land in their organization. Replaces the old "first row of the unordered list" fallback.
+  const needsLandingWorkspace =
+    needsFallbackWorkspace &&
+    (!user?.defaultWorkspace ||
+      userDefaultWorkspace === null ||
+      isDefaultWorkspaceError);
+  const {
+    data: landingWorkspace,
+    isPending: isLandingWorkspacePending,
+    isError: isLandingWorkspaceError,
+  } = useLandingWorkspace(
+    { organizationId: organizations?.[0]?.id ?? "" },
+    { enabled: needsLandingWorkspace && !!organizations?.[0]?.id },
+  );
   const { pathname } = useLocation();
   const isRootPath = matchRoute({ to: "/" });
 
@@ -103,11 +137,8 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
 
     // Reo.Dev user identification for usage tracking
     // Prefer GitHub handle if available, otherwise use email
-    const workspace = allWorkspaces?.find(
-      (ws) => ws.workspaceName === workspaceNameFromURL,
-    );
     const organization = organizations?.find(
-      (org) => org.id === workspace?.organizationId,
+      (org) => org.id === urlWorkspace?.organizationId,
     );
 
     if (user.gitHub) {
@@ -136,7 +167,7 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     user?.email,
     user?.apiKeys,
     user?.gitHub,
-    allWorkspaces,
+    urlWorkspace,
     organizations,
     workspaceNameFromURL,
     setAppUser,
@@ -165,13 +196,21 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
     return children;
   }
 
-  if (!allWorkspaces) {
+  // A failure is not an answer: hold the loader rather than telling the user their workspace is
+  // private, which is what the list-based version did while it had no data either.
+  if (
+    (workspaceNameFromURL && (isUrlWorkspacePending || isUrlWorkspaceError)) ||
+    (needsFallbackWorkspace &&
+      user.defaultWorkspace &&
+      isDefaultWorkspacePending) ||
+    (needsLandingWorkspace &&
+      organizations?.[0] &&
+      (isLandingWorkspacePending || isLandingWorkspaceError))
+  ) {
     return <Loader />;
   }
 
-  const matchedWorkspace = workspaceNameFromURL
-    ? allWorkspaces.find((ws) => ws.workspaceName === workspaceNameFromURL)
-    : null;
+  const matchedWorkspace = workspaceNameFromURL ? urlWorkspace : null;
 
   // Hidden spend workspace resolves as "not found" → private-project message.
   const workspace = isHiddenSpendWorkspace(matchedWorkspace, pathname)
@@ -186,9 +225,7 @@ const WorkspacePreloader: React.FunctionComponent<WorkspacePreloaderProps> = ({
 
     useAppStore.getState().setActiveWorkspaceName(workspace.workspaceName);
   } else {
-    const defaultWorkspace =
-      allWorkspaces.find((workspace) => workspace.default) ??
-      allWorkspaces?.[0];
+    const defaultWorkspace = userDefaultWorkspace ?? landingWorkspace;
 
     if (defaultWorkspace) {
       if (

--- a/apps/opik-frontend/src/plugins/comet/lib/workspacePointRead.ts
+++ b/apps/opik-frontend/src/plugins/comet/lib/workspacePointRead.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+import api from "../api";
+import { Workspace } from "../types";
+
+// The workspace point reads answer 404 for "no such workspace" and for "not visible to you" alike,
+// and mark it with the backend's error body. A 404 without that body is the router saying the route
+// is not there -- a frontend deployed ahead of its backend -- which is a failure, not an answer:
+// reading it as "no workspace" would send every user to the private-project page.
+export const isPointReadMiss = (error: unknown) =>
+  axios.isAxiosError(error) &&
+  error.response?.status === 404 &&
+  typeof error.response?.data === "object" &&
+  error.response?.data !== null &&
+  "code" in error.response.data;
+
+export const postWorkspacePointRead = async (
+  url: string,
+  body: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<Workspace | null> => {
+  try {
+    const { data } = await api.post<Workspace>(url, body, { signal });
+    return data;
+  } catch (error) {
+    if (isPointReadMiss(error)) return null;
+    throw error;
+  }
+};
+
+// "Not found" is already an answer rather than a failure, so retrying only delays a render that
+// cannot proceed without the workspace anyway.
+export const WORKSPACE_POINT_READ_QUERY_OPTIONS = {
+  retry: false,
+  staleTime: Infinity,
+} as const;

--- a/apps/opik-frontend/src/plugins/comet/types.ts
+++ b/apps/opik-frontend/src/plugins/comet/types.ts
@@ -56,6 +56,9 @@ export interface Organization {
   onlyAdminsInviteByEmail: boolean;
   workspaceRolesEnabled: boolean;
   costIntelligenceEnabled: boolean;
+  // Name of the organization's reserved AI-spend workspace, present only when it exists and cost
+  // intelligence is enabled — the same condition under which that workspace can be opened.
+  aiSpendWorkspaceName?: string;
 }
 
 export enum ManagementPermissionsNames {
@@ -107,6 +110,9 @@ export interface Workspace {
   workspaceName: string;
   organizationId: string;
   default: boolean;
+  // Whether the caller is a member of the workspace, as opposed to seeing it as an organization
+  // admin. Returned by the point read; absent on the list endpoints, which imply it by inclusion.
+  member?: boolean;
   createdAt?: number;
   workspaceOwner?: string;
   workspaceCreator?: string;

--- a/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
@@ -1,7 +1,7 @@
 import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
-import useAllWorkspaces from "./useAllWorkspaces";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
+import useWorkspaceByName from "./useWorkspaceByName";
 import { isAiSpendWorkspace } from "./lib/aiSpend";
 import { ORGANIZATION_PLAN_ENTERPRISE, ORGANIZATION_ROLE_TYPE } from "./types";
 
@@ -14,37 +14,28 @@ const useAiSpendManager = () => {
 
   const { data: organizations, isPending: isOrganizationsPending } =
     useOrganizations({ enabled: isEnabled });
-  const { data: allWorkspaces, isPending: isWorkspacesPending } =
-    useAllWorkspaces({ enabled: isEnabled });
 
-  const currentWorkspace = allWorkspaces?.find(
-    (w) => w.workspaceName === workspaceName,
-  );
+  const { data: currentWorkspace, isPending: isWorkspacePending } =
+    useWorkspaceByName({ workspaceName }, { enabled: isEnabled });
   const organization = organizations?.find(
     (org) => org.id === currentWorkspace?.organizationId,
   );
 
-  const spendWorkspace = allWorkspaces?.find(
-    (w) => w.organizationId === organization?.id && isAiSpendWorkspace(w),
-  );
-
-  const isEnterprise =
-    organization?.paymentPlan === ORGANIZATION_PLAN_ENTERPRISE;
-  const isOrganizationAdmin =
-    organization?.role === ORGANIZATION_ROLE_TYPE.admin;
+  // Published by the organization payload only when the workspace exists and cost intelligence is
+  // on -- the same condition under which it can be opened -- so no list has to be scanned for it.
+  const spendWorkspaceName = organization?.aiSpendWorkspaceName;
 
   return {
     isPending:
       isEnabled &&
-      (isOrganizationsPending || isWorkspacesPending || !workspaceVersion),
+      (isOrganizationsPending || isWorkspacePending || !workspaceVersion),
     organization,
-    spendWorkspace,
-    spendWorkspaceName: spendWorkspace?.workspaceName,
-    isSpendWorkspaceActive: isAiSpendWorkspace(currentWorkspace),
-    isEnterprise,
-    isOrganizationAdmin,
+    spendWorkspaceName,
+    isSpendWorkspaceActive: isAiSpendWorkspace(currentWorkspace ?? undefined),
+    isEnterprise: organization?.paymentPlan === ORGANIZATION_PLAN_ENTERPRISE,
+    isOrganizationAdmin: organization?.role === ORGANIZATION_ROLE_TYPE.admin,
     hasAccess:
-      Boolean(spendWorkspace) &&
+      Boolean(spendWorkspaceName) &&
       Boolean(organization?.costIntelligenceEnabled) &&
       workspaceVersion === "v2",
   };

--- a/apps/opik-frontend/src/plugins/comet/useCurrentOrganization.ts
+++ b/apps/opik-frontend/src/plugins/comet/useCurrentOrganization.ts
@@ -1,24 +1,15 @@
-import useAppStore from "@/store/AppStore";
-import useAllWorkspaces from "./useAllWorkspaces";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
+import useWorkspace from "./useWorkspace";
 
 const useCurrentOrganization = () => {
-  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-
   const { data: user } = useUser();
 
   const { data: organizations } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
 
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
-
-  const currentWorkspace = allWorkspaces?.find(
-    (workspace) => workspace.workspaceName === workspaceName,
-  );
+  const currentWorkspace = useWorkspace();
 
   const currentOrganization = organizations?.find((org) => {
     return org.id === currentWorkspace?.organizationId;

--- a/apps/opik-frontend/src/plugins/comet/useInviteMembersURL.ts
+++ b/apps/opik-frontend/src/plugins/comet/useInviteMembersURL.ts
@@ -1,6 +1,6 @@
 import { useOpikWorkspaceName } from "@/store/AppStore";
 import useUser from "@/plugins/comet/useUser";
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useWorkspace from "@/plugins/comet/useWorkspace";
 import { buildUrl } from "@/plugins/comet/utils";
 import { ORGANIZATION_ROLE_TYPE } from "@/plugins/comet/types";
 import useOrganizations from "@/plugins/comet/useOrganizations";
@@ -10,16 +10,11 @@ const useInviteMembersURL = () => {
   const workspaceName = useOpikWorkspaceName();
 
   const { data: user } = useUser();
-  const { data: allWorkspaces } = useAllWorkspaces({
-    enabled: !!user?.loggedIn,
-  });
   const { data: organizations = [], isLoading } = useOrganizations({
     enabled: !!user?.loggedIn,
   });
 
-  const workspace = allWorkspaces?.find(
-    (workspace) => workspace.workspaceName === workspaceName,
-  );
+  const workspace = useWorkspace(workspaceName);
   const organization = organizations?.find((org) => {
     return org.id === workspace?.organizationId;
   });

--- a/apps/opik-frontend/src/plugins/comet/useLandingWorkspace.ts
+++ b/apps/opik-frontend/src/plugins/comet/useLandingWorkspace.ts
@@ -1,0 +1,36 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import { QueryConfig } from "./api";
+import { Workspace } from "./types";
+import {
+  WORKSPACE_POINT_READ_QUERY_OPTIONS,
+  postWorkspacePointRead,
+} from "./lib/workspacePointRead";
+
+type RetrieveLandingWorkspaceParams = {
+  organizationId: string;
+};
+
+const getLandingWorkspace = ({ signal, queryKey }: QueryFunctionContext) => {
+  const { organizationId } = queryKey[1] as RetrieveLandingWorkspaceParams;
+  return postWorkspacePointRead(
+    "/workspaces/retrieve-landing",
+    { organizationId },
+    signal,
+  );
+};
+
+// Where the user lands in an organization, by the backend's rule: their own default workspace if it
+// is there, else the first they are a member of, else -- for an organization admin -- the
+// organization's first. The last resort when a user's default workspace no longer resolves.
+export default function useLandingWorkspace(
+  params: RetrieveLandingWorkspaceParams,
+  options?: QueryConfig<Workspace | null>,
+) {
+  return useQuery({
+    queryKey: ["landing-workspace", params],
+    queryFn: getLandingWorkspace,
+    ...WORKSPACE_POINT_READ_QUERY_OPTIONS,
+    ...options,
+    enabled: Boolean(params.organizationId) && (options?.enabled ?? true),
+  });
+}

--- a/apps/opik-frontend/src/plugins/comet/useWorkspace.ts
+++ b/apps/opik-frontend/src/plugins/comet/useWorkspace.ts
@@ -1,15 +1,21 @@
-import useAllWorkspaces from "@/plugins/comet/useAllWorkspaces";
+import useUser from "@/plugins/comet/useUser";
+import useWorkspaceByName from "@/plugins/comet/useWorkspaceByName";
 import useAppStore from "@/store/AppStore";
 
+// Resolves the workspace with one point read rather than downloading every workspace of the
+// organization and picking a row here. Returns undefined while in flight and when the workspace is
+// not visible to the caller, which is what the previous .find() over the list returned.
 const useWorkspace = (workspaceName?: string) => {
   const activeWorkspaceName = useAppStore((state) => state.activeWorkspaceName);
   const name = workspaceName ?? activeWorkspaceName;
 
-  const { data: allWorkspaces } = useAllWorkspaces();
+  const { data: user } = useUser();
+  const { data: workspace } = useWorkspaceByName(
+    { workspaceName: name },
+    { enabled: !!user?.loggedIn },
+  );
 
-  const workspace = allWorkspaces?.find((w) => w.workspaceName === name);
-
-  return workspace;
+  return workspace ?? undefined;
 };
 
 export default useWorkspace;

--- a/apps/opik-frontend/src/plugins/comet/useWorkspaceByName.test.tsx
+++ b/apps/opik-frontend/src/plugins/comet/useWorkspaceByName.test.tsx
@@ -1,0 +1,138 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import useWorkspaceByName from "./useWorkspaceByName";
+import api from "./api";
+
+vi.mock("./api", () => ({
+  default: { post: vi.fn() },
+}));
+
+const post = vi.mocked(api.post);
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+};
+
+const axiosError = (status: number, data: unknown = undefined) =>
+  Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: { status, data },
+  });
+
+// What the backend actually sends for "no such workspace / not visible to you".
+const notFoundBody = { msg: "No such workspace!", code: 404, data: null };
+
+const workspace = {
+  workspaceId: "ws-id",
+  workspaceName: "my-team",
+  organizationId: "org-id",
+  default: false,
+  member: true,
+};
+
+describe("useWorkspaceByName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves a workspace by name through the point read", async () => {
+    post.mockResolvedValue({ data: workspace });
+
+    const { result } = renderHook(
+      () => useWorkspaceByName({ workspaceName: "my-team" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(workspace);
+    expect(post).toHaveBeenCalledWith(
+      "/workspaces/retrieve",
+      { workspaceName: "my-team" },
+      expect.anything(),
+    );
+  });
+
+  // The endpoint answers 404 both for "no such name" and "you may not see it", exactly as the list it
+  // replaces simply did not contain the row. Surfacing that as an error would turn a normal answer
+  // into a broken render.
+  it("treats the backend's 404 as an absent workspace rather than an error", async () => {
+    post.mockRejectedValue(axiosError(404, notFoundBody));
+
+    const { result } = renderHook(
+      () => useWorkspaceByName({ workspaceName: "not-mine" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+    expect(result.current.isError).toBe(false);
+  });
+
+  // A frontend deployed ahead of its backend gets a router 404 with no error body. Reading that as
+  // "this workspace does not exist" would send every user to the private-project page.
+  it("does not mistake a missing endpoint for a missing workspace", async () => {
+    post.mockRejectedValue(axiosError(404, ""));
+
+    const { result } = renderHook(
+      () => useWorkspaceByName({ workspaceName: "my-team" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("still reports a real failure", async () => {
+    post.mockRejectedValue(axiosError(500, { msg: "boom", code: 500 }));
+
+    const { result } = renderHook(
+      () => useWorkspaceByName({ workspaceName: "my-team" }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it("does not fire without a workspace name", () => {
+    renderHook(() => useWorkspaceByName({ workspaceName: "" }), { wrapper });
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("honours an explicit enabled: false", () => {
+    renderHook(
+      () =>
+        useWorkspaceByName({ workspaceName: "my-team" }, { enabled: false }),
+      { wrapper },
+    );
+
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it("keys the query by name so two names do not share a cache entry", async () => {
+    post.mockResolvedValue({ data: workspace });
+
+    const { result, rerender } = renderHook(
+      ({ name }: { name: string }) =>
+        useWorkspaceByName({ workspaceName: name }),
+      { wrapper, initialProps: { name: "my-team" } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    post.mockResolvedValue({
+      data: { ...workspace, workspaceName: "other-team" },
+    });
+    rerender({ name: "other-team" });
+
+    await waitFor(() =>
+      expect(result.current.data?.workspaceName).toBe("other-team"),
+    );
+    expect(post).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/opik-frontend/src/plugins/comet/useWorkspaceByName.ts
+++ b/apps/opik-frontend/src/plugins/comet/useWorkspaceByName.ts
@@ -1,0 +1,33 @@
+import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
+import { QueryConfig } from "./api";
+import { Workspace } from "./types";
+import {
+  WORKSPACE_POINT_READ_QUERY_OPTIONS,
+  postWorkspacePointRead,
+} from "./lib/workspacePointRead";
+
+type RetrieveWorkspaceParams = {
+  workspaceName: string;
+};
+
+const getWorkspaceByName = ({ signal, queryKey }: QueryFunctionContext) => {
+  const { workspaceName } = queryKey[1] as RetrieveWorkspaceParams;
+  return postWorkspacePointRead(
+    "/workspaces/retrieve",
+    { workspaceName },
+    signal,
+  );
+};
+
+export default function useWorkspaceByName(
+  params: RetrieveWorkspaceParams,
+  options?: QueryConfig<Workspace | null>,
+) {
+  return useQuery({
+    queryKey: ["workspace", params],
+    queryFn: getWorkspaceByName,
+    ...WORKSPACE_POINT_READ_QUERY_OPTIONS,
+    ...options,
+    enabled: Boolean(params.workspaceName) && (options?.enabled ?? true),
+  });
+}


### PR DESCRIPTION
## Details

Eleven places needed the workspace the user is looking at, and each got it by downloading every workspace of the organization and searching the result in the browser — for an organization admin that is the whole organization, 41 MB in 2.4 s on a 300k-workspace stack, and one of the eleven runs during bootstrap. `useWorkspace` now performs a point read against the new backend endpoint and the other ten call sites delegate to it, so react-query collapses them into one request per workspace name.

- **404 means "no workspace", not "error".** The endpoint answers 404 both for a name that does not exist and for one the caller may not see — exactly what the list expressed by simply not containing the row — so `useWorkspaceByName` maps it to `null` and does not retry it.
- **`WorkspacePreloader` needed two point reads**: the workspace named in the URL, and the user's own default workspace, which is where it falls back when the URL names one they cannot see. The second name comes from `user.defaultWorkspace`, so neither lookup needs a list. Its previous fallback was `find(w => w.default) ?? list[0]`, and that `list[0]` was the first row of a query with no ordering.
- **`useAiSpendManager` makes no workspace request at all now.** It stops locating the reserved workspace by filtering the organization against a hardcoded name pattern — whose legacy `__cc_` branch the backend has not produced for some time — and reads `aiSpendWorkspaceName` off the organization payload, which is set only when that workspace exists and cost intelligence is on.
- **Wire names are `default` and `member`**, not `isDefault`/`isMember`: the backend derives them from Lombok's generated `isX()` accessors, and `workspace.default` is what this code already read.

**Not yet the payload win.** `useWorkspaceSelectorData` still uses the list — it is the one consumer that genuinely needs one, and it is OPIK_7718. Until that lands the switcher fetches `/workspaces/lite` once per page load, so this removes ten of the eleven consumers but not the download itself. Measured below.

### Backend dependencies — **two**, not one

Both must be **deployed** before this ships, not merely merged:

- **comet-ml/comet-backend#5635** — `POST /workspaces/retrieve`, the point read this PR is built on.
- **comet-ml/comet-backend#5636** — `POST /workspaces/retrieve-landing`. `useLandingWorkspace.ts` calls it from `WorkspacePreloader`, for the user whose `user.defaultWorkspace` no longer resolves. **An earlier version of this description named only #5635, which is not sufficient.** Against #5635 alone that call gets a router 404 — which this PR deliberately treats as an error rather than as "no workspace" (see the review-fix note below) — so the preloader holds its loader indefinitely for that user instead of landing them somewhere.

#5636 is stacked on #5635's branch, so deploying #5636 covers both.

### Fixed after a code review pass

- **A bare 404 is not an answer.** Only a 404 carrying the backend's error shape means "no such workspace"; a router 404 — a frontend deployed ahead of its backend — is an error. Mapping it to "absent" would have sent every user to the private-project page, and there is no list fallback behind it any more the way `useUserWorkspacesLite` has one. Covered by a test.
- **`useAiSpendManager.isPending`** now comes from the query rather than from `!currentWorkspace`, which conflated in-flight with resolved-to-nothing and pinned it true forever after a 404.
- **`WorkspacePreloader`** holds the loader on a failed lookup instead of falling through to the private-project page (the list-based version also showed a loader while it had no data); fetches the fallback workspace only once the URL one is known to be invisible, rather than unconditionally; and, for a user whose `user.defaultWorkspace` no longer resolves, asks `POST /workspaces/retrieve-landing` instead of bouncing them to login — the old `?? allWorkspaces[0]` arm had no other replacement.
- **The point read is gated on a logged-in user**, as each call site was before.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7699

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: hook and call-site migration, unit tests, local end-to-end verification
- Human verification: reviewed the diff, ran the commands below, and walked the app in a browser against a locally running platform backend

## Testing

```
npm run typecheck                                   # clean
npx eslint src/plugins/comet --max-warnings=0       # clean
npx vitest run src/plugins/comet/useWorkspaceByName.test.tsx   # 7 passed
npx vitest run                                      # 2310 passed, 43 failed
```

The 43 failures are six pre-existing `localStorage`-based test files (`localStorage.clear is not a function` under this happy-dom install); they fail identically on `main` with the change stashed, and none is a file this PR touches.

New unit tests cover the point read itself: a resolved workspace, the backend's 404 mapped to `null` rather than an error, a bare router 404 **not** mistaken for a missing workspace, a 500 still reported as an error, no request without a name, `enabled: false` honoured, and two names not sharing a cache entry.

**End-to-end, in a browser.** Ran the platform backend locally from comet-backend#5635 (MySQL, Cassandra, Redis, MinIO in containers), served this frontend in comet mode against it same-origin so the session cookie is first-party, signed up a user and walked the app.

Requests the backend logged for one page load of `/opik/<workspace>/projects`:

| request | count |
| --- | --- |
| `POST /workspaces/retrieve` | 1 |
| `GET /workspaces/lite` | 1 |

One point read serves all ten migrated consumers. The remaining `lite` call is the switcher — the OPIK_7718 consumer — which is why this PR does not yet claim the payload reduction.

Re-run after the review fixes, with the same result. Scenarios walked: a workspace the user owns renders normally with its name resolved in the header and sidebar; a workspace name the user cannot see renders the existing "This is a private project" page, whose "Go back to your workspace" link points at the user's own workspace (`/opik/fe-e2e-…`), which is the second point read working; the console is clean apart from `config.js` failing to load, which is the EM frontend's runtime config that is not served in this local setup.

Not run: the deployed-environment path, since the endpoint only exists on the backend branch.

## Documentation

None — no user-facing surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


