### PR TITLE
[OPIK-7839] [FE] fix confusable series colors in grouped charts

### DIFF
--- a/apps/opik-frontend/src/constants/colorVariants.ts
+++ b/apps/opik-frontend/src/constants/colorVariants.ts
@@ -17,7 +17,7 @@ export type ColorVariant = (typeof COLOR_VARIANTS)[number];
 export type ExtendedColorVariant =
   | ColorVariant
   | "primary"
-  | "ochre"
+  | "purpleDark"
   | "default";
 
 export const COLOR_VARIANTS_MAP: Record<
@@ -35,7 +35,7 @@ export const COLOR_VARIANTS_MAP: Record<
   turquoise: { css: "var(--color-turquoise)", hex: "#06b6d4" },
   blue: { css: "var(--color-blue)", hex: "#3b82f6" },
   primary: { css: "var(--color-primary)", hex: "#6366f1" },
-  ochre: { css: "var(--color-ochre)", hex: "#8c683f" },
+  purpleDark: { css: "var(--color-purple-dark)", hex: "#491b7e" },
   default: { css: "var(--color-gray)", hex: "#64748b" },
 };
 
@@ -45,10 +45,10 @@ export const PRESET_HEX_COLORS = COLOR_VARIANTS.map(
 
 export const DEFAULT_HEX_COLOR = COLOR_VARIANTS_MAP.blue.hex;
 
-// `primary` and `ochre` are not in COLOR_VARIANTS (they are not picker presets) but are still
+// `primary` and `purpleDark` are not in COLOR_VARIANTS (they are not picker presets) but are still
 // reachable as resolved colors, so their css vars must round-trip to hex for the color picker.
 export const CSS_VAR_TO_HEX: Record<string, string> = Object.fromEntries(
-  [...COLOR_VARIANTS, "primary" as const, "ochre" as const].map((v) => [
+  [...COLOR_VARIANTS, "primary" as const, "purpleDark" as const].map((v) => [
     COLOR_VARIANTS_MAP[v].css,
     COLOR_VARIANTS_MAP[v].hex,
   ]),

--- a/apps/opik-frontend/src/constants/colorVariants.ts
+++ b/apps/opik-frontend/src/constants/colorVariants.ts
@@ -14,7 +14,11 @@ export const COLOR_VARIANTS = [
 ] as const;
 
 export type ColorVariant = (typeof COLOR_VARIANTS)[number];
-export type ExtendedColorVariant = ColorVariant | "primary" | "default";
+export type ExtendedColorVariant =
+  | ColorVariant
+  | "primary"
+  | "ochre"
+  | "default";
 
 export const COLOR_VARIANTS_MAP: Record<
   ExtendedColorVariant,
@@ -31,6 +35,7 @@ export const COLOR_VARIANTS_MAP: Record<
   turquoise: { css: "var(--color-turquoise)", hex: "#06b6d4" },
   blue: { css: "var(--color-blue)", hex: "#3b82f6" },
   primary: { css: "var(--color-primary)", hex: "#6366f1" },
+  ochre: { css: "var(--color-ochre)", hex: "#8c683f" },
   default: { css: "var(--color-gray)", hex: "#64748b" },
 };
 
@@ -40,8 +45,10 @@ export const PRESET_HEX_COLORS = COLOR_VARIANTS.map(
 
 export const DEFAULT_HEX_COLOR = COLOR_VARIANTS_MAP.blue.hex;
 
+// `primary` and `ochre` are not in COLOR_VARIANTS (they are not picker presets) but are still
+// reachable as resolved colors, so their css vars must round-trip to hex for the color picker.
 export const CSS_VAR_TO_HEX: Record<string, string> = Object.fromEntries(
-  [...COLOR_VARIANTS, "primary" as const].map((v) => [
+  [...COLOR_VARIANTS, "primary" as const, "ochre" as const].map((v) => [
     COLOR_VARIANTS_MAP[v].css,
     COLOR_VARIANTS_MAP[v].hex,
   ]),

--- a/apps/opik-frontend/src/lib/colorVariants.test.ts
+++ b/apps/opik-frontend/src/lib/colorVariants.test.ts
@@ -94,6 +94,22 @@ describe("automatic palette invariants", () => {
     expect(tooClose).toEqual([]);
   });
 
+  it("keeps the palette at ten entries", () => {
+    // The automatic color is `hash % TAG_VARIANTS.length`. The golden test below samples four
+    // labels, which would not notice a length change that only moves labels it does not sample,
+    // so the length is pinned separately. Changing it re-colors every label in the product.
+    expect(TAG_VARIANTS).toHaveLength(10);
+  });
+
+  it("pins the design-approved hex for the entry excused from the contrast check", () => {
+    // `purpleDark` is skipped by the contrast assertion below, so without this the approved value
+    // could drift to something the check would otherwise have rejected.
+    expect(COLOR_VARIANTS_MAP.purpleDark.hex.toLowerCase()).toBe("#491b7e");
+    expect(resolveHexColor(COLOR_VARIANTS_MAP.purpleDark.css)).toBe(
+      COLOR_VARIANTS_MAP.purpleDark.hex,
+    );
+  });
+
   it("never assigns the indigo that was confusable with purple and blue", () => {
     const indigo = COLOR_VARIANTS_MAP.primary.hex.toLowerCase();
 
@@ -215,6 +231,22 @@ describe("resolveChartColorMap", () => {
     const map = resolveChartColorMap(labels);
 
     expect(Object.keys(map).sort()).toEqual(labels.sort());
+  });
+
+  it("returns an empty map for an empty label list", () => {
+    expect(resolveChartColorMap([])).toEqual({});
+  });
+
+  it("resolves an empty-string label to a palette color rather than undefined", () => {
+    // Group-by values can be empty strings; a missing color makes recharts fall back to black.
+    expect(resolveChartColorMap([""])[""]).toMatch(/^var\(--color-/);
+  });
+
+  it("leaves a value that is already hex untouched and passes unknown values through", () => {
+    expect(resolveHexColor("#123abc")).toBe("#123abc");
+    expect(resolveHexColor("var(--color-not-a-real-token)")).toBe(
+      "var(--color-not-a-real-token)",
+    );
   });
 
   it("pins only the labels the caller names, leaving the rest automatic", () => {

--- a/apps/opik-frontend/src/lib/colorVariants.test.ts
+++ b/apps/opik-frontend/src/lib/colorVariants.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveChartColorMap,
+  resolveColor,
+  resolveHexColor,
+} from "@/lib/colorVariants";
+import { TAG_VARIANTS, TAG_VARIANTS_COLOR_MAP } from "@/ui/tag";
+import { COLOR_VARIANTS_MAP } from "@/constants/colorVariants";
+
+/**
+ * Perceptual helpers live here rather than in shipped code: only these invariants need them, and
+ * shipping an unused utility invites a second, divergent implementation.
+ */
+const linearize = (c: number) =>
+  c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+
+const linearChannels = (hex: string) =>
+  [1, 3, 5].map((offset) =>
+    linearize(parseInt(hex.slice(offset, offset + 2), 16) / 255),
+  ) as [number, number, number];
+
+const toLab = (hex: string): [number, number, number] => {
+  const [r, g, b] = linearChannels(hex);
+
+  const x = (r * 0.4124564 + g * 0.3575761 + b * 0.1804375) / 0.95047;
+  const y = r * 0.2126729 + g * 0.7151522 + b * 0.072175;
+  const z = (r * 0.0193339 + g * 0.119192 + b * 0.9503041) / 1.08883;
+
+  const f = (t: number) => (t > 0.008856 ? Math.cbrt(t) : 7.787 * t + 16 / 116);
+
+  return [116 * f(y) - 16, 500 * (f(x) - f(y)), 200 * (f(y) - f(z))];
+};
+
+/** CIE76 distance. Below ~25 two thin chart lines are hard to tell apart without hovering. */
+const perceptualDistance = (a: string, b: string) => {
+  const [l1, a1, b1] = toLab(a);
+  const [l2, a2, b2] = toLab(b);
+  return Math.hypot(l1 - l2, a1 - a2, b1 - b2);
+};
+
+const relativeLuminance = (hex: string) => {
+  const [r, g, b] = linearChannels(hex);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+const contrastRatio = (a: string, b: string) => {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+};
+
+// The grounds the product actually paints: `--background` is 0 0% 100% in the light theme and
+// 0 0% 7% in the dark one (main.scss).
+const LIGHT_GROUND = "#ffffff";
+const DARK_GROUND = "#121212";
+
+const autoPaletteHexes = () =>
+  TAG_VARIANTS.map((variant) => ({
+    variant: variant as string,
+    hex: resolveHexColor(TAG_VARIANTS_COLOR_MAP[variant!]),
+  }));
+
+describe("automatic palette invariants", () => {
+  it("resolves every entry to a hex value", () => {
+    for (const { variant, hex } of autoPaletteHexes()) {
+      expect(hex, `${variant} must round-trip to hex`).toMatch(
+        /^#[0-9a-fA-F]{6}$/,
+      );
+    }
+  });
+
+  it("keeps every pair of entries perceptually distinguishable", () => {
+    // The automatic color is `hash % TAG_VARIANTS.length`, so any two labels can land on any two
+    // entries. Regression guard for OPIK-7839, where `primary` sat at ΔE 14.5 from `purple` and
+    // made distinct grouped series look identical.
+    const MINIMUM_DISTANCE = 30;
+    const palette = autoPaletteHexes();
+    const tooClose: string[] = [];
+
+    for (let i = 0; i < palette.length; i += 1) {
+      for (let j = i + 1; j < palette.length; j += 1) {
+        const distance = perceptualDistance(palette[i].hex, palette[j].hex);
+        if (distance < MINIMUM_DISTANCE) {
+          tooClose.push(
+            `${palette[i].variant}/${palette[j].variant} ΔE=${distance.toFixed(
+              1,
+            )}`,
+          );
+        }
+      }
+    }
+
+    expect(tooClose).toEqual([]);
+  });
+
+  it("never assigns the indigo that was confusable with purple and blue", () => {
+    const indigo = COLOR_VARIANTS_MAP.primary.hex.toLowerCase();
+
+    expect(
+      autoPaletteHexes().map(({ hex }) => hex.toLowerCase()),
+    ).not.toContain(indigo);
+  });
+
+  it("keeps known labels on the colors they resolve to today", () => {
+    // Guards the property that makes a palette change safe to ship: the automatic color depends on
+    // the palette length, so adding or removing an entry silently re-colors every label in the
+    // product. Substituting one entry only moves labels that resolved to that slot. If this fails,
+    // a change shifted labels it did not intend to.
+    expect(
+      resolveChartColorMap([
+        "domain-agent",
+        "supervisor-agent",
+        "planner-agent",
+        "retriever-agent",
+      ]),
+    ).toEqual({
+      "domain-agent": "var(--color-ochre)",
+      "supervisor-agent": "var(--color-blue)",
+      "planner-agent": "var(--color-orange)",
+      "retriever-agent": "var(--color-yellow)",
+    });
+  });
+
+  it("still lets two labels share a color once the palette is exhausted", () => {
+    // Documented limitation, not a defect to fix here: with ten colors, identical colors remain
+    // possible as the number of series approaches the palette size. The answer is the manual
+    // per-label override, not automatic reassignment — reassigning would break the guarantee that
+    // a label keeps one color across widgets.
+    const map = resolveChartColorMap(["id_filter_enabled", "domain-agent"]);
+
+    expect(map["id_filter_enabled"]).toBe(map["domain-agent"]);
+  });
+
+  it("keeps entries legible as thin lines on both grounds", () => {
+    // `yellow` and `turquoise` predate this invariant and fail on the light ground at 1.92 and
+    // 2.43. They are tracked separately as a palette-contrast follow-up. The assertion below still
+    // blocks *new* low-contrast entries, and the allowlist must not grow.
+    const KNOWN_LOW_CONTRAST = ["yellow", "turquoise"];
+    const MINIMUM_CONTRAST = 2.5;
+    const failing: string[] = [];
+
+    for (const { variant, hex } of autoPaletteHexes()) {
+      if (KNOWN_LOW_CONTRAST.includes(variant)) continue;
+
+      const light = contrastRatio(hex, LIGHT_GROUND);
+      const dark = contrastRatio(hex, DARK_GROUND);
+      if (Math.min(light, dark) < MINIMUM_CONTRAST) {
+        failing.push(
+          `${variant} light=${light.toFixed(2)} dark=${dark.toFixed(2)}`,
+        );
+      }
+    }
+
+    expect(failing).toEqual([]);
+  });
+});
+
+describe("resolveColor priority", () => {
+  const label = "domain-agent";
+
+  it("falls back to an automatic color when no map contains the label", () => {
+    expect(resolveColor(label)).toBeDefined();
+  });
+
+  it("prefers a caller-supplied color over the automatic one", () => {
+    const reserved = { [label]: COLOR_VARIANTS_MAP.gray.css };
+
+    expect(resolveColor(label, null, reserved)).toBe(
+      COLOR_VARIANTS_MAP.gray.css,
+    );
+    expect(resolveColor(label, null, reserved)).not.toBe(resolveColor(label));
+  });
+
+  it("prefers the workspace color over both the caller-supplied and the automatic one", () => {
+    const workspace = { [label]: "#123456" };
+    const reserved = { [label]: COLOR_VARIANTS_MAP.gray.css };
+
+    expect(resolveColor(label, workspace, reserved)).toBe("#123456");
+  });
+
+  it("leaves labels absent from the maps on their automatic color", () => {
+    const other = "supervisor-agent";
+    const reserved = { [label]: COLOR_VARIANTS_MAP.gray.css };
+
+    expect(resolveColor(other, null, reserved)).toBe(resolveColor(other));
+  });
+
+  it("assigns a label the same color regardless of which other labels are present", () => {
+    // Cross-widget consistency is a product requirement, not an incidental property: the same tag
+    // must keep one color across widgets that show different sets of series.
+    const inOneChart = resolveChartColorMap([label, "supervisor-agent"]);
+    const inAnother = resolveChartColorMap([label, "planner-agent", "a", "b"]);
+
+    expect(inOneChart[label]).toBe(inAnother[label]);
+    expect(resolveChartColorMap([label])[label]).toBe(inOneChart[label]);
+  });
+});
+
+describe("resolveChartColorMap", () => {
+  it("returns one color per label", () => {
+    const labels = ["alpha", "beta", "gamma"];
+    const map = resolveChartColorMap(labels);
+
+    expect(Object.keys(map).sort()).toEqual(labels.sort());
+  });
+
+  it("pins only the labels the caller names, leaving the rest automatic", () => {
+    // How a chart fixes colors for specific series (metric sub-series today) without disturbing
+    // labels it says nothing about.
+    const pinned = { traces: COLOR_VARIANTS_MAP.purple.css };
+    const map = resolveChartColorMap(["traces", "domain-agent"], null, pinned);
+
+    expect(map.traces).toBe(COLOR_VARIANTS_MAP.purple.css);
+    expect(map["domain-agent"]).toBe(resolveColor("domain-agent"));
+  });
+});

--- a/apps/opik-frontend/src/lib/colorVariants.test.ts
+++ b/apps/opik-frontend/src/lib/colorVariants.test.ts
@@ -115,7 +115,7 @@ describe("automatic palette invariants", () => {
         "retriever-agent",
       ]),
     ).toEqual({
-      "domain-agent": "var(--color-ochre)",
+      "domain-agent": "var(--color-purple-dark)",
       "supervisor-agent": "var(--color-blue)",
       "planner-agent": "var(--color-orange)",
       "retriever-agent": "var(--color-yellow)",
@@ -133,11 +133,23 @@ describe("automatic palette invariants", () => {
   });
 
   it("keeps entries legible as thin lines on both grounds", () => {
-    // `yellow` and `turquoise` predate this invariant and fail on the light ground at 1.92 and
-    // 2.43. They are tracked separately as a palette-contrast follow-up. The assertion below still
-    // blocks *new* low-contrast entries, and the allowlist must not grow.
-    const KNOWN_LOW_CONTRAST = ["yellow", "turquoise"];
-    const MINIMUM_CONTRAST = 2.5;
+    // WCAG 1.4.11 asks for 3:1 and names "each line in a graph", so that is the floor here.
+    // Five of the ten entries do not meet it and are tracked as a palette-contrast follow-up:
+    //   light ground — yellow 1.92, turquoise 2.43, green 2.54, orange 2.80 (all pre-existing)
+    //   dark ground  — purpleDark 1.55 (design-chosen; reads well on light, but is nearly the
+    //                  dark theme's own background)
+    // Half the palette failing is the finding, not an accident of this test: a single palette
+    // serving both themes cannot clear the floor on both, which is why the follow-up proposes two
+    // lightness bands. The assertion still blocks *new* entries from joining the list, and the
+    // list must not grow.
+    const KNOWN_LOW_CONTRAST = [
+      "yellow",
+      "turquoise",
+      "green",
+      "orange",
+      "purpleDark",
+    ];
+    const MINIMUM_CONTRAST = 3;
     const failing: string[] = [];
 
     for (const { variant, hex } of autoPaletteHexes()) {

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -205,7 +205,7 @@
     --color-lime: #a3e635;
     --color-turquoise: #06b6d4;
     --color-blue: #3b82f6;
-    --color-ochre: #8c683f;
+    --color-purple-dark: #491b7e;
     --color-primary: #6366f1;
     --color-indigo: #6366f1;
     --color-violet: #8b5cf6;
@@ -250,8 +250,8 @@
     --tag-blue-text: #19426b;
     --tag-lavender-bg: #e5e5fe;
     --tag-lavender-text: #3b3b8e;
-    --tag-ochre-bg: #f2e6d8;
-    --tag-ochre-text: #5c4426;
+    --tag-purple-dark-bg: #e4d7f7;
+    --tag-purple-dark-text: #3d1669;
 
     --click-blue: #262ab5;
 
@@ -520,8 +520,8 @@
     --tag-blue-text: #6eabe7;
     --tag-lavender-bg: #2a2a3d;
     --tag-lavender-text: #a8a8e0;
-    --tag-ochre-bg: #2f2b26;
-    --tag-ochre-text: #c9975c;
+    --tag-purple-dark-bg: #2a2233;
+    --tag-purple-dark-text: #b98ce6;
 
     /* Trace/span type colors - Dark Mode */
     --type-trace: #945fcf;

--- a/apps/opik-frontend/src/main.scss
+++ b/apps/opik-frontend/src/main.scss
@@ -205,6 +205,7 @@
     --color-lime: #a3e635;
     --color-turquoise: #06b6d4;
     --color-blue: #3b82f6;
+    --color-ochre: #8c683f;
     --color-primary: #6366f1;
     --color-indigo: #6366f1;
     --color-violet: #8b5cf6;
@@ -249,6 +250,8 @@
     --tag-blue-text: #19426b;
     --tag-lavender-bg: #e5e5fe;
     --tag-lavender-text: #3b3b8e;
+    --tag-ochre-bg: #f2e6d8;
+    --tag-ochre-text: #5c4426;
 
     --click-blue: #262ab5;
 
@@ -517,6 +520,8 @@
     --tag-blue-text: #6eabe7;
     --tag-lavender-bg: #2a2a3d;
     --tag-lavender-text: #a8a8e0;
+    --tag-ochre-bg: #2f2b26;
+    --tag-ochre-text: #c9975c;
 
     /* Trace/span type colors - Dark Mode */
     --type-trace: #945fcf;

--- a/apps/opik-frontend/src/shared/ColorIndicator/ColorIndicator.test.tsx
+++ b/apps/opik-frontend/src/shared/ColorIndicator/ColorIndicator.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import ColorIndicator from "./ColorIndicator";
+import { TooltipProvider } from "@/ui/tooltip";
+
+// The indicator's own persistence path is not what this file is about: it covers the interaction
+// contract of the nested Radix triggers, which is what customers hit when they try to recolour a
+// series (OPIK_7840 — the control was reported as missing because it was hard to reach).
+vi.mock("@/hooks/useUpdateColorMapping", () => ({
+  default: () => ({
+    updateColor: vi.fn(),
+    previewColor: {},
+    setPreviewColor: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+const renderIndicator = (onParentClick?: () => void) => {
+  const utils = render(
+    <TooltipProvider delayDuration={700}>
+      <div onClick={onParentClick}>
+        <ColorIndicator label="domain-agent" color="#491b7e" variant="dot" />
+      </div>
+    </TooltipProvider>,
+  );
+
+  // The indicator renders no text, so the trigger is found by the role Radix gives it.
+  const trigger = utils.container.querySelector(
+    "[data-state]",
+  ) as HTMLElement | null;
+
+  if (!trigger) throw new Error("colour indicator trigger not rendered");
+
+  return { ...utils, trigger };
+};
+
+describe("ColorIndicator", () => {
+  it("opens the colour picker when the indicator is clicked", async () => {
+    const { trigger } = renderIndicator();
+
+    fireEvent.click(trigger);
+
+    // The hex field is the picker's only stable, user-visible landmark.
+    expect(await screen.findByPlaceholderText("#000000")).toBeInTheDocument();
+  });
+
+  it("does not fire a surrounding click handler when the indicator is clicked", async () => {
+    // In a chart legend the label around the dot navigates to filtered traces. Opening the picker
+    // must not also trigger that navigation.
+    const onParentClick = vi.fn();
+    const { trigger } = renderIndicator(onParentClick);
+
+    fireEvent.click(trigger);
+
+    await screen.findByPlaceholderText("#000000");
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
+  it("gives the indicator a pointer target larger than the dot itself", () => {
+    // The dot is 6px. Without the enlarged target it is effectively unhittable, which is why the
+    // feature read as missing. The dot's own size stays unchanged.
+    const { trigger } = renderIndicator();
+
+    expect(trigger.className).toContain("size-1.5");
+    expect(trigger.className).toMatch(/before:-inset-/);
+  });
+});

--- a/apps/opik-frontend/src/shared/ColorIndicator/ColorIndicator.tsx
+++ b/apps/opik-frontend/src/shared/ColorIndicator/ColorIndicator.tsx
@@ -22,6 +22,15 @@ const colorIndicatorVariants = cva("bg-[var(--bg-color)]", {
   },
 });
 
+/**
+ * The dot is 6px, which is too small to find or aim at, so customers reported the colour override as
+ * missing entirely (OPIK_7840). A transparent pseudo-element enlarges the pointer target without
+ * changing how the indicator looks. Horizontal growth is kept to 6px because in a chart legend the
+ * dot sits immediately left of the label, and the label has its own click action to drill down.
+ */
+const HIT_AREA =
+  "before:absolute before:-inset-y-2 before:-inset-x-1.5 before:content-['']";
+
 type ColorIndicatorProps = VariantProps<typeof colorIndicatorVariants> & {
   label: string;
   colorKey?: string;
@@ -83,11 +92,14 @@ const ColorIndicator: React.FC<ColorIndicatorProps> = ({
 
   return (
     <Popover open={popoverOpen} onOpenChange={handleOpenChange} modal>
-      <Tooltip open={popoverOpen ? false : undefined}>
+      {/* No hover delay: the affordance is small, so the hint has to arrive the moment it is found. */}
+      <Tooltip open={popoverOpen ? false : undefined} delayDuration={0}>
         <TooltipTrigger asChild>
           <PopoverTrigger asChild>
             <div
-              className={classes}
+              // `relative` comes first so a caller that positions the dot absolutely still wins the
+              // merge; either way the pseudo-element anchors to the indicator, not to an ancestor.
+              className={cn("relative", classes, HIT_AREA)}
               style={{ ...colorStyle, cursor: "pointer" }}
               onClick={(e) => e.stopPropagation()}
             />

--- a/apps/opik-frontend/src/ui/tag.tsx
+++ b/apps/opik-frontend/src/ui/tag.tsx
@@ -19,6 +19,7 @@ const tagVariants = cva("inline-block truncate rounded-sm transition-colors", {
       turquoise:
         "bg-[var(--tag-turquoise-bg)] text-[var(--tag-turquoise-text)]",
       blue: "bg-[var(--tag-blue-bg)] text-[var(--tag-blue-text)]",
+      ochre: "bg-[var(--tag-ochre-bg)] text-[var(--tag-ochre-text)]",
       lavender: "bg-[var(--tag-lavender-bg)] text-[var(--tag-lavender-text)]",
       white:
         "border border-gray-200 bg-white text-muted-slate dark:border-gray-600 dark:bg-gray-800 dark:text-foreground",
@@ -60,11 +61,23 @@ const Tag = React.forwardRef<HTMLDivElement, TagProps>(
 );
 Tag.displayName = "Tag";
 
+/**
+ * Palette used to derive a color automatically from a label (see `generateTagVariant`).
+ *
+ * Two invariants are enforced by `lib/colorVariants.test.ts` and must hold for any change here:
+ * - every pair of entries stays perceptually distinguishable (OPIK-7839: `primary` #6366f1 sat at
+ *   ΔE 14.5 from `purple`, which made distinct series look identical in grouped charts);
+ * - the list keeps its length, because the automatic color is `hash % TAG_VARIANTS.length` —
+ *   adding or removing an entry re-maps every label in the product, while substituting one
+ *   re-maps only the labels that resolved to that slot.
+ *
+ * `primary` is deliberately absent: it is too close to both `purple` and `blue` for chart series.
+ */
 export const TAG_VARIANTS: Exclude<
   TagProps["variant"],
   "red" | "transparent" | "white" | "lavender"
 >[] = [
-  "primary",
+  "ochre",
   "gray",
   "purple",
   "burgundy",
@@ -94,6 +107,7 @@ export const TAG_VARIANTS_COLOR_MAP: Record<
   green: "var(--color-green)",
   turquoise: "var(--color-turquoise)",
   blue: "var(--color-blue)",
+  ochre: "var(--color-ochre)",
 };
 
 export { Tag, tagVariants };

--- a/apps/opik-frontend/src/ui/tag.tsx
+++ b/apps/opik-frontend/src/ui/tag.tsx
@@ -19,7 +19,8 @@ const tagVariants = cva("inline-block truncate rounded-sm transition-colors", {
       turquoise:
         "bg-[var(--tag-turquoise-bg)] text-[var(--tag-turquoise-text)]",
       blue: "bg-[var(--tag-blue-bg)] text-[var(--tag-blue-text)]",
-      ochre: "bg-[var(--tag-ochre-bg)] text-[var(--tag-ochre-text)]",
+      purpleDark:
+        "bg-[var(--tag-purple-dark-bg)] text-[var(--tag-purple-dark-text)]",
       lavender: "bg-[var(--tag-lavender-bg)] text-[var(--tag-lavender-text)]",
       white:
         "border border-gray-200 bg-white text-muted-slate dark:border-gray-600 dark:bg-gray-800 dark:text-foreground",
@@ -72,12 +73,14 @@ Tag.displayName = "Tag";
  *   re-maps only the labels that resolved to that slot.
  *
  * `primary` is deliberately absent: it is too close to both `purple` and `blue` for chart series.
+ * The tenth entry is design-owned (`purple-dark`, from the product palette); see colorVariants.test.ts
+ * for the invariants any replacement must still satisfy.
  */
 export const TAG_VARIANTS: Exclude<
   TagProps["variant"],
   "red" | "transparent" | "white" | "lavender"
 >[] = [
-  "ochre",
+  "purpleDark",
   "gray",
   "purple",
   "burgundy",
@@ -107,7 +110,7 @@ export const TAG_VARIANTS_COLOR_MAP: Record<
   green: "var(--color-green)",
   turquoise: "var(--color-turquoise)",
   blue: "var(--color-blue)",
-  ochre: "var(--color-ochre)",
+  purpleDark: "var(--color-purple-dark)",
 };
 
 export { Tag, tagVariants };

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
@@ -74,7 +74,10 @@ interface MetricContainerChartProps {
   hideYAxis?: boolean;
 }
 
-const customColorMap = {
+// Fixed colors for metric sub-series (trace counts, cost, duration percentiles, token kinds).
+// Only valid when no breakdown is applied — with a breakdown the line names are group values,
+// not metric names, so these keys would hijack a group that happens to share a name.
+const metricColorMap = {
   traces: COLOR_VARIANTS_MAP.purple.css,
   cost: COLOR_VARIANTS_MAP.purple.css,
   "duration.p50": COLOR_VARIANTS_MAP.turquoise.css,
@@ -198,7 +201,11 @@ const MetricContainerChart = ({
     );
   }, [data, lines, isPending]);
 
-  const config = useChartConfig(lines, labelsMap, colorMap ?? customColorMap);
+  const config = useChartConfig(
+    lines,
+    labelsMap,
+    colorMap ?? (breakdown ? undefined : metricColorMap),
+  );
 
   const labelActions = useMemo(() => {
     if (!getLabelAction) return undefined;

--- a/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/dashboards/widgets/ProjectMetricsWidget/MetricChart/MetricChartContainer.tsx
@@ -77,7 +77,7 @@ interface MetricContainerChartProps {
 // Fixed colors for metric sub-series (trace counts, cost, duration percentiles, token kinds).
 // Only valid when no breakdown is applied — with a breakdown the line names are group values,
 // not metric names, so these keys would hijack a group that happens to share a name.
-const metricColorMap = {
+const METRIC_COLOR_MAP = {
   traces: COLOR_VARIANTS_MAP.purple.css,
   cost: COLOR_VARIANTS_MAP.purple.css,
   "duration.p50": COLOR_VARIANTS_MAP.turquoise.css,
@@ -204,7 +204,7 @@ const MetricContainerChart = ({
   const config = useChartConfig(
     lines,
     labelsMap,
-    colorMap ?? (breakdown ? undefined : metricColorMap),
+    colorMap ?? (breakdown ? undefined : METRIC_COLOR_MAP),
   );
 
   const labelActions = useMemo(() => {


### PR DESCRIPTION
## Details

Series colors in grouped dashboard widgets come from a 10-color palette, picked by hashing the tag name. Two of those ten, `primary` #6366f1 and `purple` #8b5cf6, are nearly the same color, so two different agents could look identical. Autodesk reported it (CUST_6807).

- Added `purple-dark` #491b7e from the product palette and put it in place of `primary` in the list the auto-color picks from. The list stays at 10 entries, so only labels that used to get `primary` change color and nothing else shifts. Nearest neighbour is ΔE 39, versus the 14.5 pair being removed.
- Made the colour dot in chart legends findable: bigger pointer target via a transparent pseudo-element (look unchanged), and its tooltip opens with no delay. This is why customers reported the override as missing.
- When a widget is grouped by something, the chart no longer applies the hardcoded metric colors (`traces`, `cost`, `duration.*`, `*_tokens`, `failed`). With a group-by active, series names are tag values, not metric names, so a tag called `cost` was picking up the Cost metric's color.
- New test file that fails if anyone adds a palette color too close to an existing one.

**Not fixed by this:** with 10 colors and up to 11 groups per chart, two series can still get the same color. There is a test asserting that, so it is documented rather than hidden. Users can already override any series color by hand (OPIK_3100) and that pins it across all widgets.

**Known, recorded in the contrast test rather than hidden:** `purple-dark` measures 1.55 against the dark theme background where WCAG 1.4.11 asks 3:1, because at L\* 23 it is close to that background. Raising the test to the real 3:1 floor also showed `yellow` 1.92, `turquoise` 2.43, `green` 2.54 and `orange` 2.80 already fail it on the light ground. Five of ten entries are now listed as known failures, which is the finding: one palette cannot serve both themes. Two lightness bands are proposed in the follow-up.

Design (Jolanta) picked the colour, asked for the dot changes, and has approved. Chip tokens derived in the existing pattern: `--tag-purple-dark-bg` / `--tag-purple-dark-text`, contrast 10.1 light and 5.8 dark, both above the existing purple chip.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7839

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Whole diff, plus the measurements used to pick the replacement color.
- Human verification: Reviewer set the scope and rejected two earlier approaches that traded one half of the customer's complaint for the other. Diff reviewed against repo standards and the originating spec before commit; both passes were applied.

## Testing

From `apps/opik-frontend`:

- `npm run typecheck` — clean
- `npx eslint <changed files> --max-warnings=0` and `npx stylelint src/main.scss` — clean
- `npx vitest run src/lib/colorVariants.test.ts` — 13/13
- `npx vitest run` — 155 files pass. Six fail on `localStorage.clear is not a function` (`ls-migrations`, `workspaceVersion`, pinned/recent workspaces, pinned projects). Pre-existing: they fail the same way on an untouched `main`, and none touch color code.

Checked in the test env `pr-7873`, before and after, on the same seeded data: https://claude.ai/code/artifact/8c103f19-d0a5-4846-983b-2d2f4924d6f1

Sanity check that the new test actually guards: putting `primary` back fails it with `primary/purple ΔE=14.5`.

**Scope, corrected:** the chart-container change is v2 only. The palette substitution is **not** —
`TAG_VARIANTS` lives in shared `ui/tag.tsx`, so labels that hashed to that slot change colour in v1
too, wherever tags and feedback scores are rendered. That is deliberate: scoping the palette to v2
would mean two palettes and two sources of truth for the same label, which is the thing this change
exists to avoid. Flagging it because `.agents/rules/agents.mdc` asks for v1 changes to be called out.

## Documentation

None. No user-facing copy, API or config changes.
