### PR TITLE
[OPIK-7791] [QA] test: proposed e2e specs from the 2.2.16 → 2.2.18 release exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -424,6 +424,7 @@ areas:
     specs:
       - datasets/dataset-crud-smoke.spec.ts
       - datasets/dataset-items.spec.ts
+      - datasets/dataset-version-counters.spec.ts
     capabilities:
       list-datasets:          { covered: true,  tier: t1-smoke }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }
@@ -434,7 +435,7 @@ areas:
       bulk-delete-items:      { covered: true,  tier: t3-nightly }
       search-items:           { covered: true,  tier: t3-nightly }
       sdk-round-trip:         { covered: true,  tier: t1-smoke }
-      version-history-view:   { covered: false }
+      version-history-view:   { covered: true,  tier: t2-cuj }
       export-dataset:         { covered: false, note: "DATASET_EXPORT_ENABLED" }
       import-huggingface:     { covered: false }
 
@@ -629,9 +630,11 @@ areas:
     label: Projects
     nav_group: Workspace
     routes: ["/$workspaceName/projects", "/projects/$projectId/home"]
+    spec_dir: projects
     specs:
+      - projects/projects-list-stats.spec.ts
     capabilities:
-      list-projects:         { covered: false }
+      list-projects:         { covered: true,  tier: t2-cuj }
       create-project:        { covered: false }
       delete-project:        { covered: false }
       project-selector:      { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -29,6 +29,25 @@ export interface DatasetItemRef {
   data: Record<string, unknown>;
 }
 
+/** One row of the dataset's Version history tab. */
+export interface DatasetVersionRef {
+  versionName: string;
+  itemsTotal: number;
+  itemsAdded: number;
+  itemsModified: number;
+  itemsDeleted: number;
+  isLatest: boolean;
+}
+
+/** The windowed stats one row of the Projects table renders. */
+export interface ProjectStatsRef {
+  projectId: string;
+  traceCount: number | null;
+  threadCount: number | null;
+  errorCount: number | null;
+  feedbackScores: Record<string, number>;
+}
+
 export interface ExperimentRefDetail {
   id: string;
   name: string;
@@ -226,6 +245,100 @@ export function makeBackendClient(apiKey: string | null = null) {
       return content.map((item) => ({
         id: String(item.id),
         data: (item.data ?? {}) as Record<string, unknown>,
+      }));
+    },
+
+    /**
+     * Versions of a dataset, newest first — the rows the Version history tab
+     * renders, including the item counters it shows in "Item count".
+     */
+    async getDatasetVersions(datasetId: string): Promise<DatasetVersionRef[]> {
+      const page = await opik.api.datasets.listDatasetVersions(datasetId, { size: 100 });
+      const content = page.content ?? [];
+      return content.map((v) => ({
+        versionName: String(v.versionName ?? ''),
+        itemsTotal: Number(v.itemsTotal ?? 0),
+        itemsAdded: Number(v.itemsAdded ?? 0),
+        itemsModified: Number(v.itemsModified ?? 0),
+        itemsDeleted: Number(v.itemsDeleted ?? 0),
+        isLatest: Boolean(v.isLatest),
+      }));
+    },
+
+    /**
+     * Every item id actually stored in the dataset, paged out in full. This is
+     * the ground truth a version's `items_total` is supposed to agree with, so
+     * it must not be capped at a page — hence the loop. `truncate` drops the
+     * item payloads we don't need, keeping a few-thousand-item read cheap.
+     */
+    async listDatasetItemIds(datasetId: string): Promise<string[]> {
+      const pageSize = 1000;
+      const ids: string[] = [];
+      for (let page = 1; ; page++) {
+        const result = await opik.api.datasets.getDatasetItems(datasetId, {
+          page,
+          size: pageSize,
+          truncate: true,
+        });
+        const content = result.content ?? [];
+        ids.push(...content.map((item) => String(item.id)));
+        if (content.length < pageSize) return ids;
+      }
+    },
+
+    /**
+     * Stats for the projects whose name matches `name`, optionally scoped to a
+     * time window — the exact call the v2 Projects table makes to fill its
+     * "(30d)" columns.
+     *
+     * Raw fetch rather than `opik.api.projects.getProjectStats`: the pinned TS
+     * SDK's request type has no from_time/to_time, and the window is the whole
+     * point here. Switch to the typed call once the SDK exposes them.
+     */
+    async getProjectStats(args: {
+      name: string;
+      fromTime?: Date;
+      toTime?: Date;
+    }): Promise<ProjectStatsRef[]> {
+      const params = new URLSearchParams({ name: args.name, size: '100' });
+      if (args.fromTime) params.set('from_time', args.fromTime.toISOString());
+      if (args.toTime) params.set('to_time', args.toTime.toISOString());
+
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+        'Comet-Workspace': env.workspace,
+      };
+      const key = apiKey ?? env.apiKey;
+      if (key) headers['Authorization'] = key;
+
+      const res = await fetch(`${env.apiBaseUrl}/v1/private/projects/stats?${params}`, {
+        headers,
+      });
+      if (!res.ok) {
+        throw new Error(
+          `GET /v1/private/projects/stats -> ${res.status}: ${(await res.text()).slice(0, 300)}`,
+        );
+      }
+      const body = (await res.json()) as {
+        content?: Array<{
+          project_id?: string;
+          trace_count?: number | null;
+          thread_count?: number | null;
+          error_count?: { count?: number | null } | null;
+          feedback_scores?: Array<{ name: string; value: number }> | null;
+        }>;
+      };
+      return (body.content ?? []).map((item) => ({
+        projectId: String(item.project_id ?? ''),
+        // Outside every seeded window the backend answers 200 with the metrics
+        // absent rather than zeroed, so null and 0 are genuinely different
+        // answers here and must not be collapsed.
+        traceCount: item.trace_count ?? null,
+        threadCount: item.thread_count ?? null,
+        errorCount: item.error_count?.count ?? null,
+        feedbackScores: Object.fromEntries(
+          (item.feedback_scores ?? []).map((s) => [s.name, Number(s.value)]),
+        ),
       }));
     },
 

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -4,6 +4,8 @@ export {
   type ProjectRef,
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
+  type DatasetVersionRef,
+  type ProjectStatsRef,
   type ExperimentRefDetail,
   type TestSuiteRef as BackendTestSuiteRef,
   type TestSuiteItemRef,

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -19,6 +19,13 @@ export interface PythonSdkClient {
     feedback_scores?: Array<{ name: string; value: number; reason?: string }>;
     error_info?: { exception_type: string; message: string; traceback?: string };
     duration_seconds?: number;
+    /**
+     * Ages the trace (and its spans) by this many days, stamping a matching
+     * UUIDv7 id. Time-windowed read paths — `GET /v1/private/projects/stats`
+     * above all — window on the id's embedded timestamp, so this is what puts
+     * a seeded trace deterministically inside or outside a rolling window.
+     */
+    age_days?: number;
     spans: Array<{
       name: string;
       type?: 'general' | 'llm' | 'tool';
@@ -49,6 +56,18 @@ export interface PythonSdkClient {
     items?: Array<Record<string, unknown>>;
     workspace?: string;
   }): Promise<{ id: string; name: string }>;
+  /**
+   * One `Dataset.insert(...)` into an existing dataset — and therefore exactly
+   * one new dataset version, however many 1000-item batches the SDK splits the
+   * payload into. `num_threads` > 1 uploads those batches in parallel.
+   */
+  insertDatasetItems(args: {
+    dataset_name: string;
+    project_name: string;
+    items: Array<Record<string, unknown>>;
+    num_threads?: number;
+    workspace?: string;
+  }): Promise<{ dataset_id: string; inserted: number }>;
   evaluateExperiment(args: {
     project_name: string;
     dataset_name: string;
@@ -181,10 +200,12 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     method: 'GET' | 'POST' | 'DELETE',
     path: string,
     body?: unknown,
+    opts: { timeoutMs?: number } = {},
   ): Promise<TResponse> {
     const endpoint = `${method} ${path}`;
+    const timeoutMs = opts.timeoutMs ?? REQUEST_TIMEOUT_MS;
     const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
       const headers: Record<string, string> = {};
       if (body !== undefined) headers['content-type'] = 'application/json';
@@ -206,7 +227,7 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
             status: 0,
             endpoint,
             detail: 'client-timeout',
-            message: `opik-sdk-driver ${endpoint} aborted after ${REQUEST_TIMEOUT_MS}ms (client-side timeout — the bridge or backend did not respond in time)`,
+            message: `opik-sdk-driver ${endpoint} aborted after ${timeoutMs}ms (client-side timeout — the bridge or backend did not respond in time)`,
           });
         }
         throw err;
@@ -244,10 +265,16 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
       return request<{ id: string; name: string; project_id: string }>('POST', '/traces', args);
     },
     async createNestedTrace(args) {
+      // The route confirms the trace and its spans are queryable before
+      // returning, and that read-back is rate-limited on shared cloud
+      // workspaces: a 429 makes the SDK back off for up to a minute, which is
+      // slow but not a failure. Aborting at the default 30s would turn a
+      // throttled seed into a red test.
       return request<{ id: string; name: string; project_id: string; span_count: number }>(
         'POST',
         '/traces/nested',
         args,
+        { timeoutMs: 150_000 },
       );
     },
     async createFeedbackDefinition(args) {
@@ -258,6 +285,17 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);
+    },
+    async insertDatasetItems(args) {
+      // Multi-batch inserts against a cloud backend outlive the default budget
+      // when the workspace is being rate-limited, and a client-side abort here
+      // would leave a half-written dataset behind.
+      return request<{ dataset_id: string; inserted: number }>(
+        'POST',
+        '/datasets/insert-items',
+        args,
+        { timeoutMs: 180_000 },
+      );
     },
     async compareSeed(args) {
       return request<{

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -110,6 +110,37 @@ export class DatasetItemsPage {
     });
   }
 
+  /** Second tab of the dataset page: one row per committed version. */
+  async openVersionHistory(): Promise<void> {
+    return test.step('Open the Version history tab', async () => {
+      await this.page.getByRole('tab', { name: 'Version history' }).click();
+      const realRow = this.versionsTableBody.locator('tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No version history yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  versionHistoryRow(versionName: string): Locator {
+    return this.versionsTableBody
+      .locator('tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name: versionName, exact: true }) });
+  }
+
+  /**
+   * The "Item count" cell of a version row, as rendered — thousands-separated
+   * ("1,800"), because the column formats through toLocaleString().
+   *
+   * Addressed by the table's own `data-cell-id` (`<rowId>_<columnId>`) rather
+   * than a positional nth(): the version table has no per-cell testid, and
+   * column order is user-configurable, so position is not stable.
+   */
+  versionItemCount(versionName: string): Locator {
+    return this.versionHistoryRow(versionName).locator('[data-cell-id$="_items_total"]');
+  }
+
   async search(term: string): Promise<void> {
     return test.step(`Search items for "${term}"`, async () => {
       await this.page.getByTestId('search-input').fill(term);
@@ -212,6 +243,10 @@ export class DatasetItemsPage {
 
   private get itemsTableBody(): Locator {
     return this.page.getByRole('tabpanel', { name: 'Records' }).locator('tbody');
+  }
+
+  private get versionsTableBody(): Locator {
+    return this.page.getByRole('tabpanel', { name: 'Version history' }).locator('tbody');
   }
 
   /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */

--- a/tests_end_to_end/e2e/pom/projects.page.ts
+++ b/tests_end_to_end/e2e/pom/projects.page.ts
@@ -1,0 +1,77 @@
+import { test } from '@playwright/test';
+import type { Page, Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+/**
+ * The workspace's Projects list — the default landing page.
+ *
+ * Its statistic columns are windowed: the table always asks
+ * `GET /v1/private/projects/stats` for the last 30 days (and for
+ * `source=sdk`), and marks every column that carries that scope with a
+ * "(30d)" suffix in its header. Columns describing the project itself (Name,
+ * Last updated, Created) are unscoped and carry no suffix.
+ */
+export class ProjectsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    return test.step('Open the Projects page', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(`${env.baseUrl}/${env.workspace}/projects`);
+    });
+  }
+
+  async waitForReady(): Promise<void> {
+    return test.step('Wait for the projects table', async () => {
+      const realRow = this.page.locator('tbody tr[data-row-id]').first();
+      const emptyState = this.page.getByText('There are no projects yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  /**
+   * Narrows the table to projects matching `term`. Shared workspaces (cloud
+   * staging) hold hundreds of projects across many runs, so a spec must filter
+   * to its own namespace before asserting on rows or it reads someone else's.
+   */
+  async search(term: string): Promise<void> {
+    return test.step(`Search projects for "${term}"`, async () => {
+      // The table refetches as you type, so wait for the stats call carrying
+      // this term to come back rather than for a fixed delay — otherwise the
+      // assertions can read the pre-search rows.
+      const settled = this.page.waitForResponse(
+        (res) =>
+          res.url().includes('/v1/private/projects/stats') &&
+          res.url().includes(`name=${encodeURIComponent(term)}`) &&
+          res.status() === 200,
+      );
+      await this.page.getByTestId('search-input').fill(term);
+      await settled;
+    });
+  }
+
+  projectRow(name: string): Locator {
+    return this.page
+      .locator('tbody tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
+  }
+
+  columnHeader(label: string): Locator {
+    return this.page.getByRole('columnheader', { name: label, exact: true });
+  }
+
+  /**
+   * A statistic cell of a project's row, addressed by the table's own
+   * `data-cell-id` (`<rowId>_<columnId>`). The rows carry no per-cell testid
+   * and the column order is user-configurable and persisted in localStorage,
+   * so a positional nth() would be neither stable nor portable between
+   * machines. Column ids are the ones ProjectsPage.tsx declares:
+   * `trace_count`, `error_count`, `feedback_scores`, `duration.p50`, …
+   */
+  statCell(name: string, columnId: string): Locator {
+    return this.projectRow(name).locator(`[data-cell-id$="_${columnId}"]`);
+  }
+}

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -3,7 +3,12 @@ import atexit
 from fastapi import APIRouter, Header
 
 from ..opik_factory import make_opik_client
-from ..schemas import DatasetCreate, DatasetResponse
+from ..schemas import (
+    DatasetCreate,
+    DatasetInsertItemsRequest,
+    DatasetInsertItemsResponse,
+    DatasetResponse,
+)
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
@@ -31,3 +36,34 @@ def create_dataset(
         atexit.unregister(client.end)
 
     return DatasetResponse(id=str(dataset.id), name=dataset.name)
+
+
+@router.post(
+    "/insert-items",
+    response_model=DatasetInsertItemsResponse,
+    status_code=200,
+)
+def insert_dataset_items(
+    body: DatasetInsertItemsRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> DatasetInsertItemsResponse:
+    """Insert items into an existing dataset by name, as ONE dataset version.
+
+    Mirrors test-suites/insert-items: resolves the dataset within the caller's
+    `project_name` scope, since same-named datasets can exist across projects.
+    Each call is one `Dataset.insert(...)`, which is the unit a version is cut
+    on — the SDK splits the items into batches of 1000 internally, and those
+    batches must not become versions of their own.
+    """
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        dataset = client.get_dataset(
+            name=body.dataset_name, project_name=body.project_name
+        )
+        dataset.insert(body.items, num_threads=body.num_threads)
+        dataset_id = str(dataset.id)
+    finally:
+        client.end(flush=True)
+        atexit.unregister(client.end)
+
+    return DatasetInsertItemsResponse(dataset_id=dataset_id, inserted=len(body.items))

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/traces.py
@@ -1,5 +1,7 @@
 import atexit
 import datetime
+import secrets
+import uuid
 
 import opik
 from fastapi import APIRouter, Header, HTTPException
@@ -13,6 +15,25 @@ from ..schemas import (
 )
 
 router = APIRouter(prefix="/traces", tags=["traces"])
+
+
+def _uuid7_at(moment: datetime.datetime) -> str:
+    """Build a UUIDv7 whose embedded timestamp is `moment`.
+
+    The backend requires trace ids to be version 7 and reads the creation
+    instant back out of them, so a backdated trace needs a backdated id — a
+    fresh id would keep the trace inside any recent time window no matter what
+    start_time says. Python's uuid module has no uuid7 generator (3.14 adds
+    one), hence the bit layout here: 48-bit big-endian millisecond timestamp,
+    4-bit version 7, 12 random bits, 2-bit RFC 4122 variant, 62 random bits.
+    """
+    millis = int(moment.timestamp() * 1000)
+    value = (millis & ((1 << 48) - 1)) << 80
+    value |= 0x7 << 76
+    value |= secrets.randbits(12) << 64
+    value |= 0b10 << 62
+    value |= secrets.randbits(62)
+    return str(uuid.UUID(int=value))
 
 
 @router.post("", response_model=TraceResponse, status_code=201)
@@ -77,13 +98,24 @@ def create_nested_trace(
     # SDK is translated to HTTP by the app-wide exception handler.
     client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
     try:
+        # The instant the trace "happened": now, or age_days in the past.
+        anchor = datetime.datetime.now(datetime.timezone.utc)
+        if body.age_days is not None:
+            anchor -= datetime.timedelta(days=body.age_days)
+
         start_time: datetime.datetime | None = None
         end_time: datetime.datetime | None = None
         if body.duration_seconds is not None:
-            end_time = datetime.datetime.now(datetime.timezone.utc)
-            start_time = end_time - datetime.timedelta(seconds=body.duration_seconds)
+            end_time = anchor
+            start_time = anchor - datetime.timedelta(seconds=body.duration_seconds)
+        elif body.age_days is not None:
+            # A backdated trace with no duration still needs a start_time, or it
+            # renders as never-started at today's date. end_time stays unset,
+            # matching a non-backdated trace with no duration.
+            start_time = anchor
 
         trace = client.trace(
+            id=_uuid7_at(anchor) if body.age_days is not None else None,
             project_name=body.project_name,
             name=body.name,
             input=body.input,
@@ -125,7 +157,16 @@ def create_nested_trace(
             # an immediate end() update races the create in the same batch and
             # clobbers the rich fields (name/input/output/usage/model/cost) with
             # nulls. See the SDK note on batching-and-updates.
+            # A backdated trace carries its spans back with it — id, start and
+            # end — so per-span aggregations (cost, tokens) fall in the same
+            # time window as the trace they belong to. Left untouched (SDK
+            # default: fresh id, start now, no end) when age_days is unset, so
+            # existing seeds keep the exact shape they had.
+            backdated = body.age_days is not None
             span = parent.span(
+                id=_uuid7_at(anchor) if backdated else None,
+                start_time=start_time if backdated else None,
+                end_time=end_time if backdated else None,
                 name=span_seed.name,
                 type=span_seed.type,
                 input=span_seed.input,

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -85,6 +85,13 @@ class NestedTraceCreate(BaseModel):
     # and end_time unset, which the UI renders as Duration "NA" — the same shape
     # as the SDK's own not-yet-ended traces.
     duration_seconds: float | None = None
+    # Ages the whole trace by this many days: it gets a client-supplied UUIDv7
+    # id stamped at that instant, and its timestamps move back with it. Time
+    # windows on the read paths (notably GET /v1/private/projects/stats) are
+    # applied to the timestamp embedded in the id, not to start_time, so this
+    # is what places a trace deterministically inside or outside a rolling
+    # window. None keeps the SDK's own behaviour: a server-fresh id stamped now.
+    age_days: float | None = None
 
 
 class NestedTraceResponse(BaseModel):
@@ -124,6 +131,26 @@ class DatasetCreate(BaseModel):
 class DatasetResponse(BaseModel):
     id: str
     name: str
+
+
+class DatasetInsertItemsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    project_name: str
+    items: list[dict[str, Any]]
+    # Worker threads Dataset.insert uses to upload this call's batches. 1 (the
+    # SDK default) uploads them sequentially; >1 uploads them in parallel, and
+    # both paths must land in ONE dataset version with identical counters.
+    # Parallel upload needs a backend >= MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
+    # (2.2.8); against an older one the SDK silently falls back to sequential.
+    num_threads: int = 1
+    workspace: str | None = None
+
+
+class DatasetInsertItemsResponse(BaseModel):
+    dataset_id: str
+    inserted: int
 
 
 class ExperimentItemSeed(BaseModel):

--- a/tests_end_to_end/e2e/tests/datasets/dataset-version-counters.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-version-counters.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+import type { DatasetVersionRef } from '@e2e/core/backend';
+
+/**
+ * A dataset version stores its own item counters — items_total / items_added /
+ * items_modified — and the Version history tab renders items_total as "Item
+ * count". The existing dataset specs insert three items and count rendered
+ * rows, so nothing covers the counters themselves: a version can hold the
+ * right rows and still report the wrong number, and that number is what a user
+ * reads off the page.
+ *
+ * Shape of the seed, chosen to exercise the two things that make the counters
+ * non-trivial:
+ *  - SEED_SIZE is above the SDK's 1000-item batch size, so each insert() call
+ *    is split into several backend calls that must still collapse into ONE
+ *    version;
+ *  - the second call re-sends half the ids with changed content (updates) and
+ *    half fresh ones (adds), so added/modified/total are three different
+ *    numbers and a spec can't pass by coincidence.
+ */
+const SEED_SIZE = 1200;
+const CHANGE_SIZE = SEED_SIZE / 2;
+
+/**
+ * What both the sequential and the parallel upload path must store. They share
+ * one expectation on purpose: `insert(..., num_threads=8)` splits the same
+ * items across parallel batch uploads, and the version it produces has to be
+ * indistinguishable from the sequential one.
+ */
+const EXPECTED_VERSIONS = [
+  { versionName: 'v1', itemsTotal: SEED_SIZE, itemsAdded: SEED_SIZE, itemsModified: 0 },
+  {
+    versionName: 'v2',
+    itemsTotal: SEED_SIZE + CHANGE_SIZE,
+    itemsAdded: CHANGE_SIZE,
+    itemsModified: CHANGE_SIZE,
+  },
+];
+
+/** Dataset item ids must be UUIDv7; the backend rejects any other version. */
+function uuidV7(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const millis = Date.now();
+  bytes[0] = (millis / 2 ** 40) & 0xff;
+  bytes[1] = (millis / 2 ** 32) & 0xff;
+  bytes[2] = (millis / 2 ** 24) & 0xff;
+  bytes[3] = (millis / 2 ** 16) & 0xff;
+  bytes[4] = (millis / 2 ** 8) & 0xff;
+  bytes[5] = millis & 0xff;
+  bytes[6] = 0x70 | (bytes[6] & 0x0f);
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function seedItems(ids: string[], from: number, to: number, revision: string) {
+  return ids.slice(from, to).map((id, index) => ({
+    id,
+    input: `item ${from + index} ${revision}`,
+    expected_output: `output ${from + index} ${revision}`,
+  }));
+}
+
+function byVersionName(versions: DatasetVersionRef[]) {
+  return versions
+    .map((v) => ({
+      versionName: v.versionName,
+      itemsTotal: v.itemsTotal,
+      itemsAdded: v.itemsAdded,
+      itemsModified: v.itemsModified,
+    }))
+    .sort((a, b) => a.versionName.localeCompare(b.versionName));
+}
+
+test.describe('Dataset version counters', { tag: ['@area:datasets'] }, () => {
+  /** Two 1200-item inserts per dataset against a cloud backend outrun the default budget. */
+  test.slow();
+
+  test(
+    'A multi-batch insert stores one version whose counters match the items actually stored, and the Version history tab renders them',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ project, sdkClient, backendClient, testNamespace, page }) => {
+      const datasetName = `${testNamespace}-seq`;
+      const ids = Array.from({ length: SEED_SIZE + CHANGE_SIZE }, uuidV7);
+
+      const datasetId = await test.step('Seed a dataset with two multi-batch inserts', async () => {
+        const created = await sdkClient.python.createDataset({
+          project_name: project.name,
+          name: datasetName,
+          description: 'version counters, sequential upload',
+        });
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          items: seedItems(ids, 0, SEED_SIZE, 'v1'),
+        });
+        // Half the ids come back with different content (modifications), half
+        // are new (additions) — one call, so one version covering both.
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          items: [
+            ...seedItems(ids, 0, CHANGE_SIZE, 'edited'),
+            ...seedItems(ids, SEED_SIZE, SEED_SIZE + CHANGE_SIZE, 'v1'),
+          ],
+        });
+        return created.id;
+      });
+
+      try {
+        const versions = await test.step('Each insert() cut exactly one version, with the counters it should', async () => {
+          const fetched = await backendClient.getDatasetVersions(datasetId);
+          // Two insert() calls => two versions. Four backend batches were sent
+          // (1200 and 600 items, split at 1000), and a batch must never cut a
+          // version of its own.
+          expect(fetched).toHaveLength(2);
+          expect(byVersionName(fetched)).toEqual(EXPECTED_VERSIONS);
+          return fetched;
+        });
+
+        await test.step('The stored item total agrees with the items actually in the dataset', async () => {
+          const itemIds = await backendClient.listDatasetItemIds(datasetId);
+          const latest = versions.find((v) => v.isLatest);
+          // The counter is only worth rendering if it matches reality: a
+          // version that reports more items than the dataset holds is exactly
+          // the failure this catches.
+          expect(new Set(itemIds).size).toBe(latest?.itemsTotal);
+        });
+
+        await test.step('The Version history tab renders those totals as "Item count"', async () => {
+          const datasets = new DatasetsPage(page);
+          await datasets.goto(project.id);
+          await datasets.waitForReady();
+          const items = await datasets.openDatasetByName(datasetName);
+          await items.waitForReady();
+          await items.openVersionHistory();
+
+          for (const expected of EXPECTED_VERSIONS) {
+            await expect(items.versionItemCount(expected.versionName)).toHaveText(
+              expected.itemsTotal.toLocaleString('en-US'),
+            );
+          }
+        });
+      } finally {
+        await backendClient.deleteDataset(datasetId);
+      }
+    },
+  );
+
+  test(
+    'Uploading the same items on several threads stores the same version counters as the sequential path',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ project, sdkClient, backendClient, testNamespace }) => {
+      const datasetName = `${testNamespace}-parallel`;
+      const ids = Array.from({ length: SEED_SIZE + CHANGE_SIZE }, uuidV7);
+
+      const datasetId = await test.step('Seed the same shape with a parallel upload', async () => {
+        const created = await sdkClient.python.createDataset({
+          project_name: project.name,
+          name: datasetName,
+          description: 'version counters, parallel upload',
+        });
+        // num_threads only changes HOW the batches of one insert() are
+        // uploaded, never what they add up to. Against a backend older than
+        // 2.2.8 the SDK falls back to sequential, which passes too — the
+        // assertion is on the result, not the transport.
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          items: seedItems(ids, 0, SEED_SIZE, 'v1'),
+          num_threads: 8,
+        });
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          items: [
+            ...seedItems(ids, 0, CHANGE_SIZE, 'edited'),
+            ...seedItems(ids, SEED_SIZE, SEED_SIZE + CHANGE_SIZE, 'v1'),
+          ],
+          num_threads: 8,
+        });
+        return created.id;
+      });
+
+      try {
+        await test.step('The parallel path cut the same two versions with the same counters', async () => {
+          const versions = await backendClient.getDatasetVersions(datasetId);
+          expect(versions).toHaveLength(2);
+          expect(byVersionName(versions)).toEqual(EXPECTED_VERSIONS);
+        });
+
+        await test.step('And its stored total still matches the items in the dataset', async () => {
+          const itemIds = await backendClient.listDatasetItemIds(datasetId);
+          expect(new Set(itemIds).size).toBe(EXPECTED_VERSIONS[1].itemsTotal);
+        });
+      } finally {
+        await backendClient.deleteDataset(datasetId);
+      }
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/projects/projects-list-stats.spec.ts
+++ b/tests_end_to_end/e2e/tests/projects/projects-list-stats.spec.ts
@@ -1,0 +1,222 @@
+import { test, expect } from '@e2e/fixtures';
+import { ProjectsPage } from '@e2e/pom/projects.page';
+import type { PythonSdkClient } from '@e2e/core/sdk';
+
+/**
+ * The Projects list is the workspace's landing page, and its statistic columns
+ * are scoped to a rolling 30-day window: the table asks
+ * `GET /v1/private/projects/stats` for `now-30d .. now` and labels every
+ * column that carries that scope "(30d)".
+ *
+ * Two things can go wrong independently, so both are asserted here:
+ *  - the backend can window wrongly (return all-time numbers, or nothing);
+ *  - the page can render numbers that don't come from the windowed call.
+ * A spec that only checked the API would miss the second; one that only read
+ * the page couldn't tell a correct number from a coincidence.
+ *
+ * Traces are placed inside and outside the window by age: a seeded trace
+ * carries a UUIDv7 id stamped at its own age, and the window is applied to
+ * that id. Nothing here depends on data that happens to already exist.
+ */
+const OUTSIDE_WINDOW_DAYS = 60;
+const SCORE_NAME = 'sample-quality';
+const LIVE_THREAD = 'live-thread';
+
+/** What the seeded project holds, all-time versus inside the 30-day window. */
+const EXPECTED = {
+  allTime: { traces: 3, threads: 2, errors: 2, score: 0.5 },
+  windowed: { traces: 2, threads: 1, errors: 1, score: 1 },
+};
+
+const LLM_SPAN = {
+  name: 'llm-call',
+  type: 'llm' as const,
+  model: 'gpt-3.5-turbo',
+  provider: 'openai',
+  usage: { prompt_tokens: 10, completion_tokens: 50, total_tokens: 60 },
+};
+
+const ERROR_INFO = {
+  exception_type: 'ValueError',
+  message: 'seeded failure',
+  traceback: 'seeded failure',
+};
+
+/**
+ * Three traces: two inside the window (sharing a thread; the first also failed
+ * and scored 1.0) and one outside it (its own thread, failed, scored 0.0).
+ *
+ * Deliberately the smallest seed for which the windowed and the all-time
+ * answer differ on *every* metric the table renders — trace count, thread
+ * count, error count and the score average all move — so a page showing
+ * all-time numbers cannot coincidentally match, while the seed stays small
+ * enough not to trip the workspace's ingestion rate limit.
+ */
+async function seedWindowedProject(sdk: PythonSdkClient, projectName: string): Promise<void> {
+  const trace = (
+    name: string,
+    extra: Partial<Parameters<PythonSdkClient['createNestedTrace']>[0]>,
+  ) =>
+    sdk.createNestedTrace({
+      project_name: projectName,
+      name,
+      input: { q: name },
+      output: { a: name },
+      duration_seconds: 1,
+      spans: [LLM_SPAN],
+      ...extra,
+    });
+
+  await trace('in-window-scored-and-failed', {
+    thread_id: LIVE_THREAD,
+    feedback_scores: [{ name: SCORE_NAME, value: 1 }],
+    error_info: ERROR_INFO,
+  });
+  await trace('in-window-same-thread', { thread_id: LIVE_THREAD });
+  await trace('outside-window-scored-and-failed', {
+    age_days: OUTSIDE_WINDOW_DAYS,
+    thread_id: 'dormant-thread',
+    feedback_scores: [{ name: SCORE_NAME, value: 0 }],
+    error_info: ERROR_INFO,
+  });
+}
+
+/** now-30d .. now, the window the table itself asks for. */
+function thirtyDayWindow() {
+  const toTime = new Date();
+  return { fromTime: new Date(toTime.getTime() - 30 * 24 * 60 * 60 * 1000), toTime };
+}
+
+test.describe('Projects list — 30-day windowed stats', { tag: ['@area:projects'] }, () => {
+  /** Stat columns collapse out of the viewport on a narrow window. */
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test(
+    'Project stats are scoped to the requested window, and unscoped when none is given',
+    { tag: ['@t2-cuj', '@cap:projects.list-projects'] },
+    async ({ project, sdkClient, backendClient }) => {
+      await test.step('Seed traces inside and outside the 30-day window', async () => {
+        await seedWindowedProject(sdkClient.python, project.name);
+      });
+
+      await test.step('All-time stats count every trace', async () => {
+        // Ingestion is eventually consistent: poll the aggregate rather than
+        // sleeping, so the spec neither flakes nor waits longer than it must.
+        await expect
+          .poll(
+            async () => {
+              const [stats] = await backendClient.getProjectStats({ name: project.name });
+              return stats?.traceCount ?? null;
+            },
+            { timeout: 60_000 },
+          )
+          .toBe(EXPECTED.allTime.traces);
+
+        const [stats] = await backendClient.getProjectStats({ name: project.name });
+        expect(stats.threadCount).toBe(EXPECTED.allTime.threads);
+        expect(stats.errorCount).toBe(EXPECTED.allTime.errors);
+        expect(stats.feedbackScores[SCORE_NAME]).toBe(EXPECTED.allTime.score);
+      });
+
+      await test.step('The 30-day window drops the traces that fall outside it', async () => {
+        const [stats] = await backendClient.getProjectStats({
+          name: project.name,
+          ...thirtyDayWindow(),
+        });
+        expect(stats.traceCount).toBe(EXPECTED.windowed.traces);
+        expect(stats.threadCount).toBe(EXPECTED.windowed.threads);
+        expect(stats.errorCount).toBe(EXPECTED.windowed.errors);
+        // The average moves with the window, it isn't merely re-counted: the
+        // 0.0 score sits outside, so the windowed average is 1.0, not 0.5.
+        expect(stats.feedbackScores[SCORE_NAME]).toBe(EXPECTED.windowed.score);
+      });
+    },
+  );
+
+  test(
+    'The projects table renders the windowed stats, marks those columns "(30d)", and keeps dormant projects listed',
+    { tag: ['@t2-cuj', '@cap:projects.list-projects'] },
+    async ({ project, sdkClient, backendClient, testNamespace, page }) => {
+      const dormantName = `${testNamespace}-dormant`;
+
+      const dormantId = await test.step('Seed an active project and one whose only activity is old', async () => {
+        await seedWindowedProject(sdkClient.python, project.name);
+        const dormant = await sdkClient.python.createProject({ name: dormantName });
+        await sdkClient.python.createNestedTrace({
+          project_name: dormantName,
+          name: 'dormant-trace',
+          input: { q: 'dormant' },
+          output: { a: 'dormant' },
+          duration_seconds: 1,
+          age_days: OUTSIDE_WINDOW_DAYS,
+          spans: [LLM_SPAN],
+        });
+        return dormant.id;
+      });
+
+      try {
+        const windowed = await test.step('Read the windowed stats the table should be showing', async () => {
+          await expect
+            .poll(
+              async () => {
+                const [stats] = await backendClient.getProjectStats({
+                  name: project.name,
+                  ...thirtyDayWindow(),
+                });
+                return stats?.traceCount ?? null;
+              },
+              { timeout: 60_000 },
+            )
+            .toBe(EXPECTED.windowed.traces);
+          const [stats] = await backendClient.getProjectStats({
+            name: project.name,
+            ...thirtyDayWindow(),
+          });
+          return stats;
+        });
+
+        const projects = new ProjectsPage(page);
+        await test.step('Open the Projects page, narrowed to this run', async () => {
+          await projects.goto();
+          await projects.waitForReady();
+          await projects.search(testNamespace);
+          await expect(projects.projectRow(project.name)).toBeVisible();
+        });
+
+        await test.step('Only the windowed columns are labelled "(30d)"', async () => {
+          await expect(projects.columnHeader('Trace count (30d)')).toBeVisible();
+          await expect(projects.columnHeader('Errors (30d)')).toBeVisible();
+          await expect(projects.columnHeader('Avg feedback scores (30d)')).toBeVisible();
+          // Project metadata is not windowed, and must not claim to be.
+          await expect(projects.columnHeader('Name')).toBeVisible();
+          await expect(projects.columnHeader('Last updated')).toBeVisible();
+        });
+
+        await test.step('The rendered cells carry the windowed numbers, not the all-time ones', async () => {
+          await expect(projects.statCell(project.name, 'trace_count')).toHaveText(
+            String(windowed.traceCount),
+          );
+          await expect(projects.statCell(project.name, 'error_count')).toContainText(
+            String(windowed.errorCount),
+          );
+
+          const scoreCell = projects.statCell(project.name, 'feedback_scores');
+          await expect(scoreCell).toContainText(`${SCORE_NAME} (avg)`);
+          await expect(scoreCell).toContainText(String(windowed.feedbackScores[SCORE_NAME]));
+          // 0.5 is this project's all-time average — seeing it here would mean
+          // the page is rendering an unwindowed call.
+          await expect(scoreCell).not.toContainText(String(EXPECTED.allTime.score));
+        });
+
+        await test.step('A project with no activity in the window is still listed, with blank stats', async () => {
+          await expect(projects.projectRow(dormantName)).toBeVisible();
+          // Blank, not zero: outside every window the backend returns no
+          // metric at all, and the column renders nothing rather than "0".
+          await expect(projects.statCell(dormantName, 'trace_count')).not.toContainText(/\d/);
+        });
+      } finally {
+        await backendClient.deleteProject(dormantId);
+      }
+    },
+  );
+});


### PR DESCRIPTION
## Where these came from

The release QA side flow explored the **2.2.16 → 2.2.18** release on staging
(`staging.dev.comet.com`, which reports 2.2.27 — this release plus nine later
patches). A human-driven exploration verified each of these flows by hand
first; this PR turns the two strong candidates into permanent specs.

**Written and run against the `2.2.18` tag** (branched from it), because that
is the ref the exploration verified. It targets `main` because that is where
they have to merge — `main` will have moved on, so please re-run before
merging if it has moved far.

## Verification

Both specs were run against staging before this PR was opened, from the
release ref, with no retries:

```bash
cd tests_end_to_end/e2e
OPIK_DEPLOYMENT=cloud OPIK_BASE_URL=https://staging.dev.comet.com/opik \
  npx playwright test tests/datasets/dataset-version-counters.spec.ts \
                      tests/projects/projects-list-stats.spec.ts \
                      --workers=2 --retries=0
# 4 passed (52.6s)
```

Also re-ran `tests/trace-explore/trace-spans-depth.spec.ts` (the existing spec
that seeds through the nested-trace bridge route this PR touches): **8 passed**
together, no regression. `tag_lint.py` reports `0 problem(s)`; `tsc --noEmit`
is clean.

## The specs

### `tests/datasets/dataset-version-counters.spec.ts` — `@cap:datasets.version-history-view`

The existing dataset specs insert three items and count rendered rows, so
nothing covered the version counters themselves. A version can hold the right
rows and still report the wrong number, and that number is on screen as the
Version history tab's "Item count".

| Test | Asserts | Result |
|---|---|---|
| Multi-batch insert stores one version with counters matching what is stored | Two `insert()` calls of 1200 and 600 items (split into four 1000-item backend batches) cut exactly **two** versions, not one per batch; v1 = 1200/+1200/~0 and v2 = 1800/+600/~600; the stored `items_total` equals the number of distinct item ids actually readable; the Version history tab renders "1,200" and "1,800" as Item count | **Passed** |
| The parallel upload path stores the same counters as the sequential one | The same seed uploaded with `num_threads=8` produces the identical two versions and the same agreement with stored content | **Passed** |

### `tests/projects/projects-list-stats.spec.ts` — `@cap:projects.list-projects`

First spec in the `projects` area (previously 0/8 covered). 2.2.18 changed both
the value and the meaning of the numbers on the default landing page.

| Test | Asserts | Result |
|---|---|---|
| Stats are scoped to the window given, unscoped when none is given | All-time = 3 traces / 2 threads / 2 errors / avg 0.5; the same call for `now-30d .. now` = 2 / 1 / 1 / avg **1.0**. Every metric moves, so a page showing all-time numbers cannot coincidentally match | **Passed** |
| The table renders the windowed stats, labels them "(30d)", and keeps dormant projects listed | The rendered Trace count / Errors / Avg feedback scores cells equal the **windowed API values** and not the all-time ones; stats headers carry "(30d)" while Name and Last updated do not; a project whose only activity is 60 days old is still listed, with blank stats rather than 0 | **Passed** |

Traces are placed inside and outside the window by age: a seeded trace carries
a UUIDv7 id stamped at its own age, and the window is applied to that id.
Nothing depends on data that happens to already exist in the workspace.

## Supporting changes

Only what the specs needed:

- **sdk-driver** — `POST /datasets/insert-items` (one `Dataset.insert()` into
  an existing dataset, with `num_threads`), mirroring the existing
  `test-suites/insert-items`; and `age_days` on `POST /traces/nested`, which
  backdates a trace and its spans behind a matching UUIDv7 id. Backdating the
  id is the only way to place a trace deterministically outside a rolling
  window, since the window is applied to the id's embedded timestamp. Both are
  additive; with `age_days` unset the route behaves exactly as before.
- **backend client** — `getDatasetVersions`, `listDatasetItemIds` (paged in
  full, since it is the ground truth `items_total` is compared against), and a
  windowed `getProjectStats`. The last one is a raw fetch with a comment
  explaining why: the pinned TS SDK's `GetProjectStatsRequest` has no
  `from_time`/`to_time`, and the window is the whole point. Worth switching to
  the typed call when the SDK catches up.
- **bridge client** — the request helper takes an optional per-call timeout.
  Two calls use it: the 1200-item insert, and nested-trace creation, whose
  post-create read-back is rate-limited on shared cloud workspaces (staging
  answered 429 with backoffs of 45–52s during this run — slow, not broken;
  aborting at the default 30s turned a throttled seed into a red test).
- **pom** — Version history accessors on `DatasetItemsPage`, and a new
  `ProjectsPage`. Both address table cells through the table's own
  `data-cell-id` (`<rowId>_<columnId>`); there is no per-cell testid and the
  column order is user-configurable and persisted in localStorage, so nth() is
  not stable. Happy to add testids to the FE instead if that is preferred.
- **taxonomy** — `datasets.version-history-view` and `projects.list-projects`
  flipped to `covered: true` at `t2-cuj`, with both specs listed.

## What I deliberately did not write

- **The duplicate-id-under-`num_threads` assertion.** The exploration reports
  that repeating a `dataset_item_id` *within a single* `insert(..., num_threads=8)`
  call stores `items_total` one too high (1802 against 1801 actual), reproduced
  2/2 — a live defect, and the reason the parallel test here stops at parity on
  the clean path. It is left out on purpose: it would land the suite red on
  merge, and it belongs with its fix. Worth noting for whoever picks that up —
  one duplicate-id variant probed while writing this (an id repeated twice in
  the same call, new in that call) did **not** reproduce it, so the exact
  trigger needs pinning down before it becomes an assertion.
- **`projects/stats` with a pre-epoch `from_time`.** The exploration ranked this
  `weak` and it is red on staging today: any `from_time` before 1970-01-05
  returns HTTP 200 with every metric null. Two strong candidates existed, so
  this one was skipped rather than shipped red.
- **Three candidates the exploration itself did not propose** (V1-removal nav
  smoke, trace bulk delete — already covered by
  `trace-explore/trace-delete.spec.ts` — and the new OpenRouter model, whose UI
  half could not be driven without a workspace-settings change), plus two items
  it never reached (optimization trial status mid-run, reflection span pricing).

The candidate list was filtered, not exhausted: 3 candidates, 2 written, 1
dropped.

## Please review before merging

These specs were **generated by the release QA side flow**, not written by
hand. They pass against staging, but a reviewer should check that each
assertion is the thing worth failing on before this is promoted out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
