### PR TITLE
[OPIK-6739] [FE] fix: align the sibling experiment tabs with the Logs toolbar

### DIFF
--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel.tsx
@@ -195,6 +195,7 @@ const CompareExperimentsActionsPanel: React.FC<
       <EvaluateExperimentTracesButton experiment={singleExperiment} />
       {columnsToExport && (
         <ExportToButton
+          buttonSize="icon-2xs"
           disabled={
             disabled || columnsToExport.length === 0 || !isExportEnabled
           }

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ConfigurationTab/ConfigurationTab.tsx
@@ -169,7 +169,7 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
   return (
     <>
       <PageBodyStickyContainer
-        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4"
+        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-4"
         direction="bidirectional"
         limitWidth
       >
@@ -178,8 +178,8 @@ const ConfigurationTab: React.FunctionComponent<ConfigurationTabProps> = ({
             searchText={search as string}
             setSearchText={setSearch}
             placeholder="Search by name"
-            className="w-[320px]"
-            dimension="sm"
+            className="w-[200px] shrink-0"
+            dimension="xs"
           ></SearchInput>
           {promptVersions.map((pv) => (
             <NavigationTag

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/EvaluateExperimentTracesButton/EvaluateExperimentTracesButton.tsx
@@ -47,6 +47,7 @@ const Inner: React.FC<{ experiment: Experiment; projectId: string }> = ({
         disabled={isFetching}
         label="Evaluate"
         onClick={handleClick}
+        buttonSize="2xs"
       />
     </>
   );

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -654,7 +654,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
   return (
     <>
       <PageBodyStickyContainer
-        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 pb-6 pt-4"
+        className="-mt-4 flex flex-wrap items-center justify-between gap-x-8 gap-y-2 py-4"
         direction="bidirectional"
         limitWidth
       >
@@ -665,8 +665,8 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             placeholder={
               isTestSuite ? "Search test suite items" : "Search dataset items"
             }
-            className="w-[320px]"
-            dimension="sm"
+            className="w-[200px] shrink-0"
+            dimension="xs"
           />
           <FiltersButton
             columns={filterColumns}
@@ -674,6 +674,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             filters={filters}
             onChange={setFilters}
             layout="icon"
+            size="icon-2xs"
           />
         </div>
         <div className="flex items-center gap-2">
@@ -683,10 +684,11 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             columnsToExport={columnsToExport}
             experiments={experiments}
           />
-          <Separator orientation="vertical" className="mx-2 h-4" />
+          <Separator orientation="vertical" className="mx-[2px] h-4" />
           <DataTableRowHeightSelector
             type={height as ROW_HEIGHT}
             setType={setHeight}
+            size="icon-2xs"
           />
           <ColumnsButton
             columns={datasetColumnsData}
@@ -695,6 +697,8 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
             order={columnsOrder}
             onOrderChange={setColumnsOrder}
             sections={columnSections}
+            layout="labeled"
+            size="2xs"
           ></ColumnsButton>
         </div>
       </PageBodyStickyContainer>


### PR DESCRIPTION
## Details

**Stack layer 4 of 4 — split out deliberately.** Results and Configuration still carried the older 32px search and controls, so moving between them and the new Logs tab shifted the whole table up and down. This brings their search, filter, columns, row-size, Evaluate and export controls to the same 24px and their row padding to the same 16px.

> **Lands with #7843, not after it.** Split into its own PR only to keep the diff focused — the two are one user-visible change. Adding the Logs tab without this leaves the experiment page with a 24px toolbar on one tab and a 32px toolbar on the others, so the table jumps as you switch: that inconsistency is exactly what design review needs to not see. Note it does visibly change Results, the tab every experiment user lands on — its search shrinks 320→200px and Columns flips from icon to labelled.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- #7843

<!-- OPIK_6739 is resolved by #7843, the PR directly below this one in the stack; referencing it
     with an underscore here keeps this PR out of Jira's Development panel, per CONTRIBUTING.md. -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: whole change — control sizing and row padding on the sibling tabs
- Human verification: requested by the author after seeing the tabs side by side; measured in the DOM afterwards

## Testing

- `npm run typecheck`, `npx eslint src --max-warnings=0` — clean on this layer in isolation
- Measured in the browser against a local stack, on a single experiment and a comparison:

  | Tab | Toolbar row height | Gap to tabs | Gap to table | Control heights |
  |---|---|---|---|---|
  | Results | 57px | 0 | 0 | all 24px |
  | Configuration | 56px | 0 | 0 | all 24px |
  | Logs | 56px | 0 | 0 | all 24px |

- Before this change Results measured 72px with a 32px Evaluate button and a 32px filter funnel.

## Documentation

None — visual alignment only.
