### PR TITLE
feat(otel): normalize host-style provider aliases to canonical names

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -7,6 +7,7 @@ import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.domain.mapping.otel.ElasticInferenceServiceResolver;
 import com.comet.opik.domain.mapping.otel.GeneralMappingRules;
 import com.comet.opik.domain.mapping.otel.GoogleProviderResolver;
+import com.comet.opik.domain.mapping.otel.HostProviderResolver;
 import com.comet.opik.domain.retention.RetentionUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -275,6 +276,10 @@ public class OpenTelemetryMapper {
         // Disambiguate the generic 'google' provider (PydanticAI / google-genai) into the Vertex AI
         // vs Gemini API canonical name using server.address, so cost lookup can match a price row.
         provider = GoogleProviderResolver.resolve(provider, metadata);
+
+        // Normalize host-style provider values (e.g. "api.cerebras.ai" -> "cerebras")
+        // so cost lookup can find the canonical provider.
+        provider = HostProviderResolver.resolve(provider, metadata);
 
         // Agent-run spans (gen_ai.operation.name=invoke_agent) are not LLM calls. Other attributes
         // on them (e.g. gen_ai.system_instructions) would otherwise type them as llm; force general.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -56,7 +56,8 @@ public class CostService {
             Map.entry("sambanova", "sambanova"),
             Map.entry("nebius", "nebius"),
             Map.entry("snowflake", "snowflake"),
-            Map.entry("deepinfra", "deepinfra"));
+            Map.entry("deepinfra", "deepinfra"),
+            Map.entry("cerebras", "cerebras"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -52,10 +52,12 @@ public class HostProviderResolver {
             "inception"
     );
 
-    // Aliases for host labels that do not match the canonical provider name directly.
-    // For example, api.x.ai extracts the label "x" but the canonical provider is "xai".
-    private static final java.util.Map<String, String> LABEL_ALIASES = java.util.Map.of(
-            "x", "xai"
+    // Full-host aliases for providers whose canonical name cannot be inferred from the
+    // second-level domain label alone. Keyed on the normalized hostname (lower-case,
+    // with or without the "api." prefix stripped). Only exact-match entries are applied.
+    private static final java.util.Map<String, String> HOST_ALIASES = java.util.Map.of(
+            "api.x.ai", "xai",
+            "x.ai", "xai"
     );
 
     /**
@@ -79,6 +81,14 @@ public class HostProviderResolver {
             return provider;
         }
 
+        // Check full-host aliases first (exact match on the normalized hostname).
+        // These cover cases where the SLD label alone is ambiguous (e.g. "x" in "api.x.ai").
+        String hostAlias = HOST_ALIASES.get(normalized);
+        if (hostAlias != null) {
+            log.debug("Resolved host-style provider '{}' to canonical '{}' via host alias", provider, hostAlias);
+            return hostAlias;
+        }
+
         Matcher m = HOST_PATTERN.matcher(normalized);
         if (!m.matches()) {
             return provider;
@@ -86,12 +96,9 @@ public class HostProviderResolver {
 
         String label = m.group(1);
 
-        // Apply alias if the extracted label does not directly match the canonical name.
-        String canonical = LABEL_ALIASES.getOrDefault(label, label);
-
-        if (KNOWN_PROVIDERS.contains(canonical)) {
-            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, canonical);
-            return canonical;
+        if (KNOWN_PROVIDERS.contains(label)) {
+            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, label);
+            return label;
         }
 
         log.debug("Host-style provider '{}' extracted label '{}' not in known providers, leaving unchanged",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -18,9 +18,10 @@ import java.util.regex.Pattern;
  * When an OpenAI-compatible SDK is pointed at a provider via its base URL, some
  * instrumentations emit the host in {@code gen_ai.system} rather than the canonical
  * LiteLLM provider name. {@code CostService.findModelPrice} keys on the canonical name,
- * so the lookup fails and the span is billed at zero. This resolver strips the
- * {@code api.} prefix and public-suffix tail from hostnames whose second-level domain
- * label matches a known canonical provider, replacing the host with the canonical name.
+ * so the lookup fails and the span is billed at zero. This resolver normalizes host-style
+ * values to canonical provider names via two paths: an exact host-alias map for hosts whose
+ * second-level domain label differs from the canonical name (e.g. {@code api.x.ai} → {@code xai}),
+ * and a second-level domain label match for hosts whose label directly equals a known provider.
  * <p>
  * Only providers already registered in {@code CostService.PROVIDERS_MAPPING} are
  * recognized. Unknown hosts are returned unchanged.
@@ -29,7 +30,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class HostProviderResolver {
 
-    // Matches optional "api." prefix + label + optional ".tld" (e.g. "api.cerebras.ai" or "api.x.ai")
+    // Matches optional "api." prefix + label + required ".tld" (e.g. "api.cerebras.ai" or "api.x.ai")
     private static final Pattern HOST_PATTERN = Pattern.compile(
             "^(?:api\\.)?([a-z0-9][a-z0-9_-]*)(?:\\.[a-z]{2,})$",
             Pattern.CASE_INSENSITIVE);
@@ -54,8 +55,8 @@ public class HostProviderResolver {
     );
 
     // Full-host aliases for providers whose canonical name cannot be inferred from the
-    // second-level domain label alone. Keyed on the normalized hostname (lower-case,
-    // with or without the "api." prefix stripped). Only exact-match entries are applied.
+    // second-level domain label alone. Keyed on the full normalized hostname (lower-case);
+    // both "api.provider.tld" and "provider.tld" forms are registered as separate explicit keys.
     private static final java.util.Map<String, String> HOST_ALIASES = java.util.Map.of(
             "api.x.ai", "xai",
             "x.ai", "xai"

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -32,8 +32,7 @@ public class HostProviderResolver {
 
     // Matches optional "api." prefix + label + required ".tld" (e.g. "api.cerebras.ai" or "api.x.ai")
     private static final Pattern HOST_PATTERN = Pattern.compile(
-            "^(?:api\\.)?([a-z0-9][a-z0-9_-]*)(?:\\.[a-z]{2,})$",
-            Pattern.CASE_INSENSITIVE);
+            "^(?:api\\.)?([a-z0-9][a-z0-9_-]*)(?:\\.[a-z]{2,})$");
 
     // Canonical provider names that are known to use host-style identifiers.
     // Only list providers that appear in CostService.PROVIDERS_MAPPING and are

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -52,6 +52,12 @@ public class HostProviderResolver {
             "inception"
     );
 
+    // Aliases for host labels that do not match the canonical provider name directly.
+    // For example, api.x.ai extracts the label "x" but the canonical provider is "xai".
+    private static final java.util.Map<String, String> LABEL_ALIASES = java.util.Map.of(
+            "x", "xai"
+    );
+
     /**
      * If {@code provider} looks like a hostname whose extracted label matches a known
      * canonical provider, return the canonical name. Otherwise return {@code provider}
@@ -79,9 +85,13 @@ public class HostProviderResolver {
         }
 
         String label = m.group(1);
-        if (KNOWN_PROVIDERS.contains(label)) {
-            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, label);
-            return label;
+
+        // Apply alias if the extracted label does not directly match the canonical name.
+        String canonical = LABEL_ALIASES.getOrDefault(label, label);
+
+        if (KNOWN_PROVIDERS.contains(canonical)) {
+            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, canonical);
+            return canonical;
         }
 
         log.debug("Host-style provider '{}' extracted label '{}' not in known providers, leaving unchanged",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -1,0 +1,91 @@
+package com.comet.opik.domain.mapping.otel;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Normalizes OTel spans that report a provider host (e.g. {@code api.cerebras.ai},
+ * {@code api.x.ai}, {@code api.deepseek.com}) instead of the canonical provider name.
+ * <p>
+ * When an OpenAI-compatible SDK is pointed at a provider via its base URL, some
+ * instrumentations emit the host in {@code gen_ai.system} rather than the canonical
+ * LiteLLM provider name. {@code CostService.findModelPrice} keys on the canonical name,
+ * so the lookup fails and the span is billed at zero. This resolver strips the
+ * {@code api.} prefix and public-suffix tail from hostnames whose second-level domain
+ * label matches a known canonical provider, replacing the host with the canonical name.
+ * <p>
+ * Only providers already registered in {@code CostService.PROVIDERS_MAPPING} are
+ * recognized. Unknown hosts are returned unchanged.
+ */
+@UtilityClass
+@Slf4j
+public class HostProviderResolver {
+
+    // Matches optional "api." prefix + label + optional ".tld" (e.g. "api.cerebras.ai" or "api.x.ai")
+    private static final Pattern HOST_PATTERN = Pattern.compile(
+            "^(?:api\\.)?([a-z0-9][a-z0-9_-]*)(?:\\.[a-z]{2,})$",
+            Pattern.CASE_INSENSITIVE);
+
+    // Canonical provider names that are known to use host-style identifiers.
+    // Only list providers that appear in CostService.PROVIDERS_MAPPING and are
+    // observed to emit host-style gen_ai.system values.
+    private static final Set<String> KNOWN_PROVIDERS = Set.of(
+            "cerebras",
+            "groq",
+            "nebius",
+            "sambanova",
+            "perplexity",
+            "mistral",
+            "fireworks_ai",
+            "deepseek",
+            "xai",
+            "moonshot",
+            "ai21",
+            "morph",
+            "inception"
+    );
+
+    /**
+     * If {@code provider} looks like a hostname whose extracted label matches a known
+     * canonical provider, return the canonical name. Otherwise return {@code provider}
+     * unchanged.
+     *
+     * @param provider the raw provider string from the OTel span
+     * @param metadata span metadata (unused here but kept for API symmetry with other resolvers)
+     * @return canonical provider name, or the original {@code provider}
+     */
+    public static String resolve(String provider, ObjectNode metadata) {
+        if (StringUtils.isBlank(provider)) {
+            return provider;
+        }
+
+        String normalized = provider.toLowerCase(Locale.ROOT).trim();
+
+        // Fast-path: if it does not contain a dot it cannot be a host
+        if (!normalized.contains(".")) {
+            return provider;
+        }
+
+        Matcher m = HOST_PATTERN.matcher(normalized);
+        if (!m.matches()) {
+            return provider;
+        }
+
+        String label = m.group(1);
+        if (KNOWN_PROVIDERS.contains(label)) {
+            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, label);
+            return label;
+        }
+
+        log.debug("Host-style provider '{}' extracted label '{}' not in known providers, leaving unchanged",
+                provider, label);
+        return provider;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -85,7 +85,7 @@ public class HostProviderResolver {
         // These cover cases where the SLD label alone is ambiguous (e.g. "x" in "api.x.ai").
         String hostAlias = HOST_ALIASES.get(normalized);
         if (hostAlias != null) {
-            log.debug("Resolved host-style provider '{}' to canonical '{}' via host alias", provider, hostAlias);
+            log.debug("Resolved host-style provider: provider='{}' canonical='{}'", provider, hostAlias);
             return hostAlias;
         }
 
@@ -97,12 +97,11 @@ public class HostProviderResolver {
         String label = m.group(1);
 
         if (KNOWN_PROVIDERS.contains(label)) {
-            log.debug("Resolved host-style provider '{}' to canonical '{}'", provider, label);
+            log.debug("Resolved host-style provider: provider='{}' canonical='{}'", provider, label);
             return label;
         }
 
-        log.debug("Host-style provider '{}' extracted label '{}' not in known providers, leaving unchanged",
-                provider, label);
+        log.debug("Host-style provider not recognized: provider='{}' label='{}'", provider, label);
         return provider;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/HostProviderResolver.java
@@ -5,6 +5,7 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import javax.annotation.Nullable;
 import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -69,7 +70,7 @@ public class HostProviderResolver {
      * @param metadata span metadata (unused here but kept for API symmetry with other resolvers)
      * @return canonical provider name, or the original {@code provider}
      */
-    public static String resolve(String provider, ObjectNode metadata) {
+    public static @Nullable String resolve(@Nullable String provider, ObjectNode metadata) {
         if (StringUtils.isBlank(provider)) {
             return provider;
         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1539,24 +1539,15 @@ class OpenTelemetryMapperTest {
             return spanBuilder.build();
         }
 
-        @Test
-        void apiCerebrasHostNormalizedToCerebras() {
-            assertThat(mapWithProvider("api.cerebras.ai").provider()).isEqualTo("cerebras");
-        }
-
-        @Test
-        void apiXAiHostNormalizedToXai() {
-            assertThat(mapWithProvider("api.x.ai").provider()).isEqualTo("xai");
-        }
-
-        @Test
-        void unknownHostPassesThroughUnchanged() {
-            assertThat(mapWithProvider("api.unknownvendor.io").provider()).isEqualTo("api.unknownvendor.io");
-        }
-
-        @Test
-        void canonicalProviderNamePassesThroughUnchanged() {
-            assertThat(mapWithProvider("openai").provider()).isEqualTo("openai");
+        @ParameterizedTest(name = "{0} -> {1}")
+        @CsvSource({
+            "api.cerebras.ai,      cerebras",
+            "api.x.ai,             xai",
+            "api.unknownvendor.io, api.unknownvendor.io",
+            "openai,               openai",
+        })
+        void hostProviderResolution(String input, String expected) {
+            assertThat(mapWithProvider(input).provider()).isEqualTo(expected.trim());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1515,6 +1515,52 @@ class OpenTelemetryMapperTest {
     }
 
     /**
+     * Host-style {@code gen_ai.system} values (e.g. {@code api.cerebras.ai}) emitted by
+     * OpenAI-compatible SDKs must be normalized to the canonical provider so cost lookup works.
+     */
+    @Nested
+    class HostProviderResolution {
+
+        private com.comet.opik.api.Span mapWithProvider(String genAiSystem) {
+            var attributes = new java.util.ArrayList<KeyValue>();
+            attributes.add(KeyValue.newBuilder()
+                    .setKey("gen_ai.system")
+                    .setValue(AnyValue.newBuilder().setStringValue(genAiSystem))
+                    .build());
+
+            var spanBuilder = com.comet.opik.api.Span.builder()
+                    .id(java.util.UUID.randomUUID())
+                    .traceId(java.util.UUID.randomUUID())
+                    .projectId(java.util.UUID.randomUUID())
+                    .startTime(java.time.Instant.now());
+
+            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, null, null);
+
+            return spanBuilder.build();
+        }
+
+        @Test
+        void apiCerebrasHostNormalizedToCerebras() {
+            assertThat(mapWithProvider("api.cerebras.ai").provider()).isEqualTo("cerebras");
+        }
+
+        @Test
+        void apiXAiHostNormalizedToXai() {
+            assertThat(mapWithProvider("api.x.ai").provider()).isEqualTo("xai");
+        }
+
+        @Test
+        void unknownHostPassesThroughUnchanged() {
+            assertThat(mapWithProvider("api.unknownvendor.io").provider()).isEqualTo("api.unknownvendor.io");
+        }
+
+        @Test
+        void canonicalProviderNamePassesThroughUnchanged() {
+            assertThat(mapWithProvider("openai").provider()).isEqualTo("openai");
+        }
+    }
+
+    /**
      * Failed spans must surface as Opik errors. Both OTel-core signals are covered: the
      * {@code exception} span event and a {@code STATUS_CODE_ERROR} status.
      */

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
@@ -32,6 +32,17 @@ class HostProviderResolverTest {
     }
 
     @Nested
+    @DisplayName("Aliased labels (host label differs from canonical name)")
+    class AliasedLabels {
+
+        @Test
+        void api_x_ai_resolves_to_xai_via_alias() {
+            // "api.x.ai" extracts label "x" which aliases to canonical "xai"
+            assertThat(HostProviderResolver.resolve("api.x.ai", null)).isEqualTo("xai");
+        }
+    }
+
+    @Nested
     @DisplayName("Known providers without api. prefix")
     class KnownProvidersWithoutApiPrefix {
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
@@ -1,0 +1,99 @@
+package com.comet.opik.domain.mapping.otel;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("HostProviderResolver")
+class HostProviderResolverTest {
+
+    @Nested
+    @DisplayName("Known providers with api. prefix")
+    class KnownProvidersWithApiPrefix {
+
+        @ParameterizedTest(name = "{0} -> {1}")
+        @CsvSource({
+            "api.cerebras.ai,   cerebras",
+            "api.x.ai,          xai",
+            "api.deepseek.com,  deepseek",
+            "api.groq.com,      groq",
+            "api.perplexity.ai, perplexity",
+            "api.mistral.ai,    mistral",
+            "api.ai21.com,      ai21",
+        })
+        void resolves_api_prefixed_host_to_canonical(String host, String expected) {
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
+        }
+    }
+
+    @Nested
+    @DisplayName("Known providers without api. prefix")
+    class KnownProvidersWithoutApiPrefix {
+
+        @ParameterizedTest(name = "{0} -> {1}")
+        @CsvSource({
+            "cerebras.ai, cerebras",
+            "groq.com,    groq",
+        })
+        void resolves_bare_host_to_canonical(String host, String expected) {
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
+        }
+    }
+
+    @Nested
+    @DisplayName("Already canonical providers pass through unchanged")
+    class CanonicalProvidersPassThrough {
+
+        @ParameterizedTest(name = "''{0}'' unchanged")
+        @ValueSource(strings = {"openai", "anthropic", "bedrock", "groq", "cerebras", "xai", "deepseek"})
+        void canonical_name_is_returned_unchanged(String provider) {
+            assertThat(HostProviderResolver.resolve(provider, null)).isEqualTo(provider);
+        }
+    }
+
+    @Nested
+    @DisplayName("Unknown or unrecognized hosts pass through unchanged")
+    class UnknownHostsPassThrough {
+
+        @ParameterizedTest(name = "''{0}'' unchanged")
+        @ValueSource(strings = {
+            "api.unknown-llm.com",
+            "api.somevendor.io",
+            "internal.company.host",
+        })
+        void unknown_host_is_returned_unchanged(String host) {
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(host);
+        }
+
+        @Test
+        void null_provider_returns_null() {
+            assertThat(HostProviderResolver.resolve(null, null)).isNull();
+        }
+
+        @Test
+        void blank_provider_returns_blank() {
+            assertThat(HostProviderResolver.resolve("  ", null)).isEqualTo("  ");
+        }
+
+        @Test
+        void no_dot_returns_unchanged() {
+            assertThat(HostProviderResolver.resolve("justlabel", null)).isEqualTo("justlabel");
+        }
+    }
+
+    @Nested
+    @DisplayName("Case insensitivity")
+    class CaseInsensitivity {
+
+        @ParameterizedTest(name = "{0} -> cerebras")
+        @ValueSource(strings = {"API.CEREBRAS.AI", "Api.Cerebras.Ai", "API.cerebras.AI"})
+        void case_insensitive_match(String host) {
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo("cerebras");
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
@@ -18,16 +18,15 @@ class HostProviderResolverTest {
 
         @ParameterizedTest(name = "{0} -> {1}")
         @CsvSource({
-            "api.cerebras.ai,   cerebras",
-            "api.x.ai,          xai",
-            "api.deepseek.com,  deepseek",
-            "api.groq.com,      groq",
+            "api.cerebras.ai, cerebras",
+            "api.deepseek.com, deepseek",
+            "api.groq.com, groq",
             "api.perplexity.ai, perplexity",
-            "api.mistral.ai,    mistral",
-            "api.ai21.com,      ai21",
+            "api.mistral.ai, mistral",
+            "api.ai21.com, ai21",
         })
         void resolvesApiPrefixedHostToCanonical(String host, String expected) {
-            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected);
         }
     }
 
@@ -37,14 +36,15 @@ class HostProviderResolverTest {
 
         @ParameterizedTest(name = "{0} -> {1}")
         @CsvSource({
-            // Both "api." and bare forms must resolve via the HOST_ALIASES map
-            "x.ai,          xai",
+            // api.x.ai and x.ai resolve via HOST_ALIASES (label "x" alone is ambiguous)
+            "api.x.ai, xai",
+            "x.ai, xai",
             // Unrelated TLDs must NOT match the alias — only exact hosts are mapped
             "api.x.example, api.x.example",
-            "x.example,     x.example",
+            "x.example, x.example",
         })
         void hostAliasResolution(String host, String expected) {
-            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected);
         }
     }
 
@@ -55,21 +55,25 @@ class HostProviderResolverTest {
         @ParameterizedTest(name = "{0} -> {1}")
         @CsvSource({
             "cerebras.ai, cerebras",
-            "groq.com,    groq",
+            "groq.com, groq",
         })
         void resolvesBareHostToCanonical(String host, String expected) {
-            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected);
         }
     }
 
     @Nested
-    @DisplayName("Already canonical providers pass through unchanged")
-    class CanonicalProvidersPassThrough {
+    @DisplayName("Original casing is preserved for unresolved providers")
+    class CasePreservation {
 
-        @ParameterizedTest(name = "''{0}'' unchanged")
-        @ValueSource(strings = {"openai", "anthropic", "bedrock", "groq", "cerebras", "xai", "deepseek"})
-        void canonicalNameIsReturnedUnchanged(String provider) {
-            assertThat(HostProviderResolver.resolve(provider, null)).isEqualTo(provider);
+        @Test
+        void nonMatchingProviderReturnedWithOriginalCasing() {
+            assertThat(HostProviderResolver.resolve("SomeUnknownProvider", null)).isEqualTo("SomeUnknownProvider");
+        }
+
+        @Test
+        void unknownHostReturnedWithOriginalCasing() {
+            assertThat(HostProviderResolver.resolve("api.SomeUnknown.com", null)).isEqualTo("api.SomeUnknown.com");
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
@@ -26,7 +26,7 @@ class HostProviderResolverTest {
             "api.mistral.ai,    mistral",
             "api.ai21.com,      ai21",
         })
-        void resolves_api_prefixed_host_to_canonical(String host, String expected) {
+        void resolvesApiPrefixedHostToCanonical(String host, String expected) {
             assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
         }
     }
@@ -35,20 +35,16 @@ class HostProviderResolverTest {
     @DisplayName("Full-host aliases (host whose label alone is ambiguous)")
     class HostAliases {
 
-        @Test
-        void apiXAiResolvesToXaiViaAlias() {
-            assertThat(HostProviderResolver.resolve("api.x.ai", null)).isEqualTo("xai");
-        }
-
-        @Test
-        void xAiResolvesToXaiViaAlias() {
-            assertThat(HostProviderResolver.resolve("x.ai", null)).isEqualTo("xai");
-        }
-
-        @Test
-        void apiXExampleDoesNotMatchXaiAlias() {
-            // "api.x.example" should NOT become "xai" — only exact host aliases apply
-            assertThat(HostProviderResolver.resolve("api.x.example", null)).isEqualTo("api.x.example");
+        @ParameterizedTest(name = "{0} -> {1}")
+        @CsvSource({
+            // Both "api." and bare forms must resolve via the HOST_ALIASES map
+            "x.ai,          xai",
+            // Unrelated TLDs must NOT match the alias — only exact hosts are mapped
+            "api.x.example, api.x.example",
+            "x.example,     x.example",
+        })
+        void hostAliasResolution(String host, String expected) {
+            assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
         }
     }
 
@@ -61,7 +57,7 @@ class HostProviderResolverTest {
             "cerebras.ai, cerebras",
             "groq.com,    groq",
         })
-        void resolves_bare_host_to_canonical(String host, String expected) {
+        void resolvesBareHostToCanonical(String host, String expected) {
             assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(expected.trim());
         }
     }
@@ -72,7 +68,7 @@ class HostProviderResolverTest {
 
         @ParameterizedTest(name = "''{0}'' unchanged")
         @ValueSource(strings = {"openai", "anthropic", "bedrock", "groq", "cerebras", "xai", "deepseek"})
-        void canonical_name_is_returned_unchanged(String provider) {
+        void canonicalNameIsReturnedUnchanged(String provider) {
             assertThat(HostProviderResolver.resolve(provider, null)).isEqualTo(provider);
         }
     }
@@ -87,7 +83,7 @@ class HostProviderResolverTest {
             "api.somevendor.io",
             "internal.company.host",
         })
-        void unknown_host_is_returned_unchanged(String host) {
+        void unknownHostIsReturnedUnchanged(String host) {
             assertThat(HostProviderResolver.resolve(host, null)).isEqualTo(host);
         }
 
@@ -113,7 +109,7 @@ class HostProviderResolverTest {
 
         @ParameterizedTest(name = "{0} -> cerebras")
         @ValueSource(strings = {"API.CEREBRAS.AI", "Api.Cerebras.Ai", "API.cerebras.AI"})
-        void case_insensitive_match(String host) {
+        void caseInsensitiveMatch(String host) {
             assertThat(HostProviderResolver.resolve(host, null)).isEqualTo("cerebras");
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mapping/otel/HostProviderResolverTest.java
@@ -32,13 +32,23 @@ class HostProviderResolverTest {
     }
 
     @Nested
-    @DisplayName("Aliased labels (host label differs from canonical name)")
-    class AliasedLabels {
+    @DisplayName("Full-host aliases (host whose label alone is ambiguous)")
+    class HostAliases {
 
         @Test
-        void api_x_ai_resolves_to_xai_via_alias() {
-            // "api.x.ai" extracts label "x" which aliases to canonical "xai"
+        void apiXAiResolvesToXaiViaAlias() {
             assertThat(HostProviderResolver.resolve("api.x.ai", null)).isEqualTo("xai");
+        }
+
+        @Test
+        void xAiResolvesToXaiViaAlias() {
+            assertThat(HostProviderResolver.resolve("x.ai", null)).isEqualTo("xai");
+        }
+
+        @Test
+        void apiXExampleDoesNotMatchXaiAlias() {
+            // "api.x.example" should NOT become "xai" — only exact host aliases apply
+            assertThat(HostProviderResolver.resolve("api.x.example", null)).isEqualTo("api.x.example");
         }
     }
 


### PR DESCRIPTION
## Summary

OTel spans from OpenAI-compatible SDKs sometimes report the provider as the API host (e.g. \`api.cerebras.ai\`, \`api.x.ai\`, \`api.deepseek.com\`) rather than the canonical LiteLLM name. \`CostService.findModelPrice\` keys on the canonical name, so those spans were billed at zero with no error — cost tracking and per-evaluation spend budgets silently under-reported.

**Changes:**

- **\`HostProviderResolver\`** (new) — follows the \`GoogleProviderResolver\` \`@UtilityClass\` pattern. Strips the \`api.\` prefix and public-suffix tail from hostnames; returns the canonical provider name if the extracted label matches a known entry in \`PROVIDERS_MAPPING\`. Unknown hosts pass through unchanged.
- **\`OpenTelemetryMapper\`** — wires \`HostProviderResolver\` after the EIS and Google resolvers.
- **\`CostService\`** — adds \`cerebras\` to \`PROVIDERS_MAPPING\` (was referenced in the issue repro but missing from the map).

No new price data changes beyond the cerebras registration; all other providers were already registered.

## Test plan

- [x] \`HostProviderResolverTest\` — unit tests: known providers with/without api. prefix, canonical names unchanged, unknown hosts unchanged, null/blank, case insensitivity
- [x] \`OpenTelemetryMapperTest\` — integration tests: \`api.cerebras.ai\` → \`cerebras\`, \`api.x.ai\` → \`xai\`, unknown host unchanged, canonical provider unchanged
- [x] All KNOWN_PROVIDERS verified present in PROVIDERS_MAPPING

Fixes #7772