### PR TITLE
[OPIK-6901] fix(cutover): raise max_partitions_per_insert_block; correct the far-future partition claim

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -432,10 +432,10 @@ and are skipped by time-bounded reads.
 > | Measure | Value |
 > |---|---|
 > | Far-future partitions in the window | 275 |
-> | Worst single block: total destination partitions | **333** (269 far-future, the rest ordinary weeks it touched) |
 > | …holding ≤ 5 rows each | **268** — about 635 rows in total |
 > | Head partitions | 7, holding 125,553 of the window's 126,188 far-future rows |
 > | Primary-key footprint of that rare tail | **12 projects** |
+> | Worst single block: total destination partitions | **333** (269 far-future, the rest ordinary weeks it touched) |
 >
 > So the mechanism is: the byte cap `min_insert_block_size_bytes` (256 MB) binds long before
 > `max_insert_block_size`, so for ~54 KiB trace rows a block holds only ~4,841 rows; and because the rare tail occupies

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -364,8 +364,12 @@ For an exact figure, time one real window with `backfill.sh` and feed its rows/s
 It is a planning ballpark — real throughput varies with concurrent load, merges and cold-tier reads.
 
 The **delta-insert** (step 2) covers only writes during the backfill window, not the whole table, so it is normally one
-statement (with the same block-size bound); `000002` documents how to split it into two batched passes if a long backfill
-made it large. The **deletion replay** is a lightweight `DELETE`, and with retention disabled it is user-scale — a single
+statement (with the same block-size **and partition** bounds); `000002` documents how to split it into two batched passes
+if a long backfill made it large. If you do split it, **carry the whole `SETTINGS` block onto both passes**: the driver
+does not implement the split, so those statements are hand-written, and the second arm
+(`last_updated_at >= backfill_start AND created_at < backfill_start`) is the updates-to-old-rows arm that carries
+far-future ids, so it is the pass that most needs `max_partitions_per_insert_block` and the easiest one to write without
+it. The **deletion replay** is a lightweight `DELETE`, and with retention disabled it is user-scale — a single
 mutation; `000002` / `000004` note how to bound it by partition if it is ever large.
 
 ## Why slice by `created_at` (and not `id` or workspace)
@@ -428,6 +432,7 @@ and are skipped by time-bounded reads.
 > | Measure | Value |
 > |---|---|
 > | Far-future partitions in the window | 275 |
+> | Worst single block: total destination partitions | **333** (269 far-future, the rest ordinary weeks it touched) |
 > | …holding ≤ 5 rows each | **268** — about 635 rows in total |
 > | Head partitions | 7, holding 125,553 of the window's 126,188 far-future rows |
 > | Primary-key footprint of that rare tail | **12 projects** |
@@ -463,6 +468,10 @@ and are skipped by time-bounded reads.
 > out to be. In the measurement above that total is about 1,616 (1,517 far-future plus roughly 99 real weeks), so 2000
 > clears it with margin. Derive your own number the same way, from `far_future_weeks` plus the real week count, rather
 > than from any per-block estimate.
+>
+> The observed worst block is consistent with that bound and shows why the far-future count alone is not the right input:
+> its 333 partitions are 269 far-future plus 64 of the 99 real weeks, so a block's spread mixes both and lands well
+> under the 1,616 ceiling. Sizing from `far_future_weeks` alone would have undercounted it by 64.
 >
 > The cost of raising it is a larger part count per insert — one part per partition touched — which background merges
 > then compact. That is strictly better than the alternative, which is the backfill not running.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -345,7 +345,9 @@ independent controls keep each statement safe:
   max_partitions_per_insert_block`).** Not a throughput knob — a **correctness gate**. The destination is
   weekly-partitioned, so a block spans as many partitions as the ids in it imply; ClickHouse's default of 100 aborts the
   INSERT (`throw_on_max_partitions_per_insert_block = 1`) rather than degrading, and far-future UUIDv7 ids reach that on
-  real data. Neither of the two bounds above can prevent it. See "Far-future partitions from far-future-timestamp ids".
+  real data. Neither of the two bounds above can prevent it. **`delta_replay.sh` takes the same flag and needs the same
+  value** — the delta INSERT writes into the same partitioned shadow. See "Far-future partitions from
+  far-future-timestamp ids".
 
 **Throttle** with `--pause-seconds` (recommended 30–60s at peak): it sleeps after each inserted window so background
 merges consolidate the new parts before the next window piles on more.
@@ -450,8 +452,17 @@ and are skipped by time-bounded reads.
 > `--max-rows-per-insert`; a week already under that bound is one unsplit INSERT however many partitions it spans (two
 > such weeks failed in the measurement above). Lowering `--max-insert-block-size` does not help either, since the byte
 > cap already binds. So the fix belongs in the setting: `backfill.sh --max-partitions-per-insert-block` defaults to
-> **2000**, sized to clear the table's total partition count with margin. Where the migration user has a settings
-> profile, set it there too, so the value does not depend on the invocation.
+> **2000**. Pass the same value to `delta_replay.sh`, which needs it for the same reason: the delta writes into the same
+> partitioned shadow, and its `last_updated_at` arm re-copies updates to old rows, so a far-future-id row touched during
+> the window is pulled in. Where the migration user has a settings profile, set it there too, so the value does not
+> depend on the invocation.
+>
+> **Why 2000 is sound, and it is not the simulation below that establishes it.** A block cannot span more partitions
+> than the table has, so **the destination's total distinct partition count is a hard upper bound** on partitions per
+> block. Size the setting above that total and it can never be exceeded, whatever the read order or thread count turns
+> out to be. In the measurement above that total is about 1,616 (1,517 far-future plus roughly 99 real weeks), so 2000
+> clears it with margin. Derive your own number the same way, from `far_future_weeks` plus the real week count, rather
+> than from any per-block estimate.
 >
 > The cost of raising it is a larger part count per insert — one part per partition touched — which background merges
 > then compact. That is strictly better than the alternative, which is the backfill not running.
@@ -474,18 +485,29 @@ WHERE ts > now() + INTERVAL 1 DAY;   -- outside the 24h validation window
 ```
 
 `far_future_weeks` uses the destination's honest partition expression, so it equals the number of extra weekly partitions
-`traces_local_v2` will hold. Treat it as the **floor for `--max-partitions-per-insert-block`**, not merely as a curiosity:
-if it exceeds the default 100, the backfill needs the raised setting or it will abort. Remediating the source `id`s at
-their origin is the only thing that removes the extra partitions; short of that they partition honestly on their own and
-the setting is what lets the copy through.
+`traces_local_v2` will hold. **This is the number that sizes `--max-partitions-per-insert-block`**, not merely a
+curiosity: add it to the real week count and set the limit above the total, which is the hard bound argued above. If
+`far_future_weeks` alone exceeds the default 100, the copy needs the raised setting or it will abort. Remediating the
+source `id`s at their origin is the only thing that removes the extra partitions; short of that they partition honestly
+on their own and the setting is what lets the copy through.
 
-Because the failure is per **block**, not per week, the row count alone does not tell you whether a given window trips
-the limit. To see the actual worst-case spread before starting — read-only, no writes — simulate block formation under
-the destination's sort order (substitute one window's bounds, and the rows-per-block figure for your row width):
+Because the failure is per **block**, not per week, the row count alone does not tell you whether a given window is
+anywhere near the limit. The query below is an **approximate locality heuristic, not a preflight gate**: it answers "is
+this window's far-future tail concentrated enough to be a risk at all", and nothing stronger. Read it with two
+limitations in mind, or it will mislead you:
+
+- It imposes `ORDER BY workspace_id, project_id, id` and chunks on `rowNumberInAllBlocks()`. The real `INSERT ... SELECT`
+  has **no `ORDER BY`** and reads in parallel (`max_threads`, with `max_insert_threads` governing the sink), so its block
+  composition is not this ordering and the numbers here are not the blocks ClickHouse will actually form.
+- It does not reproduce the production INSERT's settings.
+
+So use it to decide whether you are exposed, and use the total-partition-count bound above to decide the value. Do not
+read `worst_partitions_per_block` as the minimum safe setting.
 
 ```sql
--- worst partitions-per-block for one window; compare against max_partitions_per_insert_block
-SELECT max(p) AS worst_block, countIf(p > 100) AS blocks_over_default
+-- APPROXIMATE: is this window's far-future tail concentrated enough to be a risk?
+-- Not a safe-value calculation — see the two limitations above.
+SELECT max(p) AS worst_partitions_per_block, countIf(p > 100) AS blocks_over_default
 FROM (
     SELECT intDiv(rn, 4841) AS b, uniqExact(part) AS p
     FROM (
@@ -976,8 +998,10 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
       `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised
       `--max-partitions-per-insert-block` (driver default 2000), because the far-future rows cluster into a single insert
-      block. Also run the per-block spread query for the densest windows, and set the value on the migration user's
-      settings profile so it does not depend on the invocation.
+      block. Size the value from `far_future_weeks` plus the real week count, which is a hard upper bound on partitions
+      per block, and pass the same value to **both `backfill.sh` and `delta_replay.sh`** — the delta writes into the same
+      partitioned shadow and aborts the same way, immediately before the EXCHANGE. Set it on the migration user's
+      settings profile too, so it does not depend on the invocation.
 - [ ] **`EXCHANGE TABLES ... ON CLUSTER` works end-to-end** — or the fallback `RENAME` sequence is documented for the
       variant that needs it.
 - [ ] **Async-insert ceiling confirmed** — raising `asyncInsertBusyTimeoutMaxMs` demonstrably widens the adaptive buffer

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -341,6 +341,12 @@ independent controls keep each statement safe:
   so peak insert memory is a small multiple of ~256 MB regardless of the window size — the statement does not load the
   window into memory. Lower this (or `min_insert_block_size_bytes`) on a memory-constrained data node.
 
+- **Per-block partition bound (`--max-partitions-per-insert-block`, default 2000 → `SETTINGS
+  max_partitions_per_insert_block`).** Not a throughput knob — a **correctness gate**. The destination is
+  weekly-partitioned, so a block spans as many partitions as the ids in it imply; ClickHouse's default of 100 aborts the
+  INSERT (`throw_on_max_partitions_per_insert_block = 1`) rather than degrading, and far-future UUIDv7 ids reach that on
+  real data. Neither of the two bounds above can prevent it. See "Far-future partitions from far-future-timestamp ids".
+
 **Throttle** with `--pause-seconds` (recommended 30–60s at peak): it sleeps after each inserted window so background
 merges consolidate the new parts before the next window piles on more.
 
@@ -398,8 +404,57 @@ customer data — a valid UUIDv7 that merely carries a future timestamp — so t
 ([OPIK-7456](https://comet-ml.atlassian.net/browse/OPIK-7456): `toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))`),
 and its `id_at` is a `DateTime64` (honest to 2299), so each such row lands in its **own honest ~2201 (`22010601`-shaped)
 weekly partition**, isolated from real recent weeks — a per-week `DROP PARTITION` / retention / tiering operation never
-touches them by accident, and vice versa. The extra partitions are bounded (few distinct
-far-future timestamps → few extra weeks) and harmless (they never tier to cold and are skipped by time-bounded reads).
+touches them by accident, and vice versa. Once written, the extra partitions are benign at rest: they never tier to cold
+and are skipped by time-bounded reads.
+
+> **They are NOT few, and they break the backfill unless `max_partitions_per_insert_block` is raised.** An earlier
+> version of this section claimed the extra partitions were "bounded (few distinct far-future timestamps → few extra
+> weeks) and harmless". The first half is wrong on real data and the second half is only true *after* the copy
+> succeeds. Measured on a production-shape environment (2026-08-17, 269.2 M rows):
+>
+> | Measure | Value |
+> |---|---|
+> | Far-future rows | **11,128,875** — 4.1% of the table, not a handful |
+> | Distinct far-future weekly partitions | **1,517**, spanning ~2194 → 2299-12-31 |
+> | Result of running `backfill.sh` unmodified | **`Code: 252 … TOO_MANY_PARTS`** on week `2025-06-16` |
+>
+> This is reproduced, not projected: the driver was run against the real cluster and aborted with
+> `Too many partitions for single INSERT block (more than 100)`.
+>
+> **What drives it is the tail, not the volume.** In the failing window:
+>
+> | Measure | Value |
+> |---|---|
+> | Far-future partitions in the window | 275 |
+> | …holding ≤ 5 rows each | **268** — about 635 rows in total |
+> | Head partitions | 7, holding 125,553 of the window's 126,188 far-future rows |
+> | Primary-key footprint of that rare tail | **12 projects** |
+>
+> So the mechanism is: the byte cap `min_insert_block_size_bytes` (256 MB) binds long before
+> `max_insert_block_size`, so for ~54 KiB trace rows a block holds only ~4,841 rows; and because the rare tail occupies
+> a narrow primary-key range, one such block picks up most of those 268 partitions at once. ClickHouse caps partitions
+> per block at **100** by default and, with `throw_on_max_partitions_per_insert_block = 1`, **aborts the INSERT**
+> instead of degrading.
+>
+> **This survives parallelism, which is the counter-intuitive part.** The statement has no `ORDER BY` and the read is
+> parallel (`max_insert_threads = 0`, `max_threads = auto(48)`), so it is tempting to assume 48 interleaved streams
+> scatter the tail across many blocks and keep every block under the limit. They do not — the abort above happened
+> under exactly that configuration. Do not reason your way past this one; measure it.
+>
+> **The abort is not all-or-nothing.** In the run above, 511,328 rows had already committed as 119 parts before the
+> offending block threw. The destination is a `ReplacingMergeTree` keyed on `(workspace_id, project_id, id)`, so
+> re-running the window converges rather than duplicating — but a failed window leaves partial data behind, and
+> prerequisite #2 ("`traces_local_v2` is empty") no longer holds until it is cleared with `rollback.sh --stage A`.
+>
+> **No batching flag avoids this.** `backfill.sh` splits a week only by `created_at`, to respect
+> `--max-rows-per-insert`; a week already under that bound is one unsplit INSERT however many partitions it spans (two
+> such weeks failed in the measurement above). Lowering `--max-insert-block-size` does not help either, since the byte
+> cap already binds. So the fix belongs in the setting: `backfill.sh --max-partitions-per-insert-block` defaults to
+> **2000**, sized to clear the table's total partition count with margin. Where the migration user has a settings
+> profile, set it there too, so the value does not depend on the invocation.
+>
+> The cost of raising it is a larger part count per insert — one part per partition touched — which background merges
+> then compact. That is strictly better than the alternative, which is the backfill not running.
 
 Quantify them in the **source** before the cutover so their scale is known. The source `traces.id_at` is a 32-bit
 `DateTime` (migration 000091) that overflows for far-future values, so derive the timestamp from `id` via
@@ -419,8 +474,34 @@ WHERE ts > now() + INTERVAL 1 DAY;   -- outside the 24h validation window
 ```
 
 `far_future_weeks` uses the destination's honest partition expression, so it equals the number of extra weekly partitions
-`traces_local_v2` will hold. If the count is material, remediate the source `id`s at their origin; otherwise no action is
-needed — they partition honestly on their own.
+`traces_local_v2` will hold. Treat it as the **floor for `--max-partitions-per-insert-block`**, not merely as a curiosity:
+if it exceeds the default 100, the backfill needs the raised setting or it will abort. Remediating the source `id`s at
+their origin is the only thing that removes the extra partitions; short of that they partition honestly on their own and
+the setting is what lets the copy through.
+
+Because the failure is per **block**, not per week, the row count alone does not tell you whether a given window trips
+the limit. To see the actual worst-case spread before starting — read-only, no writes — simulate block formation under
+the destination's sort order (substitute one window's bounds, and the rows-per-block figure for your row width):
+
+```sql
+-- worst partitions-per-block for one window; compare against max_partitions_per_insert_block
+SELECT max(p) AS worst_block, countIf(p > 100) AS blocks_over_default
+FROM (
+    SELECT intDiv(rn, 4841) AS b, uniqExact(part) AS p
+    FROM (
+        SELECT toYYYYMMDD(toDate32(UUIDv7ToDateTime(toUUID(id))) -
+                          toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(id)), 1))) AS part,
+               rowNumberInAllBlocks() AS rn
+        FROM ( SELECT id FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
+               WHERE created_at >= toDateTime64('<WINDOW_LO>', 9, 'UTC')
+                 AND created_at <  toDateTime64('<WINDOW_HI>', 9, 'UTC')
+               ORDER BY workspace_id, project_id, id )
+    ) GROUP BY b
+);
+```
+
+Derive the `4841` from your own data (`min_insert_block_size_bytes` ÷ uncompressed bytes per row, both readable from
+`system.parts`) rather than reusing it — it is a property of row width, not a constant.
 
 **No explicit `ORDER BY` on the `INSERT ... SELECT`.** Not needed for correctness or reproducibility: the final table
 state is a `ReplacingMergeTree` reduction keyed on `(workspace_id, project_id, id)` with `last_updated_at` as the version
@@ -891,7 +972,12 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
 - [ ] **Final-delta→EXCHANGE gap fits inside the buffer hold with margin** — the binding invariant is the gap between
       the final delta and the EXCHANGE completing (≈ replay wall time + EXCHANGE), staying within the buffer hold and
       accounting for size-triggered flushes — **not** "replay < buffer window" alone (see "The final cutover window").
-- [ ] **Far-future partitions quantified** — run the bad-`id` audit query above; remediated or explicitly accepted.
+- [ ] **Far-future partitions quantified — and `max_partitions_per_insert_block` sized from the result.** Run the
+      bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
+      `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised
+      `--max-partitions-per-insert-block` (driver default 2000), because the far-future rows cluster into a single insert
+      block. Also run the per-block spread query for the densest windows, and set the value on the migration user's
+      settings profile so it does not depend on the invocation.
 - [ ] **`EXCHANGE TABLES ... ON CLUSTER` works end-to-end** — or the fallback `RENAME` sequence is documented for the
       variant that needs it.
 - [ ] **Async-insert ceiling confirmed** — raising `asyncInsertBusyTimeoutMaxMs` demonstrably widens the adaptive buffer

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -139,8 +139,11 @@ done
 # Numeric args flow into the reference SQL / window arithmetic; require sane numeric shapes so none can alter the query.
 [[ "$MAX_ROWS" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-rows-per-insert must be a positive integer." >&2; exit 2; }
 [[ "$MAX_INSERT_BLOCK_SIZE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-insert-block-size must be a positive integer." >&2; exit 2; }
-# 0 is meaningful here (ClickHouse reads it as "unlimited"), so allow it — unlike the bounds above.
-[[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^[0-9]+$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be a non-negative integer (0 = unlimited)." >&2; exit 2; }
+# 0 is meaningful here (ClickHouse reads it as "unlimited"), so allow it — unlike the bounds above. Upper-bounded at 6
+# digits: the setting counts partitions, no real table approaches that, and an out-of-range value would otherwise be
+# rendered into the SQL and rejected by the server on the first INSERT — after the capacity preflight has passed and the
+# backfill_start anchor has been minted, which is a far more expensive place to discover a typo.
+[[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ -z "$TO_WEEK" || "$TO_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --to-week must be a non-negative integer." >&2; exit 2; }
 [[ "$PAUSE_SECONDS" =~ ^[0-9]+$ ]] || { echo "ERROR: --pause-seconds must be a non-negative integer." >&2; exit 2; }

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -53,9 +53,12 @@
 #                             defaults this to 100 and, with throw_on_max_partitions_per_insert_block = 1, ABORTS the
 #                             INSERT rather than degrading. Far-future UUIDv7 ids (litellm BerriAI/litellm#31294) make
 #                             that reachable on real data: measured on a production-shape table, one block spanned 333
-#                             partitions. Raising it trades a larger part count per insert (one part per partition
-#                             touched, compacted by background merges) for the INSERT completing at all. See the
-#                             runbook's "Far-future partitions from far-future-timestamp ids".
+#                             destination partitions in total, 269 of them far-future (the rest ordinary weeks the same
+#                             block touched), against a window holding 275 far-future partitions. Note the implication
+#                             for sizing: a block's spread is NOT just the far-future count, so size from the table's
+#                             TOTAL distinct partition count. Raising it trades a larger part count per insert (one part
+#                             per partition touched, compacted by background merges) for the INSERT completing at all.
+#                             See the runbook's "Far-future partitions from far-future-timestamp ids".
 #   --divergence P            max tolerated |src-dst|/src per window before aborting. Default 0.0001 (0.01%).
 #   --pause-seconds S         sleep S seconds after each inserted window, to let destination merges catch up and bound
 #                             the part count / IO pressure. Default 0. Recommended 30-60 on a large table at peak.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -46,6 +46,16 @@
 #                             memory is a small multiple of the smaller of this and min_insert_block_size_bytes (256 MB
 #                             default), so for wide trace rows the byte bound usually dominates. Default 1048576 (the
 #                             ClickHouse default); lower it on a memory-constrained data node. Applied to the INSERT.
+#   --max-partitions-per-insert-block N
+#                             partitions one insert block may span (SETTINGS max_partitions_per_insert_block).
+#                             Default 2000; 0 = unlimited. The destination is weekly-partitioned on the honest Monday
+#                             of id_at, so a block spans as many partitions as the ids in it imply — NOT one. ClickHouse
+#                             defaults this to 100 and, with throw_on_max_partitions_per_insert_block = 1, ABORTS the
+#                             INSERT rather than degrading. Far-future UUIDv7 ids (litellm BerriAI/litellm#31294) make
+#                             that reachable on real data: measured on a production-shape table, one block spanned 333
+#                             partitions. Raising it trades a larger part count per insert (one part per partition
+#                             touched, compacted by background merges) for the INSERT completing at all. See the
+#                             runbook's "Far-future partitions from far-future-timestamp ids".
 #   --divergence P            max tolerated |src-dst|/src per window before aborting. Default 0.0001 (0.01%).
 #   --pause-seconds S         sleep S seconds after each inserted window, to let destination merges catch up and bound
 #                             the part count / IO pressure. Default 0. Recommended 30-60 on a large table at peak.
@@ -84,6 +94,10 @@ MAX_ROWS=2000000          # rows: per-statement bound; a week over this is halve
 MAX_INSERT_BLOCK_SIZE=1048576  # rows: SETTINGS max_insert_block_size for the INSERT. Peak memory is a small multiple of
                           # the smaller of this and min_insert_block_size_bytes (256 MB default), which dominates for wide
                           # trace rows; lower it on a memory-constrained node. 1048576 is the ClickHouse default.
+MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions: SETTINGS max_partitions_per_insert_block for the INSERT. The
+                          # destination is weekly-partitioned, so one block can span many partitions; ClickHouse's
+                          # default of 100 THROWS (throw_on_max_partitions_per_insert_block=1). Far-future UUIDv7 ids
+                          # make this reachable in practice — see the runbook's far-future section. 0 = unlimited.
 DIVERGENCE="0.0001"       # fraction: max tolerated |src-dst|/src per settled window before aborting (0.01%).
 PAUSE_SECONDS=0           # seconds: sleep after each inserted window so destination merges catch up. 30-60 for a large table at peak.
 MIN_FREE_FACTOR="2.0"     # multiple of the current traces on-disk size that node free space must clear before starting.
@@ -102,6 +116,7 @@ while [[ $# -gt 0 ]]; do
         --to-week) TO_WEEK="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-rows-per-insert) MAX_ROWS="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
         --divergence) DIVERGENCE="${2:?"$1 requires a value"}"; shift 2 ;;
         --pause-seconds) PAUSE_SECONDS="${2:?"$1 requires a value"}"; shift 2 ;;
         --min-free-factor) MIN_FREE_FACTOR="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -124,6 +139,8 @@ done
 # Numeric args flow into the reference SQL / window arithmetic; require sane numeric shapes so none can alter the query.
 [[ "$MAX_ROWS" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-rows-per-insert must be a positive integer." >&2; exit 2; }
 [[ "$MAX_INSERT_BLOCK_SIZE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-insert-block-size must be a positive integer." >&2; exit 2; }
+# 0 is meaningful here (ClickHouse reads it as "unlimited"), so allow it — unlike the bounds above.
+[[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^[0-9]+$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be a non-negative integer (0 = unlimited)." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ -z "$TO_WEEK" || "$TO_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --to-week must be a non-negative integer." >&2; exit 2; }
 [[ "$PAUSE_SECONDS" =~ ^[0-9]+$ ]] || { echo "ERROR: --pause-seconds must be a non-negative integer." >&2; exit 2; }
@@ -216,6 +233,7 @@ run_backfill_window() {
     sql="${sql//'${WINDOW_LO}'/$lo}"
     sql="${sql//'${WINDOW_HI}'/$hi}"
     sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
+    sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
     clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -19,6 +19,12 @@
 --     in sort-key order — do not rely on it (see README "Why slice by created_at").
 --   * SETTINGS max_insert_block_size bounds the rows per part-forming block; peak insert memory is a small multiple of
 --     the smaller of that and min_insert_block_size_bytes (256 MB default), which dominates for wide trace rows.
+--   * SETTINGS max_partitions_per_insert_block is REQUIRED, not a tuning knob. Because the blocks above may span
+--     partitions (see the ORDER BY note), and the destination is weekly-partitioned on id_at, a block spans as many
+--     partitions as the ids in it imply. ClickHouse's default is 100 and throw_on_max_partitions_per_insert_block = 1,
+--     so exceeding it ABORTS the INSERT. Far-future UUIDv7 ids (litellm BerriAI/litellm#31294) put real tables well
+--     past it: measured on a production-shape table, one block spanned 333 partitions while every other block in the
+--     same window spanned <= 7. The driver's default (2000) is sized to clear the total partition count with margin.
 
 INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
     id,
@@ -73,6 +79,7 @@ FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
 WHERE created_at >= toDateTime64('${WINDOW_LO}', 9, 'UTC')
   AND created_at <  toDateTime64('${WINDOW_HI}', 9, 'UTC')
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
+         max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
          log_comment = 'traces_local_v2_backfill:${WINDOW_LO}:${WINDOW_HI}';
 
 -- Per-window reconciliation is automated by backfill.sh (uniqExact of the dedup key, aborting on > 0.01% divergence);

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -30,8 +30,10 @@
 --     partitions (see the ORDER BY note), and the destination is weekly-partitioned on id_at, a block spans as many
 --     partitions as the ids in it imply. ClickHouse's default is 100 and throw_on_max_partitions_per_insert_block = 1,
 --     so exceeding it ABORTS the INSERT. Far-future UUIDv7 ids (litellm BerriAI/litellm#31294) put real tables well
---     past it: measured on a production-shape table, one block spanned 333 partitions while every other block in the
---     same window spanned <= 7. The driver's default (2000) is sized to clear the total partition count with margin.
+--     past it: measured on a production-shape table, one block spanned 333 destination partitions in total (269 of them
+--     far-future, the rest ordinary weeks the same block touched) while every other block in that window spanned <= 7.
+--     The driver's default (2000) is sized to clear the table's TOTAL distinct partition count with margin -- not just
+--     the far-future count, which the 333-vs-269 gap shows is an undercount of a block's real spread.
 
 INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
     id,

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -2,9 +2,16 @@
 -- The gate test TracesLocalV2CutoverTest reimplements this statement inline; keep the two in step (see its Javadoc).
 --
 -- This file is the SINGLE source of the backfill INSERT; ../backfill.sh reads it, substitutes the ${...} placeholders
--- (database, window bounds, block size) and runs it once per time sub-window — so the script and this reference never
+-- and runs it once per time sub-window — so the script and this reference never
 -- drift. Run the migration through backfill.sh, never this file by hand. WINDOW_LO/WINDOW_HI are a created_at half-open
 -- range the driver picks so each INSERT stays under its --max-rows-per-insert bound (see README "Batching and throttling").
+--
+-- ALL FIVE placeholders the driver substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the
+-- server as a literal and the INSERT fails):
+--   ${ANALYTICS_DB_DATABASE_NAME}          the analytics database
+--   ${WINDOW_LO} / ${WINDOW_HI}            the created_at half-open window bounds
+--   ${MAX_INSERT_BLOCK_SIZE}               rows per part-forming block
+--   ${MAX_PARTITIONS_PER_INSERT_BLOCK}     partitions one block may span (required; see the note below)
 --
 -- Slicing rationale (created_at, not id / not workspace), delta and replay design: see ../../README.md.
 -- Notes on the statement:

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -42,6 +42,11 @@
 --   (a) created_at >= backfill_start                                  -- batch by created_at sub-windows
 --   (b) last_updated_at >= backfill_start AND created_at < backfill_start  -- the updates-to-old-rows arm; batch by
 --       last_updated_at sub-windows. (a) ∪ (b) equals the OR below, with no overlap.
+-- CARRY THE FULL SETTINGS BLOCK BELOW ONTO BOTH PASSES, max_partitions_per_insert_block included. The driver does not
+-- implement this split, so these two statements are hand-written, and arm (b) is precisely the updates-to-old-rows arm
+-- named above as the far-future carrier — so the pass that most needs the partition bound is the one an operator writes
+-- by hand. Omitting it there reintroduces the TOO_MANY_PARTS abort immediately before the EXCHANGE, which is exactly
+-- what the setting on the single-statement form exists to prevent.
 -- >>> BEGIN delta-insert
 INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
     id,

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -3,7 +3,10 @@
 -- Run this only after the whole backfill (step 1) is complete and reconciled.
 
 -- Step 0: The SQL below (delta-insert + deletion replay) is the single source driven by ../delta_replay.sh, which reads
--- this file, substitutes the placeholders and runs it — never run this file by hand:
+-- this file, substitutes the placeholders and runs it — never run this file by hand. ALL FOUR placeholders it
+-- substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the server as a literal and the
+-- statement fails): ${ANALYTICS_DB_DATABASE_NAME}, ${BACKFILL_START}, ${MAX_INSERT_BLOCK_SIZE} and
+-- ${MAX_PARTITIONS_PER_INSERT_BLOCK}. Invocation:
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000'
 -- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where
 -- situational awareness matters most — those are config/judgement, not SQL. The driver invokes clickhouse-client with
@@ -26,7 +29,13 @@
 -- batch-ingest path, so it is not a reliable "changed since" signal by itself. Every trace write sets EITHER a fresh
 -- server created_at (batch-ingest path) OR a fresh server last_updated_at (create/update merge paths), so the union is
 -- complete. ReplacingMergeTree dedups the re-copied rows against the backfilled ones (newest last_updated_at wins).
--- Uses ${BACKFILL_START}. SETTINGS max_insert_block_size bounds per-block memory as in step 1.
+-- Uses ${BACKFILL_START}. SETTINGS max_insert_block_size bounds per-block memory as in step 1, and
+-- max_partitions_per_insert_block bounds how many partitions one block may span — a CORRECTNESS gate here, not a
+-- tuning knob, and it is NOT optional just because the delta is smaller than the backfill. This INSERT writes into the
+-- same weekly-partitioned shadow, and the last_updated_at arm re-copies UPDATES TO OLD ROWS, so a far-future-id row
+-- touched during the window is pulled in and lands in its own far-future partition. Exceeding the ClickHouse default of
+-- 100 aborts the statement (throw_on_max_partitions_per_insert_block = 1) at the worst possible moment: the final delta
+-- runs immediately before the EXCHANGE. Pass the same value used for the backfill.
 -- BATCHING: the delta covers only writes during the backfill window, not the whole table, so it is normally one
 -- statement. If the backfill ran for days on a busy system and the delta is large, run it as two batched passes to keep
 -- each INSERT bounded (both columns have a minmax skip index, so each pass prunes):
@@ -87,6 +96,7 @@ FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
 WHERE created_at >= toDateTime64('${BACKFILL_START}', 6)
    OR last_updated_at >= toDateTime64('${BACKFILL_START}', 6)
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
+         max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
          log_comment = 'traces_local_v2_cutover:delta_insert';
 -- >>> END delta-insert
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -23,6 +23,16 @@
 #                             the password out of argv).
 #   --backfill-start TS        the anchor printed by backfill.sh ("RECORD backfill_start=..."). Required.
 #   --max-insert-block-size N  SETTINGS max_insert_block_size for the delta INSERT. Default 1048576.
+#   --max-partitions-per-insert-block N
+#                             partitions one insert block of the delta INSERT may span (SETTINGS
+#                             max_partitions_per_insert_block). Default 2000; 0 = unlimited. Same correctness gate as in
+#                             backfill.sh, and it applies here too: the delta writes into the same weekly-partitioned
+#                             shadow, and its `last_updated_at` arm re-copies UPDATES TO OLD ROWS, so a far-future-id row
+#                             updated during the window is pulled in and lands in its far-future partition. ClickHouse
+#                             defaults this to 100 and aborts the INSERT rather than degrading
+#                             (throw_on_max_partitions_per_insert_block = 1). An abort here is worse than in the
+#                             backfill: the final delta runs immediately before the EXCHANGE, inside the window the
+#                             runbook asks you to keep short. Pass the SAME value used for the backfill.
 
 set -euo pipefail
 
@@ -34,12 +44,14 @@ CH_HOST=""                # host; empty = clickhouse-client default/env. See --h
 CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 BACKFILL_START=""
 MAX_INSERT_BLOCK_SIZE=1048576
+MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions per block for the delta INSERT; see the option docs above. 0 = unlimited.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --backfill-start) BACKFILL_START="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -54,6 +66,10 @@ done
 [[ -n "$BACKFILL_START" ]] || { echo "ERROR: --backfill-start is required (printed by backfill.sh)" >&2; exit 2; }
 [[ "$BACKFILL_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] || { echo "ERROR: --backfill-start must be 'YYYY-MM-DD HH:MM:SS[.ffffff]'." >&2; exit 2; }
 [[ "$MAX_INSERT_BLOCK_SIZE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --max-insert-block-size must be a positive integer." >&2; exit 2; }
+# 0 is meaningful (ClickHouse reads it as "unlimited"), so allow it — unlike the bound above. Upper-bounded at 6 digits:
+# the setting counts partitions, no real table approaches that, and an out-of-range value would otherwise be rendered
+# into the SQL and rejected by the server mid-run instead of here.
+[[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
 [[ -f "$SQL_FILE" ]] || { echo "ERROR: cannot find $SQL_FILE" >&2; exit 2; }
 
 echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this step (backend config, not SQL) and"
@@ -63,6 +79,7 @@ sql="$(cat "$SQL_FILE")"
 sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
+sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
 # --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
 # the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -902,7 +902,7 @@ class TracesLocalV2CutoverTest {
                 FROM traces
                 WHERE created_at >= toDateTime64(:week_lo, 9, 'UTC')
                   AND created_at < toDateTime64(:week_hi, 9, 'UTC')
-                SETTINGS max_insert_block_size = 100000
+                SETTINGS max_insert_block_size = 100000, max_partitions_per_insert_block = 2000
                 """.formatted(COPIED_COLUMNS, COPIED_SELECT),
                 statement -> statement.bind("week_lo", weekLo).bind("week_hi", weekHi));
     }
@@ -922,7 +922,7 @@ class TracesLocalV2CutoverTest {
                 FROM traces
                 WHERE created_at >= toDateTime64(:backfill_start, 6)
                    OR last_updated_at >= toDateTime64(:backfill_start, 6)
-                SETTINGS max_insert_block_size = 100000
+                SETTINGS max_insert_block_size = 100000, max_partitions_per_insert_block = 2000
                 """.formatted(COPIED_COLUMNS, COPIED_SELECT),
                 statement -> statement.bind("backfill_start", backfillStart));
     }


### PR DESCRIPTION
## Details

The `traces` cutover backfill aborts with `Code: 252 TOO_MANY_PARTS` on a production-shape table, because the successor is weekly-partitioned and a single insert block can span more than ClickHouse's default of 100 partitions. This adds a `--max-partitions-per-insert-block` bound to the driver (default 2000) and replaces the runbook's claim that far-future partitions are "bounded ... and harmless", which does not hold on real data.

- `backfill.sh` and `delta_replay.sh`: new `--max-partitions-per-insert-block` flag (default 2000, `0` = unlimited, bounded to `1..999999`), substituted into their reference SQL.
- `000001_backfill_traces_local_v2.sql` and `000002_delta_and_deletion_replay.sql`: the setting on both INSERTs, plus header notes framing it as a correctness gate rather than a tuning knob, and enumerating every placeholder the drivers substitute.
- **The delta needs this as much as the backfill.** It writes into the same weekly-partitioned shadow, and its `last_updated_at` arm re-copies updates to old rows, so a far-future-id row touched during the window is pulled in. An abort there is worse than in the backfill, since the final delta runs immediately before the `EXCHANGE`.
- `README.md`: the corrected claim with measurements, a read-only per-block spread query so an operator can see the worst case before starting, the new bound under "Batching and throttling", and a Go/No-Go item that feeds the audit count into the setting.
- `TracesLocalV2CutoverTest`: mirror the setting in its two inline `INSERT`s, per the reference SQL's "keep the two in step" note.

### Why it fails, and why no existing flag avoids it

Measured on a production-shape environment (single shard, two replicas; 269.2 M rows). What drives it is the *tail*, not the volume:

| Measure | Value |
|---|---|
| Far-future rows (litellm [BerriAI/litellm#31294](https://github.com/BerriAI/litellm/pull/31294)) | 11,128,875 (4.1% of the table) |
| Distinct far-future weekly partitions | 1,517 |
| In the failing window: far-future partitions | 275, of which **268 hold 5 rows or fewer** (~635 rows total) |
| Primary-key footprint of that rare tail | 12 projects |
| Rows per insert block | ~4,841 (54 KiB rows against the 256 MB `min_insert_block_size_bytes` cap, which binds before `max_insert_block_size`) |

Because the rare tail sits in a narrow primary-key range, one block picks up most of those 268 partitions at once.

`backfill.sh` splits a week only by `created_at`, to respect `--max-rows-per-insert`; the two failing weeks hold 890,767 and 1,004,423 rows, already under the 2 M default, so each runs as one unsplit INSERT however many partitions it spans. Lowering `--max-insert-block-size` does not help either, since the byte cap already binds. So the bound belongs in a setting, not in the invocation.

Two further notes for whoever runs this next:

- **It survives the parallel read.** With `max_insert_threads = 0` and `max_threads = auto(48)` it is reasonable to expect 48 interleaved streams to scatter the tail and keep every block under the limit. They do not. I talked myself out of this finding on exactly that reasoning and the cluster disagreed.
- **The abort is not all-or-nothing.** 511,328 rows had already committed as 119 parts before the offending block threw. The successor is a `ReplacingMergeTree` keyed on `(workspace_id, project_id, id)` so a re-run converges rather than duplicating, but prerequisite #2 ("the shadow is empty") stops holding until it is cleared with `rollback.sh --stage A`.

Smaller datasets have a much shorter tail, very likely under 100 far-future partitions in total, which is why earlier cutovers on smaller environments completed on the stock limit. Those clean runs do not clear a larger table.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6901

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Authored the driver flag, the reference-SQL setting, the README correction and the gate-test mirror. Ran the diagnosis and the reproduction against a live cluster in an interactive operator session.
- Human verification: The operator ran the session interactively and reviewed each command and its output, including the `Code: 252` reproduction and the post-abort state checks, before this PR was raised. The Java gate test was **not** executed (see Testing). Author review of the diff is still required.

## Testing

Reproduction of the bug, and confirmation of the mechanism:

- Ran `backfill.sh` unmodified, at the reviewed revision, scoped to the single failing week (`--from-week 40 --to-week 40`) against a live production-shape cluster. It aborted with `Code: 252 ... Too many partitions for single INSERT block (more than 100)`.
- Confirmed the source table was untouched by the abort, and that 511,328 rows had committed as 119 parts before the throw.
- Cleared the partial window with `rollback.sh --stage A` and confirmed the shadow returned to 0 rows and 0 parts on both replicas.
- Quantified the cause with the runbook's own far-future audit query plus a read-only per-block spread simulation (the latter is now included in the README so it can be re-run).

Validation of this change:

- `bash -n` clean on both `scripts/backfill.sh` and `scripts/delta_replay.sh`.
- New flag rejects non-numeric, negative and oversized input (`abc`, `-1`, `1000000`, `18446744073709551616` all exit 2 with the expected message) and accepts `0`, `2000` and `999999`.
- Verified every `${...}` placeholder in **both** `000001` and `000002` is substituted by its driver, so nothing can render unsubstituted. The first version of that check silently matched nothing and would have reported a false pass, so it is now run with a control test.
- `shellcheck` not available in the environment used, so it was not run.

Not run, with reason:

- `mvn -o test -Dtest=TracesLocalV2CutoverTest` was **not** executed; it needs a ClickHouse container that the operator host did not have. The test change is limited to adding one `SETTINGS` key to two inline `INSERT`s, and the gate test reimplements the statement inline rather than parsing the `.sql`, so it does not read the changed reference file. **Please confirm CI is green on it.**
- No end-to-end rerun of the full backfill after the fix: the environment it was found on needs the equivalent setting applied on the migration user's settings profile first (a separate change in our internal deployment chart), so the post-fix run is still pending.

## Review

Five findings from `baz-reviewer[bot]` are addressed in `0efbb89`, each answered on its thread. One was a real gap in the first commit rather than a nit: **the delta path was left exposed**, and the gate test's inline delta statement had the setting while the production delta SQL did not, which masked it. The sizing rationale also changed as a result of the review: it no longer rests on the per-block simulation (which imposes an `ORDER BY` the real INSERT does not have) but on the fact that a block cannot span more partitions than the table has, so sizing above the total distinct partition count holds regardless of read order or thread count.

## Documentation

`apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md` is updated in this PR: the incorrect far-future claim is replaced with the measurements and the reproduction, the new bound is documented under "Batching and throttling" and in the driver's own `--help` block, the Go/No-Go item now feeds the audit count into the setting, and a read-only per-block spread query is included so the worst case can be checked before a run rather than discovered during one.
