### PR TITLE
[OPIK-6901] docs(cutover): correct a stale claim that traces has no id skip index

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -128,9 +128,17 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- as deleted but is LIVE again on the source, and the backfill/delta already copied its live version. Deleting it by key
 -- would drop a row that is live on the source — silent data loss. So the replay deletes only ids that are NOT currently
 -- live on the source (mask-honored). The `id IN (deleted_ids since anchor)` bound keeps the deleted-id set tiny
--- (retention is off, so these are user-scale deletes); `traces` has no id skip index (000088 indexes only
--- created_at/last_updated_at — id minmax/bloom indexes exist only on traces_local_v2), so this source lookup is a
--- bounded id-filtered read of that tiny set, not a value-indexed prune of the full `traces` table.
+-- (retention is off, so these are user-scale deletes). `traces` DOES carry an id skip index --
+-- `idx_traces_id_bf`, a bloom_filter(0.01) on id, added by 000113 for OPIK-7483's delete-by-id project
+-- resolution -- and its primary key is (workspace_id, project_id, id), so this source lookup prunes on both
+-- the bloom filter and the primary key rather than scanning the table.
+--
+-- An earlier revision of this comment claimed `traces` had no id skip index and that id indexes existed only
+-- on traces_local_v2. That predated 000113 and is wrong on any deployment carrying it. Corrected because the
+-- claim is load-bearing: it is the stated reason this lookup is cheap, and it was quoted during the OPIK-6901
+-- prod-test rehearsal as the explanation for an expensive verify query -- sending the investigation the wrong
+-- way. What actually makes a differing-window verdict heavy is the candidate key COUNT and its scatter under
+-- FINAL (every version of every candidate must be read), not a missing index.
 -- allow_nondeterministic_mutations: a lightweight DELETE with cross-table subqueries is flagged nondeterministic, but
 -- deletion_events_local and traces are replicated and identical on every node and the window predicate is fixed, so the
 -- subqueries resolve to the same set on every replica. Idempotent (never masks a live-on-source id, so re-runs converge).


### PR DESCRIPTION
## Details

`000002`'s deletion-replay note says `traces` has **no id skip index**, that `000088` indexes only `created_at`/`last_updated_at`, and that id minmax/bloom indexes exist **only** on `traces_local_v2`.

That was true when written. It is now wrong: **`000113` added `idx_traces_id_bf`, a `bloom_filter(0.01)` on `traces.id`** for OPIK-7483's delete-by-id project resolution. Confirmed against a live deployment's `system.data_skipping_indices`, not inferred from the migration list.

## Why a comment is worth a PR

**It is load-bearing.** It is the stated reason the resurrection guard's source lookup is cheap — *"a bounded id-filtered read of that tiny set, not a value-indexed prune of the full `traces` table"*. The conclusion still holds, but for a better reason: with the bloom filter present **and** the primary key already `(workspace_id, project_id, id)`, that lookup prunes on both.

**And it actively misled an investigation.** During the OPIK-6901 prod-test rehearsal, a verify window reported a difference and its artifact-versus-real verdict query proved expensive. This comment was quoted as the explanation — a missing id index on the source — and the diagnosis was wrong, because the index exists. The real cost driver is the candidate key **count and scatter under `FINAL`**, where every version of every candidate key must be read. The corrected note states that, so the next reader doesn't repeat the wrong turn.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6901

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Found the claim while diagnosing an expensive verify query, checked it against the live schema, identified `000113` as what invalidated it, and rewrote the note.
- Human verification: The operator identified that the version upgrade had added these indexes, which is what prompted the check. Reviewer sign-off on the diff still required.

## Testing

- Comment-only change; no SQL modified.
- `000002` still parses under `clickhouse-format -n` with placeholders substituted.
- The claim was checked against `system.data_skipping_indices` on a live deployment: `traces` carries `idx_traces_id_bf` (bloom_filter) and `idx_traces_created_at` (minmax); `traces_local_v2` additionally carries `idx_traces_id_minmax` and `idx_traces_id_at`.

## Documentation

This *is* the documentation fix. No docs-site content is affected — the corrected note lives beside the SQL it describes, which is where an operator reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)