### PR TITLE
[OPIK-7945] [QA] fix: raise test-suites/run bridge timeout to avoid nightly false failures

### DIFF
--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -350,6 +350,11 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
       );
     },
     async runTestSuite(args) {
+      // Runs real LLM judge calls across every item/run in the suite, which
+      // routinely outlives the default 30s budget on a loaded cloud
+      // workspace. Aborting early would turn a slow run into a red test.
+      // Capped at 90s, not the caller's full test.setTimeout(120_000), to
+      // leave headroom for the UI verification steps that follow this call.
       return request<{
         experiment_id: string | null;
         experiment_name: string | null;
@@ -357,7 +362,7 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
         items_passed: number;
         items_failed: number;
         items_total: number;
-      }>('POST', '/test-suites/run', args);
+      }>('POST', '/test-suites/run', args, { timeoutMs: 90_000 });
     },
     async createAnnotationQueue(args) {
       return request<{ id: string; name: string }>('POST', '/annotation-queues', args);


### PR DESCRIPTION
## Details
The `test-suites-smoke` E2E spec calls the SDK bridge's `/test-suites/run` route, which triggers real LLM judge calls across every item in the suite. That call had no custom timeout, so it inherited the bridge client's 30s default — too short under nightly production load, causing intermittent false failures. Raises the timeout to 90s (kept under the test's 120s budget so later UI-verification steps still have headroom), matching the same pattern already used for `createNestedTrace` and `insertDatasetItems` in this file.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7945

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Sonnet 5
  - Scope: full implementation — root-cause investigation, fix, and verification
  - Human verification: code review + manual local/production test runs

## Testing
- `npx tsc --noEmit` in `tests_end_to_end/e2e` — passes
- Ran `tests/test-suites/test-suites-smoke.spec.ts` locally against a Docker-based Opik stack (`./opik.sh --build`) — 2/2 passed
- Ran the same spec against production (`OPIK_DEPLOYMENT=cloud`) — 2/2 passed; the SDK-run step completed in ~19s, comfortably within both the old 30s and new 90s timeouts
- Cross-checked historical nightly Playwright/Allure artifacts to confirm the original failure was an intermittent timing spike under concurrent nightly load against production, not a deterministic regression

## Documentation
N/A
