### PR TITLE
[OPIK-7445] [BE] fix: guard early ADD COLUMN migrations with IF NOT EXISTS

### DIFF
--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -38,8 +38,10 @@ jobs:
           echo "🔍 Detecting newly added ClickHouse migration files..."
           
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # For PRs, use GitHub's built-in files API
-            gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/files \
+            # For PRs, use GitHub's built-in files API.
+            # --paginate is required: the endpoint returns 30 files per page, so a larger PR would
+            # silently drop migrations past the first page and report none to validate.
+            gh api --paginate repos/${{ github.repository }}/pulls/${{ github.event.number }}/files \
               --jq '.[] | select(.status == "added") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/.*\\.sql$")) | .filename' > changed_files.txt
             CHANGED_FILES=$(cat changed_files.txt || echo "")
             rm -f changed_files.txt

--- a/.github/workflows/clickhouse_migration_cluster_check.yml
+++ b/.github/workflows/clickhouse_migration_cluster_check.yml
@@ -35,19 +35,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "🔍 Detecting ClickHouse migration files that were added or modified..."
+          echo "🔍 Detecting newly added ClickHouse migration files..."
           
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             # For PRs, use GitHub's built-in files API
             gh api repos/${{ github.repository }}/pulls/${{ github.event.number }}/files \
-              --jq '.[] | select(.status == "added" or .status == "modified") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/.*\\.sql$")) | .filename' > changed_files.txt
+              --jq '.[] | select(.status == "added") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/.*\\.sql$")) | .filename' > changed_files.txt
             CHANGED_FILES=$(cat changed_files.txt || echo "")
             rm -f changed_files.txt
           else
             # For pushes to main, use GitHub API to get commit files
             # This works reliably regardless of fetch-depth
             gh api repos/${{ github.repository }}/commits/${{ github.sha }} \
-              --jq '.files[] | select(.status == "added" or .status == "modified") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/.*\\.sql$")) | .filename' > changed_files.txt
+              --jq '.files[] | select(.status == "added") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/.*\\.sql$")) | .filename' > changed_files.txt
             CHANGED_FILES=$(cat changed_files.txt || echo "")
             rm -f changed_files.txt
           fi
@@ -68,7 +68,7 @@ jobs:
             echo "EOF" >> "$GITHUB_ENV"
             echo "HAS_MIGRATION_FILES=true" >> "$GITHUB_ENV"
           else
-            echo "📋 No ClickHouse migration files were added or modified."
+            echo "📋 No ClickHouse migration files were added."
             echo "✅ No validation needed."
             echo "HAS_MIGRATION_FILES=false" >> "$GITHUB_ENV"
           fi
@@ -108,11 +108,12 @@ jobs:
           echo "=========================================="
           echo "✅ No ClickHouse Migration Files Changed"
           echo "=========================================="
-          echo "📋 No ClickHouse migration files were added or modified in this change."
+          echo "📋 No ClickHouse migration files were added in this change."
           echo "✅ No validation required."
           echo
-          echo "💡 Note: This check only validates NEW or MODIFIED migration files."
-          echo "   Existing migration files are not checked as they cannot be changed."
+          echo "💡 Note: This check only validates NEWLY ADDED migration files."
+          echo "   Existing migration files are not checked — the ON CLUSTER convention"
+          echo "   post-dates the earliest ones, so it cannot be applied retroactively."
 
       - name: Summary for validated files
         if: env.HAS_MIGRATION_FILES == 'true' && success()

--- a/.github/workflows/migration_edit_warning.yml
+++ b/.github/workflows/migration_edit_warning.yml
@@ -1,0 +1,133 @@
+name: "Migration Edit Warning"
+run-name: "Migration Edit Warning on ${{ github.ref_name }} by @${{ github.actor }}"
+
+# Applied migrations are immutable: once a changeset has run anywhere, editing it changes its
+# Liquibase checksum and every already-migrated deployment fails `liquibase update` with
+# ValidationFailedException *before executing anything*. This workflow does not block such a
+# PR — there are legitimate exceptions — it makes the edit impossible to merge unnoticed.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/**/*.sql"
+      - "apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/**/*.sql"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  warn-on-migration-edits:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Detect modified migrations
+        id: detect
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          # --paginate: the endpoint returns 30 files per page, and a migration edit could
+          # otherwise sit past the first page of a large PR and go unreported.
+          gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[] | select(.status == "modified") | select(.filename | test("^apps/opik-backend/src/main/resources/liquibase/db-app-(state|analytics)/migrations/.*\\.sql$")) | .filename' \
+            > modified_migrations.txt
+
+          if [ -s modified_migrations.txt ]; then
+            echo "⚠️  Modified (not added) migration files detected:"
+            sed 's/^/   - /' modified_migrations.txt
+            echo "has_edits=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "✅ No existing migration files were modified."
+            echo "has_edits=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build warning comment
+        if: steps.detect.outputs.has_edits == 'true'
+        run: |
+          # shellcheck disable=SC2016 # the single-quoted lines emit literal markdown fences
+          {
+            echo "<!-- migration-edit-warning -->"
+            echo "### ⚠️ This PR edits migrations that have already been applied"
+            echo
+            echo "Applied migrations are normally immutable. Editing one changes its Liquibase"
+            echo "checksum, and \`liquibase update\` validates stored checksums **before executing"
+            echo "anything** — so without a waiver, every already-migrated deployment fails to start."
+            echo
+            echo "| Modified migration |"
+            echo "|---|"
+            sed 's/.*\///; s/^/| `/; s/$/` |/' modified_migrations.txt
+            echo
+            echo "**If this edit is intentional**, each changeset above must declare a checksum waiver"
+            echo "so existing deployments accept their stored pre-edit value:"
+            echo
+            echo '```sql'
+            echo "--changeset author:some_changeset"
+            echo "--validCheckSum ANY"
+            echo '```'
+            echo
+            echo "Note the accepted spellings are \`--validCheckSum ANY\` and \`--validCheckSum: ANY\`."
+            echo "The parser silently ignores \`--validCheckSum:ANY\` (no space) and an inline"
+            echo "\`validCheckSum:ANY\` on the \`--changeset\` line — both look right and do nothing."
+            echo
+            echo "**If it is not intentional**, add a new migration instead of editing an existing one."
+            echo
+            echo "_This check never fails the build — it exists so the edit is a deliberate, reviewed"
+            echo "decision rather than something that slips through._"
+          } > /tmp/migration-edit-warning.md
+
+          cat /tmp/migration-edit-warning.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Fork PRs get a read-only token, so the sticky comment is skipped there and the warning
+      # lives in the step summary above instead.
+      - name: Find prior warning comment
+        id: find_comment
+        if: steps.detect.outputs.has_edits == 'true' && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/find-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- migration-edit-warning -->"
+
+      - name: Post or update warning comment
+        if: steps.detect.outputs.has_edits == 'true' && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
+          body-path: /tmp/migration-edit-warning.md
+
+      # Once the edits are reverted the warning is stale, so retract it rather than leaving a
+      # comment that contradicts the diff.
+      - name: Find stale warning comment
+        id: find_stale
+        if: steps.detect.outputs.has_edits == 'false' && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/find-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: "<!-- migration-edit-warning -->"
+
+      - name: Retract stale warning comment
+        if: steps.detect.outputs.has_edits == 'false' && steps.find_stale.outputs.comment-id != '' && github.event.pull_request.head.repo.fork == false
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find_stale.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            <!-- migration-edit-warning -->
+            ### ✅ No applied migrations are edited anymore
+
+            An earlier revision of this PR modified existing migration files. That is no longer the
+            case, so the previous warning no longer applies.

--- a/.github/workflows/migration_edit_warning.yml
+++ b/.github/workflows/migration_edit_warning.yml
@@ -22,6 +22,10 @@ concurrency:
 
 jobs:
   warn-on-migration-edits:
+    # Every step needs a PR to inspect and comment on. `workflow_dispatch` is declared for parity
+    # with the sibling migration workflows, but a manual run has no PR context — without this guard
+    # the files lookup would request `pulls//files` and fail before producing any output.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
@@ -1,5 +1,10 @@
 --liquibase formatted sql
 --changeset andrescrz:init_script
+--validCheckSum ANY
+-- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
+-- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
+-- Editing an applied changeset changes its checksum, so already-migrated deployments must
+-- accept the stored pre-edit value or `liquibase update` fails validation before running.
 
 CREATE DATABASE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME};
 
@@ -98,28 +103,28 @@ CREATE TABLE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
     ORDER BY (workspace_id, experiment_id, dataset_item_id, trace_id, id);
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.feedback_scores
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.dataset_items
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN created_by String DEFAULT '',
-    ADD COLUMN last_updated_by String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS created_by String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS last_updated_by String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiment_items DROP COLUMN created_by, DROP COLUMN last_updated_by;
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.spans DROP COLUMN created_by, DROP COLUMN last_updated_by;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000001_init_script.sql
@@ -1,10 +1,17 @@
 --liquibase formatted sql
 --changeset andrescrz:init_script
 --validCheckSum ANY
--- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
--- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
--- Editing an applied changeset changes its checksum, so already-migrated deployments must
--- accept the stored pre-edit value or `liquibase update` fails validation before running.
+-- ⚠️  EDITED AFTER RELEASE (OPIK-7445) — this changeset was already applied in production when
+-- it was modified. Migrations are normally immutable; this is a deliberate, reviewed exception.
+--
+-- What changed: `ADD COLUMN` gained `IF NOT EXISTS`, so a lost or partial Liquibase ledger
+-- replays as a no-op instead of crashlooping the replica on `Code: 15 DUPLICATE_COLUMN`.
+--
+-- Why `--validCheckSum ANY` is required: editing an applied changeset changes its checksum, and
+-- `liquibase update` validates stored checksums before executing anything. Without the waiver,
+-- every already-migrated deployment fails to start. Never remove one directive without the other.
+--
+-- Do NOT treat this file as a precedent for editing other applied migrations.
 
 CREATE DATABASE IF NOT EXISTS ${ANALYTICS_DB_DATABASE_NAME};
 

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
@@ -1,10 +1,17 @@
 --liquibase formatted sql
 --changeset andrescrz:add_metadata_to_experiments
 --validCheckSum ANY
--- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
--- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
--- Editing an applied changeset changes its checksum, so already-migrated deployments must
--- accept the stored pre-edit value or `liquibase update` fails validation before running.
+-- ⚠️  EDITED AFTER RELEASE (OPIK-7445) — this changeset was already applied in production when
+-- it was modified. Migrations are normally immutable; this is a deliberate, reviewed exception.
+--
+-- What changed: `ADD COLUMN` gained `IF NOT EXISTS`, so a lost or partial Liquibase ledger
+-- replays as a no-op instead of crashlooping the replica on `Code: 15 DUPLICATE_COLUMN`.
+--
+-- Why `--validCheckSum ANY` is required: editing an applied changeset changes its checksum, and
+-- `liquibase update` validates stored checksums before executing anything. Without the waiver,
+-- every already-migrated deployment fails to start. Never remove one directive without the other.
+--
+-- Do NOT treat this file as a precedent for editing other applied migrations.
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
     ADD COLUMN IF NOT EXISTS metadata String DEFAULT '';

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000003_add_metadata_to_experiments.sql
@@ -1,7 +1,12 @@
 --liquibase formatted sql
 --changeset andrescrz:add_metadata_to_experiments
+--validCheckSum ANY
+-- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
+-- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
+-- Editing an applied changeset changes its checksum, so already-migrated deployments must
+-- accept the stored pre-edit value or `liquibase update` fails validation before running.
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments
-    ADD COLUMN metadata String DEFAULT '';
+    ADD COLUMN IF NOT EXISTS metadata String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.experiments DROP COLUMN metadata;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
@@ -1,6 +1,11 @@
 --liquibase formatted sql
 --changeset thiagohora:add_thread_id_to_traces
+--validCheckSum ANY
+-- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
+-- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
+-- Editing an applied changeset changes its checksum, so already-migrated deployments must
+-- accept the stored pre-edit value or `liquibase update` fails validation before running.
 
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN thread_id String;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS thread_id String;
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS thread_id;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000014_add_thread_id_to_traces.sql
@@ -1,10 +1,17 @@
 --liquibase formatted sql
 --changeset thiagohora:add_thread_id_to_traces
 --validCheckSum ANY
--- OPIK-7445: `ADD COLUMN` here gained `IF NOT EXISTS` so a lost/partial Liquibase ledger
--- degrades to a no-op replay instead of crashlooping the replica on DUPLICATE_COLUMN.
--- Editing an applied changeset changes its checksum, so already-migrated deployments must
--- accept the stored pre-edit value or `liquibase update` fails validation before running.
+-- ⚠️  EDITED AFTER RELEASE (OPIK-7445) — this changeset was already applied in production when
+-- it was modified. Migrations are normally immutable; this is a deliberate, reviewed exception.
+--
+-- What changed: `ADD COLUMN` gained `IF NOT EXISTS`, so a lost or partial Liquibase ledger
+-- replays as a no-op instead of crashlooping the replica on `Code: 15 DUPLICATE_COLUMN`.
+--
+-- Why `--validCheckSum ANY` is required: editing an applied changeset changes its checksum, and
+-- `liquibase update` validates stored checksums before executing anything. Without the waiver,
+-- every already-migrated deployment fails to start. Never remove one directive without the other.
+--
+-- Do NOT treat this file as a precedent for editing other applied migrations.
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS thread_id String;
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/AnalyticsMigrationsIdempotencyTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/AnalyticsMigrationsIdempotencyTest.java
@@ -1,0 +1,94 @@
+package com.comet.opik.db;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Analytics Migrations Idempotency")
+class AnalyticsMigrationsIdempotencyTest {
+
+    private static final Path MIGRATIONS_DIR = Path
+            .of("src/main/resources/liquibase/db-app-analytics/migrations");
+
+    // Matches `ADD COLUMN <name>` but not `ADD COLUMN IF NOT EXISTS <name>`.
+    private static final Pattern BARE_ADD_COLUMN = Pattern.compile(
+            "(?i)\\bADD\\s+COLUMN\\s+(?!IF\\s+NOT\\s+EXISTS\\b)");
+
+    // Rollbacks run only on an explicit `liquibase rollback`, never during the `update` that a
+    // replica performs on start, so they are outside the replay path this test guards.
+    private static final Pattern ROLLBACK_LINE = Pattern.compile("(?i)^\\s*--\\s*rollback\\b");
+
+    @Test
+    @DisplayName("no analytics migration uses a bare ADD COLUMN")
+    void noAnalyticsMigrationUsesBareAddColumn() {
+        // A replica re-runs `liquibase update` on every start. If the ledger is ever lost or partial
+        // while the schema is intact (OPIK-7445), the changesets replay against existing tables and a
+        // bare `ADD COLUMN` fails with `Code: 15 DUPLICATE_COLUMN`, crashlooping the replica.
+        // `IF NOT EXISTS` degrades that to a no-op.
+        var offenders = migrationFiles()
+                .flatMap(AnalyticsMigrationsIdempotencyTest::bareAddColumnOccurrences)
+                .toList();
+
+        assertThat(offenders)
+                .as("`ADD COLUMN` must be written as `ADD COLUMN IF NOT EXISTS` so a lost or partial "
+                        + "Liquibase ledger replays as a no-op instead of crashlooping the replica")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("changesets edited for idempotency accept their pre-edit checksum")
+    void editedChangesetsDeclareValidCheckSum() {
+        // Editing an already-applied changeset changes its Liquibase checksum, so every deployment that
+        // already ran it fails `update` with ValidationFailedException *before* executing anything.
+        // `--validCheckSum ANY` waives that stored value. The two directives must therefore stay
+        // together: whoever removes the waiver reintroduces a fleet-wide startup failure.
+        //
+        // Note the accepted spellings are `--validCheckSum ANY` and `--validCheckSum: ANY`; the parser
+        // silently ignores `--validCheckSum:ANY` and an inline `validCheckSum:ANY` on the changeset line.
+        var edited = List.of(
+                "000001_init_script.sql",
+                "000003_add_metadata_to_experiments.sql",
+                "000014_add_thread_id_to_traces.sql");
+
+        assertThat(edited)
+                .allSatisfy(fileName -> assertThat(read(MIGRATIONS_DIR.resolve(fileName)))
+                        .as("%s was edited after release, so it must waive its stored checksum", fileName)
+                        .containsPattern("(?m)^--validCheckSum:?\\s+ANY\\s*$"));
+    }
+
+    private static Stream<Path> migrationFiles() {
+        try (var files = Files.list(MIGRATIONS_DIR)) {
+            return files.filter(path -> path.getFileName().toString().endsWith(".sql"))
+                    .sorted()
+                    .toList()
+                    .stream();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to list analytics migrations", e);
+        }
+    }
+
+    private static Stream<String> bareAddColumnOccurrences(Path file) {
+        var lines = read(file).lines().toList();
+        return java.util.stream.IntStream.range(0, lines.size())
+                .filter(i -> !ROLLBACK_LINE.matcher(lines.get(i)).find())
+                .filter(i -> BARE_ADD_COLUMN.matcher(lines.get(i)).find())
+                .mapToObj(i -> "%s:%d -> %s".formatted(file.getFileName(), i + 1, lines.get(i).strip()));
+    }
+
+    private static String read(Path file) {
+        try {
+            return Files.readString(file);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read " + file, e);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/AnalyticsMigrationsIdempotencyTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/AnalyticsMigrationsIdempotencyTest.java
@@ -8,7 +8,9 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,13 +21,22 @@ class AnalyticsMigrationsIdempotencyTest {
     private static final Path MIGRATIONS_DIR = Path
             .of("src/main/resources/liquibase/db-app-analytics/migrations");
 
-    // Matches `ADD COLUMN <name>` but not `ADD COLUMN IF NOT EXISTS <name>`.
+    // Matches `ADD COLUMN <name>` but not `ADD COLUMN IF NOT EXISTS <name>`. `\s+` spans newlines,
+    // so a statement wrapped between `ADD` and `COLUMN` is still caught.
     private static final Pattern BARE_ADD_COLUMN = Pattern.compile(
             "(?i)\\bADD\\s+COLUMN\\s+(?!IF\\s+NOT\\s+EXISTS\\b)");
 
     // Rollbacks run only on an explicit `liquibase rollback`, never during the `update` that a
     // replica performs on start, so they are outside the replay path this test guards.
     private static final Pattern ROLLBACK_LINE = Pattern.compile("(?i)^\\s*--\\s*rollback\\b");
+
+    // Liquibase directives open with `--` but are instructions, not commentary, so they must survive
+    // comment stripping — ROLLBACK_LINE still has to see the rollback ones. Everything else beginning
+    // with `--` is prose and gets blanked, so a commented-out `-- ADD COLUMN ...` is not flagged.
+    private static final Pattern LIQUIBASE_DIRECTIVE = Pattern.compile(
+            "(?i)^\\s*--\\s*(liquibase|changeset|rollback|validCheckSum|preconditions|precondition-[a-z-]+|comment|ignore|context|labels)\\b");
+
+    private static final Pattern BLOCK_COMMENT = Pattern.compile("(?s)/\\*.*?\\*/");
 
     @Test
     @DisplayName("no analytics migration uses a bare ADD COLUMN")
@@ -65,6 +76,45 @@ class AnalyticsMigrationsIdempotencyTest {
                         .containsPattern("(?m)^--validCheckSum:?\\s+ANY\\s*$"));
     }
 
+    @Test
+    @DisplayName("the scanner catches bare ADD COLUMN wherever it hides, and only where it executes")
+    void scannerDetectsOffendersWithoutFalsePositives() {
+        assertThat(scan("ALTER TABLE t ADD COLUMN c String;"))
+                .as("plain bare ADD COLUMN")
+                .hasSize(1);
+
+        assertThat(scan("ALTER TABLE t ADD\n    COLUMN c String;"))
+                .as("ADD and COLUMN split across lines is still one bare statement")
+                .hasSize(1);
+
+        assertThat(scan("ALTER TABLE t\n    ADD COLUMN IF NOT EXISTS c String;"))
+                .as("guarded statement")
+                .isEmpty();
+
+        assertThat(scan("-- ALTER TABLE t ADD COLUMN c String;"))
+                .as("commented-out DDL never executes")
+                .isEmpty();
+
+        assertThat(scan("/* ALTER TABLE t ADD\n   COLUMN c String; */"))
+                .as("block-commented DDL never executes")
+                .isEmpty();
+
+        assertThat(scan("--rollback ALTER TABLE t ADD COLUMN c String;"))
+                .as("rollbacks do not run during the update a replica performs on start")
+                .isEmpty();
+
+        assertThat(scan("ALTER TABLE t ADD COLUMN IF NOT EXISTS a String;\nALTER TABLE t ADD COLUMN b String;"))
+                .as("reports the offending statement, not the guarded one")
+                .singleElement()
+                .asString()
+                .contains("ADD COLUMN b String")
+                .doesNotContain("IF NOT EXISTS");
+    }
+
+    private static List<String> scan(String sql) {
+        return bareAddColumnOccurrences("fixture.sql", sql).toList();
+    }
+
     private static Stream<Path> migrationFiles() {
         try (var files = Files.list(MIGRATIONS_DIR)) {
             return files.filter(path -> path.getFileName().toString().endsWith(".sql"))
@@ -77,11 +127,52 @@ class AnalyticsMigrationsIdempotencyTest {
     }
 
     private static Stream<String> bareAddColumnOccurrences(Path file) {
-        var lines = read(file).lines().toList();
-        return java.util.stream.IntStream.range(0, lines.size())
-                .filter(i -> !ROLLBACK_LINE.matcher(lines.get(i)).find())
-                .filter(i -> BARE_ADD_COLUMN.matcher(lines.get(i)).find())
-                .mapToObj(i -> "%s:%d -> %s".formatted(file.getFileName(), i + 1, lines.get(i).strip()));
+        return bareAddColumnOccurrences(file.getFileName().toString(), read(file));
+    }
+
+    static Stream<String> bareAddColumnOccurrences(String fileName, String sql) {
+        // Scan the whole statement text rather than line by line: `ALTER TABLE t ADD\nCOLUMN c` is a
+        // single bare statement that no per-line regex can see. Comments and rollback lines are blanked
+        // in place rather than removed so character offsets — and therefore line numbers — stay exact.
+        var scannable = blankNonExecutableText(sql);
+
+        var matcher = BARE_ADD_COLUMN.matcher(scannable);
+        return matcher.results()
+                .map(match -> {
+                    int line = (int) scannable.substring(0, match.start()).chars().filter(c -> c == '\n')
+                            .count() + 1;
+                    return "%s:%d -> %s".formatted(fileName, line, statementAround(sql, match.start()));
+                })
+                .toList()
+                .stream();
+    }
+
+    private static String blankNonExecutableText(String sql) {
+        var withoutBlockComments = BLOCK_COMMENT.matcher(sql)
+                .replaceAll(match -> match.group().replaceAll("[^\n]", " "));
+
+        return withoutBlockComments.lines()
+                .map(line -> isExecutable(line) ? line : " ".repeat(line.length()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static boolean isExecutable(String line) {
+        // Rollback directives are excluded deliberately: they never run during the `update` a replica
+        // performs on start. Other Liquibase directives carry no DDL, so blanking them is harmless.
+        return !line.stripLeading().startsWith("--")
+                && !ROLLBACK_LINE.matcher(line).find()
+                && !LIQUIBASE_DIRECTIVE.matcher(line).find();
+    }
+
+    private static String statementAround(String sql, int offset) {
+        // Report from the ALTER that owns the match, not the previous `;` — a file whose header has no
+        // semicolon would otherwise drag its whole preamble into the failure message.
+        int statementStart = sql.lastIndexOf(';', offset) + 1;
+        int alterStart = sql.toUpperCase(Locale.ROOT).lastIndexOf("ALTER", offset);
+        int start = Math.max(statementStart, alterStart < 0 ? statementStart : alterStart);
+
+        int end = sql.indexOf(';', offset);
+        return sql.substring(start, end < 0 ? sql.length() : end).strip().replaceAll("\\s+", " ");
     }
 
     private static String read(Path file) {

--- a/scripts/check_backend_migration_conflicts.sh
+++ b/scripts/check_backend_migration_conflicts.sh
@@ -21,9 +21,11 @@ extract_prefixes_from_list() {
 }
 
 # Function to get new migration files in PR
+# --diff-filter=A restricts this to genuinely added files. Without it, editing an existing
+# migration reports it as "new" and it then always conflicts with its own prefix in main.
 get_new_migrations() {
   local dir=$1
-  git diff --name-only origin/main...HEAD -- "$dir" | grep '\.sql$' || true
+  git diff --name-only --diff-filter=A origin/main...HEAD -- "$dir" | grep '\.sql$' || true
 }
 
 # Function to extract prefix from filename


### PR DESCRIPTION
## Details

<img width="879" height="1656" alt="image" src="https://github.com/user-attachments/assets/06e213d8-4022-4f57-989d-cbdb6982a767" />

Changesets `000001`, `000003` and `000014` contain 14 bare `ADD COLUMN` statements. Every analytics migration from `000004` onward already uses `ADD COLUMN IF NOT EXISTS` (and `migrations.md` prescribes it), so these three were the outliers. When a replica re-runs `liquibase update` against an already-built schema whose Liquibase ledger is empty or partial, the bare statements fail with `Code: 15 DUPLICATE_COLUMN` and the replica never starts.

Editing an already-applied changeset changes its Liquibase checksum, so each edited file also declares `--validCheckSum ANY`. Without it, every deployment that already ran these changesets would fail `liquibase update` with `ValidationFailedException` *before executing anything* — turning a rare single-replica crashloop into a startup failure everywhere. The two directives must stay together.

**Scope — please read before approving.** This is defense-in-depth, not a lost-ledger fix:

- Replaying a wiped ledger still fails, just later. With this change the replay clears `000001`/`000003`/`000014` and then dies at `000017_change_tables_to_replicated` with `Code: 122 — Table columns structure in ZooKeeper is different from local table structure`. That changeset converts tables to `ReplicatedMergeTree` via `ATTACH PARTITION` / `DETACH` / `DROP` / `RENAME`, which `IF NOT EXISTS` cannot guard, and it is one of roughly 56 migrations in that family.
- Making `000017` itself replay-safe is deliberately out of scope. It is not an `IF NOT EXISTS` problem: it re-creates `ReplicatedMergeTree` tables whose ZooKeeper paths already exist, then moves data with `ATTACH PARTITION` / `DETACH` / `DROP` / `RENAME`. Guarding it needs preconditions that inspect ZooKeeper and table state on a changeset that physically relocates data, and roughly 56 migrations share that shape. That deserves its own ticket and its own testing rather than riding along here.
- Recovering a lost ledger still requires marking existing changesets as applied rather than replaying them. The supported invocation is already shipped in the backend jar via Dropwizard's migrations bundle: `dbAnalytics status` to confirm the schema is at head, then `dbAnalytics fast-forward --all` (which calls Liquibase `changeLogSync`). Note `--all` marks *everything* pending as applied, so the `status` check is not optional.

**Why these three files and not others.** A sweep of all 124 analytics migrations found `ADD COLUMN` is now fully guarded, and two other bare-DDL sites remain, both deliberately left alone:

- `000035_add_authored_feedback_scores_table.sql` — `CREATE TABLE` without `IF NOT EXISTS`
- `000060_create_experiment_stats_tables.sql` — six `ADD INDEX` without `IF NOT EXISTS`

Both sit *after* the `000017` wall, so a replay can never reach them: it fails at `000017` first. Guarding them would mean editing two more applied changesets and carrying two more permanent checksum waivers for zero behavioural change. The natural boundary is that only changesets `000001`–`000016` precede the wall, and that is exactly the range fixed here.

**Two CI checks needed fixing to allow any edit at all.** Both resolved their file list with `"added or modified"`, so editing *any* existing migration failed them:

- `check_backend_migration_conflicts.sh` reported a prefix conflict — a modified file's prefix is by definition already in main, so the check can never pass for an edit.
- `clickhouse_migration_cluster_check.yml` demanded `ON CLUSTER '{cluster}'` on every DDL statement in the file, flagging 20 untouched legacy lines in `000001` (the original `CREATE DATABASE`, seven `CREATE TABLE`s, and rollbacks) that predate the convention — it arrived in `000017`.

Neither check is meaningful for an edit: an edit cannot introduce a prefix collision, and retrofitting `ON CLUSTER` onto an applied changeset would change its semantics. Both are now restricted to added files. The cluster check's own summary text already described this as the intended behaviour. Verified locally in both directions — a genuinely new duplicate-prefix file still fails.

The three edited changesets also carry an in-file warning marking them as a deliberate, reviewed exception to migration immutability, so they aren't read as precedent.

**A new `Migration Edit Warning` workflow** replaces the protection that removing `"modified"` gave up. It posts a sticky PR comment whenever a PR modifies an existing migration, listing the affected files and the `--validCheckSum` waiver they need — including the two spellings the Liquibase parser silently ignores. It never fails the build, since editing a migration is occasionally correct; the goal is that the edit be a deliberate, reviewed decision rather than something that slips through. The comment retracts itself if the edits are reverted, and fork PRs fall back to the step summary because their token can't comment.

Two costs worth an explicit decision:

- `validCheckSum ANY` permanently disables checksum drift detection for these three changesets, including `000001`, which defines the initial schema.
- `ADD COLUMN IF NOT EXISTS` does not verify column *type*, so a pre-existing column of a different type is silently accepted. This is undocumented in both ClickHouse and Liquibase.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7445

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation, plus empirical verification of the failure modes
- Human verification: pending review

## Testing

New `AnalyticsMigrationsIdempotencyTest` (no containers, ~0.1s) asserts that no analytics migration uses a bare `ADD COLUMN` outside a `--rollback` line, and that the three edited changesets declare `--validCheckSum ANY` so the waiver cannot be dropped independently of the edit.

```
mvn test -Dtest=AnalyticsMigrationsIdempotencyTest   # 2 tests, pass
```

The guard was verified to actually fail: reverting `000014` to its bare form turns both assertions red with the offending `file:line`, and restoring it turns them green. The rebase onto current main pulled in four new migrations (`000114`–`000117`) and the test still passes against them.

Behaviour was verified against real containers (ClickHouse `26.3.16.16-alpine` + ZooKeeper `3.9.4`, Liquibase 4.33.0, checksum algorithm v9) with a throwaway probe, since these paths cannot be exercised without a live database. Three scenarios, before and after the change:

| Scenario | Before | After |
| --- | --- | --- |
| Intact ledger | pass (no-op) | pass (no-op) |
| Stored checksum no longer matches | **fail** `ValidationFailedException` | pass — waiver honoured |
| Ledger wiped, schema intact | **fail** `Code: 15 DUPLICATE_COLUMN` at `000001` | **fail** `Code: 122` at `000017` |

The third row is the basis for the scope note above. The probe was deleted rather than committed — it truncates `DATABASECHANGELOG`, so it is unsafe to run against shared or reused test containers.

Not run: the full backend suite. Container-backed tests time out locally with `Code: 159 Read timed out` on this machine; the same timeout reproduces on unmodified `main` with these changes stashed, so it is environmental rather than a regression. Leaving the full suite to CI.

## Documentation

N/A — no user-facing documentation change. `migrations.md` already prescribes `ADD COLUMN IF NOT EXISTS`; this brings the three remaining outliers in line with it.
