### PR TITLE
docs: add Twilio Agent Connect integration guide

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -87,6 +87,10 @@ Connect your AI coding assistant directly to your Opik workspace with the MCP se
   <Card title="Smolagents" href="/integrations/smolagents" />
   <Card title="Strands Agents" href="/integrations/strands-agents" />
   <Card title="Temporal" href="/integrations/temporal" />
+  <Card
+    title="Twilio Agent Connect"
+    href="/integrations/twilio-agent-connect"
+  />
   <Card title="VoltAgent" href="/integrations/voltagent" />
 </CardGroup>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
@@ -1,0 +1,182 @@
+---
+description: Start here to integrate Opik into your Twilio Agent Connect voice agent
+  for end-to-end LLM observability, unit testing, and optimization.
+headline: Twilio Agent Connect
+og:description: Learn to integrate Opik with Twilio Agent Connect to trace every caller
+  turn and attach call recordings to your voice agent conversations.
+og:site_name: Opik Documentation
+og:title: Integrate Opik with Twilio Agent Connect
+title: Observability for Twilio Agent Connect with Opik
+---
+
+[Twilio Agent Connect](https://www.twilio.com/docs/agent-connect) (TAC) is a framework for building AI agents that answer real phone calls. It handles the telephony, speech-to-text and text-to-speech, and calls your handler with the caller's transcribed message.
+
+This guide explains how to log your voice agent to Opik. You will trace every caller turn, group the turns of a call into a single conversation, and attach the call recording so you can listen to what the caller heard.
+
+## Account Setup
+
+[Comet](https://www.comet.com/site?from=llm&utm_source=opik&utm_medium=docs&utm_content=twilio&utm_campaign=opik) provides a hosted version of the Opik platform, [simply create an account](https://www.comet.com/signup?from=llm&utm_source=opik&utm_medium=docs&utm_content=twilio&utm_campaign=opik) and grab your API Key.
+
+> You can also run the Opik platform locally, see the [installation guide](https://www.comet.com/docs/opik/self-host/overview/?from=llm&utm_source=opik&utm_medium=docs&utm_content=twilio&utm_campaign=opik) for more information.
+
+## Getting Started
+
+### Installation
+
+Install the `opik` and `twilio-agent-connect` packages:
+
+```bash
+pip install opik twilio-agent-connect
+```
+
+### Configuring Opik
+
+Configure the Opik Python SDK for your deployment type. See the [Python SDK Configuration guide](/tracing/advanced/sdk_configuration) for detailed instructions on:
+
+- **CLI configuration**: `opik configure`
+- **Code configuration**: `opik.configure()`
+- **Self-hosted vs Cloud vs Enterprise** setup
+- **Configuration files** and environment variables
+
+## Logging traces
+
+Twilio Agent Connect calls your handler once for every caller turn. Add the `@opik.track` decorator to that handler and each turn becomes a trace.
+
+Set `thread_id` to the conversation id so that every turn of the same phone call is grouped into a single Opik thread:
+
+```python title="agent.py"
+import opik
+from opik import opik_context
+from tac import TAC, TACConfig
+from tac.models.session import ConversationSession
+from tac.models.tac import TACMemoryResponse
+
+tac = TAC(TACConfig(
+    account_sid=TWILIO_ACCOUNT_SID,
+    auth_token=TWILIO_AUTH_TOKEN,
+    api_key=TWILIO_API_KEY,
+    api_secret=TWILIO_API_SECRET,
+    phone_number=TWILIO_PHONE_NUMBER,
+))
+
+
+@opik.track(name="voice-agent-turn", project_name="my-voice-agent")
+async def handle_message_ready(
+    message: str,
+    context: ConversationSession,
+    memory: TACMemoryResponse | None,
+) -> str:
+    # Group every turn of this call into one Opik thread
+    opik_context.update_current_trace(thread_id=context.conversation_id)
+
+    response = await run_my_agent(message, context, memory)
+    return response
+
+
+tac.on_message_ready(handle_message_ready)
+```
+
+That is the whole tracing setup. One caller turn is one trace, and one phone call is one thread.
+
+<Tip>
+  Any function you call from the handler can be traced too. Add `@opik.track` to your
+  retrieval step, your tools and your LLM calls, and they appear as nested spans on the
+  turn's trace.
+</Tip>
+
+You can also log useful call details as metadata:
+
+```python
+opik_context.update_current_trace(
+    thread_id=context.conversation_id,
+    metadata={
+        "channel": context.channel,
+        "profile_id": context.profile_id,
+    },
+)
+```
+
+## Logging call recordings
+
+Your handler receives text, because Twilio performs the speech-to-text and text-to-speech. To listen to a conversation in Opik, record the call with Twilio and attach the audio to your thread. Opik plays audio attachments inline.
+
+### Step 1: Start the recording
+
+Twilio Agent Connect lets you run code when an inbound call arrives. Use that hook to start a recording, and tell Twilio where to notify you when the audio is ready:
+
+```python title="recording.py"
+from twilio.rest import Client
+from tac.models.voice import TwiMLOptions, TwiMLRequest
+
+twilio = Client(TWILIO_API_KEY, TWILIO_API_SECRET, TWILIO_ACCOUNT_SID)
+
+
+async def start_recording(request: TwiMLRequest) -> TwiMLOptions:
+    twilio.calls(request.call_sid).recordings.create(
+        recording_channels="dual",
+        recording_status_callback=f"{PUBLIC_URL}/recording",
+    )
+    return TwiMLOptions()
+
+
+voice_channel.on_inbound_call_twiml(start_recording)
+```
+
+`recording_channels="dual"` keeps the caller and the agent on separate audio channels.
+
+### Step 2: Attach the recording
+
+When the call ends, Twilio calls your webhook with a link to the audio. Download it and attach it to a trace in the same thread:
+
+```python title="recording.py"
+import httpx
+import opik
+from opik import Attachment
+
+opik_client = opik.Opik(project_name="my-voice-agent")
+
+
+@app.post("/recording")
+async def recording_ready(request: Request):
+    form = await request.form()
+    call_sid = form["CallSid"]
+
+    audio = httpx.get(
+        f"{form['RecordingUrl']}.mp3",
+        auth=(TWILIO_API_KEY, TWILIO_API_SECRET),
+    )
+
+    opik_client.trace(
+        name="call-recording",
+        thread_id=call_sid,
+        output={"duration_s": int(form["RecordingDuration"])},
+        attachments=[
+            Attachment(
+                data=audio.content,
+                file_name=f"call-{call_sid}.mp3",
+                content_type="audio/mpeg",
+            )
+        ],
+    )
+    opik_client.flush()
+```
+
+Twilio uses the call SID as the conversation id, so the recording lands in the same Opik thread as the turns of that call. Open the thread in Opik and you can read the transcript and play the audio side by side.
+
+<Note>
+  Call recording is subject to local laws on consent. Check the rules that apply where
+  your callers are before you enable it.
+</Note>
+
+## What gets logged
+
+With this setup, Opik records:
+
+- **Threads**: one per phone call, containing every turn in order
+- **Traces**: one per caller turn, with the caller's message and the agent's reply
+- **Spans**: your retrieval, tools and LLM calls, including token usage and cost
+- **Attachments**: the call recording, playable in the Opik UI
+
+## Further improvements
+
+If you have any questions or suggestions for improving the Twilio Agent Connect integration, please [open an issue](https://github.com/comet-ml/opik/issues/new/choose) on our GitHub repository.

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
@@ -78,12 +78,6 @@ tac.on_message_ready(handle_message_ready)
 
 That is the whole tracing setup. One caller turn is one trace, and one phone call is one thread.
 
-<Tip>
-  Any function you call from the handler can be traced too. Add `@opik.track` to your
-  retrieval step, your tools and your LLM calls, and they appear as nested spans on the
-  turn's trace.
-</Tip>
-
 You can also log useful call details as metadata:
 
 ```python
@@ -95,6 +89,111 @@ opik_context.update_current_trace(
     },
 )
 ```
+
+## Adding spans to a turn
+
+A voice agent usually does several things before it answers: it looks up the caller, searches a knowledge base, calls a few tools, then calls an LLM. Add `@opik.track` to each of those functions and they appear as nested spans under the turn's trace, so you can see where the time went and what each step returned.
+
+Use the `type` argument to tell Opik what kind of step it is. Opik shows `llm` and `tool` spans differently, and `llm` spans are where token usage and cost appear.
+
+```python title="agent.py"
+@opik.track(name="knowledge-search", type="general")
+def search_knowledge_base(query: str) -> list[str]:
+    return my_vector_store.search(query)
+
+
+@opik.track(name="account-lookup", type="tool")
+def account_lookup(phone: str) -> dict:
+    return billing_api.get_account(phone)
+
+
+@opik.track(name="generate-reply", type="llm")
+def generate_reply(messages: list[dict]) -> str:
+    ...
+
+
+@opik.track(name="voice-agent-turn")
+async def handle_message_ready(message, context, memory) -> str:
+    opik_context.update_current_trace(thread_id=context.conversation_id)
+
+    # Each call below becomes a span on this turn's trace
+    docs = search_knowledge_base(message)
+    account = account_lookup(context.author_info.address)
+    return generate_reply(build_messages(message, docs, account))
+```
+
+### Adding detail to a span
+
+Inside a tracked function, use `update_current_span` to record anything the arguments and return value do not already capture:
+
+```python
+from opik import opik_context
+
+
+@opik.track(name="knowledge-search", type="general")
+def search_knowledge_base(query: str) -> list[str]:
+    results = my_vector_store.search(query)
+
+    opik_context.update_current_span(
+        metadata={"index": "support-articles", "top_k": 5},
+        output={"documents": results, "hit_count": len(results)},
+    )
+    return results
+```
+
+<Tip>
+  For the full set of options, including how to log spans without a decorator, see the
+  [Log traces](/tracing/advanced/log_traces) guide.
+</Tip>
+
+### Tracking LLM calls automatically
+
+If you call an LLM provider directly, use the matching Opik integration instead of writing your own `llm` span. Token usage, cost and model parameters are then logged for you, and the spans still nest under the current turn:
+
+```python title="agent.py"
+from opik.integrations.openai import track_openai
+from openai import OpenAI
+
+client = track_openai(OpenAI())
+
+
+@opik.track(name="voice-agent-turn")
+async def handle_message_ready(message, context, memory) -> str:
+    opik_context.update_current_trace(thread_id=context.conversation_id)
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=build_messages(message, context),
+    )
+    return response.choices[0].message.content
+```
+
+See the [OpenAI](/integrations/openai), [Anthropic](/integrations/anthropic) and [Gemini](/integrations/gemini) integrations, or browse [all integrations](/integrations/overview) for the framework you use.
+
+## Adding guardrails
+
+A phone call is a live, unattended channel, so it is a good place to check what the caller says and what the agent is about to say. Opik guardrails run in the same request, and each check appears on the turn's trace with its own pass or fail result.
+
+```python title="agent.py"
+from opik import exceptions
+from opik.guardrails import Guardrail, PII, PromptInjection
+
+inbound = Guardrail(guards=[PromptInjection(threshold=0.5), PII()])
+
+
+@opik.track(name="voice-agent-turn")
+async def handle_message_ready(message, context, memory) -> str:
+    opik_context.update_current_trace(thread_id=context.conversation_id)
+
+    try:
+        inbound.validate(message)
+    except exceptions.GuardrailValidationFailed:
+        return "Sorry, I can't help with that. Let me put you through to a colleague."
+
+    return await run_my_agent(message, context, memory)
+```
+
+See the [Guardrails overview](/guardrails/overview) for the available checks, and [Custom guardrails](/guardrails/custom-guardrails) if you need one trained on your own policy.
 
 ## Logging call recordings
 
@@ -175,7 +274,16 @@ With this setup, Opik records:
 - **Threads**: one per phone call, containing every turn in order
 - **Traces**: one per caller turn, with the caller's message and the agent's reply
 - **Spans**: your retrieval, tools and LLM calls, including token usage and cost
+- **Guardrail results**: the pass or fail result of each check you run on the turn
 - **Attachments**: the call recording, playable in the Opik UI
+
+## Next steps
+
+- [Log traces](/tracing/advanced/log_traces) — the full span and trace API
+- [Log media and attachments](/tracing/advanced/log_multimodal_traces) — attachment limits and supported types
+- [Guardrails](/guardrails/overview) — check inputs and outputs in the request path
+- [Online evaluation](/production/online-evaluation/rules) — score every call automatically once it is logged
+- [All integrations](/integrations/overview) — the LLM provider and framework you use
 
 ## Further improvements
 

--- a/apps/opik-documentation/documentation/fern/versions/latest.yml
+++ b/apps/opik-documentation/documentation/fern/versions/latest.yml
@@ -716,6 +716,9 @@ navigation:
               - page: Temporal
                 path: ../docs-v2/integrations/temporal.mdx
                 slug: temporal
+              - page: Twilio Agent Connect
+                path: ../docs-v2/integrations/twilio-agent-connect.mdx
+                slug: twilio-agent-connect
               - page: VoltAgent
                 path: ../docs-v2/integrations/voltagent.mdx
                 slug: voltagent


### PR DESCRIPTION
## Details

Adds an integration guide for [Twilio Agent Connect](https://www.twilio.com/docs/agent-connect), so users building voice agents on real phone calls can log them to Opik. The guide covers tracing each caller turn with `@opik.track`, grouping the turns of a call into one thread via `conversation_id`, and attaching the Twilio call recording as an MP3 so conversations can be played back in the UI.

- New page: `fern/docs-v2/integrations/twilio-agent-connect.mdx`
- Registered in `fern/versions/latest.yml` and the integrations overview

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Drafted the new `.mdx` page and the two navigation edits. Code samples were derived by reading the installed `twilio-agent-connect` 2.1.0 and `opik` 2.2.7 SDK sources plus Twilio's public docs.
- Human verification: Pending author review of the code samples against a live deployment.

## Testing

- `fern check` — 0 errors, 4 pre-existing warnings, none referring to the new page.
- Every API used in the code samples verified against the installed `twilio-agent-connect` 2.1.0 and `opik` 2.2.7 sources: `VoiceChannel.on_inbound_call_twiml`, `TAC.on_message_ready`, `Client.calls().recordings.create`, `Opik.trace(attachments=...)`, the `opik.guardrails` exports, and the valid `@opik.track` span types.
- All nine cross-linked documentation pages confirmed to exist.

## Documentation

This PR is the documentation.
