### PR TITLE
[BE]: register replicate and watsonx as canonical providers

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -56,7 +56,9 @@ public class CostService {
             Map.entry("sambanova", "sambanova"),
             Map.entry("nebius", "nebius"),
             Map.entry("snowflake", "snowflake"),
-            Map.entry("deepinfra", "deepinfra"));
+            Map.entry("deepinfra", "deepinfra"),
+            Map.entry("replicate", "replicate"),
+            Map.entry("watsonx", "watsonx"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1062,4 +1062,38 @@ class CostServiceTest {
                                 "original_usage.prompt_tokens_details.cached_tokens", 300),
                         "0.005709"));
     }
+
+    /**
+     * Covers registering {@code replicate} as a canonical provider so that the 40 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "replicate"} are no longer silently dropped at load time. No Replicate
+     * model publishes cache rates today, so all Replicate requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesReplicateModels() {
+        // replicate/openai/o1: input 1.5e-05, output 6e-05
+        // 1000 * 1.5e-05 + 200 * 6e-05 = 0.027
+        BigDecimal cost = CostService.calculateCost("replicate/openai/o1", "replicate",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.027");
+    }
+
+    /**
+     * Covers registering {@code watsonx} as a canonical provider so that the 28 non-zero-cost
+     * entries in {@code model_prices_and_context_window.json} tagged with
+     * {@code litellm_provider: "watsonx"} are no longer silently dropped at load time. No Watsonx
+     * model publishes cache rates today, so all Watsonx requests route through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesWatsonxModels() {
+        // watsonx/openai/gpt-oss-120b: input 1.5e-07, output 6e-07
+        // 1000 * 1.5e-07 + 200 * 6e-07 = 0.00027
+        BigDecimal cost = CostService.calculateCost("watsonx/openai/gpt-oss-120b", "watsonx",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.00027");
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1064,36 +1064,27 @@ class CostServiceTest {
     }
 
     /**
-     * Covers registering {@code replicate} as a canonical provider so that the 40 non-zero-cost
-     * entries in {@code model_prices_and_context_window.json} tagged with
-     * {@code litellm_provider: "replicate"} are no longer silently dropped at load time. No Replicate
-     * model publishes cache rates today, so all Replicate requests route through
-     * {@link SpanCostCalculator#textGenerationCost}.
+     * Covers registering {@code replicate} and {@code watsonx} as canonical providers so that their
+     * token-priced entries in {@code model_prices_and_context_window.json} are no longer silently
+     * dropped at load time. Each case exercises a representative token-priced model routed through
+     * {@link SpanCostCalculator#textGenerationCost}. Per-second-priced models under these providers
+     * (for example Watsonx transcription) use a pricing shape this calculator does not cover and
+     * stay out of scope here.
      */
-    @Test
-    void calculateCostHandlesReplicateModels() {
-        // replicate/openai/o1: input 1.5e-05, output 6e-05
-        // 1000 * 1.5e-05 + 200 * 6e-05 = 0.027
-        BigDecimal cost = CostService.calculateCost("replicate/openai/o1", "replicate",
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("provideReplicateWatsonxProviderCases")
+    void calculateCostHandlesReplicateAndWatsonxModels(String provider, String model, String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, provider,
                 Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
 
-        assertThat(cost).isEqualByComparingTo("0.027");
+        assertThat(cost).isEqualByComparingTo(expectedCost);
     }
 
-    /**
-     * Covers registering {@code watsonx} as a canonical provider so that the 28 non-zero-cost
-     * entries in {@code model_prices_and_context_window.json} tagged with
-     * {@code litellm_provider: "watsonx"} are no longer silently dropped at load time. No Watsonx
-     * model publishes cache rates today, so all Watsonx requests route through
-     * {@link SpanCostCalculator#textGenerationCost}.
-     */
-    @Test
-    void calculateCostHandlesWatsonxModels() {
-        // watsonx/openai/gpt-oss-120b: input 1.5e-07, output 6e-07
-        // 1000 * 1.5e-07 + 200 * 6e-07 = 0.00027
-        BigDecimal cost = CostService.calculateCost("watsonx/openai/gpt-oss-120b", "watsonx",
-                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
-
-        assertThat(cost).isEqualByComparingTo("0.00027");
+    private static Stream<Arguments> provideReplicateWatsonxProviderCases() {
+        return Stream.of(
+                // replicate/openai/o1: input 1.5e-05, output 6e-05 -> 1000*1.5e-05 + 200*6e-05 = 0.027
+                Arguments.of("replicate", "replicate/openai/o1", "0.027"),
+                // watsonx/openai/gpt-oss-120b: input 1.5e-07, output 6e-07 -> 1000*1.5e-07 + 200*6e-07 = 0.00027
+                Arguments.of("watsonx", "watsonx/openai/gpt-oss-120b", "0.00027"));
     }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` only registers a subset of the `litellm_provider` values in `model_prices_and_context_window.json`. Models whose provider is missing from that map have their price dropped at load time (`buildModelPrice` returns null), so their spans bill at `DEFAULT_COST` (zero) and cost tracking / the per-evaluation spend budget silently under-report.

This registers two more unmapped, per-token-priced providers so their bundled prices load: `replicate` (40 priced models) and `watsonx` (28 priced models, IBM watsonx.ai). Neither publishes cache rates today, so every request routes through the standard `textGenerationCost` path and no `PROVIDERS_CACHE_COST_CALCULATOR` entry is needed.

Part of the ongoing provider-coverage cleanup (#7697).

## Testing

Added one `@Test` per provider asserting a representative model prices to a non-zero, exact expected cost (it returns zero before this change).

## Documentation

No documentation changes needed
