### PR TITLE
[OPIK-7953] [DOCS] fix: repoint broken watsonx IBM Cloud IAM links

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/watsonx.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/watsonx.mdx
@@ -47,8 +47,8 @@ If you're unable to use our LiteLLM integration with watsonx, please [open an is
 In order to configure watsonx, you will need to have:
 
 - The endpoint URL: Documentation for this parameter can be found [here](https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url)
-- Watsonx API Key: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui)
-- Watsonx Token: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/account?topic=account-iamtoken_from_apikey#iamtoken_from_apikey)
+- Watsonx API Key: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/iam?topic=iam-userapikey)
+- Watsonx Token: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/iam?topic=iam-iamtoken_from_apikey#iamtoken_from_apikey)
 - (Optional) Watsonx Project ID: Can be found in the Manage section of your project.
 
 Once you have these, you can set them as environment variables:

--- a/apps/opik-documentation/documentation/fern/docs/tracing/integrations/watsonx.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/tracing/integrations/watsonx.mdx
@@ -48,8 +48,8 @@ If you're unable to use our LiteLLM integration with watsonx, please [open an is
 In order to configure watsonx, you will need to have:
 
 - The endpoint URL: Documentation for this parameter can be found [here](https://cloud.ibm.com/apidocs/watsonx-ai#endpoint-url)
-- Watsonx API Key: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui)
-- Watsonx Token: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/account?topic=account-iamtoken_from_apikey#iamtoken_from_apikey)
+- Watsonx API Key: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/iam?topic=iam-userapikey)
+- Watsonx Token: Documentation for this parameter can be found [here](https://cloud.ibm.com/docs/iam?topic=iam-iamtoken_from_apikey#iamtoken_from_apikey)
 - (Optional) Watsonx Project ID: Can be found in the Manage section of your project.
 
 Once you have these, you can set them as environment variables:


### PR DESCRIPTION
## Details

<img width="986" height="1035" alt="image" src="https://github.com/user-attachments/assets/9a89c925-e15b-4534-a499-5144f0840806" />

IBM reorganised its IAM documentation out of the `account` section into a dedicated `iam` section, so the API-key and token links on the watsonx integration page both returned 404. Readers hit dead ends exactly where they need the two credentials the integration cannot be configured without, and the nightly `Check Documentation Links` workflow went red — which also masks any genuinely new broken link that appears later.

- Repoints both links to `https://cloud.ibm.com/docs/iam?topic=iam-userapikey` and `https://cloud.ibm.com/docs/iam?topic=iam-iamtoken_from_apikey#iamtoken_from_apikey`.
- The page is duplicated across docs versions, so both copies are updated — fixing only one would leave the crawl red.
- The neighbouring `apidocs/watsonx-ai#endpoint-url` link is untouched; it is not reported broken and still resolves.

Note on the failing check: it is the scheduled nightly crawl of the **published** site (`https://www.comet.com/docs/opik/`), triggered on cron and `workflow_dispatch` only — not a per-PR check. It will only go green once this merges **and** the docs site redeploys, so a manual run immediately after merge will still fail.

The same two-line edit currently also exists as an unrelated drive-by inside PR #7874 (a large Python SDK feature PR). Whichever of the two merges second will conflict on these lines, so that hunk should be dropped there or the branch rebased.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7953

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (link fix + verification)
- Human verification: code review

## Testing

No automated suite covers this change — the edit is two Markdown link targets, and the only gate on these files is the nightly published-site crawl, which cannot run pre-merge.

Commands run from the repository root:

- `pre-commit run --files <both watsonx.mdx paths>` — exit 0. Reported honestly: **every hook skipped with "no files to check"**, because no configured hook matches `.mdx`. The clean exit confirms nothing broke, not that anything was linted.
- `grep -rn "cloud.ibm.com/docs/account" .` — zero hits remaining, confirming no stale link was missed elsewhere in the repo.

Link verification (`curl -o /dev/null -w '%{http_code}' -L`):

- `https://cloud.ibm.com/docs/iam?topic=iam-userapikey` → **200**
- `https://cloud.ibm.com/docs/iam?topic=iam-iamtoken_from_apikey` → **200**
- `https://cloud.ibm.com/apidocs/watsonx-ai` (untouched neighbour) → **200**
- Old `https://cloud.ibm.com/docs/account?topic=account-userapikey&interface=ui` → **404**, confirming the reported breakage

The token link carries a `#iamtoken_from_apikey` fragment, so the anchor was checked separately rather than assumed: `id="iamtoken_from_apikey"` is present in the served HTML, meaning the link lands on the intended section instead of silently falling back to the top of the page.

Not run: backend, frontend and SDK suites — no code in those components is touched.

## Documentation

This PR is itself a documentation fix. Both copies of the watsonx integration page are updated:

- `apps/opik-documentation/documentation/fern/docs/tracing/integrations/watsonx.mdx` (v1)
- `apps/opik-documentation/documentation/fern/docs-v2/integrations/watsonx.mdx` (v2)

No prose, structure or code samples changed — only the two link targets in the "Configuring watsonx" section.
