### PR TITLE
[OPIK-7105] [FE] refactor: decouple Cost Intelligence from workspace-version machinery

### DIFF
--- a/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
+++ b/apps/opik-frontend/src/plugins/comet/UserMenu.tsx
@@ -8,13 +8,11 @@ import {
   Settings,
   Settings2,
   Shield,
-  Sparkles,
   UserPlus,
 } from "lucide-react";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import SupportHubSubMenu from "@/shared/SupportHub/SupportHubSubMenu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/ui/avatar";
-import { Switch } from "@/ui/switch";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,16 +30,7 @@ import { useThemeOptions } from "@/hooks/useThemeOptions";
 import { APP_VERSION } from "@/constants/app";
 import { ADMIN_DASHBOARD_LABEL } from "@/constants/labels";
 import { cn, maskAPIKey } from "@/lib/utils";
-import useAppStore, {
-  useDetectedWorkspaceVersion,
-  useOpikWorkspaceName,
-} from "@/store/AppStore";
-import {
-  getNewExperienceOptIn,
-  getVersionOverride,
-  navigateToWorkspaceRoot,
-  setNewExperienceOptIn,
-} from "@/lib/workspaceVersion";
+import useAppStore, { useOpikWorkspaceName } from "@/store/AppStore";
 import api from "./api";
 import { ORGANIZATION_ROLE_TYPE } from "./types";
 import useOrganizations from "./useOrganizations";
@@ -59,10 +48,6 @@ const UserMenu = () => {
   const { theme, themeOptions, CurrentIcon, handleThemeSelect } =
     useThemeOptions();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const detectedWorkspaceVersion = useDetectedWorkspaceVersion();
-  const hasOptedIn = getNewExperienceOptIn();
-  const showNewExperienceToggle =
-    detectedWorkspaceVersion === "v1" && getVersionOverride() === null;
 
   const { data: user } = useUser();
   const { data: organizations, isLoading } = useOrganizations({
@@ -261,24 +246,6 @@ const UserMenu = () => {
                 </DropdownMenuSubContent>
               </DropdownMenuPortal>
             </DropdownMenuSub>
-            {showNewExperienceToggle && (
-              <DropdownMenuItem
-                className="cursor-pointer"
-                onSelect={(e) => {
-                  e.preventDefault();
-                  setNewExperienceOptIn(!hasOptedIn);
-                  navigateToWorkspaceRoot(opikWorkspaceName);
-                }}
-              >
-                <Sparkles className="mr-2 size-4" />
-                <span>New Opik experience</span>
-                <Switch
-                  checked={hasOptedIn}
-                  className="pointer-events-none ml-auto"
-                  size="sm"
-                />
-              </DropdownMenuItem>
-            )}
           </DropdownMenuGroup>
           <UserMenuAppLinks isLLMOnlyOrganization={isLLMOnlyOrganization} />
           <DropdownMenuItem

--- a/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
+++ b/apps/opik-frontend/src/plugins/comet/useAiSpendManager.ts
@@ -1,4 +1,4 @@
-import useAppStore, { useWorkspaceVersion } from "@/store/AppStore";
+import useAppStore from "@/store/AppStore";
 import useAllWorkspaces from "./useAllWorkspaces";
 import useOrganizations from "./useOrganizations";
 import useUser from "./useUser";
@@ -7,7 +7,6 @@ import { ORGANIZATION_PLAN_ENTERPRISE, ORGANIZATION_ROLE_TYPE } from "./types";
 
 const useAiSpendManager = () => {
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const workspaceVersion = useWorkspaceVersion();
 
   const { data: user } = useUser();
   const isEnabled = !!user?.loggedIn;
@@ -34,9 +33,7 @@ const useAiSpendManager = () => {
     organization?.role === ORGANIZATION_ROLE_TYPE.admin;
 
   return {
-    isPending:
-      isEnabled &&
-      (isOrganizationsPending || isWorkspacesPending || !workspaceVersion),
+    isPending: isEnabled && (isOrganizationsPending || isWorkspacesPending),
     organization,
     spendWorkspace,
     spendWorkspaceName: spendWorkspace?.workspaceName,
@@ -44,9 +41,7 @@ const useAiSpendManager = () => {
     isEnterprise,
     isOrganizationAdmin,
     hasAccess:
-      Boolean(spendWorkspace) &&
-      Boolean(organization?.costIntelligenceEnabled) &&
-      workspaceVersion === "v2",
+      Boolean(spendWorkspace) && Boolean(organization?.costIntelligenceEnabled),
   };
 };
 


### PR DESCRIPTION
## Details

Cost Intelligence access now depends only on the two conditions that actually govern it: the organization has cost intelligence enabled, and a spend workspace exists. The workspace-version conjunct is removed. **Nothing is enabled or disabled** — the set of organizations with Cost Intelligence is identical before and after.

- Both removed terms were provably constant. Every writer of the workspace version writes the literal `"v2"` (`resolveSyncWorkspaceVersion` returns a constant, `WorkspaceVersionResolver` assigns a literal, `fetchWorkspaceVersion` returns a literal with no network call), so `hasAccess`'s `&& workspaceVersion === "v2"` was always true and `isPending`'s `|| !workspaceVersion` always false. `A && B && true === A && B`; `X || false === X`.
- The value is ordering, not cleanup. While this reader existed, a later removal of the version machinery would have left the store field at its initial `null`, made the comparison false, and collapsed `hasAccess` for every enterprise cloud organization — with no error, no log and no failing test. With the reader gone that failure mode is structurally impossible. The follow-up PR that removes the writers depends on this one landing first.
- Also removes the "New Opik experience" user-menu toggle: its condition `detectedWorkspaceVersion === "v1"` can never be true for the same reason, so the item was unreachable. Removing it is what makes the verification gate below meaningful.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7105

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: codebase analysis, the change itself, and this description
- Human verification: constant-folding argument checked against every writer of the store field; verification commands below run and their output inspected; sequencing relative to the follow-up PR reviewed and agreed before implementation

## Testing

```
npm --prefix apps/opik-frontend run typecheck      # exit 0
npm --prefix apps/opik-frontend run lint           # exit 0
npx vitest run src/lib/aiSpend.test.ts             # 2/2 pass
npx vitest run src/plugins/comet/                  # see note
grep -rn "workspaceVersion\|WorkspaceVersion" src/plugins/   # no matches
```

- Gate: no workspace-version reference remains anywhere under `src/plugins`.
- `src/plugins/comet/` suite reports 11 failures / 58 passes. Verified identical on `main` by stashing and re-running — a pre-existing local environment fault (`localStorage.clear is not a function`, happy-dom API mismatch), not introduced here.
- Not run: manual Cost Intelligence smoke on a Comet build. Not applicable to this PR — the change is behaviour-preserving by construction — but note for reviewers of the follow-up that local dev cannot demonstrate this path at all: `plugins/development/LayoutProvider.tsx` hardcodes `hasAccess: true`, so `npm run dev` shows a working AI Spend even on broken code.

No unit test is added: the dependency is removed rather than made correct, so there is nothing left for a regression test to protect.

## Documentation

None required. No user-facing behaviour, API or configuration changes.