### PR TITLE
[OPIK-7919] [BE] perf: engage traces_final_ids prefilter for thread-id lookups

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -79,7 +79,8 @@ class ThreadDAOImpl implements ThreadDAO {
      * <p>
      * Please refer to the SELECT_TRACES_THREAD_BY_ID query for more details.
      ***/
-    private static final String SELECT_TRACES_THREADS_BY_PROJECT_IDS = """
+    @VisibleForTesting
+    static final String SELECT_TRACES_THREADS_BY_PROJECT_IDS = """
             WITH <if(traces_final_ids)>traces_final_ids AS (
                 SELECT DISTINCT id, thread_id
                 FROM (
@@ -1360,11 +1361,26 @@ class ThreadDAOImpl implements ThreadDAO {
      * in the thread list and count queries. Mirrors {@code TraceDAO#shouldUseTraceIdPrefilter}.
      *
      * <p>Only activates when there are narrowing predicates beyond the workspace/project/uuid-range filters:
-     * either a free-text search or a TRACE-strategy filter ({@code <filters>}). When neither is present,
-     * the downstream CTEs apply the uuid range directly, skipping the prefilter scan.
+     * a free-text search, a TRACE-strategy filter ({@code <filters>}), or the thread_id EQUAL pushdown
+     * ({@code traces_pushdown_filter}). When none is present, the downstream CTEs apply the uuid range
+     * directly, skipping the prefilter scan.
+     *
+     * <p>OPIK-7919: a thread_id EQUAL filter is a TRACE_THREAD-strategy filter, so it sets
+     * {@code trace_thread_filters} / {@code traces_pushdown_filter} but never {@code filters}. Without the
+     * third condition the prefilter stayed off for every single-thread lookup, and spans_deduped deduped
+     * the whole project before being LEFT JOINed against one thread's traces — 6M rows / 1.2 GiB and ~5s
+     * for a LIMIT 1 read on production. traces_final_ids already renders the same thread_id predicate, so
+     * enabling it here narrows the spans scan to that thread's trace ids.
+     *
+     * <p>Only {@code traces_pushdown_filter} is included, not {@code trace_thread_filters} at large: the
+     * other TRACE_THREAD filters (status, tags, ...) are applied by the outer query, not inside
+     * traces_final_ids, so they would not narrow the prefilter scan and would pay for it for nothing.
      */
-    private static boolean shouldUseTracesFinalIdsPrefilter(TraceSearchCriteria criteria, ST template) {
-        return criteria.searchText() != null || template.getAttribute("filters") != null;
+    @VisibleForTesting
+    static boolean shouldUseTracesFinalIdsPrefilter(TraceSearchCriteria criteria, ST template) {
+        return criteria.searchText() != null
+                || template.getAttribute("filters") != null
+                || template.getAttribute("traces_pushdown_filter") != null;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -495,7 +495,8 @@ class ThreadDAOImpl implements ThreadDAO {
      * <p>
      * Please refer to the SELECT_TRACES_THREAD_BY_ID query for more details.
      ***/
-    private static final String SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS = """
+    @VisibleForTesting
+    static final String SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS = """
             WITH <if(traces_final_ids)>traces_final_ids AS (
                 SELECT DISTINCT id, thread_id
                 FROM (
@@ -1014,7 +1015,8 @@ class ThreadDAOImpl implements ThreadDAO {
      * 1. First level: Uses the same thread aggregation as SELECT_TRACES_THREADS_BY_PROJECT_IDS (reusing the exact CTEs and aggregation logic)
      * 2. Second level: Wraps the thread results and calculates stats across all threads (AVG, SUM, quantiles)
      ***/
-    private static final String SELECT_TRACE_THREADS_STATS = """
+    @VisibleForTesting
+    static final String SELECT_TRACE_THREADS_STATS = """
             SELECT
                 threads.workspace_id as workspace_id,
                 threads.project_id as project_id,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -567,6 +567,7 @@ class ThreadDAOImpl implements ThreadDAO {
                         AND thread_id IN (SELECT thread_id FROM traces_final_ids)
                     <endif>
                 <endif>
+                <if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>
                 ORDER BY (workspace_id, project_id, thread_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
             )

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
@@ -8,12 +8,16 @@ import com.comet.opik.infrastructure.FilterUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,6 +152,65 @@ class ThreadDAOImplTest {
         }
 
         private record Rendered(ST template, boolean gateOpen) {
+        }
+    }
+
+    @Nested
+    @DisplayName("thread_id pushdown across the templates that share it")
+    class ThreadIdPushdownTemplateSync {
+
+        private static final String THREAD_ID_PUSHDOWN = "AND thread_id = :thread_id_pushdown";
+        private static final String TRACES_FINAL_IDS_IN = "thread_id IN (SELECT thread_id FROM traces_final_ids)";
+        private static final String SEARCH_CLAUSE = "ilike(thread_id, :search_text)";
+
+        static Stream<Arguments> templatesSharingThePushdown() {
+            return Stream.of(
+                    Arguments.of("list", ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS),
+                    Arguments.of("count", ThreadDAOImpl.SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS),
+                    Arguments.of("stats", ThreadDAOImpl.SELECT_TRACE_THREADS_STATS));
+        }
+
+        /**
+         * OPIK-7919: on the uuid_from_time branch trace_threads_final skips the traces_final_ids IN, so the
+         * thread_id equality is the only predicate left that prunes — and trace_threads is
+         * ORDER BY (workspace_id, project_id, thread_id, id), so it prunes on the primary key while
+         * {@code id >= :uuid_from_time} cannot. The count template was missing this line while the list and
+         * stats templates had it, which left countThreadTotal scanning every trace_threads row of the
+         * project. This pins all three templates to emit it identically.
+         */
+        @ParameterizedTest(name = "{0} template")
+        @MethodSource("templatesSharingThePushdown")
+        @DisplayName("trace_threads_final emits the thread_id pushdown on the uuid_from_time branch")
+        void traceThreadsFinalEmitsThreadIdPushdownOnUuidBranch(String name, String query) {
+            var criteria = TraceSearchCriteria.builder()
+                    .projectId(UUID.randomUUID())
+                    .uuidFromTime(UUID.randomUUID())
+                    .filters(List.of(TraceThreadFilter.builder()
+                            .field(TraceThreadField.ID)
+                            .operator(Operator.EQUAL)
+                            .value("thread-1")
+                            .build()))
+                    .build();
+
+            var template = FilterUtils.newTraceThreadFindTemplate(query, criteria, SEARCH_CLAUSE, true);
+            if (ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(criteria, template)) {
+                template.add("traces_final_ids", true);
+            }
+
+            var traceThreadsFinal = traceThreadsFinalCte(template.render());
+
+            assertThat(traceThreadsFinal).contains("AND id >= :uuid_from_time");
+            assertThat(traceThreadsFinal).doesNotContain(TRACES_FINAL_IDS_IN);
+            assertThat(traceThreadsFinal).contains(THREAD_ID_PUSHDOWN);
+        }
+
+        /** The trace_threads_final CTE body, up to its ORDER BY — so the assertions cannot match another CTE. */
+        private static String traceThreadsFinalCte(String sql) {
+            int start = sql.indexOf("trace_threads_final AS (");
+            assertThat(start).isNotNegative();
+            int end = sql.indexOf("ORDER BY (workspace_id, project_id, thread_id, id)", start);
+            assertThat(end).isGreaterThan(start);
+            return sql.substring(start, end);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
@@ -8,6 +8,7 @@ import com.comet.opik.infrastructure.FilterUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.stringtemplate.v4.ST;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
@@ -51,27 +52,43 @@ class ThreadDAOImplTest {
     class TracesFinalIdsPrefilterGate {
 
         private static final String SPANS_PREFILTER = "AND trace_id IN (SELECT id FROM traces_final_ids)";
-        // searchClause is only consulted when searchText is set; these cases never set it.
-        private static final String UNUSED_SEARCH_CLAUSE = "ilike(thread_id, :search_text)";
+        // Rendered into the query only when searchText is set (FilterUtils#newTraceThreadFindTemplate);
+        // the searchText case below is the one that exercises it.
+        private static final String SEARCH_CLAUSE = "ilike(thread_id, :search_text)";
 
-        private static ThreadCriteriaAndTemplate render(List<TraceThreadFilter> filters) {
+        /**
+         * Mirrors the production wiring in {@link ThreadDAOImpl#search}: the {@code traces_final_ids}
+         * attribute is added only when the gate says so, so the rendered SQL asserted below is a function
+         * of the gate's result rather than of the test's own setup.
+         */
+        private static Rendered render(List<TraceThreadFilter> filters, String searchText) {
             var criteria = TraceSearchCriteria.builder()
                     .projectId(UUID.randomUUID())
                     .filters(filters)
+                    .searchText(searchText)
                     .build();
             var template = FilterUtils.newTraceThreadFindTemplate(
-                    ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria, UNUSED_SEARCH_CLAUSE, true);
-            return new ThreadCriteriaAndTemplate(criteria, template);
+                    ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria, SEARCH_CLAUSE, true);
+
+            boolean gateOpen = ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(criteria, template);
+            if (gateOpen) {
+                template.add("traces_final_ids", true);
+            }
+            return new Rendered(template, gateOpen);
+        }
+
+        private static Rendered renderWithFilter(TraceThreadField field, Operator operator, String value) {
+            return render(List.of(TraceThreadFilter.builder()
+                    .field(field)
+                    .operator(operator)
+                    .value(value)
+                    .build()), null);
         }
 
         @Test
         @DisplayName("OPIK-7919: a thread_id EQUAL filter turns the prefilter on and narrows the spans scan")
         void threadIdEqualFilterActivatesPrefilter() {
-            var rendered = render(List.of(TraceThreadFilter.builder()
-                    .field(TraceThreadField.ID)
-                    .operator(Operator.EQUAL)
-                    .value("thread-1")
-                    .build()));
+            var rendered = renderWithFilter(TraceThreadField.ID, Operator.EQUAL, "thread-1");
 
             // The regression this guards: a thread-ID filter is a TRACE_THREAD-strategy filter, so it never
             // sets "filters". Gating only on "filters" left the prefilter off and spans_deduped scanned the
@@ -79,11 +96,20 @@ class ThreadDAOImplTest {
             assertThat(rendered.template().getAttribute("filters")).isNull();
             assertThat(rendered.template().getAttribute("traces_pushdown_filter")).isNotNull();
 
-            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
-                    .isTrue();
-
-            rendered.template().add("traces_final_ids", true);
+            assertThat(rendered.gateOpen()).isTrue();
             assertThat(rendered.template().render()).contains(SPANS_PREFILTER);
+        }
+
+        @Test
+        @DisplayName("an ID filter with a non-EQUAL operator does not reach the pushdown or the prefilter")
+        void threadIdContainsFilterDoesNotActivatePrefilter() {
+            // findTraceThreadIdPushdownFilter is EQUAL-only because the pushdown SQL is hardcoded to
+            // `thread_id = :thread_id_pushdown`; a CONTAINS filter answered as an equality would be wrong.
+            var rendered = renderWithFilter(TraceThreadField.ID, Operator.CONTAINS, "thread");
+
+            assertThat(rendered.template().getAttribute("traces_pushdown_filter")).isNull();
+            assertThat(rendered.gateOpen()).isFalse();
+            assertThat(rendered.template().render()).doesNotContain(SPANS_PREFILTER);
         }
 
         @Test
@@ -91,43 +117,37 @@ class ThreadDAOImplTest {
         void nonPushdownThreadFilterDoesNotActivatePrefilter() {
             // status/tags/... are applied by the outer query, not inside traces_final_ids, so enabling the
             // prefilter for them would pay for the extra traces scan without narrowing it.
-            var rendered = render(List.of(TraceThreadFilter.builder()
-                    .field(TraceThreadField.STATUS)
-                    .operator(Operator.EQUAL)
-                    .value("active")
-                    .build()));
+            var rendered = renderWithFilter(TraceThreadField.STATUS, Operator.EQUAL, "active");
 
             assertThat(rendered.template().getAttribute("trace_thread_filters")).isNotNull();
             assertThat(rendered.template().getAttribute("traces_pushdown_filter")).isNull();
 
-            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
-                    .isFalse();
+            assertThat(rendered.gateOpen()).isFalse();
+            assertThat(rendered.template().render()).doesNotContain(SPANS_PREFILTER);
         }
 
         @Test
         @DisplayName("no narrowing predicate leaves the prefilter off and the spans scan unrestricted")
         void noNarrowingPredicateLeavesPrefilterOff() {
-            var rendered = render(null);
+            var rendered = render(null, null);
 
-            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
-                    .isFalse();
+            assertThat(rendered.gateOpen()).isFalse();
             assertThat(rendered.template().render()).doesNotContain(SPANS_PREFILTER);
         }
 
         @Test
-        @DisplayName("a free-text search still turns the prefilter on")
-        void searchTextActivatesPrefilter() {
-            var criteria = TraceSearchCriteria.builder()
-                    .projectId(UUID.randomUUID())
-                    .searchText("needle")
-                    .build();
-            var template = FilterUtils.newTraceThreadFindTemplate(
-                    ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria, UNUSED_SEARCH_CLAUSE, true);
+        @DisplayName("a free-text search satisfies the gate (the listing path may still prefer the page-pushdown)")
+        void searchTextSatisfiesTheGate() {
+            // Scoped to the gate on purpose: in ThreadDAOImpl#find a search-only criteria is page-pushdown
+            // eligible ("search_text" is not a PAGE_PUSHDOWN_DISQUALIFIER), so the listing query never
+            // reaches this branch. The gate result still holds for search/stats/count.
+            var rendered = render(null, "needle");
 
-            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(criteria, template)).isTrue();
+            assertThat(rendered.gateOpen()).isTrue();
+            assertThat(rendered.template().render()).contains(SPANS_PREFILTER);
         }
 
-        private record ThreadCriteriaAndTemplate(TraceSearchCriteria criteria, org.stringtemplate.v4.ST template) {
+        private record Rendered(ST template, boolean gateOpen) {
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
@@ -1,10 +1,18 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.TraceThread;
+import com.comet.opik.api.filter.Operator;
+import com.comet.opik.api.filter.TraceThreadField;
+import com.comet.opik.api.filter.TraceThreadFilter;
+import com.comet.opik.infrastructure.FilterUtils;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,5 +44,90 @@ class ThreadDAOImplTest {
     void firstThreadOrEmptyCompletesEmptyForEmptyStream() {
         StepVerifier.create(ThreadDAOImpl.firstThreadOrEmpty(Flux.empty()))
                 .verifyComplete();
+    }
+
+    @Nested
+    @DisplayName("traces_final_ids prefilter gate")
+    class TracesFinalIdsPrefilterGate {
+
+        private static final String SPANS_PREFILTER = "AND trace_id IN (SELECT id FROM traces_final_ids)";
+        // searchClause is only consulted when searchText is set; these cases never set it.
+        private static final String UNUSED_SEARCH_CLAUSE = "ilike(thread_id, :search_text)";
+
+        private static ThreadCriteriaAndTemplate render(List<TraceThreadFilter> filters) {
+            var criteria = TraceSearchCriteria.builder()
+                    .projectId(UUID.randomUUID())
+                    .filters(filters)
+                    .build();
+            var template = FilterUtils.newTraceThreadFindTemplate(
+                    ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria, UNUSED_SEARCH_CLAUSE, true);
+            return new ThreadCriteriaAndTemplate(criteria, template);
+        }
+
+        @Test
+        @DisplayName("OPIK-7919: a thread_id EQUAL filter turns the prefilter on and narrows the spans scan")
+        void threadIdEqualFilterActivatesPrefilter() {
+            var rendered = render(List.of(TraceThreadFilter.builder()
+                    .field(TraceThreadField.ID)
+                    .operator(Operator.EQUAL)
+                    .value("thread-1")
+                    .build()));
+
+            // The regression this guards: a thread-ID filter is a TRACE_THREAD-strategy filter, so it never
+            // sets "filters". Gating only on "filters" left the prefilter off and spans_deduped scanned the
+            // whole project for a single-thread lookup.
+            assertThat(rendered.template().getAttribute("filters")).isNull();
+            assertThat(rendered.template().getAttribute("traces_pushdown_filter")).isNotNull();
+
+            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
+                    .isTrue();
+
+            rendered.template().add("traces_final_ids", true);
+            assertThat(rendered.template().render()).contains(SPANS_PREFILTER);
+        }
+
+        @Test
+        @DisplayName("a TRACE_THREAD filter that is not the id pushdown leaves the prefilter off")
+        void nonPushdownThreadFilterDoesNotActivatePrefilter() {
+            // status/tags/... are applied by the outer query, not inside traces_final_ids, so enabling the
+            // prefilter for them would pay for the extra traces scan without narrowing it.
+            var rendered = render(List.of(TraceThreadFilter.builder()
+                    .field(TraceThreadField.STATUS)
+                    .operator(Operator.EQUAL)
+                    .value("active")
+                    .build()));
+
+            assertThat(rendered.template().getAttribute("trace_thread_filters")).isNotNull();
+            assertThat(rendered.template().getAttribute("traces_pushdown_filter")).isNull();
+
+            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
+                    .isFalse();
+        }
+
+        @Test
+        @DisplayName("no narrowing predicate leaves the prefilter off and the spans scan unrestricted")
+        void noNarrowingPredicateLeavesPrefilterOff() {
+            var rendered = render(null);
+
+            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(rendered.criteria(), rendered.template()))
+                    .isFalse();
+            assertThat(rendered.template().render()).doesNotContain(SPANS_PREFILTER);
+        }
+
+        @Test
+        @DisplayName("a free-text search still turns the prefilter on")
+        void searchTextActivatesPrefilter() {
+            var criteria = TraceSearchCriteria.builder()
+                    .projectId(UUID.randomUUID())
+                    .searchText("needle")
+                    .build();
+            var template = FilterUtils.newTraceThreadFindTemplate(
+                    ThreadDAOImpl.SELECT_TRACES_THREADS_BY_PROJECT_IDS, criteria, UNUSED_SEARCH_CLAUSE, true);
+
+            assertThat(ThreadDAOImpl.shouldUseTracesFinalIdsPrefilter(criteria, template)).isTrue();
+        }
+
+        private record ThreadCriteriaAndTemplate(TraceSearchCriteria criteria, org.stringtemplate.v4.ST template) {
+        }
     }
 }


### PR DESCRIPTION
## Details

`search_threads` reads every span in the project even when the request targets a single thread — ~6M rows / 1.2 GiB and ~5s for a `LIMIT 1` lookup on production. `spans_deduped` is only restricted by trace id when the `traces_final_ids` attribute is set, and the gate for it fired solely on `searchText` or the `filters` attribute; a thread-ID filter is a `TRACE_THREAD`-strategy filter, so it sets `trace_thread_filters` / `traces_pushdown_filter` and never `filters`. The prefilter therefore never engaged for a thread-scoped lookup, and the whole project's spans were deduped before being LEFT JOINed against one thread's traces.

- This adds `traces_pushdown_filter` to the gate. `traces_final_ids` already renders the same `thread_id = :thread_id_pushdown` predicate, so no SQL change is needed — only the gate was wrong.
- Deliberately not `trace_thread_filters` at large: the other TRACE_THREAD filters (status, tags, ...) are applied by the outer query, not inside `traces_final_ids`, so they would pay for the prefilter scan without narrowing it. Covered by a test.
- The gate is shared with `find_threads_by_project`, `thread_stats` and `count_threads_by_project`, but the shared gate alone was not enough for the count path: `SELECT_COUNT_TRACES_THREADS_BY_PROJECT_IDS`'s `trace_threads_final` was the only one of the three templates missing `<if(traces_pushdown_filter)> AND thread_id = :thread_id_pushdown <endif>`, so with a `uuid_from_time` range it took the uuid branch, skipped the `traces_final_ids` IN and never got the equality — scanning every `trace_threads` row of the project. This adds that line so all three templates emit the pushdown identically.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7919

<!--
Related but NOT resolved here: the spans-FINAL work under OPIK_7638 and its sub-tasks OPIK_7845 / OPIK_7846. Those target TraceDAO.SELECT_BY_PROJECT_ID, TraceDAO.SELECT_FEEDBACK_SCORES_STATS and ThreadDAO.SELECT_TRACES_THREAD_BY_ID. This PR touches a different constant (SELECT_TRACES_THREADS_BY_PROJECT_IDS) and is a missing predicate, not a deduplication-strategy change — no overlap in either direction.
-->

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5 (`claude-opus-5`, 1M context)
  - Scope: Whole change authored by the agent — production `query_log` profiling that found the defect, root-cause tracing through the template gate, the gate change, the tests, the production A/B replay harness, and this PR description.
  - Human verification: The human directed the investigation, chose the validation scope (multiple workspace and project sizes before opening a PR), and instructed the commit and PR. Test runs and benchmarks were executed and their output read by the agent. **The diff itself has not yet been reviewed line by line by a human — that review is still owed before merge.**

## Testing

Commands run, from `apps/opik-backend`:

- `mvn test -Dtest="FindTraceThreadsResourceTest,ThreadDAOImplTest"` → **478 tests, 0 failures, 0 errors**
- `mvn spotless:check` → exit 0
- `mvn compile -DskipTests` → exit 0

Scenarios validated:

- **Regression guard.** `ThreadDAOImplTest$TracesFinalIdsPrefilterGate` asserts that a `thread_id` EQUAL filter leaves `filters` unset (the exact reason the old gate missed it), turns the gate on, and renders `AND trace_id IN (SELECT id FROM traces_final_ids)` into the spans CTE. The helper mirrors the production wiring — the `traces_final_ids` attribute is added only when the gate returns true — so the rendered-SQL assertions are a function of the gate rather than of the test setup. Verified discriminating in both directions: reverting the gate to its pre-fix condition fails `threadIdEqualFilterActivatesPrefilter`; hardcoding the gate to `true` fails all three negative cases. Negative cases cover a non-pushdown TRACE_THREAD filter (status), an ID filter with a non-EQUAL operator (CONTAINS, which must not reach the EQUAL-only pushdown), and no predicate at all.
- **Production A/B, 9 workspaces / 9 projects.** Real `search_threads` queries captured from `system.query_log` and replayed unmodified against their own workspaces, baseline vs patched, spanning 168K → 37M rows read and limits 1 → 2000. Output compared by sha1 over the full TSV result — **byte-identical in every case, in both run orders**.

  | case | thread filter | baseline | patched | rows read (base → patched) |
  |---|---|---|---|---|
  | C05 | yes | 4465 ms | **115 ms** | 6.55M → 519K |
  | C08 | yes | 24121 ms | **188 ms** | 20.98M → 529K |
  | C01–C04, C06, C07, C09 | no | 106 ms – 57.3 s | neutral | unchanged |

- **Cache control.** Every case was re-run with the patched variant cold-first. The apparent gains on the no-thread-filter cases are page-cache artifacts — `read_rows` is unchanged there, confirming the prefilter correctly cannot help when `traces_final` is not narrowed. Reversed order: C04 1.399s (patched) vs 1.460s (baseline), C06 6.051 vs 6.212, C05 0.122 vs 4.816, C08 0.198 vs 22.078. The change is a large win where it applies and neutral everywhere else.
- **As-generated SQL, not a hand-patch.** The measurements above were re-run using the SQL the DAO actually emits once the gate fires (a real `traces_final_ids` CTE, not an inlined predicate): 0.107s vs 4.854s (C05) and 0.162s vs 18.478s (C08), same byte-identical output.
- **Count-template regression guard.** `ThreadDAOImplTest$ThreadIdPushdownTemplateSync` renders all three templates that share the `traces_pushdown_filter` concept (list, count, stats) through the same gate with a `uuid_from_time` range, slices out the `trace_threads_final` CTE and asserts it takes the uuid branch, omits the `traces_final_ids` IN, and still emits `AND thread_id = :thread_id_pushdown`. Verified discriminating: deleting the new line from the count template fails only the `count` case, list and stats stay green.
- **Count-template change verified separately on production.** The A/B above is captured `search_threads` traffic, which exercises the list path, not `countThreadTotal()`. So the count fix was measured on its own:
  - Full query: a real `count_threads_by_project` query captured from `system.query_log` (uuid range + `source` filter), replayed with a thread-ID filter added, with and without the new line — **identical result (`count=1`) both ways**.
  - The `trace_threads_final` CTE in isolation, on the project with the most threads (5.8M `trace_threads` rows), patched run cold first:

    | variant | time | rows read | bytes | peak memory | selected marks |
    |---|---|---|---|---|---|
    | baseline | 2917 ms | 5,881,000 | 759.81 MiB | 707.60 MiB | 719 |
    | patched | **5 ms** | **81,060** | **4.74 MiB** | **83.74 KiB** | **11** |

    `trace_threads` is `ORDER BY (workspace_id, project_id, thread_id, id)`, so the equality is primary-key prunable while `id >= :uuid_from_time` is not — marks drop 719 → 11.
- **Not run:** the full backend suite. The gate is exercised by four call sites in `ThreadDAO`; the thread resource suite plus the new unit tests cover them.

Environment: local process mode, macOS, testcontainers via Docker 29.7.2. Production replay ran read-only against `opik_prod` as the `agentro` read-only user.

## Documentation

No documentation update needed — internal DAO query-planning change with no API, schema, or SDK surface.
