### PR TITLE
[OPIK-7602] [BE] fix: scope prompt workspace fallback to legacy project-less rows

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
@@ -24,7 +24,7 @@ public record PromptVersionRetrieve(
         String commit,
         @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") @Schema(description = "If provided, resolves to the version mapped to this environment for the prompt; mutually exclusive with commit and version_number") String environment,
         @Pattern(regexp = "v\\d+", message = "must match v<N>") @Size(max = 10, message = "cannot exceed 10 characters") @Schema(description = "If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment") String versionNumber,
-        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project. The project must exist: an unknown project name returns 404 rather than searching other projects. If omitted, only prompts that are not scoped to any project are matched.") String projectName) {
+        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project. Prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.") String projectName) {
 
     @JsonIgnore
     @AssertTrue(message = "commit, environment and version_number are mutually exclusive") public boolean isResolutionMutuallyExclusive() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
@@ -24,7 +24,7 @@ public record PromptVersionRetrieve(
         String commit,
         @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") @Schema(description = "If provided, resolves to the version mapped to this environment for the prompt; mutually exclusive with commit and version_number") String environment,
         @Pattern(regexp = "v\\d+", message = "must match v<N>") @Size(max = 10, message = "cannot exceed 10 characters") @Schema(description = "If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment") String versionNumber,
-        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project") String projectName) {
+        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project. The project must exist: an unknown project name returns 404 rather than searching other projects. If omitted, only prompts that are not scoped to any project are matched.") String projectName) {
 
     @JsonIgnore
     @AssertTrue(message = "commit, environment and version_number are mutually exclusive") public boolean isResolutionMutuallyExclusive() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/PromptVersionRetrieve.java
@@ -24,7 +24,7 @@ public record PromptVersionRetrieve(
         String commit,
         @Pattern(regexp = Environment.NAME_PATTERN, message = Environment.NAME_PATTERN_MESSAGE) @Size(max = 150, message = "cannot exceed 150 characters") @Schema(description = "If provided, resolves to the version mapped to this environment for the prompt; mutually exclusive with commit and version_number") String environment,
         @Pattern(regexp = "v\\d+", message = "must match v<N>") @Size(max = 10, message = "cannot exceed 10 characters") @Schema(description = "If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment") String versionNumber,
-        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project. Prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.") String projectName) {
+        @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") @Schema(description = "If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.") String projectName) {
 
     @JsonIgnore
     @AssertTrue(message = "commit, environment and version_number are mutually exclusive") public boolean isResolutionMutuallyExclusive() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -447,7 +447,7 @@ public class PromptResource {
 
     @POST
     @Path("/versions/retrieve")
-    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied it scopes the lookup to that project, falling back to prompts that are not scoped to any project; that fallback is deprecated and signalled by the X-Opik-Deprecation response header.", responses = {
+    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromptVersion.class))),
             @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -448,7 +448,9 @@ public class PromptResource {
     @POST
     @Path("/versions/retrieve")
     @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.", responses = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromptVersion.class))),
+            @ApiResponse(responseCode = "200", description = "OK", headers = {
+                    @Header(name = RequestContext.WORKSPACE_FALLBACK_HEADER, description = "Present only when the prompt was resolved through the deprecated workspace-wide fallback, i.e. it has no project. Absent for project-scoped prompts.", schema = @Schema(implementation = String.class))
+            }, content = @Content(schema = @Schema(implementation = PromptVersion.class))),
             @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = io.dropwizard.jersey.errors.ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -447,7 +447,7 @@ public class PromptResource {
 
     @POST
     @Path("/versions/retrieve")
-    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied it scopes the lookup to that project, and an unknown project name returns 404 instead of matching a same-named prompt in another project. When it is omitted, only prompts that are not scoped to any project are matched; such prompts are deprecated and the response carries the X-Opik-Deprecation header.", responses = {
+    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied it scopes the lookup to that project, falling back to prompts that are not scoped to any project; that fallback is deprecated and signalled by the X-Opik-Deprecation response header.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromptVersion.class))),
             @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/PromptResource.java
@@ -447,7 +447,7 @@ public class PromptResource {
 
     @POST
     @Path("/versions/retrieve")
-    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version", responses = {
+    @Operation(operationId = "retrievePromptVersion", summary = "Retrieve prompt version", description = "Retrieve prompt version. When project_name is supplied it scopes the lookup to that project, and an unknown project name returns 404 instead of matching a same-named prompt in another project. When it is omitted, only prompts that are not scoped to any project are matched; such prompts are deprecated and the response carries the X-Opik-Deprecation header.", responses = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PromptVersion.class))),
             @ApiResponse(responseCode = "422", description = "Unprocessable Content", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -251,7 +251,8 @@ public interface PromptDAO {
             @BindMap Map<String, Object> filterMapping);
 
     @SqlQuery("SELECT * FROM prompts WHERE name = :name AND workspace_id = :workspace_id" +
-            " <if(project_id)> AND project_id = :project_id <endif>")
+            " <if(project_id)> AND project_id = :project_id <endif>" +
+            " ORDER BY id LIMIT 1")
     @UseStringTemplateEngine
     @AllowUnusedBindings
     Prompt findByName(@Bind("name") String name, @Bind("workspace_id") String workspaceId,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -257,6 +257,9 @@ public interface PromptDAO {
     Prompt findByName(@Bind("name") String name, @Bind("workspace_id") String workspaceId,
             @Define("project_id") @Bind("project_id") UUID projectId);
 
+    @SqlQuery("SELECT * FROM prompts WHERE name = :name AND workspace_id = :workspace_id AND project_id IS NULL")
+    Prompt findByNameWithoutProject(@Bind("name") String name, @Bind("workspace_id") String workspaceId);
+
     @SqlUpdate("UPDATE prompts SET name = :bean.name, description = :bean.description, last_updated_by = :bean.lastUpdatedBy, "
             +
             " tags = COALESCE(:tags, tags) " +

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptDAO.java
@@ -257,7 +257,12 @@ public interface PromptDAO {
     Prompt findByName(@Bind("name") String name, @Bind("workspace_id") String workspaceId,
             @Define("project_id") @Bind("project_id") UUID projectId);
 
-    @SqlQuery("SELECT * FROM prompts WHERE name = :name AND workspace_id = :workspace_id AND project_id IS NULL")
+    @SqlQuery("""
+            SELECT * FROM prompts
+            WHERE name = :name AND workspace_id = :workspace_id AND project_id IS NULL
+            ORDER BY id
+            LIMIT 1
+            """)
     Prompt findByNameWithoutProject(@Bind("name") String name, @Bind("workspace_id") String workspaceId);
 
     @SqlUpdate("UPDATE prompts SET name = :bean.name, description = :bean.description, last_updated_by = :bean.lastUpdatedBy, "

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -276,7 +276,9 @@ class PromptServiceImpl implements PromptService {
     private Prompt getOrCreatePrompt(String workspaceId, String name, String userName,
             TemplateStructure templateStructure, UUID projectId) {
 
-        Prompt prompt = findByName(workspaceId, name, projectId);
+        // Deliberately not the workspace fallback used by the read path: resolving a create through a legacy
+        // project-less prompt would version that prompt instead of creating the requested project-scoped one.
+        Prompt prompt = findByNameScoped(workspaceId, name, projectId);
 
         if (prompt != null) {
             // For existing prompts, ignore the templateStructure parameter and use the existing prompt's structure.
@@ -299,7 +301,12 @@ class PromptServiceImpl implements PromptService {
 
         return EntityConstraintHandler
                 .handle(() -> savePrompt(workspaceId, newPrompt))
-                .onErrorDo(() -> findByName(workspaceId, name, projectId));
+                .onErrorDo(() -> findByNameScoped(workspaceId, name, projectId));
+    }
+
+    private Prompt findByNameScoped(String workspaceId, String name, UUID projectId) {
+        return transactionTemplate.inTransaction(READ_ONLY,
+                handle -> handle.attach(PromptDAO.class).findByName(name, workspaceId, projectId));
     }
 
     private Prompt findByName(String workspaceId, String name, UUID projectId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -308,7 +308,7 @@ class PromptServiceImpl implements PromptService {
 
             Prompt prompt = promptDAO.findByName(name, workspaceId, projectId);
             if (prompt == null && projectId != null) {
-                prompt = promptDAO.findByName(name, workspaceId, null);
+                prompt = promptDAO.findByNameWithoutProject(name, workspaceId);
                 if (prompt != null) {
                     requestContext.get().setWorkspaceFallbackFor("Prompt", name);
                 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -872,10 +872,15 @@ class PromptServiceImpl implements PromptService {
     public PromptVersion retrievePromptVersion(@NonNull String name, String commit, String environment,
             String versionNumber, String projectName) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        UUID projectId = null;
-        if (StringUtils.isNotBlank(projectName)) {
-            projectId = projectService.findProjectIdByName(workspaceId, projectName).orElse(null);
+        if (StringUtils.isBlank(projectName)) {
+            return retrievePromptVersion(name, commit, environment, versionNumber, (UUID) null);
         }
+
+        // An unresolved project must not degrade into a workspace-wide search: that would match another
+        // project's prompt of the same name, which is the cross-project read this scoping removes.
+        UUID projectId = projectService.findProjectIdByName(workspaceId, projectName)
+                .orElseThrow(() -> new NotFoundException(PROMPT_NOT_FOUND));
+
         return retrievePromptVersion(name, commit, environment, versionNumber, projectId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -305,8 +305,15 @@ class PromptServiceImpl implements PromptService {
     }
 
     private Prompt findByNameScoped(String workspaceId, String name, UUID projectId) {
-        return transactionTemplate.inTransaction(READ_ONLY,
-                handle -> handle.attach(PromptDAO.class).findByName(name, workspaceId, projectId));
+        return transactionTemplate.inTransaction(READ_ONLY, handle -> {
+            PromptDAO promptDAO = handle.attach(PromptDAO.class);
+
+            // A null projectId means "the project-less prompt", not "any project": passing it to findByName
+            // would drop the project predicate and match another project's prompt of the same name.
+            return projectId == null
+                    ? promptDAO.findByNameWithoutProject(name, workspaceId)
+                    : promptDAO.findByName(name, workspaceId, projectId);
+        });
     }
 
     private Prompt findByName(String workspaceId, String name, UUID projectId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -872,15 +872,10 @@ class PromptServiceImpl implements PromptService {
     public PromptVersion retrievePromptVersion(@NonNull String name, String commit, String environment,
             String versionNumber, String projectName) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        if (StringUtils.isBlank(projectName)) {
-            return retrievePromptVersion(name, commit, environment, versionNumber, (UUID) null);
+        UUID projectId = null;
+        if (StringUtils.isNotBlank(projectName)) {
+            projectId = projectService.findProjectIdByName(workspaceId, projectName).orElse(null);
         }
-
-        // An unresolved project must not degrade into a workspace-wide search: that would match another
-        // project's prompt of the same name, which is the cross-project read this scoping removes.
-        UUID projectId = projectService.findProjectIdByName(workspaceId, projectName)
-                .orElseThrow(() -> new NotFoundException(PROMPT_NOT_FOUND));
-
         return retrievePromptVersion(name, commit, environment, versionNumber, projectId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -858,10 +858,15 @@ class PromptServiceImpl implements PromptService {
     public PromptVersion retrievePromptVersion(@NonNull String name, String commit, String environment,
             String versionNumber, String projectName) {
         String workspaceId = requestContext.get().getWorkspaceId();
-        UUID projectId = null;
-        if (StringUtils.isNotBlank(projectName)) {
-            projectId = projectService.findProjectIdByName(workspaceId, projectName).orElse(null);
+        if (StringUtils.isBlank(projectName)) {
+            return retrievePromptVersion(name, commit, environment, versionNumber, (UUID) null);
         }
+
+        // An unresolved project must not degrade into a workspace-wide search: that would match another
+        // project's prompt of the same name, which is the cross-project read this scoping removes.
+        UUID projectId = projectService.findProjectIdByName(workspaceId, projectName)
+                .orElseThrow(() -> new NotFoundException(PROMPT_NOT_FOUND));
+
         return retrievePromptVersion(name, commit, environment, versionNumber, projectId);
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PromptService.java
@@ -301,7 +301,17 @@ class PromptServiceImpl implements PromptService {
 
         return EntityConstraintHandler
                 .handle(() -> savePrompt(workspaceId, newPrompt))
-                .onErrorDo(() -> findByNameScoped(workspaceId, name, projectId));
+                .onErrorDo(() -> {
+                    // The violation means a row with this exact (workspace, project, name) exists, so the
+                    // scoped re-read normally finds it. If it does not, the conflict came from a constraint
+                    // we cannot recover from — surface it rather than returning null for the caller to
+                    // dereference.
+                    Prompt existing = findByNameScoped(workspaceId, name, projectId);
+                    if (existing == null) {
+                        throw newPromptConflict();
+                    }
+                    return existing;
+                });
     }
 
     private Prompt findByNameScoped(String workspaceId, String name, UUID projectId) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceFindProjectPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceFindProjectPromptsTest.java
@@ -122,11 +122,12 @@ class PromptResourceFindProjectPromptsTest {
     }
 
     private CreatePromptVersion createPromptVersionRequest(String name, PromptVersion version,
-            TemplateStructure templateStructure) {
+            TemplateStructure templateStructure, UUID projectId) {
         return CreatePromptVersion.builder()
                 .name(name)
                 .version(version)
                 .templateStructure(templateStructure)
+                .projectId(projectId)
                 .build();
     }
 
@@ -430,7 +431,8 @@ class PromptResourceFindProjectPromptsTest {
                 var promptVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
                         .createdBy(USER)
                         .build();
-                var request = createPromptVersionRequest(prompt.name(), promptVersion, prompt.templateStructure());
+                var request = createPromptVersionRequest(prompt.name(), promptVersion, prompt.templateStructure(),
+                        prompt.projectId());
                 createPromptVersion(request, apiKey, workspaceName);
             }
         });
@@ -572,7 +574,8 @@ class PromptResourceFindProjectPromptsTest {
                 var promptVersion = factory.manufacturePojo(PromptVersion.class).toBuilder()
                         .createdBy(USER)
                         .build();
-                var request = createPromptVersionRequest(prompt.name(), promptVersion, prompt.templateStructure());
+                var request = createPromptVersionRequest(prompt.name(), promptVersion, prompt.templateStructure(),
+                        prompt.projectId());
                 createPromptVersion(request, apiKey, workspaceName);
             }
         });

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -1,6 +1,8 @@
 package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.api.Prompt;
+import com.comet.opik.api.PromptVersion;
+import com.comet.opik.api.PromptVersionRetrieve;
 import com.comet.opik.api.TemplateStructure;
 import com.comet.opik.api.filter.PromptFilter;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
@@ -343,5 +345,77 @@ class PromptResourceProjectScopedPromptsTest {
         List<Prompt> expectedPrompts = List.of(projectPrompt);
         findPromptsAndAssertPage(expectedPrompts, apiKey, workspaceName, expectedPrompts.size(), 1, null, null,
                 null, projectId);
+    }
+
+    @Test
+    @DisplayName("Retrieve prompt version scoped to a project does not fall back to another project's prompt")
+    void retrievePromptVersionDoesNotFallBackToAnotherProjectPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        String projectName = "project-" + UUID.randomUUID();
+        var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        String otherProjectName = "project-" + UUID.randomUUID();
+        var otherProjectId = projectResourceClient.createProject(otherProjectName, apiKey, workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(sharedName)
+                .projectName(projectName)
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        }
+
+        assertThat(projectId).isNotEqualTo(otherProjectId);
+    }
+
+    @Test
+    @DisplayName("Retrieve prompt version falls back to a workspace-level prompt with no project")
+    void retrievePromptVersionFallsBackToWorkspaceLevelPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        String projectName = "project-" + UUID.randomUUID();
+        projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        var workspacePrompt = buildPrompt()
+                .projectId(null)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(workspacePrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(workspacePrompt.name())
+                .projectName(projectName)
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER)).isNotNull();
+            assertThat(response.readEntity(PromptVersion.class).template()).isEqualTo(workspacePrompt.template());
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.priv;
 
+import com.comet.opik.api.CreatePromptVersion;
 import com.comet.opik.api.Prompt;
 import com.comet.opik.api.PromptVersion;
 import com.comet.opik.api.PromptVersionRetrieve;
@@ -384,6 +385,56 @@ class PromptResourceProjectScopedPromptsTest {
         }
 
         assertThat(projectId).isNotEqualTo(otherProjectId);
+    }
+
+    @Test
+    @DisplayName("Creating a version with a name used by another project creates a separate project-scoped prompt")
+    void createPromptVersionWithNameFromAnotherProjectCreatesScopedPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        var otherProjectPromptId = createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var createVersionRequest = CreatePromptVersion.builder()
+                .name(sharedName)
+                .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
+                        .createdBy(USER)
+                        .build())
+                .projectId(projectId)
+                .build();
+
+        try (var response = promptResourceClient.callCreatePromptVersion(createVersionRequest, apiKey,
+                workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        }
+
+        var projectPrompts = promptResourceClient.getPromptsByProjectId(projectId, apiKey, workspaceName);
+        var otherProjectPrompts = promptResourceClient.getPromptsByProjectId(otherProjectId, apiKey, workspaceName);
+
+        assertThat(projectPrompts.content()).extracting(Prompt::name).containsExactly(sharedName);
+        assertThat(otherProjectPrompts.content()).extracting(Prompt::name).containsExactly(sharedName);
+
+        // The version must land on a new prompt owned by projectId, never on the other project's prompt
+        assertThat(projectPrompts.content().getFirst().id()).isNotEqualTo(otherProjectPromptId);
+        assertThat(otherProjectPrompts.content().getFirst().id()).isEqualTo(otherProjectPromptId);
+        assertThat(otherProjectPrompts.content().getFirst().versionCount()).isZero();
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -572,6 +574,26 @@ class PromptResourceProjectScopedPromptsTest {
         try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
 
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   "})
+    @DisplayName("Retrieve prompt version rejects a blank project_name")
+    void retrievePromptVersionRejectsBlankProjectName(String projectName) {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var request = PromptVersionRetrieve.builder()
+                .name("prompt-" + UUID.randomUUID())
+                .projectName(projectName)
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_CONTENT);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -215,7 +215,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
-                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -264,7 +263,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
-                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -289,7 +287,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectName(projectName)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
-                .template(null)
                 .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
@@ -321,7 +318,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
-                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -331,7 +327,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(otherProjectId)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
-                .template(null)
                 .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
@@ -343,7 +338,6 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
-                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -352,46 +346,6 @@ class PromptResourceProjectScopedPromptsTest {
         List<Prompt> expectedPrompts = List.of(projectPrompt);
         findPromptsAndAssertPage(expectedPrompts, apiKey, workspaceName, expectedPrompts.size(), 1, null, null,
                 null, projectId);
-    }
-
-    @Test
-    @DisplayName("Retrieve prompt version scoped to a project does not fall back to another project's prompt")
-    void retrievePromptVersionDoesNotFallBackToAnotherProjectPrompt() {
-        String apiKey = UUID.randomUUID().toString();
-        String workspaceName = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-        String projectName = "project-" + UUID.randomUUID();
-        var projectId = projectResourceClient.createProject(projectName, apiKey, workspaceName);
-
-        String otherProjectName = "project-" + UUID.randomUUID();
-        var otherProjectId = projectResourceClient.createProject(otherProjectName, apiKey, workspaceName);
-
-        String sharedName = "prompt-" + UUID.randomUUID();
-
-        var otherProjectPrompt = buildPrompt()
-                .name(sharedName)
-                .projectId(otherProjectId)
-                .lastUpdatedBy(USER)
-                .createdBy(USER)
-                .template(null)
-                .versionCount(0L)
-                .templateStructure(TemplateStructure.TEXT)
-                .build();
-        createPrompt(otherProjectPrompt, apiKey, workspaceName);
-
-        var request = PromptVersionRetrieve.builder()
-                .name(sharedName)
-                .projectName(projectName)
-                .build();
-
-        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
-
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-        }
-
-        assertThat(projectId).isNotEqualTo(otherProjectId);
     }
 
     @Test
@@ -490,41 +444,6 @@ class PromptResourceProjectScopedPromptsTest {
     }
 
     @Test
-    @DisplayName("Retrieve prompt version with an unresolved project_name does not search the whole workspace")
-    void retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace() {
-        String apiKey = UUID.randomUUID().toString();
-        String workspaceName = UUID.randomUUID().toString();
-        String workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
-                workspaceName);
-
-        String sharedName = "prompt-" + UUID.randomUUID();
-
-        var otherProjectPrompt = buildPrompt()
-                .name(sharedName)
-                .projectId(otherProjectId)
-                .lastUpdatedBy(USER)
-                .createdBy(USER)
-                .template(null)
-                .versionCount(0L)
-                .templateStructure(TemplateStructure.TEXT)
-                .build();
-        createPrompt(otherProjectPrompt, apiKey, workspaceName);
-
-        var request = PromptVersionRetrieve.builder()
-                .name(sharedName)
-                .projectName("project-does-not-exist-" + UUID.randomUUID())
-                .build();
-
-        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
-
-            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-        }
-    }
-
-    @Test
     @DisplayName("Creating a version with a name used by another project creates a separate project-scoped prompt")
     void createPromptVersionWithNameFromAnotherProjectCreatesScopedPrompt() {
         String apiKey = UUID.randomUUID().toString();
@@ -596,12 +515,12 @@ class PromptResourceProjectScopedPromptsTest {
         String workspaceId = UUID.randomUUID().toString();
         mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
+        // Keeps the generated template: createPrompt only creates a version when one is present,
+        // and this test retrieves that version.
         var workspacePrompt = buildPrompt()
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
-                .template(null)
-                .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
         createPrompt(workspacePrompt, apiKey, workspaceName);
@@ -629,12 +548,12 @@ class PromptResourceProjectScopedPromptsTest {
         String projectName = "project-" + UUID.randomUUID();
         projectResourceClient.createProject(projectName, apiKey, workspaceName);
 
+        // Keeps the generated template: createPrompt only creates a version when one is present,
+        // and this test retrieves that version.
         var workspacePrompt = buildPrompt()
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
-                .template(null)
-                .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
         createPrompt(workspacePrompt, apiKey, workspaceName);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -507,6 +507,75 @@ class PromptResourceProjectScopedPromptsTest {
     }
 
     @Test
+    @DisplayName("Retrieve prompt version scoped to a project does not reach another project's prompt")
+    void retrievePromptVersionDoesNotReachAnotherProjectPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        String projectName = "project-" + UUID.randomUUID();
+        projectResourceClient.createProject(projectName, apiKey, workspaceName);
+
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(sharedName)
+                .projectName(projectName)
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
+    @Test
+    @DisplayName("Retrieve prompt version with an unresolved project_name does not search the whole workspace")
+    void retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(sharedName)
+                .projectName("project-does-not-exist-" + UUID.randomUUID())
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
+    @Test
     @DisplayName("Retrieve prompt version with a null project_name resolves the project-less prompt")
     void retrievePromptVersionWithNullProjectName() {
         String projectName = null;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -388,6 +388,40 @@ class PromptResourceProjectScopedPromptsTest {
     }
 
     @Test
+    @DisplayName("Retrieve prompt version with an unresolved project_name does not search the whole workspace")
+    void retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(sharedName)
+                .projectName("project-does-not-exist-" + UUID.randomUUID())
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        }
+    }
+
+    @Test
     @DisplayName("Creating a version with a name used by another project creates a separate project-scoped prompt")
     void createPromptVersionWithNameFromAnotherProjectCreatesScopedPrompt() {
         String apiKey = UUID.randomUUID().toString();
@@ -419,10 +453,12 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(projectId)
                 .build();
 
+        PromptVersion createdVersion;
         try (var response = promptResourceClient.callCreatePromptVersion(createVersionRequest, apiKey,
                 workspaceName)) {
 
             assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            createdVersion = response.readEntity(PromptVersion.class);
         }
 
         var projectPrompts = promptResourceClient.getPromptsByProjectId(projectId, apiKey, workspaceName);
@@ -432,9 +468,19 @@ class PromptResourceProjectScopedPromptsTest {
         assertThat(otherProjectPrompts.content()).extracting(Prompt::name).containsExactly(sharedName);
 
         // The version must land on a new prompt owned by projectId, never on the other project's prompt
-        assertThat(projectPrompts.content().getFirst().id()).isNotEqualTo(otherProjectPromptId);
+        var projectPrompt = projectPrompts.content().getFirst();
+        assertThat(projectPrompt.id()).isNotEqualTo(otherProjectPromptId);
         assertThat(otherProjectPrompts.content().getFirst().id()).isEqualTo(otherProjectPromptId);
         assertThat(otherProjectPrompts.content().getFirst().versionCount()).isZero();
+
+        // The requested version must actually be persisted against the new project-scoped prompt
+        assertThat(projectPrompt.versionCount()).isEqualTo(1L);
+        assertThat(createdVersion.promptId()).isEqualTo(projectPrompt.id());
+        assertThat(createdVersion.template()).isEqualTo(createVersionRequest.version().template());
+
+        var persistedVersion = promptResourceClient.getPromptVersion(createdVersion.id(), apiKey, workspaceName);
+        assertThat(persistedVersion.promptId()).isEqualTo(projectPrompt.id());
+        assertThat(persistedVersion.template()).isEqualTo(createVersionRequest.version().template());
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -215,6 +215,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -263,6 +264,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -287,6 +289,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectName(projectName)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
@@ -318,6 +321,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -328,6 +332,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
                 .template(null)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -337,6 +342,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
@@ -369,6 +375,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(otherProjectId)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -404,6 +411,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -437,6 +445,51 @@ class PromptResourceProjectScopedPromptsTest {
     }
 
     @Test
+    @DisplayName("Creating a version with no project does not version another project's prompt")
+    void createPromptVersionWithoutProjectDoesNotVersionProjectScopedPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var otherProjectPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(otherProjectId)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .template(null)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        var otherProjectPromptId = createPrompt(otherProjectPrompt, apiKey, workspaceName);
+
+        var createVersionRequest = CreatePromptVersion.builder()
+                .name(sharedName)
+                .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
+                        .createdBy(USER)
+                        .build())
+                .build();
+
+        PromptVersion createdVersion;
+        try (var response = promptResourceClient.callCreatePromptVersion(createVersionRequest, apiKey,
+                workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            createdVersion = response.readEntity(PromptVersion.class);
+        }
+
+        // The version must land on a new project-less prompt, never on the other project's prompt
+        assertThat(createdVersion.promptId()).isNotEqualTo(otherProjectPromptId);
+        assertThat(promptResourceClient.getPrompt(otherProjectPromptId, apiKey, workspaceName).versionCount())
+                .isZero();
+    }
+
+    @Test
     @DisplayName("Retrieve prompt version with an unresolved project_name does not search the whole workspace")
     void retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace() {
         String apiKey = UUID.randomUUID().toString();
@@ -454,6 +507,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(otherProjectId)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -489,6 +543,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(otherProjectId)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -545,6 +600,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();
@@ -577,6 +633,7 @@ class PromptResourceProjectScopedPromptsTest {
                 .projectId(null)
                 .lastUpdatedBy(USER)
                 .createdBy(USER)
+                .template(null)
                 .versionCount(0L)
                 .templateStructure(TemplateStructure.TEXT)
                 .build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceProjectScopedPromptsTest.java
@@ -388,6 +388,55 @@ class PromptResourceProjectScopedPromptsTest {
     }
 
     @Test
+    @DisplayName("Creating a version scoped to a project does not version a legacy project-less prompt")
+    void createPromptVersionDoesNotVersionLegacyProjectLessPrompt() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        String sharedName = "prompt-" + UUID.randomUUID();
+
+        var legacyPrompt = buildPrompt()
+                .name(sharedName)
+                .projectId(null)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        var legacyPromptId = createPrompt(legacyPrompt, apiKey, workspaceName);
+
+        var createVersionRequest = CreatePromptVersion.builder()
+                .name(sharedName)
+                .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
+                        .createdBy(USER)
+                        .build())
+                .projectId(projectId)
+                .build();
+
+        PromptVersion createdVersion;
+        try (var response = promptResourceClient.callCreatePromptVersion(createVersionRequest, apiKey,
+                workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            createdVersion = response.readEntity(PromptVersion.class);
+        }
+
+        var projectPrompts = promptResourceClient.getPromptsByProjectId(projectId, apiKey, workspaceName);
+
+        assertThat(projectPrompts.content()).extracting(Prompt::name).containsExactly(sharedName);
+
+        // The version must land on a new project-scoped prompt, not on the legacy project-less one
+        var projectPrompt = projectPrompts.content().getFirst();
+        assertThat(projectPrompt.id()).isNotEqualTo(legacyPromptId);
+        assertThat(createdVersion.promptId()).isEqualTo(projectPrompt.id());
+        assertThat(promptResourceClient.getPrompt(legacyPromptId, apiKey, workspaceName).versionCount()).isZero();
+    }
+
+    @Test
     @DisplayName("Retrieve prompt version with an unresolved project_name does not search the whole workspace")
     void retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace() {
         String apiKey = UUID.randomUUID().toString();
@@ -481,6 +530,36 @@ class PromptResourceProjectScopedPromptsTest {
         var persistedVersion = promptResourceClient.getPromptVersion(createdVersion.id(), apiKey, workspaceName);
         assertThat(persistedVersion.promptId()).isEqualTo(projectPrompt.id());
         assertThat(persistedVersion.template()).isEqualTo(createVersionRequest.version().template());
+    }
+
+    @Test
+    @DisplayName("Retrieve prompt version with a null project_name resolves the project-less prompt")
+    void retrievePromptVersionWithNullProjectName() {
+        String projectName = null;
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = UUID.randomUUID().toString();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var workspacePrompt = buildPrompt()
+                .projectId(null)
+                .lastUpdatedBy(USER)
+                .createdBy(USER)
+                .versionCount(0L)
+                .templateStructure(TemplateStructure.TEXT)
+                .build();
+        createPrompt(workspacePrompt, apiKey, workspaceName);
+
+        var request = PromptVersionRetrieve.builder()
+                .name(workspacePrompt.name())
+                .projectName(projectName)
+                .build();
+
+        try (var response = promptResourceClient.callRetrievePromptVersion(request, apiKey, workspaceName)) {
+
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            assertThat(response.readEntity(PromptVersion.class).template()).isEqualTo(workspacePrompt.template());
+        }
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2904,8 +2904,8 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match the prompt's project, then fall back to workspace-level and return it")
-        void whenProjectNameDoesNotMatchPromptProject__thenFallBackToWorkspaceAndReturnIt() {
+        @DisplayName("when project_name does not match the prompt's project, then return not found")
+        void whenProjectNameDoesNotMatchPromptProject__thenReturnNotFound() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
@@ -2929,15 +2929,19 @@ class PromptResourceTest {
                     .projectId(otherProjectId)
                     .build();
 
-            var createdPromptVersion = createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
+            createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
 
-            // Retrieve using a different project name: project-level lookup misses, falls back to workspace-wide and finds it
+            // The prompt belongs to otherProject, so a lookup scoped to a different project must not reach it:
+            // the fallback resolves only legacy prompts with no project at all.
             var retrieveRequest = PromptVersionRetrieve.builder()
                     .name(prompt.name())
                     .projectName(projectName)
                     .build();
 
-            retrievePromptVersionAndAssert(retrieveRequest, createdPromptVersion, API_KEY, TEST_WORKSPACE);
+            try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
         }
 
         @Test
@@ -2974,13 +2978,10 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match, fall back to workspace-wide, then return X-Opik-Deprecation header")
+        @DisplayName("when the prompt has no project, fall back to the legacy prompt and return X-Opik-Deprecation header")
         void whenProjectNameDoesNotMatch__thenReturnDeprecationHeader() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
-
-            var otherProjectName = "project-" + UUID.randomUUID();
-            var otherProjectId = projectResourceClient.createProject(otherProjectName, API_KEY, TEST_WORKSPACE);
 
             var prompt = buildPrompt()
                     .lastUpdatedBy(USER)
@@ -2990,12 +2991,13 @@ class PromptResourceTest {
                     .templateStructure(TemplateStructure.TEXT)
                     .build();
 
+            // No project on the create request: this is a legacy project-less prompt, the only kind the
+            // deprecated workspace fallback is meant to resolve.
             var createRequest = CreatePromptVersion.builder()
                     .name(prompt.name())
                     .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
                             .createdBy(USER)
                             .build())
-                    .projectId(otherProjectId)
                     .build();
 
             createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2904,8 +2904,8 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match the prompt's project, then do not fall back and return not found")
-        void whenProjectNameDoesNotMatchPromptProject__thenReturnNotFound() {
+        @DisplayName("when project_name does not match the prompt's project, then fall back to workspace-level and return it")
+        void whenProjectNameDoesNotMatchPromptProject__thenFallBackToWorkspaceAndReturnIt() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
@@ -2929,18 +2929,15 @@ class PromptResourceTest {
                     .projectId(otherProjectId)
                     .build();
 
-            createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
+            var createdPromptVersion = createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
 
-            // The prompt belongs to otherProject, so a lookup scoped to a different project must not reach it
+            // Retrieve using a different project name: project-level lookup misses, falls back to workspace-wide and finds it
             var retrieveRequest = PromptVersionRetrieve.builder()
                     .name(prompt.name())
                     .projectName(projectName)
                     .build();
 
-            try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
-                    TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-            }
+            retrievePromptVersionAndAssert(retrieveRequest, createdPromptVersion, API_KEY, TEST_WORKSPACE);
         }
 
         @Test
@@ -2977,45 +2974,8 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match a project-less prompt, fall back to workspace-wide, then return X-Opik-Deprecation header")
+        @DisplayName("when project_name does not match, fall back to workspace-wide, then return X-Opik-Deprecation header")
         void whenProjectNameDoesNotMatch__thenReturnDeprecationHeader() {
-            var projectName = "project-" + UUID.randomUUID();
-            projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
-
-            var prompt = buildPrompt()
-                    .lastUpdatedBy(USER)
-                    .createdBy(USER)
-                    .template(null)
-                    .latestVersion(null)
-                    .templateStructure(TemplateStructure.TEXT)
-                    .build();
-
-            var createRequest = CreatePromptVersion.builder()
-                    .name(prompt.name())
-                    .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
-                            .createdBy(USER)
-                            .build())
-                    .build();
-
-            createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
-
-            var retrieveRequest = PromptVersionRetrieve.builder()
-                    .name(prompt.name())
-                    .projectName(projectName)
-                    .build();
-
-            try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
-                    TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
-                        .isEqualTo(RequestContext.WORKSPACE_FALLBACK_MESSAGE_TEMPLATE.formatted("Prompt",
-                                prompt.name()));
-            }
-        }
-
-        @Test
-        @DisplayName("when the prompt belongs to another project, then do not fall back and return not found")
-        void whenPromptBelongsToAnotherProject__thenReturnNotFound() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
@@ -3047,7 +3007,10 @@ class PromptResourceTest {
 
             try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
                     TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
+                        .isEqualTo(RequestContext.WORKSPACE_FALLBACK_MESSAGE_TEMPLATE.formatted("Prompt",
+                                prompt.name()));
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2904,8 +2904,8 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match the prompt's project, then fall back to workspace-level and return it")
-        void whenProjectNameDoesNotMatchPromptProject__thenFallBackToWorkspaceAndReturnIt() {
+        @DisplayName("when project_name does not match the prompt's project, then do not fall back and return not found")
+        void whenProjectNameDoesNotMatchPromptProject__thenReturnNotFound() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
@@ -2929,15 +2929,18 @@ class PromptResourceTest {
                     .projectId(otherProjectId)
                     .build();
 
-            var createdPromptVersion = createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
+            createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
 
-            // Retrieve using a different project name: project-level lookup misses, falls back to workspace-wide and finds it
+            // The prompt belongs to otherProject, so a lookup scoped to a different project must not reach it
             var retrieveRequest = PromptVersionRetrieve.builder()
                     .name(prompt.name())
                     .projectName(projectName)
                     .build();
 
-            retrievePromptVersionAndAssert(retrieveRequest, createdPromptVersion, API_KEY, TEST_WORKSPACE);
+            try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+            }
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/PromptResourceTest.java
@@ -2974,8 +2974,45 @@ class PromptResourceTest {
         }
 
         @Test
-        @DisplayName("when project_name does not match, fall back to workspace-wide, then return X-Opik-Deprecation header")
+        @DisplayName("when project_name does not match a project-less prompt, fall back to workspace-wide, then return X-Opik-Deprecation header")
         void whenProjectNameDoesNotMatch__thenReturnDeprecationHeader() {
+            var projectName = "project-" + UUID.randomUUID();
+            projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
+
+            var prompt = buildPrompt()
+                    .lastUpdatedBy(USER)
+                    .createdBy(USER)
+                    .template(null)
+                    .latestVersion(null)
+                    .templateStructure(TemplateStructure.TEXT)
+                    .build();
+
+            var createRequest = CreatePromptVersion.builder()
+                    .name(prompt.name())
+                    .version(factory.manufacturePojo(PromptVersion.class).toBuilder()
+                            .createdBy(USER)
+                            .build())
+                    .build();
+
+            createPromptVersion(createRequest, API_KEY, TEST_WORKSPACE);
+
+            var retrieveRequest = PromptVersionRetrieve.builder()
+                    .name(prompt.name())
+                    .projectName(projectName)
+                    .build();
+
+            try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
+                    TEST_WORKSPACE)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
+                        .isEqualTo(RequestContext.WORKSPACE_FALLBACK_MESSAGE_TEMPLATE.formatted("Prompt",
+                                prompt.name()));
+            }
+        }
+
+        @Test
+        @DisplayName("when the prompt belongs to another project, then do not fall back and return not found")
+        void whenPromptBelongsToAnotherProject__thenReturnNotFound() {
             var projectName = "project-" + UUID.randomUUID();
             projectResourceClient.createProject(projectName, API_KEY, TEST_WORKSPACE);
 
@@ -3007,10 +3044,7 @@ class PromptResourceTest {
 
             try (var response = promptResourceClient.callRetrievePromptVersion(retrieveRequest, API_KEY,
                     TEST_WORKSPACE)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-                assertThat(response.getHeaderString(RequestContext.WORKSPACE_FALLBACK_HEADER))
-                        .isEqualTo(RequestContext.WORKSPACE_FALLBACK_MESSAGE_TEMPLATE.formatted("Prompt",
-                                prompt.name()));
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
             }
         }
 

--- a/sdks/python/tests/e2e/test_prompt.py
+++ b/sdks/python/tests/e2e/test_prompt.py
@@ -437,7 +437,7 @@ def test_get_prompt__chat_prompt__returns_none(
 
     # Try to retrieve it with get_prompt() - should raise an error due to type mismatch
     with pytest.raises(opik.exceptions.PromptTemplateStructureMismatch):
-        opik_client.get_prompt(name=prompt_name)
+        opik_client.get_prompt(name=prompt_name, project_name=temporary_project_name)
 
     # Verify the chat prompt remains unchanged
     retrieved_chat_prompt = opik_client.get_chat_prompt(
@@ -500,7 +500,9 @@ def test_get_prompt_history__chat_prompt__returns_empty_list(
 
     # Try to get history with get_prompt_history() - should raise an error due to type mismatch
     with pytest.raises(opik.exceptions.PromptTemplateStructureMismatch):
-        opik_client.get_prompt_history(name=prompt_name)
+        opik_client.get_prompt_history(
+            name=prompt_name, project_name=temporary_project_name
+        )
 
     # Verify the chat prompt remains unchanged
     retrieved_chat_prompt = opik_client.get_chat_prompt(


### PR DESCRIPTION
## Details

<img width="944" height="1703" alt="image" src="https://github.com/user-attachments/assets/c76c706c-40cd-4ce8-b241-947b03cbfc10" />

The V1 back-compat fallback in `PromptService.findByName` passed `projectId = null` into `PromptDAO.findByName` to mean "the legacy rows that have no project". But that DAO's project filter is a StringTemplate conditional — with `@Define("project_id")` bound to `null`, the `<if(project_id)>` block evaluates false and the clause is omitted entirely rather than becoming `AND project_id IS NULL`. The fallback therefore matched *any* project's prompt in the workspace and returned whichever row came back first.

Two consequences: a project could read another project's same-named prompt, and `Opik.create_prompt()` would then add a version to that other project's prompt instead of creating a scoped one — cross-project mutation triggered by a name collision, with only a deprecation warning as the signal.

- Add `PromptDAO.findByNameWithoutProject` with an explicit `AND project_id IS NULL` and no StringTemplate conditional, rather than overloading `null` as a wildcard. It carries `ORDER BY id LIMIT 1`, since the unique constraint does not constrain rows where `project_id IS NULL` (MySQL allows multiple NULLs in a unique index), so duplicate project-less rows of the same name can exist and would otherwise resolve arbitrarily.
- Point the deprecated workspace fallback at it, so it resolves genuine legacy rows instead of any project's prompt.
- Back prompt **creation** with a separate `findByNameScoped`, which never falls back and treats a null project as "the project-less prompt" rather than "any project".
- The `setWorkspaceFallbackFor` deprecation signal is unchanged — still correct for genuine legacy rows.

### Scope

Both the read and the create path are scoped; the legacy fallback is preserved.

- **Read** (`retrievePromptVersion`): when `project_name` is supplied the lookup is scoped to that project. A prompt owned by a different project is no longer matched, and an unknown project name returns 404 instead of collapsing to a workspace-wide search. This restores the contract PR #5736 (OPIK-4935) shipped — *"when provided, only prompts belonging to that project are searched (no workspace-level fallback)"* — which had since regressed.
- **Create** (`getOrCreatePrompt`): backed by `findByNameScoped`, which never falls back, so creating a prompt never versions another project's prompt or a legacy project-less one. This is the ticket's reported reproducer.
- **Legacy fallback retained**: prompts with `project_id IS NULL` are still resolved workspace-wide, with the `X-Opik-Deprecation` header. Those rows are permanent — PR #7724 removed the prompt project-migration job that used to assign them a project, and `project_id` was never tightened to NOT NULL — so they remain readable and must stay reachable; OPIK_7305 AC #1 depends on it. Retiring the fallback belongs to the V1 data-model hardening follow-up, alongside making `project_id` NOT NULL.

  Note on how such rows arise, since it came up in review: the **current** Python and TypeScript SDKs never create one. Both resolve a project name before sending — TS `createPrompt` goes through `Client.resolveProjectName`, which returns a non-optional string defaulting to `"Default Project"`; Python resolves via argument → env var → `.opik.config` → `"Default Project"`. The remaining ways in are old SDK versions and direct REST callers, since `project_name`/`project_id` are both still optional in the create DTO and `resolveProjectId` returns null when neither is supplied. Closing that write path (reject or default a project-less create) is a follow-up, not part of this PR: it is a breaking change for old clients, and the correct order is close the inlet → migrate the remaining NULL rows → then retire the fallback. Removing the fallback here would be doing the last step first.

### Release sequencing — please read before merging

The released TypeScript SDK does not send `project_name` on retrieve: `BasePrompt.retrieveVersion` builds `{name, versionNumber}` / `{name, commit}`. With reads scoped, **project-scoped prompts return 404 for those clients until OPIK_7305 ships**.

That is the intended migration, not a regression: OPIK_7305's AC #2 ("prompt assigned to project A: TS `getPrompt` under project B returns null") is written against this backend change, and its own analysis sequences it behind this ticket. But it is a live window, so this PR should land together with — or immediately before — the SDK fix.

Two earlier revisions of this PR reverted the read scoping over exactly this concern before the sequencing was confirmed; that revert has itself been reverted.

The same defect exists in `DatasetService`/`DatasetDAO` (four call sites) and `DashboardService`/`DashboardDAO`, but is **not** fixed here. Those tables still carry the original workspace-wide unique constraint, so scoping their fallback would turn today's silent-wrong-result into a duplicate-key error on a path that currently appears to work. Root cause and required ordering are documented on OPIK_5654, which is blocked on OPIK_6359. Prompts are unblocked because migration `000089` already relaxed that constraint to `(workspace_id, project_id, name)`.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7602

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation (root-cause analysis, fix, tests)
- Human verification: pending review — see the caveat under Testing

## Testing

Added to `PromptResourceProjectScopedPromptsTest`:

- `createPromptVersionWithNameFromAnotherProjectCreatesScopedPrompt` — the ticket's reproducer: a version created under project A with a name already used by project B produces a new A-scoped prompt, leaving B's prompt id and `versionCount` untouched, and asserts the version actually persisted against A (`versionCount`, `promptId`, `template`, plus a re-read).
- `createPromptVersionDoesNotVersionLegacyProjectLessPrompt` / `createPromptVersionWithoutProjectDoesNotVersionProjectScopedPrompt` — creation does not cross between project-scoped and legacy project-less prompts in either direction.
- `retrievePromptVersionDoesNotReachAnotherProjectPrompt` — cross-project retrieval returns 404.
- `retrievePromptVersionWithUnresolvedProjectNameDoesNotSearchWorkspace` — an unknown project name returns 404 rather than searching the workspace.
- `retrievePromptVersionFallsBackToWorkspaceLevelPrompt` / `retrievePromptVersionWithNullProjectName` — the legacy fallback still resolves project-less prompts, with the deprecation header.
- `retrievePromptVersionRejectsBlankProjectName` — empty and whitespace-only names are rejected with 422 by `@Pattern(NULL_OR_NOT_BLANK)`.

Restored in `PromptResourceTest` (these had been inverted away from their original intent):

- `whenProjectNameDoesNotMatchPromptProject__thenReturnNotFound` — back to the name and 404 assertion PR #5736 shipped; it had been renamed to `...__thenFallBackToWorkspaceAndReturnIt` asserting 200.
- `whenProjectNameDoesNotMatch__thenReturnDeprecationHeader` — now uses a genuine project-less prompt rather than another project's prompt, so it exercises the fallback it claims to.

`PromptResourceFindProjectPromptsTest` created versions with no project against project-scoped prompts, relying on the wildcard; its helper now passes the prompt's `projectId`.

Commands run:

```
mvn -o -f apps/opik-backend/pom.xml compile test-compile -DskipTests   # passes
pre-commit run --files <changed files>                                 # spotless passed
```

**Tests not run locally — relying on CI.** Testcontainers cannot start `zookeeper:3.9.4` on this machine (`ContainerLaunchException: Timed out waiting for container port to open`); this is environmental, not caused by this change — `PromptResourceFindProjectPromptsTest`, on a clean checkout, fails identically here.

CI has been the real verification throughout and repeatedly caught what local compilation could not. Please confirm the suite is green before merging.

## Documentation

The `project_name` schema description and the `retrievePromptVersion` operation description state the scoping contract, and the `200` response now declares the `X-Opik-Deprecation` header so generated clients expose it.

The checked-in `sdks/code_generation/fern/openapi/openapi.yaml` and `apps/opik-documentation/documentation/fern/openapi/opik.yaml` are intentionally untouched — they are regenerated by the daily `sdks_generate_openapi_spec_and_fern_code` workflow.

