### PR TITLE
[BE]: register nscale as a canonical provider so Nscale model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -54,7 +54,8 @@ public class CostService {
             Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
             Map.entry("sambanova", "sambanova"),
-            Map.entry("nebius", "nebius"));
+            Map.entry("nebius", "nebius"),
+            Map.entry("nscale", "nscale"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -973,4 +973,21 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers registering {@code nscale} as a canonical provider so that the 14 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "nscale"} are no longer silently dropped at load time. No Nscale
+     * model publishes cache rates today, so all Nscale requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesNscaleModels() {
+        // nscale/Qwen/QwQ-32B: input 1.8e-07, output 2e-07
+        // 1000 * 1.8e-07 + 200 * 2e-07 = 0.00022
+        BigDecimal cost = CostService.calculateCost("nscale/Qwen/QwQ-32B", "nscale",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.00022");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values in `model_prices_and_context_window.json`. Models whose provider is missing from that map have their price dropped at load time (`buildModelPrice` returns null), so their spans bill at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

`nscale` is one such provider: the bundled price file carries 14 non-zero-cost Nscale entries (Qwen, DeepSeek, Llama and more served on Nscale Serverless) that never load today. This registers `nscale` as a canonical provider so those prices resolve. No Nscale model publishes cache rates today, so requests route through the standard `textGenerationCost` path; no cache calculator entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added `calculateCostHandlesNscaleModels` asserting a representative Nscale model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
