### PR TITLE
[OPIK-6739] [FE] refactor: share trace filter-chip definitions

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  TRACE_CHIP_ORDER,
+  buildTraceChipDefinitions,
+} from "./traceChipDefinitions";
+import { LOGS_SOURCE } from "@/types/traces";
+import { ChipOptionsConfig } from "@/shared/filter-chips/types";
+
+const options = { items: [], isLoading: false };
+
+const build = (
+  overrides: Partial<Parameters<typeof buildTraceChipDefinitions>[0]> = {},
+) =>
+  buildTraceChipDefinitions({
+    projectId: "p1",
+    traceScoreOptions: options,
+    spanScoreOptions: options,
+    isGuardrailsEnabled: false,
+    logsSource: LOGS_SOURCE.sdk,
+    ...overrides,
+  });
+
+/**
+ * The args a chip's option hook will be called with, for the chips that source options remotely.
+ * ChipDefinition is a union and only some members carry `value` / `key`, so this reads them off a
+ * widened shape rather than narrowing per chip kind.
+ */
+const optionArgs = (
+  definitions: ReturnType<typeof buildTraceChipDefinitions>,
+  chipId: string,
+) => {
+  const chip = definitions.find((d) => d.id === chipId) as
+    | {
+        value?: { options?: ChipOptionsConfig };
+        key?: { options?: ChipOptionsConfig };
+      }
+    | undefined;
+  const config = chip?.value?.options ?? chip?.key?.options;
+  return config && "args" in config
+    ? (config.args as Record<string, unknown>)
+    : undefined;
+};
+
+describe("buildTraceChipDefinitions", () => {
+  it("returns the chips in the declared order", () => {
+    const ids = build().map((d) => d.id);
+    expect(ids).toEqual(TRACE_CHIP_ORDER.filter((id) => id !== "guardrails"));
+  });
+
+  it("adds the guardrails chip only when the feature is on, in its declared slot", () => {
+    expect(build().map((d) => d.id)).not.toContain("guardrails");
+
+    const ids = build({ isGuardrailsEnabled: true }).map((d) => d.id);
+    expect(ids).toContain("guardrails");
+    expect(ids).toEqual(TRACE_CHIP_ORDER);
+  });
+
+  // The source decides which traces the tag / error-type / metadata-path autocompletes are computed
+  // over. Getting it wrong shows a surface options its own table would never match.
+  it.each([
+    ["tags", "tags"],
+    ["error_type", "error_type"],
+    ["metadata", "metadata"],
+    ["custom", "custom"],
+  ])("forwards the logs source to the %s options", (_name, chipId) => {
+    expect(optionArgs(build(), chipId)).toMatchObject({
+      logsSource: LOGS_SOURCE.sdk,
+    });
+
+    expect(
+      optionArgs(build({ logsSource: LOGS_SOURCE.evaluator }), chipId),
+    ).toMatchObject({ logsSource: LOGS_SOURCE.evaluator });
+
+    expect(optionArgs(build({ logsSource: undefined }), chipId)).toMatchObject({
+      logsSource: undefined,
+    });
+  });
+
+  it("keeps trace and span feedback scores as separate chips", () => {
+    const definitions = build();
+    const trace = definitions.find((d) => d.id === "feedback_scores");
+    const span = definitions.find((d) => d.id === "span_feedback_scores");
+
+    expect(trace?.label).toBe("Trace feedback scores");
+    expect(span?.label).toBe("Span feedback scores");
+    expect(trace?.field).not.toBe(span?.field);
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.ts
@@ -1,0 +1,378 @@
+import compact from "lodash/compact";
+import keyBy from "lodash/keyBy";
+
+import {
+  COLUMN_CUSTOM_ID,
+  COLUMN_FEEDBACK_SCORES_ID,
+  COLUMN_METADATA_ID,
+  COLUMN_SPAN_FEEDBACK_SCORES_ID,
+  COLUMN_TYPE,
+} from "@/types/shared";
+import { LOGS_SOURCE } from "@/types/traces";
+import { GuardrailResult } from "@/types/guardrails";
+import { TRACE_DATA_TYPE } from "@/constants/traces";
+import { CUSTOM_FILTER_VALIDATION_REGEXP } from "@/constants/filters";
+import {
+  ChipDefinition,
+  ChipOptionsResult,
+  chipOptions,
+  chipOptionsValue,
+} from "@/shared/filter-chips/types";
+import {
+  TAGS_OPERATORS,
+  FEEDBACK_SCORE_OPERATORS,
+  DICTIONARY_OPERATORS,
+  STRING_OPERATORS,
+  LIST_OPERATORS,
+} from "@/shared/filter-chips/chips/QueryBuilderChip/operators";
+import { useTagsOptions } from "@/v2/pages-shared/TagsAutocomplete/useTagsOptions";
+import { usePathsOptions } from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/usePathsOptions";
+import { useErrorTypeOptions } from "@/v2/pages-shared/traces/ErrorTypeAutocomplete/useErrorTypeOptions";
+
+/**
+ * Filter-chip definitions for traces, shared by the Logs page and by the entity-scoped trace logs
+ * view (experiment Logs tab, playground, trials, annotation queues, evaluator traces) so both
+ * surfaces filter through one definition.
+ *
+ * This lives under pages-shared rather than shared/filter-chips because the option sources
+ * (tags, metadata paths, error types) are pages-shared hooks, and shared/ may not import them.
+ */
+
+export const TRACE_CHIP_DEFINITIONS_STATIC: ChipDefinition[] = [
+  {
+    id: "start_time",
+    field: "start_time",
+    label: "Start time",
+    kind: "time",
+    columnType: COLUMN_TYPE.time,
+  },
+  {
+    id: "end_time",
+    field: "end_time",
+    label: "End time",
+    kind: "time",
+    columnType: COLUMN_TYPE.time,
+  },
+  {
+    id: "duration",
+    field: "duration",
+    label: "Duration",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.duration,
+    format: "duration",
+  },
+  {
+    id: "total_estimated_cost",
+    field: "total_estimated_cost",
+    label: "Cost",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.cost,
+    format: "currency",
+  },
+  {
+    id: "usage_total_tokens",
+    field: "usage.total_tokens",
+    label: "Tokens",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.number,
+    format: "integer",
+  },
+  {
+    id: "usage_prompt_tokens",
+    field: "usage.prompt_tokens",
+    label: "Input tokens",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.number,
+    format: "integer",
+  },
+  {
+    id: "usage_completion_tokens",
+    field: "usage.completion_tokens",
+    label: "Output tokens",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.number,
+    format: "integer",
+  },
+  {
+    id: "llm_span_count",
+    field: "llm_span_count",
+    label: "LLM calls count",
+    kind: "numeric",
+    columnType: COLUMN_TYPE.number,
+    format: "integer",
+  },
+  {
+    id: "input",
+    field: "input",
+    label: "Input",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.string,
+    operators: STRING_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Search input" },
+  },
+  {
+    id: "output",
+    field: "output",
+    label: "Output",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.string,
+    operators: STRING_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Search output" },
+  },
+  {
+    id: "name",
+    field: "name",
+    label: "Trace name",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.string,
+    operators: STRING_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Search name" },
+  },
+  {
+    id: "with_errors",
+    field: "error_info",
+    label: "With errors",
+    kind: "boolean",
+    onOperator: "is_not_empty",
+    columnType: COLUMN_TYPE.errors,
+  },
+  {
+    id: "id",
+    field: "id",
+    label: "Trace ID",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.string,
+    operators: STRING_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Enter trace ID" },
+  },
+  {
+    id: "thread_id",
+    field: "thread_id",
+    label: "Thread ID",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.string,
+    operators: STRING_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Enter thread ID" },
+  },
+  {
+    id: "annotation_queue_ids",
+    field: "annotation_queue_ids",
+    label: "Annotation queue ID",
+    kind: "query-builder",
+    columnType: COLUMN_TYPE.list,
+    operators: LIST_OPERATORS,
+    defaultOperator: "contains",
+    value: { placeholder: "Enter annotation queue ID" },
+  },
+];
+
+export const TRACE_CHIP_ORDER: string[] = [
+  "start_time",
+  "end_time",
+  "duration",
+  "total_estimated_cost",
+  "usage_total_tokens",
+  "usage_prompt_tokens",
+  "usage_completion_tokens",
+  "llm_span_count",
+  "input",
+  "output",
+  "name",
+  "with_errors",
+  "error_type",
+  "tags",
+  "id",
+  "thread_id",
+  "annotation_queue_ids",
+  "feedback_scores",
+  "span_feedback_scores",
+  "guardrails",
+  "metadata",
+  "custom",
+];
+
+export const TRACE_DEFAULT_PINNED_CHIPS = ["with_errors", "tags", "metadata"];
+
+export const buildSharedDynamicChips = ({
+  projectId,
+  type,
+  scoreOptions,
+  feedbackScoresLabel,
+  isGuardrailsEnabled,
+  logsSource = LOGS_SOURCE.sdk,
+}: {
+  projectId: string;
+  type: TRACE_DATA_TYPE;
+  scoreOptions: ChipOptionsResult;
+  feedbackScoresLabel: string;
+  isGuardrailsEnabled: boolean;
+  logsSource?: LOGS_SOURCE;
+}): Record<string, ChipDefinition> => {
+  const entityType: "spans" | "traces" =
+    type === TRACE_DATA_TYPE.spans ? "spans" : "traces";
+  const chips: Record<string, ChipDefinition> = {
+    tags: {
+      id: "tags",
+      field: "tags",
+      label: "Tags",
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.list,
+      operators: TAGS_OPERATORS,
+      defaultOperator: "contains",
+      value: {
+        placeholder: "Type a tag…",
+        options: chipOptions(useTagsOptions, {
+          projectId,
+          entityType,
+          logsSource,
+        }),
+      },
+      addLabel: "Add tag",
+    },
+    error_type: {
+      id: "error_type",
+      field: "error_type",
+      label: "Error type",
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.string,
+      operators: ["contains", "=", "not_contains", "starts_with", "ends_with"],
+      defaultOperator: "contains",
+      value: {
+        placeholder: "Select error type",
+        options: chipOptions(useErrorTypeOptions, {
+          projectId,
+          type,
+          logsSource,
+        }),
+      },
+    },
+    feedback_scores: {
+      id: "feedback_scores",
+      field: COLUMN_FEEDBACK_SCORES_ID,
+      label: feedbackScoresLabel,
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.numberDictionary,
+      operators: FEEDBACK_SCORE_OPERATORS,
+      defaultOperator: ">=",
+      key: {
+        placeholder: "Select score",
+        options: chipOptionsValue(scoreOptions),
+      },
+      value: { type: "numeric", decimals: 2, placeholder: "0" },
+    },
+    metadata: {
+      id: "metadata",
+      field: COLUMN_METADATA_ID,
+      label: "Metadata",
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.dictionary,
+      operators: DICTIONARY_OPERATORS,
+      defaultOperator: "contains",
+      key: {
+        placeholder: "key",
+        options: chipOptions(usePathsOptions, {
+          projectId,
+          type,
+          rootKeys: ["metadata"],
+          excludeRoot: true,
+          logsSource,
+        }),
+      },
+      value: { placeholder: "value" },
+    },
+    custom: {
+      id: "custom",
+      field: COLUMN_CUSTOM_ID,
+      label: "Custom filter",
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.dictionary,
+      operators: DICTIONARY_OPERATORS,
+      defaultOperator: "contains",
+      key: {
+        placeholder: "key",
+        options: chipOptions(usePathsOptions, {
+          projectId,
+          type,
+          rootKeys: ["input", "output"],
+          excludeRoot: false,
+          logsSource,
+        }),
+        validate: (k) =>
+          CUSTOM_FILTER_VALIDATION_REGEXP.test(k)
+            ? undefined
+            : 'Key must begin with "input" or "output" (e.g. "input.message")',
+      },
+      value: { placeholder: "value" },
+    },
+  };
+  if (isGuardrailsEnabled) {
+    chips.guardrails = {
+      id: "guardrails",
+      field: "guardrails",
+      label: "Guardrails",
+      kind: "single-select",
+      options: [
+        { value: GuardrailResult.FAILED, label: "Failed" },
+        { value: GuardrailResult.PASSED, label: "Passed" },
+      ],
+      columnType: COLUMN_TYPE.category,
+      operator: "=",
+    };
+  }
+  return chips;
+};
+
+/**
+ * Composes the ordered trace chip list: the static definitions plus the dynamic ones whose options
+ * come from the project (tags, error types, metadata paths, feedback score names).
+ */
+export const buildTraceChipDefinitions = ({
+  projectId,
+  traceScoreOptions,
+  spanScoreOptions,
+  isGuardrailsEnabled,
+  logsSource,
+}: {
+  projectId: string;
+  traceScoreOptions: ChipOptionsResult;
+  spanScoreOptions: ChipOptionsResult;
+  isGuardrailsEnabled: boolean;
+  logsSource?: LOGS_SOURCE;
+}): ChipDefinition[] => {
+  const dynamicChips: Record<string, ChipDefinition> = {
+    ...buildSharedDynamicChips({
+      projectId,
+      type: TRACE_DATA_TYPE.traces,
+      scoreOptions: traceScoreOptions,
+      feedbackScoresLabel: "Trace feedback scores",
+      isGuardrailsEnabled,
+      logsSource,
+    }),
+    span_feedback_scores: {
+      id: "span_feedback_scores",
+      field: COLUMN_SPAN_FEEDBACK_SCORES_ID,
+      label: "Span feedback scores",
+      kind: "query-builder",
+      columnType: COLUMN_TYPE.numberDictionary,
+      operators: FEEDBACK_SCORE_OPERATORS,
+      defaultOperator: ">=",
+      key: {
+        placeholder: "Select span score",
+        options: chipOptionsValue(spanScoreOptions),
+      },
+      value: { type: "numeric", decimals: 2, placeholder: "0" },
+    },
+  };
+
+  const byId: Record<string, ChipDefinition> = {
+    ...keyBy(TRACE_CHIP_DEFINITIONS_STATIC, "id"),
+    ...dynamicChips,
+  };
+
+  return compact(TRACE_CHIP_ORDER.map((id) => byId[id]));
+};

--- a/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/traceChipDefinitions.ts
@@ -204,14 +204,17 @@ export const buildSharedDynamicChips = ({
   scoreOptions,
   feedbackScoresLabel,
   isGuardrailsEnabled,
-  logsSource = LOGS_SOURCE.sdk,
+  logsSource,
 }: {
   projectId: string;
   type: TRACE_DATA_TYPE;
   scoreOptions: ChipOptionsResult;
   feedbackScoresLabel: string;
   isGuardrailsEnabled: boolean;
-  logsSource?: LOGS_SOURCE;
+  // Required, though it may be undefined: a default would silently scope a new surface's tag,
+  // error-type and metadata-path options to the SDK source, which is the footgun this parameter
+  // exists to remove. Undefined means "no source filter".
+  logsSource: LOGS_SOURCE | undefined;
 }): Record<string, ChipDefinition> => {
   const entityType: "spans" | "traces" =
     type === TRACE_DATA_TYPE.spans ? "spans" : "traces";
@@ -342,7 +345,7 @@ export const buildTraceChipDefinitions = ({
   traceScoreOptions: ChipOptionsResult;
   spanScoreOptions: ChipOptionsResult;
   isGuardrailsEnabled: boolean;
-  logsSource?: LOGS_SOURCE;
+  logsSource: LOGS_SOURCE | undefined;
 }): ChipDefinition[] => {
   const dynamicChips: Record<string, ChipDefinition> = {
     ...buildSharedDynamicChips({

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -41,7 +41,6 @@ import {
   COLUMN_GUARDRAIL_STATISTIC_ID,
   COLUMN_GUARDRAILS_ID,
   COLUMN_ID_ID,
-  COLUMN_CUSTOM_ID,
   COLUMN_METADATA_ID,
   COLUMN_SELECT_ID,
   COLUMN_TYPE,
@@ -54,29 +53,19 @@ import {
   ENVIRONMENT_UNTAGGED_VALUE,
   generateEnvironmentFilter,
 } from "@/lib/filters";
-import { CUSTOM_FILTER_VALIDATION_REGEXP } from "@/constants/filters";
 import useEnvironmentsList from "@/api/environments/useEnvironmentsList";
 import useFilterChips from "@/shared/filter-chips/hooks/useFilterChips";
 import FilterChipBar from "@/shared/filter-chips/FilterChipBar/FilterChipBar";
 import { useTagsChipActions } from "@/shared/filter-chips/hooks/useTagsChipActions";
 import { useQuickAttributeFilterActions } from "@/shared/filter-chips/hooks/useQuickAttributeFilterActions";
 import { QuickAttributeFilterProvider } from "@/shared/filter-chips/QuickAttributeFilterContext";
+import { ChipDefinition } from "@/shared/filter-chips/types";
+import { STRING_OPERATORS } from "@/shared/filter-chips/chips/QueryBuilderChip/operators";
 import {
-  ChipDefinition,
-  ChipOptionsResult,
-  chipOptions,
-  chipOptionsValue,
-} from "@/shared/filter-chips/types";
-import {
-  TAGS_OPERATORS,
-  FEEDBACK_SCORE_OPERATORS,
-  DICTIONARY_OPERATORS,
-  STRING_OPERATORS,
-  LIST_OPERATORS,
-} from "@/shared/filter-chips/chips/QueryBuilderChip/operators";
-import { useTagsOptions } from "@/v2/pages-shared/TagsAutocomplete/useTagsOptions";
-import { usePathsOptions } from "@/v2/pages-shared/traces/TracesOrSpansPathsAutocomplete/usePathsOptions";
-import { useErrorTypeOptions } from "@/v2/pages-shared/traces/ErrorTypeAutocomplete/useErrorTypeOptions";
+  TRACE_DEFAULT_PINNED_CHIPS,
+  buildSharedDynamicChips,
+  buildTraceChipDefinitions,
+} from "@/v2/pages-shared/traces/traceChipDefinitions";
 import {
   normalizeMetadataPaths,
   buildDynamicMetadataColumns,
@@ -145,7 +134,6 @@ import {
   DetailsActionSectionValue,
 } from "@/v2/pages-shared/traces/DetailsActionSection";
 import { getSpanTypeOptions } from "@/v2/pages-shared/traces/spanTypeFilter";
-import { GuardrailResult } from "@/types/guardrails";
 import SpanTypeCell from "@/shared/DataTableCells/SpanTypeCell";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
 import SelectionActionBar from "@/v2/components/SelectionActionBar/SelectionActionBar";
@@ -379,139 +367,6 @@ const DYNAMIC_COLUMNS_KEY_SUFFIX = "dynamic-columns";
 const PAGINATION_SIZE_KEY_SUFFIX = "pagination-size";
 const ROW_HEIGHT_KEY_SUFFIX = "row-height";
 
-const TRACE_CHIP_DEFINITIONS_STATIC: ChipDefinition[] = [
-  {
-    id: "start_time",
-    field: "start_time",
-    label: "Start time",
-    kind: "time",
-    columnType: COLUMN_TYPE.time,
-  },
-  {
-    id: "end_time",
-    field: "end_time",
-    label: "End time",
-    kind: "time",
-    columnType: COLUMN_TYPE.time,
-  },
-  {
-    id: "duration",
-    field: "duration",
-    label: "Duration",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.duration,
-    format: "duration",
-  },
-  {
-    id: "total_estimated_cost",
-    field: "total_estimated_cost",
-    label: "Cost",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.cost,
-    format: "currency",
-  },
-  {
-    id: "usage_total_tokens",
-    field: "usage.total_tokens",
-    label: "Tokens",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.number,
-    format: "integer",
-  },
-  {
-    id: "usage_prompt_tokens",
-    field: "usage.prompt_tokens",
-    label: "Input tokens",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.number,
-    format: "integer",
-  },
-  {
-    id: "usage_completion_tokens",
-    field: "usage.completion_tokens",
-    label: "Output tokens",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.number,
-    format: "integer",
-  },
-  {
-    id: "llm_span_count",
-    field: "llm_span_count",
-    label: "LLM calls count",
-    kind: "numeric",
-    columnType: COLUMN_TYPE.number,
-    format: "integer",
-  },
-  {
-    id: "input",
-    field: "input",
-    label: "Input",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.string,
-    operators: STRING_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Search input" },
-  },
-  {
-    id: "output",
-    field: "output",
-    label: "Output",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.string,
-    operators: STRING_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Search output" },
-  },
-  {
-    id: "name",
-    field: "name",
-    label: "Trace name",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.string,
-    operators: STRING_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Search name" },
-  },
-  {
-    id: "with_errors",
-    field: "error_info",
-    label: "With errors",
-    kind: "boolean",
-    onOperator: "is_not_empty",
-    columnType: COLUMN_TYPE.errors,
-  },
-  {
-    id: "id",
-    field: "id",
-    label: "Trace ID",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.string,
-    operators: STRING_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Enter trace ID" },
-  },
-  {
-    id: "thread_id",
-    field: "thread_id",
-    label: "Thread ID",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.string,
-    operators: STRING_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Enter thread ID" },
-  },
-  {
-    id: "annotation_queue_ids",
-    field: "annotation_queue_ids",
-    label: "Annotation queue ID",
-    kind: "query-builder",
-    columnType: COLUMN_TYPE.list,
-    operators: LIST_OPERATORS,
-    defaultOperator: "contains",
-    value: { placeholder: "Enter annotation queue ID" },
-  },
-];
-
 const SPAN_CHIP_DEFINITIONS_STATIC: ChipDefinition[] = [
   {
     id: "start_time",
@@ -637,31 +492,6 @@ const SPAN_CHIP_DEFINITIONS_STATIC: ChipDefinition[] = [
   },
 ];
 
-const TRACE_CHIP_ORDER: string[] = [
-  "start_time",
-  "end_time",
-  "duration",
-  "total_estimated_cost",
-  "usage_total_tokens",
-  "usage_prompt_tokens",
-  "usage_completion_tokens",
-  "llm_span_count",
-  "input",
-  "output",
-  "name",
-  "with_errors",
-  "error_type",
-  "tags",
-  "id",
-  "thread_id",
-  "annotation_queue_ids",
-  "feedback_scores",
-  "span_feedback_scores",
-  "guardrails",
-  "metadata",
-  "custom",
-];
-
 const SPAN_CHIP_ORDER: string[] = [
   "start_time",
   "end_time",
@@ -686,135 +516,7 @@ const SPAN_CHIP_ORDER: string[] = [
   "custom",
 ];
 
-const TRACE_DEFAULT_PINNED_CHIPS = ["with_errors", "tags", "metadata"];
 const SPAN_DEFAULT_PINNED_CHIPS = ["type", "tags", "with_errors", "metadata"];
-
-const buildSharedDynamicChips = ({
-  projectId,
-  type,
-  scoreOptions,
-  feedbackScoresLabel,
-  isGuardrailsEnabled,
-}: {
-  projectId: string;
-  type: TRACE_DATA_TYPE;
-  scoreOptions: ChipOptionsResult;
-  feedbackScoresLabel: string;
-  isGuardrailsEnabled: boolean;
-}): Record<string, ChipDefinition> => {
-  const entityType: "spans" | "traces" =
-    type === TRACE_DATA_TYPE.spans ? "spans" : "traces";
-  const chips: Record<string, ChipDefinition> = {
-    tags: {
-      id: "tags",
-      field: "tags",
-      label: "Tags",
-      kind: "query-builder",
-      columnType: COLUMN_TYPE.list,
-      operators: TAGS_OPERATORS,
-      defaultOperator: "contains",
-      value: {
-        placeholder: "Type a tag…",
-        options: chipOptions(useTagsOptions, {
-          projectId,
-          entityType,
-          logsSource: LOGS_SOURCE.sdk,
-        }),
-      },
-      addLabel: "Add tag",
-    },
-    error_type: {
-      id: "error_type",
-      field: "error_type",
-      label: "Error type",
-      kind: "query-builder",
-      columnType: COLUMN_TYPE.string,
-      operators: ["contains", "=", "not_contains", "starts_with", "ends_with"],
-      defaultOperator: "contains",
-      value: {
-        placeholder: "Select error type",
-        options: chipOptions(useErrorTypeOptions, {
-          projectId,
-          type,
-          logsSource: LOGS_SOURCE.sdk,
-        }),
-      },
-    },
-    feedback_scores: {
-      id: "feedback_scores",
-      field: COLUMN_FEEDBACK_SCORES_ID,
-      label: feedbackScoresLabel,
-      kind: "query-builder",
-      columnType: COLUMN_TYPE.numberDictionary,
-      operators: FEEDBACK_SCORE_OPERATORS,
-      defaultOperator: ">=",
-      key: {
-        placeholder: "Select score",
-        options: chipOptionsValue(scoreOptions),
-      },
-      value: { type: "numeric", decimals: 2, placeholder: "0" },
-    },
-    metadata: {
-      id: "metadata",
-      field: COLUMN_METADATA_ID,
-      label: "Metadata",
-      kind: "query-builder",
-      columnType: COLUMN_TYPE.dictionary,
-      operators: DICTIONARY_OPERATORS,
-      defaultOperator: "contains",
-      key: {
-        placeholder: "key",
-        options: chipOptions(usePathsOptions, {
-          projectId,
-          type,
-          rootKeys: ["metadata"],
-          excludeRoot: true,
-          logsSource: LOGS_SOURCE.sdk,
-        }),
-      },
-      value: { placeholder: "value" },
-    },
-    custom: {
-      id: "custom",
-      field: COLUMN_CUSTOM_ID,
-      label: "Custom filter",
-      kind: "query-builder",
-      columnType: COLUMN_TYPE.dictionary,
-      operators: DICTIONARY_OPERATORS,
-      defaultOperator: "contains",
-      key: {
-        placeholder: "key",
-        options: chipOptions(usePathsOptions, {
-          projectId,
-          type,
-          rootKeys: ["input", "output"],
-          excludeRoot: false,
-          logsSource: LOGS_SOURCE.sdk,
-        }),
-        validate: (k) =>
-          CUSTOM_FILTER_VALIDATION_REGEXP.test(k)
-            ? undefined
-            : 'Key must begin with "input" or "output" (e.g. "input.message")',
-      },
-      value: { placeholder: "value" },
-    },
-  };
-  if (isGuardrailsEnabled) {
-    chips.guardrails = {
-      id: "guardrails",
-      field: "guardrails",
-      label: "Guardrails",
-      kind: "single-select",
-      options: [
-        { value: GuardrailResult.FAILED, label: "Failed" },
-        { value: GuardrailResult.PASSED, label: "Passed" },
-      ],
-      columnType: COLUMN_TYPE.category,
-      operator: "=",
-    };
-  }
-  return chips;
-};
 
 type TracesSpansTabProps = {
   type: TRACE_DATA_TYPE;
@@ -990,36 +692,16 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     isSpanFeedbackScoresPending,
   ]);
 
-  const traceChipDefinitions = useMemo<ChipDefinition[]>(() => {
-    const dynamicChips: Record<string, ChipDefinition> = {
-      ...buildSharedDynamicChips({
+  const traceChipDefinitions = useMemo<ChipDefinition[]>(
+    () =>
+      buildTraceChipDefinitions({
         projectId,
-        type: TRACE_DATA_TYPE.traces,
-        scoreOptions: traceScoreOptions,
-        feedbackScoresLabel: "Trace feedback scores",
+        traceScoreOptions,
+        spanScoreOptions,
         isGuardrailsEnabled,
       }),
-      span_feedback_scores: {
-        id: "span_feedback_scores",
-        field: COLUMN_SPAN_FEEDBACK_SCORES_ID,
-        label: "Span feedback scores",
-        kind: "query-builder",
-        columnType: COLUMN_TYPE.numberDictionary,
-        operators: FEEDBACK_SCORE_OPERATORS,
-        defaultOperator: ">=",
-        key: {
-          placeholder: "Select span score",
-          options: chipOptionsValue(spanScoreOptions),
-        },
-        value: { type: "numeric", decimals: 2, placeholder: "0" },
-      },
-    };
-    const byId: Record<string, ChipDefinition> = {
-      ...keyBy(TRACE_CHIP_DEFINITIONS_STATIC, "id"),
-      ...dynamicChips,
-    };
-    return compact(TRACE_CHIP_ORDER.map((id) => byId[id]));
-  }, [isGuardrailsEnabled, projectId, traceScoreOptions, spanScoreOptions]);
+    [isGuardrailsEnabled, projectId, traceScoreOptions, spanScoreOptions],
+  );
 
   const spanChipDefinitions = useMemo<ChipDefinition[]>(() => {
     const dynamicChips: Record<string, ChipDefinition> = {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -699,6 +699,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         traceScoreOptions,
         spanScoreOptions,
         isGuardrailsEnabled,
+        logsSource: LOGS_SOURCE.sdk,
       }),
     [isGuardrailsEnabled, projectId, traceScoreOptions, spanScoreOptions],
   );
@@ -720,6 +721,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
         scoreOptions: spanScoreOptions,
         feedbackScoresLabel: "Feedback scores",
         isGuardrailsEnabled,
+        logsSource: LOGS_SOURCE.sdk,
       }),
     };
     const byId: Record<string, ChipDefinition> = {


### PR DESCRIPTION
## Details

**Stack layer 1 of 3 — no behaviour change.** Moves the trace filter-chip definitions, their display order and their default pinned set out of the Logs page so any surface showing traces can consume them; the entity-scoped trace logs view adopts them in layer 2.

- They land under `pages-shared/traces` rather than `shared/filter-chips` because the option sources (tags, metadata paths, error types) are pages-shared hooks, and the `no-shared-importing-pages` dependency rule forbids `shared/` from reaching them.
- The dynamic-chip builder gains a `logsSource` parameter — it hard-coded the SDK source, which is wrong for evaluator traces — and the Logs page imports it back for its span chips.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-6739

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: whole change — extraction and call-site rewiring
- Human verification: reviewed by the author; Logs page filtering exercised in a browser against a local stack

## Testing

- `npm run typecheck`, `npx eslint src --max-warnings=0`, `npx depcruise src --config --ignore-known` — all clean
- `npx vitest run` — 2326 pass; the 6 failing localStorage test files fail identically on `main` (pre-existing, unrelated)
- Filtering on the Logs page exercised manually: same chips, same order, same default pinned set

## Documentation

None — internal refactor with no user-visible surface.
