### PR TITLE
[OPIK-6739] [FE] feat: experiment logs as a tab, plus Copy ID

### DIFF
--- a/apps/opik-frontend/src/lib/experiments.test.ts
+++ b/apps/opik-frontend/src/lib/experiments.test.ts
@@ -1,8 +1,62 @@
 import { describe, expect, it } from "vitest";
 
-import { formatPromptVersionLabel } from "./experiments";
+import {
+  EXPERIMENT_TAB,
+  formatPromptVersionLabel,
+  getAvailableExperimentTabs,
+} from "./experiments";
+import { EVALUATION_METHOD, Experiment } from "@/types/datasets";
+
+const experiment = (overrides: Partial<Experiment> = {}) =>
+  ({
+    id: "e1",
+    name: "Geo experiment",
+    dataset_id: "d1",
+    dataset_name: "geography_questions",
+    ...overrides,
+  }) as Experiment;
+
+const testSuiteExperiment = () =>
+  experiment({ evaluation_method: EVALUATION_METHOD.TEST_SUITE });
 
 describe("experiments utilities", () => {
+  describe("getAvailableExperimentTabs", () => {
+    it("exposes every tab for a regular experiment", () => {
+      expect(getAvailableExperimentTabs([experiment()])).toEqual([
+        EXPERIMENT_TAB.items,
+        EXPERIMENT_TAB.insights,
+        EXPERIMENT_TAB.config,
+        EXPERIMENT_TAB.scores,
+        EXPERIMENT_TAB.logs,
+      ]);
+    });
+
+    it("puts logs last so it does not displace the existing tabs", () => {
+      const tabs = getAvailableExperimentTabs([experiment()]);
+      expect(tabs[tabs.length - 1]).toBe(EXPERIMENT_TAB.logs);
+    });
+
+    it("hides insights and feedback scores for a test-suite experiment but keeps logs", () => {
+      expect(getAvailableExperimentTabs([testSuiteExperiment()])).toEqual([
+        EXPERIMENT_TAB.items,
+        EXPERIMENT_TAB.config,
+        EXPERIMENT_TAB.logs,
+      ]);
+    });
+
+    it("keeps logs when several experiments are compared", () => {
+      expect(
+        getAvailableExperimentTabs([experiment(), experiment({ id: "e2" })]),
+      ).toContain(EXPERIMENT_TAB.logs);
+    });
+
+    it("hides feedback scores while no experiment has loaded yet", () => {
+      const tabs = getAvailableExperimentTabs([]);
+      expect(tabs).not.toContain(EXPERIMENT_TAB.scores);
+      expect(tabs).toContain(EXPERIMENT_TAB.logs);
+    });
+  });
+
   describe("formatPromptVersionLabel", () => {
     it("prefers the sequential version number", () => {
       expect(

--- a/apps/opik-frontend/src/lib/experiments.test.ts
+++ b/apps/opik-frontend/src/lib/experiments.test.ts
@@ -4,6 +4,7 @@ import {
   EXPERIMENT_TAB,
   formatPromptVersionLabel,
   getAvailableExperimentTabs,
+  isExperimentTabId,
 } from "./experiments";
 import { EVALUATION_METHOD, Experiment } from "@/types/datasets";
 
@@ -20,6 +21,27 @@ const testSuiteExperiment = () =>
   experiment({ evaluation_method: EVALUATION_METHOD.TEST_SUITE });
 
 describe("experiments utilities", () => {
+  // The page reads `tab` straight off the URL, so this guard is what stands between an arbitrary
+  // query value and the tab state.
+  describe("isExperimentTabId", () => {
+    it("accepts every known tab id", () => {
+      Object.values(EXPERIMENT_TAB).forEach((id) =>
+        expect(isExperimentTabId(id)).toBe(true),
+      );
+    });
+
+    it("rejects an unknown tab name", () => {
+      expect(isExperimentTabId("traces")).toBe(false);
+      expect(isExperimentTabId("")).toBe(false);
+    });
+
+    it("rejects values a URL parser can hand back that aren't strings", () => {
+      [undefined, null, 0, 42, true, {}, ["items"]].forEach((value) =>
+        expect(isExperimentTabId(value)).toBe(false),
+      );
+    });
+  });
+
   describe("getAvailableExperimentTabs", () => {
     it("exposes every tab for a regular experiment", () => {
       expect(getAvailableExperimentTabs([experiment()])).toEqual([

--- a/apps/opik-frontend/src/lib/experiments.ts
+++ b/apps/opik-frontend/src/lib/experiments.ts
@@ -40,6 +40,38 @@ export function isTestSuiteExperiment(
   return experiment?.evaluation_method === EVALUATION_METHOD.TEST_SUITE;
 }
 
+export const EXPERIMENT_TAB = {
+  items: "items",
+  insights: "insights",
+  config: "config",
+  scores: "scores",
+  logs: "logs",
+} as const;
+
+export type ExperimentTabId =
+  (typeof EXPERIMENT_TAB)[keyof typeof EXPERIMENT_TAB];
+
+/**
+ * Which tabs the experiment page exposes, in display order.
+ *
+ * Insights and feedback scores don't apply to test-suite experiments; feedback scores also need at
+ * least one loaded experiment. Logs is always available — every experiment run produces traces, and
+ * comparisons show the traces of all compared experiments (OPIK-6739).
+ */
+export const getAvailableExperimentTabs = (
+  experiments: Experiment[],
+): ExperimentTabId[] => {
+  const isTestSuite = isTestSuiteExperiment(experiments[0]);
+
+  return [
+    EXPERIMENT_TAB.items,
+    ...(!isTestSuite ? [EXPERIMENT_TAB.insights] : []),
+    EXPERIMENT_TAB.config,
+    ...(experiments.length > 0 && !isTestSuite ? [EXPERIMENT_TAB.scores] : []),
+    EXPERIMENT_TAB.logs,
+  ];
+};
+
 export const calculateLineHeight = (
   height: ROW_HEIGHT,
   lineCount: number = 1,

--- a/apps/opik-frontend/src/lib/experiments.ts
+++ b/apps/opik-frontend/src/lib/experiments.ts
@@ -51,6 +51,12 @@ export const EXPERIMENT_TAB = {
 export type ExperimentTabId =
   (typeof EXPERIMENT_TAB)[keyof typeof EXPERIMENT_TAB];
 
+const EXPERIMENT_TAB_IDS: readonly string[] = Object.values(EXPERIMENT_TAB);
+
+/** Narrows an arbitrary URL value to a known tab id, so the page can fall back when it isn't one. */
+export const isExperimentTabId = (value: unknown): value is ExperimentTabId =>
+  typeof value === "string" && EXPERIMENT_TAB_IDS.includes(value);
+
 /**
  * Which tabs the experiment page exposes, in display order.
  *

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -1,13 +1,10 @@
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import sortBy from "lodash/sortBy";
 import isNumber from "lodash/isNumber";
-import copy from "clipboard-copy";
-import { CircleCheck, Copy, GitCommitVertical } from "lucide-react";
+import { CircleCheck, GitCommitVertical } from "lucide-react";
 
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
 import BackButton from "@/shared/BackButton/BackButton";
-import { Button } from "@/ui/button";
-import { useToast } from "@/ui/use-toast";
 import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import { Experiment } from "@/types/datasets";
 import { Tag } from "@/ui/tag";
@@ -36,20 +33,10 @@ const CompareExperimentsDetails: React.FunctionComponent<
   CompareExperimentsDetailsProps
 > = ({ experiments, experimentsIds }) => {
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
-  const { toast } = useToast();
 
   const isCompare = experimentsIds.length > 1;
 
   const experiment = experiments[0];
-
-  // SDK features that act on an existing run (resuming one, for instance) need the experiment id,
-  // which was previously only recoverable from the page URL or an opt-in column in the experiments
-  // table. Hidden while comparing, where "the" experiment id would be ambiguous (OPIK-6739).
-  const copyIdClickHandler = useCallback(() => {
-    if (!experiment?.id) return;
-    copy(experiment.id);
-    toast({ description: "ID successfully copied to clipboard" });
-  }, [toast, experiment?.id]);
 
   const title = !isCompare
     ? experiment?.name
@@ -111,15 +98,7 @@ const CompareExperimentsDetails: React.FunctionComponent<
           />
           <h1 className="comet-body-accented truncate break-words">{title}</h1>
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {!isCompare && experiment?.id && (
-            <Button size="2xs" variant="outline" onClick={copyIdClickHandler}>
-              <Copy className="mr-1 size-3.5" />
-              Copy ID
-            </Button>
-          )}
-          <CompareExperimentsButton />
-        </div>
+        <CompareExperimentsButton />
       </div>
       <div className="mb-1 flex gap-1.5 overflow-x-auto">
         {!isCompare && (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails.tsx
@@ -1,10 +1,13 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import sortBy from "lodash/sortBy";
 import isNumber from "lodash/isNumber";
-import { CircleCheck, GitCommitVertical } from "lucide-react";
+import copy from "clipboard-copy";
+import { CircleCheck, Copy, GitCommitVertical } from "lucide-react";
 
 import useBreadcrumbsStore from "@/store/BreadcrumbsStore";
 import BackButton from "@/shared/BackButton/BackButton";
+import { Button } from "@/ui/button";
+import { useToast } from "@/ui/use-toast";
 import CompareExperimentsButton from "@/v2/pages/CompareExperimentsPage/CompareExperimentsButton/CompareExperimentsButton";
 import { Experiment } from "@/types/datasets";
 import { Tag } from "@/ui/tag";
@@ -21,9 +24,7 @@ import {
   SCORE_TYPE_EXPERIMENT,
 } from "@/types/shared";
 import { getScoreDisplayName } from "@/lib/feedback-scores";
-import { generateExperimentIdsFilter } from "@/lib/filters";
 import { isTestSuiteExperiment } from "@/lib/experiments";
-import TraceLogsSidebarButton from "@/v2/pages-shared/traces/TraceLogsSidebar/TraceLogsSidebarButton";
 import ExperimentTagsList from "@/v2/pages/CompareExperimentsPage/ExperimentTagsList";
 
 type CompareExperimentsDetailsProps = {
@@ -35,10 +36,20 @@ const CompareExperimentsDetails: React.FunctionComponent<
   CompareExperimentsDetailsProps
 > = ({ experiments, experimentsIds }) => {
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
+  const { toast } = useToast();
 
   const isCompare = experimentsIds.length > 1;
 
   const experiment = experiments[0];
+
+  // SDK features that act on an existing run (resuming one, for instance) need the experiment id,
+  // which was previously only recoverable from the page URL or an opt-in column in the experiments
+  // table. Hidden while comparing, where "the" experiment id would be ambiguous (OPIK-6739).
+  const copyIdClickHandler = useCallback(() => {
+    if (!experiment?.id) return;
+    copy(experiment.id);
+    toast({ description: "ID successfully copied to clipboard" });
+  }, [toast, experiment?.id]);
 
   const title = !isCompare
     ? experiment?.name
@@ -48,11 +59,6 @@ const CompareExperimentsDetails: React.FunctionComponent<
     title && setBreadcrumbParam("compare", "Compare", title);
     return () => setBreadcrumbParam("compare", "Compare", "");
   }, [title, setBreadcrumbParam]);
-
-  const experimentSourceFilters = useMemo(
-    () => generateExperimentIdsFilter(experimentsIds),
-    [experimentsIds],
-  );
 
   const experimentScores: FeedbackScoreDisplay[] = useMemo(() => {
     if (isCompare || !experiment) return [];
@@ -105,7 +111,15 @@ const CompareExperimentsDetails: React.FunctionComponent<
           />
           <h1 className="comet-body-accented truncate break-words">{title}</h1>
         </div>
-        <CompareExperimentsButton />
+        <div className="flex shrink-0 items-center gap-2">
+          {!isCompare && experiment?.id && (
+            <Button size="2xs" variant="outline" onClick={copyIdClickHandler}>
+              <Copy className="mr-1 size-3.5" />
+              Copy ID
+            </Button>
+          )}
+          <CompareExperimentsButton />
+        </div>
       </div>
       <div className="mb-1 flex gap-1.5 overflow-x-auto">
         {!isCompare && (
@@ -146,13 +160,6 @@ const CompareExperimentsDetails: React.FunctionComponent<
               prefix="Prompt"
             />
           )}
-        {experiment?.project_id && (
-          <TraceLogsSidebarButton
-            projectId={experiment.project_id}
-            sourceFilters={experimentSourceFilters}
-            title="Experiment logs"
-          />
-        )}
         {!isCompare &&
           isTestSuiteExperiment(experiment) &&
           isNumber(experiment.pass_rate) && (

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
@@ -12,8 +12,13 @@ import ExperimentInsightsTab from "@/v2/pages/CompareExperimentsPage/ExperimentI
 import useExperimentsByIds from "@/api/datasets/useExperimenstByIds";
 import useDeepMemo from "@/hooks/useDeepMemo";
 import { Experiment } from "@/types/datasets";
-import { isTestSuiteExperiment } from "@/lib/experiments";
+import {
+  EXPERIMENT_TAB,
+  getAvailableExperimentTabs,
+  isTestSuiteExperiment,
+} from "@/lib/experiments";
 import CompareExperimentsDetails from "@/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails";
+import ExperimentLogsTab from "@/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab";
 
 const CompareExperimentsPage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam, {
@@ -41,18 +46,18 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
 
   const isTestSuite = isTestSuiteExperiment(memorizedExperiments[0]);
 
-  const showScoresTab = memorizedExperiments.length > 0 && !isTestSuite;
+  const availableTabs = useMemo(
+    () => getAvailableExperimentTabs(memorizedExperiments),
+    [memorizedExperiments],
+  );
 
-  const availableTabs = useMemo(() => {
-    const tabs = new Set(["items", "config"]);
-    if (!isTestSuite) tabs.add("insights");
-    if (showScoresTab) tabs.add("scores");
-    return tabs;
-  }, [isTestSuite, showScoresTab]);
+  const showScoresTab = availableTabs.includes(EXPERIMENT_TAB.scores);
 
-  const effectiveTab = availableTabs.has(tab as string)
+  const effectiveTab = availableTabs.includes(
+    tab as (typeof availableTabs)[number],
+  )
     ? (tab as string)
-    : "items";
+    : EXPERIMENT_TAB.items;
 
   const renderContent = () => {
     return (
@@ -80,6 +85,9 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
                 Feedback scores
               </TabsTrigger>
             )}
+            <TabsTrigger variant="segmented-primary" value="logs">
+              Logs
+            </TabsTrigger>
           </TabsList>
         </PageBodyStickyContainer>
         <TabsContent value="items">
@@ -110,6 +118,12 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
             />
           </TabsContent>
         )}
+        <TabsContent value="logs">
+          <ExperimentLogsTab
+            experimentsIds={experimentsIds}
+            experiments={memorizedExperiments}
+          />
+        </TabsContent>
       </Tabs>
     );
   };

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPage.tsx
@@ -14,11 +14,21 @@ import useDeepMemo from "@/hooks/useDeepMemo";
 import { Experiment } from "@/types/datasets";
 import {
   EXPERIMENT_TAB,
+  ExperimentTabId,
   getAvailableExperimentTabs,
+  isExperimentTabId,
   isTestSuiteExperiment,
 } from "@/lib/experiments";
 import CompareExperimentsDetails from "@/v2/pages/CompareExperimentsPage/CompareExperimentsDetails/CompareExperimentsDetails";
 import ExperimentLogsTab from "@/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab";
+
+const EXPERIMENT_TAB_LABELS: Record<ExperimentTabId, string> = {
+  [EXPERIMENT_TAB.items]: "Results",
+  [EXPERIMENT_TAB.insights]: "Insights",
+  [EXPERIMENT_TAB.config]: "Configuration",
+  [EXPERIMENT_TAB.scores]: "Feedback scores",
+  [EXPERIMENT_TAB.logs]: "Logs",
+};
 
 const CompareExperimentsPage: React.FunctionComponent = () => {
   const [tab = "items", setTab] = useQueryParam("tab", StringParam, {
@@ -51,13 +61,10 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
     [memorizedExperiments],
   );
 
-  const showScoresTab = availableTabs.includes(EXPERIMENT_TAB.scores);
-
-  const effectiveTab = availableTabs.includes(
-    tab as (typeof availableTabs)[number],
-  )
-    ? (tab as string)
-    : EXPERIMENT_TAB.items;
+  const effectiveTab =
+    isExperimentTabId(tab) && availableTabs.includes(tab)
+      ? tab
+      : EXPERIMENT_TAB.items;
 
   const renderContent = () => {
     return (
@@ -69,48 +76,38 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
       >
         <PageBodyStickyContainer direction="horizontal" limitWidth>
           <TabsList variant="segmented-primary">
-            <TabsTrigger variant="segmented-primary" value="items">
-              Results
-            </TabsTrigger>
-            {!isTestSuite && (
-              <TabsTrigger variant="segmented-primary" value="insights">
-                Insights
+            {availableTabs.map((tabId) => (
+              <TabsTrigger
+                key={tabId}
+                variant="segmented-primary"
+                value={tabId}
+              >
+                {EXPERIMENT_TAB_LABELS[tabId]}
               </TabsTrigger>
-            )}
-            <TabsTrigger variant="segmented-primary" value="config">
-              Configuration
-            </TabsTrigger>
-            {showScoresTab && (
-              <TabsTrigger variant="segmented-primary" value="scores">
-                Feedback scores
-              </TabsTrigger>
-            )}
-            <TabsTrigger variant="segmented-primary" value="logs">
-              Logs
-            </TabsTrigger>
+            ))}
           </TabsList>
         </PageBodyStickyContainer>
-        <TabsContent value="items">
+        <TabsContent value={EXPERIMENT_TAB.items}>
           <ExperimentItemsTab
             experimentsIds={experimentsIds}
             experiments={memorizedExperiments}
             isTestSuite={isTestSuite}
           />
         </TabsContent>
-        {!isTestSuite && (
-          <TabsContent value="insights">
+        {availableTabs.includes(EXPERIMENT_TAB.insights) && (
+          <TabsContent value={EXPERIMENT_TAB.insights}>
             <ExperimentInsightsTab experimentsIds={experimentsIds} />
           </TabsContent>
         )}
-        <TabsContent value="config">
+        <TabsContent value={EXPERIMENT_TAB.config}>
           <ConfigurationTab
             experimentsIds={experimentsIds}
             experiments={memorizedExperiments}
             isPending={isPending}
           />
         </TabsContent>
-        {showScoresTab && (
-          <TabsContent value="scores">
+        {availableTabs.includes(EXPERIMENT_TAB.scores) && (
+          <TabsContent value={EXPERIMENT_TAB.scores}>
             <ExperimentFeedbackScoresTab
               experimentsIds={experimentsIds}
               experiments={memorizedExperiments}
@@ -118,7 +115,7 @@ const CompareExperimentsPage: React.FunctionComponent = () => {
             />
           </TabsContent>
         )}
-        <TabsContent value="logs">
+        <TabsContent value={EXPERIMENT_TAB.logs}>
           <ExperimentLogsTab
             experimentsIds={experimentsIds}
             experiments={memorizedExperiments}

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
@@ -2,6 +2,9 @@ import React, { useMemo } from "react";
 
 import { Experiment } from "@/types/datasets";
 import { generateExperimentIdsFilter } from "@/lib/filters";
+import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
+import emptyLogsLightUrl from "/images/empty-logs-light.svg";
+import emptyLogsDarkUrl from "/images/empty-logs-dark.svg";
 import TraceLogsView from "@/v2/pages-shared/traces/TraceLogsView/TraceLogsView";
 
 type ExperimentLogsTabProps = {
@@ -30,7 +33,22 @@ const ExperimentLogsTab: React.FunctionComponent<ExperimentLogsTabProps> = ({
   // loaded experiment is what tells us which one.
   const projectId = experiments.find((e) => e.project_id)?.project_id;
 
-  if (!projectId) return null;
+  // Nothing to render before the experiment loads. Once it has, a missing project means the run
+  // never produced traces — say so rather than leaving the tab blank.
+  if (!projectId) {
+    if (experiments.length === 0) return null;
+
+    return (
+      <div className="py-8">
+        <DataTableEmptyContent
+          title="There are no traces yet"
+          description="Traces will appear here once this experiment records them."
+          lightImageUrl={emptyLogsLightUrl}
+          darkImageUrl={emptyLogsDarkUrl}
+        />
+      </div>
+    );
+  }
 
   return (
     <TraceLogsView

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo } from "react";
+import isString from "lodash/isString";
+import uniq from "lodash/uniq";
 
 import { Experiment } from "@/types/datasets";
 import { generateExperimentIdsFilter } from "@/lib/filters";
@@ -13,8 +15,13 @@ import TraceLogsView, {
 // Per design, the tab's toolbar carries the columns selector and nothing else — no row-height, date
 // range or refresh. Dropping the date control also drops date filtering entirely, so the tab always
 // spans the experiment's whole life.
+//
+// Its own storage namespace, so the columns, sort, page size and pinned chips a user sets here
+// don't overwrite the ones they set in the playground or trial overlays, which take the default
+// config. Without this every host shares one arrangement.
 const EXPERIMENT_LOGS_VIEW_CONFIG: TraceLogsViewConfig = {
   ...DEFAULT_TRACE_LOGS_VIEW_CONFIG,
+  storageNamespace: "experiment-",
   showTableControls: false,
 };
 
@@ -36,19 +43,40 @@ const ExperimentLogsTab: React.FunctionComponent<ExperimentLogsTabProps> = ({
   experiments,
 }) => {
   const scopeFilters = useMemo(
-    () => generateExperimentIdsFilter(experimentsIds),
+    // JsonParam yields whatever the URL parsed to, so a malformed link could otherwise put a number
+    // or object through join(",") and emit a filter like "[object Object]".
+    () => generateExperimentIdsFilter(experimentsIds.filter(isString)),
     [experimentsIds],
   );
 
-  // Compared experiments can only be compared within a dataset, so they share a project; the first
-  // loaded experiment is what tells us which one.
-  const projectId = experiments.find((e) => e.project_id)?.project_id;
+  // Traces are queried per project, so comparing experiments that live in different ones cannot be
+  // served by a single request. That happens: an experiment's project resolves from its own
+  // project_name, independently of the dataset, and the dataset lookup itself is project-agnostic.
+  const projectIds = useMemo(
+    () => uniq(experiments.map((e) => e.project_id).filter(isString)),
+    [experiments],
+  );
+  const projectId = projectIds[0];
 
-  // Nothing to render before the experiment loads. Once it has, a missing project means the run
-  // never produced traces — say so rather than leaving the tab blank.
+  // Nothing to render before the experiment loads.
+  if (experiments.length === 0) return null;
+
+  if (projectIds.length > 1) {
+    return (
+      <div className="py-8">
+        <DataTableEmptyContent
+          title="These experiments live in different projects"
+          description="Logs are read per project, so they can't be listed together. Open an experiment on its own to see its traces."
+          lightImageUrl={emptyLogsLightUrl}
+          darkImageUrl={emptyLogsDarkUrl}
+        />
+      </div>
+    );
+  }
+
+  // A loaded experiment with no project never produced traces — say so rather than leaving the tab
+  // blank.
   if (!projectId) {
-    if (experiments.length === 0) return null;
-
     return (
       <div className="py-8">
         <DataTableEmptyContent

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
@@ -1,0 +1,44 @@
+import React, { useMemo } from "react";
+
+import { Experiment } from "@/types/datasets";
+import { generateExperimentIdsFilter } from "@/lib/filters";
+import TraceLogsView from "@/v2/pages-shared/traces/TraceLogsView/TraceLogsView";
+
+type ExperimentLogsTabProps = {
+  experimentsIds: string[];
+  experiments: Experiment[];
+};
+
+/**
+ * Traces produced by the open experiment (or, when comparing, by all compared experiments).
+ *
+ * The experiment scope is applied as a locked scope rather than seeded into the filter bar: a tab
+ * named "Logs" inside an experiment should always mean that experiment's logs, and there is no
+ * "open" event a seeded filter could hang off. No scope indicator is rendered — the page around the
+ * tab already says which experiment this is (OPIK-6739).
+ */
+const ExperimentLogsTab: React.FunctionComponent<ExperimentLogsTabProps> = ({
+  experimentsIds,
+  experiments,
+}) => {
+  const scopeFilters = useMemo(
+    () => generateExperimentIdsFilter(experimentsIds),
+    [experimentsIds],
+  );
+
+  // Compared experiments can only be compared within a dataset, so they share a project; the first
+  // loaded experiment is what tells us which one.
+  const projectId = experiments.find((e) => e.project_id)?.project_id;
+
+  if (!projectId) return null;
+
+  return (
+    <TraceLogsView
+      projectId={projectId}
+      scopeFilters={scopeFilters}
+      layout="page"
+    />
+  );
+};
+
+export default ExperimentLogsTab;

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentLogsTab/ExperimentLogsTab.tsx
@@ -5,7 +5,18 @@ import { generateExperimentIdsFilter } from "@/lib/filters";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
 import emptyLogsLightUrl from "/images/empty-logs-light.svg";
 import emptyLogsDarkUrl from "/images/empty-logs-dark.svg";
-import TraceLogsView from "@/v2/pages-shared/traces/TraceLogsView/TraceLogsView";
+import TraceLogsView, {
+  DEFAULT_TRACE_LOGS_VIEW_CONFIG,
+  TraceLogsViewConfig,
+} from "@/v2/pages-shared/traces/TraceLogsView/TraceLogsView";
+
+// Per design, the tab's toolbar carries the columns selector and nothing else — no row-height, date
+// range or refresh. Dropping the date control also drops date filtering entirely, so the tab always
+// spans the experiment's whole life.
+const EXPERIMENT_LOGS_VIEW_CONFIG: TraceLogsViewConfig = {
+  ...DEFAULT_TRACE_LOGS_VIEW_CONFIG,
+  showTableControls: false,
+};
 
 type ExperimentLogsTabProps = {
   experimentsIds: string[];
@@ -54,6 +65,7 @@ const ExperimentLogsTab: React.FunctionComponent<ExperimentLogsTabProps> = ({
     <TraceLogsView
       projectId={projectId}
       scopeFilters={scopeFilters}
+      viewConfig={EXPERIMENT_LOGS_VIEW_CONFIG}
       layout="page"
     />
   );

--- a/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
+++ b/apps/opik-frontend/src/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundOutputTable/PlaygroundOutputCell.tsx
@@ -23,7 +23,7 @@ import { parseDatasetVersionKey } from "@/utils/datasetVersionStorage";
 import { PLAYGROUND_PROMPT_COLORS } from "@/constants/llm";
 import PlaygroundNoRunsYet from "@/v2/pages/PlaygroundPage/PlaygroundOutputs/PlaygroundNoRunsYet";
 import { generateTracesURL } from "@/lib/annotation-queues";
-import { generateExperimentIdsFilter } from "@/lib/filters";
+import { EXPERIMENT_TAB } from "@/lib/experiments";
 import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { Button } from "@/ui/button";
@@ -85,17 +85,14 @@ const PlaygroundOutputCell: React.FunctionComponent<
     event.stopPropagation();
     if (!traceId || !activeProjectId) return;
 
-    // For dataset/experiment runs, open the trace in the experiment logs view (scoped by
-    // experiment_id) — the same destination as the experiment page's "Go to logs" — so the
+    // For dataset/experiment runs, open the trace on the experiment page's Logs tab, so the
     // surrounding list holds the experiment's traces. The main project Logs list filters to
-    // source=sdk and would exclude them by design.
+    // source=sdk and would exclude them by design. The tab scopes itself to the experiment, so
+    // only the tab and the trace to open need to travel in the URL.
     if (experimentId && plainDatasetId) {
       const search = new URLSearchParams({
         experiments: JSON.stringify([experimentId]),
-        tls_open: "1",
-        tls_filters: JSON.stringify(
-          generateExperimentIdsFilter([experimentId]),
-        ),
+        tab: EXPERIMENT_TAB.logs,
         tls_trace: traceId,
       }).toString();
       const basePath = import.meta.env.VITE_BASE_URL || "/";

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -562,7 +562,6 @@ areas:
       insights-tab:            { covered: false }
       configuration-tab:       { covered: false }
       logs-tab:                { covered: true,  tier: t1-smoke, note: "experiment traces inline; replaced the Go to logs tag" }
-      copy-experiment-id:      { covered: true,  tier: t1-smoke }
       export-comparison:       { covered: false }
       delete-experiment:       { covered: false }
 

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -561,6 +561,8 @@ areas:
       compare-row-detail:      { covered: true,  tier: t2-cuj }
       insights-tab:            { covered: false }
       configuration-tab:       { covered: false }
+      logs-tab:                { covered: true,  tier: t1-smoke, note: "experiment traces inline; replaced the Go to logs tag" }
+      copy-experiment-id:      { covered: true,  tier: t1-smoke }
       export-comparison:       { covered: false }
       delete-experiment:       { covered: false }
 

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -1,10 +1,58 @@
-import { expect, type Locator, type Page } from '@playwright/test';
+import { expect, test, type Locator, type Page } from '@playwright/test';
 
 export class ExperimentDetailPage {
   constructor(
     private readonly page: Page,
     private readonly experimentId: string,
   ) {}
+
+  /** The "Logs" tab trigger, which replaced the old "Go to logs" tag (OPIK-6739). */
+  get logsTab(): Locator {
+    return this.page.getByRole('tab', { name: 'Logs' });
+  }
+
+  /** The removed "Go to logs" tag — kept as a locator so tests can assert it is gone. */
+  get goToLogsTag(): Locator {
+    return this.page.getByText('Go to logs');
+  }
+
+  /** Open the Logs tab and wait for the URL to reflect it. */
+  async openLogsTab(): Promise<void> {
+    return test.step('open the Logs tab', async () => {
+      await this.logsTab.click();
+      await this.page.waitForURL((url) => url.searchParams.get('tab') === 'logs');
+    });
+  }
+
+  /** The "Copy ID" action in the page header. */
+  get copyIdButton(): Locator {
+    return this.page.getByRole('button', { name: 'Copy ID' });
+  }
+
+  /** Click "Copy ID" and return what landed on the clipboard. */
+  async copyExperimentId(): Promise<string> {
+    return test.step('copy the experiment ID', async () => {
+      await this.copyIdButton.click();
+      return this.page.evaluate(() => navigator.clipboard.readText());
+    });
+  }
+
+  /** Trace rows inside the Logs tab. The items table unmounts when the tab is inactive. */
+  get logsTraceRows(): Locator {
+    return this.page.locator('tbody tr[data-row-id]');
+  }
+
+  /** Poll until at least one trace row appears (traces land asynchronously after a run). */
+  async waitForLogsTraceRow(timeoutMs = 30_000): Promise<void> {
+    return test.step('wait for a trace row in the Logs tab', async () => {
+      await expect
+        .poll(async () => this.logsTraceRows.count(), {
+          timeout: timeoutMs,
+          intervals: [500, 1000, 2000],
+        })
+        .toBeGreaterThan(0);
+    });
+  }
 
   async waitForReady(): Promise<void> {
     // The page renders the experiment name as the h1.

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -24,48 +24,6 @@ export class ExperimentDetailPage {
     });
   }
 
-  /** The "Copy ID" action in the page header. */
-  get copyIdButton(): Locator {
-    return this.page.getByRole('button', { name: 'Copy ID' });
-  }
-
-  /**
-   * Click "Copy ID" and return what landed on the clipboard.
-   *
-   * Reads through a stub rather than `navigator.clipboard.readText()`: the suite grants no
-   * clipboard permission, and Chromium rejects a read without one. Stubbing `writeText` also keeps
-   * the assertion on what the app tried to copy, which is the behaviour under test.
-   */
-  async copyExperimentId(): Promise<string> {
-    return test.step('copy the experiment ID', async () => {
-      await this.page.evaluate(() => {
-        const w = window as unknown as { __copied?: string };
-        w.__copied = undefined;
-        Object.defineProperty(navigator, 'clipboard', {
-          configurable: true,
-          value: {
-            writeText: (text: string) => {
-              w.__copied = text;
-              return Promise.resolve();
-            },
-          },
-        });
-      });
-      await this.copyIdButton.click();
-      await expect
-        .poll(
-          async () =>
-            this.page.evaluate(
-              () => (window as unknown as { __copied?: string }).__copied,
-            ),
-          { timeout: 5_000 },
-        )
-        .toBeTruthy();
-      return this.page.evaluate(
-        () => (window as unknown as { __copied?: string }).__copied ?? '',
-      );
-    });
-  }
 
   /** Trace rows inside the Logs tab, scoped to the tab so they can't match the items table. */
   get logsTraceRows(): Locator {

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -24,7 +24,6 @@ export class ExperimentDetailPage {
     });
   }
 
-
   /** Trace rows inside the Logs tab, scoped to the tab so they can't match the items table. */
   get logsTraceRows(): Locator {
     return this.page

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -29,28 +29,65 @@ export class ExperimentDetailPage {
     return this.page.getByRole('button', { name: 'Copy ID' });
   }
 
-  /** Click "Copy ID" and return what landed on the clipboard. */
+  /**
+   * Click "Copy ID" and return what landed on the clipboard.
+   *
+   * Reads through a stub rather than `navigator.clipboard.readText()`: the suite grants no
+   * clipboard permission, and Chromium rejects a read without one. Stubbing `writeText` also keeps
+   * the assertion on what the app tried to copy, which is the behaviour under test.
+   */
   async copyExperimentId(): Promise<string> {
     return test.step('copy the experiment ID', async () => {
+      await this.page.evaluate(() => {
+        const w = window as unknown as { __copied?: string };
+        w.__copied = undefined;
+        Object.defineProperty(navigator, 'clipboard', {
+          configurable: true,
+          value: {
+            writeText: (text: string) => {
+              w.__copied = text;
+              return Promise.resolve();
+            },
+          },
+        });
+      });
       await this.copyIdButton.click();
-      return this.page.evaluate(() => navigator.clipboard.readText());
+      await expect
+        .poll(
+          async () =>
+            this.page.evaluate(
+              () => (window as unknown as { __copied?: string }).__copied,
+            ),
+          { timeout: 5_000 },
+        )
+        .toBeTruthy();
+      return this.page.evaluate(
+        () => (window as unknown as { __copied?: string }).__copied ?? '',
+      );
     });
   }
 
-  /** Trace rows inside the Logs tab. The items table unmounts when the tab is inactive. */
+  /** Trace rows inside the Logs tab, scoped to the tab so they can't match the items table. */
   get logsTraceRows(): Locator {
-    return this.page.locator('tbody tr[data-row-id]');
+    return this.page
+      .getByRole('tabpanel')
+      .locator('tbody tr[data-row-id]');
   }
 
-  /** Poll until at least one trace row appears (traces land asynchronously after a run). */
-  async waitForLogsTraceRow(timeoutMs = 30_000): Promise<void> {
-    return test.step('wait for a trace row in the Logs tab', async () => {
+  /**
+   * Poll until the Logs tab settles on exactly `expected` trace rows.
+   *
+   * An exact count, not a lower bound: the experiment scope is the point of the tab, so a run of
+   * N items must show N traces. More would mean the scope leaked and the whole project is listed.
+   */
+  async waitForLogsTraceRows(expected: number, timeoutMs = 30_000): Promise<void> {
+    return test.step(`wait for ${expected} trace rows in the Logs tab`, async () => {
       await expect
         .poll(async () => this.logsTraceRows.count(), {
           timeout: timeoutMs,
           intervals: [500, 1000, 2000],
         })
-        .toBeGreaterThan(0);
+        .toBe(expected);
     });
   }
 

--- a/tests_end_to_end/e2e/pom/experiment-detail.page.ts
+++ b/tests_end_to_end/e2e/pom/experiment-detail.page.ts
@@ -39,12 +39,9 @@ export class ExperimentDetailPage {
    */
   async waitForLogsTraceRows(expected: number, timeoutMs = 30_000): Promise<void> {
     return test.step(`wait for ${expected} trace rows in the Logs tab`, async () => {
-      await expect
-        .poll(async () => this.logsTraceRows.count(), {
-          timeout: timeoutMs,
-          intervals: [500, 1000, 2000],
-        })
-        .toBe(expected);
+      await expect(this.logsTraceRows).toHaveCount(expected, {
+        timeout: timeoutMs,
+      });
     });
   }
 

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -43,7 +43,6 @@ test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments']
       expect(experiment.scores.filter((s) => s.scoreValue === 0.0), 'fail rows').toHaveLength(1);
     });
 
-
     await test.step('Logs tab replaces the "Go to logs" tag and shows the run traces', async () => {
       await expect(detail.goToLogsTag, 'old "Go to logs" tag is gone').toHaveCount(0);
       await expect(detail.logsTab, 'Logs tab is present').toBeVisible();

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -42,5 +42,19 @@ test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments']
       expect(experiment.scores.filter((s) => s.scoreValue === 1.0), 'pass rows').toHaveLength(2);
       expect(experiment.scores.filter((s) => s.scoreValue === 0.0), 'fail rows').toHaveLength(1);
     });
+
+    await test.step('Header copies the experiment ID to the clipboard', async () => {
+      await expect(detail.copyIdButton, '"Copy ID" action is present').toBeVisible();
+      expect(await detail.copyExperimentId(), 'clipboard holds the experiment ID')
+        .toBe(experiment.experimentId);
+    });
+
+    await test.step('Logs tab replaces the "Go to logs" tag and shows the run traces', async () => {
+      await expect(detail.goToLogsTag, 'old "Go to logs" tag is gone').toHaveCount(0);
+      await expect(detail.logsTab, 'Logs tab is present').toBeVisible();
+
+      await detail.openLogsTab();
+      await detail.waitForLogsTraceRow();
+    });
   });
 });

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@e2e/fixtures';
 import { ExperimentsPage } from '@e2e/pom/experiments.page';
 
 test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments'] }, () => {
-  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores', '@cap:experiments.logs-tab', '@cap:experiments.copy-experiment-id'] }, async ({
+  test('SDK-seeded experiment renders in list, scores its items, and exposes its traces and ID', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores', '@cap:experiments.logs-tab', '@cap:experiments.copy-experiment-id'] }, async ({
     experiment,
     project,
     page,
@@ -54,7 +54,8 @@ test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments']
       await expect(detail.logsTab, 'Logs tab is present').toBeVisible();
 
       await detail.openLogsTab();
-      await detail.waitForLogsTraceRow();
+      // Exactly one trace per seeded item — more would mean the experiment scope leaked.
+      await detail.waitForLogsTraceRows(experiment.items.length);
     });
   });
 });

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@e2e/fixtures';
 import { ExperimentsPage } from '@e2e/pom/experiments.page';
 
 test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments'] }, () => {
-  test('SDK-seeded experiment renders in list, scores its items, and exposes its traces and ID', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores', '@cap:experiments.logs-tab', '@cap:experiments.copy-experiment-id'] }, async ({
+  test('SDK-seeded experiment renders in list, scores its items, and exposes its traces', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores', '@cap:experiments.logs-tab'] }, async ({
     experiment,
     project,
     page,
@@ -43,11 +43,6 @@ test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments']
       expect(experiment.scores.filter((s) => s.scoreValue === 0.0), 'fail rows').toHaveLength(1);
     });
 
-    await test.step('Header copies the experiment ID to the clipboard', async () => {
-      await expect(detail.copyIdButton, '"Copy ID" action is present').toBeVisible();
-      expect(await detail.copyExperimentId(), 'clipboard holds the experiment ID')
-        .toBe(experiment.experimentId);
-    });
 
     await test.step('Logs tab replaces the "Go to logs" tag and shows the run traces', async () => {
       await expect(detail.goToLogsTag, 'old "Go to logs" tag is gone').toHaveCount(0);

--- a/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/experiments-smoke.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@e2e/fixtures';
 import { ExperimentsPage } from '@e2e/pom/experiments.page';
 
 test.describe('Experiments — smoke', { tag: ['@t1-smoke', '@area:experiments'] }, () => {
-  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores'] }, async ({
+  test('SDK-seeded experiment renders in list and shows per-item deterministic scores', { tag: ['@cap:experiments.list-experiments', '@cap:experiments.per-item-scores', '@cap:experiments.logs-tab', '@cap:experiments.copy-experiment-id'] }, async ({
     experiment,
     project,
     page,


### PR DESCRIPTION
## Details

**Stack layer 3 of 3 — the ticket itself.** Experiment traces were reachable only through a small "Go to logs" tag in the metadata row, which users kept missing: they look for their experiment traces under Logs, don't find them, and conclude nothing was recorded. This shows them as a **Logs** tab on the experiment page and drops the tag, so there is one way in.

- Traces are always scoped to the open experiment — or every experiment in a comparison — through the locked-scope mechanism. No scope indicator is drawn; the page already says which experiment this is.
- Tab availability becomes a pure function, so the test-suite and comparison rules are testable directly.
- Adds a **Copy ID** action to the header, following the pattern already used by the experiment comparison and test-suite panels. SDK features acting on an existing run needed the id, previously recoverable only from the page URL or an opt-in column. Hidden while comparing, where the id would be ambiguous. **Note: this item was raised in the ticket thread but never signed off by design** — it is isolated so it can be dropped without disturbing the tab.
- The sibling tabs (Results, Configuration) need the same toolbar sizing or the table jumps as you switch between them and this one. That lives in **#7845**, stacked directly on top of this PR, and is meant to land with it rather than after.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-6739

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: whole change — tab, scoping, Copy ID, sibling-tab alignment, tests
- Human verification: every scenario below driven in a browser against a local stack with purpose-seeded fixtures

## Testing

- `npm run typecheck`, `npx eslint src --max-warnings=0` — clean
- `npx vitest run` — 2326 pass, including 5 new cases on tab availability. The 6 failing localStorage test files fail identically on `main`.
- New e2e scenario in `experiments-smoke.spec.ts`; both new capabilities registered in `tests_end_to_end/coverage/taxonomy.yaml` and tagged on the spec.
- Manual, local stack, with fixtures seeded for the purpose:

  | Scenario | Result |
  |---|---|
  | Regular experiment | 6/6 rows, project holds 90 |
  | Test-suite experiment | tabs `Results · Configuration · Logs`; Insights and Feedback scores stay hidden; 4/4 rows, project holds 19 |
  | Compare (2 experiments) | Logs present, 8/8 rows, Copy ID hidden |
  | Date range | opens on All time; traces from three months back are visible |
  | Row click | trace details panel opens at page level |
  | Row selection | chip bar swaps for the selection action bar |
  | Toolbar alignment | Results / Configuration / Logs all render a 56px row, no gap above or below, all controls 24px (measured in the DOM) |

- Not run: Playwright e2e locally (needs a live stack); covered in CI.

## Documentation

None — the tab replaces an existing entry point; no documented behaviour changes.
