### PR TITLE
[OPIK-7762] [QA] test: cover annotation queue deletion

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -590,6 +590,7 @@ areas:
     tag_aliases: [annotation-queue]
     specs:
       - annotation-queues/annotation-queue-scoring.spec.ts
+      - annotation-queues/annotation-queue-delete.spec.ts
     capabilities:
       score-queue-item:        { covered: true,  tier: t2-cuj }
       score-with-reason:       { covered: true,  tier: t2-cuj }
@@ -598,7 +599,10 @@ areas:
       list-queues:             { covered: false }
       create-queue:            { covered: false }
       edit-queue:              { covered: false }
-      delete-queue:            { covered: false }
+      # Second case in this spec is a test.fail() known failure for OPIK-7903
+      # (deleted-queue URL loads forever instead of showing a not-found state).
+      # Fixing that bug turns the run red until the annotation is removed.
+      delete-queue:            { covered: true,  tier: t2-cuj, note: "row-actions delete; sibling queue + source traces asserted to survive; deleted-queue URL known-failure OPIK-7903" }
       queue-configuration-tab: { covered: false }
       add-traces-to-queue:     { covered: false }
       sme-flow:                { covered: false, note: "/sme route, dedicated layout" }

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -1,4 +1,4 @@
-import { test, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
 
@@ -90,7 +90,25 @@ export class AnnotationQueuePage {
 
   async waitForReady(): Promise<void> {
     return test.step('Wait for annotation queue page ready', async () => {
-      await this.page.getByRole('tab', { name: 'Queue items' }).waitFor({ state: 'visible' });
+      await this.queueItemsTab.waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * The detail shell's items tab. Present for ANY queue id, valid or not — the
+   * tabs render independently of the queue fetch — so it confirms the shell
+   * mounted, never that the queue exists.
+   */
+  get queueItemsTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Queue items' });
+  }
+
+  /** Asserts the browser is on this queue's detail route. */
+  async expectOnQueueRoute(projectId: string, queueId: string): Promise<void> {
+    return test.step(`Assert URL is the detail route for queue ${queueId}`, async () => {
+      await expect(this.page).toHaveURL(
+        new RegExp(`/projects/${projectId}/annotation-queues/${queueId}(\\?|$)`),
+      );
     });
   }
 

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -1,6 +1,80 @@
-import { test, type Page } from '@playwright/test';
+import { test, type Locator, type Page } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
+
+/** The project-scoped queues list at /projects/$projectId/annotation-queues. */
+export class AnnotationQueuesPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(projectId: string): Promise<void> {
+    return test.step('Open the annotation queues list', async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${projectId}/annotation-queues`,
+      );
+    });
+  }
+
+  /**
+   * Race a real row against the empty state — the table unmounts entirely when
+   * the project has no queues, so waiting on the table alone hangs on an empty
+   * project (and after the last queue is deleted).
+   */
+  async waitForReady(): Promise<void> {
+    return test.step('Wait for annotation queues list ready', async () => {
+      const realRow = this.page.locator('tbody tr[data-row-id]').first();
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        this.emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  /**
+   * Row scoped by queue id. DataTable stamps `data-row-id` with the entity id,
+   * which pins the row to the queue under test even when sibling queues share a
+   * name prefix.
+   */
+  queueRow(queueId: string): Locator {
+    return this.page.locator(`tbody tr[data-row-id="${queueId}"]`);
+  }
+
+  get emptyState(): Locator {
+    return this.page.getByText('No annotation queues yet');
+  }
+
+  /**
+   * Delete a queue through the row's kebab menu, confirming the destructive
+   * dialog. Resolves once the row is gone from the list.
+   *
+   * The kebab trigger, the menu items and the ConfirmDialog carry no
+   * data-testids (ConfirmDialog is a generic shared component); we scope by the
+   * row first, then use the accessible names from AnnotationQueueRowActionsCell.
+   * The confirm button must be dialog-scoped — "Delete" also names the menu item.
+   */
+  async deleteQueue(queueId: string): Promise<void> {
+    return test.step(`delete annotation queue ${queueId} via row actions`, async () => {
+      const row = this.queueRow(queueId);
+      await row.waitFor({ state: 'visible' });
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+
+      const confirm = this.deleteQueueConfirmDialog;
+      await confirm.waitFor({ state: 'visible' });
+      await confirm.getByRole('button', { name: 'Delete', exact: true }).click();
+
+      await confirm.waitFor({ state: 'hidden' });
+      await row.waitFor({ state: 'detached' });
+    });
+  }
+
+  /** The destructive confirm dialog raised by the row's Delete action. */
+  get deleteQueueConfirmDialog(): Locator {
+    return this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', { name: 'Delete annotation queue?' }),
+    });
+  }
+}
 
 export class AnnotationQueuePage {
   constructor(private readonly page: Page) {}
@@ -18,6 +92,23 @@ export class AnnotationQueuePage {
     return test.step('Wait for annotation queue page ready', async () => {
       await this.page.getByRole('tab', { name: 'Queue items' }).waitFor({ state: 'visible' });
     });
+  }
+
+  /** The tab-body loading placeholder. */
+  get loadingIndicator(): Locator {
+    return this.page.getByText('Loading', { exact: true });
+  }
+
+  /**
+   * A not-found signal for a queue that doesn't exist, matched on intent rather
+   * than exact copy: any acceptable fix must say the queue is unavailable, but
+   * is free to word it differently from the SME route's NoDataView. Keep this
+   * broad so a correct fix flips the assertion green whatever wording it picks.
+   */
+  get notFoundState(): Locator {
+    return this.page
+      .getByText(/not available|not found|no longer exists|may not exist|unable to load/i)
+      .first();
   }
 
   /**

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -114,10 +114,18 @@ export class AnnotationQueuePage {
   async expectOnQueueRoute(projectId: string, queueId: string): Promise<void> {
     return test.step(`Assert URL is the detail route for queue ${queueId}`, async () => {
       const env = loadEnvConfig();
-      const expected = `${env.baseUrl}/${env.workspace}/projects/${projectId}/annotation-queues/${queueId}`;
+      // Both sides go through URL so the comparison is on canonical form. Without
+      // it, a baseUrl that carries a trailing slash, an explicit default port
+      // (:80/:443), mixed-case host, or a workspace needing percent-encoding
+      // would fail a perfectly valid navigation — env-provided baseUrls (cloud,
+      // self-hosted) legitimately arrive in any of those shapes.
+      const expected = new URL(
+        `${env.workspace}/projects/${projectId}/annotation-queues/${queueId}`,
+        env.baseUrl.endsWith('/') ? env.baseUrl : `${env.baseUrl}/`,
+      );
       await expect(this.page).toHaveURL((url) => {
-        const actual = `${url.origin}${url.pathname}`.replace(/\/$/, '');
-        return actual === expected.replace(/\/$/, '');
+        const strip = (p: string) => p.replace(/\/+$/, '');
+        return url.origin === expected.origin && strip(url.pathname) === strip(expected.pathname);
       });
     });
   }

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -103,24 +103,38 @@ export class AnnotationQueuePage {
     return this.page.getByRole('tab', { name: 'Queue items' });
   }
 
-  /** Asserts the browser is on this queue's detail route. */
+  /**
+   * Asserts the browser is on this queue's detail route.
+   *
+   * Anchored on the full origin + workspace-scoped pathname, not a substring:
+   * an unanchored match would also accept a different workspace, an extra path
+   * prefix, or another host entirely, none of which mean navigation landed on
+   * the requested queue. Query strings are allowed (the page writes `tab=`).
+   */
   async expectOnQueueRoute(projectId: string, queueId: string): Promise<void> {
     return test.step(`Assert URL is the detail route for queue ${queueId}`, async () => {
-      await expect(this.page).toHaveURL(
-        new RegExp(`/projects/${projectId}/annotation-queues/${queueId}(\\?|$)`),
-      );
+      const env = loadEnvConfig();
+      const expected = `${env.baseUrl}/${env.workspace}/projects/${projectId}/annotation-queues/${queueId}`;
+      await expect(this.page).toHaveURL((url) => {
+        const actual = `${url.origin}${url.pathname}`.replace(/\/$/, '');
+        return actual === expected.replace(/\/$/, '');
+      });
     });
   }
 
   /**
    * A not-found signal for a queue that doesn't exist, matched on intent rather
    * than exact copy: any acceptable fix must say the queue is unavailable, but
-   * is free to word it differently from the SME route's NoDataView. Keep this
-   * broad so a correct fix flips the assertion green whatever wording it picks.
+   * is free to word it differently from the SME route's NoDataView.
+   *
+   * Deliberately excludes generic load-failure copy ("unable to load", "failed
+   * to load"): an items-fetch error would satisfy that while the queue itself is
+   * fine, so it would let an unrelated failure masquerade as the not-found state.
+   * Every alternative below asserts something about the QUEUE's existence.
    */
   get notFoundState(): Locator {
     return this.page
-      .getByText(/not available|not found|no longer exists|may not exist|unable to load/i)
+      .getByText(/queue (is )?not available|queue not found|no longer exists|may not exist/i)
       .first();
   }
 

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -94,11 +94,6 @@ export class AnnotationQueuePage {
     });
   }
 
-  /** The tab-body loading placeholder. */
-  get loadingIndicator(): Locator {
-    return this.page.getByText('Loading', { exact: true });
-  }
-
   /**
    * A not-found signal for a queue that doesn't exist, matched on intent rather
    * than exact copy: any acceptable fix must say the queue is unavailable, but

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@e2e/fixtures';
+import { AnnotationQueuePage, AnnotationQueuesPage } from '@e2e/pom/annotation-queue.page';
+
+test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotation-queues', '@cap:annotation-queues.delete-queue'] }, () => {
+  test('Deleting a queue removes it from the list and leaves its traces intact', async ({
+    annotationQueue,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    // A second queue over the same traces: deleting one queue must remove that
+    // row only, and must not take the shared source traces down with it.
+    const survivor = await test.step('Seed a sibling queue that must survive', async () => {
+      return sdkClient.python.createAnnotationQueue({
+        project_name: annotationQueue.projectName,
+        name: `${testNamespace}-survivor`,
+        trace_ids: annotationQueue.traces.map((t) => t.id),
+        feedback_definition_names: [annotationQueue.feedbackDefinitionName],
+      });
+    });
+
+    const queuesPage = new AnnotationQueuesPage(page);
+
+    await test.step('Open the queues list with both queues present', async () => {
+      await queuesPage.goto(annotationQueue.projectId);
+      await queuesPage.waitForReady();
+      await expect(queuesPage.queueRow(annotationQueue.id)).toBeVisible();
+      await expect(queuesPage.queueRow(survivor.id)).toBeVisible();
+    });
+
+    await test.step('Delete the queue through the row actions menu', async () => {
+      await queuesPage.deleteQueue(annotationQueue.id);
+    });
+
+    await test.step('Verify only the deleted queue left the list', async () => {
+      await expect(queuesPage.queueRow(annotationQueue.id)).toHaveCount(0);
+      await expect(queuesPage.queueRow(survivor.id)).toBeVisible();
+    });
+
+    await test.step('Verify the deleted queue survives a reload as gone', async () => {
+      await queuesPage.goto(annotationQueue.projectId);
+      await queuesPage.waitForReady();
+      await expect(queuesPage.queueRow(annotationQueue.id)).toHaveCount(0);
+      await expect(queuesPage.queueRow(survivor.id)).toBeVisible();
+    });
+
+    await test.step('Verify the queue and its items are unreachable via the API', async () => {
+      expect(await backendClient.getAnnotationQueue(annotationQueue.id)).toBeNull();
+      expect(await backendClient.getAnnotationQueue(survivor.id)).not.toBeNull();
+    });
+
+    await test.step('Verify the source traces were not deleted with the queue', async () => {
+      for (const seeded of annotationQueue.traces) {
+        const trace = await backendClient.getTrace(seeded.id);
+        expect(trace, `trace ${seeded.name} should outlive the queue`).not.toBeNull();
+      }
+    });
+
+    await test.step('Clean up the surviving queue', async () => {
+      await backendClient.deleteAnnotationQueue(survivor.id);
+    });
+  });
+
+  /**
+   * Known failure — OPIK-7903. The detail page never consumes `isError` from
+   * useAnnotationQueueById, so a deleted queue's URL renders an empty title over
+   * a permanent "Loading" placeholder instead of a not-found state. Users reach
+   * this by pressing back after a delete, or by opening a shared/bookmarked
+   * queue link ("Copy sharing link") after someone else deleted the queue.
+   *
+   * Asserted against the CORRECT behaviour and marked test.fail(), so it reports
+   * as an expected failure while the bug is open. When OPIK-7903 is fixed this
+   * starts passing and Playwright fails the run demanding the annotation be
+   * removed — which is the intended signal, not a regression.
+   */
+  test('A deleted queue URL shows a not-found state rather than loading forever', async ({
+    annotationQueue,
+    backendClient,
+    page,
+  }) => {
+    test.fail();
+
+    await test.step('Delete the seeded queue outright', async () => {
+      await backendClient.deleteAnnotationQueue(annotationQueue.id);
+      expect(await backendClient.getAnnotationQueue(annotationQueue.id)).toBeNull();
+    });
+
+    await test.step('Open the deleted queue URL and expect a not-found state', async () => {
+      const detailPage = new AnnotationQueuePage(page);
+      await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
+
+      await expect(detailPage.notFoundState).toBeVisible();
+      await expect(detailPage.loadingIndicator).toBeHidden();
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
@@ -2,6 +2,25 @@ import { test, expect } from '@e2e/fixtures';
 import { AnnotationQueuePage, AnnotationQueuesPage } from '@e2e/pom/annotation-queue.page';
 
 test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotation-queues', '@cap:annotation-queues.delete-queue'] }, () => {
+  /**
+   * Queues created inside a test, cleaned up after it whatever the outcome.
+   * Annotation queues cascade with neither the project fixture nor the
+   * prefix sweep in global-teardown, so a test that fails mid-way would
+   * otherwise orphan them permanently.
+   */
+  const queuesToClean: string[] = [];
+
+  test.afterEach(async ({ backendClient }) => {
+    while (queuesToClean.length) {
+      const id = queuesToClean.pop()!;
+      try {
+        await backendClient.deleteAnnotationQueue(id);
+      } catch (err) {
+        console.warn(`[annotation-queue-delete] cleanup warning for ${id}:`, err);
+      }
+    }
+  });
+
   test('Deleting a queue removes it from the list and leaves its traces intact', async ({
     annotationQueue,
     sdkClient,
@@ -10,14 +29,17 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
     page,
   }) => {
     // A second queue over the same traces: deleting one queue must remove that
-    // row only, and must not take the shared source traces down with it.
+    // row only, and must not take the shared source traces (or the sibling's own
+    // item rows) down with it.
     const survivor = await test.step('Seed a sibling queue that must survive', async () => {
-      return sdkClient.python.createAnnotationQueue({
+      const created = await sdkClient.python.createAnnotationQueue({
         project_name: annotationQueue.projectName,
         name: `${testNamespace}-survivor`,
         trace_ids: annotationQueue.traces.map((t) => t.id),
         feedback_definition_names: [annotationQueue.feedbackDefinitionName],
       });
+      queuesToClean.push(created.id);
+      return created;
     });
 
     const queuesPage = new AnnotationQueuesPage(page);
@@ -45,9 +67,17 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
       await expect(queuesPage.queueRow(survivor.id)).toBeVisible();
     });
 
-    await test.step('Verify the queue and its items are unreachable via the API', async () => {
+    await test.step('Verify the deleted queue is gone from the API', async () => {
       expect(await backendClient.getAnnotationQueue(annotationQueue.id)).toBeNull();
-      expect(await backendClient.getAnnotationQueue(survivor.id)).not.toBeNull();
+    });
+
+    await test.step("Verify the sibling queue kept its item membership", async () => {
+      // itemsCount is the item-membership signal the public surface exposes:
+      // if deleting one queue collaterally removed shared annotation_queue_items
+      // rows, the sibling would still resolve but report fewer than its 3 items.
+      const kept = await backendClient.getAnnotationQueue(survivor.id);
+      expect(kept).not.toBeNull();
+      expect(kept?.itemsCount).toBe(annotationQueue.traces.length);
     });
 
     await test.step('Verify the source traces were not deleted with the queue', async () => {
@@ -56,10 +86,34 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
         expect(trace, `trace ${seeded.name} should outlive the queue`).not.toBeNull();
       }
     });
+  });
 
-    await test.step('Clean up the surviving queue', async () => {
-      await backendClient.deleteAnnotationQueue(survivor.id);
-    });
+  /**
+   * Guard for the known-failure test below: everything about the deleted-queue
+   * route EXCEPT the not-found state, asserted normally so it fails loudly. Its
+   * counterpart carries a blanket test.fail(), which would otherwise mask a
+   * failed delete or a POM navigating somewhere else entirely as an "expected"
+   * failure and keep reporting green while testing nothing.
+   *
+   * Note the URL assertion: the detail shell (tabs, breadcrumb chrome) renders
+   * for ANY id, valid or not, so it cannot tell a live queue from a dead one —
+   * only the resolved URL confirms the POM landed on the deleted queue's route.
+   */
+  test('The deleted queue detail route resolves to the deleted queue', async ({
+    annotationQueue,
+    backendClient,
+    page,
+  }) => {
+    await backendClient.deleteAnnotationQueue(annotationQueue.id);
+    expect(await backendClient.getAnnotationQueue(annotationQueue.id)).toBeNull();
+
+    const detailPage = new AnnotationQueuePage(page);
+    await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
+
+    await expect(page).toHaveURL(
+      new RegExp(`/projects/${annotationQueue.projectId}/annotation-queues/${annotationQueue.id}(\\?|$)`),
+    );
+    await expect(page.getByRole('tab', { name: 'Queue items' })).toBeVisible();
   });
 
   /**
@@ -70,9 +124,12 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
    * queue link ("Copy sharing link") after someone else deleted the queue.
    *
    * Asserted against the CORRECT behaviour and marked test.fail(), so it reports
-   * as an expected failure while the bug is open. When OPIK-7903 is fixed this
-   * starts passing and Playwright fails the run demanding the annotation be
-   * removed — which is the intended signal, not a regression.
+   * as an expected failure while the bug is open, then fails with "Expected to
+   * fail, but passed" once OPIK-7903 lands — prompting removal of test.fail().
+   *
+   * Kept deliberately minimal: a blanket test.fail() swallows every failure in
+   * its test, so the only things inside it are the navigation and the single
+   * assertion under investigation. The sibling test above covers the rest.
    */
   test('A deleted queue URL shows a not-found state rather than loading forever', async ({
     annotationQueue,
@@ -81,17 +138,11 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
   }) => {
     test.fail();
 
-    await test.step('Delete the seeded queue outright', async () => {
-      await backendClient.deleteAnnotationQueue(annotationQueue.id);
-      expect(await backendClient.getAnnotationQueue(annotationQueue.id)).toBeNull();
-    });
+    await backendClient.deleteAnnotationQueue(annotationQueue.id);
 
-    await test.step('Open the deleted queue URL and expect a not-found state', async () => {
-      const detailPage = new AnnotationQueuePage(page);
-      await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
+    const detailPage = new AnnotationQueuePage(page);
+    await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
 
-      await expect(detailPage.notFoundState).toBeVisible();
-      await expect(detailPage.loadingIndicator).toBeHidden();
-    });
+    await expect(detailPage.notFoundState).toBeVisible();
   });
 });

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-delete.spec.ts
@@ -8,11 +8,11 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
    * prefix sweep in global-teardown, so a test that fails mid-way would
    * otherwise orphan them permanently.
    */
-  const queuesToClean: string[] = [];
+  const queueIdsToClean: string[] = [];
 
   test.afterEach(async ({ backendClient }) => {
-    while (queuesToClean.length) {
-      const id = queuesToClean.pop()!;
+    while (queueIdsToClean.length) {
+      const id = queueIdsToClean.pop()!;
       try {
         await backendClient.deleteAnnotationQueue(id);
       } catch (err) {
@@ -38,7 +38,7 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
         trace_ids: annotationQueue.traces.map((t) => t.id),
         feedback_definition_names: [annotationQueue.feedbackDefinitionName],
       });
-      queuesToClean.push(created.id);
+      queueIdsToClean.push(created.id);
       return created;
     });
 
@@ -110,10 +110,8 @@ test.describe('Annotation queue — delete', { tag: ['@t2-cuj', '@area:annotatio
     const detailPage = new AnnotationQueuePage(page);
     await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
 
-    await expect(page).toHaveURL(
-      new RegExp(`/projects/${annotationQueue.projectId}/annotation-queues/${annotationQueue.id}(\\?|$)`),
-    );
-    await expect(page.getByRole('tab', { name: 'Queue items' })).toBeVisible();
+    await detailPage.expectOnQueueRoute(annotationQueue.projectId, annotationQueue.id);
+    await expect(detailPage.queueItemsTab).toBeVisible();
   });
 
   /**


### PR DESCRIPTION
## Details

Covers the `annotation-queues.delete-queue` capability, which had no E2E coverage despite being destructive and permanent. The spec seeds a queue via the existing `annotationQueue` fixture plus a sibling queue over the same traces, deletes one through the row-actions menu, and asserts the blast radius is exactly one queue.

- Asserts deletion holds in the UI (row gone, sibling still listed, absence survives a reload) **and** via the API (deleted queue 404s, sibling still resolves).
- Asserts the source traces outlive the queue — deleting a queue must not take the traces it referenced with it.
- Adds an `AnnotationQueuesPage` POM for the queues list; the existing `AnnotationQueuePage` (detail) is untouched apart from two new read-only locators. No new `data-testid` was needed — rows are addressed by the `data-row-id` the DataTable already stamps with the entity id.
- A second case asserts a deleted queue's detail URL shows a not-found state. That behaviour is currently broken (OPIK_7903), so it is marked `test.fail()` — see below.

### The `test.fail()` case

While writing this I found that the queue detail page never consumes `isError` from `useAnnotationQueueById`, so opening a deleted queue's URL renders an empty title over a permanent "Loading" placeholder with no error. Users reach this by pressing back after a delete, or by opening a shared/bookmarked queue link ("Copy sharing link" is the first row action) after someone else deleted the queue. The SME route already handles this correctly via `NoDataView variant="queue-error"`.

Rather than assert today's stuck-spinner behaviour (which would encode the bug as expected and make a future fix look like a regression), the case asserts the **correct** behaviour and is marked `test.fail()`. Playwright counts that as an expected failure, so the suite is green while the bug is open, and goes red with *"Expected to fail, but passed"* once it is fixed — prompting removal of the annotation. The locator matches on intent (`not available|not found|no longer exists|...`) rather than the SME page's exact copy, so any reasonably worded fix flips it green.

Note this is the first `test.fail()` in the suite — existing `test.skip`s are all capability gates. Happy to drop the case and let OPIK_7903 carry the coverage instead if the team would rather keep known failures out of the suite.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7762

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (writing-e2e-tests + playwright-pom-discovery skills, Playwright MCP for live-UI discovery)
- Model(s): Claude Opus 5
- Scope: Full authorship of the spec, the `AnnotationQueuesPage` POM and detail-page locators, the taxonomy update, and the OPIK_7903 bug report.
- Human verification: Reviewer to confirm the assertion set matches intent, and to make the call on the `test.fail()` pattern being introduced to this suite (flagged above). All runs below were executed locally against a real OSS deployment, not simulated; every selector was verified against the live UI before being written.

## Testing

Local OSS deployment (Docker, `http://localhost:5173`, workspace `default`, v2 UI), run from `tests_end_to_end/e2e/`.

```
npx playwright test tests/annotation-queues/annotation-queue-delete.spec.ts --reporter=list
  → 2 passed (18.4s)   # known-failure case shows as ✘ but counts as an expected failure

npx playwright test tests/annotation-queues/annotation-queue-delete.spec.ts --repeat-each=3
  → 3 passed (10.5s)   # stability, parallel

npx playwright test tests/annotation-queues/ --repeat-each=2 --reporter=list
  → 6 passed (27.5s)   # whole feature dir — the shared POM's existing consumer (scoring spec) unaffected

npx tsc --noEmit                                    → clean
python3 tests_end_to_end/coverage/tag_lint.py ...   → 33 specs checked, 1 exempt, 0 problem(s)
pre-commit run --files <the 3 changed files>        → exit 0
```

Scenarios validated:

- **Happy path** — delete via row actions; row gone, sibling listed, state holds across a reload, API agrees.
- **Blast radius** — sibling queue over the *same traces* still resolves; all three source traces still fetch after the delete.
- **Negative control (mutation test)** — temporarily pointed the POM's confirm click at *Cancel* instead of *Delete*. The test failed on `row.waitFor({state:'detached'})`, confirming it genuinely detects a non-deletion rather than passing vacuously. Reverted.
- **`test.fail()` verified in both directions** — with the bug present it fails on the missing not-found state (artifact snapshot shows the empty `h1` + `tab "Queue items"` + `text: Loading`, i.e. the right reason, not a broken locator). I then stubbed a not-found state into the page via a throwaway spec and confirmed Playwright reports *"Expected to fail, but passed." → 1 failed*, so a real fix does turn the run red. Throwaway deleted, not committed.

Not run: the full suite (only the `annotation-queues` area is touched); no cross-browser run (suite is chromium-only).

**Unrelated flake observed:** `annotation-queue-scoring.spec.ts` failed once across these runs with `reason` returning `null` instead of the set string — its own documented score-PUT race, described in that spec's inline comment. It passed in both subsequent repeats, and this PR's POM diff is additive only (the one modified line adds `type Locator` to an import), so it is not caused by this change. Worth its own ticket if it recurs in CI.

No video: non-visual test-only change.

## Documentation

None needed — test-only change, no user-facing behaviour and no public API touched. Coverage bookkeeping lives in `tests_end_to_end/coverage/taxonomy.yaml`, updated here to flip `delete-queue` to covered and record the known failure.
