### PR TITLE
[NA] [DOCS] fix: correct Twilio Agent Connect docs URL

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx
@@ -9,7 +9,7 @@ og:title: Integrate Opik with Twilio Agent Connect
 title: Observability for Twilio Agent Connect with Opik
 ---
 
-[Twilio Agent Connect](https://www.twilio.com/docs/agent-connect) (TAC) is a framework for building AI agents that answer real phone calls. It handles the telephony, speech-to-text and text-to-speech, and calls your handler with the caller's transcribed message.
+[Twilio Agent Connect](https://www.twilio.com/docs/conversations/agent-connect) (TAC) is a framework for building AI agents that answer real phone calls. It handles the telephony, speech-to-text and text-to-speech, and calls your handler with the caller's transcribed message.
 
 This guide explains how to log your voice agent to Opik. You will trace every caller turn, group the turns of a call into a single conversation, and attach the call recording so you can listen to what the caller heard.
 


### PR DESCRIPTION
## Details

<img width="955" height="1310" alt="image" src="https://github.com/user-attachments/assets/fe4e297e-017d-4322-ab28-5aad7309a464" />

Twilio moved the Agent Connect documentation under `/docs/conversations/`, so the link in the Twilio Agent Connect integration guide now points at a dead path. The old top-level `/docs/agent-connect` URL returns a 404 with no redirect, so Fern's link checker reports it as a hard failure rather than silently following a 301.

Because the docs preview job builds the whole site, this one broken link surfaces as a failed check on every open PR's preview — not just on docs changes. Repointing it to `https://www.twilio.com/docs/conversations/agent-connect` clears the check repo-wide.

- Swept every external URL on the page; this was the only one returning a non-200
- Swept the repo for `twilio.com/docs` references; this was the only occurrence

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- NA — drive-by fix for a broken link currently failing the docs preview check on all open PRs.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation (single-line URL change)
- Human verification: pending author review

## Testing

Link verification via `curl` (following redirects, browser user-agent):

- `https://www.twilio.com/docs/agent-connect` → **404** (old path, no redirect)
- `https://www.twilio.com/docs/conversations/agent-connect` → **200** (new path)

Also confirmed the remaining four external links on the page still resolve 200 (`comet.com/site`, `comet.com/signup`, `comet.com/docs/opik/self-host/overview/`, `github.com/comet-ml/opik/issues/new/choose`).

`pre-commit` ran on the changed file — all hooks skipped, as no linted file types were touched.

Not run: the Fern build itself. The rendered result is a single anchor href change; the docs preview check on this PR is the real confirmation.

## Documentation

This PR is the documentation change — `apps/opik-documentation/documentation/fern/docs-v2/integrations/twilio-agent-connect.mdx`.
