### PR TITLE
[OPIK-7105] [FE] fix: restore the workspace-level /prompts compat redirect

### DIFF
--- a/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.test.tsx
+++ b/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  createRootRoute,
+  createRoute,
+  type AnyRoute,
+} from "@tanstack/react-router";
+import { createV1RedirectRoutes } from "./v1RedirectConfig";
+
+/**
+ * These assert that a compat ROUTE is registered, which is the level the
+ * OPIK-7105 defect lived at. V1CompatRedirect.test.tsx exercises the component
+ * with an arbitrary `toPath` and so passes for paths that have no route at all —
+ * it could not have caught the missing /prompts entry.
+ */
+
+const buildRoutes = () => {
+  const rootRoute = createRootRoute();
+  const workspaceRoute = createRoute({
+    path: "/$workspaceName",
+    getParentRoute: () => rootRoute,
+  });
+
+  return createV1RedirectRoutes(workspaceRoute);
+};
+
+// TanStack's RouteOptions union does not surface `path` statically, so read it
+// through a narrow shape rather than widening the whole route type.
+const pathOf = (route: AnyRoute) => (route.options as { path?: string }).path;
+
+const pathsOf = (routes: AnyRoute[]) => routes.map(pathOf);
+
+describe("createV1RedirectRoutes", () => {
+  it("registers a compat route for every workspace-level V1 resource", () => {
+    expect(pathsOf(buildRoutes())).toEqual(
+      expect.arrayContaining([
+        "/experiments",
+        "/test-suites",
+        "/datasets",
+        "/prompts",
+        "/playground",
+        "/optimizations",
+        "/online-evaluation",
+        "/annotation-queues",
+        "/alerts",
+      ]),
+    );
+  });
+
+  it("registers /prompts, so workspace-level prompt links resolve", () => {
+    // The backend mints /$workspaceName/prompts/$promptId in Slack alert
+    // payloads for prompt_created and prompt_committed. Without this route the
+    // link dead-ends: V2 serves prompts only under project scope and neither
+    // router declares a notFoundComponent.
+    expect(pathsOf(buildRoutes())).toContain("/prompts");
+  });
+
+  it("gives /prompts index and splat children, so /prompts/$promptId resolves", () => {
+    const promptsRoute = buildRoutes().find(
+      (route) => pathOf(route) === "/prompts",
+    );
+
+    expect(promptsRoute).toBeDefined();
+
+    const children = (promptsRoute?.children ?? []) as AnyRoute[];
+    expect(children.map(pathOf)).toEqual(expect.arrayContaining(["/", "$"]));
+  });
+});

--- a/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
+++ b/apps/opik-frontend/src/v2/redirect/v1RedirectConfig.tsx
@@ -11,6 +11,7 @@ const V1_REDIRECT_PATHS: V1RedirectEntry[] = [
   { from: "/experiments", to: "/experiments", catchAll: true },
   { from: "/test-suites", to: "/test-suites", catchAll: true },
   { from: "/datasets", to: "/test-suites", catchAll: true },
+  { from: "/prompts", to: "/prompts", catchAll: true },
   { from: "/playground", to: "/playground" },
   { from: "/optimizations", to: "/optimizations", catchAll: true },
   { from: "/online-evaluation", to: "/online-evaluation" },


### PR DESCRIPTION
## Details

Workspace-level prompt links dead-ended. The backend emits `/$workspaceName/prompts/$promptId` in `prompt_created` and `prompt_committed` Slack alert payloads (`SlackWebhookPayloadMapper`), and V2 still offers both alert types — but V2 serves prompts only under project scope, `/prompts` was missing from `V1_REDIRECT_PATHS`, and neither router declares a `notFoundComponent`. So the link resolved to nothing. This restores the redirect with `catchAll`, matching every other workspace-level resource.

- Live customer-visible defect, independent of the V1 removal work. Ships on its own so it is not delayed behind a large review, and because deleting the V1 tree would otherwise remove the last in-tree evidence that the old URL shape existed.
- `ResourceLink` is deliberately untouched. Its `url` field is the fallback used when no active project is resolved, and it is V1-shaped for **all twelve** resource types — the other eleven resolve through exactly these compat redirects. Repointing only the prompt entry would break that symmetry, and a project-scoped URL cannot be built without a project id, which is why the fallback exists. With the route registered, `ResourceLink` becomes correct on its own.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-7105

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: defect analysis, fix, test, and this description
- Human verification: backend URL-minting sites located and read; V1 and V2 route shapes compared directly; the new test confirmed red before the fix and green after; the decision to leave `ResourceLink` alone reviewed against all twelve resource entries

## Testing

```
npx vitest run src/v2/redirect/                    # 29/29 pass
npm --prefix apps/opik-frontend run typecheck      # exit 0
npm --prefix apps/opik-frontend run lint           # exit 0
```

- **Red/green confirmed.** With the config entry removed the new test fails 3/3; with it restored, 3/3 pass.
- The test asserts against `createV1RedirectRoutes` output — the level the defect actually lived at. `V1CompatRedirect.test.tsx` already had a `/prompts` case, but it renders the component with an arbitrary `toPath` and so passes even when no route is registered; it could not have caught this. That test is left in place unchanged.
- Scenarios covered: collection path `/$ws/prompts`, individual prompt `/$ws/prompts/$promptId` via the splat child, and query-param preservation (existing suite).
- Not run: end-to-end click-through from a real Slack alert. The URL shape was verified against the backend payload mapper by reading it, not by triggering an alert.

## Documentation

None required. Restores previously-working link behaviour; no documented behaviour changes.