### PR TITLE
docs: weekly changelog update (2026-08-10)

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-07-13.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-07-13.mdx
@@ -1,0 +1,45 @@
+## Per-Evaluation Spend Budget for LLM-as-Judge Evaluators
+
+Online LLM-as-judge scoring rules for traces and threads can now be given a **Max cost per evaluation (USD)** budget. Once an evaluation's cumulative spend crosses the limit, the agentic scoring loop stops starting new tool-calling turns and returns a best-effort verdict from whatever evidence it has already gathered, instead of continuing to spend without bound. The monitoring trace for a capped run is tagged `budget_exceeded` so you can tell a budget-limited verdict apart from a fully-investigated one. The field is hidden for span-scope rules, since a single LLM call has no loop to cap.
+
+## Optimization Runs: New-Run Sidebar & Redesigned List
+
+Starting a new optimization run no longer navigates away from the runs list: the "New optimization run" form now opens as a side panel over the list (via the list's `?new` — or `?template` / `?rerun` — parameter) so you can start, clone, or re-run an optimization without losing your place. The runs list itself has a new **Item source** column (the same reusable cell used on the Experiments page), Run ID / Algorithm / Metric columns available to add, and the "Pruned" trial status is now labeled **Discarded** for clarity.
+
+## Bug Fixes & Improvements
+
+- **Diagnostics: clearer failure copy and working billing link** — Follow-ups to last week's Diagnostics failure reasons: a permission-denied run failure now shows explanatory copy instead of a generic message, and the "View billing" link in the failure dialog now opens the right settings page.
+
+- **Claude Agent SDK / Claude Code traces now show real input/output** — Spans emitted by the Claude Agent SDK and Claude Code carried their prompt, tool, and response content on attributes that no mapping rule recognized, so everything fell into a generic attribute bag instead of the trace's input/output fields. These spans are now mapped correctly, and model/provider are set so cost is calculated instead of showing as $0.
+
+- **New: Mistral AI Python integration (`track_mistral`)** — A native integration for the `mistralai` Python SDK: wrap a client with `track_mistral(client)` to trace `chat.complete`/`chat.complete_async` and `chat.stream`/`stream_async` calls (including structured-output `parse` calls and streamed responses aggregated into a single span), with input, output, token usage, and cost captured automatically.
+
+- **`opik migrate dataset` can resume after an interruption** — A crash, network drop, or OOM during `opik migrate dataset` used to mean starting over. Progress now checkpoints after each completed experiment, so a re-run picks up where it left off, and the source dataset keeps its original name until the destination copy is fully verified — a failed run leaves only a discardable temporary copy behind rather than a renamed source.
+
+- **`opik migrate dataset` no longer runs out of memory on large datasets** — The migration's read path could request full-fidelity pages large enough to exhaust the process's memory and get killed mid-run. Reads are now paged more conservatively, with an automatic page-size shrink on read timeouts/connection errors.
+
+- **`opik export`/`opik import` preserve tags for prompts, experiments, and datasets** — Tags on prompts, experiments, and datasets were silently dropped when exporting or importing via the CLI (traces and spans already round-tripped correctly). All four entity types now preserve tags end-to-end.
+
+- **`opik export ... all` no longer runs out of memory on large projects** — Exporting a project used to buffer every trace and span in memory before writing anything, so peak memory scaled with project size. Export now processes traces in bounded chunks, flushing and discarding each chunk as it's written, and an interrupted export resumes mid-project instead of restarting.
+
+- **Fixed duplicate rows in the test suite detail view** — Editing a dataset item could cause its experiment result to render multiple times in the test suite detail view, due to a join that matched more than one dataset-item version per item.
+
+- **Prompt names are now unique per project instead of per workspace** — Two prompts with the same name in different projects no longer conflict.
+
+- **Custom metrics fail loudly on an unresolvable reference key** — An `equals`/`levenshtein_ratio`/`numerical_similarity` metric configured with a reference key that matches no dataset field used to silently score every item 0, making a broken metric indistinguishable from a genuinely low-scoring run. This now raises a clear error at build time listing the available fields, and a per-item missing value is scored 0 with an explicit "Missing reference value" reason instead of a spurious perfect match.
+
+- **Fixed cost calculation for the highest LiteLLM pricing tiers** — Models with `above_128k_tokens` (e.g. Gemini 1.5 Flash) or `above_272k_tokens` (e.g. the GPT-5.4/5.5 family and their Azure-hosted equivalents) pricing tiers were being undercharged, since only the `above_200k_tokens` tier was applied. All published tiers are now taken into account.
+
+- **Fixed an outbound gzip decompression error** — Self-hosted deployments with `jerseyClient.gzipEnabled: true` could hit `ZipException: Not in GZIP format` on outbound calls that read a gzip-encoded response body (for example, some Ollama responses), because the response was decompressed twice. The stale `Content-Encoding` header is now stripped after the first decode.
+
+## Performance Improvements
+
+- **Faster Logs page loads on large projects** — The Traces/Spans/Threads "log your first trace" onboarding check used to run a full project-wide aggregation query just to see if any row existed. It now uses a minimal existence check, removing a multi-second scan from every Logs page load.
+
+- **Reduced full-table scans in dataset and experiment queries** — Several ClickHouse queries backing dataset-item filters and experiment views scanned far more data than needed — in one case, an experiment/dataset-item filter query read 75x fewer granules after being scoped to the relevant experiment's trace IDs instead of the whole workspace. These queries now carry tighter project/trace-id/workspace bounds, reducing ClickHouse load on large workspaces.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.1.15...2.1.22)
+
+_Releases_: `2.1.16`, `2.1.17`, `2.1.18`, `2.1.19`, `2.1.20`, `2.1.21`, `2.1.22`

--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-07-20.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-07-20.mdx
@@ -1,0 +1,53 @@
+## Redesigned Optimization Run Overview
+
+The single-run page in Optimization Studio has been rebuilt end to end. The header now shows the run's dataset, model, algorithm, and metric as pills (hover the metric pill for its full config), and the KPI cards show the current value, a trend badge, and a baseline → best line, with the duration now measured to actual run completion rather than the last trial's timestamp. The trials progress chart highlights the best trial by default and labels discarded trials clearly instead of the previous "pruned" terminology.
+
+A new **Best trial prompt** panel shows an inline diff of the winning prompt against the baseline, and trial details now open in a right-side panel (Results / Prompt tabs) instead of navigating to a separate page.
+
+## Stuck Optimization Runs Now Recover, and Failures Are Explained
+
+Previously, an optimization run whose worker crashed or lost contact could sit in "Initializing" or "Running" forever with no indication anything was wrong. A background job now detects runs stuck for too long (5 minutes with no worker pickup, or 8 hours still running) and marks them as failed with a system-generated reason written to the run's logs.
+
+Separately, the worker now classifies real failures — auth errors, rate limits, misconfigured datasets/metrics, out-of-memory kills, and more — into a specific, readable message instead of leaving the run to fail silently. Runs that complete but produce no usable scores now show an explicit "No usable scores" warning, including how many items failed to score when that information is available.
+
+## Bug Fixes & Improvements
+
+- **Workspace switcher now matches the projects menu** — The workspace dropdown now groups workspaces into Pinned and Recently visited sections with per-row pin/unpin controls, instead of a single flat list, matching the pattern already used for the projects menu.
+
+- **Mobile web onboarding** — Opening Opik on a phone now shows a short guided walkthrough (what a trace is, how issues get flagged, how to connect your first integration) instead of the desktop quickstart, with an option to email yourself setup instructions.
+
+- **Workspace home now always opens on Projects** — Navigating to a workspace's home URL now consistently lands on the Projects tab, instead of sometimes reopening whichever project you last viewed.
+
+- **Metadata filter dropdown no longer overlaps rows** — Long metadata keys that wrapped onto multiple lines in the filter panel's autocomplete dropdown could visually overlap the option below them; rows now grow to fit the wrapped text.
+
+- **GPT-5.6 models now behave as reasoning models** — `gpt-5.6-luna`, `gpt-5.6-sol`, and `gpt-5.6-terra` were missing from the reasoning-model list, so the Playground and online scoring still tried to send `temperature`, which these models reject. They now show the reasoning-effort selector (including a new **Max** option) instead of temperature/Top P, consistent with other reasoning models.
+
+- **Perplexity model costs now load correctly** — Perplexity was missing from the provider list used to load pricing data, so calls through Perplexity (including the `sonar` model family) were costed at $0. Pricing now loads correctly.
+
+- **Clearer errors from Python-based LLM-as-judge scoring** — A metric evaluation that hit an empty or malformed response from the scoring service previously failed with an opaque server error; it now surfaces the actual underlying error message.
+
+- **Tool-call spans from OpenTelemetry now typed correctly** — Spans carrying the OTel `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` attributes are now classified as **tool** spans in the UI, matching spans tracked directly through the SDK.
+
+- **Fixed intermittent 500s retrieving threads and experiment project lists** — Two endpoints (thread lookup, and listing the projects an experiment spans) could return an unmapped server error when the underlying query legitimately returned more than one row for the same logical entity. Both now handle this correctly.
+
+- **More accurate error codes from LLM providers** — Errors from OpenAI-compatible providers (including calls routed through OpenRouter) were sometimes parsed with the wrong error model, which could turn a rate-limit error into a generic server error. The correct error model is now selected based on the error's shape, so the real status code is surfaced.
+
+- **LangChain integration: cost capture through proxies, and provider override** — `OpikTracer` accepts a new `provider` argument to override provider auto-detection, useful when routing `ChatOpenAI` through a proxy such as LiteLLM. When the proxy reports its own cost via the `x-litellm-response-cost` response header (with `include_response_headers=True` on `ChatOpenAI`), Opik now uses that cost instead of estimating $0.
+
+- **`opik migrate` no longer risks OOM on partially-stale projects** — When a migrated experiment referenced only deleted or timestamp-less traces, the CLI fell back to an unbounded read of the entire project's spans. It now skips the unrecoverable span data for that batch (with a warning) and continues the migration instead of risking an out-of-memory crash.
+
+- **SDK tolerates new OpenAI usage fields and avoids a broken LiteLLM release** — The SDK no longer breaks when OpenAI adds new fields to its usage payload, and the LiteLLM dependency now excludes the `1.92.*` release line, which crashed on import without optional proxy dependencies installed.
+
+- **Dataset and test suite creation logs point to the right project** — The URL logged by the SDK after creating a dataset or test suite now links directly to that resource inside its actual project, instead of a generic link that could resolve to the wrong project.
+
+## Performance Improvements
+
+- **Self-hosted: ClickHouse upgraded to 26.3 LTS** — The bundled ClickHouse instance (Helm chart, docker-compose, and testcontainers) is now pinned to 26.3 LTS. No manual data migration is required, though major-version upgrades may take longer to complete.
+
+- **Self-hosted: ingestion load spreads more evenly across backend pods** — The frontend nginx proxy now recycles its keepalive connections to the backend on a schedule, instead of holding them open indefinitely. On Kubernetes deployments this prevents a small number of backend pods from absorbing a disproportionate share of ingestion traffic while others sit idle.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.1.15...2.2.0)
+
+_Releases_: `2.1.25`, `2.1.26`, `2.1.27`, `2.1.28`, `2.1.29`, `2.1.30`, `2.1.31`, `2.1.32`, `2.2.0`

--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-10.mdx
@@ -1,0 +1,55 @@
+## Build Guardrails from Stored Policies
+
+`Guardrail.from_stored_policies(names=[...])` builds a guardrail directly from named policies stored in your Opik workspace, plus any policy the workspace applies unconditionally. This keeps the checks an application runs configurable from the workspace without a code change or redeploy — the guards of every retrieved policy are checked together as one flat set.
+
+```python
+from opik.guardrails import Guardrail
+
+guardrail = Guardrail.from_stored_policies(names=["no_contact_information"])
+guardrail.validate("Call me at 555-0123")
+```
+
+A stored guard type this SDK version cannot run now raises rather than being silently skipped, since guardrails fail closed and a dropped check would otherwise quietly weaken a policy's protection.
+
+## `evaluate()` Surfaces Metric Failures Instead of Dropping Them
+
+Three cases that previously produced no score and no actionable error are now reported: a metric that doesn't declare `**kwargs` no longer fails on every item with a confusing "unexpected keyword argument" error (inputs are narrowed to what the metric's signature actually accepts), an item-level evaluator with an unsupported type now produces a failed score explaining why instead of being silently skipped, and a `scoring_key_mapping` value that matches nothing is now logged as a warning instead of at debug level.
+
+A new `error_tolerance` argument lets you opt into recording pre-scoring failures — a missing required score argument, or an item-level evaluator that can't be built — as failed score results instead of aborting the whole run and discarding every metric that already succeeded:
+
+```python
+from opik.evaluation import evaluate
+from opik.evaluation.metrics import ErrorTolerance
+
+evaluate(..., error_tolerance=ErrorTolerance.ALL_SCORING_ERRORS)
+```
+
+The default behavior is unchanged. Tolerated failures show up on their own span in the trace, and the chosen tolerance is preserved when resuming an interrupted evaluation.
+
+## Bug Fixes & Improvements
+
+- **`Experiment.batch_upload_items` for bulk experiment creation** — A new method uploads experiment items together with their traces, spans, and feedback scores in a single call, instead of creating traces first and linking them afterward. Items are validated up front, batched to respect backend limits, and retried automatically on rate limiting.
+
+- **Guardrails requests are now authenticated** — The guardrails client was building its own HTTP client instead of going through the SDK's authenticated client factory, so requests to the guardrails backend went out without an `Authorization` header. Since guardrails fail closed, this could cause validations to be rejected and block the protected code path; requests are now sent with proper authentication.
+
+- **Stuck optimization runs are detected within minutes instead of hours** — Following up on the stalled-run detection shipped previously, the reaper now derives liveness from actual trial and item progress rather than only the run's last status change, catching a run orphaned by a worker restart in around an hour instead of up to eight. A run that's still legitimately evaluating items is never mistaken for stalled, a wrongly-flagged run recovers automatically once its worker reports back, and it can now be cancelled instead of being stuck.
+
+- **Nebius and SambaNova model costs now load correctly** — Both providers were missing from the internal provider list used to load pricing data, so calls through Nebius or SambaNova models (including their DeepSeek, Qwen, and Llama catalogs) were costed at $0. Pricing now loads correctly for both.
+
+- **Project lookups no longer leak across workspaces** — Looking up a project by name cached the result under a key that didn't account for the workspace, so switching organizations in the UI without a full page reload could keep resolving a project name to the previous organization's project.
+
+- **Python UDF metric evaluation retries on transient connection drops** — When the Python scoring backend closed its connection before responding, the error wasn't recognized as retriable, so a transient connection drop failed the evaluation outright. These are now retried automatically.
+
+- **More accurate cost and usage on experiments with re-sent spans** — A span re-sent under a different parent span could be counted twice when computing usage and cost rollups for experiments and optimizations. Spans are now deduplicated by their own id, so each span is counted once regardless of how it was re-sent.
+
+## Performance Improvements
+
+- **Faster trace loading for traces with many spans** — Looking up traces by id no longer forces a full deduplication pass (`FINAL`) over the spans table; the query now filters to the relevant trace first and deduplicates only what's left, cutting CPU cost by over 90% on traces with hundreds of spans.
+
+- **Faster project-level trace stats** — The query behind trace statistics on the projects list no longer performs a full blocking sort over every span in a project's history to deduplicate them, so project pages with long-running, high-volume projects load faster.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.2.0...2.2.23)
+
+_Releases_: `2.2.19`, `2.2.20`, `2.2.21`, `2.2.22`, `2.2.23`

--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-10.mdx
@@ -1,16 +1,3 @@
-## Build Guardrails from Stored Policies
-
-`Guardrail.from_stored_policies(names=[...])` builds a guardrail directly from named policies stored in your Opik workspace, plus any policy the workspace applies unconditionally. This keeps the checks an application runs configurable from the workspace without a code change or redeploy — the guards of every retrieved policy are checked together as one flat set.
-
-```python
-from opik.guardrails import Guardrail
-
-guardrail = Guardrail.from_stored_policies(names=["no_contact_information"])
-guardrail.validate("Call me at 555-0123")
-```
-
-A stored guard type this SDK version cannot run now raises rather than being silently skipped, since guardrails fail closed and a dropped check would otherwise quietly weaken a policy's protection.
-
 ## `evaluate()` Surfaces Metric Failures Instead of Dropping Them
 
 Three cases that previously produced no score and no actionable error are now reported: a metric that doesn't declare `**kwargs` no longer fails on every item with a confusing "unexpected keyword argument" error (inputs are narrowed to what the metric's signature actually accepts), an item-level evaluator with an unsupported type now produces a failed score explaining why instead of being silently skipped, and a `scoring_key_mapping` value that matches nothing is now logged as a warning instead of at debug level.
@@ -30,7 +17,6 @@ The default behavior is unchanged. Tolerated failures show up on their own span 
 
 - **`Experiment.batch_upload_items` for bulk experiment creation** — A new method uploads experiment items together with their traces, spans, and feedback scores in a single call, instead of creating traces first and linking them afterward. Items are validated up front, batched to respect backend limits, and retried automatically on rate limiting.
 
-- **Guardrails requests are now authenticated** — The guardrails client was building its own HTTP client instead of going through the SDK's authenticated client factory, so requests to the guardrails backend went out without an `Authorization` header. Since guardrails fail closed, this could cause validations to be rejected and block the protected code path; requests are now sent with proper authentication.
 
 - **Stuck optimization runs are detected within minutes instead of hours** — Following up on the stalled-run detection shipped previously, the reaper now derives liveness from actual trial and item progress rather than only the run's last status change, catching a run orphaned by a worker restart in around an hour instead of up to eight. A run that's still legitimately evaluating items is never mistaken for stalled, a wrongly-flagged run recovers automatically once its worker reports back, and it can now be cancelled instead of being stuck.
 

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-10.mdx
@@ -1,0 +1,59 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog
+---
+
+## Build Guardrails from Stored Policies
+
+`Guardrail.from_stored_policies(names=[...])` builds a guardrail directly from named policies stored in your Opik workspace, plus any policy the workspace applies unconditionally. This keeps the checks an application runs configurable from the workspace without a code change or redeploy — the guards of every retrieved policy are checked together as one flat set.
+
+```python
+from opik.guardrails import Guardrail
+
+guardrail = Guardrail.from_stored_policies(names=["no_contact_information"])
+guardrail.validate("Call me at 555-0123")
+```
+
+A stored guard type this SDK version cannot run now raises rather than being silently skipped, since guardrails fail closed and a dropped check would otherwise quietly weaken a policy's protection.
+
+## `evaluate()` Surfaces Metric Failures Instead of Dropping Them
+
+Three cases that previously produced no score and no actionable error are now reported: a metric that doesn't declare `**kwargs` no longer fails on every item with a confusing "unexpected keyword argument" error (inputs are narrowed to what the metric's signature actually accepts), an item-level evaluator with an unsupported type now produces a failed score explaining why instead of being silently skipped, and a `scoring_key_mapping` value that matches nothing is now logged as a warning instead of at debug level.
+
+A new `error_tolerance` argument lets you opt into recording pre-scoring failures — a missing required score argument, or an item-level evaluator that can't be built — as failed score results instead of aborting the whole run and discarding every metric that already succeeded:
+
+```python
+from opik.evaluation import evaluate
+from opik.evaluation.metrics import ErrorTolerance
+
+evaluate(..., error_tolerance=ErrorTolerance.ALL_SCORING_ERRORS)
+```
+
+The default behavior is unchanged. Tolerated failures show up on their own span in the trace, and the chosen tolerance is preserved when resuming an interrupted evaluation.
+
+## Bug Fixes & Improvements
+
+- **`Experiment.batch_upload_items` for bulk experiment creation** — A new method uploads experiment items together with their traces, spans, and feedback scores in a single call, instead of creating traces first and linking them afterward. Items are validated up front, batched to respect backend limits, and retried automatically on rate limiting.
+
+- **Guardrails requests are now authenticated** — The guardrails client was building its own HTTP client instead of going through the SDK's authenticated client factory, so requests to the guardrails backend went out without an `Authorization` header. Since guardrails fail closed, this could cause validations to be rejected and block the protected code path; requests are now sent with proper authentication.
+
+- **Stuck optimization runs are detected within minutes instead of hours** — Following up on the stalled-run detection shipped previously, the reaper now derives liveness from actual trial and item progress rather than only the run's last status change, catching a run orphaned by a worker restart in around an hour instead of up to eight. A run that's still legitimately evaluating items is never mistaken for stalled, a wrongly-flagged run recovers automatically once its worker reports back, and it can now be cancelled instead of being stuck.
+
+- **Nebius and SambaNova model costs now load correctly** — Both providers were missing from the internal provider list used to load pricing data, so calls through Nebius or SambaNova models (including their DeepSeek, Qwen, and Llama catalogs) were costed at $0. Pricing now loads correctly for both.
+
+- **Project lookups no longer leak across workspaces** — Looking up a project by name cached the result under a key that didn't account for the workspace, so switching organizations in the UI without a full page reload could keep resolving a project name to the previous organization's project.
+
+- **Python UDF metric evaluation retries on transient connection drops** — When the Python scoring backend closed its connection before responding, the error wasn't recognized as retriable, so a transient connection drop failed the evaluation outright. These are now retried automatically.
+
+- **More accurate cost and usage on experiments with re-sent spans** — A span re-sent under a different parent span could be counted twice when computing usage and cost rollups for experiments and optimizations. Spans are now deduplicated by their own id, so each span is counted once regardless of how it was re-sent.
+
+## Performance Improvements
+
+- **Faster trace loading for traces with many spans** — Looking up traces by id no longer forces a full deduplication pass (`FINAL`) over the spans table; the query now filters to the relevant trace first and deduplicates only what's left, cutting CPU cost by over 90% on traces with hundreds of spans.
+
+- **Faster project-level trace stats** — The query behind trace statistics on the projects list no longer performs a full blocking sort over every span in a project's history to deduplicate them, so project pages with long-running, high-volume projects load faster.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.2.0...2.2.23)
+
+_Releases_: `2.2.19`, `2.2.20`, `2.2.21`, `2.2.22`, `2.2.23`

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-10.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-10.mdx
@@ -2,19 +2,6 @@
 canonical-url: https://www.comet.com/docs/opik/changelog
 ---
 
-## Build Guardrails from Stored Policies
-
-`Guardrail.from_stored_policies(names=[...])` builds a guardrail directly from named policies stored in your Opik workspace, plus any policy the workspace applies unconditionally. This keeps the checks an application runs configurable from the workspace without a code change or redeploy — the guards of every retrieved policy are checked together as one flat set.
-
-```python
-from opik.guardrails import Guardrail
-
-guardrail = Guardrail.from_stored_policies(names=["no_contact_information"])
-guardrail.validate("Call me at 555-0123")
-```
-
-A stored guard type this SDK version cannot run now raises rather than being silently skipped, since guardrails fail closed and a dropped check would otherwise quietly weaken a policy's protection.
-
 ## `evaluate()` Surfaces Metric Failures Instead of Dropping Them
 
 Three cases that previously produced no score and no actionable error are now reported: a metric that doesn't declare `**kwargs` no longer fails on every item with a confusing "unexpected keyword argument" error (inputs are narrowed to what the metric's signature actually accepts), an item-level evaluator with an unsupported type now produces a failed score explaining why instead of being silently skipped, and a `scoring_key_mapping` value that matches nothing is now logged as a warning instead of at debug level.
@@ -34,7 +21,6 @@ The default behavior is unchanged. Tolerated failures show up on their own span 
 
 - **`Experiment.batch_upload_items` for bulk experiment creation** — A new method uploads experiment items together with their traces, spans, and feedback scores in a single call, instead of creating traces first and linking them afterward. Items are validated up front, batched to respect backend limits, and retried automatically on rate limiting.
 
-- **Guardrails requests are now authenticated** — The guardrails client was building its own HTTP client instead of going through the SDK's authenticated client factory, so requests to the guardrails backend went out without an `Authorization` header. Since guardrails fail closed, this could cause validations to be rejected and block the protected code path; requests are now sent with proper authentication.
 
 - **Stuck optimization runs are detected within minutes instead of hours** — Following up on the stalled-run detection shipped previously, the reaper now derives liveness from actual trial and item progress rather than only the run's last status change, catching a run orphaned by a worker restart in around an hour instead of up to eight. A run that's still legitimately evaluating items is never mistaken for stalled, a wrongly-flagged run recovers automatically once its worker reports back, and it can now be cancelled instead of being stuck.
 


### PR DESCRIPTION
## Details

Adds this week's changelog entry (`2026-08-10.mdx`), covering the user-facing changes merged since the last documented entry. Also backfills `docs-v2/changelog` with the `2026-07-13` and `2026-07-20` entries — the "Latest" doc version (`versions/latest.yml`) points at `docs-v2/changelog`, but those two weeks had only been added under the legacy `docs/changelog` (`v1`), so they were missing from the live site.

Two top-level features this week:
- **Build Guardrails from Stored Policies** — `Guardrail.from_stored_policies(names=[...])` (Python SDK).
- **`evaluate()` Surfaces Metric Failures Instead of Dropping Them** — plus the new `error_tolerance` argument.

Everything else (new `Experiment.batch_upload_items`, guardrails auth fix, Nebius/SambaNova pricing fixes, cross-workspace project-cache fix, a follow-up to the previously-announced stalled-run detection, a span dedup correctness fix, and two ClickHouse performance fixes) is consolidated into "Bug Fixes & Improvements" / "Performance Improvements", per existing changelog conventions.

Verified against source before writing:
- Confirmed `Guardrail.from_stored_policies` and `Experiment.batch_upload_items` are shipped with no feature flag (`grep` for feature-flag/enabled checks came up empty).
- Confirmed exact API name/signature for both by reading `sdks/python/src/opik/guardrails/guardrail.py` and `sdks/python/src/opik/api_objects/experiment/experiment.py` directly, not just commit messages.
- Cross-checked the stalled-run detection change against the existing `2026-07-20` entry, which already announced the original stuck-run feature — folded this week's follow-up into Bug Fixes rather than giving it a new top-level section.
- Checked prior entries' releases/compare-link footer convention and matched it using the `Update versions to X` bump commits from this week (`2.2.19`–`2.2.23`), continuing from the `2.2.0` compare-link end point in the prior entry.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: Authored the changelog entry content (researched via `git log`/`git show` on this week's commits, cross-referenced against changelog conventions and source code) and the docs-v2 backfill; no application code changed.
- Human verification: Not yet reviewed by a human — opened as draft for review.

## Testing

Documentation-only change (`.mdx` files under `apps/opik-documentation/documentation/fern/docs*/changelog/`). No build/test commands run; verified:
- File diffs against sibling changelog entries to confirm frontmatter/footer format matches (`docs-v2` entries omit the `canonical-url` frontmatter block that `docs` entries carry, confirmed via `diff` against an existing shared-content entry).
- Read the actual SDK source for each API mentioned to confirm names/signatures rather than relying on commit messages/PR titles alone.

## Documentation

This PR *is* the documentation change — new entry at `apps/opik-documentation/documentation/fern/docs/changelog/2026-08-10.mdx` (and its `docs-v2` mirror), plus backfilled `docs-v2/changelog/2026-07-13.mdx` and `docs-v2/changelog/2026-07-20.mdx`.


---
_Generated by [Claude Code](https://claude.ai/code/session_013bWQQTfRxyAcenvrGdETKj)_