### PR TITLE
[OPIK-6901] feat(cutover): expose --max-insert-threads, the throughput ceiling

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -356,18 +356,34 @@ independent controls keep each statement safe:
     the `SELECT` part is executed in parallel"* (see `max_threads`).
 
   **Why the insert side is often the constraint on this table — and what is inference rather than
-  documented.** The destination carries JSON-parsing MATERIALIZED columns (`output_keys`, `input_keys`), and
-  upstream states materialized values *"are automatically calculated according to the specified materialized
-  expression when rows are inserted"*. Upstream does **not** state which pipeline stage or which threads
+  documented.** The destination carries per-row MATERIALIZED work the source does not. The expensive one is
+  **`output_keys`**, which parses the `output` JSON:
+  `arrayMap(key -> tuple(key, toString(JSONType(JSONExtractRaw(output, key)))), JSONExtractKeys(output))`.
+  There is **no `input_keys` column** — `output_keys` is traces-only and has no input counterpart, so don't go
+  looking for one. The table also materialises `truncated_input` / `truncated_output`, which substring-copy
+  documents that can be very large, plus `input_length` / `output_length` / `metadata_length`, `duration` and
+  `id_at`. Upstream states materialized values *"are automatically calculated according to the specified
+  materialized expression when rows are inserted"*. Upstream does **not** state which pipeline stage or which threads
   perform that calculation. That these columns make the insert side the bottleneck here is an **inference from
   profiling**, not a documented guarantee — so confirm it on your own data rather than assuming it:
 
   **How to confirm it:** effective cores sit near 1 while the machine is otherwise idle and
   `OSIOWaitMicroseconds` is 0 — the copy is neither CPU-saturated nor I/O bound, it is serialised. Compute
-  effective cores from `query_log` as
-  `(ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) / query_duration_ms`.
-  After raising the setting, effective cores rising towards the thread count is what turns the inference into
-  a measurement.
+  effective cores from `query_log`, **minding the units** — the `ProfileEvents` are *micro*seconds while
+  `query_duration_ms` is *milli*seconds, so the `* 1000` is not optional:
+
+  ```sql
+  (ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds'])
+      / (query_duration_ms * 1000)   -- omit the *1000 and the answer is 1000x too high
+  ```
+
+  Sanity-check the result against the node's core count: a value above it means the arithmetic is wrong, not
+  that the machine is busy.
+
+  **What this measures, precisely:** `query_log` aggregates are **query-wide CPU**. They do not separate
+  read-pipeline threads from insert-pipeline threads, so the number alone cannot attribute CPU to the insert
+  side. What makes it evidence is the *delta*: raise the setting and effective cores rise towards the thread
+  count while the read side is unchanged.
 
   **Two costs, both real:**
   - **Memory.** Upstream is explicit: *"Higher values will lead to higher memory usage."* On this table that
@@ -376,6 +392,12 @@ independent controls keep each statement safe:
     rather than raising threads alone into a fixed ceiling.
   - **Parts.** Each insert thread writes its own parts, so parts per partition grows. Watch it against
     `parts_to_throw_insert` (ClickHouse default 300) rather than assuming headroom.
+
+  **`estimate.sh` does not model this setting.** Its ETA probes the *read* side and derates it by a fixed
+  `--write-cost-factor`, so it is not specific to your thread count and will understate a run configured with
+  insert parallelism. If you are running with `--max-insert-threads` set, time one real window at that setting
+  and feed the measured throughput back via `estimate.sh --rows-per-sec`, which skips the probe and the
+  write-cost factor entirely.
 
   **Choosing a value is a capacity decision, not a benchmark:** on an idle rehearsal environment a large
   value looks free, but on production those threads compete with live query latency, so pick the share of

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -341,6 +341,46 @@ independent controls keep each statement safe:
   so peak insert memory is a small multiple of ~256 MB regardless of the window size — the statement does not load the
   window into memory. Lower this (or `min_insert_block_size_bytes`) on a memory-constrained data node.
 
+- **Insert pipeline threads (`--max-insert-threads`, default 0 → `SETTINGS max_insert_threads`).**
+  **This is often the throughput ceiling, and the default hides it.** ClickHouse documents the value `0`
+  (the default) as *"`INSERT SELECT` no parallel execution"*, so the insert side of this copy runs
+  serialised until you raise it. Raising it lets you control how much of the machine the backfill may
+  consume, and can speed the copy up substantially.
+
+  Two scope caveats worth knowing before you reach for it:
+  - The setting applies to **`INSERT SELECT`** — which is what this backfill issues — not to INSERTs
+    generally.
+  - **ClickHouse Cloud does not default it to `0`.** Upstream documents `1` / `2` / `4` by node memory, so
+    a Cloud deployment may already have parallelism here and see less benefit.
+  - It only helps if the read side is parallel too. Upstream: *"Parallel `INSERT SELECT` has effect only if
+    the `SELECT` part is executed in parallel"* (see `max_threads`).
+
+  **Why the insert side is often the constraint on this table — and what is inference rather than
+  documented.** The destination carries JSON-parsing MATERIALIZED columns (`output_keys`, `input_keys`), and
+  upstream states materialized values *"are automatically calculated according to the specified materialized
+  expression when rows are inserted"*. Upstream does **not** state which pipeline stage or which threads
+  perform that calculation. That these columns make the insert side the bottleneck here is an **inference from
+  profiling**, not a documented guarantee — so confirm it on your own data rather than assuming it:
+
+  **How to confirm it:** effective cores sit near 1 while the machine is otherwise idle and
+  `OSIOWaitMicroseconds` is 0 — the copy is neither CPU-saturated nor I/O bound, it is serialised. Compute
+  effective cores from `query_log` as
+  `(ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) / query_duration_ms`.
+  After raising the setting, effective cores rising towards the thread count is what turns the inference into
+  a measurement.
+
+  **Two costs, both real:**
+  - **Memory.** Upstream is explicit: *"Higher values will lead to higher memory usage."* On this table that
+    compounds with a known hazard — a single oversized `output` document can dominate insert memory by itself
+    (see the memory section below) — so raise this together with `max_memory_usage`, or narrow the window,
+    rather than raising threads alone into a fixed ceiling.
+  - **Parts.** Each insert thread writes its own parts, so parts per partition grows. Watch it against
+    `parts_to_throw_insert` (ClickHouse default 300) rather than assuming headroom.
+
+  **Choosing a value is a capacity decision, not a benchmark:** on an idle rehearsal environment a large
+  value looks free, but on production those threads compete with live query latency, so pick the share of
+  cores the cutover may take while serving traffic, and validate the value you will actually deploy.
+
 - **Per-block partition bound (`--max-partitions-per-insert-block`, default 2000 → `SETTINGS
   max_partitions_per_insert_block`).** Not a throughput knob — a **correctness gate**. The destination is
   weekly-partitioned, so a block spans as many partitions as the ids in it imply; ClickHouse's default of 100 aborts the

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -341,11 +341,18 @@ independent controls keep each statement safe:
   so peak insert memory is a small multiple of ~256 MB regardless of the window size — the statement does not load the
   window into memory. Lower this (or `min_insert_block_size_bytes`) on a memory-constrained data node.
 
-- **Insert pipeline threads (`--max-insert-threads`, default 0 → `SETTINGS max_insert_threads`).**
-  **This is often the throughput ceiling, and the default hides it.** ClickHouse documents the value `0`
-  (the default) as *"`INSERT SELECT` no parallel execution"*, so the insert side of this copy runs
-  serialised until you raise it. Raising it lets you control how much of the machine the backfill may
-  consume, and can speed the copy up substantially.
+- **Insert pipeline threads (`--max-insert-threads`, omitted by default → `SETTINGS max_insert_threads`).**
+  **This is often the throughput ceiling, and ClickHouse's own default hides it.** Where nothing sets the
+  setting, ClickHouse documents `0` as *"`INSERT SELECT` no parallel execution"*, so the insert side of this
+  copy runs serialised. Passing a value lets you control how much of the machine the backfill may consume,
+  and can speed the copy up substantially.
+
+  **Omitting the flag means *inherit*, not zero.** The drivers strip the setting line from the SQL entirely
+  when the flag is not passed, so whatever the server profile sets applies. That distinction is load-bearing:
+  rendering an explicit `0` would **override** a profile that sets the setting and force the insert serial —
+  a silent slowdown, not a no-op. ClickHouse Cloud ships non-zero defaults (`1`/`2`/`4` by node memory), and a
+  self-managed cluster may set it in a profile too. Pass an explicit `0` when you actually want to *force*
+  serial execution.
 
   Two scope caveats worth knowing before you reach for it:
   - The setting applies to **`INSERT SELECT`** — which is what this backfill issues — not to INSERTs

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -342,77 +342,40 @@ independent controls keep each statement safe:
   window into memory. Lower this (or `min_insert_block_size_bytes`) on a memory-constrained data node.
 
 - **Insert pipeline threads (`--max-insert-threads`, omitted by default → `SETTINGS max_insert_threads`).**
-  **This is often the throughput ceiling, and ClickHouse's own default hides it.** Where nothing sets the
-  setting, ClickHouse documents `0` as *"`INSERT SELECT` no parallel execution"*, so the insert side of this
-  copy runs serialised. Passing a value lets you control how much of the machine the backfill may consume,
-  and can speed the copy up substantially.
+  Often the throughput ceiling: where nothing sets it, ClickHouse's default `0` means *"`INSERT SELECT` no
+  parallel execution"*, so the insert side runs serialised. Passing a value controls how much of the machine
+  the backfill may use and can speed the copy up substantially.
 
-  **Omitting the flag means *inherit*, not zero.** The drivers strip the setting line from the SQL entirely
-  when the flag is not passed, so whatever the server profile sets applies. That distinction is load-bearing:
-  rendering an explicit `0` would **override** a profile that sets the setting and force the insert serial —
-  a silent slowdown, not a no-op. ClickHouse Cloud ships non-zero defaults (`1`/`2`/`4` by node memory), and a
-  self-managed cluster may set it in a profile too. Pass an explicit `0` when you actually want to *force*
-  serial execution.
+  **Omitting the flag means *inherit*, not zero.** The drivers strip the setting line from the SQL when the
+  flag isn't passed, so the server's own value applies. Rendering an explicit `0` would **override** a profile
+  that sets it and force the insert serial — a silent slowdown, not a no-op. Pass `0` only to *force* serial.
 
-  Two scope caveats worth knowing before you reach for it:
-  - The setting applies to **`INSERT SELECT`** — which is what this backfill issues — not to INSERTs
-    generally.
-  - **ClickHouse Cloud does not default it to `0`.** Upstream documents `1` / `2` / `4` by node memory, so
-    a Cloud deployment may already have parallelism here and see less benefit.
-  - It only helps if the read side is parallel too. Upstream: *"Parallel `INSERT SELECT` has effect only if
-    the `SELECT` part is executed in parallel"* (see `max_threads`).
+  Three caveats, all from upstream: the setting applies to **`INSERT SELECT`** only; **ClickHouse Cloud
+  defaults it to `1`/`2`/`4`** by node memory, not `0`; and it helps only if the read side is parallel too
+  (*"has effect only if the `SELECT` part is executed in parallel"* — see `max_threads`).
 
-  **Why the insert side is often the constraint on this table — and what is inference rather than
-  documented.** The destination carries per-row MATERIALIZED work the source does not. The expensive one is
-  **`output_keys`**, which parses the `output` JSON:
-  `arrayMap(key -> tuple(key, toString(JSONType(JSONExtractRaw(output, key)))), JSONExtractKeys(output))`.
-  There is **no `input_keys` column** — `output_keys` is traces-only and has no input counterpart, so don't go
-  looking for one. The table also materialises `truncated_input` / `truncated_output`, which substring-copy
-  documents that can be very large, plus `input_length` / `output_length` / `metadata_length`, `duration` and
-  `id_at`. Upstream states materialized values *"are automatically calculated according to the specified
-  materialized expression when rows are inserted"*. Upstream does **not** state which pipeline stage or which threads
-  perform that calculation. That these columns make the insert side the bottleneck here is an **inference from
-  profiling**, not a documented guarantee — so confirm it on your own data rather than assuming it:
-
-  **How to confirm it:** effective cores sit near 1 while the machine is otherwise idle and
-  `OSIOWaitMicroseconds` is 0 — the copy is neither CPU-saturated nor I/O bound, it is serialised. Compute
-  effective cores from `query_log`, **minding the units** — the `ProfileEvents` are *micro*seconds while
-  `query_duration_ms` is *milli*seconds, so the `* 1000` is not optional:
+  **Why the insert side, and how sure we are.** The destination materialises `output_keys` by parsing the
+  `output` JSON (there is no `input_keys` column), plus `truncated_input`/`truncated_output` and the length,
+  `duration` and `id_at` columns. Upstream says materialized values are calculated *"when rows are inserted"*
+  but not by which stage, so blaming the insert side is an **inference from profiling**, not a guarantee.
+  Confirm it on your own data: effective cores near 1 while the machine is idle and `OSIOWaitMicroseconds` is
+  0, then rising towards the thread count once raised. Mind the units — `ProfileEvents` are microseconds,
+  `query_duration_ms` is milliseconds:
 
   ```sql
-  (ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds'])
-      / (query_duration_ms * 1000)   -- omit the *1000 and the answer is 1000x too high
+  (ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) / (query_duration_ms * 1000)
   ```
 
-  Sanity-check the result against the node's core count: a value above it means the arithmetic is wrong, not
-  that the machine is busy.
+  A result above the node's core count means the arithmetic is wrong. Note it is *query-wide* CPU: `query_log`
+  does not separate read from insert threads, so the delta on raising the setting is what carries the argument.
 
-  **What this measures, precisely:** `query_log` aggregates are **query-wide CPU**. They do not separate
-  read-pipeline threads from insert-pipeline threads, so the number alone cannot attribute CPU to the insert
-  side. What makes it evidence is the *delta*: raise the setting and effective cores rise towards the thread
-  count while the read side is unchanged.
-
-  **Two costs, both real:**
-  - **Memory.** Upstream is explicit: *"Higher values will lead to higher memory usage."* On this table that
-    compounds with this table's row width, and in a way the block bullet above does **not** cover. That bullet's
-    rule — peak insert memory is a small multiple of the 256 MB byte cap — holds for ordinary wide rows. It does
-    not hold for a single very large `output` document: materialising `output_keys` over one of those is a
-    **per-row** cost that no block cap bounds, so neither `max_insert_block_size` nor `min_insert_block_size_bytes`
-    constrains it. That is precisely why the lever here is the ceiling: raise this together with
-    `max_memory_usage`, or narrow the window,
-    rather than raising threads alone into a fixed ceiling.
-  - **Parts.** Each insert thread writes its own parts, so parts per partition grows. Watch it against
-    `parts_to_throw_insert` (ClickHouse default 300) rather than assuming headroom.
-
-  **`estimate.sh` does not model this setting.** Its ETA probes the *read* side and derates it by a fixed
-  `--write-cost-factor`, so it is not specific to your thread count and will understate a run configured with
-  insert parallelism. If you are running with `--max-insert-threads` set, time one real window at that setting
-  and feed the measured throughput back via `estimate.sh --rows-per-sec`, which skips the probe and the
-  write-cost factor entirely.
-
-  **Choosing a value is a capacity decision, not a benchmark:** on an idle rehearsal environment a large
-  value looks free, but on production those threads compete with live query latency, so pick the share of
-  cores the cutover may take while serving traffic, and validate the value you will actually deploy.
+  **Two costs.** Upstream: *"higher values will lead to higher memory usage"* — and on this table a single very
+  large `output` document is a **per-row** cost that no block cap bounds, so raise `max_memory_usage` alongside
+  or narrow the window. And parts per partition grow; watch them against `parts_to_throw_insert` (default 300).
+  Value choice is a capacity decision, not a benchmark: on an idle rehearsal box a large value looks free, but
+  on production those threads compete with live query latency. `estimate.sh` does **not** model this setting —
+  time a real window at your intended value and feed it back via `--rows-per-sec`.
+  Full diagnosis in `backfill.sh`'s `--max-insert-threads` option docs.
 
 - **Per-block partition bound (`--max-partitions-per-insert-block`, default 2000 → `SETTINGS
   max_partitions_per_insert_block`).** Not a throughput knob — a **correctness gate**. The destination is

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -387,8 +387,12 @@ independent controls keep each statement safe:
 
   **Two costs, both real:**
   - **Memory.** Upstream is explicit: *"Higher values will lead to higher memory usage."* On this table that
-    compounds with a known hazard — a single oversized `output` document can dominate insert memory by itself
-    (see the memory section below) — so raise this together with `max_memory_usage`, or narrow the window,
+    compounds with this table's row width, and in a way the block bullet above does **not** cover. That bullet's
+    rule — peak insert memory is a small multiple of the 256 MB byte cap — holds for ordinary wide rows. It does
+    not hold for a single very large `output` document: materialising `output_keys` over one of those is a
+    **per-row** cost that no block cap bounds, so neither `max_insert_block_size` nor `min_insert_block_size_bytes`
+    constrains it. That is precisely why the lever here is the ceiling: raise this together with
+    `max_memory_usage`, or narrow the window,
     rather than raising threads alone into a fixed ceiling.
   - **Parts.** Each insert thread writes its own parts, so parts per partition grows. Watch it against
     `parts_to_throw_insert` (ClickHouse default 300) rather than assuming headroom.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -371,7 +371,10 @@ independent controls keep each statement safe:
 
   **Two costs.** Upstream: *"higher values will lead to higher memory usage"* — and on this table a single very
   large `output` document is a **per-row** cost that no block cap bounds, so raise `max_memory_usage` alongside
-  or narrow the window. And parts per partition grow; watch them against `parts_to_throw_insert` (default 300).
+  or narrow the window. And parts per partition grow; watch them against **this cluster's** `parts_to_throw_insert` and
+  `parts_to_delay_insert` — read them from `system.merge_tree_settings` rather than assuming ClickHouse's
+  defaults (300 / 150), because deployments routinely raise them and the real headroom can be an order of
+  magnitude different in either direction.
   Value choice is a capacity decision, not a benchmark: on an idle rehearsal box a large value looks free, but
   on production those threads compete with live query latency. `estimate.sh` does **not** model this setting —
   time a real window at your intended value and feed it back via `--rows-per-sec`.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -328,6 +328,18 @@ run_backfill_window() {
         # non-zero default) applies. Rendering an explicit 0 here would OVERRIDE that and force the insert
         # serial -- a silent slowdown on any deployment that already sets the setting.
         sql="$(grep -vF 'max_insert_threads = ${MAX_INSERT_THREADS}' <<<"$sql")"
+        # The strip is a whitespace-exact match on a SETTINGS line in ANOTHER file. If that line is ever
+        # reformatted the match silently no-ops and the placeholder reaches the server as a literal -- the exact
+        # failure that file's own header warns about. This is the DEFAULT path, so fail loudly here instead.
+        # The strip matches ONE exact spelling of a SETTINGS line that lives in ANOTHER file. Reformat that line
+        # -- even one extra space -- and the strip silently no-ops, leaving the placeholder to reach the server
+        # as a literal. So assert on the OUTCOME, whitespace-agnostically, and skip `--` comment lines, which
+        # legitimately keep the placeholder text in the file headers. This is the DEFAULT path; fail loudly.
+        if grep -v '^[[:space:]]*--' <<<"$sql" | grep -qF '${MAX_INSERT_THREADS}'; then
+            echo "ERROR: max_insert_threads strip failed -- the SETTINGS line in $BACKFILL_SQL no longer matches the" >&2
+            echo "       pattern above (was it reformatted?). Refusing to send SQL with a literal placeholder." >&2
+            exit 2
+        fi
     else
         sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
     fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -122,8 +122,11 @@
 #                                 or narrow the window, rather than raising threads alone into a fixed
 #                                 ceiling.
 #                             (2) PARTS. Each insert thread writes its own parts, so part count per
-#                                 partition grows. Watch it against parts_to_throw_insert (ClickHouse
-#                                 default 300) rather than assuming headroom.
+#                                 partition grows. Watch it against THIS cluster's parts_to_throw_insert
+#                                 and parts_to_delay_insert, read from system.merge_tree_settings -- do not
+#                                 assume ClickHouse's defaults (300 / 150). Deployments routinely raise
+#                                 them, so the real headroom can be an order of magnitude off either way,
+#                                 and "parts vs 300" is a misleading ratio on a tuned cluster.
 #
 #                             CHOOSING A VALUE IS A CAPACITY DECISION, NOT A BENCHMARK. On an idle
 #                             rehearsal environment a large value looks free; on a production cluster

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -60,9 +60,15 @@
 #                             per partition touched, compacted by background merges) for the INSERT completing at all.
 #                             See the runbook's "Far-future partitions from far-future-timestamp ids".
 #   --max-insert-threads N    threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
-#                             Default 0. ClickHouse documents 0 (or 1) as "INSERT SELECT no parallel
-#                             execution", so the copy runs its insert side single-threaded unless this
-#                             is raised. NOTE the setting is scoped to INSERT SELECT, which is what
+#                             OMITTED BY DEFAULT, and omitted means INHERIT: the setting line is stripped
+#                             from the SQL, so whatever the server profile sets applies. This matters --
+#                             rendering an explicit 0 would OVERRIDE a profile that sets it and force the
+#                             insert serial, which is a silent slowdown rather than a no-op. ClickHouse
+#                             Cloud ships non-zero defaults (1/2/4 by node memory), and a self-managed
+#                             cluster may set it in a profile too.
+#                             Pass an explicit 0 to FORCE "INSERT SELECT no parallel execution"; pass N to
+#                             request N. Where nothing sets it, ClickHouse's own default is 0, so the
+#                             insert side runs single-threaded unless raised. NOTE the setting is scoped to INSERT SELECT, which is what
 #                             this backfill issues; it is not a general INSERT knob. NOTE ALSO that
 #                             ClickHouse CLOUD does not default it to 0 -- upstream documents 1 / 2 / 4
 #                             by node memory -- so on Cloud you may already have parallelism here.
@@ -168,8 +174,9 @@ MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions: SETTINGS max_partitions_per_
                           # destination is weekly-partitioned, so one block can span many partitions; ClickHouse's
                           # default of 100 THROWS (throw_on_max_partitions_per_insert_block=1). Far-future UUIDv7 ids
                           # make this reachable in practice — see the runbook's far-future section. 0 = unlimited.
-MAX_INSERT_THREADS=0      # threads: SETTINGS max_insert_threads for the INSERT SELECT. 0 is the ClickHouse default and
-                          # means "INSERT SELECT no parallel execution", which is usually the throughput ceiling here.
+MAX_INSERT_THREADS=""     # threads: SETTINGS max_insert_threads for the INSERT SELECT. EMPTY = inherit whatever the
+                          # server profile sets (the setting line is stripped from the SQL entirely). An explicit 0
+                          # is ClickHouse's own default and means "INSERT SELECT no parallel execution".
                           # Raising it trades memory and destination part count for copy speed — see the
                           # --max-insert-threads option docs above for the full diagnosis and both costs.
 DIVERGENCE="0.0001"       # fraction: max tolerated |src-dst|/src per settled window before aborting (0.01%).
@@ -222,7 +229,7 @@ done
 # 0 is meaningful (ClickHouse default, no parallel INSERT SELECT execution), so allow it. Bounded at 2 digits:
 # this is
 # a share of cores, and a value beyond the machine's core count buys nothing while multiplying parts.
-[[ "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (ClickHouse default: no parallel INSERT SELECT execution) or 1..99." >&2; exit 2; }
+[[ -z "$MAX_INSERT_THREADS" || "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (force no parallel INSERT SELECT execution) or 1..99; omit it entirely to inherit the server's setting." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ -z "$TO_WEEK" || "$TO_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --to-week must be a non-negative integer." >&2; exit 2; }
 [[ "$PAUSE_SECONDS" =~ ^[0-9]+$ ]] || { echo "ERROR: --pause-seconds must be a non-negative integer." >&2; exit 2; }
@@ -316,7 +323,14 @@ run_backfill_window() {
     sql="${sql//'${WINDOW_HI}'/$hi}"
     sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
     sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
-    sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
+    if [[ -z "$MAX_INSERT_THREADS" ]]; then
+        # Unset means INHERIT: strip the whole setting line so the server's profile (or ClickHouse Cloud's
+        # non-zero default) applies. Rendering an explicit 0 here would OVERRIDE that and force the insert
+        # serial -- a silent slowdown on any deployment that already sets the setting.
+        sql="$(grep -vF 'max_insert_threads = ${MAX_INSERT_THREADS}' <<<"$sql")"
+    else
+        sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
+    fi
     clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -59,6 +59,56 @@
 #                             TOTAL distinct partition count. Raising it trades a larger part count per insert (one part
 #                             per partition touched, compacted by background merges) for the INSERT completing at all.
 #                             See the runbook's "Far-future partitions from far-future-timestamp ids".
+#   --max-insert-threads N    threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
+#                             Default 0. ClickHouse documents 0 (or 1) as "INSERT SELECT no parallel
+#                             execution", so the copy runs its insert side single-threaded unless this
+#                             is raised. NOTE the setting is scoped to INSERT SELECT, which is what
+#                             this backfill issues; it is not a general INSERT knob. NOTE ALSO that
+#                             ClickHouse CLOUD does not default it to 0 -- upstream documents 1 / 2 / 4
+#                             by node memory -- so on Cloud you may already have parallelism here.
+#
+#                             Raising it lets you decide how much of the machine the backfill may use,
+#                             and can speed the copy up substantially when the insert side is the
+#                             constraint.
+#
+#                             PRECONDITION, per upstream: "Parallel INSERT SELECT has effect only if
+#                             the SELECT part is executed in parallel" (see max_threads). If the read
+#                             side is serialised, raising this buys nothing.
+#
+#                             WHY THE INSERT SIDE IS OFTEN THE CONSTRAINT HERE: the destination carries
+#                             JSON-parsing MATERIALIZED columns (output_keys / input_keys), and upstream
+#                             states materialized values "are automatically calculated ... when rows are
+#                             inserted". Upstream does NOT state which pipeline stage or which threads
+#                             compute them; that the insert side is the bottleneck on this table is an
+#                             INFERENCE FROM PROFILING, not a documented guarantee -- see below for how
+#                             to confirm it on your own data rather than assuming it.
+#
+#                             HOW TO CONFIRM IT: effective cores sit near 1 while the machine is
+#                             otherwise idle and OSIOWaitMicroseconds is 0 -- i.e. the copy is neither
+#                             CPU-saturated nor I/O bound, it is serialised. Compute effective cores
+#                             from query_log as
+#                             (UserTimeMicroseconds + SystemTimeMicroseconds) / query_duration_ms.
+#                             After raising this, effective cores rising towards the thread count is
+#                             what turns the inference into a measurement.
+#
+#                             COSTS, BOTH OF THEM.
+#                             (1) MEMORY. Upstream is explicit: "Higher values will lead to higher
+#                                 memory usage." That matters more on this table than it might
+#                                 elsewhere, because a single oversized `output` document can dominate
+#                                 insert memory on its own. Raise this and max_memory_usage together,
+#                                 or narrow the window, rather than raising threads alone into a fixed
+#                                 ceiling.
+#                             (2) PARTS. Each insert thread writes its own parts, so part count per
+#                                 partition grows. Watch it against parts_to_throw_insert (ClickHouse
+#                                 default 300) rather than assuming headroom.
+#
+#                             CHOOSING A VALUE IS A CAPACITY DECISION, NOT A BENCHMARK. On an idle
+#                             rehearsal environment a large value looks free; on a production cluster
+#                             those threads compete with live query latency. Pick the share of cores
+#                             the cutover may take while serving traffic, and validate the value you
+#                             will actually deploy rather than the largest one that fits. 0 stays the
+#                             default so no existing deployment changes behaviour, and so a small
+#                             install on few cores does not silently start spawning insert threads.
 #   --divergence P            max tolerated |src-dst|/src per window before aborting. Default 0.0001 (0.01%).
 #   --pause-seconds S         sleep S seconds after each inserted window, to let destination merges catch up and bound
 #                             the part count / IO pressure. Default 0. Recommended 30-60 on a large table at peak.
@@ -97,6 +147,9 @@ MAX_ROWS=2000000          # rows: per-statement bound; a week over this is halve
 MAX_INSERT_BLOCK_SIZE=1048576  # rows: SETTINGS max_insert_block_size for the INSERT. Peak memory is a small multiple of
                           # the smaller of this and min_insert_block_size_bytes (256 MB default), which dominates for wide
                           # trace rows; lower it on a memory-constrained node. 1048576 is the ClickHouse default.
+MAX_INSERT_THREADS=0                  # threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
+                          # 0 = ClickHouse default = SINGLE-THREADED sink, usually the throughput
+                          # ceiling here. See --max-insert-threads above for the measurements.
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions: SETTINGS max_partitions_per_insert_block for the INSERT. The
                           # destination is weekly-partitioned, so one block can span many partitions; ClickHouse's
                           # default of 100 THROWS (throw_on_max_partitions_per_insert_block=1). Far-future UUIDv7 ids
@@ -120,6 +173,7 @@ while [[ $# -gt 0 ]]; do
         --max-rows-per-insert) MAX_ROWS="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-insert-threads) MAX_INSERT_THREADS="${2:?"$1 requires a value"}"; shift 2 ;;
         --divergence) DIVERGENCE="${2:?"$1 requires a value"}"; shift 2 ;;
         --pause-seconds) PAUSE_SECONDS="${2:?"$1 requires a value"}"; shift 2 ;;
         --min-free-factor) MIN_FREE_FACTOR="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -147,6 +201,9 @@ done
 # rendered into the SQL and rejected by the server on the first INSERT — after the capacity preflight has passed and the
 # backfill_start anchor has been minted, which is a far more expensive place to discover a typo.
 [[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
+# 0 is meaningful (ClickHouse default, single-threaded sink), so allow it. Bounded at 2 digits: this is
+# a share of cores, and a value beyond the machine's core count buys nothing while multiplying parts.
+[[ "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (ClickHouse default: no parallel INSERT SELECT execution) or 1..99." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ -z "$TO_WEEK" || "$TO_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --to-week must be a non-negative integer." >&2; exit 2; }
 [[ "$PAUSE_SECONDS" =~ ^[0-9]+$ ]] || { echo "ERROR: --pause-seconds must be a non-negative integer." >&2; exit 2; }
@@ -240,6 +297,7 @@ run_backfill_window() {
     sql="${sql//'${WINDOW_HI}'/$hi}"
     sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
     sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
+    sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
     clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --multiquery --query "$sql"
 }
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -164,13 +164,14 @@ MAX_ROWS=2000000          # rows: per-statement bound; a week over this is halve
 MAX_INSERT_BLOCK_SIZE=1048576  # rows: SETTINGS max_insert_block_size for the INSERT. Peak memory is a small multiple of
                           # the smaller of this and min_insert_block_size_bytes (256 MB default), which dominates for wide
                           # trace rows; lower it on a memory-constrained node. 1048576 is the ClickHouse default.
-                          # 0 = ClickHouse default = SINGLE-THREADED sink, usually the throughput
-                          # ceiling here. See --max-insert-threads above for the measurements.
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions: SETTINGS max_partitions_per_insert_block for the INSERT. The
-MAX_INSERT_THREADS=0                  # threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
                           # destination is weekly-partitioned, so one block can span many partitions; ClickHouse's
                           # default of 100 THROWS (throw_on_max_partitions_per_insert_block=1). Far-future UUIDv7 ids
                           # make this reachable in practice — see the runbook's far-future section. 0 = unlimited.
+MAX_INSERT_THREADS=0      # threads: SETTINGS max_insert_threads for the INSERT SELECT. 0 is the ClickHouse default and
+                          # means "INSERT SELECT no parallel execution", which is usually the throughput ceiling here.
+                          # Raising it trades memory and destination part count for copy speed — see the
+                          # --max-insert-threads option docs above for the full diagnosis and both costs.
 DIVERGENCE="0.0001"       # fraction: max tolerated |src-dst|/src per settled window before aborting (0.01%).
 PAUSE_SECONDS=0           # seconds: sleep after each inserted window so destination merges catch up. 30-60 for a large table at peak.
 MIN_FREE_FACTOR="2.0"     # multiple of the current traces on-disk size that node free space must clear before starting.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -219,7 +219,8 @@ done
 # rendered into the SQL and rejected by the server on the first INSERT — after the capacity preflight has passed and the
 # backfill_start anchor has been minted, which is a far more expensive place to discover a typo.
 [[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
-# 0 is meaningful (ClickHouse default, single-threaded sink), so allow it. Bounded at 2 digits: this is
+# 0 is meaningful (ClickHouse default, no parallel INSERT SELECT execution), so allow it. Bounded at 2 digits:
+# this is
 # a share of cores, and a value beyond the machine's core count buys nothing while multiplying parts.
 [[ "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (ClickHouse default: no parallel INSERT SELECT execution) or 1..99." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -76,9 +76,18 @@
 #                             side is serialised, raising this buys nothing.
 #
 #                             WHY THE INSERT SIDE IS OFTEN THE CONSTRAINT HERE: the destination carries
-#                             JSON-parsing MATERIALIZED columns (output_keys / input_keys), and upstream
-#                             states materialized values "are automatically calculated ... when rows are
-#                             inserted". Upstream does NOT state which pipeline stage or which threads
+#                             per-row MATERIALIZED work the source does not do. The expensive one is
+#                             output_keys, which PARSES the output JSON:
+#                               arrayMap(key -> tuple(key, toString(JSONType(JSONExtractRaw(output, key)))),
+#                                        JSONExtractKeys(output))
+#                             There is NO input_keys column -- output_keys is traces-only and has no input
+#                             counterpart; do not go looking for one. The table also materialises
+#                             truncated_input / truncated_output, which substring-copy documents that can
+#                             be very large, plus input_length / output_length / metadata_length, duration
+#                             and id_at.
+#
+#                             Upstream states materialized values "are automatically calculated ... when
+#                             rows are inserted", but does NOT state which pipeline stage or which threads
 #                             compute them; that the insert side is the bottleneck on this table is an
 #                             INFERENCE FROM PROFILING, not a documented guarantee -- see below for how
 #                             to confirm it on your own data rather than assuming it.
@@ -86,10 +95,18 @@
 #                             HOW TO CONFIRM IT: effective cores sit near 1 while the machine is
 #                             otherwise idle and OSIOWaitMicroseconds is 0 -- i.e. the copy is neither
 #                             CPU-saturated nor I/O bound, it is serialised. Compute effective cores
-#                             from query_log as
-#                             (UserTimeMicroseconds + SystemTimeMicroseconds) / query_duration_ms.
-#                             After raising this, effective cores rising towards the thread count is
-#                             what turns the inference into a measurement.
+#                             from query_log, MINDING THE UNITS -- the ProfileEvents are MICROseconds
+#                             and query_duration_ms is MILLIseconds, so the *1000 is not optional:
+#                               (UserTimeMicroseconds + SystemTimeMicroseconds) / (query_duration_ms * 1000)
+#                             Without it the result is 1000x too high and will read as hundreds of
+#                             cores. Sanity-check against the node's core count: a value above it means
+#                             the arithmetic is wrong, not that the machine is busy.
+#
+#                             NOTE WHAT THIS MEASURES: query_log aggregates are QUERY-WIDE CPU. They do
+#                             not separate read-pipeline threads from insert-pipeline threads, so this
+#                             number cannot by itself attribute the CPU to the sink. What makes it
+#                             evidence is the DELTA: raise the setting and effective cores rise towards
+#                             the thread count while the read side is unchanged.
 #
 #                             COSTS, BOTH OF THEM.
 #                             (1) MEMORY. Upstream is explicit: "Higher values will lead to higher
@@ -147,10 +164,10 @@ MAX_ROWS=2000000          # rows: per-statement bound; a week over this is halve
 MAX_INSERT_BLOCK_SIZE=1048576  # rows: SETTINGS max_insert_block_size for the INSERT. Peak memory is a small multiple of
                           # the smaller of this and min_insert_block_size_bytes (256 MB default), which dominates for wide
                           # trace rows; lower it on a memory-constrained node. 1048576 is the ClickHouse default.
-MAX_INSERT_THREADS=0                  # threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
                           # 0 = ClickHouse default = SINGLE-THREADED sink, usually the throughput
                           # ceiling here. See --max-insert-threads above for the measurements.
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions: SETTINGS max_partitions_per_insert_block for the INSERT. The
+MAX_INSERT_THREADS=0                  # threads for the INSERT SELECT pipeline (SETTINGS max_insert_threads).
                           # destination is weekly-partitioned, so one block can span many partitions; ClickHouse's
                           # default of 100 THROWS (throw_on_max_partitions_per_insert_block=1). Far-future UUIDv7 ids
                           # make this reachable in practice — see the runbook's far-future section. 0 = unlimited.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -12,6 +12,7 @@
 --   ${WINDOW_LO} / ${WINDOW_HI}            the created_at half-open window bounds
 --   ${MAX_INSERT_BLOCK_SIZE}               rows per part-forming block
 --   ${MAX_PARTITIONS_PER_INSERT_BLOCK}     partitions one block may span (required; see the note below)
+--   ${MAX_INSERT_THREADS}                  threads for the INSERT SELECT pipeline (0 = ClickHouse default)
 --
 -- Slicing rationale (created_at, not id / not workspace), delta and replay design: see ../../README.md.
 -- Notes on the statement:
@@ -24,6 +25,18 @@
 --     output-order guarantee, so inserted blocks may span/interleave partitions; the destination ReplacingMergeTree
 --     dedups regardless of insert order and background merges compact the parts. This is NOT a claim that rows arrive
 --     in sort-key order — do not rely on it (see README "Why slice by created_at").
+--   * SETTINGS max_insert_threads sizes the INSERT SELECT pipeline. ClickHouse documents 0 (the default) as
+--     "INSERT SELECT no parallel execution"; on ClickHouse Cloud the default is instead 1/2/4 by node memory.
+--     Raising it controls how much of the machine the backfill may use and can speed the copy up markedly,
+--     but only if the SELECT side is itself parallel (upstream: parallel INSERT SELECT "has effect only if the
+--     SELECT part is executed in parallel"). Upstream states materialized columns are calculated "when rows
+--     are inserted" but does NOT say which stage computes them -- that this table's JSON-parsing
+--     output_keys/input_keys make the insert side the constraint is an inference from profiling, confirmed by
+--     effective cores rising towards the thread count. Two costs: upstream warns "higher values will lead to
+--     higher memory usage" (which on this table compounds with oversized `output` documents, so move
+--     max_memory_usage with it), and part count per partition grows, to be watched against
+--     parts_to_throw_insert. The value is a capacity decision about what share of cores the cutover may take
+--     while serving traffic -- not a benchmark to maximise.
 --   * SETTINGS max_insert_block_size bounds the rows per part-forming block; peak insert memory is a small multiple of
 --     the smaller of that and min_insert_block_size_bytes (256 MB default), which dominates for wide trace rows.
 --   * SETTINGS max_partitions_per_insert_block is REQUIRED, not a tuning knob. Because the blocks above may span
@@ -89,6 +102,7 @@ WHERE created_at >= toDateTime64('${WINDOW_LO}', 9, 'UTC')
   AND created_at <  toDateTime64('${WINDOW_HI}', 9, 'UTC')
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
          max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
+         max_insert_threads = ${MAX_INSERT_THREADS},
          log_comment = 'traces_local_v2_backfill:${WINDOW_LO}:${WINDOW_HI}';
 
 -- Per-window reconciliation is automated by backfill.sh (uniqExact of the dedup key, aborting on > 0.01% divergence);

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -30,9 +30,11 @@
 --     Raising it controls how much of the machine the backfill may use and can speed the copy up markedly,
 --     but only if the SELECT side is itself parallel (upstream: parallel INSERT SELECT "has effect only if the
 --     SELECT part is executed in parallel"). Upstream states materialized columns are calculated "when rows
---     are inserted" but does NOT say which stage computes them -- that this table's JSON-parsing
---     output_keys/input_keys make the insert side the constraint is an inference from profiling, confirmed by
---     effective cores rising towards the thread count. Two costs: upstream warns "higher values will lead to
+--     are inserted" but does NOT say which stage computes them -- that this table's JSON-parsing output_keys
+--     (there is no input_keys column) makes the insert side the constraint is an inference from profiling,
+--     confirmed by effective cores rising towards the thread count. Mind the units when computing those:
+--     (UserTimeMicroseconds + SystemTimeMicroseconds) / (query_duration_ms * 1000), and note the figure is
+--     query-wide CPU, not sink-only. Two costs: upstream warns "higher values will lead to
 --     higher memory usage" (which on this table compounds with oversized `output` documents, so move
 --     max_memory_usage with it), and part count per partition grows, to be watched against
 --     parts_to_throw_insert. The value is a capacity decision about what share of cores the cutover may take

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -12,7 +12,9 @@
 --   ${WINDOW_LO} / ${WINDOW_HI}            the created_at half-open window bounds
 --   ${MAX_INSERT_BLOCK_SIZE}               rows per part-forming block
 --   ${MAX_PARTITIONS_PER_INSERT_BLOCK}     partitions one block may span (required; see the note below)
---   ${MAX_INSERT_THREADS}                  threads for the INSERT SELECT pipeline (0 = ClickHouse default)
+--   ${MAX_INSERT_THREADS}                  threads for the INSERT SELECT pipeline. The driver OMITS this whole
+--                                          SETTINGS line when --max-insert-threads is unset, so the server's
+--                                          value is inherited; an explicit 0 forces no parallel execution.
 --
 -- Slicing rationale (created_at, not id / not workspace), delta and replay design: see ../../README.md.
 -- Notes on the statement:

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql
@@ -29,15 +29,25 @@
 --     "INSERT SELECT no parallel execution"; on ClickHouse Cloud the default is instead 1/2/4 by node memory.
 --     Raising it controls how much of the machine the backfill may use and can speed the copy up markedly,
 --     but only if the SELECT side is itself parallel (upstream: parallel INSERT SELECT "has effect only if the
---     SELECT part is executed in parallel"). Upstream states materialized columns are calculated "when rows
---     are inserted" but does NOT say which stage computes them -- that this table's JSON-parsing output_keys
---     (there is no input_keys column) makes the insert side the constraint is an inference from profiling,
---     confirmed by effective cores rising towards the thread count. Mind the units when computing those:
---     (UserTimeMicroseconds + SystemTimeMicroseconds) / (query_duration_ms * 1000), and note the figure is
---     query-wide CPU, not sink-only. Two costs: upstream warns "higher values will lead to
---     higher memory usage" (which on this table compounds with oversized `output` documents, so move
---     max_memory_usage with it), and part count per partition grows, to be watched against
---     parts_to_throw_insert. The value is a capacity decision about what share of cores the cutover may take
+--     SELECT part is executed in parallel").
+--
+--     WHY THE INSERT SIDE, AND HOW SURE WE ARE. This table materialises output_keys by PARSING the output JSON
+--     (there is no input_keys column -- output_keys is traces-only). That computation is what makes the insert
+--     side the constraint here. Note carefully how strong that claim is: upstream says materialized columns are
+--     calculated "when rows are inserted", but it does NOT say which pipeline stage or which threads do the
+--     calculating. So the attribution to the insert side is an INFERENCE FROM PROFILING, not a documented
+--     guarantee. What supports it is the delta: raise this setting and effective cores rise towards the thread
+--     count while the read side is unchanged.
+--
+--     Computing effective cores, minding the units -- the ProfileEvents are MICROseconds while
+--     query_duration_ms is MILLIseconds, so the *1000 is not optional:
+--         (UserTimeMicroseconds + SystemTimeMicroseconds) / (query_duration_ms * 1000)
+--     Omit it and the answer is 1000x too high. Sanity-check against the node's core count. And note the figure
+--     is QUERY-WIDE CPU: query_log does not separate read-pipeline from insert-pipeline threads.
+--
+--     TWO COSTS. Upstream warns "higher values will lead to higher memory usage", which on this table compounds
+--     with oversized `output` documents, so move max_memory_usage with it. And part count per partition grows,
+--     to be watched against parts_to_throw_insert. The value is a capacity decision about what share of cores the cutover may take
 --     while serving traffic -- not a benchmark to maximise.
 --   * SETTINGS max_insert_block_size bounds the rows per part-forming block; peak insert memory is a small multiple of
 --     the smaller of that and min_insert_block_size_bytes (256 MB default), which dominates for wide trace rows.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -3,9 +3,9 @@
 -- Run this only after the whole backfill (step 1) is complete and reconciled.
 
 -- Step 0: The SQL below (delta-insert + deletion replay) is the single source driven by ../delta_replay.sh, which reads
--- this file, substitutes the placeholders and runs it — never run this file by hand. ALL FOUR placeholders it
+-- this file, substitutes the placeholders and runs it — never run this file by hand. ALL FIVE placeholders it
 -- substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the server as a literal and the
--- statement fails): ${ANALYTICS_DB_DATABASE_NAME}, ${BACKFILL_START}, ${MAX_INSERT_BLOCK_SIZE} and
+-- statement fails): ${ANALYTICS_DB_DATABASE_NAME}, ${BACKFILL_START}, ${MAX_INSERT_BLOCK_SIZE},
 -- ${MAX_PARTITIONS_PER_INSERT_BLOCK} and ${MAX_INSERT_THREADS}. Invocation:
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000'
 -- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -6,7 +6,7 @@
 -- this file, substitutes the placeholders and runs it — never run this file by hand. ALL FOUR placeholders it
 -- substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the server as a literal and the
 -- statement fails): ${ANALYTICS_DB_DATABASE_NAME}, ${BACKFILL_START}, ${MAX_INSERT_BLOCK_SIZE} and
--- ${MAX_PARTITIONS_PER_INSERT_BLOCK}. Invocation:
+-- ${MAX_PARTITIONS_PER_INSERT_BLOCK} and ${MAX_INSERT_THREADS}. Invocation:
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000'
 -- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where
 -- situational awareness matters most — those are config/judgement, not SQL. The driver invokes clickhouse-client with
@@ -48,6 +48,11 @@
 -- by hand. Omitting it there reintroduces the TOO_MANY_PARTS abort immediately before the EXCHANGE, which is exactly
 -- what the setting on the single-statement form exists to prevent.
 -- >>> BEGIN delta-insert
+-- max_insert_threads in the SETTINGS clause below sizes the INSERT SELECT pipeline, same knob and same caveats as 000001: ClickHouse
+-- documents 0 (the default) as "INSERT SELECT no parallel execution", ClickHouse Cloud instead defaults to
+-- 1/2/4 by node memory, it only helps if the SELECT side is parallel, and upstream warns "higher values will
+-- lead to higher memory usage" -- which on this table compounds with oversized `output` documents. The delta
+-- writes into the same table through the same insert path as the backfill, so it benefits identically.
 INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
     id,
     workspace_id,
@@ -102,6 +107,7 @@ WHERE created_at >= toDateTime64('${BACKFILL_START}', 6)
    OR last_updated_at >= toDateTime64('${BACKFILL_START}', 6)
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
          max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
+         max_insert_threads = ${MAX_INSERT_THREADS},
          log_comment = 'traces_local_v2_cutover:delta_insert';
 -- >>> END delta-insert
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -6,7 +6,8 @@
 -- this file, substitutes the placeholders and runs it — never run this file by hand. ALL FIVE placeholders it
 -- substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the server as a literal and the
 -- statement fails): ${ANALYTICS_DB_DATABASE_NAME}, ${BACKFILL_START}, ${MAX_INSERT_BLOCK_SIZE},
--- ${MAX_PARTITIONS_PER_INSERT_BLOCK} and ${MAX_INSERT_THREADS}. Invocation:
+-- ${MAX_PARTITIONS_PER_INSERT_BLOCK} and ${MAX_INSERT_THREADS} -- the last of which the driver instead REMOVES
+-- from the SETTINGS clause when --max-insert-threads is omitted, so the server's value is inherited. Invocation:
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000'
 -- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where
 -- situational awareness matters most — those are config/judgement, not SQL. The driver invokes clickhouse-client with

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -34,8 +34,8 @@
 #                             backfill: the final delta runs immediately before the EXCHANGE, inside the window the
 #                             runbook asks you to keep short. Pass the SAME value used for the backfill.
 #   --max-insert-threads N    threads for the delta INSERT SELECT pipeline (SETTINGS max_insert_threads).
-#                             Default 0, which ClickHouse documents as "INSERT SELECT no parallel
-#                             execution". Same knob, same caveats and same two costs (memory, part
+#                             OMITTED BY DEFAULT = INHERIT the server's setting (the line is stripped from
+#                             the SQL); an explicit 0 FORCES "INSERT SELECT no parallel execution". Same knob, same caveats and same two costs (memory, part
 #                             count) as in backfill.sh -- see its option docs for the full diagnosis.
 #                             PASS THE SAME VALUE USED FOR THE BACKFILL: the delta writes into the
 #                             same table through the same insert path.
@@ -51,8 +51,8 @@ CH_PORT=""                # native port; empty = clickhouse-client default (9000
 BACKFILL_START=""
 MAX_INSERT_BLOCK_SIZE=1048576
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions per block for the delta INSERT; see the option docs above. 0 = unlimited.
-MAX_INSERT_THREADS=0                  # threads for the delta INSERT SELECT; 0 = ClickHouse default, i.e. no parallel
-                                      # INSERT SELECT execution.
+MAX_INSERT_THREADS=""                 # threads for the delta INSERT SELECT. EMPTY = inherit the server's setting (the
+                                      # line is stripped from the SQL). Explicit 0 FORCES no parallel execution.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -79,7 +79,7 @@ done
 # the setting counts partitions, no real table approaches that, and an out-of-range value would otherwise be rendered
 # into the SQL and rejected by the server mid-run instead of here.
 [[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
-[[ "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (ClickHouse default: no parallel INSERT SELECT execution) or 1..99." >&2; exit 2; }
+[[ -z "$MAX_INSERT_THREADS" || "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (force no parallel INSERT SELECT execution) or 1..99; omit it entirely to inherit the server's setting." >&2; exit 2; }
 [[ -f "$SQL_FILE" ]] || { echo "ERROR: cannot find $SQL_FILE" >&2; exit 2; }
 
 echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this step (backend config, not SQL) and"
@@ -90,7 +90,14 @@ sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
 sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
-sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
+if [[ -z "$MAX_INSERT_THREADS" ]]; then
+    # Unset means INHERIT: strip the whole setting line so the server's profile (or ClickHouse Cloud's
+    # non-zero default) applies. Rendering an explicit 0 here would OVERRIDE that and force the insert
+    # serial -- a silent slowdown on any deployment that already sets the setting.
+    sql="$(grep -vF 'max_insert_threads = ${MAX_INSERT_THREADS}' <<<"$sql")"
+else
+    sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
+fi
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
 # --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
 # the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -95,6 +95,18 @@ if [[ -z "$MAX_INSERT_THREADS" ]]; then
     # non-zero default) applies. Rendering an explicit 0 here would OVERRIDE that and force the insert
     # serial -- a silent slowdown on any deployment that already sets the setting.
     sql="$(grep -vF 'max_insert_threads = ${MAX_INSERT_THREADS}' <<<"$sql")"
+    # The strip is a whitespace-exact match on a SETTINGS line in ANOTHER file. If that line is ever
+    # reformatted the match silently no-ops and the placeholder reaches the server as a literal -- the exact
+    # failure that file's own header warns about. This is the DEFAULT path, so fail loudly here instead.
+    # The strip matches ONE exact spelling of a SETTINGS line that lives in ANOTHER file. Reformat that line
+    # -- even one extra space -- and the strip silently no-ops, leaving the placeholder to reach the server
+    # as a literal. So assert on the OUTCOME, whitespace-agnostically, and skip `--` comment lines, which
+    # legitimately keep the placeholder text in the file headers. This is the DEFAULT path; fail loudly.
+    if grep -v '^[[:space:]]*--' <<<"$sql" | grep -qF '${MAX_INSERT_THREADS}'; then
+        echo "ERROR: max_insert_threads strip failed -- the SETTINGS line in $SQL_FILE no longer matches the" >&2
+        echo "       pattern above (was it reformatted?). Refusing to send SQL with a literal placeholder." >&2
+        exit 2
+    fi
 else
     sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
 fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -51,7 +51,8 @@ CH_PORT=""                # native port; empty = clickhouse-client default (9000
 BACKFILL_START=""
 MAX_INSERT_BLOCK_SIZE=1048576
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions per block for the delta INSERT; see the option docs above. 0 = unlimited.
-MAX_INSERT_THREADS=0                  # threads for the delta INSERT SELECT; 0 = ClickHouse default (single-threaded sink).
+MAX_INSERT_THREADS=0                  # threads for the delta INSERT SELECT; 0 = ClickHouse default, i.e. no parallel
+                                      # INSERT SELECT execution.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -33,6 +33,12 @@
 #                             (throw_on_max_partitions_per_insert_block = 1). An abort here is worse than in the
 #                             backfill: the final delta runs immediately before the EXCHANGE, inside the window the
 #                             runbook asks you to keep short. Pass the SAME value used for the backfill.
+#   --max-insert-threads N    threads for the delta INSERT SELECT pipeline (SETTINGS max_insert_threads).
+#                             Default 0, which ClickHouse documents as "INSERT SELECT no parallel
+#                             execution". Same knob, same caveats and same two costs (memory, part
+#                             count) as in backfill.sh -- see its option docs for the full diagnosis.
+#                             PASS THE SAME VALUE USED FOR THE BACKFILL: the delta writes into the
+#                             same table through the same insert path.
 
 set -euo pipefail
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -45,6 +45,7 @@ CH_PORT=""                # native port; empty = clickhouse-client default (9000
 BACKFILL_START=""
 MAX_INSERT_BLOCK_SIZE=1048576
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000  # partitions per block for the delta INSERT; see the option docs above. 0 = unlimited.
+MAX_INSERT_THREADS=0                  # threads for the delta INSERT SELECT; 0 = ClickHouse default (single-threaded sink).
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -52,6 +53,7 @@ while [[ $# -gt 0 ]]; do
         --backfill-start) BACKFILL_START="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-insert-threads) MAX_INSERT_THREADS="${2:?"$1 requires a value"}"; shift 2 ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -70,6 +72,7 @@ done
 # the setting counts partitions, no real table approaches that, and an out-of-range value would otherwise be rendered
 # into the SQL and rejected by the server mid-run instead of here.
 [[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
+[[ "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (ClickHouse default: no parallel INSERT SELECT execution) or 1..99." >&2; exit 2; }
 [[ -f "$SQL_FILE" ]] || { echo "ERROR: cannot find $SQL_FILE" >&2; exit 2; }
 
 echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this step (backend config, not SQL) and"
@@ -80,6 +83,7 @@ sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
 sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
+sql="${sql//'${MAX_INSERT_THREADS}'/$MAX_INSERT_THREADS}"
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
 # --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
 # the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/estimate.sh
@@ -12,6 +12,12 @@
 # in by --write-cost-factor. For an exact figure, time one real window with backfill.sh and pass its rows/sec via
 # --rows-per-sec.
 #
+# THIS ESTIMATE DOES NOT MODEL --max-insert-threads. The probe measures the READ side and derates it by a fixed
+# --write-cost-factor, so a run configured with insert parallelism can copy substantially faster than the number
+# printed here, and the estimate is not specific to your thread setting either way. If you intend to run the
+# backfill with --max-insert-threads set, do not tune against this figure: time one real window at THAT setting
+# and pass the result via --rows-per-sec, which bypasses the probe and the write-cost factor entirely.
+#
 # Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
 # NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
 # --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -104,6 +104,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code exchange_and_wrap.sh}'s replication-settle gate, {@code finalize.sh}'s empty-live refusal — are exercised by the
  * OPIK-6901 staging dry-run, not by this test (which runs the SQL those scripts wrap, directly). This test asserts the
  * logic is correct when invoked; the staging rehearsal asserts the scripts invoke it safely.
+ *
+ * <p><b>Tuning settings are deliberately NOT mirrored from the drivers, and that is not drift.</b> The statements
+ * below hardcode {@code max_insert_block_size = 100000} and carry neither {@code max_partitions_per_insert_block}
+ * nor {@code max_insert_threads}, while {@code backfill.sh} / {@code delta_replay.sh} make all three configurable.
+ * The omissions are intentional: an absent {@code SETTINGS} key is exactly the ClickHouse default, so leaving a
+ * pacing knob out changes no behaviour this gate asserts, and pinning a value here would assert an operator's
+ * tuning choice rather than the SQL's logic. The block size is fixed only to keep CI memory predictable. Note the
+ * standing gap this implies: because the values are hardcoded rather than read from the scripts, this gate cannot
+ * catch a driver whose configured value is invalid — that belongs to the staging dry-run. If a future setting
+ * changes RESULTS rather than pacing, it must be mirrored here; {@code 000002}'s header asks that the SQL and this
+ * test be kept in step, and tuning settings are the documented exception to that.
  */
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -105,16 +105,25 @@ import static org.assertj.core.api.Assertions.assertThat;
  * OPIK-6901 staging dry-run, not by this test (which runs the SQL those scripts wrap, directly). This test asserts the
  * logic is correct when invoked; the staging rehearsal asserts the scripts invoke it safely.
  *
- * <p><b>Tuning settings are deliberately NOT mirrored from the drivers, and that is not drift.</b> The statements
- * below hardcode {@code max_insert_block_size = 100000} and carry neither {@code max_partitions_per_insert_block}
- * nor {@code max_insert_threads}, while {@code backfill.sh} / {@code delta_replay.sh} make all three configurable.
- * The omissions are intentional: an absent {@code SETTINGS} key is exactly the ClickHouse default, so leaving a
- * pacing knob out changes no behaviour this gate asserts, and pinning a value here would assert an operator's
- * tuning choice rather than the SQL's logic. The block size is fixed only to keep CI memory predictable. Note the
- * standing gap this implies: because the values are hardcoded rather than read from the scripts, this gate cannot
- * catch a driver whose configured value is invalid — that belongs to the staging dry-run. If a future setting
- * changes RESULTS rather than pacing, it must be mirrored here; {@code 000002}'s header asks that the SQL and this
- * test be kept in step, and tuning settings are the documented exception to that.
+ * <p><b>On the {@code SETTINGS} these statements carry.</b> They hardcode {@code max_insert_block_size = 100000}
+ * and {@code max_partitions_per_insert_block = 2000}, and omit {@code max_insert_threads} — while
+ * {@code backfill.sh} / {@code delta_replay.sh} make all three configurable. The split is deliberate and follows
+ * what each setting can do:
+ *
+ * <ul>
+ * <li>{@code max_partitions_per_insert_block} is <b>mirrored because it is a correctness gate, not pacing</b>: a
+ * value below the number of partitions a block spans aborts the INSERT outright ({@code TOO_MANY_PARTS}), which is
+ * exactly the failure the runbook's far-future section exists for. It is pinned at the drivers' own default.</li>
+ * <li>{@code max_insert_threads} is <b>omitted because it is pacing</b>, and because omitting it is meaningful
+ * here in the same way it is in the drivers: an absent key inherits whatever the server sets, so this gate asserts
+ * the SQL's logic rather than an operator's tuning choice.</li>
+ * <li>{@code max_insert_block_size} is fixed only to keep CI memory predictable.</li>
+ * </ul>
+ *
+ * <p>The standing gap this implies: because the mirrored values are hardcoded rather than read from the scripts,
+ * this gate cannot catch a driver configured with an invalid value — that belongs to the staging dry-run. A future
+ * setting that changes RESULTS rather than pacing must be mirrored here; {@code 000002}'s header asks that the SQL
+ * and this test be kept in step, and pacing settings are the documented exception to that.
  */
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)


### PR DESCRIPTION
## Details

**The copy is sink-bound by default and nothing says so.** ClickHouse documents `max_insert_threads = 0` — the default — as *"`INSERT SELECT` no parallel execution"*, so the insert side of this copy runs serialised until it is raised.

Exposing the setting **lets an operator control how much of the machine the backfill may use, and so speed the copy up substantially** when the insert side is what is holding it back.

- `backfill.sh` and `delta_replay.sh` gain `--max-insert-threads N` (omitted = inherit the server's setting; explicit `0` forces serial; validated empty, `0`, or `1..99`).
- `000001` and `000002` gain the setting, so the delta benefits too — it writes into the same table through the same insert path.
- README documents the *diagnosis*, not just the knob.

### Scope caveats, per upstream

Each of these changes who actually benefits, so they are stated rather than left implicit:

- The setting applies to **`INSERT SELECT`** — which is what this backfill issues — not to INSERTs generally.
- **ClickHouse Cloud does not default it to `0`.** Upstream documents `1` / `2` / `4` by node memory, so a Cloud deployment may already have parallelism here and see less benefit.
- It only helps if the read side is parallel too: *"Parallel `INSERT SELECT` has effect only if the `SELECT` part is executed in parallel"* (`max_threads`).

### What is documented, and what is inference

Worth separating, because the PR previously blurred it. Upstream states materialized values *"are automatically calculated according to the specified materialized expression when rows are inserted"* — but it does **not** state which pipeline stage or which threads perform that calculation. So attributing the bottleneck to the insert side, where this table's JSON-parsing `output_keys` is computed, is an **inference from profiling, not a documented guarantee.** The docs therefore tell an operator how to confirm it on their own data instead of asserting it.

## How to recognise this condition

The reusable part. **Effective cores sit near 1 while the machine is otherwise idle and `OSIOWaitMicroseconds` is 0** — the copy is neither CPU-saturated nor I/O bound, it is serialised. From `query_log`:

```sql
(ProfileEvents['UserTimeMicroseconds'] + ProfileEvents['SystemTimeMicroseconds']) / query_duration_ms
```

After raising the setting, effective cores rising towards the thread count confirms the diagnosis rather than merely correlating with it.

## What it is *not*

Each of these was ruled out on this profile before the sink was identified, and each is worth ruling out again elsewhere before reaching for the flag:

| Suspect | How it was ruled out |
|---|---|
| Disk I/O | `OSIOWaitMicroseconds` zero; `DiskWriteElapsed` a negligible share of window wall time |
| CPU saturation | node load and user CPU both low relative to core count |
| Read-thread starvation | the read side already had many threads participating |
| Client/network | `INSERT … SELECT` is server-side; only the query text crosses the wire |
| `max_insert_block_size` | tested — moved memory and time by a fraction of a percent |

## Why a flag and not a settings profile

The right value is a **per-run operational decision, not deployed state.** It depends on what share of cores the cutover may take *while serving traffic*, which differs between an idle rehearsal environment and production, and between an off-peak window and a daytime one. Tuning it through a chart profile costs a PR, a merge and a sync **per data point**.

By contrast, `max_memory_usage` belongs on the profile and is deliberately **not** exposed here: a memory ceiling is a guardrail against destabilising the server, so letting an operator raise their own limit per invocation defeats its purpose. Flags for pacing, profile for quotas.

## The default is *omission*, and omission means inherit

Originally this shipped as `default 0`, and the PR claimed that meant no deployment changed behaviour. **That was wrong**, caught in review and fixed in `96fc611`. An explicit `0` in a `SETTINGS` clause does not mean "leave alone" — it *overrides*. Verified on a cluster whose profile sets `3`:

```
SELECT getSetting('max_insert_threads')                                  -> 3
SELECT getSetting('max_insert_threads') SETTINGS max_insert_threads = 0  -> 0
```

So the original form would have forced serial inserts on every deployment that had already tuned the setting — ClickHouse Cloud (`1`/`2`/`4` by node memory) and our own environments included. A change advertised as a speed-up would have shipped as a **silent slowdown by default**.

Now: omitting the flag strips the setting line from the SQL entirely, so the server's value applies; an explicit `0` is retained and means *force* serial. Verified by extracting the drivers' own render block and running it against the real SQL — omitted renders no key, `0` renders `0`, `3` renders `3`, all three parse.

## Costs — both of the documented ones

**Memory.** Upstream is explicit: *"Higher values will lead to higher memory usage."* On this table that compounds with a known hazard — a single oversized `output` document can dominate insert memory by itself, which is what produced the `Code: 241` abort earlier in this cutover. So the docs say to move `max_memory_usage` with this setting, or narrow the window, rather than raising threads alone into a fixed ceiling.

**Parts.** Each insert thread writes its own parts, so **part count per partition grows**. The README says to watch it against `parts_to_throw_insert` (ClickHouse default `300`) rather than assume headroom, and the flag is bounded at 99 because a value beyond the machine's core count buys nothing while multiplying parts.

The docs also frame value selection as a **capacity decision, not a benchmark** — on an idle rehearsal environment a large value looks free, but on production those threads compete with live query latency, so validate the value you will actually deploy.

## Review round: four factual defects found and fixed

Review caught real errors in the docs this PR adds, two of which would have actively misled an operator. Each was verified before fixing rather than applied on faith.

| Finding | Verdict | Evidence |
|---|---|---|
| Docs named `input_keys` as a destination column | **Real — fixed** | `git grep input_keys` → **0 hits** repo-wide; `000115` states outright that `output_keys` is traces-only with no counterpart. An operator would have hunted a column that doesn't exist. |
| Effective-cores formula divided µs by ms | **Real — fixed** | Ran both forms on real backfill windows: as documented it returns **1628 effective cores on a 48-core node**; with `*1000` it returns **1.63**. The quoted measurements used the correct form, so only the *published* formula was wrong — worse, since that's the part an operator runs. |
| Formula measures query-wide CPU, not sink CPU | **Real — fixed** | `query_log` aggregates don't separate read from insert threads. Now stated, together with what *does* make it evidence: the delta when the setting is raised while the read side is unchanged. |
| `estimate.sh` doesn't model the setting | **Real — fixed** | It probes the read side and derates by a fixed `--write-cost-factor`; no thread input exists. Both `estimate.sh` and the README now say the ETA excludes sink parallelism and point at `--rows-per-sec`. |
| `000002` header said "ALL FOUR placeholders" listing five, doubled conjunction | **Real — fixed** | Stale count in the one comment whose purpose is that "a new one is never missed here". |
| `delta_replay.sh` Options header omitted the flag | **Real — fixed** | Every other flag had an entry; an operator reading the header couldn't discover this one. |
| Defaults block ordered opposite to header and arg parser | **Real — fixed** | Cosmetic, but the three lists are kept parallel so they diff by eye. |
| Add a bash test seam for flag validation | **Declined, with reasoning** | See below. |

**On the test-seam request.** There is no shell-test harness anywhere in `apps/opik-backend` — `0` bats files, no `tests/` dir in the cutover folder — so this would mean introducing test infrastructure for one-shot migration drivers that are deleted after the cutover completes. The validator is a single regex, and I exercised its full boundary on **both** drivers (`0`/`3`/`99` accepted; `100`/`abc`/`-1` rejected) rather than reasoning about it. I'd rather not land a harness whose only user is a script with a scheduled death; happy to be overruled if you disagree.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6901

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Profiled a live backfill from `query_log` ProfileEvents, ruled out I/O, CPU saturation, read-thread starvation, the client path and block-size tuning, identified the sink, validated the fix by deploying a value and re-measuring, then authored the flag and docs.
- Human verification: The operator directed the value down so that what was validated is what production can deploy, and reviewed each measurement in-session. Reviewer sign-off on the diff still required.

## Testing

- `bash -n` clean on both drivers.
- Flag validation exercised: `0`, `3`, `99` accepted; `100`, `abc`, `-1` rejected with the expected message.
- Verified every `${...}` placeholder in **both** `000001` and `000002` is substituted by its driver, run with a control assertion so a silently-empty check cannot pass.
- The speedup is **measured on a live cluster, not projected**: a value was deployed via the settings profile and re-measured against the recorded baseline.
- **Every claim about `max_insert_threads` was checked against upstream**, not written from memory — read back from `system.settings` on the running server (26.3.16) and cross-checked against the ClickHouse docs. That check is what caught the Cloud-default error and the missing memory warning, both now fixed in this PR.
- Both SQL files parse: `clickhouse-format -n` clean on `000001` and `000002` with placeholders substituted, run differentially against the pre-edit file and with a deliberately-broken control to prove the parser was actually rejecting things.
- `bash -n` clean on all three touched drivers after the review fixes.
- **Flag boundary re-exercised on both drivers after the defaults-block reordering** (which could have regressed it): `0`/`3`/`99` accepted, `100`/`abc`/`-1` rejected with the corrected message. The first run of this test was malformed and reported every `delta_replay.sh` value as accepted; it was re-run with correct quoting rather than believed.
- The 1000× formula error was confirmed **empirically, not by inspection** — both forms run against `system.query_log` on a live cluster, with the node's core count as the sanity ceiling that makes the wrong answer obviously wrong.

Not run, with reason:

- `mvn -o test -Dtest=TracesLocalV2CutoverTest` — the gate test **deliberately omits** this setting. An absent `SETTINGS` key is exactly the default, so there is no behavioural drift, and adding a third hardcoded value would compound the already-noted gap that the test hardcodes settings rather than reading configured ones. Please confirm CI is green.

## Follow-up

The post-change sample is small. Direction and mechanism are solid and were confirmed by effective cores tracking the thread count; the precise multiple should be treated as indicative until it is confirmed over more windows.

## Documentation

Documentation **is** the substance of this change — the flag itself is a two-line diff. All of it lives with the code rather than in the docs site, because the audience is an operator running these scripts from a checkout, not a reader of `opik.com/docs`:

- `README.md` — the `--max-insert-threads` entry: what the setting does, the three upstream scope caveats (INSERT SELECT only, Cloud defaults differ, needs a parallel read side), how to confirm the diagnosis on your own data with correct units, both documented costs (memory and part count), and the `estimate.sh` caveat.
- `scripts/backfill.sh` and `scripts/delta_replay.sh` — full option docs in each `# Options:` header.
- `scripts/db-app-analytics/000001` and `000002` — a note beside the `SETTINGS` clause carrying the same caveats, so someone reading the SQL alone isn't missing them.
- `scripts/estimate.sh` — an explicit warning that its ETA excludes sink-thread effects.

No user-facing product documentation is affected: this is an internal migration runbook, and the flag defaults to current behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

