### PR TITLE
[OPIK-7833] [BE] Move the JC label → Jira automation from n8n into a GitHub Action

### DIFF
--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -1,0 +1,96 @@
+# JC label → Jira sync
+
+Applying the **`JC`** label to a GitHub issue in this repo opens a matching
+ticket in the `OPIK` Jira project and comments the link back on the issue.
+
+This directory holds the resolution logic for that sync. See
+[OPIK-7833](https://comet-ml.atlassian.net/browse/OPIK-7833).
+
+> **Status: step 1 of 5 — read-only.** Nothing here writes to Jira or GitHub.
+> The create path, the workflow, and the n8n cutover come later.
+
+## Files
+
+| File | What it does |
+|---|---|
+| `resolve.mjs` | Pure logic: issue-type resolution, dedupe, Markdown→wiki. No I/O. |
+| `resolve.test.mjs` | Unit tests. `node --test .github/scripts/jc-sync/resolve.test.mjs` |
+| `dryrun.mjs` | Replays the resolver over every `JC`-labeled issue and reports what it *would* do. |
+
+## The two decisions
+
+### Issue type
+
+Precedence: **GitHub labels** → **title prefix** → default to `Task`.
+
+Labels come first because a human applied them. The previous flow keyed only on
+the title prefix and silently defaulted to `Bug`, which mis-typed 5 of the first
+50 synced tickets.
+
+### Has this issue already been synced?
+
+Three tiers, any hit meaning "do not create":
+
+1. **Remote link** by deterministic `globalId`
+   (`github-issue-<repoId>-<issueNumber>`) — exact and indexed. The fast path
+   for everything created from now on.
+2. **JQL** over the GitHub URL in the ticket description — catches the ~50
+   tickets created before remote links existed. Text search, so it can lag right
+   after a create; never the primary key.
+3. **The `Jira Ticket Created:` comment** on the GitHub issue — catches tickets
+   whose description was edited, and lets an interrupted run recover on retry.
+
+Tier 3 exists because runs really do get interrupted: GitHub issue #7000 was
+labeled three times in eight minutes and produced two tickets (OPIK-6834 and
+OPIK-6835), only one of which was ever commented back.
+
+## Running the dry run
+
+```bash
+GITHUB_TOKEN="$(gh auth token)" node .github/scripts/jc-sync/dryrun.mjs
+```
+
+Optional flags: `--limit=N` to sample, `--json=out.json` for the full per-issue
+record.
+
+Jira credentials are optional. Without them tiers 1–2 are skipped and the replay
+exercises tier 3 only — still useful, and it needs no Jira access at all:
+
+```bash
+export JIRA_BASE_URL=https://comet-ml.atlassian.net
+export JIRA_USER_EMAIL=you@comet.com
+export JIRA_API_TOKEN=...
+```
+
+### Reading the output
+
+- `match OPIK-1234 (via)` — an existing ticket was found; the live sync would
+  skip creation.
+- `WOULD-CREATE` — no ticket found.
+- `[DUPES ...]` — more than one ticket points at this issue. Pre-existing data
+  problems, surfaced rather than hidden.
+- `[type:unconfident]` — no label and no title prefix; type fell back to `Task`.
+
+## Latest replay
+
+79 labeled issues, tier 3 only (no Jira credentials):
+
+```
+matched existing  65
+would create      14
+duplicate pairs    1     (#4440 → OPIK-3453/3454/3455/3456)
+unconfident type   4
+```
+
+The 14 unmatched are **not** resolver failures. Verified by hand:
+
+- **4 are test issues** — "[Bug]: This is a test", "[FR]: test", "Test", "Test2".
+- **2 have tickets created manually**, with a reworded summary and no
+  comment-back (#6619 → OPIK-7647, #6344 → OPIK-6058). Tier 2 catches these once
+  Jira credentials are supplied; tier 3 cannot, because nothing was ever posted
+  to the issue.
+- **The rest were never synced** — the label was applied and nothing happened.
+  That silent-failure mode is the core thing this rewrite fixes.
+
+Re-run with Jira credentials before the cutover to confirm tier 2 closes the
+gap on the second group.

--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -64,33 +64,53 @@ export JIRA_API_TOKEN=...
 
 ### Reading the output
 
-- `match OPIK-1234 (via)` — an existing ticket was found; the live sync would
-  skip creation.
-- `WOULD-CREATE` — no ticket found.
-- `[DUPES ...]` — more than one ticket points at this issue. Pre-existing data
-  problems, surfaced rather than hidden.
+- `match OPIK-1234 (via)` — an existing synced ticket was found; the live sync
+  would skip creation.
+- `WOULD-CREATE` — no synced ticket found.
+- `[DUPES ...]` — several **sync-created** tickets point at this issue. A real
+  double-create; pre-existing, surfaced rather than hidden.
+- `[related ...]` — a ticket cites this issue but was not created by the sync.
+  Not a match: the sync would still create. Worth a human look.
 - `[type:unconfident]` — no label and no title prefix; type fell back to `Task`.
 
 ## Latest replay
 
-79 labeled issues, tier 3 only (no Jira credentials):
+79 labeled issues, all three tiers live:
 
 ```
-matched existing  65
+matched existing  65      (tier 2: 64, tier 3: 1)
 would create      14
-duplicate pairs    1     (#4440 → OPIK-3453/3454/3455/3456)
+  ...referenced by a non-synced ticket: 4
+duplicate pairs    6
 unconfident type   4
 ```
 
-The 14 unmatched are **not** resolver failures. Verified by hand:
+### Duplicates: 6, not 33
 
-- **4 are test issues** — "[Bug]: This is a test", "[FR]: test", "Test", "Test2".
-- **2 have tickets created manually**, with a reworded summary and no
-  comment-back (#6619 → OPIK-7647, #6344 → OPIK-6058). Tier 2 catches these once
-  Jira credentials are supplied; tier 3 cannot, because nothing was ever posted
-  to the issue.
-- **The rest were never synced** — the label was applied and nothing happened.
-  That silent-failure mode is the core thing this rewrite fixes.
+The GitHub URL appears in more than one ticket whenever an engineer cites the
+issue from a follow-up. Matching on the URL alone reported 33 "duplicates"; only
+6 were real. Tier 2 therefore filters on the `github-sync` label — only tickets
+this automation created count — and reports a `related` list for citing tickets
+so they surface for triage without being mistaken for a double-create.
 
-Re-run with Jira credentials before the cutover to confirm tier 2 closes the
-gap on the second group.
+The 6 genuine ones (two sync-created tickets for one issue) are pre-existing data
+problems, not resolver output:
+
+```
+#4639 OPIK-3825/3748   #4504 OPIK-3722/3721   #4440 OPIK-3456/3455
+#4439 OPIK-3451/3450   #4379 OPIK-3400/3399   #3680 OPIK-3722/3721
+```
+
+### The 14 unmatched are all correct
+
+Verified individually:
+
+- **4 test issues** — "[Bug]: This is a test", "Test", "Test2", "[FR]: test".
+  These were synced to the unrelated `YT` project, which the resolver correctly
+  ignores.
+- **4 have only a citing ticket** (`related=`), never a synced one — #6619,
+  #6344, #4633, #4483. A human wrote those tickets by hand.
+- **6 were never synced at all** — the label went on and nothing happened. That
+  silent-failure mode is the core thing this rewrite fixes.
+
+No issue that was genuinely synced is reported as WOULD-CREATE.

--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -6,13 +6,10 @@ ticket in the `OPIK` Jira project and comments the link back on the issue.
 This directory holds the resolution logic for that sync. See
 [OPIK-7833](https://comet-ml.atlassian.net/browse/OPIK-7833).
 
-> **Status: complete and verified, not yet enabled.** The sync works end to end
-> and is wired to the `JC` label. Two things are needed to turn it on, both
-> outside this repo: the three config values below, and switching off the
-> existing n8n workflow that reacts to the same label.
->
-> **Do not merge this while n8n is still live** — both would react to the same
-> label and each would create its own ticket.
+> **Status: complete and verified, off by default.** The sync works end to end
+> and is wired to the `JC` label, but the job will not run until
+> `vars.JC_SYNC_ENABLED` is `'true'`. Merging is therefore safe while n8n is
+> still live; see the cutover checklist at the bottom.
 
 ## Files
 
@@ -29,9 +26,16 @@ The workflow is [`.github/workflows/jc_label_to_jira.yml`](../../workflows/jc_la
 
 | Name | Kind | Purpose |
 |---|---|---|
+| `JC_SYNC_ENABLED` | variable | Must be `'true'` or the job does not run. The cutover switch. |
 | `JC_JIRA_BASE_URL` | variable | e.g. `https://comet-ml.atlassian.net` |
 | `JC_JIRA_USER_EMAIL` | secret | Jira account the tickets are created as |
 | `JC_JIRA_API_TOKEN` | secret | Atlassian API token for that account |
+
+`JC_SYNC_ENABLED` exists because merging cannot be the thing that turns this on:
+while the n8n workflow still reacts to the same label, both producers would
+create their own ticket, and GitHub's concurrency group cannot serialise an
+external system. Set it only once n8n is confirmed off. It gates the manual path
+too, so a `workflow_dispatch` cannot bypass it.
 
 Use a service account, not a personal token: the reporter on every synced ticket
 is whoever owns the credential, and a personal token breaks when it is rotated
@@ -64,12 +68,14 @@ Re-run **JC Label to Jira** from the Actions tab with the issue number.
 
 ## Cutover checklist
 
-1. Create the Jira service account and add the three config values above.
-2. Disable the n8n workflow that currently reacts to the `JC` label (n8n lives
+1. Create the Jira service account and add the config values above, leaving
+   `JC_SYNC_ENABLED` unset.
+2. Merge this. With the switch off, nothing runs — merging is safe on its own.
+3. Disable the n8n workflow that currently reacts to the `JC` label (n8n lives
    at `n8n.dev.comet.com`; the deployment is in `comet-gitops`). Nothing in this
    repo can turn it off.
-3. Merge this.
-4. Apply `JC` to one issue and confirm a single ticket, a single remote link, and
+4. Set `JC_SYNC_ENABLED` to `true`.
+5. Apply `JC` to one issue and confirm a single ticket, a single remote link, and
    one comment.
 5. Optionally backfill: run the workflow manually against previously-labeled
    issues to attach remote links to the ~50 legacy tickets, upgrading them to the

--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -6,8 +6,13 @@ ticket in the `OPIK` Jira project and comments the link back on the issue.
 This directory holds the resolution logic for that sync. See
 [OPIK-7833](https://comet-ml.atlassian.net/browse/OPIK-7833).
 
-> **Status: steps 1–3 of 5.** The sync works end to end and is wired to the
-> label. Still to do: shadow-run against n8n, then switch n8n off.
+> **Status: complete and verified, not yet enabled.** The sync works end to end
+> and is wired to the `JC` label. Two things are needed to turn it on, both
+> outside this repo: the three config values below, and switching off the
+> existing n8n workflow that reacts to the same label.
+>
+> **Do not merge this while n8n is still live** — both would react to the same
+> label and each would create its own ticket.
 
 ## Files
 
@@ -56,6 +61,35 @@ label as a retry — and how issue #7000 ended up with two tickets. Instead this
 - says explicitly to re-run the workflow rather than re-label.
 
 Re-run **JC Label to Jira** from the Actions tab with the issue number.
+
+## Cutover checklist
+
+1. Create the Jira service account and add the three config values above.
+2. Disable the n8n workflow that currently reacts to the `JC` label (n8n lives
+   at `n8n.dev.comet.com`; the deployment is in `comet-gitops`). Nothing in this
+   repo can turn it off.
+3. Merge this.
+4. Apply `JC` to one issue and confirm a single ticket, a single remote link, and
+   one comment.
+5. Optionally backfill: run the workflow manually against previously-labeled
+   issues to attach remote links to the ~50 legacy tickets, upgrading them to the
+   tier 1 fast path. Idempotent, so it can be re-run freely.
+
+### Verified before handover
+
+- Live create, then two re-runs: one ticket, one remote link, one comment. The
+  second and third runs matched via tier 1.
+- Two consecutive failures left exactly one notice; the recovery run cleared it.
+- Replay across all 79 labeled issues: 65 matched, 14 correctly unmatched
+  (4 test issues, 4 with only a hand-written citing ticket, 6 never synced).
+- `actionlint` and `zizmor` (offline, high severity) clean; 28 unit tests pass.
+
+### Not yet exercised
+
+The workflow has never run on GitHub's runners — it was driven directly. The
+`if:` gate, concurrency group and dry-run wiring were checked against
+representative event payloads, but the first real label event is still the first
+true test of the YAML itself.
 
 ## The two decisions
 

--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -6,8 +6,8 @@ ticket in the `OPIK` Jira project and comments the link back on the issue.
 This directory holds the resolution logic for that sync. See
 [OPIK-7833](https://comet-ml.atlassian.net/browse/OPIK-7833).
 
-> **Status: step 1 of 5 — read-only.** Nothing here writes to Jira or GitHub.
-> The create path, the workflow, and the n8n cutover come later.
+> **Status: steps 1–3 of 5.** The sync works end to end and is wired to the
+> label. Still to do: shadow-run against n8n, then switch n8n off.
 
 ## Files
 
@@ -15,7 +15,47 @@ This directory holds the resolution logic for that sync. See
 |---|---|
 | `resolve.mjs` | Pure logic: issue-type resolution, dedupe, Markdown→wiki. No I/O. |
 | `resolve.test.mjs` | Unit tests. `node --test .github/scripts/jc-sync/resolve.test.mjs` |
+| `sync.mjs` | The write path: ensure ticket, link, comment. Driven by the workflow. |
 | `dryrun.mjs` | Replays the resolver over every `JC`-labeled issue and reports what it *would* do. |
+
+The workflow is [`.github/workflows/jc_label_to_jira.yml`](../../workflows/jc_label_to_jira.yml).
+
+## Configuration
+
+| Name | Kind | Purpose |
+|---|---|---|
+| `JC_JIRA_BASE_URL` | variable | e.g. `https://comet-ml.atlassian.net` |
+| `JC_JIRA_USER_EMAIL` | secret | Jira account the tickets are created as |
+| `JC_JIRA_API_TOKEN` | secret | Atlassian API token for that account |
+
+Use a service account, not a personal token: the reporter on every synced ticket
+is whoever owns the credential, and a personal token breaks when it is rotated
+or the person leaves.
+
+## Idempotence
+
+Safe to run repeatedly — a re-label, a retry, or a resumed run converges rather
+than duplicating:
+
+- dedupe runs before any create;
+- the remote link is keyed on a deterministic `globalId`, and re-POSTing it
+  returns the same link;
+- the comment is skipped when that ticket is already announced;
+- the failure notice is updated in place, and deleted once a run succeeds.
+
+Order is **create → link → comment**. A process that dies midway leaves a ticket
+the next run finds via tier 2 or 3 and backfills.
+
+## When it fails
+
+The old flow failed silently, which is why maintainers learned to toggle the
+label as a retry — and how issue #7000 ended up with two tickets. Instead this:
+
+- fails the job (visible in the Actions tab);
+- posts a notice on the issue with the reason and a link to the run;
+- says explicitly to re-run the workflow rather than re-label.
+
+Re-run **JC Label to Jira** from the Actions tab with the issue number.
 
 ## The two decisions
 

--- a/.github/scripts/jc-sync/README.md
+++ b/.github/scripts/jc-sync/README.md
@@ -6,10 +6,18 @@ ticket in the `OPIK` Jira project and comments the link back on the issue.
 This directory holds the resolution logic for that sync. See
 [OPIK-7833](https://comet-ml.atlassian.net/browse/OPIK-7833).
 
-> **Status: complete and verified, off by default.** The sync works end to end
-> and is wired to the `JC` label, but the job will not run until
-> `vars.JC_SYNC_ENABLED` is `'true'`. Merging is therefore safe while n8n is
-> still live; see the cutover checklist at the bottom.
+> **Status: off by default, not yet run on GitHub Actions.**
+>
+> The script's logic is verified — dedupe was replayed over the whole labelled
+> backlog, and create / idempotence / failure-recovery were exercised against
+> the real GitHub and Jira APIs. But every one of those runs invoked the script
+> directly. **The workflow itself has never executed on a runner**, so the
+> trigger, gating, checkout and secret wiring are unproven until a real label
+> event succeeds.
+>
+> The job will not run until `vars.JC_SYNC_ENABLED` is `'true'`, so merging is
+> safe while n8n is still live. Treat the first enabled run as the acceptance
+> test — see the cutover checklist at the bottom.
 
 ## Files
 
@@ -75,27 +83,43 @@ Re-run **JC Label to Jira** from the Actions tab with the issue number.
    at `n8n.dev.comet.com`; the deployment is in `comet-gitops`). Nothing in this
    repo can turn it off.
 4. Set `JC_SYNC_ENABLED` to `true`.
-5. Apply `JC` to one issue and confirm a single ticket, a single remote link, and
+5. Run the workflow manually with **dry run** ticked, against an
+   already-synced issue. This is the first execution on a runner, so it proves
+   the trigger, secrets and checkout while writing nothing. Expect it to report
+   the existing ticket and decline to create.
+6. Apply `JC` to one issue and confirm a single ticket, a single remote link, and
    one comment.
 5. Optionally backfill: run the workflow manually against previously-labeled
    issues to attach remote links to the ~50 legacy tickets, upgrading them to the
    tier 1 fast path. Idempotent, so it can be re-run freely.
 
-### Verified before handover
+### Verified — by invoking the script directly
 
 - Live create, then two re-runs: one ticket, one remote link, one comment. The
   second and third runs matched via tier 1.
 - Two consecutive failures left exactly one notice; the recovery run cleared it.
-- Replay across all 79 labeled issues: 65 matched, 14 correctly unmatched
+- A dry run against a legacy n8n ticket (issue #7516 → OPIK-7425, no remote
+  link) matched on tier 2 and declined to create.
+- An issue without the `JC` label is refused before any write.
+- Replay across all 79 labelled issues: 65 matched, 14 correctly unmatched
   (4 test issues, 4 with only a hand-written citing ticket, 6 never synced).
-- `actionlint` and `zizmor` (offline, high severity) clean; 28 unit tests pass.
+- `actionlint` and `zizmor` (offline, high severity) clean; 29 unit tests pass.
 
-### Not yet exercised
+### Unverified — the workflow on a runner
 
-The workflow has never run on GitHub's runners — it was driven directly. The
-`if:` gate, concurrency group and dry-run wiring were checked against
-representative event payloads, but the first real label event is still the first
-true test of the YAML itself.
+None of the above ran through GitHub Actions. The `if:` gate, concurrency group
+and dry-run wiring were checked against representative event payloads, and the
+repo label was confirmed to be exactly `JC` (the gate is case-sensitive), but
+these remain untested in a real run:
+
+- the `issues: labeled` trigger firing and passing the right issue number;
+- `vars.JC_SYNC_ENABLED` and the secrets resolving on the runner;
+- the sparse checkout providing the script;
+- the step summary and failure notice rendering from Actions.
+
+Watch the first enabled label event, and prefer a manual `workflow_dispatch`
+with **dry run** ticked as the very first exercise — it proves the wiring
+without writing anything.
 
 ## The two decisions
 

--- a/.github/scripts/jc-sync/dryrun.mjs
+++ b/.github/scripts/jc-sync/dryrun.mjs
@@ -102,18 +102,43 @@ async function findByRemoteLink(globalId) {
   return null;
 }
 
-/** Tier 2 — JQL over the GitHub URL in the description. */
+/**
+ * Tier 2 — JQL over the GitHub URL in the description.
+ *
+ * A GitHub URL can legitimately appear in more than one ticket: engineers cite
+ * the issue in follow-up and sibling tickets. Only tickets carrying
+ * `github-sync` were created by this automation, so:
+ *
+ *   - prefer a `github-sync` ticket as the match, and
+ *   - only report `duplicates` when *several* of them exist, which is the
+ *     genuine double-create this sync must prevent.
+ *
+ * Without that filter the replay reported 33 "duplicates", of which only 6 were
+ * real — the other 27 were hand-written tickets that merely referenced the URL.
+ */
 async function findByJql(jql) {
   if (!JIRA_READY) return null;
-  const body = JSON.stringify({ jql, maxResults: 2, fields: ['key'] });
+  const body = JSON.stringify({
+    jql,
+    maxResults: 10,
+    fields: ['key', 'labels'],
+  });
   const data = await jira('/rest/api/3/search/jql', { method: 'POST', body });
   const issues = data.issues || [];
-  if (issues.length > 1) {
-    // Two tickets pointing at one GitHub issue: exactly the OPIK-6834/6835
-    // duplicate class this ticket exists to prevent. Surface it.
-    return { key: issues[0].key, duplicates: issues.map((i) => i.key) };
+  if (!issues.length) return null;
+
+  const synced = issues.filter((i) =>
+    (i.fields?.labels || []).includes('github-sync'),
+  );
+
+  if (synced.length > 1) {
+    return { key: synced[0].key, duplicates: synced.map((i) => i.key) };
   }
-  return issues.length ? issues[0].key : null;
+  if (synced.length === 1) return synced[0].key;
+
+  // No sync-created ticket. Something references this issue, but the sync never
+  // made one — report the reference so it can be triaged, not as a duplicate.
+  return { key: issues[0].key, related: issues.map((i) => i.key) };
 }
 
 async function main() {
@@ -148,6 +173,7 @@ async function main() {
   const tally = {
     matched: 0,
     wouldCreate: 0,
+    relatedOnly: 0,
     duplicates: 0,
     unconfidentType: 0,
     byVia: {},
@@ -187,16 +213,20 @@ async function main() {
 
     const key = existing?.key ?? null;
     const dupes = existing?.duplicates ?? null;
+    const related = existing?.related ?? null;
 
     tally.byType[type.type] = (tally.byType[type.type] || 0) + 1;
     tally.bySignal[type.signal] = (tally.bySignal[type.signal] || 0) + 1;
     if (!type.confident) tally.unconfidentType += 1;
 
+    // `key` is null when only citing tickets were found, so the live sync would
+    // still create. Count that as would-create and flag it for a human.
     if (key) {
       tally.matched += 1;
       tally.byVia[existing.via] = (tally.byVia[existing.via] || 0) + 1;
     } else if (!error) {
       tally.wouldCreate += 1;
+      if (related) tally.relatedOnly += 1;
     }
     if (dupes) tally.duplicates += 1;
 
@@ -211,6 +241,7 @@ async function main() {
       existingKey: key,
       matchedVia: existing?.via ?? null,
       duplicates: dupes,
+      related,
       error,
     });
 
@@ -222,6 +253,7 @@ async function main() {
     const warn = [
       type.confident ? '' : ' [type:unconfident]',
       dupes ? ` [DUPES ${dupes.join(',')}]` : '',
+      related ? ` [related ${related.join(',')}]` : '',
     ].join('');
     console.log(
       `#${String(issue.number).padEnd(5)} ${type.type.padEnd(4)} ${verdict}${warn}`,
@@ -232,6 +264,7 @@ async function main() {
   console.log(`replayed          ${rows.length}`);
   console.log(`matched existing  ${tally.matched}`);
   console.log(`would create      ${tally.wouldCreate}`);
+  console.log(`  ...of which referenced by a non-synced ticket: ${tally.relatedOnly}`);
   console.log(`duplicate pairs   ${tally.duplicates}`);
   console.log(`unconfident type  ${tally.unconfidentType}`);
   console.log(`matched via       ${JSON.stringify(tally.byVia)}`);

--- a/.github/scripts/jc-sync/dryrun.mjs
+++ b/.github/scripts/jc-sync/dryrun.mjs
@@ -97,6 +97,14 @@ async function jira(path, init = {}) {
   return res.json();
 }
 
+async function jiraSearch(jql, maxResults = 10) {
+  const data = await jira('/rest/api/3/search/jql', {
+    method: 'POST',
+    body: JSON.stringify({ jql, maxResults, fields: ['key', 'labels'] }),
+  });
+  return data.issues || [];
+}
+
 /**
  * Tier 1 — exact remote-link lookup.
  *
@@ -107,13 +115,7 @@ async function jira(path, init = {}) {
  */
 async function findByRemoteLink(globalId) {
   if (!JIRA_READY) return null;
-  const body = JSON.stringify({
-    jql: remoteLinkJql(globalId),
-    maxResults: 2,
-    fields: ['key'],
-  });
-  const data = await jira('/rest/api/3/search/jql', { method: 'POST', body });
-  const issues = data.issues || [];
+  const issues = await jiraSearch(remoteLinkJql(globalId), 2);
   return issues.length ? issues[0].key : null;
 }
 
@@ -133,19 +135,11 @@ async function findByRemoteLink(globalId) {
  */
 async function findByJql(jql) {
   if (!JIRA_READY) return null;
-  const body = JSON.stringify({
-    jql,
-    maxResults: 10,
-    fields: ['key', 'labels'],
-  });
-  const data = await jira('/rest/api/3/search/jql', { method: 'POST', body });
-  const issues = data.issues || [];
-  if (!issues.length) return null;
 
-  const synced = issues.filter((i) =>
-    (i.fields?.labels || []).includes('github-sync'),
-  );
-
+  // Ask Jira for the synced tickets directly. Filtering a capped page
+  // client-side would let a synced ticket fall off the end of a heavily-cited
+  // issue and read as "none synced" — which downstream means "create".
+  const synced = await jiraSearch(`${jql} AND labels = "github-sync"`, 50);
   if (synced.length > 1) {
     return { key: synced[0].key, duplicates: synced.map((i) => i.key) };
   }
@@ -153,7 +147,9 @@ async function findByJql(jql) {
 
   // No sync-created ticket. Something references this issue, but the sync never
   // made one — report the reference so it can be triaged, not as a duplicate.
-  return { key: issues[0].key, related: issues.map((i) => i.key) };
+  const any = await jiraSearch(jql, 20);
+  if (!any.length) return null;
+  return { key: any[0].key, related: any.map((i) => i.key) };
 }
 
 async function main() {

--- a/.github/scripts/jc-sync/dryrun.mjs
+++ b/.github/scripts/jc-sync/dryrun.mjs
@@ -1,0 +1,251 @@
+/**
+ * JC → Jira sync: dry-run validator (OPIK-7833).
+ *
+ * Replays the resolver over every GitHub issue that already carries the `JC`
+ * label and reports what the sync *would* do. Writes nothing, to either side.
+ *
+ * The point is to prove the dedupe resolver against the real backlog before any
+ * create path exists: every one of these issues has already been synced, so a
+ * correct resolver must find an existing ticket for all of them. Anything
+ * reported as WOULD-CREATE is either a genuine miss by the old flow or a bug in
+ * the resolver — both worth knowing before going live.
+ *
+ * Usage:
+ *   GITHUB_TOKEN=...            (or gh auth)
+ *   JIRA_BASE_URL=https://comet-ml.atlassian.net
+ *   JIRA_USER_EMAIL=...
+ *   JIRA_API_TOKEN=...
+ *   node .github/scripts/jc-sync/dryrun.mjs [--limit=N] [--json=out.json]
+ *
+ * Jira credentials are optional: without them tiers 1 and 2 are skipped and the
+ * run degrades to comment-only matching, which still exercises tier 3.
+ */
+import { findExistingTicket, resolveIssueType } from './resolve.mjs';
+
+const REPO_OWNER = process.env.JC_REPO_OWNER || 'comet-ml';
+const REPO_NAME = process.env.JC_REPO_NAME || 'opik';
+const TRIGGER_LABEL = process.env.JC_LABEL || 'JC';
+
+const args = process.argv.slice(2);
+const argOf = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+const LIMIT = Number(argOf('limit', '0')) || 0;
+const JSON_OUT = argOf('json', '');
+
+const GH_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const JIRA_BASE = (process.env.JIRA_BASE_URL || '').replace(/\/+$/, '');
+const JIRA_EMAIL = process.env.JIRA_USER_EMAIL || '';
+const JIRA_TOKEN = process.env.JIRA_API_TOKEN || '';
+const JIRA_READY = Boolean(JIRA_BASE && JIRA_EMAIL && JIRA_TOKEN);
+
+if (!GH_TOKEN) {
+  console.error('GITHUB_TOKEN (or GH_TOKEN) is required.');
+  process.exit(2);
+}
+
+const ghHeaders = {
+  authorization: `Bearer ${GH_TOKEN}`,
+  accept: 'application/vnd.github+json',
+  'x-github-api-version': '2022-11-28',
+  'user-agent': 'opik-jc-sync-dryrun',
+};
+
+const jiraHeaders = JIRA_READY
+  ? {
+      authorization: `Basic ${Buffer.from(`${JIRA_EMAIL}:${JIRA_TOKEN}`).toString('base64')}`,
+      accept: 'application/json',
+      'content-type': 'application/json',
+    }
+  : null;
+
+/** Fetch with a bounded retry on 429/5xx, so a long replay doesn't die midway. */
+async function request(url, opts = {}, attempt = 0) {
+  const res = await fetch(url, opts);
+  if ((res.status === 429 || res.status >= 500) && attempt < 4) {
+    const retryAfter = Number(res.headers.get('retry-after')) || 0;
+    const wait = retryAfter * 1000 || 2 ** attempt * 500;
+    await new Promise((r) => setTimeout(r, wait));
+    return request(url, opts, attempt + 1);
+  }
+  return res;
+}
+
+async function gh(path) {
+  const res = await request(`https://api.github.com${path}`, {
+    headers: ghHeaders,
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} on ${path}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function jira(path, init = {}) {
+  const res = await request(`${JIRA_BASE}${path}`, {
+    ...init,
+    headers: { ...jiraHeaders, ...(init.headers || {}) },
+  });
+  if (!res.ok) {
+    throw new Error(`Jira ${res.status} on ${path}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+/** Tier 1 — exact remote-link lookup. */
+async function findByRemoteLink(globalId) {
+  if (!JIRA_READY) return null;
+  // Jira has no "search remote links across issues" endpoint, so this is only
+  // resolvable once a ticket is known. Historical tickets have no remote links
+  // at all, so in a replay this correctly returns null and we fall through.
+  return null;
+}
+
+/** Tier 2 — JQL over the GitHub URL in the description. */
+async function findByJql(jql) {
+  if (!JIRA_READY) return null;
+  const body = JSON.stringify({ jql, maxResults: 2, fields: ['key'] });
+  const data = await jira('/rest/api/3/search/jql', { method: 'POST', body });
+  const issues = data.issues || [];
+  if (issues.length > 1) {
+    // Two tickets pointing at one GitHub issue: exactly the OPIK-6834/6835
+    // duplicate class this ticket exists to prevent. Surface it.
+    return { key: issues[0].key, duplicates: issues.map((i) => i.key) };
+  }
+  return issues.length ? issues[0].key : null;
+}
+
+async function main() {
+  console.log(
+    `Replaying label "${TRIGGER_LABEL}" on ${REPO_OWNER}/${REPO_NAME}` +
+      (JIRA_READY ? ' (Jira: on)' : ' (Jira: OFF — tier 3 only)'),
+  );
+
+  const repo = await gh(`/repos/${REPO_OWNER}/${REPO_NAME}`);
+  const repoId = repo.id;
+  console.log(`repo id ${repoId}\n`);
+
+  // Collect labeled issues (issues only — the label is never used on PRs, but
+  // filter defensively since the search endpoint returns both).
+  const issues = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await gh(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues` +
+        `?labels=${encodeURIComponent(TRIGGER_LABEL)}` +
+        `&state=all&per_page=100&page=${page}`,
+    );
+    if (!batch.length) break;
+    issues.push(...batch.filter((i) => !i.pull_request));
+    if (batch.length < 100) break;
+    if (LIMIT && issues.length >= LIMIT) break;
+  }
+
+  const scope = LIMIT ? issues.slice(0, LIMIT) : issues;
+  console.log(`${scope.length} labeled issues to replay\n`);
+
+  const rows = [];
+  const tally = {
+    matched: 0,
+    wouldCreate: 0,
+    duplicates: 0,
+    unconfidentType: 0,
+    byVia: {},
+    byType: {},
+    bySignal: {},
+  };
+
+  for (const issue of scope) {
+    const type = resolveIssueType({
+      labels: issue.labels,
+      title: issue.title,
+    });
+
+    let existing = null;
+    let error = null;
+    try {
+      existing = await findExistingTicket(
+        {
+          repoId,
+          issueNumber: issue.number,
+          issueUrl: issue.html_url,
+        },
+        {
+          findByRemoteLink,
+          findByJql,
+          listIssueComments: async () => {
+            const comments = await gh(
+              `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments?per_page=100`,
+            );
+            return comments.map((c) => c.body);
+          },
+        },
+      );
+    } catch (err) {
+      error = err.message;
+    }
+
+    const key = existing?.key ?? null;
+    const dupes = existing?.duplicates ?? null;
+
+    tally.byType[type.type] = (tally.byType[type.type] || 0) + 1;
+    tally.bySignal[type.signal] = (tally.bySignal[type.signal] || 0) + 1;
+    if (!type.confident) tally.unconfidentType += 1;
+
+    if (key) {
+      tally.matched += 1;
+      tally.byVia[existing.via] = (tally.byVia[existing.via] || 0) + 1;
+    } else if (!error) {
+      tally.wouldCreate += 1;
+    }
+    if (dupes) tally.duplicates += 1;
+
+    rows.push({
+      number: issue.number,
+      state: issue.state,
+      title: issue.title,
+      labels: issue.labels.map((l) => l.name),
+      resolvedType: type.type,
+      typeSignal: type.signal,
+      typeConfident: type.confident,
+      existingKey: key,
+      matchedVia: existing?.via ?? null,
+      duplicates: dupes,
+      error,
+    });
+
+    const verdict = error
+      ? `ERROR ${error.slice(0, 60)}`
+      : key
+        ? `match ${key} (${existing.via})`
+        : 'WOULD-CREATE';
+    const warn = [
+      type.confident ? '' : ' [type:unconfident]',
+      dupes ? ` [DUPES ${dupes.join(',')}]` : '',
+    ].join('');
+    console.log(
+      `#${String(issue.number).padEnd(5)} ${type.type.padEnd(4)} ${verdict}${warn}`,
+    );
+  }
+
+  console.log('\n--- summary ---');
+  console.log(`replayed          ${rows.length}`);
+  console.log(`matched existing  ${tally.matched}`);
+  console.log(`would create      ${tally.wouldCreate}`);
+  console.log(`duplicate pairs   ${tally.duplicates}`);
+  console.log(`unconfident type  ${tally.unconfidentType}`);
+  console.log(`matched via       ${JSON.stringify(tally.byVia)}`);
+  console.log(`type distribution ${JSON.stringify(tally.byType)}`);
+  console.log(`type signal       ${JSON.stringify(tally.bySignal)}`);
+
+  if (JSON_OUT) {
+    const { writeFile } = await import('node:fs/promises');
+    await writeFile(JSON_OUT, JSON.stringify({ tally, rows }, null, 2));
+    console.log(`\nwrote ${JSON_OUT}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/jc-sync/dryrun.mjs
+++ b/.github/scripts/jc-sync/dryrun.mjs
@@ -20,7 +20,11 @@
  * Jira credentials are optional: without them tiers 1 and 2 are skipped and the
  * run degrades to comment-only matching, which still exercises tier 3.
  */
-import { findExistingTicket, resolveIssueType } from './resolve.mjs';
+import {
+  findExistingTicket,
+  remoteLinkJql,
+  resolveIssueType,
+} from './resolve.mjs';
 
 const REPO_OWNER = process.env.JC_REPO_OWNER || 'comet-ml';
 const REPO_NAME = process.env.JC_REPO_NAME || 'opik';
@@ -93,13 +97,24 @@ async function jira(path, init = {}) {
   return res.json();
 }
 
-/** Tier 1 — exact remote-link lookup. */
+/**
+ * Tier 1 — exact remote-link lookup.
+ *
+ * `issuesWithRemoteLinksByGlobalId()` is an indexed JQL function, so this is a
+ * true exact match rather than tier 2's text search. Historical tickets carry
+ * no remote links, so during a replay of the backlog this correctly returns
+ * null and falls through.
+ */
 async function findByRemoteLink(globalId) {
   if (!JIRA_READY) return null;
-  // Jira has no "search remote links across issues" endpoint, so this is only
-  // resolvable once a ticket is known. Historical tickets have no remote links
-  // at all, so in a replay this correctly returns null and we fall through.
-  return null;
+  const body = JSON.stringify({
+    jql: remoteLinkJql(globalId),
+    maxResults: 2,
+    fields: ['key'],
+  });
+  const data = await jira('/rest/api/3/search/jql', { method: 'POST', body });
+  const issues = data.issues || [];
+  return issues.length ? issues[0].key : null;
 }
 
 /**

--- a/.github/scripts/jc-sync/resolve.mjs
+++ b/.github/scripts/jc-sync/resolve.mjs
@@ -156,11 +156,23 @@ export async function findExistingTicket(
   // would match unrelated tickets.
   const needle = issueUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '');
   const jql = `project = ${JIRA_PROJECT} AND description ~ ${JSON.stringify(`"${needle}"`)}`;
-  // Callers may return a bare key or {key, duplicates}; normalise both.
+  // Callers may return a bare key, or {key, duplicates} / {key, related}.
+  // `duplicates` means several sync-created tickets exist (a real double-create).
+  // `related` means only hand-written tickets reference this issue — a weak
+  // match worth reporting but not the same failure.
   const byJql = await findByJql(jql);
-  if (byJql) {
-    const key = typeof byJql === 'string' ? byJql : byJql.key;
-    const dupes = typeof byJql === 'string' ? null : byJql.duplicates;
+  const jqlRelated =
+    byJql && typeof byJql !== 'string' && byJql.related?.length
+      ? byJql.related
+      : null;
+
+  // A `related`-only result is NOT a match — those tickets merely cite the
+  // issue. Fall through to tier 3 rather than short-circuiting on it, or an
+  // issue that has both a citing ticket and a real marker comment gets missed.
+  if (byJql && !jqlRelated) {
+    const isStr = typeof byJql === 'string';
+    const key = isStr ? byJql : byJql.key;
+    const dupes = isStr ? null : byJql.duplicates;
     if (key) {
       return {
         key,
@@ -171,8 +183,8 @@ export async function findExistingTicket(
   }
 
   // Collect across *all* marker comments rather than returning on the first.
-  // Issue #4348 carries four (YT-51/52/53/54) — stopping early would report a
-  // clean single match and hide exactly the duplication this sync must surface.
+  // Issue #4348 carries four — stopping early would report a clean single match
+  // and hide exactly the duplication this sync must surface.
   const comments = await listIssueComments();
   const keys = [];
   for (const body of comments) {
@@ -186,7 +198,13 @@ export async function findExistingTicket(
       key: keys[0],
       via: 'github-comment',
       ...(keys.length > 1 ? { duplicates: keys } : {}),
+      ...(jqlRelated ? { related: jqlRelated } : {}),
     };
+  }
+
+  // Nothing synced, but something cites the issue — surface it for triage.
+  if (jqlRelated) {
+    return { key: null, via: null, related: jqlRelated };
   }
 
   return null;

--- a/.github/scripts/jc-sync/resolve.mjs
+++ b/.github/scripts/jc-sync/resolve.mjs
@@ -29,6 +29,16 @@ export const TRIGGER_LABEL = 'JC';
 export const COMMENT_MARKER = 'Jira Ticket Created:';
 
 /**
+ * JQL that finds the issue carrying a given remote-link globalId.
+ *
+ * Jira indexes remote links, so this is an exact lookup rather than the text
+ * search tier 2 relies on. Verified against a live ticket.
+ */
+export function remoteLinkJql(globalId) {
+  return `issue in issuesWithRemoteLinksByGlobalId(${JSON.stringify(globalId)})`;
+}
+
+/**
  * Deterministic Jira remote-link id for a GitHub issue.
  *
  * Keyed on the numeric repo id rather than `owner/name` so a repo rename or

--- a/.github/scripts/jc-sync/resolve.mjs
+++ b/.github/scripts/jc-sync/resolve.mjs
@@ -1,0 +1,258 @@
+/**
+ * JC label → Jira sync: pure resolution logic.
+ *
+ * This module holds the two decisions the sync has to make before it writes
+ * anything:
+ *
+ *   1. resolveIssueType()  — is this a Bug or a Task?
+ *   2. findExistingTicket() — has this GitHub issue already been synced?
+ *
+ * Everything here is dependency-injected (see the `deps` params) so the logic
+ * can be exercised against real data with no writes and no Actions runtime.
+ * See OPIK-7833.
+ */
+
+/** Jira project the tickets land in. */
+export const JIRA_PROJECT = 'OPIK';
+
+/** Labels every synced ticket carries. */
+export const SYNCED_LABELS = ['JC', 'Opik_Ops', 'github-sync'];
+
+/** The label that triggers a sync. */
+export const TRIGGER_LABEL = 'JC';
+
+/**
+ * Marker used in the "ticket created" comment posted back on the GitHub issue.
+ * Also parsed as the third-tier dedupe fallback, so the shape is load-bearing:
+ * changing it orphans the history.
+ */
+export const COMMENT_MARKER = 'Jira Ticket Created:';
+
+/**
+ * Deterministic Jira remote-link id for a GitHub issue.
+ *
+ * Keyed on the numeric repo id rather than `owner/name` so a repo rename or
+ * transfer doesn't silently break dedupe and start duplicating tickets.
+ */
+export function remoteLinkGlobalId(repoId, issueNumber) {
+  if (!Number.isInteger(repoId) || repoId <= 0) {
+    throw new TypeError(`repoId must be a positive integer, got ${repoId}`);
+  }
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new TypeError(
+      `issueNumber must be a positive integer, got ${issueNumber}`,
+    );
+  }
+  return `github-issue-${repoId}-${issueNumber}`;
+}
+
+/**
+ * Decide the Jira issue type for a GitHub issue.
+ *
+ * Precedence, highest first:
+ *   1. GitHub labels — the strongest signal, because a human applied them.
+ *   2. Title prefix — `[Bug]` / `[FR]`, the convention in the issue templates.
+ *   3. Default to Task, flagged as low confidence.
+ *
+ * The old n8n flow used only the title prefix and silently defaulted to Bug,
+ * which mis-typed 5 of the first 50 synced tickets — OPIK-6872 ("Able to view
+ * the full agent loop run in a single trace") is a feature request filed as a
+ * Bug. Labels first fixes that class of error.
+ *
+ * @returns {{type: 'Bug'|'Task', signal: string, confident: boolean}}
+ */
+export function resolveIssueType({ labels = [], title = '' } = {}) {
+  const lower = new Set(
+    labels
+      .map((l) => (typeof l === 'string' ? l : l?.name))
+      .filter(Boolean)
+      .map((n) => n.toLowerCase()),
+  );
+
+  // Feature-ish labels win over bug-ish ones: an issue carrying both is a
+  // feature request that someone also triaged as broken behaviour, and filing
+  // it as a Task keeps it off the bug count.
+  if (lower.has('feature_request') || lower.has('enhancement')) {
+    return { type: 'Task', signal: 'github-label', confident: true };
+  }
+  if (lower.has('bug')) {
+    return { type: 'Bug', signal: 'github-label', confident: true };
+  }
+
+  const t = title.trimStart();
+  if (/^\[FR\]/i.test(t)) {
+    return { type: 'Task', signal: 'title-prefix', confident: true };
+  }
+  if (/^\[Bug\]/i.test(t)) {
+    return { type: 'Bug', signal: 'title-prefix', confident: true };
+  }
+
+  // No signal. Task is the safer default — a mislabelled Task is untidy, a
+  // mislabelled Bug pollutes bug metrics and on-call triage.
+  return { type: 'Task', signal: 'default', confident: false };
+}
+
+/**
+ * Extract every `OPIK-1234` key from a blob of text, in order, deduped.
+ *
+ * Scoped to the target project on purpose. A generic `[A-Z]+-\d+` also matches
+ * keys from other projects that happen to be linked in the same comment — the
+ * replay found `YT-51`/`YT-44`/`YT-39` (a different Jira project) being picked
+ * up as if they were the synced ticket.
+ */
+export function parseTicketKeys(text, project = JIRA_PROJECT) {
+  if (!text) return [];
+  const re = new RegExp(`\\b(${project}-\\d+)\\b`, 'g');
+  const seen = new Set();
+  for (const m of String(text).matchAll(re)) seen.add(m[1]);
+  return [...seen];
+}
+
+/** First matching ticket key in `text`, or null. */
+export function parseTicketKey(text, project = JIRA_PROJECT) {
+  return parseTicketKeys(text, project)[0] ?? null;
+}
+
+/**
+ * Find an already-synced Jira ticket for a GitHub issue.
+ *
+ * Three tiers, cheapest and most reliable first. Any hit means "do not create".
+ *
+ *   1. Remote link by globalId — exact, indexed, and what this sync writes
+ *      going forward. The fast path for everything created from now on.
+ *   2. JQL on the GitHub URL in the description — catches the ~50 tickets the
+ *      old n8n flow created, which have no remote link. Text search, so it can
+ *      lag right after a create; never the primary key.
+ *   3. The `Jira Ticket Created:` comment on the GitHub issue itself — catches
+ *      tickets whose description was later edited, and any case where Jira
+ *      search is unavailable.
+ *
+ * Tier 3 matters more than it looks. On GitHub issue #7000 the label was
+ * toggled three times in eight minutes and produced two tickets (OPIK-6834 and
+ * OPIK-6835) — only the second was commented back, so the first was orphaned.
+ * Reading the comments is how an interrupted run recovers on retry.
+ *
+ * @param {object} args
+ * @param {number} args.repoId
+ * @param {number} args.issueNumber
+ * @param {string} args.issueUrl        - html_url of the GitHub issue
+ * @param {object} deps
+ * @param {(globalId: string) => Promise<string|null>} deps.findByRemoteLink
+ * @param {(jql: string) => Promise<string|null>}      deps.findByJql
+ * @param {() => Promise<string[]>}                    deps.listIssueComments
+ * @returns {Promise<{key: string, via: string}|null>}
+ */
+export async function findExistingTicket(
+  { repoId, issueNumber, issueUrl },
+  { findByRemoteLink, findByJql, listIssueComments },
+) {
+  const globalId = remoteLinkGlobalId(repoId, issueNumber);
+
+  const byLink = await findByRemoteLink(globalId);
+  if (byLink) return { key: byLink, via: 'remote-link' };
+
+  // Match on the path only. The stored URL may carry a trailing slash, an
+  // anchor, or http/https — and `~` is a word-ish match, so a bare number
+  // would match unrelated tickets.
+  const needle = issueUrl.replace(/^https?:\/\//, '').replace(/\/+$/, '');
+  const jql = `project = ${JIRA_PROJECT} AND description ~ ${JSON.stringify(`"${needle}"`)}`;
+  // Callers may return a bare key or {key, duplicates}; normalise both.
+  const byJql = await findByJql(jql);
+  if (byJql) {
+    const key = typeof byJql === 'string' ? byJql : byJql.key;
+    const dupes = typeof byJql === 'string' ? null : byJql.duplicates;
+    if (key) {
+      return {
+        key,
+        via: 'jql-description',
+        ...(dupes && dupes.length > 1 ? { duplicates: dupes } : {}),
+      };
+    }
+  }
+
+  // Collect across *all* marker comments rather than returning on the first.
+  // Issue #4348 carries four (YT-51/52/53/54) — stopping early would report a
+  // clean single match and hide exactly the duplication this sync must surface.
+  const comments = await listIssueComments();
+  const keys = [];
+  for (const body of comments) {
+    if (!body?.includes(COMMENT_MARKER)) continue;
+    for (const key of parseTicketKeys(body)) {
+      if (!keys.includes(key)) keys.push(key);
+    }
+  }
+  if (keys.length) {
+    return {
+      key: keys[0],
+      via: 'github-comment',
+      ...(keys.length > 1 ? { duplicates: keys } : {}),
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Convert GitHub-flavoured Markdown to Jira wiki markup.
+ *
+ * Deliberately partial. The Jira description is a convenience copy — the GitHub
+ * issue stays the source of truth, which is why the backlink matters more than
+ * perfect fidelity. Anything not handled here passes through as readable plain
+ * text rather than breaking.
+ *
+ * Targets the v2 REST API, which takes wiki markup as a plain string. The v3
+ * API would require building an ADF document tree, i.e. vendoring a Markdown→ADF
+ * converter — a real dependency for a workflow whose whole point is being easy
+ * to maintain.
+ */
+export function markdownToWiki(md) {
+  if (!md) return '';
+
+  // Pull fenced blocks out first so their contents can't be touched by the
+  // inline rules below, then restore them at the end.
+  const fences = [];
+  let out = String(md).replace(
+    /```([A-Za-z0-9_+-]*)\r?\n([\s\S]*?)```/g,
+    (_, lang, code) => {
+      const token = ` FENCE${fences.length} `;
+      const header = lang ? `{code:${lang}}` : '{code}';
+      fences.push(`${header}\n${code.replace(/\s+$/, '')}\n{code}`);
+      return token;
+    },
+  );
+
+  out = out
+    // Headings: #### and deeper collapse to h4. — Jira has no h5/h6 in practice.
+    .replace(/^#{4,}\s+(.+)$/gm, 'h4. $1')
+    .replace(/^###\s+(.+)$/gm, 'h3. $1')
+    .replace(/^##\s+(.+)$/gm, 'h2. $1')
+    .replace(/^#\s+(.+)$/gm, 'h1. $1')
+    // Task list items -> bullets carrying their state, before generic bullets.
+    .replace(/^(\s*)[-*]\s+\[[xX]\]\s+(.+)$/gm, '$1* (/) $2')
+    .replace(/^(\s*)[-*]\s+\[\s\]\s+(.+)$/gm, '$1* (x) $2')
+    // Unordered list markers -> *, preserving indent depth.
+    .replace(/^(\s*)[-*]\s+(.+)$/gm, '$1* $2')
+    // Bold/italic. Bold first: ** would otherwise be eaten as two italics.
+    .replace(/\*\*([^*\n]+)\*\*/g, '*$1*')
+    .replace(/(^|[\s(])_([^_\n]+)_(?=[\s.,;:!?)]|$)/g, '$1_$2_')
+    // Inline code.
+    .replace(/`([^`\n]+)`/g, '{{$1}}')
+    // [text](url) -> [text|url]
+    .replace(/\[([^\]\n]+)\]\((https?:\/\/[^)\s]+)\)/g, '[$1|$2]');
+
+  return out.replace(/ FENCE(\d+) /g, (_, i) => fences[Number(i)]);
+}
+
+/**
+ * Build the Jira description for a synced issue.
+ *
+ * The trailing `GitHub: <url>` line is load-bearing: it is what the tier-2 JQL
+ * fallback matches on. Keep it last and keep it bare.
+ */
+export function buildDescription({ body, issueUrl }) {
+  const converted = markdownToWiki(body).trim();
+  const parts = ['*Synced from GitHub issue body*', ''];
+  parts.push(converted.length ? converted : '_No description provided._');
+  parts.push('', `GitHub: ${issueUrl}`);
+  return parts.join('\n');
+}

--- a/.github/scripts/jc-sync/resolve.test.mjs
+++ b/.github/scripts/jc-sync/resolve.test.mjs
@@ -1,0 +1,317 @@
+/**
+ * Tests for the JC → Jira resolution logic (OPIK-7833).
+ *
+ * Run: node --test .github/scripts/jc-sync/
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildDescription,
+  findExistingTicket,
+  markdownToWiki,
+  parseTicketKey,
+  parseTicketKeys,
+  remoteLinkGlobalId,
+  resolveIssueType,
+} from './resolve.mjs';
+
+test('remoteLinkGlobalId is deterministic and repo-id keyed', () => {
+  assert.equal(remoteLinkGlobalId(12345, 7760), 'github-issue-12345-7760');
+  assert.equal(
+    remoteLinkGlobalId(12345, 7760),
+    remoteLinkGlobalId(12345, 7760),
+  );
+  // Different issues must not collide.
+  assert.notEqual(
+    remoteLinkGlobalId(12345, 776),
+    remoteLinkGlobalId(12345, 7760),
+  );
+});
+
+test('remoteLinkGlobalId rejects bad input rather than making a junk key', () => {
+  assert.throws(() => remoteLinkGlobalId(0, 1), TypeError);
+  assert.throws(() => remoteLinkGlobalId(1, 0), TypeError);
+  assert.throws(() => remoteLinkGlobalId('12345', 1), TypeError);
+  assert.throws(() => remoteLinkGlobalId(1, 1.5), TypeError);
+});
+
+test('labels take precedence over title prefix', () => {
+  // The real regression: issue #7000 carried `enhancement` and was titled
+  // "[FR]: ...". Both agree here, but the label is what we trust.
+  assert.deepEqual(
+    resolveIssueType({
+      labels: ['enhancement'],
+      title: '[FR]: Support OPIK_TRACK_DISABLE in Typescript SDK',
+    }),
+    { type: 'Task', signal: 'github-label', confident: true },
+  );
+
+  // Label disagrees with prefix -> label wins.
+  assert.equal(
+    resolveIssueType({ labels: ['enhancement'], title: '[Bug]: something' })
+      .type,
+    'Task',
+  );
+  assert.equal(
+    resolveIssueType({ labels: ['Bug'], title: '[FR]: something' }).type,
+    'Bug',
+  );
+});
+
+test('feature labels outrank bug labels when both are present', () => {
+  assert.equal(
+    resolveIssueType({ labels: ['Bug', 'enhancement'], title: 'x' }).type,
+    'Task',
+  );
+});
+
+test('label matching is case insensitive and accepts label objects', () => {
+  assert.equal(
+    resolveIssueType({ labels: [{ name: 'Feature_Request' }], title: 'x' })
+      .type,
+    'Task',
+  );
+  assert.equal(
+    resolveIssueType({ labels: ['BUG'], title: 'x' }).type,
+    'Bug',
+  );
+});
+
+test('title prefix is used when no label signal exists', () => {
+  assert.deepEqual(
+    resolveIssueType({ labels: ['JC'], title: '[Bug]: broken thing' }),
+    { type: 'Bug', signal: 'title-prefix', confident: true },
+  );
+  assert.deepEqual(resolveIssueType({ labels: [], title: '[FR] add thing' }), {
+    type: 'Task',
+    signal: 'title-prefix',
+    confident: true,
+  });
+});
+
+test('no signal defaults to Task and is flagged unconfident', () => {
+  // OPIK-6872: a feature request the old flow silently filed as a Bug.
+  const r = resolveIssueType({
+    labels: ['JC'],
+    title: 'Able to view the full agent loop run in a single trace',
+  });
+  assert.deepEqual(r, { type: 'Task', signal: 'default', confident: false });
+});
+
+test('resolveIssueType tolerates missing input', () => {
+  assert.equal(resolveIssueType().type, 'Task');
+  assert.equal(resolveIssueType({}).confident, false);
+});
+
+test('parseTicketKey pulls the ticket out of a comment body', () => {
+  assert.equal(
+    parseTicketKey(
+      '**Jira Ticket Created:** [OPIK-6835](https://comet-ml.atlassian.net/browse/OPIK-6835)',
+    ),
+    'OPIK-6835',
+  );
+  assert.equal(parseTicketKey('no key here'), null);
+  assert.equal(parseTicketKey(null), null);
+});
+
+test('parseTicketKey ignores keys from other Jira projects', () => {
+  // Regression: the replay matched YT-51/YT-44/YT-39 (a different project) as
+  // if they were the synced ticket.
+  assert.equal(
+    parseTicketKey(
+      '**Jira Ticket Created:** [YT-51](https://comet-ml.atlassian.net/browse/YT-51)',
+    ),
+    null,
+  );
+  assert.equal(
+    parseTicketKey('linked YT-51 but created OPIK-1234'),
+    'OPIK-1234',
+  );
+});
+
+test('parseTicketKeys returns every distinct key in order', () => {
+  assert.deepEqual(
+    parseTicketKeys('OPIK-51 then OPIK-52 then OPIK-51 again'),
+    ['OPIK-51', 'OPIK-52'],
+  );
+  assert.deepEqual(parseTicketKeys(''), []);
+});
+
+// --- dedupe ---------------------------------------------------------------
+
+const ISSUE = {
+  repoId: 12345,
+  issueNumber: 7760,
+  issueUrl: 'https://github.com/comet-ml/opik/issues/7760',
+};
+
+test('tier 1: remote link short-circuits before any other lookup', async () => {
+  let jqlCalls = 0;
+  let commentCalls = 0;
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async (id) =>
+      id === 'github-issue-12345-7760' ? 'OPIK-7825' : null,
+    findByJql: async () => {
+      jqlCalls += 1;
+      return null;
+    },
+    listIssueComments: async () => {
+      commentCalls += 1;
+      return [];
+    },
+  });
+  assert.deepEqual(hit, { key: 'OPIK-7825', via: 'remote-link' });
+  assert.equal(jqlCalls, 0, 'must not fall through after a remote-link hit');
+  assert.equal(commentCalls, 0);
+});
+
+test('tier 2: falls back to JQL for legacy tickets with no remote link', async () => {
+  let seenJql = '';
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async (jql) => {
+      seenJql = jql;
+      return 'OPIK-7825';
+    },
+    listIssueComments: async () => [],
+  });
+  assert.deepEqual(hit, { key: 'OPIK-7825', via: 'jql-description' });
+  // Must search on the URL path, protocol-stripped and quoted for phrase match.
+  assert.match(seenJql, /project = OPIK/);
+  assert.match(seenJql, /github\.com\/comet-ml\/opik\/issues\/7760/);
+  assert.ok(!seenJql.includes('https://'), 'protocol should be stripped');
+});
+
+test('tier 3: recovers an orphaned ticket from the GitHub comment', async () => {
+  // The OPIK-6834 case: created, never linked, never found by search.
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => null,
+    listIssueComments: async () => [
+      'Hi, I am Scout. Let me look into this.',
+      '**Jira Ticket Created:** [OPIK-6834](https://comet-ml.atlassian.net/browse/OPIK-6834)',
+    ],
+  });
+  assert.deepEqual(hit, { key: 'OPIK-6834', via: 'github-comment' });
+});
+
+test('tier 3 surfaces multiple tickets instead of hiding them', async () => {
+  // Regression: GitHub issue #4348 carries four marker comments
+  // (YT-51/52/53/54 in reality). Returning on the first match reported a clean
+  // single hit and concealed the duplication.
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => null,
+    listIssueComments: async () => [
+      '**Jira Ticket Created:** [OPIK-51](https://x/browse/OPIK-51)',
+      '**Jira Ticket Created:** [OPIK-52](https://x/browse/OPIK-52)',
+      '**Jira Ticket Created:** [OPIK-53](https://x/browse/OPIK-53)',
+    ],
+  });
+  assert.equal(hit.key, 'OPIK-51');
+  assert.equal(hit.via, 'github-comment');
+  assert.deepEqual(hit.duplicates, ['OPIK-51', 'OPIK-52', 'OPIK-53']);
+});
+
+test('tier 2 duplicate reports are normalised onto the result', async () => {
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => ({
+      key: 'OPIK-6834',
+      duplicates: ['OPIK-6834', 'OPIK-6835'],
+    }),
+    listIssueComments: async () => [],
+  });
+  assert.equal(hit.key, 'OPIK-6834');
+  assert.equal(hit.via, 'jql-description');
+  assert.deepEqual(hit.duplicates, ['OPIK-6834', 'OPIK-6835']);
+});
+
+test('a single-key result carries no duplicates field', async () => {
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => 'OPIK-7825',
+    listIssueComments: async () => [],
+  });
+  assert.equal(hit.key, 'OPIK-7825');
+  assert.ok(!('duplicates' in hit));
+});
+
+test('a comment with the marker but no parseable key does not count as a hit', async () => {
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => null,
+    listIssueComments: async () => ['Jira Ticket Created: (pending)'],
+  });
+  assert.equal(hit, null);
+});
+
+test('no match anywhere returns null so the caller creates', async () => {
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => null,
+    listIssueComments: async () => ['unrelated chatter'],
+  });
+  assert.equal(hit, null);
+});
+
+// --- markdown -------------------------------------------------------------
+
+test('fenced code becomes a Jira code macro with its language', () => {
+  const wiki = markdownToWiki('before\n```python\nx = 1\n```\nafter');
+  assert.match(wiki, /\{code:python\}\nx = 1\n\{code\}/);
+  assert.match(wiki, /before/);
+  assert.match(wiki, /after/);
+});
+
+test('inline rules do not corrupt fenced code contents', () => {
+  // Markdown-ish syntax inside a code block must survive verbatim.
+  const wiki = markdownToWiki('```\n- [x] **not bold** `nested`\n```');
+  assert.match(wiki, /- \[x\] \*\*not bold\*\* `nested`/);
+});
+
+test('headings, emphasis, inline code and links convert', () => {
+  assert.match(markdownToWiki('### Describe the problem'), /^h3\. Describe/m);
+  assert.match(markdownToWiki('##### deep'), /^h4\. deep/m);
+  assert.equal(markdownToWiki('**bold**'), '*bold*');
+  assert.equal(markdownToWiki('`code`'), '{{code}}');
+  assert.equal(
+    markdownToWiki('[text](https://example.com)'),
+    '[text|https://example.com]',
+  );
+});
+
+test('task list checkboxes keep their state', () => {
+  const wiki = markdownToWiki('- [x] Opik UI\n- [ ] Opik Server');
+  assert.match(wiki, /\* \(\/\) Opik UI/);
+  assert.match(wiki, /\* \(x\) Opik Server/);
+});
+
+test('nested list indentation is preserved', () => {
+  const wiki = markdownToWiki('- top\n  - nested');
+  assert.match(wiki, /^\* top$/m);
+  assert.match(wiki, /^ {2}\* nested$/m);
+});
+
+test('buildDescription ends with a bare GitHub URL for the JQL fallback', () => {
+  const d = buildDescription({
+    body: '### Problem\n\nIt broke.',
+    issueUrl: 'https://github.com/comet-ml/opik/issues/7760',
+  });
+  assert.match(d, /^\*Synced from GitHub issue body\*/);
+  assert.match(d, /h3\. Problem/);
+  assert.ok(
+    d.trimEnd().endsWith('GitHub: https://github.com/comet-ml/opik/issues/7760'),
+    'the URL line must be last and unadorned',
+  );
+});
+
+test('buildDescription handles an empty issue body', () => {
+  const d = buildDescription({
+    body: '',
+    issueUrl: 'https://github.com/comet-ml/opik/issues/1',
+  });
+  assert.match(d, /_No description provided\._/);
+  assert.match(d, /GitHub: https/);
+});

--- a/.github/scripts/jc-sync/resolve.test.mjs
+++ b/.github/scripts/jc-sync/resolve.test.mjs
@@ -138,6 +138,15 @@ test('parseTicketKeys returns every distinct key in order', () => {
   assert.deepEqual(parseTicketKeys(''), []);
 });
 
+test('parseTicketKeys does not match a shorter key by prefix', () => {
+  // The announcement check keys off this. A substring test would treat a
+  // comment announcing OPIK-123 as announcing OPIK-12 and skip a needed post.
+  const body = '**Jira Ticket Created:** [OPIK-123](https://x/browse/OPIK-123)';
+  assert.ok(body.includes('OPIK-12'), 'substring match is the trap');
+  assert.deepEqual(parseTicketKeys(body), ['OPIK-123']);
+  assert.ok(!parseTicketKeys(body).includes('OPIK-12'));
+});
+
 // --- dedupe ---------------------------------------------------------------
 
 const ISSUE = {

--- a/.github/scripts/jc-sync/resolve.test.mjs
+++ b/.github/scripts/jc-sync/resolve.test.mjs
@@ -228,6 +228,42 @@ test('tier 2 duplicate reports are normalised onto the result', async () => {
   assert.deepEqual(hit.duplicates, ['OPIK-6834', 'OPIK-6835']);
 });
 
+test('tier 2 related-only hits are not treated as a match', async () => {
+  // Engineers cite the GitHub URL in follow-up tickets. Those reference the
+  // issue but were never created by the sync, so they must not read as a
+  // duplicate — 27 of 33 reported "duplicates" in the first replay were these.
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => ({ key: 'OPIK-4121', related: ['OPIK-4121'] }),
+    listIssueComments: async () => [],
+  });
+  assert.equal(hit.key, null, 'a citing ticket is not a synced ticket');
+  assert.deepEqual(hit.related, ['OPIK-4121']);
+  assert.ok(!('duplicates' in hit));
+});
+
+test('a related-only tier 2 hit still falls through to tier 3', async () => {
+  // Regression: returning early on `related` skipped the comment check, so
+  // issues with both a citing ticket and a real marker comment (#5551) were
+  // reported as WOULD-CREATE despite having been synced.
+  let commentsRead = false;
+  const hit = await findExistingTicket(ISSUE, {
+    findByRemoteLink: async () => null,
+    findByJql: async () => ({ key: 'OPIK-6426', related: ['OPIK-6426'] }),
+    listIssueComments: async () => {
+      commentsRead = true;
+      return [
+        '**Jira Ticket Created:** [OPIK-5551](https://x/browse/OPIK-5551)',
+      ];
+    },
+  });
+  assert.ok(commentsRead, 'tier 3 must still run');
+  assert.equal(hit.key, 'OPIK-5551');
+  assert.equal(hit.via, 'github-comment');
+  // The citing ticket is still reported alongside the real match.
+  assert.deepEqual(hit.related, ['OPIK-6426']);
+});
+
 test('a single-key result carries no duplicates field', async () => {
   const hit = await findExistingTicket(ISSUE, {
     findByRemoteLink: async () => null,

--- a/.github/scripts/jc-sync/sync.mjs
+++ b/.github/scripts/jc-sync/sync.mjs
@@ -89,6 +89,39 @@ async function gh(path, init = {}) {
   return res.status === 204 ? null : res.json();
 }
 
+/**
+ * Pull a readable message out of a Jira error body.
+ *
+ * Jira returns `errorMessages` / `errors` as JSON, and localises some of them
+ * to the account's language — a raw dump is close to useless in a log. Fall
+ * back to the status line when there's nothing quotable.
+ */
+function jiraError(status, path, body) {
+  let detail = '';
+  try {
+    const parsed = JSON.parse(body);
+    const parts = [
+      ...(parsed.errorMessages || []),
+      ...Object.entries(parsed.errors || {}).map(([k, v]) => `${k}: ${v}`),
+    ];
+    detail = parts.join('; ');
+  } catch {
+    detail = body.slice(0, 200);
+  }
+
+  // The common failures deserve a hint rather than a bare status code.
+  const hint =
+    status === 401
+      ? ' — check JC_JIRA_USER_EMAIL / JC_JIRA_API_TOKEN'
+      : status === 403
+        ? ' — the Jira account lacks permission on this project'
+        : status === 404 && path.includes('/remotelink')
+          ? ' — ticket not visible to this account (often a bad token rather than a missing ticket)'
+          : '';
+
+  return `Jira ${status} on ${path}${hint}${detail ? `: ${detail}` : ''}`;
+}
+
 async function jira(path, init = {}) {
   const res = await request(`${JIRA_BASE}${path}`, {
     ...init,
@@ -100,7 +133,7 @@ async function jira(path, init = {}) {
     },
   });
   if (!res.ok) {
-    throw new Error(`Jira ${res.status} ${path}: ${await res.text()}`);
+    throw new Error(jiraError(res.status, path, await res.text()));
   }
   const text = await res.text();
   return text ? JSON.parse(text) : null;
@@ -134,18 +167,47 @@ async function findByJql(jql) {
   return { key: issues[0].key, related: issues.map((i) => i.key) };
 }
 
+/**
+ * Identifies this automation's failure notice so a retry updates the existing
+ * comment rather than posting another. Load-bearing — changing it strands old
+ * notices on issues.
+ */
+const FAILURE_MARKER = '<!-- jc-sync:failure -->';
+
 const summary = [];
 const note = (line) => {
   console.log(line);
   summary.push(line);
 };
 
+/** Remove a stale failure notice once a later run succeeds. */
+async function clearFailureNotice() {
+  if (DRY_RUN) return;
+  try {
+    const existing = await gh(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/comments?per_page=100`,
+    );
+    for (const c of existing.filter((c) => c.body?.includes(FAILURE_MARKER))) {
+      await gh(`/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${c.id}`, {
+        method: 'DELETE',
+      });
+      note('Cleared a stale failure notice.');
+    }
+  } catch (err) {
+    console.error(`::warning::Could not clear failure notice: ${err.message}`);
+  }
+}
+
 async function writeSummary() {
   if (!process.env.GITHUB_STEP_SUMMARY) return;
   const { appendFile } = await import('node:fs/promises');
+  const issueUrl = `${process.env.GITHUB_SERVER_URL || 'https://github.com'}/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}`;
+  const heading = DRY_RUN
+    ? `### JC → Jira — [#${ISSUE_NUMBER}](${issueUrl}) (dry run)`
+    : `### JC → Jira — [#${ISSUE_NUMBER}](${issueUrl})`;
   await appendFile(
     process.env.GITHUB_STEP_SUMMARY,
-    `### JC → Jira sync — #${ISSUE_NUMBER}\n\n${summary.map((l) => `- ${l}`).join('\n')}\n`,
+    `${heading}\n\n${summary.map((l) => `- ${l}`).join('\n')}\n\n`,
   );
 }
 
@@ -264,6 +326,8 @@ async function main() {
     note(`Commented ${key} on #${issue.number}.`);
   }
 
+  await clearFailureNotice();
+
   if (process.env.GITHUB_OUTPUT) {
     const { appendFile } = await import('node:fs/promises');
     await appendFile(process.env.GITHUB_OUTPUT, `ticket=${key}\n`);
@@ -271,9 +335,66 @@ async function main() {
   await writeSummary();
 }
 
+/**
+ * Tell the labeller the sync failed, on the issue itself.
+ *
+ * The old flow failed silently, so maintainers learned to toggle the label as a
+ * retry — which is how issue #7000 ended up with two tickets. A visible failure
+ * plus a documented re-run path removes the reason to toggle.
+ *
+ * Best-effort and idempotent: keyed on FAILURE_MARKER so a retry loop replaces
+ * the previous notice instead of stacking notices, and any error posting it is
+ * swallowed so it can't mask the original failure.
+ */
+async function reportFailure(message) {
+  if (DRY_RUN || !Number.isInteger(ISSUE_NUMBER) || ISSUE_NUMBER <= 0) return;
+
+  const runUrl =
+    process.env.GITHUB_SERVER_URL && process.env.GITHUB_RUN_ID
+      ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+      : null;
+
+  const body = [
+    FAILURE_MARKER,
+    '',
+    'Automatic Jira ticket creation failed for this issue.',
+    '',
+    `> ${message}`,
+    '',
+    runUrl ? `[View the failed run](${runUrl})` : null,
+    '',
+    'The `JC` label has been left in place. Re-run the **JC Label to Jira** ' +
+      'workflow from the Actions tab once the cause is fixed — removing and ' +
+      're-adding the label is not needed, and risks creating a duplicate.',
+  ]
+    .filter((l) => l !== null)
+    .join('\n');
+
+  try {
+    const path = `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/comments`;
+    const existing = await gh(`${path}?per_page=100`);
+    const prior = existing.find((c) => c.body?.includes(FAILURE_MARKER));
+
+    if (prior) {
+      await gh(
+        `/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${prior.id}`,
+        { method: 'PATCH', body: JSON.stringify({ body }) },
+      );
+      console.log('Updated the existing failure notice on the issue.');
+    } else {
+      await gh(path, { method: 'POST', body: JSON.stringify({ body }) });
+      console.log('Posted a failure notice on the issue.');
+    }
+  } catch (err) {
+    // Never let the notice hide the real error.
+    console.error(`::warning::Could not post failure notice: ${err.message}`);
+  }
+}
+
 main().catch(async (err) => {
   console.error(`::error::${err.message}`);
   summary.push(`**Failed:** ${err.message}`);
+  await reportFailure(err.message);
   await writeSummary().catch(() => {});
   process.exit(1);
 });

--- a/.github/scripts/jc-sync/sync.mjs
+++ b/.github/scripts/jc-sync/sync.mjs
@@ -22,10 +22,12 @@ import {
   COMMENT_MARKER,
   findExistingTicket,
   JIRA_PROJECT,
+  parseTicketKeys,
   remoteLinkGlobalId,
   remoteLinkJql,
   resolveIssueType,
   SYNCED_LABELS,
+  TRIGGER_LABEL,
 } from './resolve.mjs';
 
 const args = process.argv.slice(2);
@@ -153,18 +155,25 @@ async function findByRemoteLink(globalId) {
   return issues.length ? issues[0].key : null;
 }
 
-/** Tier 2 — text search on the GitHub URL, restricted to sync-created tickets. */
+/**
+ * Tier 2 — text search on the GitHub URL, restricted to sync-created tickets.
+ *
+ * Asks Jira for the synced tickets directly rather than fetching a capped page
+ * and filtering client-side: a popular issue can be cited by more tickets than
+ * one page holds, and a synced ticket falling off the end would read as "none
+ * synced" and create a duplicate. The unfiltered query runs only to report
+ * citing tickets, where truncation is cosmetic.
+ */
 async function findByJql(jql) {
-  const issues = await jiraSearch(jql);
-  if (!issues.length) return null;
-  const synced = issues.filter((i) =>
-    (i.fields?.labels || []).includes('github-sync'),
-  );
+  const synced = await jiraSearch(`${jql} AND labels = "github-sync"`, 50);
   if (synced.length > 1) {
     return { key: synced[0].key, duplicates: synced.map((i) => i.key) };
   }
   if (synced.length === 1) return synced[0].key;
-  return { key: issues[0].key, related: issues.map((i) => i.key) };
+
+  const any = await jiraSearch(jql, 20);
+  if (!any.length) return null;
+  return { key: any[0].key, related: any.map((i) => i.key) };
 }
 
 /**
@@ -173,6 +182,30 @@ async function findByJql(jql) {
  * notices on issues.
  */
 const FAILURE_MARKER = '<!-- jc-sync:failure -->';
+
+/**
+ * Every comment on the issue, across all pages.
+ *
+ * A single `per_page=100` read silently truncates on busy issues, and each of
+ * the three decisions that reads comments — recovery lookup, announcement
+ * check, failure-notice housekeeping — turns a missed marker into a duplicate.
+ * Cached per run because all three want the same list; pass `{fresh: true}`
+ * after posting.
+ */
+let commentCache = null;
+async function listAllComments({ fresh = false } = {}) {
+  if (commentCache && !fresh) return commentCache;
+  const all = [];
+  for (let page = 1; ; page += 1) {
+    const batch = await gh(
+      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/comments?per_page=100&page=${page}`,
+    );
+    all.push(...batch);
+    if (batch.length < 100) break;
+  }
+  commentCache = all;
+  return all;
+}
 
 const summary = [];
 const note = (line) => {
@@ -184,9 +217,7 @@ const note = (line) => {
 async function clearFailureNotice() {
   if (DRY_RUN) return;
   try {
-    const existing = await gh(
-      `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/comments?per_page=100`,
-    );
+    const existing = await listAllComments();
     for (const c of existing.filter((c) => c.body?.includes(FAILURE_MARKER))) {
       await gh(`/repos/${REPO_OWNER}/${REPO_NAME}/issues/comments/${c.id}`, {
         method: 'DELETE',
@@ -222,6 +253,22 @@ async function main() {
     return;
   }
 
+  // The label is the authorisation to sync, so re-check it here rather than
+  // trusting the caller. workflow_dispatch takes an arbitrary issue number, and
+  // creating a ticket labelled `JC` for an unlabelled issue would retroactively
+  // invent the trigger. Also covers the label being removed between the event
+  // firing and this run.
+  const labelNames = (issue.labels || []).map((l) =>
+    typeof l === 'string' ? l : l?.name,
+  );
+  if (!labelNames.includes(TRIGGER_LABEL)) {
+    note(
+      `#${issue.number} does not carry the \`${TRIGGER_LABEL}\` label — nothing to do.`,
+    );
+    await writeSummary();
+    return;
+  }
+
   const globalId = remoteLinkGlobalId(repo.id, issue.number);
   const type = resolveIssueType({ labels: issue.labels, title: issue.title });
   note(
@@ -238,12 +285,8 @@ async function main() {
     {
       findByRemoteLink,
       findByJql,
-      listIssueComments: async () => {
-        const comments = await gh(
-          `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments?per_page=100`,
-        );
-        return comments.map((c) => c.body);
-      },
+      listIssueComments: async () =>
+        (await listAllComments()).map((c) => c.body),
     },
   );
 
@@ -306,11 +349,13 @@ async function main() {
 
   // Comment back only if this exact ticket isn't already announced, so a
   // re-label doesn't add a second identical comment.
-  const comments = await gh(
-    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments?per_page=100`,
-  );
+  // Compare parsed keys, not substrings: `includes('OPIK-12')` is also true of
+  // a comment announcing OPIK-123, which would suppress a genuinely needed
+  // announcement.
+  const comments = await listAllComments();
   const announced = comments.some(
-    (c) => c.body?.includes(COMMENT_MARKER) && c.body.includes(key),
+    (c) =>
+      c.body?.includes(COMMENT_MARKER) && parseTicketKeys(c.body).includes(key),
   );
 
   if (announced) {
@@ -372,7 +417,7 @@ async function reportFailure(message) {
 
   try {
     const path = `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}/comments`;
-    const existing = await gh(`${path}?per_page=100`);
+    const existing = await listAllComments({ fresh: true });
     const prior = existing.find((c) => c.body?.includes(FAILURE_MARKER));
 
     if (prior) {

--- a/.github/scripts/jc-sync/sync.mjs
+++ b/.github/scripts/jc-sync/sync.mjs
@@ -1,0 +1,279 @@
+/**
+ * JC label → Jira sync: the write path (OPIK-7833).
+ *
+ * Given one GitHub issue, ensure a Jira ticket exists for it, is linked back,
+ * and is announced on the issue. Safe to run repeatedly: every step is
+ * idempotent, so a re-label, a retry, or a resumed run converges rather than
+ * duplicating.
+ *
+ * Order is deliberate — create, then link, then comment. If the process dies
+ * between create and link, the next run still finds the ticket via tier 2 or 3
+ * and backfills what's missing. The reverse order could strand a link with no
+ * ticket.
+ *
+ * Usage (normally invoked by .github/workflows/jc_label_to_jira.yml):
+ *   node .github/scripts/jc-sync/sync.mjs --issue=7760 [--dry-run]
+ *
+ * Env: GITHUB_TOKEN, GITHUB_REPOSITORY,
+ *      JIRA_BASE_URL, JIRA_USER_EMAIL, JIRA_API_TOKEN
+ */
+import {
+  buildDescription,
+  COMMENT_MARKER,
+  findExistingTicket,
+  JIRA_PROJECT,
+  remoteLinkGlobalId,
+  remoteLinkJql,
+  resolveIssueType,
+  SYNCED_LABELS,
+} from './resolve.mjs';
+
+const args = process.argv.slice(2);
+const argOf = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+const DRY_RUN = args.includes('--dry-run');
+const ISSUE_NUMBER = Number(argOf('issue', ''));
+
+const [REPO_OWNER, REPO_NAME] = (
+  process.env.GITHUB_REPOSITORY || 'comet-ml/opik'
+).split('/');
+
+const GH_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const JIRA_BASE = (process.env.JIRA_BASE_URL || '').replace(/\/+$/, '');
+const JIRA_EMAIL = process.env.JIRA_USER_EMAIL || '';
+const JIRA_TOKEN = process.env.JIRA_API_TOKEN || '';
+
+function fail(msg) {
+  console.error(`::error::${msg}`);
+  process.exit(1);
+}
+
+if (!Number.isInteger(ISSUE_NUMBER) || ISSUE_NUMBER <= 0) {
+  fail('--issue=<number> is required');
+}
+if (!GH_TOKEN) fail('GITHUB_TOKEN is required');
+if (!JIRA_BASE || !JIRA_EMAIL || !JIRA_TOKEN) {
+  fail('JIRA_BASE_URL, JIRA_USER_EMAIL and JIRA_API_TOKEN are required');
+}
+
+const ghHeaders = {
+  authorization: `Bearer ${GH_TOKEN}`,
+  accept: 'application/vnd.github+json',
+  'x-github-api-version': '2022-11-28',
+  'user-agent': 'opik-jc-sync',
+};
+const jiraAuth = `Basic ${Buffer.from(`${JIRA_EMAIL}:${JIRA_TOKEN}`).toString('base64')}`;
+
+async function request(url, opts = {}, attempt = 0) {
+  const res = await fetch(url, opts);
+  if ((res.status === 429 || res.status >= 500) && attempt < 4) {
+    const retryAfter = Number(res.headers.get('retry-after')) || 0;
+    await new Promise((r) =>
+      setTimeout(r, retryAfter * 1000 || 2 ** attempt * 500),
+    );
+    return request(url, opts, attempt + 1);
+  }
+  return res;
+}
+
+async function gh(path, init = {}) {
+  const res = await request(`https://api.github.com${path}`, {
+    ...init,
+    headers: { ...ghHeaders, ...(init.headers || {}) },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub ${res.status} ${path}: ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+async function jira(path, init = {}) {
+  const res = await request(`${JIRA_BASE}${path}`, {
+    ...init,
+    headers: {
+      authorization: jiraAuth,
+      accept: 'application/json',
+      'content-type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Jira ${res.status} ${path}: ${await res.text()}`);
+  }
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}
+
+async function jiraSearch(jql, maxResults = 10) {
+  const data = await jira('/rest/api/3/search/jql', {
+    method: 'POST',
+    body: JSON.stringify({ jql, maxResults, fields: ['key', 'labels'] }),
+  });
+  return data.issues || [];
+}
+
+/** Tier 1 — indexed exact lookup by remote-link globalId. */
+async function findByRemoteLink(globalId) {
+  const issues = await jiraSearch(remoteLinkJql(globalId), 2);
+  return issues.length ? issues[0].key : null;
+}
+
+/** Tier 2 — text search on the GitHub URL, restricted to sync-created tickets. */
+async function findByJql(jql) {
+  const issues = await jiraSearch(jql);
+  if (!issues.length) return null;
+  const synced = issues.filter((i) =>
+    (i.fields?.labels || []).includes('github-sync'),
+  );
+  if (synced.length > 1) {
+    return { key: synced[0].key, duplicates: synced.map((i) => i.key) };
+  }
+  if (synced.length === 1) return synced[0].key;
+  return { key: issues[0].key, related: issues.map((i) => i.key) };
+}
+
+const summary = [];
+const note = (line) => {
+  console.log(line);
+  summary.push(line);
+};
+
+async function writeSummary() {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+  const { appendFile } = await import('node:fs/promises');
+  await appendFile(
+    process.env.GITHUB_STEP_SUMMARY,
+    `### JC → Jira sync — #${ISSUE_NUMBER}\n\n${summary.map((l) => `- ${l}`).join('\n')}\n`,
+  );
+}
+
+async function main() {
+  const repo = await gh(`/repos/${REPO_OWNER}/${REPO_NAME}`);
+  const issue = await gh(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${ISSUE_NUMBER}`,
+  );
+
+  if (issue.pull_request) {
+    note('Target is a pull request, not an issue — nothing to do.');
+    return;
+  }
+
+  const globalId = remoteLinkGlobalId(repo.id, issue.number);
+  const type = resolveIssueType({ labels: issue.labels, title: issue.title });
+  note(
+    `Resolved type **${type.type}** (${type.signal}${type.confident ? '' : ', low confidence'})`,
+  );
+  if (!type.confident) {
+    console.log(
+      `::warning::No label or title prefix on #${issue.number}; defaulted to ${type.type}`,
+    );
+  }
+
+  const existing = await findExistingTicket(
+    { repoId: repo.id, issueNumber: issue.number, issueUrl: issue.html_url },
+    {
+      findByRemoteLink,
+      findByJql,
+      listIssueComments: async () => {
+        const comments = await gh(
+          `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments?per_page=100`,
+        );
+        return comments.map((c) => c.body);
+      },
+    },
+  );
+
+  if (existing?.duplicates) {
+    console.log(
+      `::warning::#${issue.number} already has multiple synced tickets: ${existing.duplicates.join(', ')}`,
+    );
+  }
+  if (existing?.related) {
+    note(`Tickets citing this issue (not sync-created): ${existing.related.join(', ')}`);
+  }
+
+  let key = existing?.key ?? null;
+
+  if (key) {
+    note(`Existing ticket **${key}** found via ${existing.via} — not creating.`);
+  } else if (DRY_RUN) {
+    note(`DRY RUN — would create a ${type.type} in ${JIRA_PROJECT}.`);
+    await writeSummary();
+    return;
+  } else {
+    const created = await jira('/rest/api/2/issue', {
+      method: 'POST',
+      body: JSON.stringify({
+        fields: {
+          project: { key: JIRA_PROJECT },
+          issuetype: { name: type.type },
+          summary: issue.title.slice(0, 255),
+          description: buildDescription({
+            body: issue.body,
+            issueUrl: issue.html_url,
+          }),
+          labels: SYNCED_LABELS,
+          priority: { name: 'Medium' },
+        },
+      }),
+    });
+    key = created.key;
+    note(`Created **${key}** (${type.type}).`);
+  }
+
+  // Backfill the link even on an existing ticket: the ~50 tickets from the old
+  // flow have none, and adding one upgrades them to the tier 1 fast path.
+  // POSTing the same globalId twice returns the same link, so this is safe.
+  if (DRY_RUN) {
+    note(`DRY RUN — would ensure remote link \`${globalId}\` on ${key}.`);
+  } else {
+    await jira(`/rest/api/3/issue/${key}/remotelink`, {
+      method: 'POST',
+      body: JSON.stringify({
+        globalId,
+        object: {
+          url: issue.html_url,
+          title: `${REPO_OWNER}/${REPO_NAME}#${issue.number}`,
+        },
+      }),
+    });
+    note(`Remote link ensured (\`${globalId}\`).`);
+  }
+
+  // Comment back only if this exact ticket isn't already announced, so a
+  // re-label doesn't add a second identical comment.
+  const comments = await gh(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments?per_page=100`,
+  );
+  const announced = comments.some(
+    (c) => c.body?.includes(COMMENT_MARKER) && c.body.includes(key),
+  );
+
+  if (announced) {
+    note(`${key} already announced on the issue — no comment posted.`);
+  } else if (DRY_RUN) {
+    note(`DRY RUN — would comment ${key} on #${issue.number}.`);
+  } else {
+    const url = `${JIRA_BASE}/browse/${key}`;
+    await gh(`/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issue.number}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body: `**${COMMENT_MARKER}** [${key}](${url})` }),
+    });
+    note(`Commented ${key} on #${issue.number}.`);
+  }
+
+  if (process.env.GITHUB_OUTPUT) {
+    const { appendFile } = await import('node:fs/promises');
+    await appendFile(process.env.GITHUB_OUTPUT, `ticket=${key}\n`);
+  }
+  await writeSummary();
+}
+
+main().catch(async (err) => {
+  console.error(`::error::${err.message}`);
+  summary.push(`**Failed:** ${err.message}`);
+  await writeSummary().catch(() => {});
+  process.exit(1);
+});

--- a/.github/workflows/jc_label_to_jira.yml
+++ b/.github/workflows/jc_label_to_jira.yml
@@ -44,6 +44,24 @@ jobs:
       issues: write # to comment the Jira link back on the issue
 
     steps:
+      # Fail before touching the issue. Without this, an unconfigured repo would
+      # reach the sync, fail on a Jira 401, and leave a failure notice on a real
+      # issue — noise caused by setup, not by the issue.
+      - name: Check Jira credentials are configured
+        env:
+          JIRA_BASE_URL: ${{ vars.JC_JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JC_JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JC_JIRA_API_TOKEN }}
+        run: |
+          missing=""
+          [ -n "${JIRA_BASE_URL}" ]   || missing="${missing} vars.JC_JIRA_BASE_URL"
+          [ -n "${JIRA_USER_EMAIL}" ] || missing="${missing} secrets.JC_JIRA_USER_EMAIL"
+          [ -n "${JIRA_API_TOKEN}" ]  || missing="${missing} secrets.JC_JIRA_API_TOKEN"
+          if [ -n "${missing}" ]; then
+            echo "::error::JC → Jira is not configured. Missing:${missing}"
+            exit 1
+          fi
+
       - name: Checkout
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/jc_label_to_jira.yml
+++ b/.github/workflows/jc_label_to_jira.yml
@@ -1,0 +1,70 @@
+name: JC Label to Jira
+
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch'
+      && format('JC → Jira for issue {0} (manual)', inputs.issue_number)
+      || format('JC → Jira for issue {0}', github.event.issue.number) }}
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to sync
+        required: true
+        type: number
+      dry_run:
+        description: Resolve and report, but write nothing
+        required: false
+        default: false
+        type: boolean
+
+# Serialise per issue. Maintainers re-label to retry (issue #7760 saw five label
+# events in 34 minutes), and concurrent runs would both miss the dedupe check
+# and create. cancel-in-progress stays false so an in-flight create is never
+# killed halfway.
+concurrency:
+  group: jc-sync-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    # Only the JC label triggers a sync; every other label event is a no-op.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.label.name == 'JC'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write # to comment the Jira link back on the issue
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          sparse-checkout: .github/scripts/jc-sync
+          persist-credentials: false
+
+      - name: Sync issue to Jira
+        # Everything is passed through env: rather than interpolated into the
+        # run body — issue titles and bodies are attacker-controlled text.
+        # See https://docs.github.com/en/actions/reference/security/secure-use
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          JIRA_BASE_URL: ${{ vars.JC_JIRA_BASE_URL }}
+          JIRA_USER_EMAIL: ${{ secrets.JC_JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JC_JIRA_API_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: |
+          if [ "${DRY_RUN}" = "true" ]; then
+            node .github/scripts/jc-sync/sync.mjs --issue="${ISSUE_NUMBER}" --dry-run
+          else
+            node .github/scripts/jc-sync/sync.mjs --issue="${ISSUE_NUMBER}"
+          fi

--- a/.github/workflows/jc_label_to_jira.yml
+++ b/.github/workflows/jc_label_to_jira.yml
@@ -33,10 +33,20 @@ permissions:
 
 jobs:
   sync:
-    # Only the JC label triggers a sync; every other label event is a no-op.
+    # Two gates:
+    #
+    #  - `vars.JC_SYNC_ENABLED` must be 'true'. Merging this while the n8n
+    #    workflow still reacts to the same label would have both producers
+    #    create their own ticket, and GitHub concurrency cannot serialise an
+    #    external system. The variable is the cutover switch: set it only once
+    #    n8n is confirmed off. It gates the manual path too, so a dispatch
+    #    cannot bypass it.
+    #  - the label must be exactly `JC` (case-sensitive, matching the repo
+    #    label); every other label event is a no-op.
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.label.name == 'JC'
+      vars.JC_SYNC_ENABLED == 'true'
+      && (github.event_name == 'workflow_dispatch'
+          || github.event.label.name == 'JC')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Details

Replaces the externally-hosted n8n automation that turns a `JC` label into a Jira ticket with a GitHub Action in this repo, so the flow is reviewable in a PR and has run history next to the code. Requested by Yariv Hashai; the motivation was maintainability.

Not a port — n8n was treated as a black box and this is a clean build against its observable contract (label on → OPIK ticket out → link commented back), with the failure modes of the old flow fixed:

- **Idempotent.** Re-labelling, retrying, or resuming converges instead of duplicating. Dedupe runs before any create, the Jira remote link is keyed on a deterministic `globalId`, and the comment is skipped when the ticket is already announced.
- **Issue type from labels first.** The old flow keyed only on the title prefix and silently defaulted to Bug, mis-typing 5 of the first 50 synced tickets.
- **Failures are visible.** The job fails, posts a notice on the issue, and says to re-run the workflow rather than re-label — re-labelling as a retry is what produced the duplicate on OPIK_7000's issue.

> [!IMPORTANT]
> **Off by default.** The job does not run until `vars.JC_SYNC_ENABLED` is `'true'`, so merging is safe while n8n is still live. Cutover is then a deliberate, separate step:
> 1. Jira service account + `vars.JC_JIRA_BASE_URL`, `secrets.JC_JIRA_USER_EMAIL`, `secrets.JC_JIRA_API_TOKEN`.
> 2. Disable the n8n workflow reacting to the same label (nothing in this repo can do that).
> 3. Set `JC_SYNC_ENABLED` to `true`.
>
> Still a draft until the service account exists.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7833

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigation of the existing flow, all four files under `.github/scripts/jc-sync/`, the workflow, and this description.
- Human verification: Author reviewed the design and directed the approach; the dry-run replay was run against the live backlog and the create/idempotence/failure paths were exercised against the real GitHub and Jira APIs (evidence below).

## Testing

Unit tests — 29 pass:

```
node --test .github/scripts/jc-sync/resolve.test.mjs
```

Linters, matching what the Code Quality workflow runs:

```
actionlint .github/workflows/jc_label_to_jira.yml
uvx zizmor@1.27.0 --offline --min-severity high --persona regular --no-progress .github/workflows/jc_label_to_jira.yml
```

Both clean.

**Dedupe against the live backlog.** Replayed all 79 `JC`-labelled issues read-only:

```
node .github/scripts/jc-sync/dryrun.mjs
→ 65 matched, 14 would-create, 6 duplicate pairs
```

Every one of the 14 was checked by hand: 4 are test issues synced to the unrelated `YT` project, 4 have only a hand-written ticket citing them, and 6 were never synced at all. Nothing genuinely synced reports as would-create.

The 6 duplicate pairs are pre-existing data problems this surfaces rather than causes. An earlier version reported 33 — the GitHub URL legitimately appears in follow-up tickets, so dedupe now filters on the `github-sync` label and reports mere citations separately.

**Create + idempotence.** Against a private scratch GitHub repo and the real OPIK project: first run created the ticket, attached the remote link and commented; two further runs matched via the remote-link fast path and wrote nothing. Final state was exactly one ticket, one remote link, one comment. Description verified to parse into real headings, code blocks and lists.

**Failure + recovery.** With a deliberately invalid Jira token: two consecutive failures left exactly one notice on the issue (the second updated the first rather than stacking), and the recovery run deleted it.

**Not exercised:** the workflow has never run on GitHub's runners — the script was driven directly. The `if:` gate, concurrency group and dry-run wiring were checked against representative event payloads, and the repo label was confirmed to be exactly `JC` (the gate is case-sensitive), but the first real label event is still the first true test of the YAML. That is the main thing to watch on merge.

## Documentation

`.github/scripts/jc-sync/README.md` covers the design, the three config values, the idempotence guarantees, the failure path, and a cutover checklist including the optional backfill that attaches remote links to the ~50 legacy tickets.
