### PR TITLE
[NA] [DOCS] docs: stop repeated seeds silently drifting the query-performance fixture

### DIFF
--- a/.agents/skills/query-performance/environments.md
+++ b/.agents/skills/query-performance/environments.md
@@ -33,15 +33,22 @@ it dies with the JVM. The flow:
    environment refuses: log flushing, cache drops, stopping merges, and `INSERT`.
 4. **Extrapolate to 20k / 500k / 1M** driving entities, each scale in **its own workspace id** so the
    ladders coexist and one rendering can be pointed at any of them. Derive the parameters from the
-   fixtures rather than inventing them.
-5. **Validate the shape before trusting a number**: compare the container's `EXPLAIN indexes = 1`
-   against a real environment's and check that pruning *behaves* the same way — the same conditions
-   reach the index, the same key prefixes are hit, the same skip indexes engage or are ignored.
-   Absolute granule and mark counts will not match across different data volumes, so compare
-   behaviour, not ratios. Pruning that behaves differently means the seeding is wrong; fix it before
-   continuing.
+   fixtures rather than inventing them. Seed each scale **once**: the container is reused across runs,
+   so a repeated seed does not overwrite anything — with deterministic ids it appends another row per
+   id, which the queries read as another *version of the same logical key*, silently inflating the
+   dedup depth you were trying to hold fixed. Re-running the test adds fixture rows the same way. If a
+   scale needs rebuilding, seed it into a new workspace id rather than repeating it, and do not clear
+   the query tables — the fixtures the extrapolation is derived from live there.
+5. **Validate the data, then the shape.** First confirm the fixture is what you intended — entity
+   count, rows per logical key, part count — because a drifted fixture is otherwise invisible and
+   every number after it is wrong. Then compare the container's `EXPLAIN indexes = 1` against a real
+   environment's and check that pruning *behaves* the same way — the same conditions reach the index,
+   the same key prefixes are hit, the same skip indexes engage or are ignored. Absolute granule and
+   mark counts will not match across different data volumes, so compare behaviour, not ratios.
+   Pruning that behaves differently means the seeding is wrong; fix it before continuing.
 
 **What the extrapolation must preserve**, because each of these moves the plan: fanout (child rows per
 entity); rows per logical key, which is what dedup steps pay for; part count; cardinality of the
 columns used as prunes; skew, so the worst-case entity exists; array and string density; and insert
-order relative to the primary key. Ids must be unique and, ideally, reproducible across re-seeds.
+order relative to the primary key. Ids must be unique and, ideally, reproducible, so a scale can be
+rebuilt from scratch in a fresh workspace id.

--- a/.agents/skills/query-performance/environments.md
+++ b/.agents/skills/query-performance/environments.md
@@ -41,8 +41,11 @@ it dies with the JVM. The flow:
 
    Derive the parameters from the fixtures rather than inventing them, and seed each scale **once**:
    the container is reused across runs, so a repeated seed does not overwrite anything — with
-   deterministic ids it appends another row per id, which the queries read as another *version of the
-   same logical key*, silently inflating the dedup depth you were trying to hold fixed. Re-running the
+   deterministic ids it appends another row per id. What that row becomes depends on the whole key the
+   dedup step groups on, not on the id alone: repeat the full key and the query sees another *version*,
+   inflating the dedup depth you were holding fixed; vary any other dimension of that key and you get a
+   *distinct* key instead, inflating entity count. Both are drift, they need different fixes, and the
+   count check in step 5 is what tells them apart. Re-running the
    *test* is a different hazard: fixture helpers usually mint a fresh workspace and fresh ids per run,
    so a rerun adds volume and parts to the shared tables rather than versions of an existing key. Both
    distort a measurement; only the first distorts dedup depth, so know which one you are looking at. If

--- a/.agents/skills/query-performance/environments.md
+++ b/.agents/skills/query-performance/environments.md
@@ -36,7 +36,10 @@ it dies with the JVM. The flow:
    fixtures rather than inventing them. Seed each scale **once**: the container is reused across runs,
    so a repeated seed does not overwrite anything — with deterministic ids it appends another row per
    id, which the queries read as another *version of the same logical key*, silently inflating the
-   dedup depth you were trying to hold fixed. Re-running the test adds fixture rows the same way. If a
+   dedup depth you were trying to hold fixed. Re-running the *test* is a different hazard: fixture
+   helpers usually mint a fresh workspace and fresh ids per run, so a rerun adds volume and parts to
+   the shared tables rather than versions of an existing key. Both distort a measurement; only the
+   first distorts dedup depth, so know which one you are looking at. If a
    scale needs rebuilding, seed it into a new workspace id rather than repeating it, and do not clear
    the query tables — the fixtures the extrapolation is derived from live there.
    Note what the workspace id does and does not isolate: it separates results and lets a prefix prune
@@ -49,7 +52,9 @@ it dies with the JVM. The flow:
    count, rows per logical key, active part count — because a drifted fixture is otherwise invisible
    and every number after it is wrong. Count **raw stored rows**, scoped to the workspace you seeded:
    a deduplicated count is blind to precisely the extra version a repeated seed creates, so it would
-   pass a drifted fixture as clean. Then compare the container's `EXPLAIN indexes = 1` against a real
+   pass a drifted fixture as clean. Row counts and version depth are exact; part count is not, because
+   background merges and insert ordering move it — hold merges while measuring, or read it as a
+   magnitude rather than an equality. Then compare the container's `EXPLAIN indexes = 1` against a real
    environment's and check that pruning *behaves* the same way — the same conditions reach the index,
    the same key prefixes are hit, the same skip indexes engage or are ignored. Absolute granule and
    mark counts will not match across different data volumes, so compare behaviour, not ratios.

--- a/.agents/skills/query-performance/environments.md
+++ b/.agents/skills/query-performance/environments.md
@@ -31,23 +31,23 @@ it dies with the JVM. The flow:
 3. **Attach to the surviving container** on its mapped native port (it changes per run) as `default`,
    database `opik` (`ClickHouseContainerUtils.DATABASE_NAME`). Being admin here unlocks what a real
    environment refuses: log flushing, cache drops, stopping merges, and `INSERT`.
-4. **Extrapolate to 20k / 500k / 1M** driving entities, each scale in **its own workspace id** so the
-   ladders coexist and one rendering can be pointed at any of them. Derive the parameters from the
-   fixtures rather than inventing them. Seed each scale **once**: the container is reused across runs,
-   so a repeated seed does not overwrite anything — with deterministic ids it appends another row per
-   id, which the queries read as another *version of the same logical key*, silently inflating the
-   dedup depth you were trying to hold fixed. Re-running the *test* is a different hazard: fixture
-   helpers usually mint a fresh workspace and fresh ids per run, so a rerun adds volume and parts to
-   the shared tables rather than versions of an existing key. Both distort a measurement; only the
-   first distorts dedup depth, so know which one you are looking at. If a
-   scale needs rebuilding, seed it into a new workspace id rather than repeating it, and do not clear
+4. **Extrapolate to 20k / 500k / 1M** driving entities, choosing the layout by the question first. For
+   *per-scale* plan shape, put each scale in **its own workspace id** so the ladders coexist and one
+   rendering can be pointed at any of them. For the growth curve *across* scales, give each scale its
+   own rig — a separate database or container. The reason is what a workspace id does not isolate: it
+   separates results and lets a prefix prune work, but coexisting scales still share parts, partitions
+   and merge history, so physical numbers are measured against a table holding every scale at once, and
+   absolute parts and granule totals are comparable only within one seeded state.
+
+   Derive the parameters from the fixtures rather than inventing them, and seed each scale **once**:
+   the container is reused across runs, so a repeated seed does not overwrite anything — with
+   deterministic ids it appends another row per id, which the queries read as another *version of the
+   same logical key*, silently inflating the dedup depth you were trying to hold fixed. Re-running the
+   *test* is a different hazard: fixture helpers usually mint a fresh workspace and fresh ids per run,
+   so a rerun adds volume and parts to the shared tables rather than versions of an existing key. Both
+   distort a measurement; only the first distorts dedup depth, so know which one you are looking at. If
+   a scale needs rebuilding, seed it into a new workspace id rather than repeating it, and do not clear
    the query tables — the fixtures the extrapolation is derived from live there.
-   Note what the workspace id does and does not isolate: it separates results and lets a prefix prune
-   work, but coexisting scales still share parts, partitions and merge history, so physical numbers are
-   measured against a table holding every scale at once. Absolute parts and granule totals are
-   therefore comparable only within one seeded state. When the growth curve *across* scales is the
-   point, give each scale its own rig — a separate database or container — rather than reading
-   cross-scale physical costs off a shared one.
 5. **Validate the data, then the shape.** First confirm the fixture is what you intended — entity
    count, rows per logical key, active part count — because a drifted fixture is otherwise invisible
    and every number after it is wrong. Count **raw stored rows**, scoped to the workspace you seeded:

--- a/.agents/skills/query-performance/environments.md
+++ b/.agents/skills/query-performance/environments.md
@@ -39,9 +39,17 @@ it dies with the JVM. The flow:
    dedup depth you were trying to hold fixed. Re-running the test adds fixture rows the same way. If a
    scale needs rebuilding, seed it into a new workspace id rather than repeating it, and do not clear
    the query tables — the fixtures the extrapolation is derived from live there.
+   Note what the workspace id does and does not isolate: it separates results and lets a prefix prune
+   work, but coexisting scales still share parts, partitions and merge history, so physical numbers are
+   measured against a table holding every scale at once. Absolute parts and granule totals are
+   therefore comparable only within one seeded state. When the growth curve *across* scales is the
+   point, give each scale its own rig — a separate database or container — rather than reading
+   cross-scale physical costs off a shared one.
 5. **Validate the data, then the shape.** First confirm the fixture is what you intended — entity
-   count, rows per logical key, part count — because a drifted fixture is otherwise invisible and
-   every number after it is wrong. Then compare the container's `EXPLAIN indexes = 1` against a real
+   count, rows per logical key, active part count — because a drifted fixture is otherwise invisible
+   and every number after it is wrong. Count **raw stored rows**, scoped to the workspace you seeded:
+   a deduplicated count is blind to precisely the extra version a repeated seed creates, so it would
+   pass a drifted fixture as clean. Then compare the container's `EXPLAIN indexes = 1` against a real
    environment's and check that pruning *behaves* the same way — the same conditions reach the index,
    the same key prefixes are hit, the same skip indexes engage or are ignored. Absolute granule and
    mark counts will not match across different data volumes, so compare behaviour, not ratios.


### PR DESCRIPTION
## Details

Follow-up to #7829, which is now merged. Fixes a hole found in review of that PR: the extrapolation procedure could drift its own fixture with no way to notice.

The container is reused across runs and the seeding advice recommends deterministic ids, so re-running a seed does not overwrite anything — it appends another row per id, which these queries read as another *version of the same logical key*. Version depth is what the `LIMIT 1 BY` dedup steps pay for, and it is one of the invariants the same section tells the reader to preserve, so every repeated attempt inflated dedup cost while looking untouched. Re-running the test against the reused container adds fixture rows the same way.

- Seed each scale **once**; rebuild into a fresh workspace id rather than repeating one. Explicitly *not* by clearing the query tables — the fixtures the extrapolation is derived from live there, so resetting destroys the sample the procedure depends on.
- **Validate the data before the plan**: entity count, rows per logical key, part count. The previous gate compared pruning behaviour only, which cannot see a drifted fixture — that was the actual gap.
- Reproducible ids are for rebuilding a scale in a fresh workspace, not for re-seeding an existing one.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- n/a — no ticket for this change (`[NA]`)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: drafted the wording change from a review finding on #7829.
- Human verification: author reviewed the change and the reasoning behind rejecting the table-reset remedy.

## Testing

No automated tests — markdown only. The mechanism is derived from `ClickHouseContainerUtils` (containers are created `withReuse(true)`, so tables persist between runs) and from how the DAO queries dedup, `ORDER BY … DESC` + `LIMIT 1 BY` per logical key, which is what makes an appended row read as an extra version rather than a duplicate.

## Documentation

No user-facing documentation change; this edits agent-skill documentation under `.agents/skills/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
