### PR TITLE
[issue-3224] [FE] fix: render OpenWebUI response messages

### DIFF
--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/canShowMessagesTab.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/canShowMessagesTab.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { canShowMessagesTab } from "./canShowMessagesTab";
+
+describe("canShowMessagesTab", () => {
+  it("keeps the viewer gate open for renderable messages with malformed tool calls", () => {
+    expect(
+      canShowMessagesTab(
+        { messages: [{ role: "user", content: "Hello" }] },
+        {
+          messages: [
+            {
+              role: "assistant",
+              content: "The response is still renderable",
+              tool_calls: [null],
+            },
+          ],
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("closes the viewer gate for unsupported non-empty fields", () => {
+    expect(
+      canShowMessagesTab(
+        { messages: [{ role: "user", content: "Hello" }] },
+        { unsupported: true },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/canShowMessagesTab.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/canShowMessagesTab.ts
@@ -1,0 +1,16 @@
+import { detectLLMMessages } from "./detectLLMMessages";
+
+export const canShowMessagesTab = (
+  input: unknown,
+  output: unknown,
+): boolean => {
+  const inputDetection = detectLLMMessages(input, { fieldType: "input" });
+  const outputDetection = detectLLMMessages(output, { fieldType: "output" });
+
+  const hasValid = inputDetection.supported || outputDetection.supported;
+  const hasInvalid =
+    (!inputDetection.supported && !inputDetection.empty) ||
+    (!outputDetection.supported && !outputDetection.empty);
+
+  return hasValid && !hasInvalid;
+};

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
@@ -1,4 +1,5 @@
 export { detectLLMMessages } from "./detectLLMMessages";
+export { canShowMessagesTab } from "./canShowMessagesTab";
 export { mapAndCombineMessages } from "./mapAndCombineMessages";
 
 export type {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { mapAndCombineMessages } from "./mapAndCombineMessages";
+
+describe("mapAndCombineMessages", () => {
+  it("keeps renderable output visible when an optional tool call is malformed", () => {
+    const result = mapAndCombineMessages(
+      {},
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: "The response is still renderable",
+            tool_calls: [null],
+          },
+        ],
+      },
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].blocks.map((block) => block.blockType)).toEqual([
+      "text",
+      "code",
+    ]);
+  });
+
+  it("does not duplicate a complete OpenWebUI output conversation", () => {
+    const input = {
+      messages: [{ role: "user", content: "What is Opik?" }],
+    };
+    const output = {
+      messages: [
+        { role: "user", content: "What is Opik?" },
+        { role: "assistant", content: "An observability platform." },
+      ],
+    };
+
+    const result = mapAndCombineMessages(input, output);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+  });
+
+  it("keeps standard OpenAI input and output messages separate", () => {
+    const input = {
+      messages: [{ role: "user", content: "What is Opik?" }],
+    };
+    const output = {
+      choices: [
+        {
+          message: { role: "assistant", content: "An observability platform." },
+        },
+      ],
+    };
+
+    const result = mapAndCombineMessages(input, output);
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
@@ -90,6 +90,44 @@ describe("detectOpenAIFormat", () => {
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
     });
 
+    it("should reject message-list output with malformed tool calls", () => {
+      for (const toolCall of [null, "invalid tool call", 42]) {
+        const data = {
+          messages: [
+            {
+              role: "assistant",
+              content: "The response is still renderable",
+              tool_calls: [toolCall],
+            },
+          ],
+        };
+
+        expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(false);
+      }
+    });
+
+    it("should detect message-list output with valid tool calls", () => {
+      const data = {
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"city":"Paris"}',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
+    });
+
     it("should reject invalid output format", () => {
       const data = { invalid: "format" };
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(false);

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
@@ -90,7 +90,7 @@ describe("detectOpenAIFormat", () => {
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
     });
 
-    it("should reject message-list output with malformed tool calls", () => {
+    it("should keep message-list output detectable with malformed tool calls", () => {
       for (const toolCall of [null, "invalid tool call", 42]) {
         const data = {
           messages: [
@@ -102,7 +102,7 @@ describe("detectOpenAIFormat", () => {
           ],
         };
 
-        expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(false);
+        expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
       }
     });
 
@@ -126,6 +126,17 @@ describe("detectOpenAIFormat", () => {
       };
 
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
+    });
+
+    it("should reject malformed choices without a valid message-list fallback", () => {
+      for (const choices of [
+        [null],
+        [{ message: { role: "assistant", content: "ok" } }, null],
+      ]) {
+        expect(detectOpenAIFormat({ choices }, { fieldType: "output" })).toBe(
+          false,
+        );
+      }
     });
 
     it("should reject invalid output format", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts
@@ -82,6 +82,14 @@ describe("detectOpenAIFormat", () => {
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
     });
 
+    it("should detect an OpenWebUI response envelope", () => {
+      const data = {
+        chat_id: "chat-123",
+        messages: [{ role: "assistant", content: "Hello from OpenWebUI" }],
+      };
+      expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(true);
+    });
+
     it("should reject invalid output format", () => {
       const data = { invalid: "format" };
       expect(detectOpenAIFormat(data, { fieldType: "output" })).toBe(false);

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
@@ -66,7 +66,7 @@ const isCustomInputMessage = (
  * Checks if an object has OpenAI chat completion input format
  * (messages array with role/content objects)
  */
-const hasOpenAIInputFormat = (data: unknown): boolean => {
+const hasOpenAIMessageListFormat = (data: unknown): boolean => {
   if (!data || typeof data !== "object") return false;
   const d = data as Record<string, unknown>;
 
@@ -166,7 +166,7 @@ export const detectOpenAIFormat: FormatDetector = (data, prettifyConfig) => {
   // Check for input formats
   if (isInput) {
     // Standard format: { messages: [...] }
-    if (hasOpenAIInputFormat(data)) {
+    if (hasOpenAIMessageListFormat(data)) {
       return true;
     }
     // Direct array format: [{ role: "user", content: "..." }]
@@ -183,6 +183,10 @@ export const detectOpenAIFormat: FormatDetector = (data, prettifyConfig) => {
   if (isOutput) {
     // Standard format: { choices: [...] }
     if (hasOpenAIOutputFormat(data)) {
+      return true;
+    }
+    // OpenWebUI stores the completed conversation as { messages: [...] }
+    if (hasOpenAIMessageListFormat(data)) {
       return true;
     }
     // Custom output format: { text: "...", usage: {...}, finish_reason: "..." }

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
@@ -19,6 +19,19 @@ interface OpenAIChoice {
   index?: number;
 }
 
+const isOpenAIToolCall = (toolCall: unknown): boolean => {
+  if (!toolCall || typeof toolCall !== "object") return false;
+
+  const functionCall = (toolCall as Record<string, unknown>).function;
+  if (!functionCall || typeof functionCall !== "object") return false;
+
+  const functionData = functionCall as Record<string, unknown>;
+  return (
+    typeof functionData.name === "string" &&
+    typeof functionData.arguments === "string"
+  );
+};
+
 /**
  * Checks if a message object has the OpenAI message format structure
  */
@@ -36,6 +49,13 @@ const isOpenAIMessage = (msg: unknown): msg is OpenAIMessage => {
   // Content can be string, array, null, or undefined (for tool_calls)
   // Tool messages should have content
   if (m.role === "tool" && m.content === undefined) return false;
+
+  if (
+    m.tool_calls !== undefined &&
+    (!Array.isArray(m.tool_calls) || !m.tool_calls.every(isOpenAIToolCall))
+  ) {
+    return false;
+  }
 
   return true;
 };

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts
@@ -1,4 +1,5 @@
 import { FormatDetector } from "../../types";
+import { OPENAI_RENDER_LIMITS } from "./limits";
 
 interface OpenAIMessage {
   role?: string;
@@ -19,19 +20,6 @@ interface OpenAIChoice {
   index?: number;
 }
 
-const isOpenAIToolCall = (toolCall: unknown): boolean => {
-  if (!toolCall || typeof toolCall !== "object") return false;
-
-  const functionCall = (toolCall as Record<string, unknown>).function;
-  if (!functionCall || typeof functionCall !== "object") return false;
-
-  const functionData = functionCall as Record<string, unknown>;
-  return (
-    typeof functionData.name === "string" &&
-    typeof functionData.arguments === "string"
-  );
-};
-
 /**
  * Checks if a message object has the OpenAI message format structure
  */
@@ -50,10 +38,10 @@ const isOpenAIMessage = (msg: unknown): msg is OpenAIMessage => {
   // Tool messages should have content
   if (m.role === "tool" && m.content === undefined) return false;
 
-  if (
-    m.tool_calls !== undefined &&
-    (!Array.isArray(m.tool_calls) || !m.tool_calls.every(isOpenAIToolCall))
-  ) {
+  // Keep the message detectable when an optional tool call is malformed. The
+  // mapper represents invalid entries safely so renderable message content is
+  // not hidden by the detector.
+  if (m.tool_calls !== undefined && !Array.isArray(m.tool_calls)) {
     return false;
   }
 
@@ -95,7 +83,9 @@ const hasOpenAIMessageListFormat = (data: unknown): boolean => {
   if (d.messages.length === 0) return false;
 
   // Check that all messages have valid OpenAI message structure
-  return d.messages.every(isOpenAIMessage);
+  return d.messages
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .every(isOpenAIMessage);
 };
 
 /**
@@ -106,7 +96,7 @@ const isOpenAIMessageArray = (data: unknown): boolean => {
   if (data.length === 0) return false;
 
   // Check that all items are valid OpenAI messages
-  return data.every(isOpenAIMessage);
+  return data.slice(0, OPENAI_RENDER_LIMITS.messages).every(isOpenAIMessage);
 };
 
 /**
@@ -122,7 +112,9 @@ const hasCustomInputFormat = (data: unknown): boolean => {
   if (d.input.length === 0) return false;
 
   // Check that all messages have valid custom input message structure
-  return d.input.every(isCustomInputMessage);
+  return d.input
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .every(isCustomInputMessage);
 };
 
 /**
@@ -138,11 +130,13 @@ const hasOpenAIOutputFormat = (data: unknown): boolean => {
   if (d.choices.length === 0) return false;
 
   // Check that all choices have a valid message
-  return d.choices.every((choice: unknown) => {
-    if (!choice || typeof choice !== "object") return false;
-    const c = choice as OpenAIChoice;
-    return c.message && isOpenAIMessage(c.message);
-  });
+  return d.choices
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .every((choice: unknown) => {
+      if (!choice || typeof choice !== "object") return false;
+      const c = choice as OpenAIChoice;
+      return c.message && isOpenAIMessage(c.message);
+    });
 };
 
 /**

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/index.ts
@@ -1,11 +1,12 @@
 import { LLMMessageFormatImplementation } from "../../types";
 import { detectOpenAIFormat } from "./detector";
-import { mapOpenAIMessages } from "./mapper";
+import { combineOpenAIMessages, mapOpenAIMessages } from "./mapper";
 
 export const openaiFormat: LLMMessageFormatImplementation = {
   name: "openai",
   detector: detectOpenAIFormat,
   mapper: mapOpenAIMessages,
+  combiner: combineOpenAIMessages,
 };
 
-export { detectOpenAIFormat, mapOpenAIMessages };
+export { combineOpenAIMessages, detectOpenAIFormat, mapOpenAIMessages };

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/limits.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/limits.ts
@@ -1,0 +1,6 @@
+export const OPENAI_RENDER_LIMITS = {
+  messages: 100,
+  toolCallsPerMessage: 50,
+  toolArgumentsLength: 50_000,
+  toolArgumentsTotalLength: 100_000,
+} as const;

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mapOpenAIMessages } from "./mapper";
+import { combineOpenAIMessages, mapOpenAIMessages } from "./mapper";
 
 describe("mapOpenAIMessages", () => {
   describe("Input formats", () => {
@@ -814,5 +814,57 @@ describe("mapOpenAIMessages", () => {
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0].blocks).toHaveLength(0);
     });
+  });
+});
+
+describe("combineOpenAIMessages with truncation", () => {
+  const manyMessages = (count: number, prefix: string) =>
+    Array.from({ length: count }, (_, index) => ({
+      role: "assistant" as const,
+      content: prefix + "-" + index,
+    }));
+
+  it("uses the output once when both views are truncated at the same point", () => {
+    const input = mapOpenAIMessages(
+      { messages: manyMessages(60, "m") },
+      { fieldType: "input" },
+    );
+    const output = mapOpenAIMessages(
+      { messages: manyMessages(62, "m") },
+      { fieldType: "output" },
+    );
+
+    const combined = combineOpenAIMessages(
+      { raw: undefined, mapped: input },
+      { raw: undefined, mapped: output },
+    );
+
+    // Input and output are truncated with different omitted counts, but the
+    // placeholder fingerprint is stable, so the output is recognized as a
+    // superset and rendered once instead of duplicating the history.
+    expect(combined.messages.length).toBeLessThan(
+      input.messages.length + output.messages.length,
+    );
+    expect(combined.messages).toEqual(output.messages);
+  });
+
+  it("keeps concatenation when the output is not a superset", () => {
+    const input = mapOpenAIMessages(
+      { messages: [{ role: "user" as const, content: "hello" }] },
+      { fieldType: "input" },
+    );
+    const output = mapOpenAIMessages(
+      { messages: [{ role: "assistant" as const, content: "hi there" }] },
+      { fieldType: "output" },
+    );
+
+    const combined = combineOpenAIMessages(
+      { raw: undefined, mapped: input },
+      { raw: undefined, mapped: output },
+    );
+
+    expect(combined.messages).toHaveLength(
+      input.messages.length + output.messages.length,
+    );
   });
 });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
@@ -185,6 +185,26 @@ describe("mapOpenAIMessages", () => {
         );
       }
     });
+
+    it("should map an OpenWebUI response envelope", () => {
+      const data = {
+        chat_id: "chat-123",
+        messages: [
+          { role: "user", content: "What is Opik?" },
+          { role: "assistant", content: "An observability platform." },
+        ],
+      };
+      const result = mapOpenAIMessages(data, { fieldType: "output" });
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].role).toBe("user");
+      expect(result.messages[1].role).toBe("assistant");
+      if (result.messages[1].blocks[0].blockType === "text") {
+        expect(result.messages[1].blocks[0].props.children).toBe(
+          "An observability platform.",
+        );
+      }
+    });
   });
 
   describe("Edge cases", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
@@ -276,6 +276,72 @@ describe("mapOpenAIMessages", () => {
         expect(result.messages[1].role).toBe("assistant");
       }
     });
+
+    it("should safely ignore malformed choices without a message-list fallback", () => {
+      for (const choices of [
+        [null],
+        [{ message: { role: "assistant", content: "ok" } }, null],
+      ]) {
+        expect(() =>
+          mapOpenAIMessages({ choices }, { fieldType: "output" }),
+        ).not.toThrow();
+        expect(mapOpenAIMessages({ choices }, { fieldType: "output" })).toEqual(
+          { messages: [] },
+        );
+      }
+    });
+
+    it("should bound tool-call argument rendering", () => {
+      const oversizedArguments = "x".repeat(50_001);
+      const result = mapOpenAIMessages(
+        {
+          messages: [
+            {
+              role: "assistant",
+              tool_calls: [
+                {
+                  function: {
+                    name: "large_tool",
+                    arguments: oversizedArguments,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        { fieldType: "output" },
+      );
+
+      expect(result.messages[0].blocks).toHaveLength(1);
+      expect(result.messages[0].blocks[0].blockType).toBe("code");
+      if (result.messages[0].blocks[0].blockType === "code") {
+        expect(result.messages[0].blocks[0].props.code).not.toContain(
+          oversizedArguments,
+        );
+        expect(result.messages[0].blocks[0].props.code).toContain(
+          "rendering limit",
+        );
+      }
+    });
+
+    it("should add a visible placeholder when message output is truncated", () => {
+      const result = mapOpenAIMessages(
+        {
+          messages: [
+            ...Array.from({ length: 100 }, (_, index) => ({
+              role: "assistant",
+              content: `message-${index}`,
+            })),
+            { role: "invalid", content: "ignored" },
+          ],
+        },
+        { fieldType: "output" },
+      );
+
+      expect(result.messages).toHaveLength(101);
+      expect(result.messages.at(-1)?.id).toBe("output-truncated");
+      expect(result.messages.at(-1)?.blocks[0].blockType).toBe("code");
+    });
   });
 
   describe("Edge cases", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts
@@ -205,6 +205,77 @@ describe("mapOpenAIMessages", () => {
         );
       }
     });
+
+    it("should keep rendering messages with malformed tool calls", () => {
+      for (const toolCall of [null, "invalid tool call", 42]) {
+        const data = {
+          messages: [
+            {
+              role: "assistant",
+              content: "The response is still renderable",
+              tool_calls: [toolCall],
+            },
+          ],
+        };
+
+        expect(() =>
+          mapOpenAIMessages(data, { fieldType: "output" }),
+        ).not.toThrow();
+
+        const result = mapOpenAIMessages(data, { fieldType: "output" });
+        expect(result.messages).toHaveLength(1);
+        expect(result.messages[0].blocks[0].blockType).toBe("text");
+      }
+    });
+
+    it("should preserve valid tool-call rendering", () => {
+      const data = {
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: {
+                  name: "get_weather",
+                  arguments: '{"city":"Paris"}',
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = mapOpenAIMessages(data, { fieldType: "output" });
+
+      expect(result.messages[0].blocks).toHaveLength(1);
+      expect(result.messages[0].blocks[0].blockType).toBe("code");
+      if (result.messages[0].blocks[0].blockType === "code") {
+        expect(result.messages[0].blocks[0].props.label).toBe("get_weather");
+        expect(result.messages[0].blocks[0].props.code).toContain('"city"');
+      }
+    });
+
+    it("should prioritize a valid message list over text or choices", () => {
+      const messages = [
+        { role: "user", content: "What is Opik?" },
+        { role: "assistant", content: "An observability platform." },
+      ];
+      const payloads = [
+        { messages, text: "Summary only" },
+        { messages, choices: [] },
+        { messages, choices: [null] },
+      ];
+
+      for (const data of payloads) {
+        const result = mapOpenAIMessages(data, { fieldType: "output" });
+
+        expect(result.messages).toHaveLength(2);
+        expect(result.messages[0].role).toBe("user");
+        expect(result.messages[1].role).toBe("assistant");
+      }
+    });
   });
 
   describe("Edge cases", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -35,7 +35,9 @@ interface OpenAIInputAudioContent {
 }
 
 type OpenAIContentItem =
-  OpenAITextContent | OpenAIImageContent | OpenAIInputAudioContent;
+  | OpenAITextContent
+  | OpenAIImageContent
+  | OpenAIInputAudioContent;
 
 interface OpenAIToolCall {
   id: string;
@@ -330,7 +332,9 @@ const mapToolCalls = (
       blockType: "code",
       component: PrettyLLMMessage.CodeBlock,
       props: {
-        code: `[${toolCalls.length - OPENAI_RENDER_LIMITS.toolCallsPerMessage} additional tool calls omitted]`,
+        code: `[${
+          toolCalls.length - OPENAI_RENDER_LIMITS.toolCallsPerMessage
+        } additional tool calls omitted]`,
         label: "Tool calls truncated",
       },
     });
@@ -525,16 +529,53 @@ const mapCustomInputMessage = (
   };
 };
 
-const buildOpenAIMessageFingerprint = (message: OpenAIMessage): string =>
-  JSON.stringify({
-    role: message.role,
-    content: message.content,
-    tool_calls: message.tool_calls,
-    tool_call_id: message.tool_call_id,
-    name: message.name,
-    refusal: message.refusal,
-    audio: message.audio,
-  });
+// Placeholder marker for truncated message lists. The count is deliberately
+// not part of the fingerprint: the input and output views of the same
+// conversation can be truncated at different points, and the superset check
+// only cares whether the output contains the input's real messages.
+const TRUNCATED_PLACEHOLDER_FINGERPRINT = "truncated";
+
+// Cap each serialized part so the fingerprint stays bounded on very large
+// payloads (the Messages tab renders limited blocks, but the raw message can
+// still carry unbounded content and tool arguments).
+const FINGERPRINT_PART_MAX_LENGTH = 1000;
+
+const buildOpenAIMessageFingerprint = (message: OpenAIMessage): string => {
+  const parts: string[] = [
+    message.role,
+    message.name ?? "",
+    message.tool_call_id ?? "",
+    message.refusal ?? "",
+  ];
+
+  if (typeof message.content === "string") {
+    parts.push(message.content);
+  } else if (Array.isArray(message.content)) {
+    for (const block of message.content) {
+      if (typeof block === "string") {
+        parts.push("text:" + block);
+      } else if (block && typeof block === "object") {
+        const text = (block as OpenAITextContent).text;
+        if (typeof text === "string") {
+          parts.push("text:" + text);
+        } else {
+          parts.push((block as { type?: string }).type ?? "block");
+        }
+      }
+    }
+  }
+
+  for (const call of message.tool_calls ?? []) {
+    if (!call || typeof call !== "object") continue;
+    parts.push(
+      "call:" + call.function?.name + ":" + (call.function?.arguments ?? ""),
+    );
+  }
+
+  return parts
+    .map((part) => part.slice(0, FINGERPRINT_PART_MAX_LENGTH))
+    .join("\u0000");
+};
 
 /**
  * Maps an OpenAI message to our normalized LLMMessageDescriptor structure
@@ -583,7 +624,7 @@ const appendMessageLimitPlaceholder = (
         },
       },
     ],
-    contentFingerprint: `truncated:${omittedCount}`,
+    contentFingerprint: TRUNCATED_PLACEHOLDER_FINGERPRINT,
   });
 };
 
@@ -731,12 +772,23 @@ const isOutputSupersetOfInput = (
   inputMsgs: LLMMessageDescriptor[],
   outputMsgs: LLMMessageDescriptor[],
 ): boolean => {
-  if (outputMsgs.length < inputMsgs.length) return false;
+  // Truncation placeholders are not real messages: the input and output views
+  // of the same conversation can be truncated at different points, so compare
+  // only the actual messages positionally.
+  const inputReal = inputMsgs.filter(
+    (message) =>
+      message.contentFingerprint !== TRUNCATED_PLACEHOLDER_FINGERPRINT,
+  );
+  const outputReal = outputMsgs.filter(
+    (message) =>
+      message.contentFingerprint !== TRUNCATED_PLACEHOLDER_FINGERPRINT,
+  );
+  if (outputReal.length < inputReal.length) return false;
 
-  return inputMsgs.every(
+  return inputReal.every(
     (message, index) =>
       message.contentFingerprint !== undefined &&
-      message.contentFingerprint === outputMsgs[index]?.contentFingerprint,
+      message.contentFingerprint === outputReal[index]?.contentFingerprint,
   );
 };
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -33,9 +33,7 @@ interface OpenAIInputAudioContent {
 }
 
 type OpenAIContentItem =
-  | OpenAITextContent
-  | OpenAIImageContent
-  | OpenAIInputAudioContent;
+  OpenAITextContent | OpenAIImageContent | OpenAIInputAudioContent;
 
 interface OpenAIToolCall {
   id: string;
@@ -108,6 +106,28 @@ interface OpenAICustomOutputFormat {
 }
 
 type OpenAIDirectArrayInput = OpenAIMessage[];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object";
+
+const isMappableOpenAIMessage = (message: unknown): message is OpenAIMessage =>
+  isRecord(message) && typeof message.role === "string";
+
+const isMappableOpenAIMessageList = (
+  data: unknown,
+): data is OpenAIMessageListData =>
+  isRecord(data) &&
+  Array.isArray(data.messages) &&
+  data.messages.length > 0 &&
+  data.messages.every(isMappableOpenAIMessage);
+
+const isMappableOpenAIOutput = (data: unknown): data is OpenAIOutputData =>
+  isRecord(data) &&
+  Array.isArray(data.choices) &&
+  data.choices.length > 0 &&
+  data.choices.every(
+    (choice) => isRecord(choice) && isMappableOpenAIMessage(choice.message),
+  );
 
 /**
  * Generates a deterministic ID for a message
@@ -241,32 +261,36 @@ const processMultimodalContent = (
  * Maps tool calls to code block descriptors with formatted JSON arguments.
  */
 const mapToolCalls = (
-  toolCalls: OpenAIToolCall[],
+  toolCalls: unknown[],
   blocks: LLMBlockDescriptor[],
 ): void => {
   toolCalls.forEach((toolCall) => {
-    // Guard: skip if function is missing or invalid
+    const functionCall =
+      isRecord(toolCall) && isRecord(toolCall.function)
+        ? toolCall.function
+        : undefined;
+    const functionName = functionCall?.name;
+    const functionArguments = functionCall?.arguments;
+
     if (
-      !toolCall.function ||
-      typeof toolCall.function !== "object" ||
-      !toolCall.function.name ||
-      typeof toolCall.function.arguments !== "string"
+      typeof functionName !== "string" ||
+      typeof functionArguments !== "string"
     ) {
-      // Use safe fallback
       blocks.push({
         blockType: "code",
         component: PrettyLLMMessage.CodeBlock,
         props: {
           code: "",
-          label: toolCall.function?.name ?? `unknown tool`,
+          label:
+            typeof functionName === "string" ? functionName : "unknown tool",
         },
       });
       return;
     }
 
-    let formattedArgs = toolCall.function.arguments;
+    let formattedArgs = functionArguments;
     try {
-      const parsed = JSON.parse(toolCall.function.arguments);
+      const parsed = JSON.parse(functionArguments);
       formattedArgs = JSON.stringify(parsed, null, 2);
     } catch {
       // Keep original if not parseable
@@ -277,7 +301,7 @@ const mapToolCalls = (
       component: PrettyLLMMessage.CodeBlock,
       props: {
         code: formattedArgs,
-        label: toolCall.function.name,
+        label: functionName,
       },
     });
   });
@@ -391,7 +415,7 @@ const buildContentBlocks = (
   }
 
   // Handle tool calls (assistant requesting tools)
-  if (toolCalls && toolCalls.length > 0) {
+  if (Array.isArray(toolCalls) && toolCalls.length > 0) {
     mapToolCalls(toolCalls, blocks);
   }
 
@@ -504,7 +528,7 @@ const mapOpenAIMessageList = (
   data: OpenAIMessageListData,
   prefix: string,
 ): LLMMapperResult => {
-  if (!data.messages || !Array.isArray(data.messages)) {
+  if (!isMappableOpenAIMessageList(data)) {
     return { messages: [] };
   }
 
@@ -522,7 +546,7 @@ const mapOpenAIInput = (data: OpenAIInputData): LLMMapperResult =>
  * Maps OpenAI output format to LLMMapperResult
  */
 const mapOpenAIOutput = (data: OpenAIOutputData): LLMMapperResult => {
-  if (!data.choices || !Array.isArray(data.choices)) {
+  if (!isMappableOpenAIOutput(data)) {
     return { messages: [] };
   }
 
@@ -645,23 +669,18 @@ export const mapOpenAIMessages: FormatMapper = (data, prettifyConfig) => {
   }
 
   if (isOutput) {
+    if (isMappableOpenAIMessageList(data)) {
+      return mapOpenAIMessageList(data, "output");
+    }
+
     // Check for custom output format { text: "...", usage: {...}, ... }
-    if (
-      typeof data === "object" &&
-      "text" in data &&
-      typeof (data as OpenAICustomOutputFormat).text === "string"
-    ) {
-      return mapCustomOutputFormat(data as OpenAICustomOutputFormat);
+    if (isRecord(data) && "text" in data && typeof data.text === "string") {
+      return mapCustomOutputFormat(data as unknown as OpenAICustomOutputFormat);
     }
 
     // Standard format { choices: [...] }
-    if (typeof data === "object" && "choices" in data) {
-      return mapOpenAIOutput(data as OpenAIOutputData);
-    }
-
-    // OpenWebUI stores the completed conversation as { messages: [...] }
-    if (typeof data === "object" && "messages" in data) {
-      return mapOpenAIMessageList(data as OpenAIMessageListData, "output");
+    if (isMappableOpenAIOutput(data)) {
+      return mapOpenAIOutput(data);
     }
   }
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -82,6 +82,8 @@ interface OpenAIInputData {
   messages: OpenAIMessage[];
 }
 
+type OpenAIMessageListData = OpenAIInputData;
+
 interface OpenAIOutputData {
   choices: OpenAIChoice[];
   usage?: {
@@ -498,17 +500,23 @@ const mapOpenAIMessage = (
 /**
  * Maps OpenAI input format to LLMMapperResult
  */
-const mapOpenAIInput = (data: OpenAIInputData): LLMMapperResult => {
+const mapOpenAIMessageList = (
+  data: OpenAIMessageListData,
+  prefix: string,
+): LLMMapperResult => {
   if (!data.messages || !Array.isArray(data.messages)) {
     return { messages: [] };
   }
 
   const messages = data.messages.map((msg, index) =>
-    mapOpenAIMessage(msg, index, "input"),
+    mapOpenAIMessage(msg, index, prefix),
   );
 
   return { messages };
 };
+
+const mapOpenAIInput = (data: OpenAIInputData): LLMMapperResult =>
+  mapOpenAIMessageList(data, "input");
 
 /**
  * Maps OpenAI output format to LLMMapperResult
@@ -649,6 +657,11 @@ export const mapOpenAIMessages: FormatMapper = (data, prettifyConfig) => {
     // Standard format { choices: [...] }
     if (typeof data === "object" && "choices" in data) {
       return mapOpenAIOutput(data as OpenAIOutputData);
+    }
+
+    // OpenWebUI stores the completed conversation as { messages: [...] }
+    if (typeof data === "object" && "messages" in data) {
+      return mapOpenAIMessageList(data as OpenAIMessageListData, "output");
     }
   }
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -1,5 +1,6 @@
 import PrettyLLMMessage from "@/shared/PrettyLLMMessage";
 import {
+  FormatCombiner,
   FormatMapper,
   LLMMessageDescriptor,
   LLMBlockDescriptor,
@@ -7,6 +8,7 @@ import {
 } from "../../types";
 import { MessageRole } from "@/shared/PrettyLLMMessage/types";
 import { isPlaceholder } from "../../utils";
+import { OPENAI_RENDER_LIMITS } from "./limits";
 
 /**
  * OpenAI message content item types
@@ -119,15 +121,19 @@ const isMappableOpenAIMessageList = (
   isRecord(data) &&
   Array.isArray(data.messages) &&
   data.messages.length > 0 &&
-  data.messages.every(isMappableOpenAIMessage);
+  data.messages
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .every(isMappableOpenAIMessage);
 
 const isMappableOpenAIOutput = (data: unknown): data is OpenAIOutputData =>
   isRecord(data) &&
   Array.isArray(data.choices) &&
   data.choices.length > 0 &&
-  data.choices.every(
-    (choice) => isRecord(choice) && isMappableOpenAIMessage(choice.message),
-  );
+  data.choices
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .every(
+      (choice) => isRecord(choice) && isMappableOpenAIMessage(choice.message),
+    );
 
 /**
  * Generates a deterministic ID for a message
@@ -264,47 +270,71 @@ const mapToolCalls = (
   toolCalls: unknown[],
   blocks: LLMBlockDescriptor[],
 ): void => {
-  toolCalls.forEach((toolCall) => {
-    const functionCall =
-      isRecord(toolCall) && isRecord(toolCall.function)
-        ? toolCall.function
-        : undefined;
-    const functionName = functionCall?.name;
-    const functionArguments = functionCall?.arguments;
+  let renderedArgumentsLength = 0;
+  toolCalls
+    .slice(0, OPENAI_RENDER_LIMITS.toolCallsPerMessage)
+    .forEach((toolCall) => {
+      const functionCall =
+        isRecord(toolCall) && isRecord(toolCall.function)
+          ? toolCall.function
+          : undefined;
+      const functionName = functionCall?.name;
+      const functionArguments = functionCall?.arguments;
 
-    if (
-      typeof functionName !== "string" ||
-      typeof functionArguments !== "string"
-    ) {
+      if (
+        typeof functionName !== "string" ||
+        typeof functionArguments !== "string"
+      ) {
+        blocks.push({
+          blockType: "code",
+          component: PrettyLLMMessage.CodeBlock,
+          props: {
+            code: "",
+            label:
+              typeof functionName === "string" ? functionName : "unknown tool",
+          },
+        });
+        return;
+      }
+
+      let formattedArgs = functionArguments;
+      const exceedsArgumentLimit =
+        functionArguments.length > OPENAI_RENDER_LIMITS.toolArgumentsLength ||
+        renderedArgumentsLength + functionArguments.length >
+          OPENAI_RENDER_LIMITS.toolArgumentsTotalLength;
+
+      if (exceedsArgumentLimit) {
+        formattedArgs = `[Tool arguments omitted: payload exceeds the ${OPENAI_RENDER_LIMITS.toolArgumentsLength.toLocaleString()}-character rendering limit]`;
+      } else {
+        renderedArgumentsLength += functionArguments.length;
+        try {
+          const parsed = JSON.parse(functionArguments);
+          formattedArgs = JSON.stringify(parsed, null, 2);
+        } catch {
+          // Keep original if not parseable
+        }
+      }
+
       blocks.push({
         blockType: "code",
         component: PrettyLLMMessage.CodeBlock,
         props: {
-          code: "",
-          label:
-            typeof functionName === "string" ? functionName : "unknown tool",
+          code: formattedArgs,
+          label: functionName,
         },
       });
-      return;
-    }
+    });
 
-    let formattedArgs = functionArguments;
-    try {
-      const parsed = JSON.parse(functionArguments);
-      formattedArgs = JSON.stringify(parsed, null, 2);
-    } catch {
-      // Keep original if not parseable
-    }
-
+  if (toolCalls.length > OPENAI_RENDER_LIMITS.toolCallsPerMessage) {
     blocks.push({
       blockType: "code",
       component: PrettyLLMMessage.CodeBlock,
       props: {
-        code: formattedArgs,
-        label: functionName,
+        code: `[${toolCalls.length - OPENAI_RENDER_LIMITS.toolCallsPerMessage} additional tool calls omitted]`,
+        label: "Tool calls truncated",
       },
     });
-  });
+  }
 };
 
 /**
@@ -495,6 +525,17 @@ const mapCustomInputMessage = (
   };
 };
 
+const buildOpenAIMessageFingerprint = (message: OpenAIMessage): string =>
+  JSON.stringify({
+    role: message.role,
+    content: message.content,
+    tool_calls: message.tool_calls,
+    tool_call_id: message.tool_call_id,
+    name: message.name,
+    refusal: message.refusal,
+    audio: message.audio,
+  });
+
 /**
  * Maps an OpenAI message to our normalized LLMMessageDescriptor structure
  */
@@ -518,7 +559,31 @@ const mapOpenAIMessage = (
     role,
     label,
     blocks,
+    contentFingerprint: buildOpenAIMessageFingerprint(message),
   };
+};
+
+const appendMessageLimitPlaceholder = (
+  messages: LLMMessageDescriptor[],
+  prefix: string,
+  omittedCount: number,
+): void => {
+  if (omittedCount <= 0) return;
+
+  messages.push({
+    id: `${prefix}-truncated`,
+    role: "assistant",
+    blocks: [
+      {
+        blockType: "code",
+        component: PrettyLLMMessage.CodeBlock,
+        props: {
+          code: `[${omittedCount} additional messages omitted]`,
+          label: "Messages truncated",
+        },
+      },
+    ],
+  });
 };
 
 /**
@@ -532,8 +597,13 @@ const mapOpenAIMessageList = (
     return { messages: [] };
   }
 
-  const messages = data.messages.map((msg, index) =>
-    mapOpenAIMessage(msg, index, prefix),
+  const messages = data.messages
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .map((msg, index) => mapOpenAIMessage(msg, index, prefix));
+  appendMessageLimitPlaceholder(
+    messages,
+    prefix,
+    data.messages.length - OPENAI_RENDER_LIMITS.messages,
   );
 
   return { messages };
@@ -550,16 +620,23 @@ const mapOpenAIOutput = (data: OpenAIOutputData): LLMMapperResult => {
     return { messages: [] };
   }
 
-  const messages = data.choices.map((choice, index) => {
-    const message = mapOpenAIMessage(choice.message, index, "output");
+  const messages = data.choices
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .map((choice, index) => {
+      const message = mapOpenAIMessage(choice.message, index, "output");
 
-    // Add finish reason to message if available
-    if (choice.finish_reason) {
-      message.finishReason = choice.finish_reason;
-    }
+      // Add finish reason to message if available
+      if (choice.finish_reason) {
+        message.finishReason = choice.finish_reason;
+      }
 
-    return message;
-  });
+      return message;
+    });
+  appendMessageLimitPlaceholder(
+    messages,
+    "output",
+    data.choices.length - OPENAI_RENDER_LIMITS.messages,
+  );
 
   return {
     messages,
@@ -575,8 +652,13 @@ const mapDirectArrayInput = (data: OpenAIDirectArrayInput): LLMMapperResult => {
     return { messages: [] };
   }
 
-  const messages = data.map((msg, index) =>
-    mapOpenAIMessage(msg, index, "input"),
+  const messages = data
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .map((msg, index) => mapOpenAIMessage(msg, index, "input"));
+  appendMessageLimitPlaceholder(
+    messages,
+    "input",
+    data.length - OPENAI_RENDER_LIMITS.messages,
   );
 
   return { messages };
@@ -592,8 +674,13 @@ const mapCustomInputFormat = (
     return { messages: [] };
   }
 
-  const messages = data.input.map((msg, index) =>
-    mapCustomInputMessage(msg, index, "input"),
+  const messages = data.input
+    .slice(0, OPENAI_RENDER_LIMITS.messages)
+    .map((msg, index) => mapCustomInputMessage(msg, index, "input"));
+  appendMessageLimitPlaceholder(
+    messages,
+    "input",
+    data.input.length - OPENAI_RENDER_LIMITS.messages,
   );
 
   return { messages };
@@ -636,6 +723,33 @@ const mapCustomOutputFormat = (
   return {
     messages: [message],
     usage: data.usage,
+  };
+};
+
+const isOutputSupersetOfInput = (
+  inputMsgs: LLMMessageDescriptor[],
+  outputMsgs: LLMMessageDescriptor[],
+): boolean => {
+  if (outputMsgs.length < inputMsgs.length) return false;
+
+  return inputMsgs.every(
+    (message, index) =>
+      message.contentFingerprint !== undefined &&
+      message.contentFingerprint === outputMsgs[index]?.contentFingerprint,
+  );
+};
+
+export const combineOpenAIMessages: FormatCombiner = (input, output) => {
+  if (isOutputSupersetOfInput(input.mapped.messages, output.mapped.messages)) {
+    return {
+      messages: output.mapped.messages,
+      usage: output.mapped.usage,
+    };
+  }
+
+  return {
+    messages: [...input.mapped.messages, ...output.mapped.messages],
+    usage: output.mapped.usage,
   };
 };
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -583,6 +583,7 @@ const appendMessageLimitPlaceholder = (
         },
       },
     ],
+    contentFingerprint: `truncated:${omittedCount}`,
   });
 };
 

--- a/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v1/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -41,7 +41,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v1/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
-import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
+import { canShowMessagesTab as canShowLLMMessagesTab } from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 
 type TraceDataViewerProps = {
@@ -91,17 +91,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(transformedInput, { fieldType: "input" });
-    const output = detectLLMMessages(transformedOutput, {
-      fieldType: "output",
-    });
-
-    const hasValid = input.supported || output.supported;
-    const hasInvalid =
-      (!input.supported && !input.empty) ||
-      (!output.supported && !output.empty);
-
-    return hasValid && !hasInvalid;
+    return canShowLLMMessagesTab(transformedInput, transformedOutput);
   }, [transformedInput, transformedOutput]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -36,7 +36,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
-import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
+import { canShowMessagesTab as canShowLLMMessagesTab } from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 
 type TraceDataViewerProps = {
@@ -82,17 +82,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(transformedInput, { fieldType: "input" });
-    const output = detectLLMMessages(transformedOutput, {
-      fieldType: "output",
-    });
-
-    const hasValid = input.supported || output.supported;
-    const hasInvalid =
-      (!input.supported && !input.empty) ||
-      (!output.supported && !output.empty);
-
-    return hasValid && !hasInvalid;
+    return canShowLLMMessagesTab(transformedInput, transformedOutput);
   }, [transformedInput, transformedOutput]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";


### PR DESCRIPTION
## Details

The OpenWebUI Opik filter stores the completed conversation as a `{ messages: [...] }` response envelope. Opik already recognized that shape as OpenAI input, but did not recognize or map it when it appeared in a span output, so the Messages tab fell back to raw JSON.

This reuses the existing OpenAI message-list mapping for output fields and adds regression coverage for the detector and mapper. Standard OpenAI `choices` responses remain unchanged.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #3224

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Codex coding assistant
- Model(s): GPT-5
- Scope: Repository investigation, implementation, tests, and PR draft
- Human verification: The account owner authorized this submission. No separate human code review was available before opening this draft; the resulting diff was checked against the existing detector/mapper contracts and the OpenWebUI filter payload.

## Testing

- `npm exec -- vitest run src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm exec -- prettier --check src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.ts src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts src/shared/PrettyLLMMessage/llmMessages/providers/openai/detector.test.ts src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.test.ts`

The focused Vitest run passes all 43 tests. The initial system Node 25 invocation was blocked by a missing Homebrew `libllhttp`; the checks above were then run with the bundled Node 24 runtime. TypeScript, ESLint/stylelint, and Prettier completed without errors.

## Documentation

No documentation changes are needed for this compatibility fix.