### PR TITLE
[NA] [DEV] feat: add --cost-api-restart to dev-runner

### DIFF
--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -848,7 +848,10 @@ stop_cost_api_local() {
     if [ -f "$COST_API_PID_FILE" ]; then
         local cost_api_pid
         cost_api_pid=$(cat "$COST_API_PID_FILE")
-        if kill -0 "$cost_api_pid" 2>/dev/null; then
+        # A negative value would make `kill` signal a whole process group, so anything
+        # that is not a plain decimal PID is treated as no process at all.
+        case "$cost_api_pid" in ''|*[!0-9]*) cost_api_pid="" ;; esac
+        if [ -n "$cost_api_pid" ] && kill -0 "$cost_api_pid" 2>/dev/null; then
             log_info "Stopping cost-api (PID: $cost_api_pid)..."
             # `uv run` spawns the uvicorn worker as a child; snapshot the
             # descendant tree before killing the parent so we can chase it down.
@@ -878,6 +881,14 @@ stop_cost_api_local() {
 # start path as a full run, so its env, ports and auth mode can't drift from what
 # dev-runner would otherwise set. Combine with the modifier flags as usual, e.g.
 # `--platform-enabled --cost-api-restart`.
+cost_api_managed_alive() {
+    [ -f "$COST_API_PID_FILE" ] || return 1
+    local pid
+    pid=$(cat "$COST_API_PID_FILE")
+    case "$pid" in ''|*[!0-9]*) return 1 ;; esac
+    kill -0 "$pid" 2>/dev/null
+}
+
 restart_cost_api_only() {
     if ! cost_api_enabled; then
         log_error "cost-api is not configured: AI_COST_BACKEND_PATH is empty and no sibling ai-cost-backend checkout was found"
@@ -886,9 +897,11 @@ restart_cost_api_only() {
 
     log_info "=== Restarting cost-api (leaving the rest of the stack up) ==="
 
-    # A reused instance has no PID file, so stop_cost_api_local would no-op and the
-    # start below would just adopt the same stale process.
-    if [ ! -f "$COST_API_PID_FILE" ] && cost_api_healthy; then
+    # Liveness, not just the file: with a PID file left over from a dead process and
+    # something healthy on the port, stop_cost_api_local would clean up the file
+    # without killing anything and start_cost_api_local would adopt that instance --
+    # reporting a restart that never happened.
+    if cost_api_healthy && ! cost_api_managed_alive; then
         log_error "cost-api on port ${AI_COST_BACKEND_PORT} was not started by this dev-runner, so it cannot be stopped here"
         log_error "Stop it where you started it, then re-run this command"
         return 1

--- a/scripts/dev-runner.sh
+++ b/scripts/dev-runner.sh
@@ -874,6 +874,30 @@ stop_cost_api_local() {
     log_success "cost-api stopped"
 }
 
+# Bounce only cost-api, leaving the rest of the stack running. Goes through the same
+# start path as a full run, so its env, ports and auth mode can't drift from what
+# dev-runner would otherwise set. Combine with the modifier flags as usual, e.g.
+# `--platform-enabled --cost-api-restart`.
+restart_cost_api_only() {
+    if ! cost_api_enabled; then
+        log_error "cost-api is not configured: AI_COST_BACKEND_PATH is empty and no sibling ai-cost-backend checkout was found"
+        return 1
+    fi
+
+    log_info "=== Restarting cost-api (leaving the rest of the stack up) ==="
+
+    # A reused instance has no PID file, so stop_cost_api_local would no-op and the
+    # start below would just adopt the same stale process.
+    if [ ! -f "$COST_API_PID_FILE" ] && cost_api_healthy; then
+        log_error "cost-api on port ${AI_COST_BACKEND_PORT} was not started by this dev-runner, so it cannot be stopped here"
+        log_error "Stop it where you started it, then re-run this command"
+        return 1
+    fi
+
+    stop_cost_api_local
+    start_cost_api_local
+}
+
 display_cost_api_process_status() {
     if [ -f "$COST_API_PID_FILE" ] && kill -0 "$(cat "$COST_API_PID_FILE")" 2>/dev/null; then
         echo -e "cost-api: ${GREEN}RUNNING${NC} (PID: $(cat "$COST_API_PID_FILE"))"
@@ -1610,6 +1634,8 @@ show_usage() {
     echo "  --stop          - Stop Docker infrastructure, and BE and FE processes"
     echo "  --restart       - Stop, build, and start Docker infrastructure, and BE and FE processes (DEFAULT IF NO OPTIONS PROVIDED)"
     echo "  --quick-restart - Quick restart: stop BE/FE, rebuild BE only, start BE/FE (keeps infrastructure running)"
+    echo "  --cost-api-restart - Opik-team only: restart just cost-api (ai-cost-backend), leaving"
+    echo "                     everything else running. Combine with --platform-enabled to keep auth on."
     echo "  --verify        - Verify status of Docker infrastructure, and BE and FE processes"
     echo ""
     echo "BE-Only Mode (BE as process, FE in Docker):"
@@ -1835,6 +1861,9 @@ case "${1:-}" in
         ;;
     "--quick-restart")
         quick_restart_services
+        ;;
+    "--cost-api-restart")
+        restart_cost_api_only || exit 1
         ;;
     "--verify")
         verify_services


### PR DESCRIPTION
## Details

Adds `--cost-api-restart` to dev-runner, so iterating on ai-cost-backend no longer means rebuilding the Java backend. `--restart` tears down and rebuilds Docker infrastructure; `--quick-restart` skips that but still runs a full Maven build and does not touch cost-api at all. Picking up a one-line Python edit therefore cost minutes.

- Bounces cost-api through the existing `stop_cost_api_local` / `start_cost_api_local` path rather than a bespoke one, so its ports, DB targets and auth mode cannot drift from what a full run would set — notably `AUTH_ENABLED`, which only platform mode turns on, so `--platform-enabled --cost-api-restart` keeps org-scoped endpoints working.
- Refuses to act on an instance dev-runner did not start. Those have no PID file, so `stop_cost_api_local` would silently no-op and the start would adopt the same stale process — the command would report success while changing nothing.
- Named component-first to match the existing single-component flags (`--be-only-start` / `-stop` / `-restart` / `-verify`) rather than reading as a variant of `--quick-restart`, which rebuilds the Java backend where this only bounces a process.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA — developer tooling, no ticket

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: manual testing against a local stack

## Testing

`bash -n scripts/dev-runner.sh` — clean. No unit-test harness exists for this script; verification was by exercising both dispatch paths locally.

Scenarios validated:

- `--cost-api-restart` against a cost-api started outside dev-runner (no PID file): the guard fires, prints where to stop it, and exits non-zero. This is the case the guard exists for, and it was confirmed on a real running instance — the process was left untouched.
- `--restart-cost-api` (the pre-review spelling) now returns `Unknown option`, confirming the rename is complete and no alias survives.
- `--help` lists the flag beside `--quick-restart`.

Not run: the happy path where dev-runner both starts and restarts cost-api. That requires tearing down a cost-api instance whose environment only exists in the owning terminal session, so it was deliberately not exercised here.

## Documentation

N/A — the flag documents itself in `--help`; no external docs surface covers dev-runner.
