### PR TITLE
helm: per-component registry + honour the repository override in the demo-data job

### DIFF
--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -266,6 +266,7 @@ Call opik api on http://localhost:5173/api
 | component.backend.env.UI_DEFAULT_PAGE_SIZE | string | `"100"` |  |
 | component.backend.envFrom[0].configMapRef.name | string | `"opik-backend"` |  |
 | component.backend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| component.backend.image.registry | string | `nil` | Registry for this component only. Defaults to the chart-wide `registry`. Set it when one component is pulled from a different registry. |
 | component.backend.image.repository | string | `"opik-backend"` |  |
 | component.backend.ingress.annotations | object | `{}` |  |
 | component.backend.ingress.enabled | bool | `false` |  |
@@ -379,6 +380,7 @@ Call opik api on http://localhost:5173/api
 | component.frontend.extraServerHeaders.X-XSS-Protection | string | `"0"` |  |
 | component.frontend.hstsEnabled | bool | `false` |  |
 | component.frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| component.frontend.image.registry | string | `nil` | Registry for this component only. Defaults to the chart-wide `registry`. Set it when one component is pulled from a different registry. |
 | component.frontend.image.repository | string | `"opik-frontend"` |  |
 | component.frontend.ingress.annotations | object | `{}` |  |
 | component.frontend.ingress.enabled | bool | `false` |  |
@@ -434,6 +436,7 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.env.REDIS_URL | string | `"redis://:wFSuJX9nDBdCa25sKZG7bh@opik-redis-master:6379/"` |  |
 | component.python-backend.envFrom[0].configMapRef.name | string | `"opik-python-backend"` |  |
 | component.python-backend.image.pullPolicy | string | `"IfNotPresent"` |  |
+| component.python-backend.image.registry | string | `nil` | Registry for this component only. Defaults to the chart-wide `registry`. Set it when one component is pulled from a different registry. |
 | component.python-backend.image.repository | string | `"opik-python-backend"` |  |
 | component.python-backend.ingress.annotations | object | `{}` |  |
 | component.python-backend.ingress.enabled | bool | `false` |  |

--- a/deployment/helm_chart/opik/templates/demo-data-generator-job.yaml
+++ b/deployment/helm_chart/opik/templates/demo-data-generator-job.yaml
@@ -49,7 +49,7 @@ spec:
         args: ['while [ $(curl -ksw "%{http_code}" "http://opik-frontend:5173" -o /dev/null) -ne 200 ]; do sleep 5; echo "Opik Frontend is not available. Waiting for the Opik Frontend..."; done']
       containers:
       - name: demo-data-generator
-        image: "{{ .Values.registry }}/opik-python-backend:{{ default .Chart.AppVersion (index .Values.component "python-backend" "image" "tag") }}"
+        image: "{{ default .Values.registry (index .Values.component "python-backend" "image" "registry") }}/{{ index .Values.component "python-backend" "image" "repository" }}:{{ default .Chart.AppVersion (index .Values.component "python-backend" "image" "tag") }}"
         command: [ "sh", "-c", "./demo_data_entrypoint.sh" ]
         env:
         - name: CREATE_DEMO_DATA

--- a/deployment/helm_chart/opik/templates/deployment.yaml
+++ b/deployment/helm_chart/opik/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       initContainers:
       {{- if and $value.usesJavaTrustStore (or $.Values.caCerts.additionalCACerts $.Values.caCerts.existingAdditionalCACertsRef) (not $.Values.caCerts.overwriteJavaCATrustStore.enabled) }}
         - name: ca-cert-injection
-          image: "{{ $.Values.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
+          image: "{{ default $.Values.registry $value.image.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
           imagePullPolicy: {{ $value.image.pullPolicy }}
           securityContext:
             {{- toYaml $value.securityContext | nindent 12 }}
@@ -151,7 +151,7 @@ spec:
       {{- end }}
       {{- if and (eq $key "backend") $value.run_migration }}
         - name: backend-migrations
-          image: "{{ $.Values.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
+          image: "{{ default $.Values.registry $value.image.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
           imagePullPolicy: {{ $value.image.pullPolicy }}
           securityContext:
             {{- toYaml $value.securityContext | nindent 12 }}
@@ -184,7 +184,7 @@ spec:
         - name: {{ include "opik.name" $ }}-{{ $key | lower }}
           securityContext:
             {{- toYaml $value.securityContext | nindent 12 }}
-          image: "{{ $.Values.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
+          image: "{{ default $.Values.registry $value.image.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
           imagePullPolicy: {{ $value.image.pullPolicy }}
           {{- with $value.ports }}
           ports:

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -92,6 +92,9 @@ component:
     metrics:
       enabled: false
     image:
+      # -- Registry for this component only. Defaults to the chart-wide `registry`.
+      # Set it when one component is pulled from a different registry.
+      registry:
       repository: opik-backend
       pullPolicy: IfNotPresent
     replicaCount: 1
@@ -232,6 +235,9 @@ component:
     metrics:
       enabled: false
     image:
+      # -- Registry for this component only. Defaults to the chart-wide `registry`.
+      # Set it when one component is pulled from a different registry.
+      registry:
       repository: opik-python-backend
       pullPolicy: IfNotPresent
     replicaCount: 1
@@ -407,6 +413,9 @@ component:
     metrics:
       enabled: false
     image:
+      # -- Registry for this component only. Defaults to the chart-wide `registry`.
+      # Set it when one component is pulled from a different registry.
+      registry:
       repository: opik-frontend
       pullPolicy: IfNotPresent
     replicaCount: 1


### PR DESCRIPTION
Two related gaps in the Helm chart make it impossible to pull one component from a different registry, or to rename a component's image at all once the demo-data job is enabled.

## 1. Component images ignore a per-component registry

`deployment.yaml` built the three component images from the chart-wide registry only:

```
image: "{{ $.Values.registry }}/{{ $value.image.repository }}:{{ default $.Chart.AppVersion $value.image.tag }}"
```

The chart already supports a per-component override — but only on the init containers:

```
image: "{{ default $.Values.registry $value.waitForMysql.image.registry }}/…"
```

The three component refs now follow that same idiom, so one component can come from another registry while the rest use the chart-wide default. Useful when mirroring a single image, or pinning one component to an upstream release while the others come from an internal build.

## 2. The demo-data job hardcodes the repository name

```
image: "{{ .Values.registry }}/opik-python-backend:{{ default .Chart.AppVersion (index .Values.component "python-backend" "image" "tag") }}"
```

It honours `registry` and the python-backend *tag*, but ignores `component.python-backend.image.repository`. Any deployment that renames that image — a mirror, a fork, a prefixed internal build — gets a path that doesn't exist, and the job fails with `ImagePullBackOff`. Since `demoDataJob.enabled` defaults to `true`, renaming the python-backend image currently breaks a default install.

It now derives both registry and repository from the component values, consistent with change 1.

## Compatibility

`values.yaml` documents the new optional `registry` key on each component image. It is **unset by default**, so `default` falls back to the chart-wide `registry` and rendered output is byte-identical for existing installs.

## Verification

Rendered three ways:

| case | result |
|---|---|
| defaults | `ghcr.io/comet-ml/opik/opik-{backend,frontend,python-backend}:2.2.24` — unchanged |
| `demoDataJob.enabled=true`, default registry | demo job → `ghcr.io/comet-ml/opik/opik-python-backend` — unchanged |
| custom registry + renamed backend/frontend + `python-backend.image.registry` pointing at ghcr | each component resolves independently, demo job follows python-backend |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
