### PR TITLE
[OPIK-7955] [SDK] fix: exclude litellm 1.97.* on Python 3.10

### DIFF
--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -27,7 +27,13 @@ dependencies = [
     # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
     #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
     #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*",
+    # - Exclude 1.97.* on Python 3.10 only: Message cannot be constructed there -- the nested
+    #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+    #   completion() raises PydanticUserError. 3.11+ evaluate the annotations natively and are
+    #   unaffected, so they stay unrestricted and keep tracking latest litellm.
+    #   See: https://github.com/BerriAI/litellm/issues/36384
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*; python_version < '3.11'",
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
     "mcp>=1.0.0",
     "opik>=1.9.7",
     "optuna",

--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -28,7 +28,13 @@ setup(
         #   affects 1.81.16-1.83.6, fixed in 1.83.7).
         #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
         # Please keep this list in sync with the one in sdks/opik_optimizer/pyproject.toml
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
+        # - Exclude 1.97.* on Python 3.10 only: Message cannot be constructed there -- the nested
+        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #   completion() raises PydanticUserError. 3.11+ evaluate the annotations natively and are
+        #   unaffected, so they stay unrestricted and keep tracking latest litellm.
+        #   See: https://github.com/BerriAI/litellm/issues/36384
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*; python_version < '3.11'",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
         "opik>=1.7.17",
         "optuna",
         "pandas",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -51,7 +51,13 @@ setup(
         # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
         #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
         #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*",
+        # - Exclude 1.97.* on Python 3.10 only: Message cannot be constructed there -- the nested
+        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #   completion() raises PydanticUserError. 3.11+ evaluate the annotations natively and are
+        #   unaffected, so they stay unrestricted and keep tracking latest litellm.
+        #   See: https://github.com/BerriAI/litellm/issues/36384
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*; python_version < '3.11'",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",


### PR DESCRIPTION
## Details

litellm 1.97.0 cannot construct its own `Message` model under Python 3.10, and `Message` backs every `completion()` response — so every LLM-judge metric fails before reaching the network. A clean `pip install opik` on 3.10 was broken. This excludes `1.97.*` **on Python 3.10 only**.

The breakage is 3.10-exclusive: 3.11+ evaluate the PEP 604 annotations natively and never resolve the bad reference in that namespace. So the exclusion is marker-scoped rather than global — there is no reason to restrict interpreters that work, and holding 3.11+ back from latest litellm would be a regression of its own.

> [!IMPORTANT]
> **This is one of two alternative PRs for OPIK-7955. They are mutually exclusive — merge one, close the other.**
>
> Both scope the change to Python 3.10 and leave 3.11+ untouched. They differ in **one operator**:
>
> | | 3.10 constraint | Behaviour if 1.98 final ships still-broken |
> |---|---|---|
> | **This PR** | `!=1.97.*` | 1.98 resolves on 3.10 → breaks again → another dependency PR |
> | #7877 | `<1.97` | 1.98 held out automatically → no action needed |
>
> Both resolve `litellm==1.96.2` on 3.10 **today** — the difference is only about what happens next.
>
> @alexkuzmik — flagging you as Python SDK principal to make the call. This PR is the surgical option: it excludes only the version known to be bad and stays eligible for 1.98/1.99 the moment upstream fixes them. #7877 is the standing-guard option. The choice depends on whether we expect litellm to fix 3.10 in 1.99+, and how long we intend to support 3.10.

- Matches the shape of all three prior exclusions (`19ae79d6e3`, `c913ed72cb`, `addccfb24e`) — version-scoped, not an upper bound.
- Dependency metadata only; no runtime code, no reaching into litellm internals.
- Also syncs `sdks/opik_optimizer/setup.py`, which had silently drifted (missing the `1.92.*` exclusion). It is dead metadata — `pyproject.toml` declares `[project].dependencies`, which wins — but a stale copy invites edits to the wrong file.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7955

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: dependency constraint + comments in the three spec files; reproduction and verification runs
- Human verification: reviewed diff; reproduction, bisection and negative control re-run and confirmed

## Testing

Reproduction (no API key needed — it fails before any network call):

```bash
uv venv --python 3.10 /tmp/v && uv pip install --python /tmp/v/bin/python litellm==1.97.0 openai==2.54.0
/tmp/v/bin/python -c "from litellm.types.utils import Message; Message()"
# -> PydanticUserError: `Message` is not fully defined
```

Bisection: `1.96.0` OK → `1.97.0` FAIL on 3.10; both fine on 3.11.

Installed this branch's spec on real interpreters:

| Interpreter | Resolves to | `Message()` / `ModelResponse()` / `Hallucination()` |
|---|---|---|
| Python 3.10 | `litellm==1.96.2` | OK |
| Python 3.11 | `litellm==1.97.0` (unrestricted) | OK |

Negative control: forcing `litellm==1.97.0` back into the 3.10 env reproduces the original error, confirming the constraint is what fixes it.

`pre-commit run --files sdks/python/setup.py sdks/opik_optimizer/pyproject.toml sdks/opik_optimizer/setup.py` — clean.

## Notes

- Upstream issue already exists and is linked from the comment: https://github.com/BerriAI/litellm/issues/36384 (open, filed 2026-08-10, same bug). No duplicate filed.
- **Merging alone does not reach users** — published 2.2.30 still carries the permissive range, so a patch release is required. Anyone already broken can use `pip install 'litellm<1.97'` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

No documentation site changes. The constraint is inline-documented in all three specs, following the existing litellm exclusion comment block (symptom, affected range, upstream link), and this PR does not change any public API, CLI flag, or configuration surface that the docs describe.

Two user-facing notes belong in the **release notes** for whichever patch ships this, rather than in the docs site:

- Python 3.10 installs now resolve `litellm<1.97` (currently `1.96.2`). Python 3.11+ are unaffected and continue to resolve the latest litellm.
- Users already broken on Python 3.10 are not repaired by upgrading alone if they pin litellm themselves — the immediate workaround is `pip install 'litellm<1.97'`.

If an application on Python 3.10 directly requires `litellm>=1.97`, that requirement is now unsatisfiable alongside `opik` — intentionally, since litellm 1.97 cannot execute a single completion on 3.10. The options are to move to Python 3.11+, or drop the explicit litellm requirement.
