### PR TITLE
[OPIK-7944] [QA] test: e2e coverage for online evaluation enable/disable rule

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -624,6 +624,7 @@ areas:
     specs:
       - online-evaluation/online-evaluation-smoke.spec.ts
       - online-evaluation/online-evaluation-delete-rule.spec.ts
+      - online-evaluation/online-evaluation-enable-disable-rule.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
       llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
@@ -636,7 +637,7 @@ areas:
       sampling-rate:           { covered: false }
       clone-rule:              { covered: false }
       edit-rule:               { covered: false }
-      enable-disable-rule:     { covered: false }
+      enable-disable-rule:     { covered: true,  tier: t2-cuj, note: "edit-dialog switch; control rule proves scoring stopped, then resumed" }
       delete-rule:             { covered: true,  tier: t2-cuj, note: "row kebab delete; control rule proves scoring stopped" }
       automation-logs:         { covered: false }
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -83,6 +83,7 @@ export interface AutomationRuleRef {
   id: string;
   name: string;
   projectIds: string[];
+  enabled: boolean;
 }
 
 export interface AnnotationQueueReviewerRef {
@@ -459,6 +460,7 @@ export function makeBackendClient(apiKey: string | null = null) {
         id: String(r.id),
         name: r.name,
         projectIds: (r.projects ?? []).map((p) => String(p.projectId)),
+        enabled: r.enabled ?? true,
       }));
     },
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -6,6 +6,10 @@ import {
   type PollFeedbackScoreOpts,
 } from './poll-feedback-score';
 import {
+  waitForTraceScoresSettled,
+  type WaitForScoresSettledOpts,
+} from './wait-for-scores-settled';
+import {
   pollOptimizationStatus,
   type OptimizationStatus,
   type PollOptimizationStatusOpts,
@@ -448,6 +452,13 @@ export function makeBackendClient(apiKey: string | null = null) {
       opts: PollFeedbackScoreOpts = {},
     ): Promise<FeedbackScoreRef> {
       return pollTraceForFeedbackScore(localGetTrace, traceId, scoreName, opts);
+    },
+
+    async waitForTraceScoresSettled(
+      traceId: string,
+      opts: WaitForScoresSettledOpts = {},
+    ): Promise<TraceDetail> {
+      return waitForTraceScoresSettled(localGetTrace, traceId, opts);
     },
 
     async listAutomationRulesForProject(projectId: string): Promise<AutomationRuleRef[]> {

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -16,3 +16,4 @@ export {
   type AnnotationQueueReviewerRef,
 } from './client';
 export { type PollFeedbackScoreOpts } from './poll-feedback-score';
+export { type WaitForScoresSettledOpts } from './wait-for-scores-settled';

--- a/tests_end_to_end/e2e/core/backend/wait-for-scores-settled.ts
+++ b/tests_end_to_end/e2e/core/backend/wait-for-scores-settled.ts
@@ -1,0 +1,68 @@
+import type { TraceDetail } from './client';
+
+export interface WaitForScoresSettledOpts {
+  /** How long the score set must stay unchanged before it counts as settled. */
+  quietPeriodMs?: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Poll a trace until its feedback-score set stops changing for `quietPeriodMs`,
+ * then return the settled trace.
+ *
+ * Needed because a single rule's score landing does NOT mean every rule has
+ * finished with the trace: OnlineScoringSampler enqueues rules via
+ * `evaluators.parallelStream()` onto per-type Redis streams that are consumed
+ * asynchronously, so there is no ordering guarantee between two rules' scores.
+ * Asserting "rule X did not score this trace" immediately after rule Y's score
+ * arrives can therefore pass while X is still in flight.
+ *
+ * Throws if the trace is missing — a deleted or never-ingested trace must fail
+ * loudly rather than present as an empty score list, which would make an
+ * absence assertion pass vacuously.
+ */
+export async function waitForTraceScoresSettled(
+  getTrace: (traceId: string) => Promise<TraceDetail | null>,
+  traceId: string,
+  opts: WaitForScoresSettledOpts = {},
+): Promise<TraceDetail> {
+  const quietPeriodMs = opts.quietPeriodMs ?? 10_000;
+  const timeoutMs = opts.timeoutMs ?? 90_000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 2_000;
+
+  const start = Date.now();
+  let lastFingerprint: string | null = null;
+  let lastChangeAt = Date.now();
+  let lastTrace: TraceDetail | null = null;
+
+  while (Date.now() - start < timeoutMs) {
+    lastTrace = await getTrace(traceId);
+    if (lastTrace === null) {
+      throw new Error(
+        `waitForTraceScoresSettled: trace ${traceId} not found — ` +
+          `cannot assert on its feedback scores.`,
+      );
+    }
+
+    const fingerprint = lastTrace.feedbackScores
+      .map((fs) => `${fs.name}=${fs.value}`)
+      .sort()
+      .join(',');
+
+    if (fingerprint !== lastFingerprint) {
+      lastFingerprint = fingerprint;
+      lastChangeAt = Date.now();
+    } else if (Date.now() - lastChangeAt >= quietPeriodMs) {
+      return lastTrace;
+    }
+
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+
+  throw new Error(
+    `waitForTraceScoresSettled timed out after ${Date.now() - start}ms on trace ${traceId}: ` +
+      `feedback scores never stayed unchanged for ${quietPeriodMs}ms. ` +
+      `Last observed: [${lastFingerprint ?? '<none>'}]`,
+  );
+}

--- a/tests_end_to_end/e2e/core/backend/wait-for-scores-settled.ts
+++ b/tests_end_to_end/e2e/core/backend/wait-for-scores-settled.ts
@@ -5,6 +5,14 @@ export interface WaitForScoresSettledOpts {
   quietPeriodMs?: number;
   timeoutMs?: number;
   pollIntervalMs?: number;
+  /**
+   * Minimum number of feedback scores required before the quiet period is
+   * allowed to start. Defaults to 1: an empty score set is treated as "the
+   * evaluators have not produced anything yet", not as settled, so a slow
+   * evaluator cannot be mistaken for a rule that correctly declined to score.
+   * Set to 0 only when a genuinely empty result is the expected end state.
+   */
+  minScores?: number;
 }
 
 /**
@@ -30,6 +38,7 @@ export async function waitForTraceScoresSettled(
   const quietPeriodMs = opts.quietPeriodMs ?? 10_000;
   const timeoutMs = opts.timeoutMs ?? 90_000;
   const pollIntervalMs = opts.pollIntervalMs ?? 2_000;
+  const minScores = opts.minScores ?? 1;
 
   const start = Date.now();
   let lastFingerprint: string | null = null;
@@ -53,16 +62,28 @@ export async function waitForTraceScoresSettled(
     if (fingerprint !== lastFingerprint) {
       lastFingerprint = fingerprint;
       lastChangeAt = Date.now();
-    } else if (Date.now() - lastChangeAt >= quietPeriodMs) {
+    } else if (
+      lastTrace.feedbackScores.length >= minScores &&
+      Date.now() - lastChangeAt >= quietPeriodMs
+    ) {
       return lastTrace;
     }
 
-    await new Promise((r) => setTimeout(r, pollIntervalMs));
+    // Never sleep past the deadline — otherwise the effective timeout overruns
+    // by up to one poll interval, which matters when a caller has sized this
+    // wait to fit inside a larger test budget.
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) break;
+    await new Promise((r) => setTimeout(r, Math.min(pollIntervalMs, remaining)));
   }
 
+  const observedCount = lastTrace?.feedbackScores.length ?? 0;
+  const reason =
+    observedCount < minScores
+      ? `only ${observedCount} feedback score(s) ever appeared (need at least ${minScores})`
+      : `feedback scores never stayed unchanged for ${quietPeriodMs}ms`;
   throw new Error(
     `waitForTraceScoresSettled timed out after ${Date.now() - start}ms on trace ${traceId}: ` +
-      `feedback scores never stayed unchanged for ${quietPeriodMs}ms. ` +
-      `Last observed: [${lastFingerprint ?? '<none>'}]`,
+      `${reason}. Last observed: [${lastFingerprint ?? '<none>'}]`,
   );
 }

--- a/tests_end_to_end/e2e/pom/online-evaluation.page.ts
+++ b/tests_end_to_end/e2e/pom/online-evaluation.page.ts
@@ -122,6 +122,52 @@ export class OnlineEvaluationPage {
     });
   }
 
+  /**
+   * The read-only Status cell for a rule row ("Enabled" / "Disabled"), rendered
+   * by RuleEnabledCell. There is no row-level toggle — the only control that
+   * changes `enabled` is the switch inside the edit dialog (see
+   * `setRuleEnabledByName`).
+   */
+  ruleStatusCell(name: string, status: 'Enabled' | 'Disabled'): Locator {
+    return this.ruleRow(name).getByRole('cell', { name: status, exact: true });
+  }
+
+  /** The "Enable rule" switch inside the add/edit dialog. */
+  get enableRuleSwitch(): Locator {
+    return this.dialog.getByRole('switch', { name: 'Enable rule' });
+  }
+
+  /**
+   * Flip a rule's enabled state through the row's kebab → Edit → "Enable rule"
+   * switch → submit. Resolves once the dialog has closed and the row's Status
+   * cell reflects the new state.
+   *
+   * The switch is asserted into the expected starting state before clicking, so
+   * a UI regression that hydrates the dialog from the wrong value fails here
+   * rather than silently toggling the rule the wrong way.
+   */
+  async setRuleEnabledByName(name: string, enabled: boolean): Promise<void> {
+    return test.step(`set rule "${name}" enabled=${enabled} via edit dialog`, async () => {
+      const row = this.ruleRow(name);
+      await row.waitFor({ state: 'visible' });
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Edit' }).click();
+
+      await this.dialog.waitFor({ state: 'visible' });
+      const toggle = this.enableRuleSwitch;
+      await expect(toggle, 'edit dialog hydrates the switch from the persisted value').toBeChecked({
+        checked: !enabled,
+      });
+      await toggle.click();
+      await expect(toggle).toBeChecked({ checked: enabled });
+
+      await this.dialog.getByTestId('add-edit-rule-dialog-submit').click();
+      await this.dialog.waitFor({ state: 'hidden' });
+
+      await expect(this.ruleStatusCell(name, enabled ? 'Enabled' : 'Disabled')).toBeVisible();
+    });
+  }
+
   /** The destructive confirm dialog raised by the row's Delete action. */
   get deleteRuleConfirmDialog(): Locator {
     return this.page.getByRole('dialog').filter({

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
@@ -11,7 +11,7 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
     testNamespace,
     page,
   }) => {
-    test.setTimeout(300_000);
+    test.setTimeout(420_000);
 
     // Two deterministic Python rules: one gets toggled, the other stays enabled
     // as a control. The control is what turns "no score from the target" into a
@@ -101,8 +101,11 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
       );
       expect(controlScore.value, 'control rule still scores new traces').toBe(1.0);
 
-      const trace = await backendClient.getTrace(disabledTrace.id);
-      const scoreNames = (trace?.feedbackScores ?? []).map((fs) => fs.name);
+      // The control's score arriving does not mean every rule is done with this
+      // trace — the sampler enqueues rules in parallel onto async streams — so
+      // wait for the score set to stop changing before asserting an absence.
+      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id);
+      const scoreNames = trace.feedbackScores.map((fs) => fs.name);
       expect(
         scoreNames,
         'a disabled rule must not score traces created while it was disabled',
@@ -138,8 +141,8 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
     });
 
     await test.step('The trace seeded while disabled is still unscored by the target rule', async () => {
-      const trace = await backendClient.getTrace(disabledTrace.id);
-      const scoreNames = (trace?.feedbackScores ?? []).map((fs) => fs.name);
+      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id);
+      const scoreNames = trace.feedbackScores.map((fs) => fs.name);
       expect(
         scoreNames,
         're-enabling must not backfill scores onto traces seen while disabled',

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
@@ -11,7 +11,13 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
     testNamespace,
     page,
   }) => {
-    test.setTimeout(420_000);
+    // Budget sits above the sum of the inner waits (3x90s polls + 40s/20s
+    // settles + UI steps ~= 590s worst case) on purpose: every async wait here
+    // throws a diagnostic naming the trace and the scores it actually saw, and
+    // that is far more useful than an opaque "test timeout exceeded". The test
+    // finishes in ~40-55s in practice; this ceiling only governs which error
+    // you get on a genuine stall.
+    test.setTimeout(660_000);
 
     // Two deterministic Python rules: one gets toggled, the other stays enabled
     // as a control. The control is what turns "no score from the target" into a
@@ -104,7 +110,14 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
       // The control's score arriving does not mean every rule is done with this
       // trace — the sampler enqueues rules in parallel onto async streams — so
       // wait for the score set to stop changing before asserting an absence.
-      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id);
+      // The control score is already in hand, so a short quiet period is enough
+      // to cover the parallel-dispatch skew; the timeout is bounded well below
+      // the test budget so a stall fails here, with this helper's diagnostic,
+      // rather than blowing the whole test's timeout.
+      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id, {
+        quietPeriodMs: 8_000,
+        timeoutMs: 40_000,
+      });
       const scoreNames = trace.feedbackScores.map((fs) => fs.name);
       expect(
         scoreNames,
@@ -141,7 +154,12 @@ test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@
     });
 
     await test.step('The trace seeded while disabled is still unscored by the target rule', async () => {
-      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id);
+      // This trace already settled in the step above; re-confirm nothing has
+      // been backfilled since the rule was re-enabled, so a short wait is enough.
+      const trace = await backendClient.waitForTraceScoresSettled(disabledTrace.id, {
+        quietPeriodMs: 4_000,
+        timeoutMs: 20_000,
+      });
       const scoreNames = trace.feedbackScores.map((fs) => fs.name);
       expect(
         scoreNames,

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@e2e/fixtures';
+import { OnlineEvaluationPage } from '@e2e/pom/online-evaluation.page';
+
+const REFERENCE_OUTPUT = 'seed output';
+
+test.describe('Online Evaluation — enable/disable rule', { tag: ['@t2-cuj', '@area:online-evaluation'] }, () => {
+  test('Disabling a rule stops it scoring new traces; re-enabling resumes it', { tag: ['@cap:online-evaluation.enable-disable-rule'] }, async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    test.setTimeout(300_000);
+
+    // Two deterministic Python rules: one gets toggled, the other stays enabled
+    // as a control. The control is what turns "no score from the target" into a
+    // real negative rather than a timing guess — once the control's score lands
+    // on a trace created while the target was disabled, the engine has
+    // demonstrably processed that trace, so the target's absent score means
+    // "not scored", not "not scored yet".
+    const targetRule = `${testNamespace}-target`;
+    const controlRule = `${testNamespace}-control`;
+
+    const onlineEval = new OnlineEvaluationPage(page);
+
+    await test.step('Create the target and control rules via the UI', async () => {
+      await onlineEval.goto(project.id);
+      await onlineEval.waitForReady();
+
+      await onlineEval.openCreateRuleDialog();
+      await onlineEval.fillAndSubmitCreateRuleDialogPythonEquals({
+        name: targetRule,
+        referenceValue: REFERENCE_OUTPUT,
+      });
+      await expect(onlineEval.ruleRow(targetRule)).toBeVisible();
+
+      await onlineEval.openCreateRuleDialog();
+      await onlineEval.fillAndSubmitCreateRuleDialogPythonEquals({
+        name: controlRule,
+        referenceValue: REFERENCE_OUTPUT,
+      });
+      await expect(onlineEval.ruleRow(controlRule)).toBeVisible();
+    });
+
+    await test.step('Both rules start out Enabled in the list', async () => {
+      await expect(onlineEval.ruleStatusCell(targetRule, 'Enabled')).toBeVisible();
+      await expect(onlineEval.ruleStatusCell(controlRule, 'Enabled')).toBeVisible();
+    });
+
+    const preDisableTrace = await test.step('Seed a trace while both rules are enabled', async () =>
+      sdkClient.python.createTrace({
+        project_name: project.name,
+        name: `${testNamespace}-pre-disable`,
+        input: 'whatever',
+        output: REFERENCE_OUTPUT,
+      }));
+
+    await test.step('Both rules score the pre-disable trace', async () => {
+      const [targetScore, controlScore] = await Promise.all([
+        backendClient.pollTraceForFeedbackScore(preDisableTrace.id, targetRule, {
+          timeoutMs: 90_000,
+        }),
+        backendClient.pollTraceForFeedbackScore(preDisableTrace.id, controlRule, {
+          timeoutMs: 90_000,
+        }),
+      ]);
+      expect(targetScore.value, 'target rule scores a matching trace while enabled').toBe(1.0);
+      expect(controlScore.value, 'control rule scores a matching trace').toBe(1.0);
+    });
+
+    await test.step('Disable the target rule and verify the list', async () => {
+      await onlineEval.setRuleEnabledByName(targetRule, false);
+      await expect(onlineEval.ruleStatusCell(targetRule, 'Disabled')).toBeVisible();
+      await expect(
+        onlineEval.ruleStatusCell(controlRule, 'Enabled'),
+        'disabling one rule must not touch the others',
+      ).toBeVisible();
+    });
+
+    await test.step('The disabled state is persisted in the backend', async () => {
+      const rules = await backendClient.listAutomationRulesForProject(project.id);
+      const byName = new Map(rules.map((r) => [r.name, r.enabled]));
+      expect(byName.get(targetRule), 'target rule persisted as disabled').toBe(false);
+      expect(byName.get(controlRule), 'control rule stays enabled').toBe(true);
+    });
+
+    const disabledTrace = await test.step('Seed a trace while the target is disabled', async () =>
+      sdkClient.python.createTrace({
+        project_name: project.name,
+        name: `${testNamespace}-while-disabled`,
+        input: 'whatever',
+        output: REFERENCE_OUTPUT,
+      }));
+
+    await test.step('Control rule scores the new trace; the disabled rule does not', async () => {
+      const controlScore = await backendClient.pollTraceForFeedbackScore(
+        disabledTrace.id,
+        controlRule,
+        { timeoutMs: 90_000 },
+      );
+      expect(controlScore.value, 'control rule still scores new traces').toBe(1.0);
+
+      const trace = await backendClient.getTrace(disabledTrace.id);
+      const scoreNames = (trace?.feedbackScores ?? []).map((fs) => fs.name);
+      expect(
+        scoreNames,
+        'a disabled rule must not score traces created while it was disabled',
+      ).not.toContain(targetRule);
+    });
+
+    await test.step('Re-enable the target rule', async () => {
+      await onlineEval.setRuleEnabledByName(targetRule, true);
+      await expect(onlineEval.ruleStatusCell(targetRule, 'Enabled')).toBeVisible();
+
+      const rules = await backendClient.listAutomationRulesForProject(project.id);
+      expect(
+        rules.find((r) => r.name === targetRule)?.enabled,
+        'target rule persisted as enabled again',
+      ).toBe(true);
+    });
+
+    const reEnabledTrace = await test.step('Seed a trace after re-enabling', async () =>
+      sdkClient.python.createTrace({
+        project_name: project.name,
+        name: `${testNamespace}-post-enable`,
+        input: 'whatever',
+        output: REFERENCE_OUTPUT,
+      }));
+
+    await test.step('The re-enabled rule scores the new trace again', async () => {
+      const targetScore = await backendClient.pollTraceForFeedbackScore(
+        reEnabledTrace.id,
+        targetRule,
+        { timeoutMs: 90_000 },
+      );
+      expect(targetScore.value, 'scoring resumes once the rule is re-enabled').toBe(1.0);
+    });
+
+    await test.step('The trace seeded while disabled is still unscored by the target rule', async () => {
+      const trace = await backendClient.getTrace(disabledTrace.id);
+      const scoreNames = (trace?.feedbackScores ?? []).map((fs) => fs.name);
+      expect(
+        scoreNames,
+        're-enabling must not backfill scores onto traces seen while disabled',
+      ).not.toContain(targetRule);
+    });
+
+    await test.step('Cleanup: delete both rules (project teardown does not cascade)', async () => {
+      const rules = await backendClient.listAutomationRulesForProject(project.id);
+      for (const rule of rules) {
+        await backendClient.deleteAutomationRule(project.id, rule.id);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Details

Adds a `@t2-cuj` E2E spec covering `@cap:online-evaluation.enable-disable-rule`, which was reserved but uncovered in `taxonomy.yaml`. Online evaluation runs silently in the background, so a broken enable/disable control is a genuinely silent failure — a rule can read "Enabled" while scoring nothing (or the reverse) for weeks before anyone notices a gap in feedback scores.

- Mirrors the control-rule pattern from `online-evaluation-delete-rule.spec.ts`: a second, always-enabled rule proves the engine actually processed each trace, so the target's missing score is a real negative rather than a timing artifact.
- Also asserts that re-enabling does **not** backfill scores onto the trace seen while the rule was disabled.
- Worth knowing for reviewers: there is no enable/disable control in the rule list. The Status column (`RuleEnabledCell`) is read-only text and the row kebab (`RuleRowActionsCell`) offers only Edit / Clone / Delete. The only control that changes `enabled` is the "Enable rule" switch inside the Edit dialog, so the POM drives row kebab → Edit → flip switch → Update rule. If a row-level toggle is added later, the POM method moves but the assertions do not.
- No frontend change was needed — every element had a stable `data-testid` or accessible name.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7944

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (`writing-e2e-tests` and `playwright-pom-discovery` skills), Playwright MCP for live-UI selector discovery
- Model(s): Claude Opus 5
- Scope: the new spec, the three new POM methods on `online-evaluation.page.ts`, the `AutomationRuleRef.enabled` field on the backend client, and the `taxonomy.yaml` update — i.e. the whole diff
- Human verification: pending reviewer sign-off. Selectors were verified against the live local UI rather than inferred from source, and the spec was run to green locally before this PR was opened (output below).

## Testing

Run against local OSS (`http://localhost:5173`, workspace `default`, Docker deployment), from `tests_end_to_end/e2e/`:

```
npx playwright test tests/online-evaluation/online-evaluation-enable-disable-rule.spec.ts --reporter=list
  ✓ Disabling a rule stops it scoring new traces; re-enabling resumes it (20.2s)
  1 passed (28.3s)
```

Because this touches the shared `online-evaluation.page.ts` and `core/backend/client.ts`, the whole feature directory was run as well:

```
npx playwright test tests/online-evaluation/ --reporter=list
  1 skipped
  3 passed (34.4s)
```

The skip is the pre-existing LLM-judge smoke case, which skips whenever no provider API key is set locally (`pom/model-availability.ts`). It is unrelated to this change — this spec uses the deterministic Python metric and needs no LLM.

Tag and type checks:

```
python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
  tag-lint: 35 specs checked, 1 exempt, 0 problem(s)

npx tsc --noEmit
  (clean)
```

Scenarios validated by the spec itself: both rules score a trace while enabled; disabling flips the Status cell and persists `enabled: false`; a trace seeded while disabled is scored by the control but not the target; re-enabling restores both the cell and the flag and resumes scoring; and the trace seen while disabled is not retroactively scored.

Discovery state (a scratch project and rule created while exploring the live UI) was torn down via the API.

Not run: the suite against a cloud/staging deployment — this spec is deployment-agnostic and the local OSS target is the suite's default.

## Documentation

None. This is test-estate work with no user-facing surface; the coverage change is recorded in `taxonomy.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
