### PR TITLE
[OPIK-7793] [FE] chore: baseline the outstanding pages-shared dependency violation

### DIFF
--- a/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
@@ -11,13 +11,15 @@ The baseline file allows us to:
 
 ## Current Violations Summary
 
-### Circular Dependencies (12) - MUST FIX
+### Circular Dependencies (13) - MUST FIX
 These create maintenance nightmares and potential runtime issues:
 - `useOpenAICompatibleModels` ↔ `provider.ts` ↔ `useLLMProviderModelsData`
 - `useProviderKeys` → `provider.ts` → `useLLMProviderModelsData` → `useOpenAICompatibleModels`
 - `MetricTag` ↔ `PlaygroundOutputScores`
 - `useDatasetItemData` ↔ `useDatasetItemFormHelpers` (2 locations)
 - FeedbackScoreTable cells ↔ `utils.ts` ↔ `constants.ts` (5 violations)
+- `useAiSpendAllBreakdowns` ↔ `useAiSpendLaneBreakdown` — in the private ai-spend plugin, so
+  the fix belongs in `comet-ml/opik-plugin-ai-spend`. Only matched when that plugin is staged.
 
 ### Shared → Pages-shared (35) - Refactor needed
 Components in `shared/` importing from `pages-shared/`:
@@ -27,11 +29,12 @@ Components in `shared/` importing from `pages-shared/`:
 
 **Fix:** Move these components to `pages-shared/` or extract shared utilities
 
-### Pages-shared → Pages (8) - Extract shared code
+### Pages-shared → Pages (9) - Extract shared code
 - `AddToDatasetDialog` → `AddEditDatasetDialog`
 - `DatasetSelectBox` → `AddEditDatasetDialog`
 - `ThreadDetailsPanel` → `WorkspacePreferencesTab/types.ts`
 - `ExperimentsRadarChart` → `useCompareExperimentsChartsData`
+- `IntegrationDetailsDialog` → `AgentOnboardingContext`
 
 **Fix:** Extract shared types/utilities to `pages-shared/` or `lib/`
 

--- a/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.README.md
@@ -11,15 +11,13 @@ The baseline file allows us to:
 
 ## Current Violations Summary
 
-### Circular Dependencies (13) - MUST FIX
+### Circular Dependencies (12) - MUST FIX
 These create maintenance nightmares and potential runtime issues:
 - `useOpenAICompatibleModels` ↔ `provider.ts` ↔ `useLLMProviderModelsData`
 - `useProviderKeys` → `provider.ts` → `useLLMProviderModelsData` → `useOpenAICompatibleModels`
 - `MetricTag` ↔ `PlaygroundOutputScores`
 - `useDatasetItemData` ↔ `useDatasetItemFormHelpers` (2 locations)
 - FeedbackScoreTable cells ↔ `utils.ts` ↔ `constants.ts` (5 violations)
-- `useAiSpendAllBreakdowns` ↔ `useAiSpendLaneBreakdown` — in the private ai-spend plugin, so
-  the fix belongs in `comet-ml/opik-plugin-ai-spend`. Only matched when that plugin is staged.
 
 ### Shared → Pages-shared (35) - Refactor needed
 Components in `shared/` importing from `pages-shared/`:

--- a/apps/opik-frontend/.dependency-cruiser-known-violations.json
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.json
@@ -660,32 +660,6 @@
     }
   },
   {
-    "type": "cycle",
-    "from": "src/plugins/ai-spend/api/useAiSpendAllBreakdowns.ts",
-    "to": "src/plugins/ai-spend/api/useAiSpendLaneBreakdown.ts",
-    "rule": {
-      "severity": "error",
-      "name": "no-circular"
-    },
-    "cycle": [
-      {
-        "name": "src/plugins/ai-spend/api/useAiSpendLaneBreakdown.ts",
-        "dependencyTypes": [
-          "local",
-          "type-only",
-          "import"
-        ]
-      },
-      {
-        "name": "src/plugins/ai-spend/api/useAiSpendAllBreakdowns.ts",
-        "dependencyTypes": [
-          "local",
-          "import"
-        ]
-      }
-    ]
-  },
-  {
     "type": "dependency",
     "from": "src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx",
     "to": "src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx",

--- a/apps/opik-frontend/.dependency-cruiser-known-violations.json
+++ b/apps/opik-frontend/.dependency-cruiser-known-violations.json
@@ -658,5 +658,40 @@
       "severity": "info",
       "name": "no-orphans"
     }
+  },
+  {
+    "type": "cycle",
+    "from": "src/plugins/ai-spend/api/useAiSpendAllBreakdowns.ts",
+    "to": "src/plugins/ai-spend/api/useAiSpendLaneBreakdown.ts",
+    "rule": {
+      "severity": "error",
+      "name": "no-circular"
+    },
+    "cycle": [
+      {
+        "name": "src/plugins/ai-spend/api/useAiSpendLaneBreakdown.ts",
+        "dependencyTypes": [
+          "local",
+          "type-only",
+          "import"
+        ]
+      },
+      {
+        "name": "src/plugins/ai-spend/api/useAiSpendAllBreakdowns.ts",
+        "dependencyTypes": [
+          "local",
+          "import"
+        ]
+      }
+    ]
+  },
+  {
+    "type": "dependency",
+    "from": "src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx",
+    "to": "src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx",
+    "rule": {
+      "severity": "error",
+      "name": "no-pages-shared-importing-pages"
+    }
   }
 ]


### PR DESCRIPTION
## Details

`npm run deps:validate` fails on `main` today. It is wired into `dev-runner.sh --lint-fe` but into no workflow, so violations landed unnoticed. Two were outstanding when this branch opened:

```
error no-pages-shared-importing-pages: src/v2/pages-shared/onboarding/IntegrationExplorer/components/IntegrationDetailsDialog.tsx
  → src/v2/pages/GetStartedPage/AgentOnboarding/AgentOnboardingContext.tsx
error no-circular: src/plugins/ai-spend/api/useAiSpendAllBreakdowns.ts
  → useAiSpendLaneBreakdown.ts → useAiSpendAllBreakdowns.ts
```

**The cycle is now fixed rather than baselined.** It lived in the private `opik-plugin-ai-spend` repo, which is staged into `src/plugins/ai-spend` at build time; comet-ml/opik-plugin-ai-spend#69 moved the breakdown response types out of the hooks and is merged, so that entry was added here and then removed again — the diff carries only the `pages-shared → pages` entry. Baselined debt in a repo with no CI of its own does not get revisited, which is why it was worth fixing at the source.

What remains is the layering violation: `IntegrationDetailsDialog` in `v2/pages-shared` imports `AgentOnboardingContext` from `v2/pages`, against the one-way `pages-shared → pages` rule. Adding it to `.dependency-cruiser-known-violations.json` is what that file is for: the command then passes on existing debt and fails on anything *new*. That is the precondition for running it as a check instead of leaving it to whoever remembers `--lint-fe`.

Two things deliberately not done:

- **The pages-shared violation is not fixed.** Baselining hides it further, and it is a layering break its author may want to resolve properly, so it is called out here and listed in the README rather than fixed blind.
- **The baseline was not regenerated.** `depcruise --output-type baseline` would also prune 4 entries that no longer match — real cleanup, but unrelated, so the diff stays at one appended entry.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7793

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Reproducing the failure, generating the baseline entry, the README update.
- Human verification: Both violations reproduced locally before and after; the entry generated with depcruise itself rather than hand-written; the violation traced to the commit that introduced it.

## Testing

Run in `apps/opik-frontend`, macOS, local Node. `npm run deps:validate` exits 0 in all three shapes the tree takes, re-verified after the plugin fix merged:

- **No plugin present** (OSS checkout): exit 0.
- **Plugin symlinked** (dev-runner layout): exit 0.
- **Plugin main copied in** (how the comet image stages it): exit 0, 27 known violations matched, no `ai-spend` violation of any rule.

Before the change the same command exits 2 in every shape, on the pages-shared violation alone once the plugin cycle is fixed.

The entry was produced by `npx depcruise src --config --output-type baseline` and diffed against the committed baseline, so its shape matches what dependency-cruiser itself writes.

## Documentation

`.dependency-cruiser-known-violations.README.md` is updated in the same branch: the entry is listed under its category with the count bumped. No user-facing or public documentation change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
