### PR TITLE
[OPIK-7900] [CI] chore: let QA approve generated model-definition sync PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,3 +21,10 @@
 /sdks/opik_optimizer @comet-ml/comet-opik-optimizer-devs @comet-ml/comet-opik-devs
 
 /tests_end_to_end/ @comet-ml/comet-qa @comet-ml/comet-opik-devs
+
+/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/*/*ModelName.java @comet-ml/comet-qa @comet-ml/comet-opik-devs
+/apps/opik-backend/src/main/resources/llm-models-default.yaml @comet-ml/comet-qa @comet-ml/comet-opik-devs
+/apps/opik-backend/src/main/resources/model_prices_and_context_window.json @comet-ml/comet-qa @comet-ml/comet-opik-devs
+/apps/opik-frontend/src/constants/providerModels.ts @comet-ml/comet-qa @comet-ml/comet-opik-devs
+/apps/opik-frontend/src/data/model_prices_and_context_window.json @comet-ml/comet-qa @comet-ml/comet-opik-devs
+/apps/opik-frontend/src/types/providers.ts @comet-ml/comet-qa @comet-ml/comet-opik-devs


### PR DESCRIPTION
## Details

<img width="959" height="1252" alt="image" src="https://github.com/user-attachments/assets/d44675f0-a755-4c87-941a-b3bdca525219" />

Two automations open add-only PRs against generated data files: the provider model sync (`.github/workflows/sync_provider_models.yml`) and the model prices sync. Every file they touch fell under the catch-all `* @comet-ml/comet-opik-devs`, so a mechanical list update had to wait on developer availability even though the content is exactly what QA can verify. This adds CODEOWNERS entries for those generated files owned by `@comet-ml/comet-qa` and `@comet-ml/comet-opik-devs`, so either team can approve. Mirrors the scoped-ownership pattern from #7176.

Scope was taken from the generators rather than from sampled PRs, which matters:

- `scripts/sync_provider_models.py` declares its outputs explicitly (lines 38-46): five `*ModelName.java` enums plus `providers.ts`, `providerModels.ts` and `llm-models-default.yaml`. The workflow stages the whole `infrastructure/llm/` directory, so any provider enum can appear in a sync PR.
- Across the last 20 sync commits the enums appear at very different rates — OpenRouter 18, Anthropic 5, Gemini 3, OpenAI 2, VertexAI 1. Covering only OpenRouter (the two most recent PRs) would have left roughly a quarter of sync PRs still dev-only.
- The prices sync is separate automation on its own schedule and has touched exactly the two `model_prices_and_context_window.json` copies across its last 20 commits.
- `AnthropicClientGeneratorTest.java` is deliberately excluded — it appeared in one historical sync commit but is not in the workflow's `git add` list and was last modified by hand, so tests keep requiring developer review.

`@comet-ml/comet-devops` is intentionally not listed: these are application data files, not CI or deployment infrastructure.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7900

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5
  - Scope: full implementation (six-line CODEOWNERS edit) plus scope investigation against the sync generators and commit history
  - Human verification: code review; reviewer pushed back on an over-broad `**` glob and a redundant comment block, both corrected

## Testing

No build or test impact — the change is limited to `.github/CODEOWNERS`, and every pre-commit hook skipped for lack of matching file types.

Glob correctness was verified with git's own pathspec matcher, which shares CODEOWNERS' glob semantics:

- `git ls-files "apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/*/*ModelName.java"` returns exactly the five provider enums and none of the other ~61 Java files under that tree.
- `git ls-files` against the five explicit paths returns all five, confirming no typo silently fails open.
- All five `*ModelName.java` files sit at uniform depth (`llm/<provider>/`), so the single-level `*/` glob is exact rather than speculative.

Scope was cross-checked against 20 real sync commits for each automation (`git log --grep`), and against the sync script's declared output paths.

Not verified here, and worth confirming before merge: whether "Require review from Code Owners" is enabled on `main`. If it is not, this changes who gets auto-requested but not who can satisfy the merge gate.

## Documentation

N/A — no docs changes. The ownership rationale lives in OPIK-7900.
