### PR TITLE
[NA] [DOCS] fix: restore the star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Opik allows you to evaluate your LLM application during development through [Dat
 
 If you find Opik useful, please consider giving us a star! Your support helps us grow our community and continue improving the product.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+[![Star History Chart](https://star-history.dera.page/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
 
 <a id="-contributing"></a>
 ## 🤝 Contributing

--- a/readme_CN.md
+++ b/readme_CN.md
@@ -376,7 +376,7 @@ Opik 允许你在开发阶段通过[数据集](https://www.comet.com/docs/opik/v
 
 如果你觉得 Opik 有用，请考虑给我们点个 star！你的支持将帮助我们壮大社区并持续改进产品。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+[![Star History Chart](https://star-history.dera.page/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
 
 <a id="-contributing"></a>
 ## 🤝 参与贡献

--- a/readme_DE.md
+++ b/readme_DE.md
@@ -376,7 +376,7 @@ Mit Opik können Sie Ihre LLM-Anwendung während der Entwicklung anhand von [Dat
 
 Wenn Sie Opik nützlich finden, geben Sie uns bitte einen Stern! Ihre Unterstützung hilft uns, unsere Community wachsen zu lassen und das Produkt weiter zu verbessern.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+[![Star History Chart](https://star-history.dera.page/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
 
 <a id="-contributing"></a>
 ## 🤝 Mitwirken

--- a/readme_ES.md
+++ b/readme_ES.md
@@ -375,7 +375,7 @@ Opik te permite evaluar tu aplicación de LLM durante el desarrollo a través de
 
 Si Opik te resulta útil, ¡considera darnos una estrella! Tu apoyo nos ayuda a hacer crecer nuestra comunidad y a seguir mejorando el producto.
 
-[![Gráfico del historial de estrellas](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+[![Gráfico del historial de estrellas](https://star-history.dera.page/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
 
 <a id="-contributing"></a>
 ## 🤝 Contribuir

--- a/readme_FR.md
+++ b/readme_FR.md
@@ -376,7 +376,7 @@ Opik vous permet d'évaluer votre application LLM pendant le développement grâ
 
 Si vous trouvez Opik utile, envisagez de nous donner une étoile ! Votre soutien nous aide à faire grandir notre communauté et à continuer d'améliorer le produit.
 
-[![Graphique de l'historique des étoiles](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+[![Graphique de l'historique des étoiles](https://star-history.dera.page/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
 
 <a id="-contributing"></a>
 ## 🤝 Contribuer


### PR DESCRIPTION
The Star History chart in the project READMEs is currently broken: the image no longer renders, leaving a broken placeholder on the GitHub project page.

This change points the chart to a working mirror in all five READMEs (English, French, German, Chinese, and Spanish) so the stargazer history displays again. Only the chart image is updated; the rest of the README content is untouched.