### PR TITLE
[NA] [FE] fix: scope project-by-name cache by workspace

### DIFF
--- a/apps/opik-frontend/src/api/projects/useProjectByName.ts
+++ b/apps/opik-frontend/src/api/projects/useProjectByName.ts
@@ -8,6 +8,7 @@ import { Project } from "@/types/projects";
 
 type UseProjectByNameParams = {
   projectName: string;
+  workspaceName?: string;
 };
 
 const getProjectByName = async (


### PR DESCRIPTION
## Details

`useProjectByName` keyed its cache on the project name alone, but the workspace is only ever sent as the `Comet-Workspace` request header — so the same name resolved to one shared cache entry across every workspace. Because switching workspace is a client-side navigation, that entry survives the switch, and a caller passing `refetchOnMount: false` keeps reading the project id resolved in the previous workspace until a full page reload.

- `workspaceName` is optional and used only in the query key, so callers that look up a project by a name which exists in more than one workspace can opt in.
- Existing callers are untouched: with the field absent the key is unchanged, so this is inert on its own.
- Prefix and partial key matching are unaffected, so the existing `invalidateQueries` / `removeQueries` calls against the `project` key keep matching.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: investigation and full implementation
- Human verification: author review of the diff; reproduction and scope of the fix reviewed and narrowed during the session

## Testing

Commands run in `apps/opik-frontend`:

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npx vitest run` — pass (170 files, 2479 tests)

Scenarios validated:

- The stale-cache behaviour was reproduced locally with a temporary unit test that mounts the hook in one workspace, remounts it in another with `refetchOnMount: false`, and asserts the resolved project id. Without `workspaceName` in the params it fails with `expected 'project-in-workspace-a' to be 'project-in-workspace-b'` — the reported symptom; with it, two separate fetches and the correct id per workspace. The test was intentionally not kept, since with the field in place the isolation is a property of the query key rather than of logic in this hook.
- Regression check that omitting the field changes nothing: keys are byte-identical to before for all nine existing call sites (playground, agent onboarding, project redirects), which continue to compile and behave unchanged.

Not run: no manual UI verification in this PR, as no caller in this repository passes the new field yet.

## Documentation

N/A
