### PR TITLE
[OPIK-7860] [SDK] fix: preserve langchain usage when model metadata is absent

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_usage_extractor.py
@@ -35,8 +35,19 @@ class AnthropicUsageExtractor(
             return False
 
     def get_llm_usage_info(self, run_dict: Dict[str, Any]) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name resolution must not drop an already-extracted
+        # usage payload; continue with model=None and let the SDK still record
+        # token counts for downstream cost/usage analytics.
         usage_dict = _try_get_token_usage(run_dict)
-        model = _try_get_model_name(run_dict)
+        try:
+            model = _try_get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably Anthropic LLM langchain run, "
+                "continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
 
         return llm_usage.LLMUsageInfo(
             provider=self.PROVIDER, model=model, usage=usage_dict
@@ -80,16 +91,25 @@ def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
         "model_name",  # detected in langchain-anthropic 0.3.17
     ]
     model = None
+    outputs = run_dict.get("outputs") or {}
+    llm_output = outputs.get("llm_output")
     for model_name_key in POSSIBLE_MODEL_NAME_KEYS:
         try:
-            if run_dict["outputs"]["llm_output"] is not None:
-                model = run_dict["outputs"]["llm_output"][model_name_key]
+            if llm_output is not None:
+                model = llm_output.get(model_name_key, model)
             else:
-                # Handle the streaming mode
-                model = run_dict["outputs"]["generations"][-1][-1]["message"]["kwargs"][
-                    "response_metadata"
-                ][model_name_key]
-        except KeyError:
+                # Handle the streaming mode. Walk the chain with .get() so
+                # an empty generations list (IndexError) or a missing
+                # "message" / "kwargs" / "response_metadata" key (KeyError,
+                # TypeError on a None hop) returns None instead of raising
+                # into the orchestrator and dropping the usage payload.
+                generations = outputs.get("generations") or []
+                if generations and generations[-1]:
+                    last_message = generations[-1][-1].get("message") or {}
+                    kwargs = last_message.get("kwargs") or {}
+                    response_metadata = kwargs.get("response_metadata") or {}
+                    model = response_metadata.get(model_name_key, model)
+        except (KeyError, IndexError, TypeError, AttributeError):
             continue
 
     if model is None:

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_vertexai_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_vertexai_usage_extractor.py
@@ -38,8 +38,18 @@ class AnthropicVertexAIUsageExtractor(
             return False
 
     def get_llm_usage_info(self, run_dict: Dict[str, Any]) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name resolution must not drop an already-extracted
+        # usage payload; continue with model=None.
         usage_dict = _try_get_token_usage(run_dict)
-        model = _try_get_model_name(run_dict)
+        try:
+            model = _try_get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably Anthropic LLM vertexai "
+                "langchain run, continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
 
         return llm_usage.LLMUsageInfo(
             provider=self.PROVIDER, model=model, usage=usage_dict
@@ -62,6 +72,8 @@ def _try_get_token_usage(run_dict: Dict[str, Any]) -> Optional[llm_usage.OpikUsa
 
 
 def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
-    if invocation_params := run_dict["extra"].get("invocation_params"):
+    # Use .get() with a default dict so a missing "extra" key returns None
+    # instead of raising into the orchestrator and dropping the usage payload.
+    if invocation_params := (run_dict.get("extra") or {}).get("invocation_params"):
         return invocation_params.get("model_name")
     return None

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/google_generative_ai_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/google_generative_ai_usage_extractor.py
@@ -45,8 +45,18 @@ class GoogleGenerativeAIUsageExtractor(
             return False
 
     def get_llm_usage_info(self, run_dict: Dict[str, Any]) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name resolution must not drop an already-extracted
+        # usage payload; continue with model=None.
         usage_dict = _try_get_token_usage(run_dict)
-        model = _get_model_name(run_dict)
+        try:
+            model = _get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably Google Generative AI "
+                "langchain run, continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
 
         return llm_usage.LLMUsageInfo(
             provider=self.PROVIDER, model=model, usage=usage_dict
@@ -95,7 +105,11 @@ def _get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
     if (ls_metadata := langchain_run_helpers.try_get_ls_metadata(run_dict)) is not None:
         model = ls_metadata.model
 
-    elif (invocation_params := run_dict["extra"].get("invocation_params")) is not None:
+    # Use .get() with a default dict so a missing "extra" key returns None
+    # instead of raising into the orchestrator and dropping the usage payload.
+    elif (
+        invocation_params := (run_dict.get("extra") or {}).get("invocation_params")
+    ) is not None:
         model = invocation_params.get("model")
 
     if model is not None:

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/groq_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/groq_usage_extractor.py
@@ -40,8 +40,18 @@ class GroqUsageExtractor(
             return False
 
     def get_llm_usage_info(self, run_dict: Dict[str, Any]) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name resolution must not drop an already-extracted
+        # usage payload; continue with model=None.
         opik_usage = _try_get_token_usage(run_dict)
-        model = _try_get_model_name(run_dict)
+        try:
+            model = _try_get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably Groq LLM langchain run, "
+                "continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
 
         return llm_usage.LLMUsageInfo(
             provider=self.PROVIDER, model=model, usage=opik_usage
@@ -85,7 +95,9 @@ def _try_get_token_usage(run_dict: Dict[str, Any]) -> Optional[llm_usage.OpikUsa
 
 
 def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
-    model = run_dict["extra"].get("metadata", {}).get("ls_model_name")
+    # Use .get() with a default dict so a missing "extra" key returns None
+    # instead of raising into the orchestrator and dropping the usage payload.
+    model = (run_dict.get("extra") or {}).get("metadata", {}).get("ls_model_name")
     if model is not None:
         model = model.split("/")[-1]
 

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/openai_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/openai_usage_extractor.py
@@ -39,9 +39,29 @@ class OpenAIUsageExtractor(
             return False
 
     def get_llm_usage_info(self, run_dict: Dict[str, Any]) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name or provider resolution must not drop an
+        # already-extracted usage payload; the SDK records token counts even
+        # when the model is unknown so cost/usage analytics stay accurate.
         opik_usage = _try_get_token_usage(run_dict)
-        model = _try_get_model_name(run_dict)
-        provider = self._get_provider(run_dict)
+        try:
+            model = _try_get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably OpenAI LLM langchain run, "
+                "continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
+        try:
+            provider = self._get_provider(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract provider from presumably OpenAI LLM langchain run, "
+                "falling back to %s.",
+                self.PROVIDER,
+                exc_info=True,
+            )
+            provider = self.PROVIDER
 
         return llm_usage.LLMUsageInfo(provider=provider, model=model, usage=opik_usage)
 
@@ -51,8 +71,11 @@ class OpenAIUsageExtractor(
         """
         provider = self.PROVIDER
 
-        # Check base URL to detect custom providers
-        if base_url := run_dict["extra"].get("invocation_params", {}).get("base_url"):
+        # Check base URL to detect custom providers. Use .get() so a missing
+        # "extra" key (e.g. a partial run_dict) returns the canonical provider
+        # rather than raising into the orchestrator.
+        extra = run_dict.get("extra") or {}
+        if base_url := extra.get("invocation_params", {}).get("base_url"):
             if base_url.host != "api.openai.com":
                 provider = base_url.host
 
@@ -103,22 +126,30 @@ def _try_get_token_usage(run_dict: Dict[str, Any]) -> Optional[llm_usage.OpikUsa
 
 def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
     """
-    Extracts the model name from the run dictionary.
+    Extracts the model name from the run dictionary. Returns None when the
+    run shape is missing the keys this helper normally reads (older or
+    partial langchain runs, custom stream wrappers) instead of raising.
     """
     model = None
 
-    # Get model from metadata
-    if metadata := run_dict["extra"].get("metadata"):
+    # Get model from metadata. Use .get() chains so a missing "extra" or
+    # "outputs" key returns None rather than raising into the orchestrator
+    # and dropping the already-extracted usage.
+    extra = run_dict.get("extra") or {}
+    if metadata := extra.get("metadata"):
         model = metadata.get("ls_model_name")
 
+    outputs = run_dict.get("outputs") or {}
     # Try to detect model+version more precise way if possible
     # .invoke() mode
-    if llm_output := run_dict["outputs"].get("llm_output"):
+    if llm_output := outputs.get("llm_output"):
         model = llm_output.get("model_name", model)
     # streaming mode
-    elif generation_info := run_dict["outputs"]["generations"][-1][-1][
-        "generation_info"
-    ]:
-        model = generation_info.get("model_name", model)
+    else:
+        generations = outputs.get("generations") or []
+        if generations and generations[-1]:
+            last = generations[-1][-1] or {}
+            if generation_info := last.get("generation_info"):
+                model = generation_info.get("model_name", model)
 
     return model

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/vertexai_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/vertexai_usage_extractor.py
@@ -51,8 +51,18 @@ class VertexAIUsageExtractor(
         self,
         run_dict: Dict[str, Any],
     ) -> llm_usage.LLMUsageInfo:
+        # A failure in model-name resolution must not drop an already-extracted
+        # usage payload; continue with model=None.
         usage_dict = _try_get_token_usage(run_dict)
-        model = _try_get_model_name(run_dict)
+        try:
+            model = _try_get_model_name(run_dict)
+        except Exception:
+            LOGGER.debug(
+                "Failed to extract model name from presumably VertexAI LLM langchain run, "
+                "continuing with model=None.",
+                exc_info=True,
+            )
+            model = None
 
         return llm_usage.LLMUsageInfo(
             provider=self.PROVIDER, model=model, usage=usage_dict
@@ -99,7 +109,11 @@ def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
     if (ls_metadata := langchain_run_helpers.try_get_ls_metadata(run_dict)) is not None:
         model = ls_metadata.model
 
-    elif (invocation_params := run_dict["extra"].get("invocation_params")) is not None:
+    # Use .get() with a default dict so a missing "extra" key returns None
+    # instead of raising into the orchestrator and dropping the usage payload.
+    elif (
+        invocation_params := (run_dict.get("extra") or {}).get("invocation_params")
+    ) is not None:
         model = invocation_params.get("model_name")
 
     if model is not None:

--- a/sdks/python/tests/unit/integrations/langchain/test_usage_extractor_partial_success.py
+++ b/sdks/python/tests/unit/integrations/langchain/test_usage_extractor_partial_success.py
@@ -1,0 +1,236 @@
+"""Regression for OPIK-7860: LangChain usage extractors discard an already-extracted
+usage payload whenever the model-name or provider lookup raises.
+
+The orchestrator in `provider_usage_extractors.usage_extractor.try_extract_provider_usage_data`
+catches every exception from `get_llm_usage_info` and returns `None`, so any
+unguarded `run_dict["extra"]` / `run_dict["outputs"]` access in the model
+extraction helpers would silently drop the usage. The fix hardens each
+extractor's `_try_get_model_name` / `_get_provider` to return `None` on a
+missing key, and wraps the model extraction call in `get_llm_usage_info` in a
+defensive `try/except` so a partial-success payload (usage extracted, model
+unresolvable) is preserved end-to-end.
+
+This test verifies the per-extractor behaviour by mocking the token-usage
+helper to return a known OpikUsage and then asserting that `get_llm_usage_info`
+returns an LLMUsageInfo with the usage preserved and `model=None` when the
+run_dict is missing the keys the helper would normally read.
+
+The end-to-end test at the bottom exercises the orchestrator with a
+streaming-shape OpenAI run whose generation dict has no `generation_info` key
+(the issue's exact repro) and asserts the result is not `None`.
+"""
+
+from typing import Any, Dict
+from unittest import mock
+
+import pytest
+
+from opik import llm_usage
+from opik.integrations.langchain.provider_usage_extractors import (
+    anthropic_usage_extractor,
+    anthropic_vertexai_usage_extractor,
+    google_generative_ai_usage_extractor,
+    groq_usage_extractor,
+    openai_usage_extractor,
+    usage_extractor,
+    vertexai_usage_extractor,
+)
+from opik.llm_usage import opik_usage as opik_usage_module
+
+
+# A minimal OpikUsage covering all three token counts so we can assert
+# the helper preserved the value end-to-end.
+@pytest.fixture
+def stub_opik_usage() -> llm_usage.OpikUsage:
+    return opik_usage_module.OpikUsage(
+        completion_tokens=5,
+        prompt_tokens=10,
+        total_tokens=15,
+        provider_usage=opik_usage_module.unknown_usage.UnknownUsage(
+            original_usage={"input_tokens": 10, "output_tokens": 5}
+        ),
+    )
+
+
+# Provider -> (extractor_instance, module_that_owns_its__try_get_token_usage).
+# Each entry is one call site that had to be hardened.
+PROVIDER_EXTRACTORS = [
+    pytest.param(
+        openai_usage_extractor.OpenAIUsageExtractor(),
+        openai_usage_extractor,
+        id="openai",
+    ),
+    pytest.param(
+        anthropic_usage_extractor.AnthropicUsageExtractor(),
+        anthropic_usage_extractor,
+        id="anthropic",
+    ),
+    pytest.param(
+        groq_usage_extractor.GroqUsageExtractor(),
+        groq_usage_extractor,
+        id="groq",
+    ),
+    pytest.param(
+        vertexai_usage_extractor.VertexAIUsageExtractor(),
+        vertexai_usage_extractor,
+        id="vertexai",
+    ),
+    pytest.param(
+        anthropic_vertexai_usage_extractor.AnthropicVertexAIUsageExtractor(),
+        anthropic_vertexai_usage_extractor,
+        id="anthropic_vertexai",
+    ),
+    pytest.param(
+        google_generative_ai_usage_extractor.GoogleGenerativeAIUsageExtractor(),
+        google_generative_ai_usage_extractor,
+        id="google_generative_ai",
+    ),
+]
+
+
+@pytest.mark.parametrize("extractor,source_module", PROVIDER_EXTRACTORS)
+def test_get_llm_usage_info_preserves_usage_when_model_keys_missing(
+    extractor: Any, source_module: Any, stub_opik_usage: llm_usage.OpikUsage
+) -> None:
+    """A run_dict missing the model-extraction keys must not drop the usage.
+
+    Before the fix, `get_llm_usage_info` accessed `run_dict["extra"]` /
+    `run_dict["outputs"]["generations"][-1][-1]["generation_info"]` directly
+    and raised into the orchestrator's catch-all, which returned `None` and
+    silently dropped the already-extracted usage. After the fix, the
+    `_try_get_model_name` helpers return `None` and `get_llm_usage_info` wraps
+    the model call in a defensive `try/except` so the partial-success payload
+    is preserved.
+    """
+    # Empty `extra` and empty `outputs` mimic the run_dict shape the issue
+    # reported for partial / older langchain runs. Pre-fix this raised
+    # KeyError; post-fix the model extraction returns None and the usage
+    # is returned untouched.
+    run_dict: Dict[str, Any] = {"extra": {}, "outputs": {}}
+
+    with mock.patch.object(
+        source_module, "_try_get_token_usage", return_value=stub_opik_usage
+    ):
+        result = extractor.get_llm_usage_info(run_dict)
+
+    assert result is not None
+    assert result.usage is stub_opik_usage, (
+        "Usage payload was dropped when the model-extraction keys were "
+        "missing from the run_dict."
+    )
+    assert result.model is None, (
+        "Model must be None when the run_dict is missing the keys the "
+        "extractor normally reads; the issue's expected behavior is to "
+        "keep the usage and report model=None rather than raising."
+    )
+
+
+def test_openai_streaming_without_generation_info_keeps_usage(
+    stub_opik_usage: llm_usage.OpikUsage,
+) -> None:
+    """The issue's exact repro for openai: streaming shape with usage in
+    `message.kwargs.usage_metadata` but no `generation_info` on the generation
+    dict. Pre-fix, the unguarded `run_dict["outputs"]["generations"][-1][-1][
+    "generation_info"]` raised KeyError into the orchestrator and the usage
+    was dropped. Post-fix, the helper returns None and the usage is kept.
+    """
+    run_dict: Dict[str, Any] = {
+        "extra": {},
+        "outputs": {
+            "generations": [
+                [
+                    {
+                        "message": {
+                            "kwargs": {
+                                "usage_metadata": {
+                                    "input_tokens": 10,
+                                    "output_tokens": 5,
+                                    "total_tokens": 15,
+                                }
+                            }
+                        }
+                    }
+                ]
+            ]
+        },
+    }
+
+    with mock.patch.object(
+        openai_usage_extractor, "_try_get_token_usage", return_value=stub_opik_usage
+    ):
+        result = openai_usage_extractor.OpenAIUsageExtractor().get_llm_usage_info(
+            run_dict
+        )
+
+    assert result is not None
+    assert result.usage is stub_opik_usage
+    assert result.model is None
+
+
+def test_anthropic_empty_generations_keeps_usage(
+    stub_opik_usage: llm_usage.OpikUsage,
+) -> None:
+    """Anthropic: empty generations list raised `IndexError` (only `KeyError`
+    was caught) and dropped the usage. Post-fix the helper returns None.
+    """
+    run_dict: Dict[str, Any] = {
+        "extra": {},
+        "outputs": {"generations": []},
+    }
+
+    with mock.patch.object(
+        anthropic_usage_extractor,
+        "_try_get_token_usage",
+        return_value=stub_opik_usage,
+    ):
+        result = anthropic_usage_extractor.AnthropicUsageExtractor().get_llm_usage_info(
+            run_dict
+        )
+
+    assert result is not None
+    assert result.usage is stub_opik_usage
+    assert result.model is None
+
+
+def test_orchestrator_returns_usage_when_openai_extractor_preserves_partial_success(
+    stub_opik_usage: llm_usage.OpikUsage,
+) -> None:
+    """End-to-end: the orchestrator iterates the registered extractors, the
+    OpenAI extractor matches the `openai_api_key` in `serialized.kwargs`, and
+    the partial-success payload is returned (not None) when the model
+    extraction cannot resolve a model name.
+    """
+    run_dict: Dict[str, Any] = {
+        "serialized": {"kwargs": {"openai_api_key": "test-key"}},
+        "extra": {},
+        "outputs": {
+            "generations": [
+                [
+                    {
+                        "message": {
+                            "kwargs": {
+                                "usage_metadata": {
+                                    "input_tokens": 10,
+                                    "output_tokens": 5,
+                                    "total_tokens": 15,
+                                }
+                            }
+                        }
+                    }
+                ]
+            ]
+        },
+    }
+
+    with mock.patch.object(
+        openai_usage_extractor, "_try_get_token_usage", return_value=stub_opik_usage
+    ):
+        result = usage_extractor.try_extract_provider_usage_data(run_dict)
+
+    assert result is not None, (
+        "Orchestrator returned None despite the OpenAI extractor being able "
+        "to resolve a usage payload; the partial-success contract from the "
+        "issue is broken."
+    )
+    assert result.usage is stub_opik_usage
+    assert result.model is None


### PR DESCRIPTION
## Summary

The six provider usage extractors under `integrations/langchain/provider_usage_extractors/` reach into `run_dict["extra"]` and `run_dict["outputs"]` without guarding against missing keys, and `AnthropicUsageExtractor._try_get_model_name` only catches `KeyError` on the streaming path (empty generations raise `IndexError`).

The orchestrator in `usage_extractor.try_extract_provider_usage_data` catches every exception from `get_llm_usage_info` and returns `None`, so any unguarded lookup drops the already-extracted usage payload. The span is emitted with no token counts even when the tokens were extractable.

The issue's exact repro: a streaming-shape OpenAI run whose usage sits in the message `usage_metadata` but whose generation dict has no `generation_info` key — `try_extract_provider_usage_data` returns `None` instead of the usage.

## Fix

- Replace `run_dict["extra"]` / `run_dict["outputs"]` with `.get()` chains in the six affected extractors' model-name and provider helpers, so a partial run_dict returns `None` instead of raising.
- Catch `(KeyError, IndexError, TypeError, AttributeError)` in `AnthropicUsageExtractor._try_get_model_name` so the empty-generations IndexError also returns `None`.
- Wrap the model-name and provider resolution calls in each `get_llm_usage_info` in a defensive `try/except` that falls back to `model=None` (and the canonical provider) while keeping the already-extracted usage.

## Affected files

- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/openai_usage_extractor.py`
- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_usage_extractor.py`
- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/groq_usage_extractor.py`
- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/vertexai_usage_extractor.py`
- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_vertexai_usage_extractor.py`
- `sdks/python/src/opik/integrations/langchain/provider_usage_extractors/google_generative_ai_usage_extractor.py`

`BedrockUsageExtractor` was already safe (`run_dict.get("serialized", {}).get("kwargs", {})` chain).

## Testing

Adds a regression test at `sdks/python/tests/unit/integrations/langchain/test_usage_extractor_partial_success.py` that:
- Patches each extractor's `_try_get_token_usage` to return a known `OpikUsage`, then verifies `get_llm_usage_info` returns the usage with `model=None` when the run_dict is missing the model-extraction keys (parameterised over all 6 affected providers).
- Exercises the issue's exact openai streaming repro end-to-end through the orchestrator.
- Exercises the empty-generations `IndexError` path on anthropic.

Results:
- 9/9 new tests pass (`tests/unit/integrations/langchain/test_usage_extractor_partial_success.py`)
- 65/65 pre-existing `tests/unit/llm_usage/` tests pass — no regression in the broader usage suite
- `ruff format` + `ruff check` clean
- `mypy` clean (13 source files)

Commands run:
```
cd sdks/python && .venv/bin/python -m pytest tests/unit/integrations/langchain/ tests/unit/llm_usage/ -v
cd sdks/python && .venv/bin/python -m ruff format src/opik/integrations/langchain/provider_usage_extractors/ tests/unit/integrations/langchain/test_usage_extractor_partial_success.py
cd sdks/python && .venv/bin/python -m ruff check src/opik/integrations/langchain/provider_usage_extractors/ tests/unit/integrations/langchain/test_usage_extractor_partial_success.py
cd sdks/python && .venv/bin/python -m mypy src/opik/integrations/langchain/provider_usage_extractors/
```

## Risk

Minimal. The change only affects the model-name / provider resolution helpers; the usage-extraction path is unchanged. Behaviour change is limited to: previously-dropped spans now report the usage with `model=None`, and a debug log line is added when the resolution fails. No public API change.

## Issues

- Resolves #7860

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude (Mavis)
- Model(s): MiniMax-M3
- Scope: source code fix in 6 langchain usage extractors + regression test
- Human verification: ran pytest (9/9 new tests pass, 65/65 pre-existing tests pass), ruff format/check, mypy

## Documentation

No user-facing doc change; the affected helpers are private to the langchain integration.
