### PR TITLE
feat(cost): derive provider set from price file, keep only genuine aliases

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -226,13 +226,16 @@ public class CostService {
             String modelPrefix = originalModelName.substring(0, prefixSlash);
             String canonicalFromPrefix = PROVIDER_ALIASES.getOrDefault(modelPrefix, modelPrefix);
             if (canonicalFromPrefix != null && !canonicalFromPrefix.equalsIgnoreCase(provider)) {
-                String prefixKey = createModelProviderKey(modelName, canonicalFromPrefix);
-                ModelPrice prefixMatch = modelProviderPrices.get(prefixKey);
-                if (prefixMatch != null) {
-                    log.debug(
-                            "Found model price using model-name provider prefix. Original model: '{}', supplied provider: '{}', prefix-derived provider: '{}'",
-                            originalModelName, provider, canonicalFromPrefix);
-                    return prefixMatch;
+                for (String candidate : new String[]{modelName, normalizedModelName, baseOriginalModelName,
+                        baseNormalizedModelName, baseOriginalVersionName, baseNormalizedVersionName}) {
+                    ModelPrice prefixMatch = modelProviderPrices
+                            .get(createModelProviderKey(candidate, canonicalFromPrefix));
+                    if (prefixMatch != null) {
+                        log.debug(
+                                "Found model price using model-name provider prefix. Original model: '{}', supplied provider: '{}', prefix-derived provider: '{}'",
+                                originalModelName, provider, canonicalFromPrefix);
+                        return prefixMatch;
+                    }
                 }
             }
         }
@@ -408,7 +411,7 @@ public class CostService {
      */
     private static String buildRuntimeKey(String modelName, ModelCostData modelCost) {
         String provider = Optional.ofNullable(modelCost.litellmProvider()).orElse("");
-        if (provider.isEmpty()) {
+        if (provider.isBlank()) {
             return null;
         }
         String canonical = PROVIDER_ALIASES.getOrDefault(provider, provider);
@@ -420,11 +423,11 @@ public class CostService {
 
     private static ModelPrice buildModelPrice(ModelCostData modelCost) {
         String provider = Optional.ofNullable(modelCost.litellmProvider()).orElse("");
-        if (provider.isEmpty()) {
+        if (provider.isBlank()) {
             return null;
         }
         // Resolve alias; unknown providers use their own name as canonical.
-        provider = PROVIDER_ALIASES.getOrDefault(provider, provider);
+        String canonicalProvider = PROVIDER_ALIASES.getOrDefault(provider, provider);
 
         BigDecimal inputPrice = Optional.ofNullable(modelCost.inputCostPerToken()).map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -225,7 +225,7 @@ public class CostService {
         if (prefixSlash > 0) {
             String modelPrefix = originalModelName.substring(0, prefixSlash);
             String canonicalFromPrefix = PROVIDER_ALIASES.getOrDefault(modelPrefix, modelPrefix);
-            if (canonicalFromPrefix != null && !canonicalFromPrefix.equalsIgnoreCase(provider)) {
+            if (!canonicalFromPrefix.equalsIgnoreCase(provider)) {
                 for (String candidate : new String[]{modelName, normalizedModelName, baseOriginalModelName,
                         baseNormalizedModelName, baseOriginalVersionName, baseNormalizedVersionName}) {
                     ModelPrice prefixMatch = modelProviderPrices
@@ -392,7 +392,7 @@ public class CostService {
     private static void applyDirectOverride(Map<String, ModelPrice> prices, String modelName, ModelCostData override) {
         String runtimeKey = buildRuntimeKey(modelName, override);
         if (runtimeKey == null) {
-            log.warn("Override entry '{}' has unknown provider '{}'; skipping",
+            log.warn("Override entry '{}' skipped: provider '{}' is blank or resolves to a legacy Bedrock path",
                     modelName, override.litellmProvider());
             return;
         }
@@ -426,9 +426,6 @@ public class CostService {
         if (provider.isBlank()) {
             return null;
         }
-        // Resolve alias; unknown providers use their own name as canonical.
-        String canonicalProvider = PROVIDER_ALIASES.getOrDefault(provider, provider);
-
         BigDecimal inputPrice = Optional.ofNullable(modelCost.inputCostPerToken()).map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);
         BigDecimal outputPrice = Optional.ofNullable(modelCost.outputCostPerToken()).map(BigDecimal::new)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -39,8 +39,7 @@ public class CostService {
             Map.entry("bedrock_converse", "bedrock"),
             Map.entry("microsoft", "azure"),
             Map.entry("moonshotai", "moonshot"),
-            Map.entry("z-ai", "zai"),
-            Map.entry("cerebras", "cerebras"));
+            Map.entry("z-ai", "zai"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -27,36 +27,20 @@ import java.util.function.BiFunction;
 public class CostService {
     private static final char MODEL_PROVIDER_SEPARATOR = '/';
     private static final Map<String, ModelPrice> modelProviderPrices;
-    private static final Map<String, String> PROVIDERS_MAPPING = Map.ofEntries(
-            Map.entry("openai", "openai"),
+    // Alias table: maps litellm_provider values to the canonical provider name used as the
+    // price-map key. Only entries where the names genuinely differ are needed; providers whose
+    // litellm_provider value already equals the canonical name are handled automatically by the
+    // identity fallback in buildRuntimeKey / buildModelPrice (any provider present in the price
+    // file is priced; only the aliases below need explicit entries).
+    private static final Map<String, String> PROVIDER_ALIASES = Map.ofEntries(
             Map.entry("vertex_ai-language-models", "google_vertexai"),
             Map.entry("gemini", "google_ai"),
-            Map.entry("anthropic", "anthropic"),
             Map.entry("vertex_ai-anthropic_models", "anthropic_vertexai"),
-            Map.entry("bedrock", "bedrock"),
             Map.entry("bedrock_converse", "bedrock"),
-            Map.entry("groq", "groq"),
-            Map.entry("jina_ai", "jina_ai"),
-            Map.entry("elastic", "elastic"),
             Map.entry("microsoft", "azure"),
-            Map.entry("azure", "azure"),
-            Map.entry("mistral", "mistral"),
-            Map.entry("xai", "xai"),
-            Map.entry("deepseek", "deepseek"),
-            Map.entry("perplexity", "perplexity"),
-            Map.entry("fireworks_ai", "fireworks_ai"),
-            Map.entry("moonshot", "moonshot"),
             Map.entry("moonshotai", "moonshot"),
-            Map.entry("ai21", "ai21"),
-            Map.entry("morph", "morph"),
-            Map.entry("inception", "inception"),
-            Map.entry("meta", "meta"),
-            Map.entry("zai", "zai"),
             Map.entry("z-ai", "zai"),
-            Map.entry("sambanova", "sambanova"),
-            Map.entry("nebius", "nebius"),
-            Map.entry("snowflake", "snowflake"),
-            Map.entry("deepinfra", "deepinfra"));
+            Map.entry("cerebras", "cerebras"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider
@@ -241,7 +225,7 @@ public class CostService {
         int prefixSlash = originalModelName.indexOf('/');
         if (prefixSlash > 0) {
             String modelPrefix = originalModelName.substring(0, prefixSlash);
-            String canonicalFromPrefix = PROVIDERS_MAPPING.get(modelPrefix);
+            String canonicalFromPrefix = PROVIDER_ALIASES.getOrDefault(modelPrefix, modelPrefix);
             if (canonicalFromPrefix != null && !canonicalFromPrefix.equalsIgnoreCase(provider)) {
                 String prefixKey = createModelProviderKey(modelName, canonicalFromPrefix);
                 ModelPrice prefixMatch = modelProviderPrices.get(prefixKey);
@@ -418,15 +402,17 @@ public class CostService {
 
     /**
      * Computes the runtime key {@code <parsedModel>/<canonicalProvider>} for a price-map entry.
-     * Returns null if the provider isn't in {@link #PROVIDERS_MAPPING} or the entry is invalid
-     * for the resolved provider (e.g. legacy Bedrock paths).
+     * Returns null only if the entry is invalid for the resolved provider (e.g. legacy Bedrock paths)
+     * or the provider string is blank. Any non-blank litellm_provider is accepted: aliases in
+     * {@link #PROVIDER_ALIASES} are remapped; all others use the provider value as-is so new
+     * providers in the price file are priced automatically without requiring a code change.
      */
     private static String buildRuntimeKey(String modelName, ModelCostData modelCost) {
         String provider = Optional.ofNullable(modelCost.litellmProvider()).orElse("");
-        String canonical = PROVIDERS_MAPPING.get(provider);
-        if (canonical == null) {
+        if (provider.isEmpty()) {
             return null;
         }
+        String canonical = PROVIDER_ALIASES.getOrDefault(provider, provider);
         if (!isValidModelProvider(modelName, canonical)) {
             return null;
         }
@@ -435,9 +421,11 @@ public class CostService {
 
     private static ModelPrice buildModelPrice(ModelCostData modelCost) {
         String provider = Optional.ofNullable(modelCost.litellmProvider()).orElse("");
-        if (!PROVIDERS_MAPPING.containsKey(provider)) {
+        if (provider.isEmpty()) {
             return null;
         }
+        // Resolve alias; unknown providers use their own name as canonical.
+        provider = PROVIDER_ALIASES.getOrDefault(provider, provider);
 
         BigDecimal inputPrice = Optional.ofNullable(modelCost.inputCostPerToken()).map(BigDecimal::new)
                 .orElse(BigDecimal.ZERO);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -503,7 +503,7 @@ class CostServiceTest {
     }
 
     /**
-     * Mistral cost tracking: until `mistral` was added to PROVIDERS_MAPPING the entire set of
+     * Mistral cost tracking: until `mistral` was added to PROVIDER_ALIASES the entire set of
      * upstream LiteLLM `litellm_provider: "mistral"` rows was dropped at startup, so every
      * Mistral span returned cost = 0. This locks in both the upstream-sourced rows and the
      * two override-only rows (Medium 3.5, Small 4) added alongside the registry fix.
@@ -538,7 +538,7 @@ class CostServiceTest {
 
     /**
      * Overrides file: `litellm_provider: "microsoft"` is remapped to canonical `azure` via
-     * PROVIDERS_MAPPING. A span emitted with provider=`azure` and the model name must hit
+     * PROVIDER_ALIASES. A span emitted with provider=`azure` and the model name must hit
      * the override row for `azure/multilingual-e5-large`.
      */
     @Test
@@ -894,7 +894,7 @@ class CostServiceTest {
      * OpenRouter exposes Moonshot's Kimi family under a different namespace prefix
      * ({@code moonshotai/*}) than LiteLLM's canonical ({@code moonshot/*}) — see the
      * {@code MOONSHOTAI_*} entries in {@code OpenRouterModelName}. Without a
-     * {@code moonshotai -> moonshot} alias in {@link CostService#PROVIDERS_MAPPING}, the
+     * {@code moonshotai -> moonshot} alias in {@link CostService#PROVIDER_ALIASES}, the
      * provider-prefix fallback returns null and the aggregator-routed request resolves to
      * {@code DEFAULT_COST}, silently under-charging every Kimi call routed through OpenRouter.
      * With the alias, the fallback maps {@code moonshotai} to the canonical {@code moonshot}
@@ -972,7 +972,7 @@ class CostServiceTest {
      * Same gap as the {@code moonshotai} alias, for five more vendors OpenRouter resells.
      * {@code ai21}, {@code morph}, {@code inception}, {@code meta} and {@code zai} all carry
      * non-zero-cost rows in {@code model_prices_and_context_window.json}, but none were in
-     * {@link CostService#PROVIDERS_MAPPING}, so {@code buildModelPrice} dropped every one of
+     * {@link CostService#PROVIDER_ALIASES}, so {@code buildModelPrice} dropped every one of
      * them at load time and the provider-prefix fallback had nothing to resolve against. Any
      * call routed through OpenRouter fell through to {@code DEFAULT_COST}.
      * <p>
@@ -1061,5 +1061,18 @@ class CostServiceTest {
                                 "original_usage.completion_tokens", 200,
                                 "original_usage.prompt_tokens_details.cached_tokens", 300),
                         "0.005709"));
+    }
+
+    /**
+     * Providers present in the price file but previously absent from PROVIDER_ALIASES were silently
+     * dropped, resulting in zero cost. With the identity-fallback change, any non-blank litellm_provider
+     * is priced automatically if its models appear in the file.
+     */
+    @Test
+    void calculateCostForPreviouslyUnregisteredProvider() {
+        // together_ai is in model_prices_and_context_window.json but was never in the old allowlist.
+        var usage = Map.of("prompt_tokens", 100, "completion_tokens", 50);
+        BigDecimal cost = CostService.calculateCost("together-ai-21.1b-41b", "together_ai", usage, null);
+        assertThat(cost).isNotNull().isGreaterThan(BigDecimal.ZERO);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1071,8 +1071,10 @@ class CostServiceTest {
     @Test
     void calculateCostForPreviouslyUnregisteredProvider() {
         // together_ai is in model_prices_and_context_window.json but was never in the old allowlist.
+        // together-ai-21.1b-41b: input_cost_per_token=8e-7, output_cost_per_token=8e-7
+        // Expected: (100 * 8e-7) + (50 * 8e-7) = 0.00012
         var usage = Map.of("prompt_tokens", 100, "completion_tokens", 50);
         BigDecimal cost = CostService.calculateCost("together-ai-21.1b-41b", "together_ai", usage, null);
-        assertThat(cost).isNotNull().isGreaterThan(BigDecimal.ZERO);
+        assertThat(cost).isNotNull().isEqualByComparingTo(new BigDecimal("0.00012"));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1014,6 +1014,8 @@ class CostServiceTest {
                 Arguments.of("z-ai/glm-4.5", "openrouter", "0.00104"),
                 // Date-suffixed variant: prefix fallback must also try date-stripped name.
                 Arguments.of("z-ai/glm-4.5-2025-12-17", "openrouter", "0.00104"),
+                // Version-suffixed variant: primary lookup misses, z-ai canonicalizes to zai, :0 stripped.
+                Arguments.of("z-ai/glm-4.5:0", "openrouter", "0.00104"),
                 Arguments.of("z-ai/glm-5", "openrouter", "0.00164"),
                 Arguments.of("morph/morph-v3-fast", "openrouter", "0.00104"),
                 Arguments.of("morph/morph-v3-large", "openrouter", "0.00128"),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1012,6 +1012,8 @@ class CostServiceTest {
                 Arguments.of("ai21/jamba-mini-1.7", "openrouter", "0.00028"),
                 // OpenRouter namespaces Z.ai as z-ai/, the price file as zai/.
                 Arguments.of("z-ai/glm-4.5", "openrouter", "0.00104"),
+                // Date-suffixed variant: prefix fallback must also try date-stripped name.
+                Arguments.of("z-ai/glm-4.5-2025-12-17", "openrouter", "0.00104"),
                 Arguments.of("z-ai/glm-5", "openrouter", "0.00164"),
                 Arguments.of("morph/morph-v3-fast", "openrouter", "0.00104"),
                 Arguments.of("morph/morph-v3-large", "openrouter", "0.00128"),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -503,10 +503,11 @@ class CostServiceTest {
     }
 
     /**
-     * Mistral cost tracking: until `mistral` was added to PROVIDER_ALIASES the entire set of
-     * upstream LiteLLM `litellm_provider: "mistral"` rows was dropped at startup, so every
-     * Mistral span returned cost = 0. This locks in both the upstream-sourced rows and the
-     * two override-only rows (Medium 3.5, Small 4) added alongside the registry fix.
+     * Mistral cost tracking: the identity fallback in {@code buildRuntimeKey} / {@code buildModelPrice}
+     * loads any provider present in the price file without an explicit {@code PROVIDER_ALIASES} entry,
+     * so the entire set of upstream LiteLLM {@code litellm_provider: "mistral"} rows is now loaded at
+     * startup. This locks in both the upstream-sourced rows and the two override-only rows
+     * (Medium 3.5, Small 4).
      */
     @ParameterizedTest
     @MethodSource("provideMistralModels")
@@ -969,17 +970,14 @@ class CostServiceTest {
     }
 
     /**
-     * Same gap as the {@code moonshotai} alias, for five more vendors OpenRouter resells.
-     * {@code ai21}, {@code morph}, {@code inception}, {@code meta} and {@code zai} all carry
-     * non-zero-cost rows in {@code model_prices_and_context_window.json}, but none were in
-     * {@link CostService#PROVIDER_ALIASES}, so {@code buildModelPrice} dropped every one of
-     * them at load time and the provider-prefix fallback had nothing to resolve against. Any
-     * call routed through OpenRouter fell through to {@code DEFAULT_COST}.
+     * Five vendors OpenRouter resells: {@code ai21}, {@code morph}, {@code inception}, {@code meta},
+     * and {@code zai} all carry non-zero-cost rows in {@code model_prices_and_context_window.json}.
+     * The identity fallback in {@code buildRuntimeKey} / {@code buildModelPrice} loads them
+     * automatically without explicit {@link CostService#PROVIDER_ALIASES} entries.
      * <p>
-     * {@code z-ai} needs two entries for the same reason {@code moonshot} does: the map is read
-     * both with the price file's {@code litellm_provider} ({@code zai}) when loading rows, and
-     * with the model-name prefix OpenRouter uses ({@code z-ai}) when resolving the fallback.
-     * The other four spell both the same way, so one entry each.
+     * {@code z-ai} still needs an explicit alias ({@code z-ai} to {@code zai}) because OpenRouter
+     * uses {@code z-ai} as the model-name prefix while the price file's {@code litellm_provider}
+     * is {@code zai}. The other four spell both the same way, so the identity fallback is enough.
      * <p>
      * All of these take the {@link SpanCostCalculator#textGenerationCost} path. Four of the
      * models below publish a {@code cache_read_input_token_cost}, but none of these providers is


### PR DESCRIPTION
## Summary

\`CostService.PROVIDERS_MAPPING\` was an allowlist gate: any \`litellm_provider\` absent from the map caused \`buildRuntimeKey\` / \`buildModelPrice\` to drop the price row, billing those spans at zero. This silently affected ~200+ models across providers like \`together_ai\`, \`oci\`, \`replicate\`, \`databricks\`, \`watsonx\`, and others that are fully priced in the bundled \`model_prices_and_context_window.json\`.

**Changes:**

- Renamed \`PROVIDERS_MAPPING\` to \`PROVIDER_ALIASES\` to reflect the new semantic
- Stripped the 21 identity entries (\`openai -> openai\`, \`groq -> groq\`, etc.) — these are now handled by the identity fallback
- Kept the 7 genuine aliases where \`litellm_provider\` differs from the canonical key:

| litellm_provider | canonical |
|---|---|
| \`vertex_ai-language-models\` | \`google_vertexai\` |
| \`gemini\` | \`google_ai\` |
| \`vertex_ai-anthropic_models\` | \`anthropic_vertexai\` |
| \`bedrock_converse\` | \`bedrock\` |
| \`microsoft\` | \`azure\` |
| \`moonshotai\` | \`moonshot\` |
| \`z-ai\` | \`zai\` |

- \`buildRuntimeKey\` and \`buildModelPrice\` now use \`getOrDefault(provider, provider)\` so any non-blank \`litellm_provider\` present in the price file is priced automatically
- New regression test: \`together_ai\` model (previously zero-cost) now returns a non-zero price

No new provider registrations needed — this change is self-applying for every current and future provider in the price file.

## Test plan

- [x] Regression test: \`together_ai\` model priced correctly (was zero before)
- [x] All existing \`CostServiceTest\` tests still pass (aliases, Bedrock, Google, Azure, moonshot, z-ai)

Fixes #7794