### PR TITLE
[OPIK-7849] [SDK] fix: append %s to LOGGER.debug format strings in stream error paths

### DIFF
--- a/sdks/python/src/opik/decorator/generator_wrappers.py
+++ b/sdks/python/src/opik/decorator/generator_wrappers.py
@@ -80,7 +80,7 @@ class BaseTrackedGenerator(Generic[YieldType]):
 
     def _handle_generator_exception_before_raising(self, exception: Exception) -> None:
         LOGGER.debug(
-            "Exception raised from tracked generator",
+            "Exception raised from tracked generator: %s",
             str(exception),
             exc_info=True,
         )

--- a/sdks/python/src/opik/integrations/anthropic/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/anthropic/stream_patchers.py
@@ -88,7 +88,7 @@ def patch_sync_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from anthropic.Stream.",
+                    "Exception raised from anthropic.Stream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -150,7 +150,7 @@ def patch_async_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from anthropic.AsyncStream.",
+                    "Exception raised from anthropic.AsyncStream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -222,7 +222,7 @@ def patch_sync_message_stream_manager(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from anthropic.MessageStream.",
+                    "Exception raised from anthropic.MessageStream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -312,7 +312,7 @@ def patch_async_message_stream_manager(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from anthropic.AsyncMessageStream.",
+                    "Exception raised from anthropic.AsyncMessageStream: %s",
                     str(exception),
                     exc_info=True,
                 )

--- a/sdks/python/src/opik/integrations/bedrock/converse/stream_wrappers.py
+++ b/sdks/python/src/opik/integrations/bedrock/converse/stream_wrappers.py
@@ -29,7 +29,7 @@ def wrap_stream(
             yield item
     except Exception as exception:
         LOGGER.debug(
-            "Exception raised from botocore.eventstream.EventStream.",
+            "Exception raised from botocore.eventstream.EventStream: %s",
             str(exception),
             exc_info=True,
         )

--- a/sdks/python/src/opik/integrations/genai/stream_wrappers.py
+++ b/sdks/python/src/opik/integrations/genai/stream_wrappers.py
@@ -38,7 +38,7 @@ def wrap_sync_iterator(
             yield item
     except Exception as exception:
         LOGGER.debug(
-            "Exception raised in genai response stream.",
+            "Exception raised in genai response stream: %s",
             str(exception),
             exc_info=True,
         )
@@ -75,7 +75,7 @@ async def wrap_async_iterator(
             yield item
     except Exception as exception:
         LOGGER.debug(
-            "Exception raised in genai response stream.",
+            "Exception raised in genai response stream: %s",
             str(exception),
             exc_info=True,
         )

--- a/sdks/python/src/opik/integrations/groq/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/groq/stream_patchers.py
@@ -41,7 +41,7 @@ def patch_sync_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from groq.Stream.",
+                    "Exception raised from groq.Stream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -94,7 +94,7 @@ def patch_async_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from groq.AsyncStream.",
+                    "Exception raised from groq.AsyncStream: %s",
                     str(exception),
                     exc_info=True,
                 )

--- a/sdks/python/src/opik/integrations/openai/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/openai/stream_patchers.py
@@ -57,7 +57,7 @@ def patch_sync_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from openai.Stream.",
+                    "Exception raised from openai.Stream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -120,7 +120,7 @@ def patch_async_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from openai.AsyncStream.",
+                    "Exception raised from openai.AsyncStream: %s",
                     str(exception),
                     exc_info=True,
                 )

--- a/sdks/python/tests/unit/decorator/test_debug_log_format_strings.py
+++ b/sdks/python/tests/unit/decorator/test_debug_log_format_strings.py
@@ -1,0 +1,126 @@
+"""Regression for OPIK-7849: 12 LOGGER.debug calls in stream/generator error paths
+were passing str(exception) as a positional argument to a format string that had no
+%s placeholder, so logging's msg % args interpolation raised TypeError and silently
+dropped the record.
+
+The test scans the affected source files and asserts that every LOGGER.debug call
+in an `except Exception as exception:` block that passes `str(exception)` as a
+positional arg has a corresponding `%s` in its format string. The check is
+intentionally static (no module import) so it runs without the integration SDKs
+(anthropic, openai, etc.) being installed.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# (relative-path from sdks/python, expected error-path format string).
+# Each entry pins a single LOGGER.debug(...) call site that was fixed. If the
+# call site is renamed or moved, the regression test fails loudly so the next
+# person can update both the source and the test in one change.
+AFFECTED_CALL_SITES = [
+    (
+        "src/opik/decorator/generator_wrappers.py",
+        "Exception raised from tracked generator: %s",
+    ),
+    (
+        "src/opik/integrations/anthropic/stream_patchers.py",
+        "Exception raised from anthropic.Stream: %s",
+    ),
+    (
+        "src/opik/integrations/anthropic/stream_patchers.py",
+        "Exception raised from anthropic.AsyncStream: %s",
+    ),
+    (
+        "src/opik/integrations/anthropic/stream_patchers.py",
+        "Exception raised from anthropic.MessageStream: %s",
+    ),
+    (
+        "src/opik/integrations/anthropic/stream_patchers.py",
+        "Exception raised from anthropic.AsyncMessageStream: %s",
+    ),
+    (
+        "src/opik/integrations/bedrock/converse/stream_wrappers.py",
+        "Exception raised from botocore.eventstream.EventStream: %s",
+    ),
+    (
+        "src/opik/integrations/genai/stream_wrappers.py",
+        "Exception raised in genai response stream: %s",
+    ),
+    (
+        "src/opik/integrations/groq/stream_patchers.py",
+        "Exception raised from groq.Stream: %s",
+    ),
+    (
+        "src/opik/integrations/groq/stream_patchers.py",
+        "Exception raised from groq.AsyncStream: %s",
+    ),
+    (
+        "src/opik/integrations/openai/stream_patchers.py",
+        "Exception raised from openai.Stream: %s",
+    ),
+    (
+        "src/opik/integrations/openai/stream_patchers.py",
+        "Exception raised from openai.AsyncStream: %s",
+    ),
+]
+
+# Pattern that captures a LOGGER.debug call passing str(exception) as a positional
+# argument to a format string. The captured group is the format string; the regex
+# is non-greedy on the string literal so it stops at the first closing quote.
+LOGGER_DEBUG_WITH_EXCEPTION_PATTERN = re.compile(
+    r'LOGGER\.debug\(\s*"([^"]*)"\s*,\s*str\(\s*exception\s*\)',
+    re.DOTALL,
+)
+
+
+def _scan_log_format_strings(relative_path: str) -> list[tuple[str, int]]:
+    """Return [(format_string, line_number), ...] for every LOGGER.debug that
+    passes str(exception) as a positional argument, anywhere in the file.
+
+    Some call sites are inside a helper method that an `except` block calls (e.g.
+    `generator_wrappers.py:_handle_generator_exception_before_raising`); others are
+    inline in the `except` block itself. Scanning the whole file covers both.
+    """
+    source_path = Path(__file__).resolve().parents[3] / relative_path
+    with open(source_path, encoding="utf-8") as fp:
+        source = fp.read()
+    return [
+        (match.group(1), source[: match.start()].count("\n") + 1)
+        for match in LOGGER_DEBUG_WITH_EXCEPTION_PATTERN.finditer(source)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("relative_path", "expected_format"),
+    AFFECTED_CALL_SITES,
+    ids=[f"{p}::{expected}" for p, expected in AFFECTED_CALL_SITES],
+)
+def test_log_format_string_has_placeholder_for_exception(
+    relative_path: str, expected_format: str
+) -> None:
+    """Pin the exact format string used by each fixed call site. If a future
+    refactor drops the %s, this test fails."""
+    found = _scan_log_format_strings(relative_path)
+    matching = [fmt for fmt, _ in found if fmt == expected_format]
+    assert matching, (
+        f"{relative_path}: expected format string {expected_format!r} not found. "
+        f"Found: {[fmt for fmt, _ in found]!r}. If the call site was renamed, "
+        "update both the source and this test in the same change."
+    )
+
+
+def test_no_remaining_broken_log_calls() -> None:
+    """Sanity: every LOGGER.debug(...) call in an except block that passes
+    str(exception) as a positional arg has a %s in its format string. This
+    catches new call sites that follow the same pattern but are not in the
+    fixed list yet."""
+    for relative_path, _ in AFFECTED_CALL_SITES:
+        for fmt, line_number in _scan_log_format_strings(relative_path):
+            assert "%s" in fmt, (
+                f"{relative_path}:{line_number}: format string {fmt!r} is passed "
+                "str(exception) but has no %s placeholder. With debug logging "
+                "enabled, logging's msg % args interpolation raises TypeError and "
+                "silently drops the record (see OPIK-7849)."
+            )


### PR DESCRIPTION
## Details

Twelve `LOGGER.debug(...)` calls in the streaming / generator error paths pass `str(exception)` as a positional argument to a format string with no `%s` placeholder. With DEBUG logging enabled, logging's `msg % args` interpolation raises `TypeError: not all arguments converted during string formatting` inside `Handler.emit`, and the record is silently dropped — the message and the `exc_info` traceback never reach the handler.

The fix appends `: %s` to each of the 12 affected format strings so the exception string is rendered into the record. The two `anthropic.BetaMessageStream` / `anthropic.BetaAsyncMessageStream` sites (lines 405, 489) also log the same message but do not pass `str(exception)` at all; those are a different fix (include the exception in the log) and are out of scope here.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7849

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.6
- Scope: 12-line `: %s` append across 6 source files + static regression test that scans for the broken pattern
- Human verification: locally ran `pytest tests/unit/decorator/test_debug_log_format_strings.py` (12 passed) and a sanity test reverting one fix (2 failed with a clear error pointing at the reverted call site); also ran `ruff format` / `ruff check` / `mypy` clean

## Testing

- `cd sdks/python && pytest tests/unit/decorator/test_debug_log_format_strings.py` — 12/12 pass (11 parametrized format-string pin tests + 1 sanity check that catches any new `LOGGER.debug(..., str(exception), ...)` call without a `%s`)
- `cd sdks/python && pytest tests/unit/decorator/` — 155/155 pass (no regression in the broader decorator test suite)
- `ruff format` and `ruff check` — clean
- `mypy tests/unit/decorator/test_debug_log_format_strings.py` — no issues
- Manual sanity test: temporarily reverted one fix (`%s` removed from the openai.Stream format string); the regression test caught it with `AssertionError: src/opik/integrations/openai/stream_patchers.py:59: format string 'Exception raised from openai.Stream.' is passed str(exception) but has no %s placeholder.`

Pre-existing test failures in `tests/unit/evaluation/metrics/test_sentiment.py` (an `ImportError` in `opik.evaluation.metrics.heuristics.sentiment`, unrelated to this change) and in `tests/unit/evaluation/models/test_litellm_chat_model.py` are confirmed pre-existing on the main branch via `git stash` + re-run.

## Documentation

N/A — purely a logging-correctness fix; no public docs affected.
