### PR TITLE
[BE]: register oci as a canonical provider so OCI model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -54,7 +54,8 @@ public class CostService {
             Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
             Map.entry("sambanova", "sambanova"),
-            Map.entry("nebius", "nebius"));
+            Map.entry("nebius", "nebius"),
+            Map.entry("oci", "oci"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -973,4 +973,21 @@ class CostServiceTest {
                 // custom-llm hits the same fallback, as it does for perplexity and moonshot.
                 Arguments.of("z-ai/glm-4.5", "custom-llm", "0.00104"));
     }
+
+    /**
+     * Covers registering {@code oci} as a canonical provider so that the 44 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "oci"} are no longer silently dropped at load time. No OCI
+     * model publishes cache rates today, so all OCI requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesOCIModels() {
+        // oci/xai.grok-3: input 3e-06, output 1.5e-05
+        // 1000 * 3e-06 + 200 * 1.5e-05 = 0.006
+        BigDecimal cost = CostService.calculateCost("oci/xai.grok-3", "oci",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.006");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values in `model_prices_and_context_window.json`. Models whose provider is missing from that map have their price dropped at load time (`buildModelPrice` returns null), so their spans bill at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

`oci` is one such provider: the bundled price file carries 44 non-zero-cost OCI entries (the Grok, Cohere, Llama and other models served through Oracle Cloud Infrastructure Generative AI) that never load today. This registers `oci` as a canonical provider so those prices resolve. No OCI model publishes cache rates today, so requests route through the standard `textGenerationCost` path; no cache calculator entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added `calculateCostHandlesOciModels` asserting a representative OCI model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
