### PR TITLE
[OPIK-7836] [BE] perf: gate the guardrails join and the dedup sort out of the traces count

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1546,6 +1546,24 @@ class TraceDAOImpl implements TraceDAO {
             SETTINGS log_comment = '<log_comment>'
             """;
 
+    /**
+     * Total-row count behind the traces list page. Numbers in OPIK-7836; re-measure before changing either gate.
+     *
+     * <p>Two things this template must NOT do when nothing consumes them:
+     *
+     * <ul>
+     * <li>{@code guardrails_agg} is joined only under {@code guardrails_filters}, matching the other filter-side
+     * joins in this class. Nothing else in the count reads {@code gagg.guardrails_result}, and the join is also what
+     * makes {@code trace_id_prefilter} referenced - so leaving it in costs a second full scan of the project on
+     * every page load (measured 15.9M read rows on a 7.9M-row project). The gate cannot silently return a wrong
+     * count: {@code FilterUtils} sets {@code guardrails_filters} in exactly the cases that render the {@code gagg}
+     * alias into {@code filters}, so a mismatch fails to parse (see {@link #canDedupByArgMax}).</li>
+     * <li>The {@code ORDER BY} + {@code LIMIT 1 BY id} dedup of {@code ReplacingMergeTree} versions is kept only
+     * under {@code trace_aggregation_filters}, whose branch groups by {@code t.id} and so needs one row per version.
+     * Otherwise the count is {@code count(DISTINCT id)}: the {@code WHERE} is applied before dedup either way, so
+     * both forms count the ids where any version matched, but only one of them sorts every matching row.</li>
+     * </ul>
+     */
     private static final String COUNT_BY_PROJECT_ID = """
             WITH <if(trace_id_prefilter)>trace_id_prefilter AS (
                 SELECT DISTINCT id
@@ -1799,7 +1817,7 @@ class TraceDAOImpl implements TraceDAO {
             )
             <endif>
             SELECT
-                count(id) as count
+                <if(trace_aggregation_filters)>count(id)<else>count(DISTINCT id)<endif> as count
             FROM (
                 SELECT
                     t.id
@@ -1810,10 +1828,9 @@ class TraceDAOImpl implements TraceDAO {
                     <endif>
                 FROM (
                     SELECT
-                        id,
-                        duration
+                        id
                     FROM traces
-                        LEFT JOIN guardrails_agg gagg ON gagg.entity_id = traces.id
+                        <if(guardrails_filters)>LEFT JOIN guardrails_agg gagg ON gagg.entity_id = traces.id<endif>
                     <if(feedback_scores_empty_filters)>
                     LEFT JOIN fsc ON fsc.entity_id = traces.id
                     <endif>
@@ -1871,8 +1888,10 @@ class TraceDAOImpl implements TraceDAO {
                         LIMIT 1 BY id
                     )
                     <endif>
+                    <if(trace_aggregation_filters)>
                     ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                     LIMIT 1 BY id
+                    <endif>
                 ) AS t
                 <if(trace_aggregation_filters)>
                 LEFT JOIN (


### PR DESCRIPTION
## Details

`COUNT_BY_PROJECT_ID` is the total-count companion of the traces list page and fires once per page load — 11,046 runs / 4h on prod, matching `find_traces_by_project_id` exactly. p50 is fine (36 ms) but p99 is 4,950 ms and max 13,245 ms, for **2,341 s of ClickHouse query time and 1.74 TiB read per 4h**. Two slots in the template were unconditional and account for almost all of it.

- **The guardrails join was ungated.** `LEFT JOIN guardrails_agg` rendered in **10,880 / 10,880** count queries, even though nothing in the count reads `gagg.guardrails_result` without a `GUARDRAILS` filter. It is also what makes `trace_id_prefilter` referenced, so it cost a **second full scan of the project** — 15.9M read rows on a 7.9M-row project. The sibling filter-side joins in this class were already gated on `guardrails_filters` in `ac29c35809` (CUST-4702); this one was missed. The projection joins at `:1479` / `:2658` genuinely emit the guardrails field and are left alone.
- **A full sort to dedupe `ReplacingMergeTree` versions.** `ORDER BY … LIMIT 1 BY id` sorted every matching row to drop **68 duplicates out of 7,672,577**, costing ~2.2 s and up to 2.6 GiB peak RAM. The `WHERE` is applied before dedup either way, so `count(DISTINCT id)` counts the same ids without sorting. Kept under `trace_aggregation_filters`, whose branch groups by `t.id` and needs one row per version.
- Also drops the inner `duration` column, which nothing referenced.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7836

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: prod `system.query_log` investigation, A/B benchmarking and correctness runs against `opik_prod`, patch and PR/ticket drafting
- Human verification: reviewed by @thiagoh

## Testing

**Unit / compile**

```
mvn -o -DskipTests compile                     # BUILD SUCCESS
mvn -o test -Dtest=TraceDAOImplTest            # 21/21 pass
mvn -o test -Dtest=GetTracesByProjectResourceTest
```

`GetTracesByProjectResourceTest` is the meaningful gate: its filter tests route through `TraceTestAssertion` -> `TraceAssertions.assertPage`, which asserts `actualPage.total()` — the exact value this query produces. `whenFilterGuardrails__thenReturnTracesFiltered` covers the gated path (failed and passed guardrails, across the page/stream/stats endpoints) and lives in the `FilterTest` class below.

The first full run reported **1 failure out of 1,764**: `whenFilterSpanFeedbackScoresGreaterThan[1]`, asserting `ProjectStats.trace_count` = 2 vs an expected 1. That is the **stats** endpoint, served by `SELECT_TRACES_SPANS_STATS`; `COUNT_BY_PROJECT_ID` is referenced only from `countTotal` and nothing in this PR touches the stats template. Chased down rather than assumed:

| run | result |
| --- | --- |
| failing test in isolation, this branch | 3/3 pass |
| full `FilterTest` on base `main` (file reverted to `HEAD~1`) | **1642/1642 pass** |
| full `FilterTest` on this branch (change restored) | **1642/1642 pass** |

Not reproducible on either side, so it reads as a pre-existing flake in that test's random score data rather than anything introduced here. Flagging it because it did fail once.

**Correctness against production data**

Three raw SQL variants were hand-built and replayed against two **static** projects in `opik_prod` (no ingestion, so counts are directly comparable): the current query, the join-gated query, and both fixes. Every shape the patch can emit returns the same count as today.

| case | current | + join gate | + both fixes |
| --- | --- | --- | --- |
| plain | 1,928 / 24,543 | 1,928 / 24,543 | 1,928 / 24,543 |
| wide (`input CONTAINS`) | 742 / 16,805 | 742 / 16,805 | 742 / 16,805 |
| feedback-score filter | — / 22,459 | — / 22,459 | — / 22,459 |
| time-bounded (`id >=`) | 24,543 | 24,543 | 24,543 |
| guardrails filter = `failed` | 195 / 0 | 195 / 0 *(gate keeps the join — SQL identical to current)* | 195 / 0 |
| guardrails filter = `passed` | 1,732 / 0 | 1,732 / 0 *(idem)* | 1,732 / 0 |

The first project carries 37,735 guardrail rows across 12,664 entities against 1,928 traces — a join fan-out would have shown up as an inflated baseline. It did not; `guardrails_agg` emits one row per `entity_id`. Note 195 + 1,732 = 1,927 of that project's 1,928 traces, i.e. the two guardrail values partition it as expected.

The guardrails rows are the ones worth reading twice: when a `GUARDRAILS` filter is present the gate **keeps** the join, so the `+ join gate` column is the same SQL as `current`, and the `+ both fixes` column is the shape this PR actually ships for that case — measured, not assumed.

<details>
<summary>Negative control: what happens if the gate is ever broken</summary>

Forcing the join-*removed* SQL to run with a guardrails predicate — i.e. simulating a wrong gate — produces a parse error, not a wrong number:

```
Unknown expression or function identifier 'gagg.guardrails_result'
```

`FilterUtils` sets `guardrails_filters` exactly when a `GUARDRAILS` filter exists, which is also the only thing that renders the `gagg` alias into `<filters>`, so the two cannot drift apart silently. This gate fails loud.

</details>

**Performance against production data**

5 runs per variant per project, **interleaved** round-robin so load variance hits all variants equally; durations, rows and memory read back from `system.query_log`.

| project | variant | median | min–max | read rows | peak mem |
| --- | --- | --- | --- | --- | --- |
| 7.91M traces | current | 4,830 ms | 4,736–5,094 | 15.91 M | 2.33 GiB |
| | + join gate | 3,212 ms | 2,889–4,013 | 7.94 M | 1.07 GiB |
| | **+ both** | **548 ms** | 526–613 | 7.95 M | **490 MiB** |
| 7.67M traces | current | 4,722 ms | 4,502–4,815 | 15.47 M | 2.26 GiB |
| | + join gate | 2,662 ms | 2,574–2,859 | 7.73 M | 1018 MiB |
| | **+ both** | **590 ms** | 504–684 | 7.74 M | **481 MiB** |

**8.0–8.8x faster, 4.7x less memory.** The `read_rows` column is the direct evidence of the removed double scan: 15.9M → 7.9M on a 7.9M-row project.

`INPUT CONTAINS` shape, 4 runs interleaved, warm: **2,804 ms → 20 ms**, 15.49M → 20.06k read rows — the join was defeating skip-index pruning entirely.

**Blast radius** (prod, 8h): `GUARDRAILS` filter on a count query **0 / 10,388**; `trace_aggregation_filters` **45 / 10,894 (0.4%)**. So the join gate applies essentially always and the dedup removal to 99.6% of calls. At the observed mix this reclaims roughly **1,600 s of ClickHouse query time per 4h**.

**Not run:** the wider backend suite — this change touches one query template, and the 63 total-asserting filter tests above are its behavioural contract.

## Documentation

None — internal query shape only, no API or behaviour change.
