### PR TITLE
[OPIK-7532] [QA] Proposed taxonomy changes from app surface

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -267,6 +267,8 @@ areas:
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
       agent-graph-tab:        { covered: false }
       attachments-media:      { covered: false }
+      set-guardrail:          { covered: false, note: "SetGuardrailDialog — GUARDRAILS_ENABLED flag" }
+      guardrail-results:      { covered: false, note: "GuardrailsCell column + Guardrails tree block — GUARDRAILS_ENABLED flag" }
       delete-traces:          { covered: true,  tier: t2-cuj }
       delete-traces-api:      { covered: true,  tier: t2-cuj, note: "SDK/API delete reflected in the Logs table" }
       export-traces:          { covered: false, note: "EXPORT_ENABLED flag" }


### PR DESCRIPTION
## Proposed by nightly taxonomy discovery

Read the app's route/nav/tab surface and compared it against `taxonomy.yaml`.
Baseline before this change: **18 areas, 189 functional capabilities**.

# Taxonomy discovery — proposal

**Measured against**

- `opik` ref: `a08a48948f` — *[OPIK-7521][BE][FE] Count optimizer-internal (reflection) spend in total_optimization_cost (#7683)*, branch `main`
- Tree state: **clean** (`git -C opik status --porcelain` empty)
- Surface source: pre-generated `./surface.json` (60 routes, 20 nav items, 9 tab groups, **1** unmatched surface)
- Date: 2026-08-13

The unmatched-surface count matches the documented baseline (1, `/$workspaceName/home`). The
proposal below comes from the **nav / tab / docs** diff, not from `unmatched_surfaces`.

---

## 1. What changed

Two capabilities added to the existing `traces` area. No new areas.

```yaml
      set-guardrail:          { covered: false, note: "SetGuardrailDialog — GUARDRAILS_ENABLED flag" }
      guardrail-results:      { covered: false, note: "GuardrailsCell column + Guardrails tree block — GUARDRAILS_ENABLED flag" }
```

Both land as `covered: false` with no `tier:` — `reconcile.py` owns those fields.

### Evidence

**Guardrails is a shipped, user-visible frontend surface with zero taxonomy representation.**
`grep -niE 'guardrail' opik/tests_end_to_end/` returns only the two `release_surface.untracked`
lines for the *backend* service (`taxonomy.yaml:212-213`). There is no guardrails area, no
guardrails capability, and no spec.

#### `traces.set-guardrail`

| Signal | Citation |
|---|---|
| Nav-level button on the Logs page | `apps/opik-frontend/src/v2/pages/LogsPage/LogsPage.tsx:47-57` — `<Button>… Set a guardrail</Button>` |
| Opens a substantial dialog | `src/v2/pages-shared/traces/GuardrailConfig/SetGuardrailDialog.tsx` (218 lines) — a `SideDialog` titled "Set a guardrail" with five configurable guardrail types (Topic, PII, Prompt injection, Custom classifier, LLM judge), each with threshold/entity/model inputs |
| Live code generation | `GuardrailConfigCode.tsx`, driven by `guardrailsConfig.ts` `codeBuilder` per type — the dialog emits an SDK snippet as the user toggles guardrails |
| Product vocabulary | `fern/versions/latest.yml:444-462` — **Guardrails** is a top-level docs section (Overview, Policies, Guards, Prompt injection model, Custom models, Guardrails server) |
| Reachable, not scaffolded | Component defined (813 lines across `GuardrailConfig/`), mounted from `LogsPage`, gated only by `FeatureToggleKeys.GUARDRAILS_ENABLED`, which **defaults to `true`** (`src/contexts/feature-toggles-provider.tsx:25` and `:79`) |

#### `traces.guardrail-results`

The other half — reading guardrail outcomes back off a trace. Two render sites, one behaviour:

| Signal | Citation |
|---|---|
| "Guardrails" column in the Logs table | `src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx:1594-1603` — `COLUMN_GUARDRAILS_ID`, `label: "Guardrails"`, `cell: GuardrailsCell`, accessor `row.guardrails_validations` |
| "Guardrails" data block in the span-details tree | `src/v2/pages-shared/traces/TraceDetailsPanel/TraceTreeViewer/SpanDetailsButton.tsx:50-52` — `{ label: "Guardrails", value: TREE_DATABLOCK_TYPE.GUARDRAILS }`; enabled by default in `treeConfig.ts:9` |

Kept as **one** capability rather than two: a user would describe both as "see whether the guardrail
passed or failed", and splitting them would be interaction-level altitude (`click-save-button`),
not behaviour-level.

#### Why not a `guardrails` **area**

Tempting — it is a top-level docs section — but it would break a documented invariant. The
`release_surface` path→area mapping is derived by joining the router tree with each area's
`routes:` (`taxonomy.yaml:156-172`), and that comment records *"all 18 areas join to at least one
component, and no component resolves to more than two areas."* Guardrails has **no route and no nav
entry** — the only route it could claim is `/projects/$projectId/logs` (`LogsPage`), which already
resolves to `traces` and `threads`. A third claimant would break the invariant. So the surfaces go
to the area that owns the route they live on.

#### `cloud_only`

**Not set**, correctly. `GUARDRAILS_ENABLED` is a `FeatureToggleKey`, not a `usePluginsStore`
component gate — per the skill's rule, a flag can be on self-hosted too (and here it defaults on).
Recorded in the `note:` instead, matching the existing `export-traces: { note: "EXPORT_ENABLED flag" }`.

### Altitude caveat — flagged for the reviewer

This takes `traces` from 17 to **19** functional capabilities, past the 5–15 guide (`configuration`
is the current maximum at 18). I did not shrink the proposal to fit — the guide exists to catch
over-splitting, and neither entry is a split of an existing one. But if a reviewer wants `traces`
narrower, guardrails is the obvious seam, and the right fix is a structural one (a route for the
guardrails surface, then its own area) rather than dropping the capabilities.

---

## 2. Coverage arithmetic

Recounted from the file, both before and after. Per dimension, never blended.

| Dimension | Before | After |
|---|---|---|
| **functional** (all) | 80/189 (42.3%) | **80/191 (41.9%)** |
| **functional** (self-hosted, excl. `cloud_only`) | 70/165 (42.4%) | **70/167 (41.9%)** |
| visual | 30/54 (55.6%) | 30/54 (55.6%) — unchanged |
| load | 0/9 (0.0%) | 0/9 (0.0%) — unchanged |

Area-level: `traces` **10/17 (58.8%) → 10/19 (52.6%)**.

The drop is the point. Two real surfaces that were never in the denominator now are, and the
numerator does not move because no test touches them.

---

## 2b. Surfaces considered and rejected

### `/$workspaceName/home` — the one unmatched surface. **Rejected: it is a redirect.**

`surface.json` classifies it `kind: surface`, `has_nav_entry: true`. Both are misleading:

- The component is a 21-line redirect. `src/v2/pages/HomePage/HomePage.tsx` renders `<Loader/>` and
  `useEffect(() => navigate({ to: "/$workspaceName/projects", replace: true }))`. Nothing is
  user-visible and no assertion is possible beyond "the redirect fires."
- `src/v2/router.tsx:157` says so in the source: `// ----------- home (redirects to the workspace Projects tab)`.
- `has_nav_entry: true` is a **false positive**. The nav item labelled "Home" is
  `projectPath("/home")` = `/$workspaceName/projects/$projectId/home` →
  `ProjectHomePage` (`getMenuItems.ts:66-72`), which is a different route, already owned by
  `projects.project-home`. `surface.py` matched on the `/home` suffix.
- `has_api_client: false`.

**Extractor note for a human:** `surface.py` recognises `<Navigate/>`-style and `*Redirect`-named
components, but not the `useEffect` + `useNavigate` idiom this one uses. That is why it reports
`kind: surface` rather than `kind: redirect`. Worth teaching the classifier, so this route stops
being re-litigated every night.

### Guardrails surfaces deliberately **not** proposed — already owned by a neighbour

| Surface | Citation | Owning capability |
|---|---|---|
| Guardrails Passed/Failed filter chip | `TracesSpansTab.tsx:803-810` | `traces.filter-traces` (covered) — a filter field, not a new behaviour |
| `guardrail` option in the span-type filter | `spanTypeFilter.tsx:16-20` | `traces.filter-traces` |
| "Guardrails (last N)" column on the Projects list | `ProjectsPage.tsx:249-259` | `projects.list-projects` (covered by `projects-list-stats.spec.ts`) — a column of that list |
| `trace_guardrails_triggered` alert trigger + guardrail-type picker | `AlertsPage/AddEditAlertPage/EventTriggers.tsx:245-249, 380-381` | `alerts.event-triggers` (`covered: false`) — a trigger type inside the generic capability |

Adding any of these would be a near-duplicate of an existing key.

### Tabs — diffed by hand from `surface.json.tabs`, all accounted for

| Component | Tab values | Resolution |
|---|---|---|
| `CompareExperimentsPage.tsx` | config, insights, items, scores | `experiments.configuration-tab`, `.insights-tab`, `.compare-side-by-side`, `.compare-feedback-tab` |
| `DatasetItemsPage.tsx` | items, version-history | `datasets.view-items`, `.version-history-view` |
| `AnnotationQueuePage.tsx` | configuration, items | `annotation-queues.queue-configuration-tab`, `.score-queue-item` |
| `PromptPage.tsx` | experiments, prompt | `prompts.experiments-tab` |
| `TrialSidebarContent.tsx` | prompt, results | `optimization-studio.trial-detail`, `.best-trial-prompt` |
| `ThreadDetailsPanel.tsx` | feedback_scores, messages | `threads.thread-feedback-score`, `.open-thread-panel` / `.turn-order-io` |
| `TraceDataViewer.tsx` | details, feedback_scores, graph, messages, prompts | `traces.open-trace-panel`, `.manual-feedback-score`, `.agent-graph-tab` — see judgement call below |
| `AgentRunnerEmptyState.tsx` | python, typescript | **not a capability** — a format toggle on one code panel |
| `CreateDatasetSidebar.tsx` | python, typescript | **not a capability** — same |

**Judgement call, left out:** `TraceDataViewer`'s Details / Messages / Prompts tabs have no
*functional* capability of their own — only visual ones (`trace-sidebar-details`,
`trace-sidebar-messages`, `trace-sidebar-prompts`). One could argue for three functional entries.
I left them out: `open-trace-panel` plausibly owns them, the visual dimension already enumerates
them, and `traces` is already the widest area in the file. Flagging rather than proposing, because
I cannot tell with confidence whether they are a gap or a duplicate.

### Nav labels — all 20 accounted for

Every entry in `surface.json.nav_items` maps to an existing area (Logs→traces/threads,
Prompt library→prompts, Optimization runs→optimization-studio, Opik Connect→ollie, and so on).
No nav label is orphaned.

### Docs sections without an area — checked, no action

`Gateway` (`latest.yml:474-480`) has no frontend surface: `grep -rln -i gateway src/` hits only a
custom-provider field, a price table, and the guardrails docs link. `Administration → Admin
Dashboard` (Workspaces, Users, Organization Settings, Service Accounts) has no in-tree route — it
is plugin territory, see the blind spot below.

---

## 3. Removals

**None.**

All 18 areas still resolve to live routes, including the less obvious ones:
`ollie` → `/pair/v1`, `diagnostics` → `/diagnostics/resolved`,
`annotation-queues` → `/$workspaceName/sme`, `online-evaluation` → `/$workspaceName/automation-logs`,
`onboarding` → `/$workspaceName/get-started` + `/quickstart`. Nothing in the taxonomy points at a
route, nav entry or component that has been deleted, so no `@cap:` tag is at risk of being orphaned.

---

## 4. Rename notes for a human

**None.** No key was renamed and none needs to be.

One naming observation, for the record and **not** a proposed change: the `traces` area carries
`spec_dir: trace-explore` with the note *"dir name != product vocabulary (Logs)"*. That is the
existing, deliberate handling; nothing new to do.

---

## 5. The blind spot

> This sweep reads only what is in the opik repo.
> `PluginsStore.collectRoutes()` and `PluginsStore.sidebarSections` let the
> out-of-tree `comet` plugin inject routes and nav entries that are invisible
> here, so surfaces that exist only in the commercial build are not covered by
> this diff.

Concretely, `surface.json.nav_gating.plugin_components` names three
plugin-supplied components on this ref — `AssistantSidebar`,
`SidebarWorkspaceSelectorComponent`, `sidebarSections`. Anything the `comet` plugin mounts through
them is outside what this proposal can see or count. The `Administration → Admin Dashboard` docs
section above is one likely instance.

---

## Verification performed

```
python3 -c "import yaml; yaml.safe_load(open('taxonomy.yaml'))"   -> valid
git -C opik diff --stat tests_end_to_end/coverage/taxonomy.yaml   -> 1 file changed, 2 insertions(+)
```

Two inserted lines and nothing else — no reformatting, no `covered:`/`tier:` written on any
existing entry.

**Not done, by instruction:** no commit, no push, no PR.

---

### Why this is a draft

The denominator is a reviewed file — adding a capability lowers coverage
until a test exists, and removing one raises it. Both need a human.
New capabilities land `covered: false` with no `tier:`; `reconcile.py`
fills those in once a tagged spec exists.

Run: https://github.com/comet-ml/comet-automation-tests/actions/runs/31670849422


[OPIK-7521]: https://comet-ml.atlassian.net/browse/OPIK-7521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ