### PR TITLE
[OPIK-7972] [SDK] fix(adk): report silent span-conversion failures, and pin the fix to the deferred-class case

### DIFF
--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -288,9 +288,12 @@ class LegacyOpikTracer:
                 if usage_data is not None:
                     model = usage_data.model
                     usage = usage_data.opik_usage
-            except Exception as e:
-                LOGGER.debug(
-                    f"Error converting LlmResponse to dict or extracting usage data, reason: {e}",
+            except Exception:
+                # Not debug: this is silent data loss. The span is still logged, but
+                # without output or usage, and nothing else reports that.
+                LOGGER.error(
+                    "Error converting LlmResponse to dict or extracting usage data, "
+                    "the LLM span will be logged without output and usage",
                     exc_info=True,
                 )
 

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -442,9 +442,12 @@ class OpikTracer:
                 if usage_data is not None:
                     model = usage_data.model
                     usage = usage_data.opik_usage
-            except Exception as e:
-                LOGGER.debug(
-                    f"Error converting LlmResponse to dict or extracting usage data, reason: {e}",
+            except Exception:
+                # Not debug: this is silent data loss. The span is still logged, but
+                # without output or usage, and nothing else reports that.
+                LOGGER.error(
+                    "Error converting LlmResponse to dict or extracting usage data, "
+                    "the LLM span will be logged without output and usage",
                     exc_info=True,
                 )
 

--- a/sdks/python/src/opik/integrations/adk/patchers/llm_response_wrapper.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/llm_response_wrapper.py
@@ -94,12 +94,19 @@ def _wrap_llm_response_create(
     if response.custom_metadata is None:
         response.custom_metadata = {}
 
-    # Store the usage as a plain dict, not the genai pydantic model. ``custom_metadata``
-    # is typed ``dict[str, Any]``, so pydantic has no serializer for a model placed in
-    # it and dumping the whole LlmResponse later raises "'MockValSer' object is not an
-    # instance of 'SchemaSerializer'". after_model_callback swallows that, which is how
-    # the LLM spans ended up with no output and no usage. The reader below already
-    # handles a dict - that is what it gets from the dumped result in the streaming path.
+    # Store the usage as a plain dict, never the genai model itself. Since google-genai
+    # 2.18.0 (googleapis/python-genai#2784) these classes defer their pydantic build, so
+    # a class holds a MockValSer until something rebuilds it. Serializing one from an
+    # Any-typed field (custom_metadata is dict[str, Any]) takes pydantic's inference
+    # path, which downcasts to SchemaSerializer in Rust without firing the lazy rebuild
+    # hook a Python-level call would, and raises "'MockValSer' object is not an instance
+    # of 'SchemaSerializer'" - fallback=str does not rescue it. That broke both
+    # after_model_callback (silently, losing output and usage) and ADK's own response
+    # serialization (HTTP 500). Upstream, still open:
+    # https://github.com/pydantic/pydantic/issues/13647
+    # Dumping the model directly goes through Python and does rebuild the class, so the
+    # dict we attach is always safe. The reader below already handles a dict - that is
+    # what it gets from the dumped result in the streaming path.
     response.custom_metadata["opik_usage"] = adk_helpers.convert_adk_base_model_to_dict(
         usage_metadata
     )

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import AsyncGenerator
 
 import pydantic
@@ -117,11 +118,22 @@ def test_wrap_llm_response_create__usage_class_not_rebuilt_yet__still_dumpable()
         ),
     )
 
-    # Both serialization paths that broke: ours, and the one ADK itself uses.
-    dumped = adk_helpers.convert_adk_base_model_to_dict(response)
-    response.model_dump_json()
+    # Both paths that broke, each reported independently. Chaining them would let a
+    # failure in ours mask whether ADK's own serializer - the one that produced the
+    # HTTP 500 - is actually fixed.
+    failures = {}
+    try:
+        dumped = adk_helpers.convert_adk_base_model_to_dict(response)
+        assert dumped["custom_metadata"]["opik_usage"]["total_token_count"] == 8
+    except Exception as opik_path_error:
+        failures["opik convert_adk_base_model_to_dict"] = repr(opik_path_error)
+    try:
+        # What ADK hands to starlette.
+        response.model_dump_json()
+    except Exception as adk_path_error:
+        failures["adk model_dump_json"] = repr(adk_path_error)
 
-    assert dumped["custom_metadata"]["opik_usage"]["total_token_count"] == 8
+    assert not failures, f"deferred usage class broke serialization: {failures}"
 
 
 @pytest.mark.parametrize(
@@ -155,7 +167,9 @@ def test_tracer_conversion_failure__both_tracers__logs_at_error_level(
 
     handler = re.search(
         r"except Exception[^:]*:\s*\n(?:\s*#.*\n)*\s*LOGGER\.(\w+)\(\s*\n?\s*"
-        r"\"Error converting LlmResponse to dict",
+        r"\"Error converting LlmResponse to dict"
+        # Capture the rest of the call so exc_info can be checked too.
+        r"(?P<rest>(?:[^)]|\)(?!\s*\n))*\))",
         source,
     )
     assert handler, (
@@ -164,6 +178,12 @@ def test_tracer_conversion_failure__both_tracers__logs_at_error_level(
     assert handler.group(1) == "error", (
         f"{tracer_module_name}: conversion failure is logged at "
         f"LOGGER.{handler.group(1)}, expected LOGGER.error"
+    )
+    # Without the traceback the ERROR says something broke but not where, which is
+    # most of the value on a failure this indirect.
+    assert "exc_info=True" in handler.group("rest"), (
+        f"{tracer_module_name}: conversion failure is logged without exc_info=True, "
+        f"so the traceback is lost"
     )
 
 
@@ -263,9 +283,15 @@ def test_adk_llm_span__deferred_usage_metadata__output_and_usage_reach_the_backe
     """
     _run_fake_agent()
 
-    # Derived, not hardcoded: the provider depends on GOOGLE_GENAI_USE_VERTEXAI,
-    # which CI sets and a local run usually does not.
-    expected_provider = adk_helpers.get_adk_provider().value
+    # Read the environment directly rather than calling get_adk_provider(): deriving
+    # the expectation from the helper under test would mirror a provider-detection
+    # regression instead of catching it. Hardcoding is not an option either - the
+    # ADK workflow sets this variable and a local shell usually does not.
+    expected_provider = (
+        "google_vertexai"
+        if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "0").lower() in ("true", "1")
+        else "google_ai"
+    )
 
     EXPECTED_LLM_OUTPUT = {
         "content": {"parts": [{"text": "sunny, 22C"}], "role": "model"},

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -1,11 +1,12 @@
 import asyncio
+from typing import AsyncGenerator
 
 import pydantic
 import pytest
 from google.adk import agents as adk_agents
 from google.adk import models as adk_models
 from google.adk import runners as adk_runners
-from google.adk.models import base_llm
+from google.adk.models import base_llm, llm_request, llm_response
 from google.adk.sessions import in_memory_session_service
 from google.genai import types as genai_types
 
@@ -13,6 +14,7 @@ from opik.integrations.adk import OpikTracer
 from opik.integrations.adk import helpers as adk_helpers
 from opik.integrations.adk.patchers import llm_response_wrapper
 from . import helpers
+from ...testlib import ANY_BUT_NONE, ANY_DICT, SpanModel, TraceModel, assert_equal
 
 
 def _generate_content_response() -> genai_types.GenerateContentResponse:
@@ -126,7 +128,9 @@ def test_wrap_llm_response_create__usage_class_not_rebuilt_yet__still_dumpable()
     "tracer_module_name",
     ["opik_tracer", "legacy_opik_tracer"],
 )
-def test_both_tracers_report_conversion_failure_at_error_level(tracer_module_name):
+def test_tracer_conversion_failure__both_tracers__logs_at_error_level(
+    tracer_module_name,
+):
     """A conversion failure must not be swallowed at DEBUG in either tracer.
 
     When it happens the span is still logged, but without output or usage, and nothing
@@ -184,7 +188,9 @@ class _FakeUsageModel(base_llm.BaseLlm):
 
     model: str = "fake-gemini"
 
-    async def generate_content_async(self, llm_request, stream=False):  # type: ignore[no-untyped-def]
+    async def generate_content_async(
+        self, request: llm_request.LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[llm_response.LlmResponse, None]:
         generate_content_response = genai_types.GenerateContentResponse(
             candidates=[
                 genai_types.Candidate(
@@ -206,19 +212,8 @@ class _FakeUsageModel(base_llm.BaseLlm):
         )
 
 
-@helpers.pytest_skip_for_adk_older_than_1_3_0
-def test_adk_llm_span__carries_output_and_usage(fake_backend):
-    """The user-facing symptom: an LLM span must actually arrive with output and usage.
-
-    Every other test here stops at ``pop_llm_usage_data`` returning the right
-    counts, which leaves the gap that broke production - the values parsed
-    correctly but never reached the span, because the exception was swallowed
-    upstream of the assignment. This drives a real ADK agent and asserts on the
-    span the backend receives.
-
-    A fake model keeps it offline; what a live Gemini call adds on top is only
-    whether the provider really returns usage metadata, not whether we record it.
-    """
+def _run_fake_agent() -> None:
+    """Drive a real ADK agent through the fake model, offline."""
     tracer = OpikTracer(project_name="adk-usage-test")
     agent = adk_agents.LlmAgent(
         name="weather_agent",
@@ -231,16 +226,14 @@ def test_adk_llm_span__carries_output_and_usage(fake_backend):
     )
 
     session_service = in_memory_session_service.InMemorySessionService()
-    asyncio.run(
-        session_service.create_session(
-            app_name="usage-probe", user_id="u1", session_id="s1"
-        )
-    )
     runner = adk_runners.Runner(
         agent=agent, app_name="usage-probe", session_service=session_service
     )
 
     async def _run() -> None:
+        await session_service.create_session(
+            app_name="usage-probe", user_id="u1", session_id="s1"
+        )
         async for _ in runner.run_async(
             user_id="u1",
             session_id="s1",
@@ -253,23 +246,78 @@ def test_adk_llm_span__carries_output_and_usage(fake_backend):
     asyncio.run(_run())
     tracer.flush()
 
-    llm_spans = [
-        span
-        for trace in fake_backend.trace_trees
-        for span in _walk(trace.spans)
-        if span.type == "llm"
-    ]
-    assert llm_spans, "expected at least one LLM span"
 
-    for span in llm_spans:
-        assert span.output, f"LLM span {span.name} has no output"
-        assert span.usage, f"LLM span {span.name} has no usage"
-        assert span.usage["original_usage.total_token_count"] == 18
-        assert span.usage["prompt_tokens"] == 11
-        assert span.usage["total_tokens"] == 18
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_adk_llm_span__deferred_usage_metadata__output_and_usage_reach_the_backend(
+    fake_backend,
+):
+    """The user-facing symptom: the span the backend receives must carry both.
 
+    Every other test here stops at ``pop_llm_usage_data`` returning the right
+    counts, which is exactly what failed to protect us - the counts parsed fine,
+    the exception was swallowed upstream of the assignment, and the span went out
+    empty. So this asserts the recorded tree, not the parser.
 
-def _walk(spans):
-    for span in spans:
-        yield span
-        yield from _walk(span.spans)
+    A fake model keeps it offline. What a live Gemini call adds on top is only
+    whether the provider really returns usage metadata, not whether we record it.
+    """
+    _run_fake_agent()
+
+    EXPECTED_LLM_OUTPUT = {
+        "content": {"parts": [{"text": "sunny, 22C"}], "role": "model"},
+        "model_version": "fake-gemini-1.0",
+        "finish_reason": "STOP",
+        "custom_metadata": {"provider": "google_ai"},
+        "usage_metadata": {
+            "candidates_token_count": 7,
+            "prompt_token_count": 11,
+            "total_token_count": 18,
+        },
+        "avg_logprobs": None,
+        "citation_metadata": None,
+        "grounding_metadata": None,
+        "logprobs_result": None,
+    }
+
+    EXPECTED_TRACE_TREE = TraceModel(
+        id=ANY_BUT_NONE,
+        name="weather_agent",
+        input={"parts": [{"text": "weather?"}], "role": "user"},
+        output=EXPECTED_LLM_OUTPUT,
+        metadata=ANY_DICT,
+        # ADK's session id becomes the Opik thread id.
+        thread_id="s1",
+        start_time=ANY_BUT_NONE,
+        end_time=ANY_BUT_NONE,
+        last_updated_at=ANY_BUT_NONE,
+        project_name="adk-usage-test",
+        spans=[
+            SpanModel(
+                id=ANY_BUT_NONE,
+                name="fake-gemini-1.0",
+                type="llm",
+                input=ANY_DICT,
+                output=EXPECTED_LLM_OUTPUT,
+                # The whole point of the ticket: not merely present, but correct.
+                usage={
+                    "completion_tokens": 7,
+                    "prompt_tokens": 11,
+                    "total_tokens": 18,
+                    "original_usage.candidates_token_count": 7,
+                    "original_usage.prompt_token_count": 11,
+                    "original_usage.total_token_count": 18,
+                },
+                model="fake-gemini-1.0",
+                provider="google_ai",
+                metadata=ANY_DICT,
+                start_time=ANY_BUT_NONE,
+                end_time=ANY_BUT_NONE,
+                last_updated_at=ANY_BUT_NONE,
+                project_name="adk-usage-test",
+                spans=[],
+            )
+        ],
+    )
+
+    assert len(fake_backend.trace_trees) == 1
+    assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -200,10 +200,13 @@ class _DeferredUsageMetadata(genai_types.GenerateContentResponseUsageMetadata):
 class _FakeUsageModel(base_llm.BaseLlm):
     """An ADK model that carries usage metadata without touching the network.
 
-    Routes its response through the patched ``LlmResponse.create`` the real
-    provider path uses, so the usage lands in ``custom_metadata`` exactly as it
-    does in production - and carries a deferred usage class, so the agent run
-    reproduces the failure rather than a healthy variant of it.
+    Calls ``LlmResponse.create`` plainly, exactly as a real model does, and relies
+    on ``patch_adk`` having replaced it - so the test also covers that the patch is
+    installed and still lands on the boundary ADK actually uses. Wrapping the call
+    explicitly would keep passing even if the patching broke entirely.
+
+    The usage it carries is a deferred class, so the agent run reproduces the
+    failure rather than a healthy variant of it.
     """
 
     model: str = "fake-gemini"
@@ -227,9 +230,7 @@ class _FakeUsageModel(base_llm.BaseLlm):
             )
         )
         generate_content_response.model_version = "fake-gemini-1.0"
-        yield llm_response_wrapper._wrap_llm_response_create(
-            generate_content_response, adk_models.LlmResponse.create
-        )
+        yield adk_models.LlmResponse.create(generate_content_response)
 
 
 def _run_fake_agent() -> None:

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -263,11 +263,15 @@ def test_adk_llm_span__deferred_usage_metadata__output_and_usage_reach_the_backe
     """
     _run_fake_agent()
 
+    # Derived, not hardcoded: the provider depends on GOOGLE_GENAI_USE_VERTEXAI,
+    # which CI sets and a local run usually does not.
+    expected_provider = adk_helpers.get_adk_provider().value
+
     EXPECTED_LLM_OUTPUT = {
         "content": {"parts": [{"text": "sunny, 22C"}], "role": "model"},
         "model_version": "fake-gemini-1.0",
         "finish_reason": "STOP",
-        "custom_metadata": {"provider": "google_ai"},
+        "custom_metadata": {"provider": expected_provider},
         "usage_metadata": {
             "candidates_token_count": 7,
             "prompt_token_count": 11,
@@ -308,7 +312,7 @@ def test_adk_llm_span__deferred_usage_metadata__output_and_usage_reach_the_backe
                     "original_usage.total_token_count": 18,
                 },
                 model="fake-gemini-1.0",
-                provider="google_ai",
+                provider=expected_provider,
                 metadata=ANY_DICT,
                 start_time=ANY_BUT_NONE,
                 end_time=ANY_BUT_NONE,

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -1,3 +1,5 @@
+import pydantic
+import pytest
 from google.adk import models as adk_models
 from google.genai import types as genai_types
 
@@ -66,3 +68,88 @@ def test_pop_llm_usage_data__reads_the_attached_dict():
     assert provider_usage["prompt_token_count"] == 3
     assert provider_usage["candidates_token_count"] == 5
     assert provider_usage["total_token_count"] == 8
+
+
+def test_wrap_llm_response_create__usage_class_not_rebuilt_yet__still_dumpable():
+    """Pins the fix to the deferred-class state that actually caused the outage.
+
+    Since google-genai 2.18.0 (googleapis/python-genai#2784) every genai model sets
+    ``defer_build=True``, so a class still holds a ``MockValSer`` until something
+    rebuilds it. Serializing such an instance through ``custom_metadata`` (typed
+    ``dict[str, Any]``) takes pydantic's inference path, which downcasts to
+    ``SchemaSerializer`` in Rust without firing the lazy rebuild hook a Python-level
+    call would, and raises "'MockValSer' object is not an instance of
+    'SchemaSerializer'" - ``fallback=str`` does not rescue it. Upstream, still open:
+    pydantic/pydantic#13647.
+
+    A throwaway subclass keeps this deterministic. The real usage class self-heals the
+    moment any earlier test dumps it directly, so a test built on it passes against
+    unfixed code depending on test order - which is exactly how this regression could
+    slip back in unnoticed.
+    """
+
+    class _DeferredUsage(genai_types.GenerateContentResponseUsageMetadata):
+        model_config = pydantic.ConfigDict(defer_build=True)
+
+    assert not _DeferredUsage.__pydantic_complete__, (
+        "the class must still be deferred for this test to exercise the bug"
+    )
+
+    generate_content_response = _generate_content_response()
+    generate_content_response.usage_metadata = _DeferredUsage.model_construct(
+        prompt_token_count=3, candidates_token_count=5, total_token_count=8
+    )
+
+    response = llm_response_wrapper._wrap_llm_response_create(
+        generate_content_response,
+        lambda _: adk_models.LlmResponse(
+            content=generate_content_response.candidates[0].content
+        ),
+    )
+
+    # Both serialization paths that broke: ours, and the one ADK itself uses.
+    dumped = adk_helpers.convert_adk_base_model_to_dict(response)
+    response.model_dump_json()
+
+    assert dumped["custom_metadata"]["opik_usage"]["total_token_count"] == 8
+
+
+@pytest.mark.parametrize(
+    "tracer_module_name",
+    ["opik_tracer", "legacy_opik_tracer"],
+)
+def test_both_tracers_report_conversion_failure_at_error_level(tracer_module_name):
+    """A conversion failure must not be swallowed at DEBUG in either tracer.
+
+    When it happens the span is still logged, but without output or usage, and nothing
+    else surfaces that - so it has to be loud enough for an operator to see. DEBUG here
+    is why a week of silent span data loss went unnoticed while CI only went red
+    because ADK crashed on its own. Both tracers share ``llm_response_wrapper``, so
+    both need the same treatment.
+
+    Asserted against the except-block itself. Driving the real callback would need
+    span, context and registry state this module has no business assembling, and a test
+    that rebuilds the logging call instead of executing it would pass no matter what
+    the handler does.
+    """
+    import importlib
+    import inspect
+    import re
+
+    tracer_module = importlib.import_module(
+        f"opik.integrations.adk.{tracer_module_name}"
+    )
+    source = inspect.getsource(tracer_module)
+
+    handler = re.search(
+        r"except Exception[^:]*:\s*\n(?:\s*#.*\n)*\s*LOGGER\.(\w+)\(\s*\n?\s*"
+        r"\"Error converting LlmResponse to dict",
+        source,
+    )
+    assert handler, (
+        f"{tracer_module_name}: could not find the conversion-failure handler"
+    )
+    assert handler.group(1) == "error", (
+        f"{tracer_module_name}: conversion failure is logged at "
+        f"LOGGER.{handler.group(1)}, expected LOGGER.error"
+    )

--- a/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
+++ b/sdks/python/tests/library_integration/adk/test_llm_response_wrapper.py
@@ -1,10 +1,18 @@
+import asyncio
+
 import pydantic
 import pytest
+from google.adk import agents as adk_agents
 from google.adk import models as adk_models
+from google.adk import runners as adk_runners
+from google.adk.models import base_llm
+from google.adk.sessions import in_memory_session_service
 from google.genai import types as genai_types
 
+from opik.integrations.adk import OpikTracer
 from opik.integrations.adk import helpers as adk_helpers
 from opik.integrations.adk.patchers import llm_response_wrapper
+from . import helpers
 
 
 def _generate_content_response() -> genai_types.GenerateContentResponse:
@@ -153,3 +161,115 @@ def test_both_tracers_report_conversion_failure_at_error_level(tracer_module_nam
         f"{tracer_module_name}: conversion failure is logged at "
         f"LOGGER.{handler.group(1)}, expected LOGGER.error"
     )
+
+
+class _DeferredUsageMetadata(genai_types.GenerateContentResponseUsageMetadata):
+    """Usage whose class is still deferred, as google-genai >= 2.18.0 ships them.
+
+    Module-level so the class is shared, but ``defer_build=True`` means it stays
+    unbuilt until something dumps it - which is the state that broke production.
+    """
+
+    model_config = pydantic.ConfigDict(defer_build=True)
+
+
+class _FakeUsageModel(base_llm.BaseLlm):
+    """An ADK model that carries usage metadata without touching the network.
+
+    Routes its response through the patched ``LlmResponse.create`` the real
+    provider path uses, so the usage lands in ``custom_metadata`` exactly as it
+    does in production - and carries a deferred usage class, so the agent run
+    reproduces the failure rather than a healthy variant of it.
+    """
+
+    model: str = "fake-gemini"
+
+    async def generate_content_async(self, llm_request, stream=False):  # type: ignore[no-untyped-def]
+        generate_content_response = genai_types.GenerateContentResponse(
+            candidates=[
+                genai_types.Candidate(
+                    content=genai_types.Content(
+                        role="model", parts=[genai_types.Part(text="sunny, 22C")]
+                    ),
+                    finish_reason=genai_types.FinishReason.STOP,
+                )
+            ],
+        )
+        generate_content_response.usage_metadata = (
+            _DeferredUsageMetadata.model_construct(
+                prompt_token_count=11, candidates_token_count=7, total_token_count=18
+            )
+        )
+        generate_content_response.model_version = "fake-gemini-1.0"
+        yield llm_response_wrapper._wrap_llm_response_create(
+            generate_content_response, adk_models.LlmResponse.create
+        )
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_adk_llm_span__carries_output_and_usage(fake_backend):
+    """The user-facing symptom: an LLM span must actually arrive with output and usage.
+
+    Every other test here stops at ``pop_llm_usage_data`` returning the right
+    counts, which leaves the gap that broke production - the values parsed
+    correctly but never reached the span, because the exception was swallowed
+    upstream of the assignment. This drives a real ADK agent and asserts on the
+    span the backend receives.
+
+    A fake model keeps it offline; what a live Gemini call adds on top is only
+    whether the provider really returns usage metadata, not whether we record it.
+    """
+    tracer = OpikTracer(project_name="adk-usage-test")
+    agent = adk_agents.LlmAgent(
+        name="weather_agent",
+        model=_FakeUsageModel(),
+        instruction="Answer the weather question.",
+        before_agent_callback=tracer.before_agent_callback,
+        after_agent_callback=tracer.after_agent_callback,
+        before_model_callback=tracer.before_model_callback,
+        after_model_callback=tracer.after_model_callback,
+    )
+
+    session_service = in_memory_session_service.InMemorySessionService()
+    asyncio.run(
+        session_service.create_session(
+            app_name="usage-probe", user_id="u1", session_id="s1"
+        )
+    )
+    runner = adk_runners.Runner(
+        agent=agent, app_name="usage-probe", session_service=session_service
+    )
+
+    async def _run() -> None:
+        async for _ in runner.run_async(
+            user_id="u1",
+            session_id="s1",
+            new_message=genai_types.Content(
+                role="user", parts=[genai_types.Part(text="weather?")]
+            ),
+        ):
+            pass
+
+    asyncio.run(_run())
+    tracer.flush()
+
+    llm_spans = [
+        span
+        for trace in fake_backend.trace_trees
+        for span in _walk(trace.spans)
+        if span.type == "llm"
+    ]
+    assert llm_spans, "expected at least one LLM span"
+
+    for span in llm_spans:
+        assert span.output, f"LLM span {span.name} has no output"
+        assert span.usage, f"LLM span {span.name} has no usage"
+        assert span.usage["original_usage.total_token_count"] == 18
+        assert span.usage["prompt_tokens"] == 11
+        assert span.usage["total_tokens"] == 18
+
+
+def _walk(spans):
+    for span in spans:
+        yield span
+        yield from _walk(span.spans)


### PR DESCRIPTION
## Details

<img width="962" height="1533" alt="image" src="https://github.com/user-attachments/assets/641fdf4d-e68d-45f5-aa70-1ad078337128" />

**Rescoped.** This PR originally carried the ADK serialization fix, but #7874 merged it first (commit `8e8c5d7`). Rebased onto current `main` and reduced to the delta — one commit, no conflicts. The serialization fix and its two tests are already upstream; what follows is what #7874 did **not** include.

**Report the failure instead of hiding it.** When converting the `LlmResponse` or extracting usage fails, the span is still logged — just with no output and no usage — and nothing else says so. Both `OpikTracer` and `LegacyOpikTracer` swallowed that at DEBUG, which is why a week of silent data loss went unnoticed while CI only went red because ADK crashed on its own. Every sibling callback in both files already uses `LOGGER.error(..., exc_info=True)` for a swallowed exception, so DEBUG was the outlier. The message is static now — `exc_info=True` already carries the exception, so interpolating it duplicated the text.

**Pin the fix to the state that caused the outage.** The merged test attaches a normally-constructed usage model, which does not reproduce the bug. google-genai 2.18.0 defers the pydantic build, and a Python-level dump of that class rebuilds it *process-wide* — so any earlier test that dumps it leaves the class healthy for the rest of the session, and a test relying on it passes against unfixed code depending on test order. I hit this while building it: my first attempt passed against unfixed code. The new test builds a throwaway `defer_build=True` subclass and asserts both serialization paths that broke — ours, and `model_dump_json`, the one ADK itself uses.

**Correct the root-cause comment at the fix site.** The merged comment says pydantic "has no serializer for a model placed in" a `dict[str, Any]` field. That is not the mechanism, and it makes the constraint impossible to verify. Deferred classes hold a `MockValSer` whose lazy rebuild hook fires on Python attribute access but **not** on the Rust downcast used when serializing from an `Any`-typed slot. Now links [pydantic#13647](https://github.com/pydantic/pydantic/issues/13647) (open, acknowledged, no target version) and [python-genai#2784](https://github.com/googleapis/python-genai/pull/2784), so the version gate is checkable.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7972

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (root-cause investigation, SDK change, tests)
- Human verification: pending review

## Testing

Commands run from `sdks/python`, against a venv matching CI (google-adk 2.7.1 / google-genai 2.18.1 / pydantic 2.13.4, Python 3.12):

- `pytest tests/library_integration/adk/test_llm_response_wrapper.py` — 5 passed
- `pytest tests/library_integration/adk/{test_helpers,test_adk_graph_builder,test_llm_response_wrapper}.py` — 15 passed
- `pre-commit run --files <the four changed files>` — ruff, ruff-format, mypy pass

Regression asserted in both directions, per half of the change:

- Restoring `main`'s DEBUG handlers fails both `test_both_tracers_report_conversion_failure_at_error_level` parameters — and each tracer fails independently, so neither can regress alone.
- Reverting the serialization fix (now on `main`) fails both dumpable tests, the deferred one with the exact CI error string: `TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'`.

Not run, and why:

- The E2E Lib Integration matrix (3.10–3.14) and `adk_legacy_1_3_0_tests` — need CI. Both were green on the pre-rebase revision of this branch.
- A live-credential ADK run confirming spans carry non-empty output and non-zero usage — needs Vertex credentials not available locally. **This acceptance criterion is still open**; CI proves the suites pass, not that the user-facing symptom is gone.
- Java backend and frontend suites — no changes in those components.

## Review follow-ups

Three findings from the automated review on the pre-rebase revision, all carried into this commit:

- **`LegacyOpikTracer` left at DEBUG** — a real gap I had missed; it has the same swallowed handler. Both are now ERROR, and the log-level test is parametrized over both.
- **Interpolated `{e}` alongside `exc_info=True`** — removed; the traceback already carries it.
- **Bare upstream references** — now full URLs at the fix site.

One suggestion partly declined: driving `after_model_callback` end-to-end with a mocked converter. Reaching that handler needs span, context and registry state this test module has no business assembling; the version I prototyped re-implemented the logging call rather than executing it, so it would have passed regardless of what the handler did. The source assertion is narrower but honest about what it checks. The reviewer accepted that reasoning on the thread.

## Documentation

N/A — no API or configuration change. The reasoning lives in the code comment at the fix site and the regression test's docstring, both pointing at the upstream issue.
