### PR TITLE
test(frontend): cover useQueryParamAndLocalStorageState

### DIFF
--- a/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.test.ts
+++ b/apps/opik-frontend/src/hooks/useQueryParamAndLocalStorageState.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { StringParam } from "use-query-params";
+
+const mockSetQueryValue = vi.fn();
+const mockSetLocalStorageValue = vi.fn();
+
+let queryValue: string | null | undefined;
+let localStorageValue: string | null | undefined;
+
+vi.mock("use-query-params", () => ({
+  StringParam: {},
+  useQueryParam: () => [queryValue, mockSetQueryValue],
+}));
+
+vi.mock("use-local-storage-state", () => ({
+  default: (_key: string, options: { defaultValue: string }) => [
+    localStorageValue ?? options.defaultValue,
+    mockSetLocalStorageValue,
+  ],
+}));
+
+import useQueryParamAndLocalStorageState from "./useQueryParamAndLocalStorageState";
+
+const renderSubject = (overrides: Record<string, unknown> = {}) =>
+  renderHook(() =>
+    useQueryParamAndLocalStorageState<string | null | undefined>({
+      localStorageKey: "test-key",
+      queryKey: "test_param",
+      defaultValue: "fallback",
+      queryParamConfig: StringParam,
+      syncQueryWithLocalStorageOnInit: true,
+      ...overrides,
+    }),
+  );
+
+describe("useQueryParamAndLocalStorageState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryValue = undefined;
+    localStorageValue = undefined;
+  });
+
+  describe("value resolution", () => {
+    it("should prefer the URL value over the stored one", () => {
+      queryValue = "from-url";
+      localStorageValue = "from-storage";
+
+      const { result } = renderSubject();
+
+      expect(result.current[0]).toBe("from-url");
+    });
+
+    it("should fall back to the stored value when the URL is empty", () => {
+      localStorageValue = "from-storage";
+
+      const { result } = renderSubject();
+
+      expect(result.current[0]).toBe("from-storage");
+    });
+
+    it("should fall back to the default when neither is set", () => {
+      const { result } = renderSubject();
+
+      expect(result.current[0]).toBe("fallback");
+    });
+  });
+
+  describe("setValue", () => {
+    it("should write to both the URL and storage, so the choice survives navigation", () => {
+      const { result } = renderSubject();
+
+      result.current[1]("chosen");
+
+      expect(mockSetLocalStorageValue).toHaveBeenCalledWith("chosen");
+      expect(mockSetQueryValue).toHaveBeenCalledWith("chosen");
+    });
+
+    it("should resolve an updater function against the current value", () => {
+      queryValue = "from-url";
+
+      const { result } = renderSubject();
+
+      result.current[1]((current) => `${current}-updated`);
+
+      expect(mockSetLocalStorageValue).toHaveBeenCalledWith("from-url-updated");
+      expect(mockSetQueryValue).toHaveBeenCalledWith("from-url-updated");
+    });
+  });
+
+  describe("init sync", () => {
+    it("should seed the URL from the current value on mount when the URL is empty", () => {
+      renderSubject();
+
+      expect(mockSetQueryValue).toHaveBeenCalledWith("fallback");
+    });
+
+    it("should seed the URL from the stored value when one exists", () => {
+      localStorageValue = "from-storage";
+
+      renderSubject();
+
+      expect(mockSetQueryValue).toHaveBeenCalledWith("from-storage");
+    });
+
+    it("should not overwrite a value already present in the URL", () => {
+      queryValue = "from-url";
+
+      renderSubject();
+
+      expect(mockSetQueryValue).not.toHaveBeenCalled();
+    });
+
+    it("should not sync when syncQueryWithLocalStorageOnInit is off", () => {
+      renderSubject({ syncQueryWithLocalStorageOnInit: false });
+
+      expect(mockSetQueryValue).not.toHaveBeenCalled();
+    });
+
+    it("should sync only once, not on every render", () => {
+      const { rerender } = renderSubject();
+      rerender();
+      rerender();
+
+      expect(mockSetQueryValue).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Details

`useQueryParamAndLocalStorageState` decides how a URL query param and a `localStorage` value combine, and it backs the date-range state on the Logs and Dashboards pages — but it had no tests. This adds them. No production code is touched.

Two behaviours are easy to break without noticing and hard to infer from the code, so they are the focus:
- the **URL takes precedence** over the stored value;
- the **localStorage → URL seeding runs once on mount** and must not overwrite a value the URL already carries.

Also covers `setValue` writing both sides (so a choice survives navigation) and resolving updater functions, plus the default-value fallback.

Split out of #7801 on review feedback: that PR had briefly added an `initSyncReady` option here, and once the option proved unnecessary it was reverted so the PR stops touching this shared hook. The coverage seemed worth keeping on its own rather than dropping, hence this PR.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
-

No Jira ticket — test-only follow-up. Split out of OPIK_7793 / #7801 (related, not resolved here).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Wrote the test file. No production code changed.
- Human verification: Author reviewed the diff. The mutation results below were run and are reproducible.

## Testing

```
cd apps/opik-frontend
npx vitest run src/hooks/useQueryParamAndLocalStorageState.test.ts   # 10 passed
npx eslint --max-warnings=0 src/hooks/useQueryParamAndLocalStorageState.test.ts
npx tsc --project tsconfig.json --noEmit
```

Rather than assume the assertions bite, each was mutation-checked against the unmodified hook — every mutation below is caught:

| Mutation | Result |
|---|---|
| Swap precedence to `localStorageValue ?? (queryValue as T)` | **2 failed** |
| Drop the `isUndefined(queryValue)` guard on the init sync | **1 failed** |
| Remove the effect's dependency array (syncs every render) | **1 failed** |
| Unmodified hook | 10 passed |

The hook is mocked at its two dependencies (`use-query-params`, `use-local-storage-state`) so the tests assert this hook's own combining logic rather than those libraries'.

Not run: nothing else — the change is a single new test file.

## Documentation

None needed; no behaviour change.
