### PR TITLE
[OPIK-7955] [SDK] fix: cap litellm below 1.97 on Python 3.10 (ALT to #7876)

### DIFF
--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
     #                completion() raises PydanticUserError.
     #                https://github.com/BerriAI/litellm/issues/36384
     #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
-    #                (3.11+ only; should come from typing_extensions).
+    #                typing.NotRequired does not exist on 3.10 (added in 3.11);
+    #                litellm should import it from typing_extensions.
     #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
     #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
     #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).

--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -27,11 +27,19 @@ dependencies = [
     # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
     #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
     #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-    # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
-    #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
-    #   completion() fails with PydanticUserError. 3.11+ unaffected.
-    #   See: https://github.com/BerriAI/litellm/issues/36384
-    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
+    # - Cap Python 3.10 at <1.97: litellm declares requires-python >=3.10 but ships 3.11+
+    #   typing, and every recent break has been 3.10-only with a distinct root cause:
+    #     1.97.*     Message model unconstructible -- the nested forward reference
+    #                ChatCompletionReasoningSummaryTextBlock never resolves, so every
+    #                completion() raises PydanticUserError.
+    #                https://github.com/BerriAI/litellm/issues/36384
+    #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
+    #                (3.11+ only; should come from typing_extensions).
+    #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
+    #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
+    #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,<1.97; python_version < '3.11'",
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
     "mcp>=1.0.0",
     "opik>=1.9.7",
     "optuna",

--- a/sdks/opik_optimizer/pyproject.toml
+++ b/sdks/opik_optimizer/pyproject.toml
@@ -27,7 +27,11 @@ dependencies = [
     # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
     #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
     #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*",
+    # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
+    #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+    #   completion() fails with PydanticUserError. 3.11+ unaffected.
+    #   See: https://github.com/BerriAI/litellm/issues/36384
+    "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
     "mcp>=1.0.0",
     "opik>=1.9.7",
     "optuna",

--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -28,11 +28,19 @@ setup(
         #   affects 1.81.16-1.83.6, fixed in 1.83.7).
         #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
         # Please keep this list in sync with the one in sdks/opik_optimizer/pyproject.toml
-        # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
-        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
-        #   completion() fails with PydanticUserError. 3.11+ unaffected.
-        #   See: https://github.com/BerriAI/litellm/issues/36384
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
+        # - Cap Python 3.10 at <1.97: litellm declares requires-python >=3.10 but ships 3.11+
+        #   typing, and every recent break has been 3.10-only with a distinct root cause:
+        #     1.97.*     Message model unconstructible -- the nested forward reference
+        #                ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #                completion() raises PydanticUserError.
+        #                https://github.com/BerriAI/litellm/issues/36384
+        #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
+        #                (3.11+ only; should come from typing_extensions).
+        #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
+        #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
+        #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,<1.97; python_version < '3.11'",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
         "opik>=1.7.17",
         "optuna",
         "pandas",

--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -35,7 +35,8 @@ setup(
         #                completion() raises PydanticUserError.
         #                https://github.com/BerriAI/litellm/issues/36384
         #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
-        #                (3.11+ only; should come from typing_extensions).
+        #                typing.NotRequired does not exist on 3.10 (added in 3.11);
+        #                litellm should import it from typing_extensions.
         #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
         #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
         #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).

--- a/sdks/opik_optimizer/setup.py
+++ b/sdks/opik_optimizer/setup.py
@@ -28,7 +28,11 @@ setup(
         #   affects 1.81.16-1.83.6, fixed in 1.83.7).
         #   See: https://docs.litellm.ai/blog/cve-2026-42208-litellm-proxy-sql-injection
         # Please keep this list in sync with the one in sdks/opik_optimizer/pyproject.toml
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6",
+        # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
+        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #   completion() fails with PydanticUserError. 3.11+ unaffected.
+        #   See: https://github.com/BerriAI/litellm/issues/36384
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
         "opik>=1.7.17",
         "optuna",
         "pandas",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -51,7 +51,11 @@ setup(
         # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
         #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
         #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*",
+        # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
+        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #   completion() fails with PydanticUserError. 3.11+ unaffected.
+        #   See: https://github.com/BerriAI/litellm/issues/36384
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -51,11 +51,19 @@ setup(
         # - Exclude 1.92.*: core completion() eagerly imports litellm.proxy modules that require
         #   fastapi/orjson (proxy-only extras), so any completion crashes without litellm[proxy].
         #   Reverted in 1.93. See litellm/main.py -> responses.mcp.litellm_proxy_mcp_handler.
-        # - Exclude 1.97.*: Message model cannot be constructed on Python 3.10 -- the nested
-        #   forward reference ChatCompletionReasoningSummaryTextBlock never resolves, so every
-        #   completion() fails with PydanticUserError. 3.11+ unaffected.
-        #   See: https://github.com/BerriAI/litellm/issues/36384
-        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,!=1.97.*",
+        # - Cap Python 3.10 at <1.97: litellm declares requires-python >=3.10 but ships 3.11+
+        #   typing, and every recent break has been 3.10-only with a distinct root cause:
+        #     1.97.*     Message model unconstructible -- the nested forward reference
+        #                ChatCompletionReasoningSummaryTextBlock never resolves, so every
+        #                completion() raises PydanticUserError.
+        #                https://github.com/BerriAI/litellm/issues/36384
+        #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
+        #                (3.11+ only; should come from typing_extensions).
+        #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
+        #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
+        #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*,<1.97; python_version < '3.11'",
+        "litellm>=1.79.2,!=1.81.*,!=1.82.*,!=1.83.0,!=1.83.1,!=1.83.2,!=1.83.3,!=1.83.4,!=1.83.5,!=1.83.6,!=1.92.*; python_version >= '3.11'",
         "openai",
         "pydantic-settings>=2.0.0,<3.0.0,!=2.9.0",
         "pydantic>=2.0.0,<3.0.0",

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -58,7 +58,8 @@ setup(
         #                completion() raises PydanticUserError.
         #                https://github.com/BerriAI/litellm/issues/36384
         #     1.98.0rc1  ImportError: cannot import name 'NotRequired' from 'typing'
-        #                (3.11+ only; should come from typing_extensions).
+        #                typing.NotRequired does not exist on 3.10 (added in 3.11);
+        #                litellm should import it from typing_extensions.
         #   Both are still unfixed on litellm main, so 1.99+ is expected to break on 3.10 too.
         #   The cap is the standing guard; 3.11+ deliberately stays uncapped. Lift it once
         #   upstream actually tests 3.10 (or once we drop 3.10 -- see OPIK_7955).


### PR DESCRIPTION
## Details

Same bug and same scope as #7876 — litellm 1.97.0 cannot construct its `Message` model on Python 3.10, breaking every LLM-judge metric. Like #7876, this is marker-scoped to 3.10 and leaves 3.11+ completely untouched (3.11+ are not affected, so there is nothing to fix there).

The difference is one operator: this caps 3.10 at `<1.97` instead of excluding `!=1.97.*`.

> [!IMPORTANT]
> **This is one of two alternative PRs for OPIK-7955. They are mutually exclusive — merge one, close the other.**
>
> | | 3.10 constraint | Behaviour if 1.98 final ships still-broken |
> |---|---|---|
> | #7876 | `!=1.97.*` | 1.98 resolves on 3.10 → breaks again → another dependency PR |
> | **This PR** | `<1.97` | 1.98 held out automatically → no action needed |
>
> Both resolve `litellm==1.96.2` on 3.10 **today**, and both leave 3.11 on `1.97.0`. The difference is only about what happens next.
>
> @alexkuzmik — flagging you as Python SDK principal to make the call. Both are legitimate; it comes down to two judgement calls that are yours, not the diff's: **whether we expect litellm to fix 3.10 in 1.99+**, and **how long we intend to life-support Python 3.10**.

### Why the cap might be the better bet

The question is whether 1.99+ will break on 3.10 too. 1.99 doesn't exist yet (newest artifact on PyPI is `1.98.0rc1`), so I checked upstream's source and stated support instead:

| Evidence | Reading | State |
|---|---|---|
| `requires-python` on litellm main | still `>=3.10, <3.15` — they *intend* to support 3.10 | claimed |
| 1.97 bug | `types/utils.py` on main: no `from __future__ import annotations`, never imports the missing name, never calls `model_rebuild` | **unfixed on main** |
| 1.98 bug | `compact.py` on main still does `from typing import … NotRequired …` (3.11+ only) | **unfixed on main** |
| pattern | two consecutive releases, two *independent* root causes, both 3.10-exclusive | systemic |

I confirmed `1.98.0rc1` fails on 3.10 with `ImportError: cannot import name 'NotRequired' from 'typing'` — a different bug from 1.97's, same interpreter. Both defects are live on `main`, which is what 1.98 final and 1.99 get cut from. So `!=1.97.*` would likely need extending again on someone else's schedule; a cap absorbs that class of break without another PR.

**The cost, stated plainly:** 3.10 users freeze at 1.96.2 and drift further behind the longer upstream stays broken. Today that's ~5 days of drift and costs nothing; in three months it might. The cap is meant as a temporary guard — lifted once upstream actually tests 3.10, or made moot if we drop 3.10.

**Note this is not the blanket upper bound that failed before.** `76a8c684c1` capped *every* Python at `<=1.77.1` and had to be unwound by a later "relax dependencies" PR. This confines the freeze to the one interpreter that is actually broken.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7955

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: marker-scoped dependency constraint + comments in the three spec files; upstream-source research and verification runs
- Human verification: reviewed diff; marker semantics and both resolutions re-run and confirmed

## Testing

Marker semantics validated with `packaging` before trusting any resolver:

```
Requirement("litellm>=1.79.2,...,<1.97; python_version < '3.11'")
  py3.10 -> applies = True
  py3.11 -> applies = False
  py3.12 -> applies = False
  py3.14 -> applies = False
```

Installed this branch's spec on real interpreters:

| Interpreter | Resolves to | `Message()` / `ModelResponse()` / `Hallucination()` |
|---|---|---|
| Python 3.10 | `litellm==1.96.2` | OK |
| Python 3.11 | `litellm==1.97.0` (unrestricted) | OK |

`pre-commit run --files sdks/python/setup.py sdks/opik_optimizer/pyproject.toml sdks/opik_optimizer/setup.py` — clean.

## Notes

- Upstream issue for the 1.97 bug: https://github.com/BerriAI/litellm/issues/36384 (open).
- The 1.98 `NotRequired` bug appears to have **no upstream issue yet** — worth filing separately; it is what makes a fixed 1.99 more likely, and would weaken the argument for this PR over #7876.
- Whichever PR lands, a patch release is required to reach users, and anyone already broken can use `pip install 'litellm<1.97'` today.
- Recurring 3.10-only breakage is arguably data for a separate `python_requires` conversation — noted, not proposed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Documentation

No documentation site changes. The cap is inline-documented in all three specs, following the existing litellm exclusion comment block (symptom, affected range, upstream link), and this PR does not change any public API, CLI flag, or configuration surface that the docs describe.

Because this variant is a **cap** rather than a single-version exclusion, it has a broader user-visible footprint than #7876 and warrants explicit **release-note** coverage:

- Python 3.10 installs are capped at `litellm<1.97` (currently resolving `1.96.2`) and will not pick up 1.97, 1.98 or later while the cap stands. Python 3.11+ are unaffected and continue to resolve the latest litellm.
- The cap is a temporary guard against an upstream 3.10 regression, not a permanent position — it should be lifted once litellm actually tests 3.10.
- Users already broken on Python 3.10 are not repaired by upgrading alone if they pin litellm themselves — the immediate workaround is `pip install 'litellm<1.97'`.

**Known incompatibility:** an application on Python 3.10 that directly requires `litellm>=1.97` can no longer install or upgrade `opik` without changing its own dependencies. This is intentional — litellm 1.97+ cannot execute a single completion on 3.10 — but it is a real resolution break, and the honest options are to move to Python 3.11+, drop the explicit litellm requirement, or stay on the previous Opik release. This is the main practical cost of the cap versus #7876's narrower `!=1.97.*`, and worth weighing when choosing between them.

## Reviewer feedback

- **Baz — "Misstates interpreter causing LiteLLM failure":** valid, fixed in e5eba5c473. The parenthetical read `(3.11+ only)`, which describes the *symbol* but parses as though the ImportError occurs on 3.11+ — backwards, and confusing beside a `python_version < '3.11'` guard. Verified `typing.NotRequired` is absent on 3.10 and present on 3.11; comment reworded in all three specs.
- **Baz — "Unannounced Python 3.10 dependency break":** valid, addressed in the Documentation section above rather than in code — the cap, the `litellm<1.97` workaround, the previous-release option, and the 3.10-vs-3.11+ distinction are now all stated explicitly for release notes.
