### PR TITLE
[OPIK-7958] [SDK] fix: repoint the Groq integration test off the decommissioned llama-3.3-70b-versatile model

### DIFF
--- a/sdks/python/tests/library_integration/groq/test_groq.py
+++ b/sdks/python/tests/library_integration/groq/test_groq.py
@@ -17,7 +17,9 @@ from ...testlib import (
     assert_equal,
 )
 
-MODEL = "llama-3.3-70b-versatile"
+MODEL = "openai/gpt-oss-20b"
+# Groq reports the served model without the vendor namespace it is requested under.
+LOGGED_MODEL = MODEL.split("/")[-1]
 
 
 @pytest.mark.usefixtures("ensure_groq_configured")
@@ -71,7 +73,7 @@ def test_groq_chat_completions_create__e2e__generator_tracked_correctly(
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(MODEL),
+                model=ANY_STRING.starting_with(LOGGED_MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -135,7 +137,7 @@ def test_groq_chat_completions_create__async__e2e__generator_tracked_correctly(
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(MODEL),
+                model=ANY_STRING.starting_with(LOGGED_MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -201,7 +203,7 @@ def test_groq_chat_completions_create__stream_mode_is_on__e2e__generator_tracked
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(MODEL),
+                model=ANY_STRING.starting_with(LOGGED_MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -267,7 +269,7 @@ def test_groq_chat_completions_create__async__stream_mode_is_on__e2e__generator_
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(MODEL),
+                model=ANY_STRING.starting_with(LOGGED_MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",

--- a/sdks/python/tests/library_integration/groq/test_groq.py
+++ b/sdks/python/tests/library_integration/groq/test_groq.py
@@ -17,6 +17,7 @@ from ...testlib import (
     assert_equal,
 )
 
+# Groq retired the Llama chat models; this is one of the current production ones.
 MODEL = "openai/gpt-oss-20b"
 
 

--- a/sdks/python/tests/library_integration/groq/test_groq.py
+++ b/sdks/python/tests/library_integration/groq/test_groq.py
@@ -18,8 +18,6 @@ from ...testlib import (
 )
 
 MODEL = "openai/gpt-oss-20b"
-# Groq reports the served model without the vendor namespace it is requested under.
-LOGGED_MODEL = MODEL.split("/")[-1]
 
 
 @pytest.mark.usefixtures("ensure_groq_configured")
@@ -73,7 +71,7 @@ def test_groq_chat_completions_create__e2e__generator_tracked_correctly(
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(LOGGED_MODEL),
+                model=ANY_STRING.starting_with(MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -137,7 +135,7 @@ def test_groq_chat_completions_create__async__e2e__generator_tracked_correctly(
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(LOGGED_MODEL),
+                model=ANY_STRING.starting_with(MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -203,7 +201,7 @@ def test_groq_chat_completions_create__stream_mode_is_on__e2e__generator_tracked
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(LOGGED_MODEL),
+                model=ANY_STRING.starting_with(MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",
@@ -269,7 +267,7 @@ def test_groq_chat_completions_create__async__stream_mode_is_on__e2e__generator_
                         "total_tokens": ANY_BUT_NONE,
                     }
                 ),
-                model=ANY_STRING.starting_with(LOGGED_MODEL),
+                model=ANY_STRING.starting_with(MODEL),
                 provider="groq",
                 spans=[],
                 source="sdk",


### PR DESCRIPTION
## Details

<img width="761" height="717" alt="image" src="https://github.com/user-attachments/assets/f989081e-91ea-418f-986d-b16d6c11a3c5" />

Groq retired `llama-3.3-70b-versatile`, which the Python SDK's Groq library-integration suite was pinned to. Every
request now comes back as `404 model_not_found`, failing four of the five tests in `test_groq.py` on every Python
version — and because `lib-groq-tests.yml` runs `fail-fast: true` inside the SDK Library Integration Tests Runner,
the first failing leg cancels its siblings and reds the whole run, blocking unrelated SDK pull requests.

Repoints `MODEL` at `openai/gpt-oss-20b`, the model `tests/library_integration/langchain/test_langchain_groq.py`
already uses — so both Groq test paths track the same model instead of rotting independently.

No SDK source, workflow or documentation changes — the integration code is fine, only the test's model pin was stale.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7958

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full change (test model repoint)
- Human verification: code review; live-API verification via the `groq_tests` CI job

## Testing

The Groq suite talks to the real Groq API and requires `GROQ_API_KEY`, which is a CI secret not available locally —
so **this change is verified by the `groq_tests` job**, not by a local run. Please confirm it is green across the
3.10–3.14 matrix before merging.

Run locally:

- `pre-commit run --files sdks/python/tests/library_integration/groq/test_groq.py` — ruff and ruff-format pass

Reasoning behind the replacement model:

- `openai/gpt-oss-20b` is already exercised against the live API by the langchain Groq test on `main`, which is
  evidence the CI credentials can serve it.

An earlier revision of this PR also split out a `LOGGED_MODEL = MODEL.split("/")[-1]` for the tracked-model
assertions, on the theory that Groq strips the vendor namespace when reporting the served model. A test run
disproved that: the direct Groq SDK path logs the model exactly as requested (`openai/gpt-oss-20b`). The bare
`gpt-oss-20b` form asserted by the langchain test is langchain's own normalization and does not apply here. That
split has been removed, so the diff against `main` is now a single line.

Not run: the Java backend, frontend and TypeScript SDK suites — no changes in those components.

One thing to watch after merge: `openai/gpt-oss-20b` is a reasoning-family model and the tests pass `max_tokens=10`.
The assertions check trace/span shape rather than message text, so an empty completion would not fail them — but if
these tests ever go flaky, raising `max_tokens` is the correct lever rather than loosening assertions.

## Documentation

None. `supported_models.mdx` still lists `llama-3.3-70b-versatile` alongside several other decommissioned Groq
models (`llama-3.1-405b-reasoning`, `mixtral-8x7b-32768`, `llama2-70b-4096`, the `-preview` entries). That list is
generated and its cleanup is deliberately out of scope here — this PR is scoped to unblocking CI.
