### PR TITLE
[OPIK-7940] [BE] [FE] feat: dynamic token auth (OAuth2 client credentials) for custom AI providers

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1203,6 +1203,21 @@ partitionMetrics:
   lwdTables: ${PARTITION_METRICS_LWD_TABLES:-traces,spans}
 
 # LLM providers client configuration
+# Configuration for dynamic token auth on custom LLM providers (auth_config recipes)
+llmProviderTokenAuth:
+  # Default: 0.25
+  # Description: Refresh the cached token once its remaining lifetime drops below this fraction of the total lifetime
+  refreshFraction: ${LLM_PROVIDER_TOKEN_AUTH_REFRESH_FRACTION:-0.25}
+  # Default: 10s
+  # Description: Timeout for the token fetch call to the configured auth service
+  fetchTimeout: ${LLM_PROVIDER_TOKEN_AUTH_FETCH_TIMEOUT:-10s}
+  # Default: 15s
+  # Description: Lease time for the cross-pod single-flight lock around a token fetch
+  lockTimeout: ${LLM_PROVIDER_TOKEN_AUTH_LOCK_TIMEOUT:-15s}
+  # Default: 1000000
+  # Description: Maximum accepted size (in characters) of a token endpoint reply
+  maxResponseChars: ${LLM_PROVIDER_TOKEN_AUTH_MAX_RESPONSE_CHARS:-1000000}
+
 llmProviderClient:
   # Default: 3
   # Description: Max amount of attempts to reach the LLM provider before giving up

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1217,6 +1217,11 @@ llmProviderTokenAuth:
   # Default: 1000000
   # Description: Maximum accepted size (in characters) of a token endpoint reply
   maxResponseChars: ${LLM_PROVIDER_TOKEN_AUTH_MAX_RESPONSE_CHARS:-1000000}
+  # Default: strict
+  # Description: SSRF guard on the token URL. "strict" refuses non-HTTPS and private/internal
+  # destinations; "relaxed" allows internal gateways. Strict by default so a missing override fails
+  # loudly instead of exposing the deployment
+  destinationGuard: ${LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD:-strict}
 
 llmProviderClient:
   # Default: 3

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1215,7 +1215,7 @@ llmProviderTokenAuth:
   # Description: Lease time for the cross-pod single-flight lock around a token fetch
   lockTimeout: ${LLM_PROVIDER_TOKEN_AUTH_LOCK_TIMEOUT:-15s}
   # Default: 1000000
-  # Description: Maximum accepted size (in characters) of a token endpoint reply
+  # Description: Maximum accepted size (in characters) of a token endpoint reply. Capped at 10000000
   maxResponseChars: ${LLM_PROVIDER_TOKEN_AUTH_MAX_RESPONSE_CHARS:-1000000}
   # Default: strict
   # Description: SSRF guard on the token URL. "strict" refuses non-HTTPS and private/internal

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1218,9 +1218,14 @@ llmProviderTokenAuth:
   # Description: Maximum accepted size (in characters) of a token endpoint reply. Capped at 10000000
   maxResponseChars: ${LLM_PROVIDER_TOKEN_AUTH_MAX_RESPONSE_CHARS:-1000000}
   # Default: strict
-  # Description: SSRF guard on the token URL. "strict" refuses non-HTTPS and private/internal
-  # destinations; "relaxed" allows internal gateways. Strict by default so a missing override fails
-  # loudly instead of exposing the deployment
+  # Values: ['strict', 'relaxed']
+  #   - strict: requires https and resolves the host before connecting, refusing loopback,
+  #     link-local (including the cloud metadata endpoint 169.254.169.254), RFC 1918 private
+  #     ranges, IPv6 unique-local (fc00::/7), multicast, wildcard, and unresolvable hosts
+  #   - relaxed: no destination restrictions, for deployments whose auth service is internal
+  # Description: SSRF guard applied to the customer-supplied token URL before each fetch. This
+  # strict default protects cloud; note that the docker-compose and Helm distributions ship
+  # 'relaxed' explicitly, so self-hosted installs are NOT covered by this default
   destinationGuard: ${LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD:-strict}
 
 llmProviderClient:

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/EncryptedAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/EncryptedAuthConfig.java
@@ -1,0 +1,81 @@
+package com.comet.opik.api;
+
+import com.comet.opik.infrastructure.EncryptionUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Objects;
+
+/**
+ * A {@link ProviderAuthConfig} that hides whether it currently holds the parsed document (when
+ * built from a request) or the AES-GCM ciphertext (when loaded from the database). Decryption is
+ * lazy and memoized: rows that are loaded but never consulted — e.g. sibling providers filtered
+ * out while resolving a model — never materialize plaintext credentials on the heap.
+ *
+ * <p>On the wire this is invisible: it serializes as, and deserializes from, the plain
+ * {@link ProviderAuthConfig} object.
+ */
+public final class EncryptedAuthConfig {
+
+    private final String ciphertext;
+    private volatile ProviderAuthConfig value;
+
+    private EncryptedAuthConfig(String ciphertext, ProviderAuthConfig value) {
+        this.ciphertext = ciphertext;
+        this.value = value;
+    }
+
+    /** DB path: holds the ciphertext, parses only on first {@link #value()} access. */
+    public static EncryptedAuthConfig fromCiphertext(String ciphertext) {
+        return ciphertext == null ? null : new EncryptedAuthConfig(ciphertext, null);
+    }
+
+    /** Request/in-memory path: already parsed. */
+    @JsonCreator
+    public static EncryptedAuthConfig of(ProviderAuthConfig value) {
+        return value == null ? null : new EncryptedAuthConfig(null, value);
+    }
+
+    @JsonValue
+    public ProviderAuthConfig value() {
+        ProviderAuthConfig parsed = value;
+        if (parsed == null) {
+            parsed = JsonUtils.readValue(EncryptionUtils.decryptGcm(ciphertext), ProviderAuthConfig.class);
+            value = parsed;
+        }
+        return parsed;
+    }
+
+    /** Persistence form; reuses the stored ciphertext when the value was never re-parsed. */
+    public String ciphertextOrEncrypt() {
+        return ciphertext != null
+                ? ciphertext
+                : EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(value));
+    }
+
+    /**
+     * Stable input for cache-key hashing without decryption. DB-loaded configs hash their
+     * ciphertext — identical on every pod until the row is rewritten, which is exactly the
+     * "any config save is an instant deployment-wide cache miss" semantic.
+     */
+    public String hashSource() {
+        return ciphertext != null ? ciphertext : JsonUtils.writeValueAsString(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof EncryptedAuthConfig that && Objects.equals(value(), that.value());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value());
+    }
+
+    @Override
+    public String toString() {
+        // never triggers decryption; the parsed form's own toString is redacted
+        return value != null ? value.toString() : "EncryptedAuthConfig{ciphertext}";
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/LlmProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/LlmProvider.java
@@ -41,4 +41,13 @@ public enum LlmProvider {
     public boolean supportsProviderName() {
         return this == CUSTOM_LLM || this == BEDROCK || this == OLLAMA;
     }
+
+    /**
+     * Providers whose requests route through {@code CustomLlmClientGenerator} — the only client
+     * that injects a dynamically fetched bearer, so the only ones where an {@code auth_config}
+     * takes effect.
+     */
+    public boolean supportsDynamicTokenAuth() {
+        return this == CUSTOM_LLM || this == BEDROCK || this == OLLAMA;
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -41,6 +42,10 @@ public record ProviderApiKey(
         @JsonView({View.Public.class, View.Write.class}) Map<String, String> configuration,
         @JsonView({View.Public.class,
                 View.Write.class}) @Pattern(regexp = NULL_OR_NOT_BLANK, message = "must not be blank") String baseUrl,
+        @JsonView({View.Public.class,
+                View.Write.class}) @Valid @Schema(description = "Dynamic token auth recipe. When set, Opik fetches a short-lived bearer from the configured auth service instead of using a static api_key. "
+                        +
+                        "Only supported for custom providers. Secret credential values read back masked.") ProviderAuthConfig authConfig,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
@@ -57,6 +62,7 @@ public record ProviderApiKey(
                 ", name='" + name + '\'' +
                 ", providerName='" + providerName + '\'' +
                 ", headers=" + headers +
+                ", authConfig=" + authConfig +
                 ", baseUrl='" + baseUrl + '\'' +
                 ", createdAt=" + createdAt +
                 ", createdBy='" + createdBy + '\'' +

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKey.java
@@ -45,7 +45,7 @@ public record ProviderApiKey(
         @JsonView({View.Public.class,
                 View.Write.class}) @Valid @Schema(description = "Dynamic token auth recipe. When set, Opik fetches a short-lived bearer from the configured auth service instead of using a static api_key. "
                         +
-                        "Only supported for custom providers. Secret credential values read back masked.") ProviderAuthConfig authConfig,
+                        "Only supported for custom providers. Secret credential values read back masked.", implementation = ProviderAuthConfig.class) EncryptedAuthConfig authConfig,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant createdAt,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) String createdBy,
         @JsonView({View.Public.class}) @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKeyUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderApiKeyUpdate.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 
@@ -27,7 +28,11 @@ public record ProviderApiKeyUpdate(
         @JsonView({ProviderApiKey.View.Public.class, ProviderApiKey.View.Write.class}) Map<String, String> headers,
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) Map<String, String> configuration,
-        @JsonView({ProviderApiKey.View.Public.class, ProviderApiKey.View.Write.class}) String baseUrl) {
+        @JsonView({ProviderApiKey.View.Public.class, ProviderApiKey.View.Write.class}) String baseUrl,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Valid @Schema(description = "Dynamic token auth recipe. Send the '"
+                        + ProviderAuthConfig.SECRET_SENTINEL
+                        + "' sentinel as a credential value to keep the stored secret; send an empty object to clear the auth config.") ProviderAuthConfig authConfig) {
 
     @Override
     public String toString() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthCheck.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api;
 
+import com.comet.opik.api.validation.ProviderAuthCheckValidation;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -18,6 +19,7 @@ import java.util.UUID;
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@ProviderAuthCheckValidation
 public record ProviderAuthCheck(
         @Schema(description = "Test the stored auth config of this provider; also the sentinel-resolution target when auth_config is sent") UUID providerId,
         @Valid @Schema(description = "Auth config to test as-submitted; omit to test the stored one") ProviderAuthConfig authConfig) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthCheck.java
@@ -1,0 +1,31 @@
+package com.comet.opik.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import lombok.Builder;
+
+import java.util.UUID;
+
+/**
+ * Test-connection request for a provider's dynamic token auth. Two modes, both executed by the
+ * backend: by {@code provider_id} alone the stored recipe is used (secrets never transit the
+ * browser); with an {@code auth_config} the submitted values are used, resolving
+ * {@code __SECRET__} sentinels against the stored recipe when {@code provider_id} is also given.
+ */
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ProviderAuthCheck(
+        @Schema(description = "Test the stored auth config of this provider; also the sentinel-resolution target when auth_config is sent") UUID providerId,
+        @Valid @Schema(description = "Auth config to test as-submitted; omit to test the stored one") ProviderAuthConfig authConfig) {
+
+    @Builder(toBuilder = true)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Result(
+            @Schema(description = "Lifetime of the fetched token in seconds; the token itself is never returned") long lifetimeSeconds) {
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -64,6 +64,15 @@ public record ProviderAuthConfig(
         public String toString() {
             return "Credential{key='" + key + "', value='*******', secret=" + secret + '}';
         }
+
+        // Hand-declared so Lombok skips its generated toString(), which would print the
+        // plaintext value — reachable via toBuilder() in mask() and the sentinel merge
+        public static class CredentialBuilder {
+            @Override
+            public String toString() {
+                return "CredentialBuilder{key='" + key + "', value='*******', secret=" + secret + '}';
+            }
+        }
     }
 
     @Getter

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -45,7 +45,7 @@ public record ProviderAuthConfig(
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token lifetime in seconds in the reply; dot-path for nested replies", example = "expires_in") String expiresField,
         @JsonView({ProviderApiKey.View.Public.class,
-                ProviderApiKey.View.Write.class}) @Min(0) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one; 0 forces a fetch per call") Long fallbackTtlSeconds) {
+                ProviderApiKey.View.Write.class}) @Min(0) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one; 0 means such tokens are not cached (fetched per call)") Long fallbackTtlSeconds) {
 
     public static final String SECRET_SENTINEL = "__SECRET__";
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -1,0 +1,141 @@
+package com.comet.opik.api;
+
+import com.comet.opik.utils.ValidationUtils;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonView;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Recipe describing how to fetch a short-lived bearer token before calling a custom LLM provider.
+ * Stored as a single AES-GCM-encrypted JSON document in {@code llm_provider_api_key.auth_config};
+ * a row without one behaves exactly as before (static api_key auth).
+ */
+@Builder(toBuilder = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ProviderAuthConfig(
+        @JsonView({
+                ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Schema(description = "Auth service URL the credentials are sent to", example = "https://developer.api.example.com/authentication/v1/token") String tokenUrl,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Schema(description = "How credentials are sent: form body (default), JSON body, or basic auth (id/secret in an HTTP Basic header, remaining fields in the form body)") SendAs sendAs,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Valid @Schema(description = "Fields sent to the token URL. Values flagged as secret are write-only: they read back as the '"
+                        + ProviderAuthConfig.SECRET_SENTINEL + "' sentinel") List<Credential> credentials,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token in the reply; dot-path for nested replies", example = "access_token") String tokenField,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token lifetime in seconds in the reply; dot-path for nested replies", example = "expires_in") String expiresField,
+        @JsonView({ProviderApiKey.View.Public.class,
+                ProviderApiKey.View.Write.class}) @Min(0) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one; 0 forces a fetch per call") Long fallbackTtlSeconds) {
+
+    public static final String SECRET_SENTINEL = "__SECRET__";
+
+    @Builder(toBuilder = true)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+    public record Credential(
+            @JsonView({
+                    ProviderApiKey.View.Public.class,
+                    ProviderApiKey.View.Write.class}) @NotBlank @Size(max = 250) String key,
+            @JsonView({ProviderApiKey.View.Public.class, ProviderApiKey.View.Write.class}) String value,
+            @JsonView({ProviderApiKey.View.Public.class,
+                    ProviderApiKey.View.Write.class}) @Schema(description = "Secret values are encrypted at rest and never read back; once true it cannot be unset") boolean secret) {
+
+        @Override
+        public String toString() {
+            return "Credential{key='" + key + "', value='*******', secret=" + secret + '}';
+        }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public enum SendAs {
+        FORM("form"),
+        JSON("json"),
+        BASIC("basic"),
+        ;
+
+        @JsonValue
+        private final String value;
+
+        @JsonCreator
+        public static SendAs fromString(String value) {
+            return Arrays.stream(values())
+                    .filter(sendAs -> sendAs.value.equals(value))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("Unknown send_as '%s'".formatted(value)));
+        }
+    }
+
+    /**
+     * An empty object ({@code {}}) is the API convention for clearing the auth config on update,
+     * mirroring how an empty headers map clears headers.
+     */
+    @JsonIgnore
+    public boolean isEmpty() {
+        return StringUtils.isBlank(tokenUrl) && CollectionUtils.isEmpty(credentials);
+    }
+
+    /**
+     * Requiredness rules shared by the create validator and the update path. Field-level Jakarta
+     * annotations can't carry these because the empty clear-object must pass bean validation.
+     */
+    @JsonIgnore
+    public List<String> validationErrors() {
+        var errors = new ArrayList<String>();
+        if (!ValidationUtils.isAbsoluteUri(tokenUrl)) {
+            errors.add("auth_config.token_url must be a valid absolute URI");
+        }
+        if (CollectionUtils.isEmpty(credentials)) {
+            errors.add("auth_config.credentials must not be empty");
+        }
+        return errors;
+    }
+
+    /**
+     * Copy safe to return from the API: secret values are replaced with {@link #SECRET_SENTINEL}.
+     */
+    public ProviderAuthConfig mask() {
+        if (CollectionUtils.isEmpty(credentials)) {
+            return this;
+        }
+        return toBuilder()
+                .credentials(credentials.stream()
+                        .map(credential -> credential.secret()
+                                ? credential.toBuilder().value(SECRET_SENTINEL).build()
+                                : credential)
+                        .toList())
+                .build();
+    }
+
+    @Override
+    public String toString() {
+        return "ProviderAuthConfig{" +
+                "tokenUrl='" + tokenUrl + '\'' +
+                ", sendAs=" + sendAs +
+                ", credentials=" + credentials +
+                ", tokenField='" + tokenField + '\'' +
+                ", expiresField='" + expiresField + '\'' +
+                ", fallbackTtlSeconds=" + fallbackTtlSeconds +
+                '}';
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -17,7 +17,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,6 +47,7 @@ public record ProviderAuthConfig(
                 ProviderApiKey.View.Write.class}) @Min(0) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one; 0 means such tokens are not cached (fetched per call)") Long fallbackTtlSeconds) {
 
     public static final String SECRET_SENTINEL = "__SECRET__";
+    private static final ProviderAuthConfig EMPTY = ProviderAuthConfig.builder().build();
 
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -87,12 +87,12 @@ public record ProviderAuthConfig(
     }
 
     /**
-     * An empty object ({@code {}}) is the API convention for clearing the auth config on update,
-     * mirroring how an empty headers map clears headers.
+     * A literal empty object ({@code {}}) is the API convention for clearing the auth config on
+     * update, mirroring how an empty headers map clears headers.
      */
     @JsonIgnore
     public boolean isEmpty() {
-        return StringUtils.isBlank(tokenUrl) && CollectionUtils.isEmpty(credentials);
+        return equals(EMPTY);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -1,6 +1,5 @@
 package com.comet.opik.api;
 
-import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -19,7 +18,6 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -38,14 +36,14 @@ public record ProviderAuthConfig(
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) @Schema(description = "How credentials are sent: form body (default), JSON body, or basic auth (id/secret in an HTTP Basic header, remaining fields in the form body)") SendAs sendAs,
         @JsonView({ProviderApiKey.View.Public.class,
-                ProviderApiKey.View.Write.class}) @Valid @Schema(description = "Fields sent to the token URL. Values flagged as secret are write-only: they read back as the '"
+                ProviderApiKey.View.Write.class}) @Valid @Size(max = 20) @Schema(description = "Fields sent to the token URL. Values flagged as secret are write-only: they read back as the '"
                         + ProviderAuthConfig.SECRET_SENTINEL + "' sentinel") List<Credential> credentials,
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token in the reply; dot-path for nested replies", example = "access_token") String tokenField,
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token lifetime in seconds in the reply; dot-path for nested replies", example = "expires_in") String expiresField,
         @JsonView({ProviderApiKey.View.Public.class,
-                ProviderApiKey.View.Write.class}) @Min(0) @Max(31_536_000) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one, capped at one year; 0 means such tokens are not cached (fetched per call)") Long fallbackTtlSeconds) {
+                ProviderApiKey.View.Write.class}) @Min(0) @Max(31_536_000) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one, capped at one year; 0 disables caching for such replies. A reply-stated lifetime always wins") Long fallbackTtlSeconds) {
 
     public static final String SECRET_SENTINEL = "__SECRET__";
     private static final ProviderAuthConfig EMPTY = ProviderAuthConfig.builder().build();
@@ -57,7 +55,8 @@ public record ProviderAuthConfig(
             @JsonView({
                     ProviderApiKey.View.Public.class,
                     ProviderApiKey.View.Write.class}) @NotBlank @Size(max = 250) String key,
-            @JsonView({ProviderApiKey.View.Public.class, ProviderApiKey.View.Write.class}) String value,
+            @JsonView({ProviderApiKey.View.Public.class,
+                    ProviderApiKey.View.Write.class}) @Size(max = 2000) String value,
             @JsonView({ProviderApiKey.View.Public.class,
                     ProviderApiKey.View.Write.class}) @Schema(description = "Secret values are encrypted at rest and never read back; once true it cannot be unset") boolean secret) {
 
@@ -94,22 +93,6 @@ public record ProviderAuthConfig(
     @JsonIgnore
     public boolean isEmpty() {
         return equals(EMPTY);
-    }
-
-    /**
-     * Requiredness rules shared by the create validator and the update path. Field-level Jakarta
-     * annotations can't carry these because the empty clear-object must pass bean validation.
-     */
-    @JsonIgnore
-    public List<String> validationErrors() {
-        var errors = new ArrayList<String>();
-        if (!ValidationUtils.isAbsoluteUri(tokenUrl)) {
-            errors.add("auth_config.token_url must be a valid absolute URI");
-        }
-        if (CollectionUtils.isEmpty(credentials)) {
-            errors.add("auth_config.credentials must not be empty");
-        }
-        return errors;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/ProviderAuthConfig.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -44,7 +45,7 @@ public record ProviderAuthConfig(
         @JsonView({ProviderApiKey.View.Public.class,
                 ProviderApiKey.View.Write.class}) @Size(max = 250) @Schema(description = "Field holding the token lifetime in seconds in the reply; dot-path for nested replies", example = "expires_in") String expiresField,
         @JsonView({ProviderApiKey.View.Public.class,
-                ProviderApiKey.View.Write.class}) @Min(0) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one; 0 means such tokens are not cached (fetched per call)") Long fallbackTtlSeconds) {
+                ProviderApiKey.View.Write.class}) @Min(0) @Max(31_536_000) @Schema(description = "Lifetime in seconds assumed when the reply doesn't state one, capped at one year; 0 means such tokens are not cached (fetched per call)") Long fallbackTtlSeconds) {
 
     public static final String SECRET_SENTINEL = "__SECRET__";
     private static final ProviderAuthConfig EMPTY = ProviderAuthConfig.builder().build();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -135,7 +135,7 @@ public class LlmProviderApiKeyResource {
     @PATCH
     @Path("{id}")
     @RequiredPermissions(WorkspaceUserPermission.AI_PROVIDER_UPDATE)
-    @Operation(operationId = "updateLlmProviderApiKey", summary = "Update LLM Provider's ApiKey", description = "Update LLM Provider's ApiKey", responses = {
+    @Operation(operationId = "updateLlmProviderApiKey", summary = "Update LLM Provider's ApiKey", description = "Update LLM Provider's ApiKey. api_key and auth_config are mutually exclusive: setting a valid auth_config on a provider that holds a static api_key clears the stored key; send auth_config as an empty object to clear the recipe and switch back to a static key", responses = {
             @ApiResponse(responseCode = "204", description = "No Content"),
             @ApiResponse(responseCode = "401", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
             @ApiResponse(responseCode = "403", description = "Access forbidden", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -161,7 +161,8 @@ public class LlmProviderApiKeyResource {
             +
             "Send provider_id to test the stored config, auth_config to test submitted values, or both to resolve secret sentinels against the stored config.", responses = {
                     @ApiResponse(responseCode = "200", description = "Token fetched", content = @Content(schema = @Schema(implementation = ProviderAuthCheck.Result.class))),
-                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "400", description = "Bad Request — the token fetch itself failed (unreachable URL, rejected credentials, malformed reply)", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "422", description = "Unprocessable Content — the request is invalid (neither provider_id nor auth_config, or an invalid auth_config)", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "403", description = "Access forbidden", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
                     @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
             })

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.v1.priv;
 
 import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.BatchDelete;
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
 import com.comet.opik.api.ProviderAuthCheck;
@@ -74,7 +75,7 @@ public class LlmProviderApiKeyResource {
                                 ? maskApiKey(decrypt(providerApiKey.apiKey()))
                                 : "null")
                         .authConfig(providerApiKey.authConfig() != null
-                                ? providerApiKey.authConfig().mask()
+                                ? EncryptedAuthConfig.of(providerApiKey.authConfig().value().mask())
                                 : null)
                         .build())
                 .toList();
@@ -106,7 +107,9 @@ public class LlmProviderApiKeyResource {
 
         return Response.ok().entity(providerApiKey.toBuilder()
                 .apiKey(providerApiKey.apiKey() != null ? maskApiKey(decrypt(providerApiKey.apiKey())) : null)
-                .authConfig(providerApiKey.authConfig() != null ? providerApiKey.authConfig().mask() : null)
+                .authConfig(providerApiKey.authConfig() != null
+                        ? EncryptedAuthConfig.of(providerApiKey.authConfig().value().mask())
+                        : null)
                 .build()).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -4,11 +4,13 @@ import com.codahale.metrics.annotation.Timed;
 import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthCheck;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.domain.LlmProviderApiKeyService;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.RequiredPermissions;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -149,6 +151,30 @@ public class LlmProviderApiKeyResource {
         log.info("Updated api key for LLM provider with id '{}' on workspaceId '{}'", id, workspaceId);
 
         return Response.noContent().build();
+    }
+
+    @POST
+    @Path("/auth-config/test")
+    @RateLimited
+    @RequiredPermissions(WorkspaceUserPermission.AI_PROVIDER_UPDATE)
+    @Operation(operationId = "testLlmProviderAuthConfig", summary = "Test a provider's dynamic token auth", description = "Runs the token fetch once, backend-side, and reports the token lifetime. The token itself is never returned. "
+            +
+            "Send provider_id to test the stored config, auth_config to test submitted values, or both to resolve secret sentinels against the stored config.", responses = {
+                    @ApiResponse(responseCode = "200", description = "Token fetched", content = @Content(schema = @Schema(implementation = ProviderAuthCheck.Result.class))),
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "403", description = "Access forbidden", content = @Content(schema = @Schema(implementation = ErrorMessage.class))),
+                    @ApiResponse(responseCode = "404", description = "Not found", content = @Content(schema = @Schema(implementation = ErrorMessage.class)))
+            })
+    public Response testAuthConfig(
+            @NotNull @RequestBody(content = @Content(schema = @Schema(implementation = ProviderAuthCheck.class))) @Valid ProviderAuthCheck providerAuthTest) {
+        String workspaceId = requestContext.get().getWorkspaceId();
+
+        log.info("Testing LLM provider auth config on workspace_id '{}'", workspaceId);
+        ProviderAuthCheck.Result result = llmProviderApiKeyService.testAuthConfig(providerAuthTest, workspaceId);
+        log.info("Tested LLM provider auth config on workspace_id '{}': token received, lifetime '{}'s",
+                workspaceId, result.lifetimeSeconds());
+
+        return Response.ok(result).build();
     }
 
     @POST

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResource.java
@@ -71,6 +71,9 @@ public class LlmProviderApiKeyResource {
                         .apiKey(providerApiKey.apiKey() != null
                                 ? maskApiKey(decrypt(providerApiKey.apiKey()))
                                 : "null")
+                        .authConfig(providerApiKey.authConfig() != null
+                                ? providerApiKey.authConfig().mask()
+                                : null)
                         .build())
                 .toList();
 
@@ -101,6 +104,7 @@ public class LlmProviderApiKeyResource {
 
         return Response.ok().entity(providerApiKey.toBuilder()
                 .apiKey(providerApiKey.apiKey() != null ? maskApiKey(decrypt(providerApiKey.apiKey())) : null)
+                .authConfig(providerApiKey.authConfig() != null ? providerApiKey.authConfig().mask() : null)
                 .build()).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
@@ -44,9 +44,9 @@ public class ProviderApiKeyValidator
             return isValidAuthConfig(providerApiKey, context);
         }
 
-        if (providerApiKey.authConfig() != null) {
+        if (providerApiKey.authConfig() != null && !provider.supportsDynamicTokenAuth()) {
             context.buildConstraintViolationWithTemplate(
-                    "auth_config is only supported for providers with provider_name (custom LLM, Bedrock, Ollama)")
+                    "auth_config is only supported for custom LLM, Bedrock, and Ollama providers")
                     .addPropertyNode("authConfig")
                     .addConstraintViolation();
             return false;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
@@ -70,7 +70,7 @@ public class ProviderApiKeyValidator
         }
 
         boolean valid = true;
-        for (String error : authConfig.validationErrors()) {
+        for (String error : ProviderAuthConfigValidator.validationErrors(authConfig)) {
             context.buildConstraintViolationWithTemplate(error)
                     .addPropertyNode("authConfig")
                     .addConstraintViolation();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
@@ -1,9 +1,13 @@
 package com.comet.opik.api.validation;
 
 import com.comet.opik.api.ProviderApiKey;
+import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.List;
+import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -37,7 +41,15 @@ public class ProviderApiKeyValidator
             }
 
             // If provider supports naming, no need to validate api key
-            return true;
+            return isValidAuthConfig(providerApiKey, context);
+        }
+
+        if (providerApiKey.authConfig() != null) {
+            context.buildConstraintViolationWithTemplate(
+                    "auth_config is only supported for providers with provider_name (custom LLM, Bedrock, Ollama)")
+                    .addPropertyNode("authConfig")
+                    .addConstraintViolation();
+            return false;
         }
 
         // Validate API key for non-custom providers
@@ -49,5 +61,41 @@ public class ProviderApiKeyValidator
         }
 
         return true;
+    }
+
+    private boolean isValidAuthConfig(ProviderApiKey providerApiKey, ConstraintValidatorContext context) {
+        var authConfig = providerApiKey.authConfig();
+        if (authConfig == null) {
+            return true;
+        }
+
+        boolean valid = true;
+        for (String error : authConfig.validationErrors()) {
+            context.buildConstraintViolationWithTemplate(error)
+                    .addPropertyNode("authConfig")
+                    .addConstraintViolation();
+            valid = false;
+        }
+
+        // The sentinel means "keep the stored secret" — meaningless on create, where nothing is stored yet
+        boolean hasSentinel = Optional.ofNullable(authConfig.credentials()).orElse(List.of()).stream()
+                .anyMatch(credential -> ProviderAuthConfig.SECRET_SENTINEL.equals(credential.value()));
+        if (hasSentinel) {
+            context.buildConstraintViolationWithTemplate(
+                    "auth_config credential values must not be the '%s' sentinel on create"
+                            .formatted(ProviderAuthConfig.SECRET_SENTINEL))
+                    .addPropertyNode("authConfig")
+                    .addConstraintViolation();
+            valid = false;
+        }
+
+        if (providerApiKey.apiKey() != null && !isBlank(EncryptionUtils.decrypt(providerApiKey.apiKey()))) {
+            context.buildConstraintViolationWithTemplate("api_key must not be set when auth_config is set")
+                    .addPropertyNode("apiKey")
+                    .addConstraintViolation();
+            valid = false;
+        }
+
+        return valid;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderApiKeyValidator.java
@@ -64,10 +64,10 @@ public class ProviderApiKeyValidator
     }
 
     private boolean isValidAuthConfig(ProviderApiKey providerApiKey, ConstraintValidatorContext context) {
-        var authConfig = providerApiKey.authConfig();
-        if (authConfig == null) {
+        if (providerApiKey.authConfig() == null) {
             return true;
         }
+        var authConfig = providerApiKey.authConfig().value();
 
         boolean valid = true;
         for (String error : ProviderAuthConfigValidator.validationErrors(authConfig)) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthCheckValidation.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthCheckValidation.java
@@ -1,0 +1,24 @@
+package com.comet.opik.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = {ProviderAuthCheckValidator.class})
+@Documented
+public @interface ProviderAuthCheckValidation {
+
+    String message() default "invalid auth check request";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthCheckValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthCheckValidator.java
@@ -1,0 +1,35 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.ProviderAuthCheck;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Request-only rules of the auth-config test endpoint. What stays in the service is the pair
+ * that reads the DB: "the provider has no auth_config to test" and the secret-sentinel merge.
+ */
+public class ProviderAuthCheckValidator implements ConstraintValidator<ProviderAuthCheckValidation, ProviderAuthCheck> {
+
+    @Override
+    public boolean isValid(ProviderAuthCheck request, ConstraintValidatorContext context) {
+        context.disableDefaultConstraintViolation();
+
+        var authConfig = request.authConfig();
+        if ((authConfig == null || authConfig.isEmpty()) && request.providerId() == null) {
+            context.buildConstraintViolationWithTemplate("either provider_id or auth_config must be provided")
+                    .addConstraintViolation();
+            return false;
+        }
+
+        if (authConfig != null && !authConfig.isEmpty()) {
+            var errors = ProviderAuthConfigValidator.validationErrors(authConfig);
+            if (!errors.isEmpty()) {
+                errors.forEach(error -> context.buildConstraintViolationWithTemplate(error)
+                        .addPropertyNode("authConfig")
+                        .addConstraintViolation());
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
@@ -7,7 +7,9 @@ import org.apache.commons.collections4.CollectionUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Requiredness rules for {@link ProviderAuthConfig}, shared by the create validator and the
@@ -31,6 +33,14 @@ public final class ProviderAuthConfigValidator {
         }
         if (CollectionUtils.isEmpty(authConfig.credentials())) {
             errors.add("auth_config.credentials must not be empty");
+        } else {
+            Set<String> seen = new HashSet<>();
+            authConfig.credentials().stream()
+                    .map(ProviderAuthConfig.Credential::key)
+                    .filter(key -> !seen.add(key))
+                    .distinct()
+                    .forEach(duplicate -> errors
+                            .add("auth_config.credentials contains duplicate key '%s'".formatted(duplicate)));
         }
         return errors;
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
@@ -26,9 +26,12 @@ public final class ProviderAuthConfigValidator {
         if (!ValidationUtils.isAbsoluteUri(authConfig.tokenUrl())) {
             errors.add("auth_config.token_url must be a valid absolute URI");
         } else {
-            String scheme = URI.create(authConfig.tokenUrl()).getScheme();
+            URI uri = URI.create(authConfig.tokenUrl());
+            String scheme = uri.getScheme();
             if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
                 errors.add("auth_config.token_url must use http or https");
+            } else if (uri.getHost() == null) {
+                errors.add("auth_config.token_url must include a host");
             }
         }
         if (CollectionUtils.isEmpty(authConfig.credentials())) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/ProviderAuthConfigValidator.java
@@ -1,0 +1,37 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.utils.ValidationUtils;
+import lombok.NonNull;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Requiredness rules for {@link ProviderAuthConfig}, shared by the create validator and the
+ * update/test paths. Field-level Jakarta annotations can't carry these because the empty
+ * clear-object ({@code {}}) must pass bean validation.
+ */
+public final class ProviderAuthConfigValidator {
+
+    private ProviderAuthConfigValidator() {
+    }
+
+    public static List<String> validationErrors(@NonNull ProviderAuthConfig authConfig) {
+        var errors = new ArrayList<String>();
+        if (!ValidationUtils.isAbsoluteUri(authConfig.tokenUrl())) {
+            errors.add("auth_config.token_url must be a valid absolute URI");
+        } else {
+            String scheme = URI.create(authConfig.tokenUrl()).getScheme();
+            if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+                errors.add("auth_config.token_url must use http or https");
+            }
+        }
+        if (CollectionUtils.isEmpty(authConfig.credentials())) {
+            errors.add("auth_config.credentials must not be empty");
+        }
+        return errors;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
 import com.comet.opik.api.ProviderAuthConfig;
@@ -71,6 +72,11 @@ public interface LlmProviderApiKeyDAO {
     @SqlQuery("SELECT * FROM llm_provider_api_key " +
             " WHERE workspace_id = :workspaceId ")
     List<ProviderApiKey> find(@Bind("workspaceId") String workspaceId);
+
+    @SqlQuery("SELECT * FROM llm_provider_api_key " +
+            " WHERE workspace_id = :workspaceId AND provider IN (<providers>) ")
+    List<ProviderApiKey> findByProviders(@Bind("workspaceId") String workspaceId,
+            @BindList("providers") Set<LlmProvider> providers);
 
     @SqlUpdate("DELETE FROM llm_provider_api_key WHERE id IN (<ids>) AND workspace_id = :workspaceId")
     void delete(@BindList("ids") Set<UUID> ids, @Bind("workspaceId") String workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
@@ -2,7 +2,9 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.infrastructure.db.MapFlatArgumentFactory;
+import com.comet.opik.infrastructure.db.ProviderAuthConfigArgumentFactory;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterColumnMapper;
@@ -21,14 +23,15 @@ import java.util.UUID;
 @RegisterRowMapper(ProviderApiKeyRowMapper.class)
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 @RegisterArgumentFactory(MapFlatArgumentFactory.class)
+@RegisterArgumentFactory(ProviderAuthConfigArgumentFactory.class)
 @RegisterColumnMapper(MapFlatArgumentFactory.class)
 public interface LlmProviderApiKeyDAO {
 
     String NULL_SENTINEL = "__NULL__";
 
-    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, provider_name, created_by, last_updated_by, headers, base_url, configuration) "
+    @SqlUpdate("INSERT INTO llm_provider_api_key (id, provider, workspace_id, api_key, name, provider_name, created_by, last_updated_by, headers, base_url, configuration, auth_config) "
             +
-            "VALUES (:bean.id, :bean.provider, :workspaceId, :bean.apiKey, :bean.name, :providerName, :bean.createdBy, :bean.lastUpdatedBy, :bean.headers, :bean.baseUrl, :bean.configuration)")
+            "VALUES (:bean.id, :bean.provider, :workspaceId, :bean.apiKey, :bean.name, :providerName, :bean.createdBy, :bean.lastUpdatedBy, :bean.headers, :bean.baseUrl, :bean.configuration, :bean.authConfig)")
     void saveInternal(@Bind("workspaceId") String workspaceId,
             @Bind("providerName") String providerName,
             @BindMethods("bean") ProviderApiKey providerApiKey);
@@ -50,12 +53,17 @@ public interface LlmProviderApiKeyDAO {
             "headers = CASE WHEN :bean.headers IS NULL THEN headers ELSE :bean.headers END, " +
             "base_url = CASE WHEN :bean.baseUrl IS NULL THEN base_url ELSE :bean.baseUrl END, " +
             "configuration = CASE WHEN :bean.configuration IS NULL THEN configuration ELSE :bean.configuration END, " +
+            "auth_config = CASE WHEN :clearAuthConfig THEN NULL " +
+            "WHEN :authConfig IS NULL THEN auth_config " +
+            "ELSE :authConfig END, " +
             "last_updated_by = :lastUpdatedBy " +
             "WHERE id = :id AND workspace_id = :workspaceId")
     void update(@Bind("id") UUID id,
             @Bind("workspaceId") String workspaceId,
             @Bind("lastUpdatedBy") String lastUpdatedBy,
-            @BindMethods("bean") ProviderApiKeyUpdate providerApiKeyUpdate);
+            @BindMethods("bean") ProviderApiKeyUpdate providerApiKeyUpdate,
+            @Bind("clearAuthConfig") boolean clearAuthConfig,
+            @Bind("authConfig") ProviderAuthConfig authConfig);
 
     @SqlQuery("SELECT * FROM llm_provider_api_key WHERE id = :id AND workspace_id = :workspaceId")
     ProviderApiKey findById(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyDAO.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
 import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.infrastructure.db.EncryptedAuthConfigArgumentFactory;
 import com.comet.opik.infrastructure.db.MapFlatArgumentFactory;
 import com.comet.opik.infrastructure.db.ProviderAuthConfigArgumentFactory;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
@@ -25,6 +26,7 @@ import java.util.UUID;
 @RegisterArgumentFactory(UUIDArgumentFactory.class)
 @RegisterArgumentFactory(MapFlatArgumentFactory.class)
 @RegisterArgumentFactory(ProviderAuthConfigArgumentFactory.class)
+@RegisterArgumentFactory(EncryptedAuthConfigArgumentFactory.class)
 @RegisterColumnMapper(MapFlatArgumentFactory.class)
 public interface LlmProviderApiKeyDAO {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -45,6 +45,8 @@ public interface LlmProviderApiKeyService {
 
     ProviderApiKey.ProviderApiKeyPage find(String workspaceId);
 
+    List<ProviderApiKey> findByProviders(String workspaceId, Set<LlmProvider> providers);
+
     ProviderApiKey saveApiKey(ProviderApiKey providerApiKey, String userName, String workspaceId);
 
     void updateApiKey(UUID id, ProviderApiKeyUpdate providerApiKeyUpdate, String userName, String workspaceId);
@@ -73,6 +75,18 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
             var repository = handle.attach(LlmProviderApiKeyDAO.class);
 
             return repository.fetch(id, workspaceId).orElseThrow(this::createNotFoundError);
+        });
+    }
+
+    /**
+     * Narrow read for the LLM request path: only the candidate provider types are loaded, so the
+     * row mapper never decrypts the auth_config of providers that can't match the request.
+     */
+    @Override
+    public List<ProviderApiKey> findByProviders(@NonNull String workspaceId, @NonNull Set<LlmProvider> providers) {
+        return template.inTransaction(READ_ONLY, handle -> {
+            var repository = handle.attach(LlmProviderApiKeyDAO.class);
+            return repository.findByProviders(workspaceId, providers);
         });
     }
 
@@ -232,8 +246,9 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         if (incoming.isEmpty()) {
             return new AuthConfigUpdate(true, null);
         }
-        if (!stored.provider().supportsProviderName()) {
-            throw new BadRequestException("auth_config is only supported for providers with provider_name");
+        if (!stored.provider().supportsDynamicTokenAuth()) {
+            throw new BadRequestException(
+                    "auth_config is only supported for custom LLM, Bedrock, and Ollama providers");
         }
         var errors = ProviderAuthConfigValidator.validationErrors(incoming);
         if (!errors.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -200,12 +200,14 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         }
     }
 
+    /**
+     * Request-only validation (provider_id-or-auth_config, recipe validity) lives in
+     * {@link com.comet.opik.api.validation.ProviderAuthCheckValidator} at the API boundary; only
+     * the rules that read the DB remain here.
+     */
     private ProviderAuthConfig resolveAuthConfigForTest(ProviderAuthCheck request, String workspaceId) {
         ProviderAuthConfig incoming = request.authConfig();
         if (incoming == null || incoming.isEmpty()) {
-            if (request.providerId() == null) {
-                throw new BadRequestException("either provider_id or auth_config must be provided");
-            }
             ProviderAuthConfig stored = find(request.providerId(), workspaceId).authConfig();
             if (stored == null) {
                 throw new BadRequestException("the provider has no auth_config to test");
@@ -213,23 +215,12 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
             return stored;
         }
 
-        var errors = ProviderAuthConfigValidator.validationErrors(incoming);
-        if (!errors.isEmpty()) {
-            throw new BadRequestException(String.join("; ", errors));
-        }
         ProviderAuthConfig stored = request.providerId() != null
                 ? find(request.providerId(), workspaceId).authConfig()
                 : null;
         return mergeSecretSentinels(incoming, stored);
     }
 
-    /**
-     * The resolved auth_config decision plus the effective update to persist. The api_key /
-     * auth_config mutual exclusion is enforced entirely inside
-     * {@link #resolveAuthConfigUpdate}: it both validates the incoming pair and blanks the
-     * stored key when the update switches to token auth, so callers persist
-     * {@code effectiveUpdate} as-is and cannot hold the invariant wrong.
-     */
     private record AuthConfigUpdate(ProviderApiKeyUpdate effectiveUpdate, boolean clear,
             ProviderAuthConfig authConfig) {
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -176,15 +176,10 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
 
             var authConfigUpdate = resolveAuthConfigUpdate(providerApiKeyUpdate, providerApiKey);
 
-            var update = providerApiKeyUpdate;
-            if (authConfigUpdate.authConfig() != null && update.apiKey() == null) {
-                update = update.toBuilder().apiKey(EncryptionUtils.encrypt("")).build();
-            }
-
             repository.update(providerApiKey.id(),
                     workspaceId,
                     userName,
-                    update,
+                    authConfigUpdate.effectiveUpdate(),
                     authConfigUpdate.clear(),
                     authConfigUpdate.authConfig());
 
@@ -228,7 +223,15 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         return mergeSecretSentinels(incoming, stored);
     }
 
-    private record AuthConfigUpdate(boolean clear, ProviderAuthConfig authConfig) {
+    /**
+     * The resolved auth_config decision plus the effective update to persist. The api_key /
+     * auth_config mutual exclusion is enforced entirely inside
+     * {@link #resolveAuthConfigUpdate}: it both validates the incoming pair and blanks the
+     * stored key when the update switches to token auth, so callers persist
+     * {@code effectiveUpdate} as-is and cannot hold the invariant wrong.
+     */
+    private record AuthConfigUpdate(ProviderApiKeyUpdate effectiveUpdate, boolean clear,
+            ProviderAuthConfig authConfig) {
     }
 
     /**
@@ -241,10 +244,10 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         if (incoming == null) {
             validateNoStaticKeyConflict(
                     update.apiKey() != null ? update.apiKey() : stored.apiKey(), stored.authConfig());
-            return new AuthConfigUpdate(false, null);
+            return new AuthConfigUpdate(update, false, null);
         }
         if (incoming.isEmpty()) {
-            return new AuthConfigUpdate(true, null);
+            return new AuthConfigUpdate(update, true, null);
         }
         if (!stored.provider().supportsDynamicTokenAuth()) {
             throw new BadRequestException(
@@ -254,9 +257,15 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         if (!errors.isEmpty()) {
             throw new BadRequestException(String.join("; ", errors));
         }
+        // only an api_key set in this same request conflicts: an update carrying none switches
+        // the provider to token auth, which implicitly clears the stored static key below —
+        // the dialog hides the key field in token mode, so the swap must be self-contained
         validateNoStaticKeyConflict(update.apiKey(), incoming);
         var merged = mergeSecretSentinels(incoming, stored.authConfig());
-        return new AuthConfigUpdate(false, merged);
+        var effectiveUpdate = update.apiKey() == null
+                ? update.toBuilder().apiKey(EncryptionUtils.encrypt("")).build()
+                : update;
+        return new AuthConfigUpdate(effectiveUpdate, false, merged);
     }
 
     private void validateNoStaticKeyConflict(String encryptedApiKey, ProviderAuthConfig authConfig) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -3,17 +3,21 @@ package com.comet.opik.domain;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
+import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
+import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
@@ -23,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.FreeModelConfig.FREE_MODEL_PROVIDER_ID;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
@@ -147,13 +153,90 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
             ProviderApiKey providerApiKey = repository.fetch(id, workspaceId)
                     .orElseThrow(this::createNotFoundError);
 
+            var authConfigUpdate = resolveAuthConfigUpdate(providerApiKeyUpdate, providerApiKey);
+
             repository.update(providerApiKey.id(),
                     workspaceId,
                     userName,
-                    providerApiKeyUpdate);
+                    providerApiKeyUpdate,
+                    authConfigUpdate.clear(),
+                    authConfigUpdate.authConfig());
 
             return null;
         });
+    }
+
+    private record AuthConfigUpdate(boolean clear, ProviderAuthConfig authConfig) {
+    }
+
+    /**
+     * Maps the update's auth_config to the DAO binds: absent -> keep (null value, no clear),
+     * empty object -> clear, otherwise validate + resolve {@code __SECRET__} sentinels against
+     * the stored recipe -> set.
+     */
+    private AuthConfigUpdate resolveAuthConfigUpdate(ProviderApiKeyUpdate update, ProviderApiKey stored) {
+        ProviderAuthConfig incoming = update.authConfig();
+        if (incoming == null) {
+            validateNoStaticKeyConflict(
+                    update.apiKey() != null ? update.apiKey() : stored.apiKey(), stored.authConfig());
+            return new AuthConfigUpdate(false, null);
+        }
+        if (incoming.isEmpty()) {
+            return new AuthConfigUpdate(true, null);
+        }
+        if (!stored.provider().supportsProviderName()) {
+            throw new BadRequestException("auth_config is only supported for providers with provider_name");
+        }
+        var errors = incoming.validationErrors();
+        if (!errors.isEmpty()) {
+            throw new BadRequestException(String.join("; ", errors));
+        }
+        validateNoStaticKeyConflict(update.apiKey() != null ? update.apiKey() : stored.apiKey(), incoming);
+        var merged = mergeSecretSentinels(incoming, stored.authConfig());
+        return new AuthConfigUpdate(false, merged);
+    }
+
+    private void validateNoStaticKeyConflict(String encryptedApiKey, ProviderAuthConfig authConfig) {
+        if (authConfig != null && encryptedApiKey != null
+                && StringUtils.isNotBlank(EncryptionUtils.decrypt(encryptedApiKey))) {
+            throw new BadRequestException(
+                    "api_key and auth_config cannot both be set; clear one of them (send auth_config as an empty object to clear it)");
+        }
+    }
+
+    /**
+     * Resolves {@code __SECRET__} sentinel values ("keep the stored secret") and enforces that a
+     * secret flag can never be unset once saved. Sentinels are only accepted where the stored
+     * recipe holds a secret under the same key — so a literal password that happens to look masked
+     * can never be confused with "unchanged".
+     */
+    private ProviderAuthConfig mergeSecretSentinels(ProviderAuthConfig incoming, ProviderAuthConfig stored) {
+        Map<String, ProviderAuthConfig.Credential> storedByKey = stored == null || stored.credentials() == null
+                ? Map.of()
+                : stored.credentials().stream()
+                        .collect(Collectors.toMap(
+                                ProviderAuthConfig.Credential::key, Function.identity(), (first, second) -> second));
+
+        var mergedCredentials = incoming.credentials().stream()
+                .map(credential -> {
+                    var storedCredential = storedByKey.get(credential.key());
+                    boolean lockedInStore = storedCredential != null && storedCredential.secret();
+                    if (ProviderAuthConfig.SECRET_SENTINEL.equals(credential.value())) {
+                        if (!lockedInStore) {
+                            throw new BadRequestException(
+                                    "credential '%s' uses the secret sentinel but no stored secret exists under that key; provide the value"
+                                            .formatted(credential.key()));
+                        }
+                        return credential.toBuilder().value(storedCredential.value()).secret(true).build();
+                    }
+                    // once saved as secret, a credential stays secret
+                    return lockedInStore && !credential.secret()
+                            ? credential.toBuilder().secret(true).build()
+                            : credential;
+                })
+                .toList();
+
+        return incoming.toBuilder().credentials(mergedCredentials).build();
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -7,6 +7,7 @@ import com.comet.opik.api.ProviderAuthCheck;
 import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
+import com.comet.opik.api.validation.ProviderAuthConfigValidator;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.llm.customllm.AuthTokenException;
@@ -161,10 +162,15 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
 
             var authConfigUpdate = resolveAuthConfigUpdate(providerApiKeyUpdate, providerApiKey);
 
+            var update = providerApiKeyUpdate;
+            if (authConfigUpdate.authConfig() != null && update.apiKey() == null) {
+                update = update.toBuilder().apiKey(EncryptionUtils.encrypt("")).build();
+            }
+
             repository.update(providerApiKey.id(),
                     workspaceId,
                     userName,
-                    providerApiKeyUpdate,
+                    update,
                     authConfigUpdate.clear(),
                     authConfigUpdate.authConfig());
 
@@ -198,7 +204,7 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
             return stored;
         }
 
-        var errors = incoming.validationErrors();
+        var errors = ProviderAuthConfigValidator.validationErrors(incoming);
         if (!errors.isEmpty()) {
             throw new BadRequestException(String.join("; ", errors));
         }
@@ -229,11 +235,11 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         if (!stored.provider().supportsProviderName()) {
             throw new BadRequestException("auth_config is only supported for providers with provider_name");
         }
-        var errors = incoming.validationErrors();
+        var errors = ProviderAuthConfigValidator.validationErrors(incoming);
         if (!errors.isEmpty()) {
             throw new BadRequestException(String.join("; ", errors));
         }
-        validateNoStaticKeyConflict(update.apiKey() != null ? update.apiKey() : stored.apiKey(), incoming);
+        validateNoStaticKeyConflict(update.apiKey(), incoming);
         var merged = mergeSecretSentinels(incoming, stored.authConfig());
         return new AuthConfigUpdate(false, merged);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
@@ -29,6 +30,7 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -206,19 +208,25 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
      * the rules that read the DB remain here.
      */
     private ProviderAuthConfig resolveAuthConfigForTest(ProviderAuthCheck request, String workspaceId) {
+        ProviderApiKey storedProvider = request.providerId() != null
+                ? find(request.providerId(), workspaceId)
+                : null;
+        if (storedProvider != null && !storedProvider.provider().supportsDynamicTokenAuth()) {
+            throw new BadRequestException(
+                    "auth_config is only supported for custom LLM, Bedrock, and Ollama providers");
+        }
+
         ProviderAuthConfig incoming = request.authConfig();
         if (incoming == null || incoming.isEmpty()) {
-            ProviderAuthConfig stored = find(request.providerId(), workspaceId).authConfig();
+            EncryptedAuthConfig stored = storedProvider.authConfig();
             if (stored == null) {
                 throw new BadRequestException("the provider has no auth_config to test");
             }
-            return stored;
+            return stored.value();
         }
 
-        ProviderAuthConfig stored = request.providerId() != null
-                ? find(request.providerId(), workspaceId).authConfig()
-                : null;
-        return mergeSecretSentinels(incoming, stored);
+        EncryptedAuthConfig stored = storedProvider == null ? null : storedProvider.authConfig();
+        return mergeSecretSentinels(incoming, stored == null ? null : stored.value());
     }
 
     private record AuthConfigUpdate(ProviderApiKeyUpdate effectiveUpdate, boolean clear,
@@ -234,7 +242,7 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         ProviderAuthConfig incoming = update.authConfig();
         if (incoming == null) {
             validateNoStaticKeyConflict(
-                    update.apiKey() != null ? update.apiKey() : stored.apiKey(), stored.authConfig());
+                    update.apiKey() != null ? update.apiKey() : stored.apiKey(), stored.authConfig() != null);
             return new AuthConfigUpdate(update, false, null);
         }
         if (incoming.isEmpty()) {
@@ -251,16 +259,17 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
         // only an api_key set in this same request conflicts: an update carrying none switches
         // the provider to token auth, which implicitly clears the stored static key below —
         // the dialog hides the key field in token mode, so the swap must be self-contained
-        validateNoStaticKeyConflict(update.apiKey(), incoming);
-        var merged = mergeSecretSentinels(incoming, stored.authConfig());
+        validateNoStaticKeyConflict(update.apiKey(), true);
+        var merged = mergeSecretSentinels(incoming,
+                stored.authConfig() == null ? null : stored.authConfig().value());
         var effectiveUpdate = update.apiKey() == null
                 ? update.toBuilder().apiKey(EncryptionUtils.encrypt("")).build()
                 : update;
         return new AuthConfigUpdate(effectiveUpdate, false, merged);
     }
 
-    private void validateNoStaticKeyConflict(String encryptedApiKey, ProviderAuthConfig authConfig) {
-        if (authConfig != null && encryptedApiKey != null
+    private void validateNoStaticKeyConflict(String encryptedApiKey, boolean authConfigPresent) {
+        if (authConfigPresent && encryptedApiKey != null
                 && StringUtils.isNotBlank(EncryptionUtils.decrypt(encryptedApiKey))) {
             throw new BadRequestException(
                     "api_key and auth_config cannot both be set; clear one of them (send auth_config as an empty object to clear it)");
@@ -274,6 +283,13 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
      * can never be confused with "unchanged".
      */
     private ProviderAuthConfig mergeSecretSentinels(ProviderAuthConfig incoming, ProviderAuthConfig stored) {
+        boolean hasSentinel = incoming.credentials().stream()
+                .anyMatch(credential -> ProviderAuthConfig.SECRET_SENTINEL.equals(credential.value()));
+        if (hasSentinel && stored != null && !Objects.equals(incoming.tokenUrl(), stored.tokenUrl())) {
+            throw new BadRequestException(
+                    "auth_config uses the secret sentinel with a different token_url; changing the destination requires resubmitting full credentials");
+        }
+
         Map<String, ProviderAuthConfig.Credential> storedByKey = stored == null || stored.credentials() == null
                 ? Map.of()
                 : stored.credentials().stream()

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LlmProviderApiKeyService.java
@@ -3,11 +3,14 @@ package com.comet.opik.domain;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthCheck;
 import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.llm.customllm.AuthTokenException;
+import com.comet.opik.infrastructure.llm.customllm.AuthTokenProvider;
 import com.google.inject.ImplementedBy;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -46,6 +49,8 @@ public interface LlmProviderApiKeyService {
     void updateApiKey(UUID id, ProviderApiKeyUpdate providerApiKeyUpdate, String userName, String workspaceId);
 
     void delete(Set<UUID> ids, String workspaceId);
+
+    ProviderAuthCheck.Result testAuthConfig(ProviderAuthCheck request, String workspaceId);
 }
 
 @Slf4j
@@ -57,6 +62,7 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
     private final @NonNull IdGenerator idGenerator;
     private final @NonNull TransactionTemplate template;
     private final @NonNull OpikConfiguration configuration;
+    private final @NonNull AuthTokenProvider authTokenProvider;
 
     @Override
     public ProviderApiKey find(@NonNull UUID id, @NonNull String workspaceId) {
@@ -164,6 +170,42 @@ class LlmProviderApiKeyServiceImpl implements LlmProviderApiKeyService {
 
             return null;
         });
+    }
+
+    @Override
+    public ProviderAuthCheck.Result testAuthConfig(@NonNull ProviderAuthCheck request, @NonNull String workspaceId) {
+        ProviderAuthConfig resolved = resolveAuthConfigForTest(request, workspaceId);
+        try {
+            return new ProviderAuthCheck.Result(authTokenProvider.testFetch(resolved));
+        } catch (AuthTokenException exception) {
+            // the message is user-facing and redacted by contract; a failed test is the caller's
+            // configuration problem, not a server error
+            log.info("Auth config test failed on workspace_id '{}': {}", workspaceId, exception.getMessage());
+            throw new BadRequestException(exception.getMessage());
+        }
+    }
+
+    private ProviderAuthConfig resolveAuthConfigForTest(ProviderAuthCheck request, String workspaceId) {
+        ProviderAuthConfig incoming = request.authConfig();
+        if (incoming == null || incoming.isEmpty()) {
+            if (request.providerId() == null) {
+                throw new BadRequestException("either provider_id or auth_config must be provided");
+            }
+            ProviderAuthConfig stored = find(request.providerId(), workspaceId).authConfig();
+            if (stored == null) {
+                throw new BadRequestException("the provider has no auth_config to test");
+            }
+            return stored;
+        }
+
+        var errors = incoming.validationErrors();
+        if (!errors.isEmpty()) {
+            throw new BadRequestException(String.join("; ", errors));
+        }
+        ProviderAuthConfig stored = request.providerId() != null
+                ? find(request.providerId(), workspaceId).authConfig()
+                : null;
+        return mergeSecretSentinels(incoming, stored);
     }
 
     private record AuthConfigUpdate(boolean clear, ProviderAuthConfig authConfig) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProviderApiKeyRowMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProviderApiKeyRowMapper.java
@@ -1,11 +1,9 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
-import com.comet.opik.api.ProviderAuthConfig;
-import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.db.MapFlatArgumentFactory;
-import com.comet.opik.utils.JsonUtils;
 import lombok.NonNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -39,7 +37,7 @@ public class ProviderApiKeyRowMapper implements RowMapper<ProviderApiKey> {
                 .providerName(providerName)
                 .headers(mapMapper.map(rs, "headers", ctx))
                 .configuration(mapMapper.map(rs, "configuration", ctx))
-                .authConfig(readAuthConfig(rs.getString("auth_config")))
+                .authConfig(EncryptedAuthConfig.fromCiphertext(rs.getString("auth_config")))
                 .baseUrl(rs.getString("base_url"))
                 .createdAt(rs.getTimestamp("created_at").toInstant())
                 .createdBy(rs.getString("created_by"))
@@ -48,10 +46,4 @@ public class ProviderApiKeyRowMapper implements RowMapper<ProviderApiKey> {
                 .build();
     }
 
-    private static ProviderAuthConfig readAuthConfig(String encryptedAuthConfig) {
-        if (encryptedAuthConfig == null) {
-            return null;
-        }
-        return JsonUtils.readValue(EncryptionUtils.decryptGcm(encryptedAuthConfig), ProviderAuthConfig.class);
-    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProviderApiKeyRowMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProviderApiKeyRowMapper.java
@@ -2,7 +2,10 @@ package com.comet.opik.domain;
 
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.ProviderApiKey;
+import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.db.MapFlatArgumentFactory;
+import com.comet.opik.utils.JsonUtils;
 import lombok.NonNull;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -36,11 +39,19 @@ public class ProviderApiKeyRowMapper implements RowMapper<ProviderApiKey> {
                 .providerName(providerName)
                 .headers(mapMapper.map(rs, "headers", ctx))
                 .configuration(mapMapper.map(rs, "configuration", ctx))
+                .authConfig(readAuthConfig(rs.getString("auth_config")))
                 .baseUrl(rs.getString("base_url"))
                 .createdAt(rs.getTimestamp("created_at").toInstant())
                 .createdBy(rs.getString("created_by"))
                 .lastUpdatedAt(rs.getTimestamp("last_updated_at").toInstant())
                 .lastUpdatedBy(rs.getString("last_updated_by"))
                 .build();
+    }
+
+    private static ProviderAuthConfig readAuthConfig(String encryptedAuthConfig) {
+        if (encryptedAuthConfig == null) {
+            return null;
+        }
+        return JsonUtils.readValue(EncryptionUtils.decryptGcm(encryptedAuthConfig), ProviderAuthConfig.class);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EncryptionUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/EncryptionUtils.java
@@ -8,18 +8,27 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.util.Base64;
 
 @UtilityClass
 public class EncryptionUtils {
 
     private static final String ALGO = "AES";
+    // AES-GCM for larger, structured payloads (e.g. auth_config JSON): the legacy no-IV mode is
+    // deterministic, which is acceptable for short random keys but not for predictable plaintext.
+    private static final String GCM_ALGO = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_BITS = 128;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final Base64.Encoder mimeEncoder = Base64.getMimeEncoder();
     private static final Base64.Decoder mimeDecoder = Base64.getMimeDecoder();
     private static Key key;
@@ -50,6 +59,34 @@ public class EncryptionUtils {
             return new String(decValue);
         } catch (BadPaddingException | NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException
                 | IllegalBlockSizeException ex) {
+            throw new SecurityException("Failed to decrypt. " + ex.getMessage(), ex);
+        }
+    }
+
+    public static String encryptGcm(@NonNull String data) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            SECURE_RANDOM.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(GCM_ALGO);
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, iv));
+            byte[] encrypted = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+            byte[] payload = new byte[iv.length + encrypted.length];
+            System.arraycopy(iv, 0, payload, 0, iv.length);
+            System.arraycopy(encrypted, 0, payload, iv.length, encrypted.length);
+            return Base64.getEncoder().encodeToString(payload);
+        } catch (GeneralSecurityException ex) {
+            throw new SecurityException("Failed to encrypt. " + ex.getMessage(), ex);
+        }
+    }
+
+    public static String decryptGcm(@NonNull String encryptedData) {
+        try {
+            byte[] payload = Base64.getDecoder().decode(encryptedData);
+            Cipher cipher = Cipher.getInstance(GCM_ALGO);
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(GCM_TAG_BITS, payload, 0, GCM_IV_LENGTH));
+            byte[] decrypted = cipher.doFinal(payload, GCM_IV_LENGTH, payload.length - GCM_IV_LENGTH);
+            return new String(decrypted, StandardCharsets.UTF_8);
+        } catch (GeneralSecurityException | IllegalArgumentException ex) {
             throw new SecurityException("Failed to decrypt. " + ex.getMessage(), ex);
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
@@ -1,0 +1,43 @@
+package com.comet.opik.infrastructure;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.validation.MinDuration;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tuning for dynamic token auth on custom LLM providers (the {@code auth_config} recipes).
+ */
+@Data
+public class LlmProviderTokenAuthConfig {
+
+    /**
+     * A cached token is refreshed once its remaining lifetime drops below this fraction of the
+     * total lifetime. Proportional rather than absolute so the same default behaves correctly for
+     * a 60-second token and a 25-hour one.
+     */
+    @JsonProperty
+    @DecimalMin("0.0") @DecimalMax("0.99") private double refreshFraction = 0.25;
+
+    @JsonProperty
+    @NotNull @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
+    private Duration fetchTimeout = Duration
+            .seconds(10);
+
+    /**
+     * Lease time for the cross-pod single-flight lock around a token fetch. Must comfortably cover
+     * one fetch, so a pod dying mid-fetch doesn't block the others for long.
+     */
+    @JsonProperty
+    @NotNull @MinDuration(value = 1, unit = TimeUnit.MILLISECONDS)
+    private Duration lockTimeout = Duration.seconds(15);
+
+    @JsonProperty
+    @Min(1) private int maxResponseChars = 1_000_000;
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
@@ -6,6 +6,7 @@ import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -40,7 +41,7 @@ public class LlmProviderTokenAuthConfig {
     private Duration lockTimeout = Duration.seconds(15);
 
     @JsonProperty
-    @Min(1) private int maxResponseChars = 1_000_000;
+    @Min(1) @Max(10_000_000) private int maxResponseChars = 1_000_000;
 
     /**
      * SSRF guard on the token URL: {@code strict} refuses non-HTTPS and private/internal

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/LlmProviderTokenAuthConfig.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure;
 
+import com.comet.opik.infrastructure.net.DestinationGuard;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.util.Duration;
 import io.dropwizard.validation.MinDuration;
@@ -40,4 +41,13 @@ public class LlmProviderTokenAuthConfig {
 
     @JsonProperty
     @Min(1) private int maxResponseChars = 1_000_000;
+
+    /**
+     * SSRF guard on the token URL: {@code strict} refuses non-HTTPS and private/internal
+     * destinations; {@code relaxed} allows internal gateways. Strict by default so a missing
+     * override fails loudly instead of exposing the deployment; the self-hosted distributions
+     * can ship {@code relaxed} explicitly.
+     */
+    @JsonProperty
+    @NotNull private DestinationGuard.Mode destinationGuard = DestinationGuard.Mode.STRICT;
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -77,6 +77,9 @@ public class OpikConfiguration extends JobConfiguration {
     private LlmProviderClientConfig llmProviderClient = new LlmProviderClientConfig();
 
     @Valid @NotNull @JsonProperty
+    private LlmProviderTokenAuthConfig llmProviderTokenAuth = new LlmProviderTokenAuthConfig();
+
+    @Valid @NotNull @JsonProperty
     private CacheConfiguration cacheManager = new CacheConfiguration();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/EncryptedAuthConfigArgumentFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/EncryptedAuthConfigArgumentFactory.java
@@ -1,0 +1,30 @@
+package com.comet.opik.infrastructure.db;
+
+import com.comet.opik.api.EncryptedAuthConfig;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+/**
+ * Binds the wrapper's persistence form: the original ciphertext when untouched (no pointless
+ * re-encryption on updates that never parsed it), a fresh AES-GCM encryption otherwise.
+ */
+public class EncryptedAuthConfigArgumentFactory extends AbstractArgumentFactory<EncryptedAuthConfig> {
+
+    public EncryptedAuthConfigArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(EncryptedAuthConfig value, ConfigRegistry config) {
+        return (position, statement, ctx) -> {
+            if (value == null) {
+                statement.setNull(position, Types.VARCHAR);
+            } else {
+                statement.setString(position, value.ciphertextOrEncrypt());
+            }
+        };
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ProviderAuthConfigArgumentFactory.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/ProviderAuthConfigArgumentFactory.java
@@ -1,0 +1,33 @@
+package com.comet.opik.infrastructure.db;
+
+import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.infrastructure.EncryptionUtils;
+import com.comet.opik.utils.JsonUtils;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+
+import java.sql.Types;
+
+/**
+ * Binds a {@link ProviderAuthConfig} as its AES-GCM-encrypted JSON representation, so the recipe
+ * (which can contain several secrets) is never stored or logged in plaintext. The read side lives
+ * in {@code ProviderApiKeyRowMapper}.
+ */
+public class ProviderAuthConfigArgumentFactory extends AbstractArgumentFactory<ProviderAuthConfig> {
+
+    public ProviderAuthConfigArgumentFactory() {
+        super(Types.VARCHAR);
+    }
+
+    @Override
+    protected Argument build(ProviderAuthConfig value, ConfigRegistry config) {
+        return (position, statement, ctx) -> {
+            if (value == null) {
+                statement.setNull(position, Types.VARCHAR);
+            } else {
+                statement.setString(position, EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(value)));
+            }
+        };
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
@@ -1,13 +1,15 @@
 package com.comet.opik.infrastructure.llm;
 
+import com.comet.opik.api.ProviderAuthConfig;
 import lombok.Builder;
 import lombok.ToString;
 
 import java.util.Map;
+import java.util.UUID;
 
 @Builder
 public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<String, String> headers, String baseUrl,
-        Map<String, String> configuration) {
+        Map<String, String> configuration, UUID providerId, String workspaceId, ProviderAuthConfig authConfig) {
 
     @Override
     public String toString() {
@@ -16,6 +18,9 @@ public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<St
                 ", headers=" + headers +
                 ", baseUrl='" + baseUrl + '\'' +
                 ", configuration=" + configuration +
+                ", providerId=" + providerId +
+                ", workspaceId='" + workspaceId + '\'' +
+                ", authConfig=" + authConfig +
                 '}';
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderClientApiConfig.java
@@ -1,6 +1,6 @@
 package com.comet.opik.infrastructure.llm;
 
-import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.api.EncryptedAuthConfig;
 import lombok.Builder;
 import lombok.ToString;
 
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 @Builder
 public record LlmProviderClientApiConfig(@ToString.Exclude String apiKey, Map<String, String> headers, String baseUrl,
-        Map<String, String> configuration, UUID providerId, String workspaceId, ProviderAuthConfig authConfig) {
+        Map<String, String> configuration, UUID providerId, String workspaceId, EncryptedAuthConfig authConfig) {
 
     @Override
     public String toString() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
@@ -30,7 +30,9 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.infrastructure.EncryptionUtils.decrypt;
 import static com.comet.opik.infrastructure.EncryptionUtils.encrypt;
@@ -59,6 +61,10 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
                 .orElseThrow(() -> new LlmProviderUnsupportedException(
                         "LLM provider not supported: %s".formatted(llmProvider)));
     }
+
+    private static final Set<LlmProvider> NAMED_PROVIDERS = Arrays.stream(LlmProvider.values())
+            .filter(LlmProvider::supportsProviderName)
+            .collect(Collectors.toUnmodifiableSet());
 
     private LlmProviderClientApiConfig buildConfig(ProviderApiKey providerConfig, String workspaceId) {
         var configuration = Optional.ofNullable(providerConfig.configuration()).orElse(Map.of());
@@ -174,25 +180,17 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
                     .build();
         }
 
-        return llmProviderApiKeyService.find(workspaceId).content().stream()
-                .filter(providerApiKey -> {
-                    // For providers that support naming, match the model against configured models
-                    // Both CUSTOM_LLM and BEDROCK use the same "custom-llm/" prefix for models
-                    if (llmProvider.supportsProviderName()) {
-                        // Match against providers that support naming since they share the model prefix
-                        if (!providerApiKey.provider().supportsProviderName()) {
-                            return false;
-                        }
-                        return isModelConfiguredForProvider(model, providerApiKey);
-                    }
+        // Provider-type filtering happens in SQL so this per-request read never loads — and the
+        // row mapper never decrypts — the auth_config of providers that can't match. Named
+        // providers share the "custom-llm/" model prefix, so they're fetched as one family and
+        // matched by model in memory (the models list lives inside the configuration JSON).
+        Set<LlmProvider> candidates = llmProvider.supportsProviderName()
+                ? NAMED_PROVIDERS
+                : Set.of(llmProvider);
 
-                    // Match provider type for non-custom providers
-                    if (!llmProvider.equals(providerApiKey.provider())) {
-                        return false;
-                    }
-
-                    return true;
-                })
+        return llmProviderApiKeyService.findByProviders(workspaceId, candidates).stream()
+                .filter(providerApiKey -> !llmProvider.supportsProviderName()
+                        || isModelConfiguredForProvider(model, providerApiKey))
                 .findFirst()
                 .orElseThrow(() -> new BadRequestException(
                         "API key not configured for LLM. provider='%s', model='%s'".formatted(

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryImpl.java
@@ -52,7 +52,7 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
     public LlmProviderService getService(@NonNull String workspaceId, @NonNull String model) {
         var llmProvider = getLlmProvider(model);
         var providerConfig = getProviderApiKey(workspaceId, llmProvider, model);
-        var config = buildConfig(providerConfig);
+        var config = buildConfig(providerConfig, workspaceId);
 
         return Optional.ofNullable(services.get(llmProvider))
                 .map(provider -> provider.getService(config))
@@ -60,7 +60,7 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
                         "LLM provider not supported: %s".formatted(llmProvider)));
     }
 
-    private LlmProviderClientApiConfig buildConfig(ProviderApiKey providerConfig) {
+    private LlmProviderClientApiConfig buildConfig(ProviderApiKey providerConfig, String workspaceId) {
         var configuration = Optional.ofNullable(providerConfig.configuration()).orElse(Map.of());
 
         // For providers that support naming, add provider_name to configuration if present
@@ -75,6 +75,9 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
                 .headers(Optional.ofNullable(providerConfig.headers()).orElse(Map.of()))
                 .baseUrl(providerConfig.baseUrl())
                 .configuration(configuration)
+                .providerId(providerConfig.id())
+                .workspaceId(workspaceId)
+                .authConfig(providerConfig.authConfig())
                 .build();
     }
 
@@ -82,7 +85,7 @@ class LlmProviderFactoryImpl implements LlmProviderFactory {
             @NonNull LlmAsJudgeModelParameters modelParameters) {
         var llmProvider = getLlmProvider(modelParameters.name());
         var providerConfig = getProviderApiKey(workspaceId, llmProvider, modelParameters.name());
-        var config = buildConfig(providerConfig);
+        var config = buildConfig(providerConfig, workspaceId);
 
         return Optional.ofNullable(services.get(llmProvider))
                 .map(provider -> provider.getLanguageModel(config, modelParameters))

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenException.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenException.java
@@ -1,0 +1,17 @@
+package com.comet.opik.infrastructure.llm.customllm;
+
+/**
+ * A token fetch for a custom provider's {@code auth_config} recipe failed. The message is
+ * user-facing by contract: it carries the upstream status/body with credential values and tokens
+ * already redacted, so callers can surface it verbatim (eval logs, playground, test-connection).
+ */
+public class AuthTokenException extends RuntimeException {
+
+    public AuthTokenException(String message) {
+        super(message);
+    }
+
+    public AuthTokenException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -330,7 +330,7 @@ public class AuthTokenProvider {
                 String clientSecret = credentialValue(credentials, CLIENT_SECRET_KEY);
                 if (clientId == null || clientSecret == null) {
                     throw new AuthTokenException(
-                            "basic auth mode requires '%s' and '%s' credentials".formatted(CLIENT_ID_KEY,
+                            "requires '%s' and '%s' credentials".formatted(CLIENT_ID_KEY,
                                     CLIENT_SECRET_KEY));
                 }
                 var bodyCredentials = credentials.stream()

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -19,6 +19,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
@@ -32,12 +33,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Base64;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -68,9 +65,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 public class AuthTokenProvider {
 
     record FetchedToken(String token, long ttlSeconds) {
-    }
-
-    record CachedToken(String token, long expiresAtEpochMs, long ttlSeconds) {
     }
 
     private static final String CACHE_KEY_FORMAT = "llm_auth_token:%s:%s";
@@ -132,10 +126,10 @@ public class AuthTokenProvider {
     public String bearer(@NonNull String workspaceId, @NonNull UUID providerId,
             @NonNull ProviderAuthConfig authConfig) {
         String cacheKey = cacheKey(providerId, authConfig);
-        CachedToken cached = readCache(cacheKey);
-        if (isFresh(cached)) {
+        String cached = readCache(cacheKey);
+        if (cached != null) {
             recordRequestMetric(workspaceId, providerId, "cache_hit");
-            return cached.token();
+            return cached;
         }
 
         try {
@@ -149,6 +143,15 @@ public class AuthTokenProvider {
             if (token != null) {
                 recordRequestMetric(workspaceId, providerId, "fetched");
                 return token;
+            }
+            // Empty result = we gave up waiting for the lock holder, who has likely written the
+            // token by now — re-read before fetching. Distinct metric so a rising rate can flag
+            // a mistuned lockTimeout. Known gap: if the holder's fetch failed, waiters still
+            // fall through and fetch directly.
+            String refreshed = readCache(cacheKey);
+            if (refreshed != null) {
+                recordRequestMetric(workspaceId, providerId, "lock_timeout_recovered");
+                return refreshed;
             }
             log.warn("Timed out waiting for the token fetch lock for provider '{}'; fetching directly", providerId);
         } catch (AuthTokenException exception) {
@@ -183,62 +186,45 @@ public class AuthTokenProvider {
 
     private String refreshUnderLock(String cacheKey, ProviderAuthConfig authConfig) {
         // another pod may have refreshed while this one waited on the lock
-        CachedToken cached = readCache(cacheKey);
-        if (isFresh(cached)) {
-            return cached.token();
+        String cached = readCache(cacheKey);
+        if (cached != null) {
+            return cached;
         }
         FetchedToken fetched = fetchToken(authConfig);
-        // a resolved lifetime of 0 (the fallback for a reply that states none) means: don't cache
-        if (fetched.ttlSeconds() > 0) {
-            writeCache(cacheKey, fetched);
-        }
+        writeCache(cacheKey, fetched);
         return fetched.token();
     }
 
-    private boolean isFresh(CachedToken cached) {
-        if (cached == null) {
-            return false;
-        }
-        long refreshWindowMs = (long) (cached.ttlSeconds() * 1_000 * config.getRefreshFraction());
-        return Instant.now().toEpochMilli() < cached.expiresAtEpochMs() - refreshWindowMs;
-    }
-
-    private CachedToken readCache(String cacheKey) {
+    private String readCache(String cacheKey) {
         try {
             String encrypted = redisClient.getBucket(cacheKey).get();
-            if (encrypted == null) {
-                return null;
-            }
-            return JsonUtils.readValue(EncryptionUtils.decryptGcm(encrypted), CachedToken.class);
+            return encrypted == null ? null : EncryptionUtils.decryptGcm(encrypted);
         } catch (RuntimeException exception) {
             log.warn("Failed to read the cached token for key '{}': {}", cacheKey, exception.getMessage());
             return null;
         }
     }
 
+    /**
+     * The bucket's own TTL is the refresh point ({@code lifetime * (1 - refreshFraction)}), so
+     * freshness is simply key existence and Redis's clock is the single source of truth.
+     */
     private void writeCache(String cacheKey, FetchedToken fetched) {
+        long refreshPointMs = (long) (fetched.ttlSeconds() * 1_000 * (1 - config.getRefreshFraction()));
+        // a resolved lifetime of 0 (the fallback for a reply that states none) means: don't cache
+        if (refreshPointMs <= 0) {
+            return;
+        }
         try {
-            var entry = new CachedToken(fetched.token(),
-                    Instant.now().toEpochMilli() + fetched.ttlSeconds() * 1_000, fetched.ttlSeconds());
             redisClient.getBucket(cacheKey)
-                    .set(EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(entry)),
-                            Duration.ofSeconds(fetched.ttlSeconds()));
+                    .set(EncryptionUtils.encryptGcm(fetched.token()), Duration.ofMillis(refreshPointMs));
         } catch (RuntimeException exception) {
             log.warn("Failed to cache the token for key '{}'; the token is still returned", cacheKey, exception);
         }
     }
 
     private String cacheKey(UUID providerId, ProviderAuthConfig authConfig) {
-        return CACHE_KEY_FORMAT.formatted(providerId, sha256Hex(JsonUtils.writeValueAsString(authConfig)));
-    }
-
-    private static String sha256Hex(String value) {
-        try {
-            return HexFormat.of()
-                    .formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
-        } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException(exception);
-        }
+        return CACHE_KEY_FORMAT.formatted(providerId, DigestUtils.sha256Hex(JsonUtils.writeValueAsString(authConfig)));
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.llm.customllm;
 
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.LlmProviderTokenAuthConfig;
@@ -25,6 +26,7 @@ import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -124,7 +126,7 @@ public class AuthTokenProvider {
      * @throws AuthTokenException with a redacted, user-facing message when the fetch fails
      */
     public String bearer(@NonNull String workspaceId, @NonNull UUID providerId,
-            @NonNull ProviderAuthConfig authConfig) {
+            @NonNull EncryptedAuthConfig authConfig) {
         String cacheKey = cacheKey(providerId, authConfig);
         String cached = readCache(cacheKey);
         if (cached != null) {
@@ -162,7 +164,7 @@ public class AuthTokenProvider {
                     exception);
         }
 
-        String token = fetchToken(authConfig).token();
+        String token = fetchToken(authConfig.value()).token();
         recordRequestMetric(workspaceId, providerId, "degraded_direct");
         return token;
     }
@@ -174,7 +176,7 @@ public class AuthTokenProvider {
      * failure here only delays the cleanup until the bucket's own expiry.
      */
     public void invalidateAfterGatewayRejection(@NonNull String workspaceId, @NonNull UUID providerId,
-            @NonNull ProviderAuthConfig authConfig) {
+            @NonNull EncryptedAuthConfig authConfig) {
         recordRequestMetric(workspaceId, providerId, "gateway_rejected");
         String cacheKey = cacheKey(providerId, authConfig);
         try {
@@ -184,13 +186,13 @@ public class AuthTokenProvider {
         }
     }
 
-    private String refreshUnderLock(String cacheKey, ProviderAuthConfig authConfig) {
+    private String refreshUnderLock(String cacheKey, EncryptedAuthConfig authConfig) {
         // another pod may have refreshed while this one waited on the lock
         String cached = readCache(cacheKey);
         if (cached != null) {
             return cached;
         }
-        FetchedToken fetched = fetchToken(authConfig);
+        FetchedToken fetched = fetchToken(authConfig.value());
         writeCache(cacheKey, fetched);
         return fetched.token();
     }
@@ -223,8 +225,8 @@ public class AuthTokenProvider {
         }
     }
 
-    private String cacheKey(UUID providerId, ProviderAuthConfig authConfig) {
-        return CACHE_KEY_FORMAT.formatted(providerId, DigestUtils.sha256Hex(JsonUtils.writeValueAsString(authConfig)));
+    private String cacheKey(UUID providerId, EncryptedAuthConfig authConfig) {
+        return CACHE_KEY_FORMAT.formatted(providerId, DigestUtils.sha256Hex(authConfig.hashSource()));
     }
 
     /**
@@ -254,9 +256,15 @@ public class AuthTokenProvider {
                     exception);
         }
         HttpRequest request = buildRequest(authConfig);
-        HttpResponse<String> response;
+        HttpResponse<InputStream> response;
+        byte[] bodyBytes;
         try {
-            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+            // bounded read: at most cap+1 bytes ever reach the heap; closing the stream
+            // cancels whatever the endpoint is still sending
+            try (InputStream bodyStream = response.body()) {
+                bodyBytes = bodyStream.readNBytes(config.getMaxResponseChars() + 1);
+            }
         } catch (IOException exception) {
             recordFetchMetric(startNanos, "unreachable", origin);
             throw new AuthTokenException("token fetch failed: could not reach '%s': %s"
@@ -266,17 +274,17 @@ public class AuthTokenProvider {
             recordFetchMetric(startNanos, "interrupted", origin);
             throw new AuthTokenException("token fetch was interrupted", exception);
         }
+        if (bodyBytes.length > config.getMaxResponseChars()) {
+            recordFetchMetric(startNanos, "oversized_reply", origin);
+            throw new AuthTokenException("token reply from '%s' exceeds the maximum accepted size"
+                    .formatted(authConfig.tokenUrl()));
+        }
 
-        String body = Optional.ofNullable(response.body()).orElse("");
+        String body = new String(bodyBytes, StandardCharsets.UTF_8);
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
             recordFetchMetric(startNanos, "upstream_error", origin);
             throw new AuthTokenException("token fetch failed with status '%d' from '%s': %s"
                     .formatted(response.statusCode(), authConfig.tokenUrl(), redact(authConfig, body)));
-        }
-        if (body.length() > config.getMaxResponseChars()) {
-            recordFetchMetric(startNanos, "oversized_reply", origin);
-            throw new AuthTokenException("token reply from '%s' exceeds the maximum accepted size"
-                    .formatted(authConfig.tokenUrl()));
         }
 
         JsonNode root;
@@ -424,16 +432,16 @@ public class AuthTokenProvider {
         if (isBlank(text)) {
             return "";
         }
-        String result = text.length() > ERROR_BODY_SNIPPET_CHARS
-                ? text.substring(0, ERROR_BODY_SNIPPET_CHARS) + "…"
-                : text;
+        String result = text;
         for (var credential : Optional.ofNullable(authConfig.credentials())
                 .orElse(List.<ProviderAuthConfig.Credential>of())) {
             if (isNotBlank(credential.value())) {
                 result = result.replace(credential.value(), REDACTED);
             }
         }
-        return result;
+        return result.length() > ERROR_BODY_SNIPPET_CHARS
+                ? result.substring(0, ERROR_BODY_SNIPPET_CHARS) + "…"
+                : result;
     }
 
     private void recordRequestMetric(String workspaceId, UUID providerId, String outcome) {
@@ -445,4 +453,5 @@ public class AuthTokenProvider {
         fetchDurationMs.record((System.nanoTime() - startNanos) / 1_000_000,
                 Attributes.of(OUTCOME, outcome, ORIGIN, origin));
     }
+
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -112,7 +112,7 @@ public class AuthTokenProvider {
         this.tokenRequests = meter.counterBuilder("llm_provider_token_requests")
                 .setDescription("Bearer requests against the token cache, by outcome")
                 .build();
-        this.fetchDurationMs = meter.histogramBuilder("llm_provider_token_fetch_duration_ms")
+        this.fetchDurationMs = meter.histogramBuilder("llm_provider_token_fetch_duration")
                 .setDescription("Duration of HTTP fetches against customers' auth services")
                 .setUnit("ms")
                 .ofLongs()

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -79,6 +79,8 @@ public class AuthTokenProvider {
     private static final String CLIENT_SECRET_KEY = "client_secret";
     private static final String REDACTED = "***";
     private static final int ERROR_BODY_SNIPPET_CHARS = 500;
+    // Upper bound on any token lifetime (1 year): beyond this a reply is malformed or malicious
+    static final long MAX_TTL_SECONDS = 31_536_000L;
 
     private static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
     private static final AttributeKey<String> WORKSPACE_ID = AttributeKey.stringKey("workspace_id");
@@ -367,10 +369,11 @@ public class AuthTokenProvider {
             }
         }
         if (ttlSeconds != null) {
-            if (ttlSeconds <= 0) {
+            if (ttlSeconds <= 0 || ttlSeconds > MAX_TTL_SECONDS) {
                 recordFetchMetric(startNanos, "lifetime_invalid", origin);
-                throw new AuthTokenException("token reply states a non-positive lifetime of '%d' seconds"
-                        .formatted(ttlSeconds));
+                throw new AuthTokenException(
+                        "token reply states a lifetime of '%d' seconds, outside the accepted range of 1 to %d"
+                                .formatted(ttlSeconds, MAX_TTL_SECONDS));
             }
             return ttlSeconds;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -29,6 +29,7 @@ import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -84,6 +85,7 @@ public class AuthTokenProvider {
 
     private static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
     private static final AttributeKey<String> WORKSPACE_ID = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> PROVIDER_ID = AttributeKey.stringKey("provider_id");
     private static final AttributeKey<String> ORIGIN = AttributeKey.stringKey("origin");
     private static final String ORIGIN_REQUEST = "request";
     private static final String ORIGIN_TEST = "test";
@@ -132,7 +134,7 @@ public class AuthTokenProvider {
         String cacheKey = cacheKey(providerId, authConfig);
         CachedToken cached = readCache(cacheKey);
         if (isFresh(cached)) {
-            recordRequestMetric(workspaceId, "cache_hit");
+            recordRequestMetric(workspaceId, providerId, "cache_hit");
             return cached.token();
         }
 
@@ -145,12 +147,12 @@ public class AuthTokenProvider {
                     .block(Duration.ofMillis(
                             config.getLockTimeout().toMilliseconds() + config.getFetchTimeout().toMilliseconds()));
             if (token != null) {
-                recordRequestMetric(workspaceId, "fetched");
+                recordRequestMetric(workspaceId, providerId, "fetched");
                 return token;
             }
             log.warn("Timed out waiting for the token fetch lock for provider '{}'; fetching directly", providerId);
         } catch (AuthTokenException exception) {
-            recordRequestMetric(workspaceId, "failed");
+            recordRequestMetric(workspaceId, providerId, "failed");
             throw exception;
         } catch (RuntimeException exception) {
             log.warn("Token cache unavailable for provider '{}'; falling back to a direct fetch", providerId,
@@ -158,16 +160,19 @@ public class AuthTokenProvider {
         }
 
         String token = fetchToken(authConfig).token();
-        recordRequestMetric(workspaceId, "degraded_direct");
+        recordRequestMetric(workspaceId, providerId, "degraded_direct");
         return token;
     }
 
     /**
-     * Drops the cached token — for the 401-retry path, so a revocation discovered by one pod is
-     * seen by all of them at once. Best-effort: a Redis failure here only delays the cleanup until
-     * the bucket's own expiry.
+     * The LLM gateway rejected the current bearer (401, or 403 with a token-rejection hint):
+     * records the "is this integration broken" signal, then drops the cached token so a revocation
+     * discovered by one pod is seen by all of them at once. The drop is best-effort: a Redis
+     * failure here only delays the cleanup until the bucket's own expiry.
      */
-    public void invalidate(@NonNull UUID providerId, @NonNull ProviderAuthConfig authConfig) {
+    public void invalidateAfterGatewayRejection(@NonNull String workspaceId, @NonNull UUID providerId,
+            @NonNull ProviderAuthConfig authConfig) {
+        recordRequestMetric(workspaceId, providerId, "gateway_rejected");
         String cacheKey = cacheKey(providerId, authConfig);
         try {
             redisClient.getBucket(cacheKey).delete();
@@ -316,8 +321,14 @@ public class AuthTokenProvider {
                 .orElse(List.of());
         var sendAs = Optional.ofNullable(authConfig.sendAs()).orElse(ProviderAuthConfig.SendAs.FORM);
 
-        var builder = HttpRequest.newBuilder(URI.create(authConfig.tokenUrl()))
-                .timeout(Duration.ofMillis(config.getFetchTimeout().toMilliseconds()));
+        Builder builder;
+        try {
+            builder = HttpRequest.newBuilder(URI.create(authConfig.tokenUrl()))
+                    .timeout(Duration.ofMillis(config.getFetchTimeout().toMilliseconds()));
+        } catch (IllegalArgumentException exception) {
+            throw new AuthTokenException(
+                    "token_url '%s' is not a usable http(s) URL".formatted(authConfig.tokenUrl()), exception);
+        }
 
         switch (sendAs) {
             case FORM -> builder
@@ -439,8 +450,9 @@ public class AuthTokenProvider {
         return result;
     }
 
-    private void recordRequestMetric(String workspaceId, String outcome) {
-        tokenRequests.add(1, Attributes.of(OUTCOME, outcome, WORKSPACE_ID, workspaceId));
+    private void recordRequestMetric(String workspaceId, UUID providerId, String outcome) {
+        tokenRequests.add(1, Attributes.of(
+                OUTCOME, outcome, WORKSPACE_ID, workspaceId, PROVIDER_ID, providerId.toString()));
     }
 
     private void recordFetchMetric(long startNanos, String outcome, String origin) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -204,7 +204,7 @@ public class AuthTokenProvider {
             }
             return JsonUtils.readValue(EncryptionUtils.decryptGcm(encrypted), CachedToken.class);
         } catch (RuntimeException exception) {
-            log.warn("Failed to read the cached token for key '{}'", cacheKey, exception);
+            log.warn("Failed to read the cached token for key '{}': {}", cacheKey, exception.getMessage());
             return null;
         }
     }
@@ -349,7 +349,7 @@ public class AuthTokenProvider {
 
     /**
      * Resolves the token lifetime, in order: the reply's lifetime field (number or numeric string;
-     * a non-positive value is an error), else the recipe's fallback (where 0 meansthe token is
+     * a non-positive value is an error), else the recipe's fallback (where 0 means the token is
      * served uncached), else an error naming the missing field.
      */
     private long resolveTtlSeconds(JsonNode root, ProviderAuthConfig authConfig, long startNanos, String origin) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -1,0 +1,418 @@
+package com.comet.opik.infrastructure.llm.customllm;
+
+import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.infrastructure.EncryptionUtils;
+import com.comet.opik.infrastructure.LlmProviderTokenAuthConfig;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.redis.StringRedisClient;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongHistogram;
+import io.opentelemetry.api.metrics.Meter;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+/**
+ * Executes a custom provider's {@link ProviderAuthConfig} recipe and manages the resulting
+ * short-lived bearer's lifecycle.
+ *
+ * <p>Tokens are cached in Redis — one bucket per provider, AES-GCM-encrypted, shared by every
+ * backend pod — so a deployment makes roughly one fetch per refresh window regardless of pod count.
+ * The cache key includes a hash of the recipe: any config edit is an instant deployment-wide cache
+ * miss, no invalidation signal needed. A token is refreshed lazily, on the request path, once its
+ * remaining lifetime drops inside the proportional refresh window. Cold-cache bursts collapse into
+ * a single fetch via the distributed lock; on any Redis failure the provider degrades to a direct
+ * fetch rather than failing the LLM call.
+ *
+ * <p>Every error message thrown from here is user-facing by contract: upstream status and body are
+ * surfaced (never a generic "auth failed"), with credential values redacted.
+ */
+@Singleton
+@Slf4j
+public class AuthTokenProvider {
+
+    record FetchedToken(String token, long ttlSeconds) {
+    }
+
+    record CachedToken(String token, long expiresAtEpochMs, long ttlSeconds) {
+    }
+
+    private static final String CACHE_KEY_FORMAT = "llm_auth_token:%s:%s";
+    private static final String DEFAULT_TOKEN_FIELD = "access_token";
+    private static final String DEFAULT_EXPIRES_FIELD = "expires_in";
+    private static final String CLIENT_ID_KEY = "client_id";
+    private static final String CLIENT_SECRET_KEY = "client_secret";
+    private static final String REDACTED = "***";
+    private static final int ERROR_BODY_SNIPPET_CHARS = 500;
+
+    private static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
+    private static final AttributeKey<String> WORKSPACE_ID = AttributeKey.stringKey("workspace_id");
+
+    private final @NonNull StringRedisClient redisClient;
+    private final @NonNull LockService lockService;
+    private final @NonNull LlmProviderTokenAuthConfig config;
+    private final HttpClient httpClient;
+    private final LongCounter tokenRequests;
+    private final LongHistogram fetchDurationMs;
+
+    @Inject
+    public AuthTokenProvider(@NonNull StringRedisClient redisClient, @NonNull LockService lockService,
+            @NonNull @Config("llmProviderTokenAuth") LlmProviderTokenAuthConfig config) {
+        this.redisClient = redisClient;
+        this.lockService = lockService;
+        this.config = config;
+        // Same posture as the LLM clients: HTTP/1.1 and no redirect following (a token endpoint
+        // redirecting elsewhere is a misconfiguration or an attack, never a flow to honor).
+        this.httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .followRedirects(HttpClient.Redirect.NEVER)
+                .connectTimeout(Duration.ofMillis(config.getFetchTimeout().toMilliseconds()))
+                .build();
+        Meter meter = GlobalOpenTelemetry.get().getMeter("opik.llm_provider_token_auth");
+        this.tokenRequests = meter.counterBuilder("llm_provider_token_requests")
+                .setDescription("Bearer requests against the token cache, by outcome")
+                .build();
+        this.fetchDurationMs = meter.histogramBuilder("llm_provider_token_fetch_duration_ms")
+                .setDescription("Duration of HTTP fetches against customers' auth services")
+                .setUnit("ms")
+                .ofLongs()
+                .build();
+    }
+
+    /**
+     * Returns a bearer for the given recipe, fetching or refreshing through the shared cache as
+     * needed. Blocking — meant to be called from the LLM client's request path.
+     *
+     * @throws AuthTokenException with a redacted, user-facing message when the fetch fails
+     */
+    public String bearer(@NonNull String workspaceId, @NonNull UUID providerId,
+            @NonNull ProviderAuthConfig authConfig) {
+        String cacheKey = cacheKey(providerId, authConfig);
+        CachedToken cached = readCache(cacheKey);
+        if (isFresh(cached)) {
+            recordRequestMetric(workspaceId, "cache_hit");
+            return cached.token();
+        }
+
+        try {
+            String token = lockService
+                    .executeWithLockCustomExpire(
+                            new LockService.Lock(cacheKey + ":fetch-lock"),
+                            Mono.fromCallable(() -> refreshUnderLock(cacheKey, authConfig)),
+                            Duration.ofMillis(config.getLockTimeout().toMilliseconds()))
+                    .block(Duration.ofMillis(
+                            config.getLockTimeout().toMilliseconds() + config.getFetchTimeout().toMilliseconds()));
+            if (token != null) {
+                recordRequestMetric(workspaceId, "fetched");
+                return token;
+            }
+            log.warn("Timed out waiting for the token fetch lock for provider '{}'; fetching directly", providerId);
+        } catch (AuthTokenException exception) {
+            recordRequestMetric(workspaceId, "failed");
+            throw exception;
+        } catch (RuntimeException exception) {
+            log.warn("Token cache unavailable for provider '{}'; falling back to a direct fetch", providerId,
+                    exception);
+        }
+
+        String token = fetchToken(authConfig).token();
+        recordRequestMetric(workspaceId, "degraded_direct");
+        return token;
+    }
+
+    /**
+     * Drops the cached token — for the 401-retry path, so a revocation discovered by one pod is
+     * seen by all of them at once. Best-effort: a Redis failure here only delays the cleanup until
+     * the bucket's own expiry.
+     */
+    public void invalidate(@NonNull UUID providerId, @NonNull ProviderAuthConfig authConfig) {
+        String cacheKey = cacheKey(providerId, authConfig);
+        try {
+            redisClient.getBucket(cacheKey).delete();
+        } catch (RuntimeException exception) {
+            log.warn("Failed to invalidate cached token for provider '{}'", providerId, exception);
+        }
+    }
+
+    private String refreshUnderLock(String cacheKey, ProviderAuthConfig authConfig) {
+        // another pod may have refreshed while this one waited on the lock
+        CachedToken cached = readCache(cacheKey);
+        if (isFresh(cached)) {
+            return cached.token();
+        }
+        FetchedToken fetched = fetchToken(authConfig);
+        // a resolved lifetime of 0 (the fallback for a reply that states none) means: don't cache
+        if (fetched.ttlSeconds() > 0) {
+            writeCache(cacheKey, fetched);
+        }
+        return fetched.token();
+    }
+
+    private boolean isFresh(CachedToken cached) {
+        if (cached == null) {
+            return false;
+        }
+        long refreshWindowMs = (long) (cached.ttlSeconds() * 1_000 * config.getRefreshFraction());
+        return Instant.now().toEpochMilli() < cached.expiresAtEpochMs() - refreshWindowMs;
+    }
+
+    private CachedToken readCache(String cacheKey) {
+        try {
+            String encrypted = redisClient.getBucket(cacheKey).get();
+            if (encrypted == null) {
+                return null;
+            }
+            return JsonUtils.readValue(EncryptionUtils.decryptGcm(encrypted), CachedToken.class);
+        } catch (RuntimeException exception) {
+            log.warn("Failed to read the cached token for key '{}'", cacheKey, exception);
+            return null;
+        }
+    }
+
+    private void writeCache(String cacheKey, FetchedToken fetched) {
+        try {
+            var entry = new CachedToken(fetched.token(),
+                    Instant.now().toEpochMilli() + fetched.ttlSeconds() * 1_000, fetched.ttlSeconds());
+            redisClient.getBucket(cacheKey)
+                    .set(EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(entry)),
+                            Duration.ofSeconds(fetched.ttlSeconds()));
+        } catch (RuntimeException exception) {
+            log.warn("Failed to cache the token for key '{}'; the token is still returned", cacheKey, exception);
+        }
+    }
+
+    private String cacheKey(UUID providerId, ProviderAuthConfig authConfig) {
+        return CACHE_KEY_FORMAT.formatted(providerId, sha256Hex(JsonUtils.writeValueAsString(authConfig)));
+    }
+
+    private static String sha256Hex(String value) {
+        try {
+            return HexFormat.of()
+                    .formatHex(MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    // --- recipe execution ---
+
+    FetchedToken fetchToken(@NonNull ProviderAuthConfig authConfig) {
+        HttpRequest request = buildRequest(authConfig);
+        long startNanos = System.nanoTime();
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException exception) {
+            recordFetchMetric(startNanos, "unreachable");
+            throw new AuthTokenException("token fetch failed: could not reach '%s': %s"
+                    .formatted(authConfig.tokenUrl(), redact(authConfig, exception.getMessage())), exception);
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            recordFetchMetric(startNanos, "interrupted");
+            throw new AuthTokenException("token fetch was interrupted", exception);
+        }
+
+        String body = Optional.ofNullable(response.body()).orElse("");
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            recordFetchMetric(startNanos, "upstream_error");
+            throw new AuthTokenException("token fetch failed with status '%d' from '%s': %s"
+                    .formatted(response.statusCode(), authConfig.tokenUrl(), redact(authConfig, body)));
+        }
+        if (body.length() > config.getMaxResponseChars()) {
+            recordFetchMetric(startNanos, "oversized_reply");
+            throw new AuthTokenException("token reply from '%s' exceeds the maximum accepted size"
+                    .formatted(authConfig.tokenUrl()));
+        }
+
+        JsonNode root;
+        try {
+            root = JsonUtils.getJsonNodeFromString(body);
+        } catch (UncheckedIOException exception) {
+            recordFetchMetric(startNanos, "non_json_reply");
+            throw new AuthTokenException("token endpoint at '%s' returned a non-JSON reply (status '%d')"
+                    .formatted(authConfig.tokenUrl(), response.statusCode()));
+        }
+
+        String tokenField = defaultIfBlank(authConfig.tokenField(), DEFAULT_TOKEN_FIELD);
+        JsonNode tokenNode = atDotPath(root, tokenField);
+        if (!tokenNode.isTextual() || isBlank(tokenNode.asText())) {
+            recordFetchMetric(startNanos, "token_field_missing");
+            // field names are safe to surface; values never are
+            throw new AuthTokenException("field '%s' not found in the token reply; top-level fields: %s"
+                    .formatted(tokenField, root.properties().stream().map(Map.Entry::getKey).toList()));
+        }
+
+        long ttlSeconds = resolveTtlSeconds(root, authConfig, startNanos);
+        recordFetchMetric(startNanos, "success");
+        return new FetchedToken(tokenNode.asText(), ttlSeconds);
+    }
+
+    private HttpRequest buildRequest(ProviderAuthConfig authConfig) {
+        List<ProviderAuthConfig.Credential> credentials = Optional.ofNullable(authConfig.credentials())
+                .orElse(List.of());
+        var sendAs = Optional.ofNullable(authConfig.sendAs()).orElse(ProviderAuthConfig.SendAs.FORM);
+
+        var builder = HttpRequest.newBuilder(URI.create(authConfig.tokenUrl()))
+                .timeout(Duration.ofMillis(config.getFetchTimeout().toMilliseconds()));
+
+        switch (sendAs) {
+            case FORM -> builder
+                    .header("Content-Type", "application/x-www-form-urlencoded")
+                    .POST(HttpRequest.BodyPublishers.ofString(formEncode(credentials)));
+            case JSON -> builder
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(jsonEncode(credentials)));
+            case BASIC -> {
+                // OAuth2-standard mixed mode: client id/secret in the Basic header, every
+                // remaining field in the form body
+                String clientId = credentialValue(credentials, CLIENT_ID_KEY);
+                String clientSecret = credentialValue(credentials, CLIENT_SECRET_KEY);
+                if (clientId == null || clientSecret == null) {
+                    throw new AuthTokenException(
+                            "basic auth mode requires '%s' and '%s' credentials".formatted(CLIENT_ID_KEY,
+                                    CLIENT_SECRET_KEY));
+                }
+                var bodyCredentials = credentials.stream()
+                        .filter(credential -> !CLIENT_ID_KEY.equals(credential.key())
+                                && !CLIENT_SECRET_KEY.equals(credential.key()))
+                        .toList();
+                builder.header("Authorization", "Basic " + Base64.getEncoder().encodeToString(
+                        (clientId + ":" + clientSecret).getBytes(StandardCharsets.UTF_8)))
+                        .header("Content-Type", "application/x-www-form-urlencoded")
+                        .POST(HttpRequest.BodyPublishers.ofString(formEncode(bodyCredentials)));
+            }
+        }
+        return builder.build();
+    }
+
+    /**
+     * Resolves the token lifetime, in order: the reply's lifetime field (number or numeric string;
+     * a non-positive value is an error), else the recipe's fallback (where 0 meansthe token is
+     * served uncached), else an error naming the missing field.
+     */
+    private long resolveTtlSeconds(JsonNode root, ProviderAuthConfig authConfig, long startNanos) {
+        String expiresField = defaultIfBlank(authConfig.expiresField(), DEFAULT_EXPIRES_FIELD);
+        JsonNode expiresNode = atDotPath(root, expiresField);
+
+        Long ttlSeconds = null;
+        if (expiresNode.isNumber()) {
+            ttlSeconds = expiresNode.longValue();
+        } else if (expiresNode.isTextual() && isNotBlank(expiresNode.asText())) {
+            try {
+                ttlSeconds = Long.parseLong(expiresNode.asText().trim());
+            } catch (NumberFormatException ignored) {
+                // fall through to the fallback
+            }
+        }
+        if (ttlSeconds != null) {
+            if (ttlSeconds <= 0) {
+                recordFetchMetric(startNanos, "lifetime_invalid");
+                throw new AuthTokenException("token reply states a non-positive lifetime of '%d' seconds"
+                        .formatted(ttlSeconds));
+            }
+            return ttlSeconds;
+        }
+        // the configured fallback may legitimately be 0: the fetch-per-call convention
+        if (authConfig.fallbackTtlSeconds() == null) {
+            recordFetchMetric(startNanos, "lifetime_missing");
+            throw new AuthTokenException(
+                    "token reply has no lifetime field '%s' and no fallback lifetime is configured"
+                            .formatted(expiresField));
+        }
+        return authConfig.fallbackTtlSeconds();
+    }
+
+    private static String credentialValue(List<ProviderAuthConfig.Credential> credentials, String key) {
+        return credentials.stream()
+                .filter(credential -> key.equals(credential.key()))
+                .map(ProviderAuthConfig.Credential::value)
+                .filter(StringUtils::isNotBlank)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private static String formEncode(List<ProviderAuthConfig.Credential> credentials) {
+        return credentials.stream()
+                .map(credential -> URLEncoder.encode(credential.key(), StandardCharsets.UTF_8) + "="
+                        + URLEncoder.encode(Optional.ofNullable(credential.value()).orElse(""),
+                                StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+    }
+
+    private static String jsonEncode(List<ProviderAuthConfig.Credential> credentials) {
+        var node = JsonUtils.createObjectNode();
+        credentials.forEach(credential -> node.put(credential.key(), credential.value()));
+        return node.toString();
+    }
+
+    private static JsonNode atDotPath(JsonNode root, String dotPath) {
+        JsonNode current = root;
+        for (String part : dotPath.split("\\.")) {
+            current = current.path(part);
+        }
+        return current;
+    }
+
+    /**
+     * Scrubs every credential value out of text destined for error messages and truncates it.
+     * Applied to upstream bodies and transport errors alike — the one choke point that lets the
+     * rest of the class surface upstream errors verbatim.
+     */
+    private static String redact(ProviderAuthConfig authConfig, String text) {
+        if (isBlank(text)) {
+            return "";
+        }
+        String result = text.length() > ERROR_BODY_SNIPPET_CHARS
+                ? text.substring(0, ERROR_BODY_SNIPPET_CHARS) + "…"
+                : text;
+        for (var credential : Optional.ofNullable(authConfig.credentials())
+                .orElse(List.<ProviderAuthConfig.Credential>of())) {
+            if (isNotBlank(credential.value())) {
+                result = result.replace(credential.value(), REDACTED);
+            }
+        }
+        return result;
+    }
+
+    private void recordRequestMetric(String workspaceId, String outcome) {
+        tokenRequests.add(1, Attributes.of(OUTCOME, outcome, WORKSPACE_ID, workspaceId));
+    }
+
+    private void recordFetchMetric(long startNanos, String outcome) {
+        fetchDurationMs.record((System.nanoTime() - startNanos) / 1_000_000,
+                Attributes.of(OUTCOME, outcome));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProvider.java
@@ -4,6 +4,8 @@ import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.LlmProviderTokenAuthConfig;
 import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.net.DestinationGuard;
+import com.comet.opik.infrastructure.net.DestinationGuardException;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -80,10 +82,14 @@ public class AuthTokenProvider {
 
     private static final AttributeKey<String> OUTCOME = AttributeKey.stringKey("outcome");
     private static final AttributeKey<String> WORKSPACE_ID = AttributeKey.stringKey("workspace_id");
+    private static final AttributeKey<String> ORIGIN = AttributeKey.stringKey("origin");
+    private static final String ORIGIN_REQUEST = "request";
+    private static final String ORIGIN_TEST = "test";
 
     private final @NonNull StringRedisClient redisClient;
     private final @NonNull LockService lockService;
     private final @NonNull LlmProviderTokenAuthConfig config;
+    private final DestinationGuard destinationGuard;
     private final HttpClient httpClient;
     private final LongCounter tokenRequests;
     private final LongHistogram fetchDurationMs;
@@ -94,6 +100,7 @@ public class AuthTokenProvider {
         this.redisClient = redisClient;
         this.lockService = lockService;
         this.config = config;
+        this.destinationGuard = new DestinationGuard(config.getDestinationGuard());
         // Same posture as the LLM clients: HTTP/1.1 and no redirect following (a token endpoint
         // redirecting elsewhere is a misconfiguration or an attack, never a flow to honor).
         this.httpClient = HttpClient.newBuilder()
@@ -227,32 +234,54 @@ public class AuthTokenProvider {
         }
     }
 
+    /**
+     * Runs the recipe once for the test-connection endpoint. Returns the resolved token lifetime —
+     * never the token itself.
+     *
+     * @throws AuthTokenException with a redacted, user-facing message when the fetch fails
+     */
+    public long testFetch(@NonNull ProviderAuthConfig authConfig) {
+        return fetchToken(authConfig, ORIGIN_TEST).ttlSeconds();
+    }
+
     // --- recipe execution ---
 
     FetchedToken fetchToken(@NonNull ProviderAuthConfig authConfig) {
-        HttpRequest request = buildRequest(authConfig);
+        return fetchToken(authConfig, ORIGIN_REQUEST);
+    }
+
+    private FetchedToken fetchToken(ProviderAuthConfig authConfig, String origin) {
         long startNanos = System.nanoTime();
+        try {
+            destinationGuard.validate(authConfig.tokenUrl());
+        } catch (DestinationGuardException exception) {
+            recordFetchMetric(startNanos, "destination_refused", origin);
+            throw new AuthTokenException(exception.getMessage()
+                    + " (self-hosted deployments with internal auth services can set LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed)",
+                    exception);
+        }
+        HttpRequest request = buildRequest(authConfig);
         HttpResponse<String> response;
         try {
             response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         } catch (IOException exception) {
-            recordFetchMetric(startNanos, "unreachable");
+            recordFetchMetric(startNanos, "unreachable", origin);
             throw new AuthTokenException("token fetch failed: could not reach '%s': %s"
                     .formatted(authConfig.tokenUrl(), redact(authConfig, exception.getMessage())), exception);
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
-            recordFetchMetric(startNanos, "interrupted");
+            recordFetchMetric(startNanos, "interrupted", origin);
             throw new AuthTokenException("token fetch was interrupted", exception);
         }
 
         String body = Optional.ofNullable(response.body()).orElse("");
         if (response.statusCode() < 200 || response.statusCode() >= 300) {
-            recordFetchMetric(startNanos, "upstream_error");
+            recordFetchMetric(startNanos, "upstream_error", origin);
             throw new AuthTokenException("token fetch failed with status '%d' from '%s': %s"
                     .formatted(response.statusCode(), authConfig.tokenUrl(), redact(authConfig, body)));
         }
         if (body.length() > config.getMaxResponseChars()) {
-            recordFetchMetric(startNanos, "oversized_reply");
+            recordFetchMetric(startNanos, "oversized_reply", origin);
             throw new AuthTokenException("token reply from '%s' exceeds the maximum accepted size"
                     .formatted(authConfig.tokenUrl()));
         }
@@ -261,7 +290,7 @@ public class AuthTokenProvider {
         try {
             root = JsonUtils.getJsonNodeFromString(body);
         } catch (UncheckedIOException exception) {
-            recordFetchMetric(startNanos, "non_json_reply");
+            recordFetchMetric(startNanos, "non_json_reply", origin);
             throw new AuthTokenException("token endpoint at '%s' returned a non-JSON reply (status '%d')"
                     .formatted(authConfig.tokenUrl(), response.statusCode()));
         }
@@ -269,14 +298,14 @@ public class AuthTokenProvider {
         String tokenField = defaultIfBlank(authConfig.tokenField(), DEFAULT_TOKEN_FIELD);
         JsonNode tokenNode = atDotPath(root, tokenField);
         if (!tokenNode.isTextual() || isBlank(tokenNode.asText())) {
-            recordFetchMetric(startNanos, "token_field_missing");
+            recordFetchMetric(startNanos, "token_field_missing", origin);
             // field names are safe to surface; values never are
             throw new AuthTokenException("field '%s' not found in the token reply; top-level fields: %s"
                     .formatted(tokenField, root.properties().stream().map(Map.Entry::getKey).toList()));
         }
 
-        long ttlSeconds = resolveTtlSeconds(root, authConfig, startNanos);
-        recordFetchMetric(startNanos, "success");
+        long ttlSeconds = resolveTtlSeconds(root, authConfig, startNanos, origin);
+        recordFetchMetric(startNanos, "success", origin);
         return new FetchedToken(tokenNode.asText(), ttlSeconds);
     }
 
@@ -323,7 +352,7 @@ public class AuthTokenProvider {
      * a non-positive value is an error), else the recipe's fallback (where 0 meansthe token is
      * served uncached), else an error naming the missing field.
      */
-    private long resolveTtlSeconds(JsonNode root, ProviderAuthConfig authConfig, long startNanos) {
+    private long resolveTtlSeconds(JsonNode root, ProviderAuthConfig authConfig, long startNanos, String origin) {
         String expiresField = defaultIfBlank(authConfig.expiresField(), DEFAULT_EXPIRES_FIELD);
         JsonNode expiresNode = atDotPath(root, expiresField);
 
@@ -339,7 +368,7 @@ public class AuthTokenProvider {
         }
         if (ttlSeconds != null) {
             if (ttlSeconds <= 0) {
-                recordFetchMetric(startNanos, "lifetime_invalid");
+                recordFetchMetric(startNanos, "lifetime_invalid", origin);
                 throw new AuthTokenException("token reply states a non-positive lifetime of '%d' seconds"
                         .formatted(ttlSeconds));
             }
@@ -347,7 +376,7 @@ public class AuthTokenProvider {
         }
         // the configured fallback may legitimately be 0: the fetch-per-call convention
         if (authConfig.fallbackTtlSeconds() == null) {
-            recordFetchMetric(startNanos, "lifetime_missing");
+            recordFetchMetric(startNanos, "lifetime_missing", origin);
             throw new AuthTokenException(
                     "token reply has no lifetime field '%s' and no fallback lifetime is configured"
                             .formatted(expiresField));
@@ -411,8 +440,8 @@ public class AuthTokenProvider {
         tokenRequests.add(1, Attributes.of(OUTCOME, outcome, WORKSPACE_ID, workspaceId));
     }
 
-    private void recordFetchMetric(long startNanos, String outcome) {
+    private void recordFetchMetric(long startNanos, String outcome, String origin) {
         fetchDurationMs.record((System.nanoTime() - startNanos) / 1_000_000,
-                Attributes.of(OUTCOME, outcome));
+                Attributes.of(OUTCOME, outcome, ORIGIN, origin));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmClientGenerator.java
@@ -19,12 +19,14 @@ import org.apache.commons.lang3.StringUtils;
 import java.net.http.HttpClient;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 @Slf4j
 public class CustomLlmClientGenerator implements LlmProviderClientGenerator<OpenAiClient> {
 
     private final @NonNull LlmProviderClientConfig llmProviderClientConfig;
+    private final @NonNull AuthTokenProvider authTokenProvider;
 
     public OpenAiClient newCustomLlmClient(@NonNull LlmProviderClientApiConfig config) {
         var baseUrl = Optional.ofNullable(config.baseUrl())
@@ -126,7 +128,27 @@ public class CustomLlmClientGenerator implements LlmProviderClientGenerator<Open
         if (!requiresInterceptingBuilder(config)) {
             return jdkHttpClientBuilder;
         }
-        return new InterceptingHttpClientBuilder(jdkHttpClientBuilder, config.configuration(), config.apiKey());
+        return new InterceptingHttpClientBuilder(jdkHttpClientBuilder, config.configuration(), config.apiKey(),
+                bearerSupplier(config), tokenInvalidator(config));
+    }
+
+    /**
+     * Per-request bearer source for token-auth providers. The supplier form matters: clients are
+     * rebuilt per call but requests are what carry auth, so the interceptor asks the shared cache
+     * on every request and refresh/rotation need no client rebuild.
+     */
+    private Supplier<String> bearerSupplier(LlmProviderClientApiConfig config) {
+        if (config.authConfig() == null) {
+            return null;
+        }
+        return () -> authTokenProvider.bearer(config.workspaceId(), config.providerId(), config.authConfig());
+    }
+
+    private Runnable tokenInvalidator(LlmProviderClientApiConfig config) {
+        if (config.authConfig() == null) {
+            return null;
+        }
+        return () -> authTokenProvider.invalidate(config.providerId(), config.authConfig());
     }
 
     /**
@@ -144,6 +166,6 @@ public class CustomLlmClientGenerator implements LlmProviderClientGenerator<Open
                                         configuration.get(InterceptingHttpClient.SUPPRESS_DEFAULT_AUTH_CONFIG_KEY))));
         boolean hasModelPlaceholder = config.baseUrl() != null
                 && config.baseUrl().contains(InterceptingHttpClient.MODEL_PLACEHOLDER);
-        return hasNewConfigKeys || hasModelPlaceholder;
+        return hasNewConfigKeys || hasModelPlaceholder || config.authConfig() != null;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmClientGenerator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmClientGenerator.java
@@ -148,7 +148,8 @@ public class CustomLlmClientGenerator implements LlmProviderClientGenerator<Open
         if (config.authConfig() == null) {
             return null;
         }
-        return () -> authTokenProvider.invalidate(config.providerId(), config.authConfig());
+        return () -> authTokenProvider.invalidateAfterGatewayRejection(config.workspaceId(), config.providerId(),
+                config.authConfig());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/CustomLlmModule.java
@@ -15,8 +15,9 @@ public class CustomLlmModule extends AbstractModule {
     @Singleton
     @Named("customLlmGenerator")
     public CustomLlmClientGenerator clientGenerator(
-            @NonNull @Config("llmProviderClient") LlmProviderClientConfig config) {
-        return new CustomLlmClientGenerator(config);
+            @NonNull @Config("llmProviderClient") LlmProviderClientConfig config,
+            @NonNull AuthTokenProvider authTokenProvider) {
+        return new CustomLlmClientGenerator(config, authTokenProvider);
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClient.java
@@ -22,7 +22,9 @@ import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * HTTP client decorator for the Custom LLM provider that mutates outgoing
@@ -69,6 +71,12 @@ class InterceptingHttpClient implements HttpClient {
 
     private static final TypeReference<Map<String, String>> QUERY_PARAMS_TYPE = new TypeReference<>() {
     };
+
+    // RFC 6750 signals a token problem via WWW-Authenticate error="invalid_token", but the
+    // http client abstraction surfaces only status + body; gateways typically echo the marker
+    // in the body, so that is the signal available here.
+    private static final Pattern TOKEN_REJECTION_HINT = Pattern.compile("invalid_token|expired|revoked",
+            Pattern.CASE_INSENSITIVE);
 
     private final @NonNull HttpClient delegate;
     private final Map<String, String> configuration;
@@ -119,9 +127,20 @@ class InterceptingHttpClient implements HttpClient {
         delegate.execute(mutate(request), parser, new RetryOnAuthFailureListener(request, parser, listener));
     }
 
+    /**
+     * 401 is unambiguous. A 403 is usually a policy/quota/WAF decision, so reying only when
+     * the response body hints the token itself was rejected.
+     */
     private boolean shouldRetryWithFreshToken(HttpException exception) {
-        return tokenSupplier != null
-                && (exception.statusCode() == 401 || exception.statusCode() == 403);
+        if (tokenSupplier == null) {
+            return false;
+        }
+        if (exception.statusCode() == 401) {
+            return true;
+        }
+        return exception.statusCode() == 403
+                && exception.getMessage() != null
+                && TOKEN_REJECTION_HINT.matcher(exception.getMessage()).find();
     }
 
     private void invalidateToken() {
@@ -141,29 +160,29 @@ class InterceptingHttpClient implements HttpClient {
         private final HttpRequest originalRequest;
         private final ServerSentEventParser parser;
         private final ServerSentEventListener downstream;
-        private boolean delivered;
+        private final AtomicBoolean delivered = new AtomicBoolean(false);
 
         @Override
         public void onOpen(SuccessfulHttpResponse response) {
-            delivered = true;
+            delivered.set(true);
             downstream.onOpen(response);
         }
 
         @Override
         public void onEvent(ServerSentEvent event, ServerSentEventContext context) {
-            delivered = true;
+            delivered.set(true);
             downstream.onEvent(event, context);
         }
 
         @Override
         public void onEvent(ServerSentEvent event) {
-            delivered = true;
+            delivered.set(true);
             downstream.onEvent(event);
         }
 
         @Override
         public void onError(Throwable throwable) {
-            if (!delivered && throwable instanceof HttpException httpException
+            if (!delivered.get() && throwable instanceof HttpException httpException
                     && shouldRetryWithFreshToken(httpException)) {
                 invalidateToken();
                 try {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClient.java
@@ -7,9 +7,12 @@ import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventContext;
 import dev.langchain4j.http.client.sse.ServerSentEventListener;
 import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
@@ -19,6 +22,7 @@ import java.net.URISyntaxException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * HTTP client decorator for the Custom LLM provider that mutates outgoing
@@ -39,6 +43,13 @@ import java.util.Map;
  *   <li>Removes the default {@code Authorization: Bearer <apiKey>} header when
  *       {@code configuration["suppress_default_auth"]} is {@code "true"}. Used
  *       by gateways whose policy rejects an {@code Authorization} header.</li>
+ *   <li>Injects a dynamically fetched bearer for token-auth providers ({@code auth_config}):
+ *       the token is asked from the shared cache on every request and placed in
+ *       {@code Authorization: Bearer} (or raw under the configured {@code auth_header_name}).
+ *       Precedence: the fetched token wins — a pre-configured static {@code Authorization}
+ *       header is dropped with a warn. A 401/403 from the gateway invalidates the cached token
+ *       and retries the request once; for streamed responses only before the first delivered
+ *       event.</li>
  * </ul>
  *
  * <p>When none of the relevant config keys are set and no {@code {model}}
@@ -62,6 +73,12 @@ class InterceptingHttpClient implements HttpClient {
     private final @NonNull HttpClient delegate;
     private final Map<String, String> configuration;
     private final String apiKey;
+    private final Supplier<String> tokenSupplier;
+    private final Runnable tokenInvalidator;
+
+    InterceptingHttpClient(@NonNull HttpClient delegate, Map<String, String> configuration, String apiKey) {
+        this(delegate, configuration, apiKey, null, null);
+    }
 
     /**
      * Normalizes a null {@code configuration} to an empty map so helpers can
@@ -69,26 +86,107 @@ class InterceptingHttpClient implements HttpClient {
      * {@code {model}}-only providers (which may carry no new config keys yet
      * still reach {@code mutate()}) safe.
      */
-    InterceptingHttpClient(@NonNull HttpClient delegate, Map<String, String> configuration, String apiKey) {
+    InterceptingHttpClient(@NonNull HttpClient delegate, Map<String, String> configuration, String apiKey,
+            Supplier<String> tokenSupplier, Runnable tokenInvalidator) {
         this.delegate = delegate;
         this.configuration = configuration != null ? configuration : Map.of();
         this.apiKey = apiKey;
+        this.tokenSupplier = tokenSupplier;
+        this.tokenInvalidator = tokenInvalidator;
     }
 
     @Override
     public SuccessfulHttpResponse execute(HttpRequest request) throws HttpException, RuntimeException {
-        return delegate.execute(mutate(request));
+        try {
+            return delegate.execute(mutate(request));
+        } catch (HttpException exception) {
+            if (!shouldRetryWithFreshToken(exception)) {
+                throw exception;
+            }
+            invalidateToken();
+            // re-mutating asks the supplier again, which now yields a fresh token
+            return delegate.execute(mutate(request));
+        }
     }
 
     @Override
     public void execute(HttpRequest request, ServerSentEventParser parser,
             ServerSentEventListener listener) {
-        delegate.execute(mutate(request), parser, listener);
+        if (tokenSupplier == null) {
+            delegate.execute(mutate(request), parser, listener);
+            return;
+        }
+        delegate.execute(mutate(request), parser, new RetryOnAuthFailureListener(request, parser, listener));
+    }
+
+    private boolean shouldRetryWithFreshToken(HttpException exception) {
+        return tokenSupplier != null
+                && (exception.statusCode() == 401 || exception.statusCode() == 403);
+    }
+
+    private void invalidateToken() {
+        if (tokenInvalidator != null) {
+            tokenInvalidator.run();
+        }
+    }
+
+    /**
+     * Retries a streamed request once on 401/403, but only while nothing has been delivered to
+     * the downstream listener — once content flowed, a retry would splice two half-responses, so
+     * the failure propagates honestly instead.
+     */
+    @RequiredArgsConstructor
+    private class RetryOnAuthFailureListener implements ServerSentEventListener {
+
+        private final HttpRequest originalRequest;
+        private final ServerSentEventParser parser;
+        private final ServerSentEventListener downstream;
+        private boolean delivered;
+
+        @Override
+        public void onOpen(SuccessfulHttpResponse response) {
+            delivered = true;
+            downstream.onOpen(response);
+        }
+
+        @Override
+        public void onEvent(ServerSentEvent event, ServerSentEventContext context) {
+            delivered = true;
+            downstream.onEvent(event, context);
+        }
+
+        @Override
+        public void onEvent(ServerSentEvent event) {
+            delivered = true;
+            downstream.onEvent(event);
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            if (!delivered && throwable instanceof HttpException httpException
+                    && shouldRetryWithFreshToken(httpException)) {
+                invalidateToken();
+                try {
+                    // retry straight to the downstream listener: a second failure must not retry again
+                    delegate.execute(mutate(originalRequest), parser, downstream);
+                    return;
+                } catch (RuntimeException retryFailure) {
+                    downstream.onError(retryFailure);
+                    return;
+                }
+            }
+            downstream.onError(throwable);
+        }
+
+        @Override
+        public void onClose() {
+            downstream.onClose();
+        }
     }
 
     private HttpRequest mutate(HttpRequest request) {
         boolean hasPlaceholder = request.url() != null && request.url().contains(MODEL_PLACEHOLDER);
-        if (configuration.isEmpty() && !hasPlaceholder) {
+        if (configuration.isEmpty() && !hasPlaceholder && tokenSupplier == null) {
             return request;
         }
 
@@ -155,6 +253,9 @@ class InterceptingHttpClient implements HttpClient {
     }
 
     private Map<String, List<String>> applyAuthHeaders(Map<String, List<String>> headers) {
+        if (tokenSupplier != null) {
+            return applyBearerToken(headers);
+        }
         String customHeaderName = configuration.get(AUTH_HEADER_NAME_CONFIG_KEY);
         boolean addCustomHeader = StringUtils.isNotBlank(customHeaderName)
                 && StringUtils.isNotBlank(apiKey);
@@ -186,6 +287,31 @@ class InterceptingHttpClient implements HttpClient {
         if (addCustomHeader) {
             mutated.put(customHeaderName, List.of(apiKey));
         }
+        return mutated;
+    }
+
+    /**
+     * Token-auth mode: the fetched bearer is the sole credential on the request. It lands in
+     * {@code Authorization: Bearer <token>} by default, or raw under the configured
+     * {@code auth_header_name}. A pre-existing {@code Authorization} (e.g. a static header from
+     * the provider's headers map) loses to the fetched token and is dropped loudly.
+     */
+    private Map<String, List<String>> applyBearerToken(Map<String, List<String>> headers) {
+        String token = tokenSupplier.get();
+        String customHeaderName = StringUtils.trimToNull(configuration.get(AUTH_HEADER_NAME_CONFIG_KEY));
+        String targetHeader = customHeaderName != null ? customHeaderName : AUTHORIZATION_HEADER;
+        String targetValue = customHeaderName != null ? token : "Bearer " + token;
+
+        var mutated = new LinkedHashMap<String, List<String>>(headers.size() + 1);
+        for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+            if (AUTHORIZATION_HEADER.equalsIgnoreCase(entry.getKey())
+                    || targetHeader.equalsIgnoreCase(entry.getKey())) {
+                log.warn("Dropping pre-configured '{}' header: the fetched token takes precedence", entry.getKey());
+                continue;
+            }
+            mutated.put(entry.getKey(), entry.getValue());
+        }
+        mutated.put(targetHeader, List.of(targetValue));
         return mutated;
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientBuilder.java
@@ -6,11 +6,13 @@ import dev.langchain4j.http.client.HttpClientBuilder;
 import lombok.NonNull;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Decorates an {@link HttpClientBuilder} so the produced {@link HttpClient} is
  * wrapped with {@link InterceptingHttpClient} to apply Custom LLM-specific
- * request mutations (query params, auth headers, {@code {model}} substitution).
+ * request mutations (query params, auth headers, {@code {model}} substitution,
+ * dynamic bearer injection).
  *
  * <p>Timeout forwarding is inherited from {@link DelegatingHttpClientBuilder}; only the
  * {@link #wrap(HttpClient)} step is specific to this builder.
@@ -19,16 +21,20 @@ class InterceptingHttpClientBuilder extends DelegatingHttpClientBuilder {
 
     private final Map<String, String> configuration;
     private final String apiKey;
+    private final Supplier<String> tokenSupplier;
+    private final Runnable tokenInvalidator;
 
     InterceptingHttpClientBuilder(@NonNull HttpClientBuilder delegate, Map<String, String> configuration,
-            String apiKey) {
+            String apiKey, Supplier<String> tokenSupplier, Runnable tokenInvalidator) {
         super(delegate);
         this.configuration = configuration;
         this.apiKey = apiKey;
+        this.tokenSupplier = tokenSupplier;
+        this.tokenInvalidator = tokenInvalidator;
     }
 
     @Override
     protected HttpClient wrap(HttpClient delegate) {
-        return new InterceptingHttpClient(delegate, configuration, apiKey);
+        return new InterceptingHttpClient(delegate, configuration, apiKey, tokenSupplier, tokenInvalidator);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/net/DestinationGuard.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/net/DestinationGuard.java
@@ -1,0 +1,113 @@
+package com.comet.opik.infrastructure.net;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+/**
+ * Pre-flight check for outbound calls to user-supplied URLs (SSRF guard). In {@code STRICT} mode
+ * (cloud) it requires HTTPS and resolves the hostname before anyone connects, refusing addresses
+ * only our own network can reach: loopback, link-local (including the cloud metadata endpoint at
+ * 169.254.169.254), RFC 1918 private ranges, IPv6 unique-local, multicast, and unresolvable hosts.
+ * In {@code RELAXED} mode (self-hosted default) it is a no-op — internal gateways legitimately
+ * live on private ranges there.
+ *
+ * <p>Resolve-then-decide is the accepted level of protection here: the later connection resolves
+ * again, so a DNS-rebinding attacker with a sub-TTL flip could theoretically pass the check. The
+ * surfaces this guards are admin-configured (not anonymous input), which keeps that residual risk
+ * acceptable; connection-time pinning would require a custom socket layer.
+ */
+@RequiredArgsConstructor
+public class DestinationGuard {
+
+    public enum Mode {
+        RELAXED("relaxed"),
+        STRICT("strict"),
+        ;
+
+        @JsonValue
+        private final String value;
+
+        Mode(String value) {
+            this.value = value;
+        }
+
+        @JsonCreator
+        public static Mode fromString(String value) {
+            return Arrays.stream(values())
+                    .filter(mode -> mode.value.equalsIgnoreCase(value))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "Unknown destination guard mode '%s'".formatted(value)));
+        }
+    }
+
+    private final @NonNull Mode mode;
+
+    /**
+     * @throws DestinationGuardException with a user-facing message when the destination is refused
+     */
+    public void validate(@NonNull String url) {
+        if (mode == Mode.RELAXED) {
+            return;
+        }
+
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException exception) {
+            throw new DestinationGuardException("destination '%s' is not a valid URL".formatted(url));
+        }
+        if (!"https".equalsIgnoreCase(uri.getScheme())) {
+            throw new DestinationGuardException(
+                    "destination '%s' was refused: only https URLs are allowed".formatted(url));
+        }
+        String host = uri.getHost();
+        if (isBlank(host)) {
+            throw new DestinationGuardException("destination '%s' has no valid host".formatted(url));
+        }
+
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException exception) {
+            throw new DestinationGuardException(
+                    "destination host '%s' could not be resolved".formatted(host));
+        }
+        for (InetAddress address : addresses) {
+            if (isNonPublic(address)) {
+                // deliberately not echoing the resolved address: the hostname is the user's own
+                // input, the address it maps to inside our network is not theirs to learn
+                throw new DestinationGuardException(
+                        "destination host '%s' was refused: it resolves to a private or internal address"
+                                .formatted(host));
+            }
+        }
+    }
+
+    private static boolean isNonPublic(InetAddress address) {
+        return address.isAnyLocalAddress()
+                || address.isLoopbackAddress()
+                || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress()
+                || address.isMulticastAddress()
+                || isUniqueLocalIpv6(address);
+    }
+
+    /**
+     * fc00::/7 — Java's {@code isSiteLocalAddress} only covers the deprecated fec0::/10 for IPv6.
+     */
+    private static boolean isUniqueLocalIpv6(InetAddress address) {
+        return address instanceof Inet6Address && (address.getAddress()[0] & 0xFE) == 0xFC;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/net/DestinationGuardException.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/net/DestinationGuardException.java
@@ -1,0 +1,12 @@
+package com.comet.opik.infrastructure.net;
+
+/**
+ * A user-supplied outbound destination was refused by {@link DestinationGuard}. The message is
+ * user-facing: it names the URL the user configured, never the address it resolved to.
+ */
+public class DestinationGuardException extends RuntimeException {
+
+    public DestinationGuardException(String message) {
+        super(message);
+    }
+}

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000095_add_auth_config_to_llm_provider_api_key.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000095_add_auth_config_to_llm_provider_api_key.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+--changeset miguelg:000095_add_auth_config_to_llm_provider_api_key
+--comment: Add encrypted auth_config column for dynamic token auth on custom providers
+
+ALTER TABLE llm_provider_api_key ADD COLUMN auth_config TEXT DEFAULT NULL;
+
+--rollback ALTER TABLE llm_provider_api_key DROP COLUMN auth_config;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/EncryptedAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/EncryptedAuthConfigTest.java
@@ -1,0 +1,69 @@
+package com.comet.opik.api;
+
+import com.comet.opik.infrastructure.EncryptionUtils;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptedAuthConfigTest {
+
+    @BeforeAll
+    static void setUpAll() {
+        var config = new OpikConfiguration();
+        config.getEncryption().setKey("0123456789abcdef");
+        EncryptionUtils.setConfig(config);
+    }
+
+    private ProviderAuthConfig recipe() {
+        return ProviderAuthConfig.builder()
+                .tokenUrl("https://auth.example.com/oauth2/token")
+                .credentials(List.of(
+                        ProviderAuthConfig.Credential.builder()
+                                .key("client_secret").value("s3cr3t").secret(true).build()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("a DB-loaded config decrypts only when the value is touched")
+    void decryptionIsLazy() {
+        var garbage = EncryptedAuthConfig.fromCiphertext("not-even-base64!");
+
+        assertThatCode(() -> {
+            garbage.toString();
+            garbage.hashSource();
+            garbage.ciphertextOrEncrypt();
+        }).doesNotThrowAnyException();
+
+        assertThatThrownBy(garbage::value).isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    @DisplayName("an untouched config persists its original ciphertext, byte for byte")
+    void untouchedConfigPreservesCiphertext() {
+        var ciphertext = EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(recipe()));
+        var loaded = EncryptedAuthConfig.fromCiphertext(ciphertext);
+
+        assertThat(loaded.ciphertextOrEncrypt()).isEqualTo(ciphertext);
+        assertThat(loaded.hashSource()).isEqualTo(ciphertext);
+
+        // still the same ciphertext after a read: value() memoizes, it never re-encrypts
+        assertThat(loaded.value()).isEqualTo(recipe());
+        assertThat(loaded.ciphertextOrEncrypt()).isEqualTo(ciphertext);
+    }
+
+    @Test
+    @DisplayName("DB-loaded and request-built forms of the same recipe are equal")
+    void equalityBridgesBothForms() {
+        var ciphertext = EncryptionUtils.encryptGcm(JsonUtils.writeValueAsString(recipe()));
+
+        assertThat(EncryptedAuthConfig.fromCiphertext(ciphertext)).isEqualTo(EncryptedAuthConfig.of(recipe()));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
@@ -44,6 +44,8 @@ class ProviderAuthConfigTest {
     @Test
     void toStringNeverExposesCredentialValues() {
         assertThat(AUTH_CONFIG.toString()).doesNotContain("s3cr3t", "opik-prod", "client_credentials");
+        // Lombok builders don't inherit the record's toString() override; the builder skeleton does
+        assertThat(credential("client_secret", "s3cr3t", true).toBuilder().toString()).doesNotContain("s3cr3t");
         assertThat(AUTH_CONFIG.credentials().getLast().toString()).doesNotContain("s3cr3t");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
@@ -42,6 +42,19 @@ class ProviderAuthConfigTest {
     }
 
     @Test
+    void partialConfigsAreNotEmptySoTheyValidateInsteadOfClearing() {
+        // any single field set means "not the clear convention" — the update path must
+        // route these through validationErrors(), never silently clear the stored recipe
+        assertThat(ProviderAuthConfig.builder().sendAs(ProviderAuthConfig.SendAs.BASIC).build().isEmpty()).isFalse();
+        assertThat(ProviderAuthConfig.builder().tokenField("access_token").build().isEmpty()).isFalse();
+        assertThat(ProviderAuthConfig.builder().expiresField("expires_in").build().isEmpty()).isFalse();
+        assertThat(ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build().isEmpty()).isFalse();
+
+        assertThat(ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build().validationErrors())
+                .isNotEmpty();
+    }
+
+    @Test
     void validationErrorsRequireTokenUrlAndCredentials() {
         assertThat(AUTH_CONFIG.validationErrors()).isEmpty();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
@@ -1,0 +1,60 @@
+package com.comet.opik.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ProviderAuthConfigTest {
+
+    private static final ProviderAuthConfig AUTH_CONFIG = ProviderAuthConfig.builder()
+            .tokenUrl("https://auth.example.com/oauth/token")
+            .sendAs(ProviderAuthConfig.SendAs.BASIC)
+            .credentials(List.of(
+                    credential("grant_type", "client_credentials", false),
+                    credential("client_id", "opik-prod", false),
+                    credential("client_secret", "s3cr3t", true)))
+            .tokenField("access_token")
+            .expiresField("expires_in")
+            .build();
+
+    private static ProviderAuthConfig.Credential credential(String key, String value, boolean secret) {
+        return ProviderAuthConfig.Credential.builder().key(key).value(value).secret(secret).build();
+    }
+
+    @Test
+    void maskReplacesOnlySecretValues() {
+        var masked = AUTH_CONFIG.mask();
+
+        assertThat(masked.credentials()).containsExactly(
+                credential("grant_type", "client_credentials", false),
+                credential("client_id", "opik-prod", false),
+                credential("client_secret", ProviderAuthConfig.SECRET_SENTINEL, true));
+        assertThat(masked.tokenUrl()).isEqualTo(AUTH_CONFIG.tokenUrl());
+    }
+
+    @Test
+    void emptyObjectIsTheClearConvention() {
+        assertThat(ProviderAuthConfig.builder().build().isEmpty()).isTrue();
+        assertThat(AUTH_CONFIG.isEmpty()).isFalse();
+        assertThat(ProviderAuthConfig.builder().tokenUrl("https://auth.example.com").build().isEmpty()).isFalse();
+    }
+
+    @Test
+    void validationErrorsRequireTokenUrlAndCredentials() {
+        assertThat(AUTH_CONFIG.validationErrors()).isEmpty();
+
+        assertThat(AUTH_CONFIG.toBuilder().tokenUrl("not a uri").build().validationErrors())
+                .containsExactly("auth_config.token_url must be a valid absolute URI");
+        assertThat(AUTH_CONFIG.toBuilder().credentials(List.of()).build().validationErrors())
+                .containsExactly("auth_config.credentials must not be empty");
+        assertThat(ProviderAuthConfig.builder().build().validationErrors()).hasSize(2);
+    }
+
+    @Test
+    void toStringNeverExposesCredentialValues() {
+        assertThat(AUTH_CONFIG.toString()).doesNotContain("s3cr3t", "opik-prod", "client_credentials");
+        assertThat(AUTH_CONFIG.credentials().getLast().toString()).doesNotContain("s3cr3t");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
@@ -1,15 +1,10 @@
 package com.comet.opik.api;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class ProviderAuthConfigTest {
 
@@ -44,37 +39,6 @@ class ProviderAuthConfigTest {
         assertThat(ProviderAuthConfig.builder().build().isEmpty()).isTrue();
         assertThat(AUTH_CONFIG.isEmpty()).isFalse();
         assertThat(ProviderAuthConfig.builder().tokenUrl("https://auth.example.com").build().isEmpty()).isFalse();
-    }
-
-    // any single field set means "not the clear convention" — the update path must
-    // route these through validationErrors(), never silently clear the stored recipe
-    static Stream<Arguments> partialConfigs() {
-        return Stream.of(
-                arguments("sendAs", ProviderAuthConfig.builder().sendAs(ProviderAuthConfig.SendAs.BASIC).build()),
-                arguments("credentials", ProviderAuthConfig.builder()
-                        .credentials(List.of(credential("client_id", "opik", false)))
-                        .build()),
-                arguments("tokenField", ProviderAuthConfig.builder().tokenField("access_token").build()),
-                arguments("expiresField", ProviderAuthConfig.builder().expiresField("expires_in").build()),
-                arguments("fallbackTtlSeconds", ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build()));
-    }
-
-    @ParameterizedTest(name = "only {0} set")
-    @MethodSource("partialConfigs")
-    void partialConfigsAreNotEmptySoTheyValidateInsteadOfClearing(String field, ProviderAuthConfig partial) {
-        assertThat(partial.isEmpty()).isFalse();
-        assertThat(partial.validationErrors()).isNotEmpty();
-    }
-
-    @Test
-    void validationErrorsRequireTokenUrlAndCredentials() {
-        assertThat(AUTH_CONFIG.validationErrors()).isEmpty();
-
-        assertThat(AUTH_CONFIG.toBuilder().tokenUrl("not a uri").build().validationErrors())
-                .containsExactly("auth_config.token_url must be a valid absolute URI");
-        assertThat(AUTH_CONFIG.toBuilder().credentials(List.of()).build().validationErrors())
-                .containsExactly("auth_config.credentials must not be empty");
-        assertThat(ProviderAuthConfig.builder().build().validationErrors()).hasSize(2);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/ProviderAuthConfigTest.java
@@ -1,10 +1,15 @@
 package com.comet.opik.api;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class ProviderAuthConfigTest {
 
@@ -41,17 +46,24 @@ class ProviderAuthConfigTest {
         assertThat(ProviderAuthConfig.builder().tokenUrl("https://auth.example.com").build().isEmpty()).isFalse();
     }
 
-    @Test
-    void partialConfigsAreNotEmptySoTheyValidateInsteadOfClearing() {
-        // any single field set means "not the clear convention" — the update path must
-        // route these through validationErrors(), never silently clear the stored recipe
-        assertThat(ProviderAuthConfig.builder().sendAs(ProviderAuthConfig.SendAs.BASIC).build().isEmpty()).isFalse();
-        assertThat(ProviderAuthConfig.builder().tokenField("access_token").build().isEmpty()).isFalse();
-        assertThat(ProviderAuthConfig.builder().expiresField("expires_in").build().isEmpty()).isFalse();
-        assertThat(ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build().isEmpty()).isFalse();
+    // any single field set means "not the clear convention" — the update path must
+    // route these through validationErrors(), never silently clear the stored recipe
+    static Stream<Arguments> partialConfigs() {
+        return Stream.of(
+                arguments("sendAs", ProviderAuthConfig.builder().sendAs(ProviderAuthConfig.SendAs.BASIC).build()),
+                arguments("credentials", ProviderAuthConfig.builder()
+                        .credentials(List.of(credential("client_id", "opik", false)))
+                        .build()),
+                arguments("tokenField", ProviderAuthConfig.builder().tokenField("access_token").build()),
+                arguments("expiresField", ProviderAuthConfig.builder().expiresField("expires_in").build()),
+                arguments("fallbackTtlSeconds", ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build()));
+    }
 
-        assertThat(ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build().validationErrors())
-                .isNotEmpty();
+    @ParameterizedTest(name = "only {0} set")
+    @MethodSource("partialConfigs")
+    void partialConfigsAreNotEmptySoTheyValidateInsteadOfClearing(String field, ProviderAuthConfig partial) {
+        assertThat(partial.isEmpty()).isFalse();
+        assertThat(partial.validationErrors()).isNotEmpty();
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LlmProviderApiKeyResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/LlmProviderApiKeyResourceClient.java
@@ -5,6 +5,7 @@ import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Page;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthCheck;
 import com.comet.opik.api.resources.utils.TestUtils;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.client.Entity;
@@ -69,6 +70,17 @@ public class LlmProviderApiKeyResourceClient {
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .method(HttpMethod.PATCH, Entity.json(providerApiKeyUpdate));
+    }
+
+    public Response callTestAuthConfig(ProviderAuthCheck providerAuthTest, String apiKey, String workspaceName) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path("auth-config")
+                .path("test")
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(providerAuthTest));
     }
 
     public Response callDeleteProviderApiKeys(Set<UUID> ids, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -1034,9 +1034,8 @@ class LlmProviderApiKeyResourceTest {
 
             try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(
                     ProviderAuthCheck.builder().build(), apiKey, workspaceName)) {
-                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
-                assertThat(response.readEntity(ErrorMessage.class).getMessage())
-                        .contains("either provider_id or auth_config");
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_UNPROCESSABLE_CONTENT);
+                assertThat(response.readEntity(String.class)).contains("either provider_id or auth_config");
             }
 
             var staticProvider = llmProviderApiKeyResourceClient.createProviderApiKey(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Page;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
@@ -619,6 +620,227 @@ class LlmProviderApiKeyResourceTest {
                 workspaceName, 201);
         actualProviderApiKeyPage = llmProviderApiKeyResourceClient.getAll(workspaceName, apiKey);
         assertPage(actualProviderApiKeyPage, List.of(expectedProviderApiKey));
+    }
+
+    @Nested
+    @DisplayName("Auth config:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AuthConfigTest {
+
+        private static final String SECRET_VALUE = "super-s3cr3t";
+
+        private ProviderAuthConfig tokenAuthConfig() {
+            return ProviderAuthConfig.builder()
+                    .tokenUrl("https://auth.example.com/oauth/token")
+                    .sendAs(ProviderAuthConfig.SendAs.BASIC)
+                    .credentials(List.of(
+                            credential("grant_type", "client_credentials", false),
+                            credential("client_id", "opik-prod", false),
+                            credential("client_secret", SECRET_VALUE, true)))
+                    .tokenField("access_token")
+                    .expiresField("expires_in")
+                    .fallbackTtlSeconds(3600L)
+                    .build();
+        }
+
+        private ProviderAuthConfig.Credential credential(String key, String value, boolean secret) {
+            return ProviderAuthConfig.Credential.builder().key(key).value(value).secret(secret).build();
+        }
+
+        private ProviderApiKey customProviderWithAuthConfig() {
+            return factory.manufacturePojo(ProviderApiKey.class).toBuilder()
+                    .provider(LlmProvider.CUSTOM_LLM)
+                    .providerName(UUID.randomUUID().toString())
+                    .apiKey(null)
+                    .authConfig(tokenAuthConfig())
+                    .build();
+        }
+
+        private ProviderAuthConfig storedAuthConfig(UUID id, String workspaceId) {
+            return mySqlTemplate.inTransaction(READ_ONLY,
+                    handle -> handle.attach(LlmProviderApiKeyDAO.class).findById(id, workspaceId).authConfig());
+        }
+
+        @Test
+        @DisplayName("create stores the recipe encrypted and reads it back masked")
+        void createAndGetMasksSecrets() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            var actual = llmProviderApiKeyResourceClient.getById(created.id(), workspaceName, apiKey,
+                    HttpStatus.SC_OK);
+            assertThat(actual.authConfig()).isEqualTo(tokenAuthConfig().mask());
+            assertThat(actual.authConfig().credentials().getLast().value())
+                    .isEqualTo(ProviderAuthConfig.SECRET_SENTINEL);
+
+            var page = llmProviderApiKeyResourceClient.getAll(workspaceName, apiKey);
+            assertThat(page.content().getFirst().authConfig()).isEqualTo(tokenAuthConfig().mask());
+
+            String rawColumn = mySqlTemplate.inTransaction(READ_ONLY, handle -> handle
+                    .createQuery("SELECT auth_config FROM llm_provider_api_key WHERE id = :id")
+                    .bind("id", created.id().toString())
+                    .mapTo(String.class)
+                    .one());
+            assertThat(rawColumn).doesNotContain(SECRET_VALUE, "client_id", "token_url");
+            assertThat(EncryptionUtils.decryptGcm(rawColumn)).contains(SECRET_VALUE);
+        }
+
+        @Test
+        @DisplayName("update with the sentinel keeps the stored secret, and a lock can't be removed")
+        void updateWithSentinelKeepsStoredSecret() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            // sentinel for the secret (also trying to unlock it), a new value for client_id
+            var update = ProviderApiKeyUpdate.builder()
+                    .authConfig(tokenAuthConfig().toBuilder()
+                            .credentials(List.of(
+                                    credential("grant_type", "client_credentials", false),
+                                    credential("client_id", "rotated-id", false),
+                                    credential("client_secret", ProviderAuthConfig.SECRET_SENTINEL, false)))
+                            .build())
+                    .build();
+            llmProviderApiKeyResourceClient.updateProviderApiKey(created.id(), update, apiKey, workspaceName,
+                    HttpStatus.SC_NO_CONTENT);
+
+            var stored = storedAuthConfig(created.id(), workspaceId);
+            var storedByKey = stored.credentials().stream()
+                    .collect(java.util.stream.Collectors
+                            .toMap(ProviderAuthConfig.Credential::key, Function.identity()));
+            assertThat(storedByKey.get("client_secret").value()).isEqualTo(SECRET_VALUE);
+            assertThat(storedByKey.get("client_secret").secret()).isTrue();
+            assertThat(storedByKey.get("client_id").value()).isEqualTo("rotated-id");
+        }
+
+        @Test
+        @DisplayName("sentinel on a key without a stored secret is rejected")
+        void updateSentinelUnknownKeyIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            var update = ProviderApiKeyUpdate.builder()
+                    .authConfig(tokenAuthConfig().toBuilder()
+                            .credentials(List.of(
+                                    credential("brand_new_key", ProviderAuthConfig.SECRET_SENTINEL, true)))
+                            .build())
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callUpdateProviderApiKey(created.id(), update,
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("brand_new_key");
+            }
+        }
+
+        @Test
+        @DisplayName("empty object clears the auth config, allowing the switch back to a static key")
+        void clearAuthConfigAndSwitchToStaticKey() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            var update = ProviderApiKeyUpdate.builder()
+                    .apiKey("brand-new-static-key")
+                    .authConfig(ProviderAuthConfig.builder().build())
+                    .build();
+            llmProviderApiKeyResourceClient.updateProviderApiKey(created.id(), update, apiKey, workspaceName,
+                    HttpStatus.SC_NO_CONTENT);
+
+            var actual = llmProviderApiKeyResourceClient.getById(created.id(), workspaceName, apiKey,
+                    HttpStatus.SC_OK);
+            assertThat(actual.authConfig()).isNull();
+            checkEncryption(created.id(), workspaceId, "brand-new-static-key");
+        }
+
+        @Test
+        @DisplayName("setting a static key while token auth is configured is rejected")
+        void updateApiKeyWhileTokenModeActiveIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            var update = ProviderApiKeyUpdate.builder().apiKey("some-static-key").build();
+            try (var response = llmProviderApiKeyResourceClient.callUpdateProviderApiKey(created.id(), update,
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        @Test
+        @DisplayName("auth config on a provider without provider_name is rejected")
+        void authConfigOnStandardProviderIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // create
+            llmProviderApiKeyResourceClient.createProviderApiKey(
+                    createProviderApiKey().toBuilder().authConfig(tokenAuthConfig()).build(),
+                    apiKey, workspaceName, HttpStatus.SC_UNPROCESSABLE_CONTENT);
+
+            // update
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(createProviderApiKey(), apiKey,
+                    workspaceName, HttpStatus.SC_CREATED);
+            var update = ProviderApiKeyUpdate.builder().authConfig(tokenAuthConfig()).build();
+            try (var response = llmProviderApiKeyResourceClient.callUpdateProviderApiKey(created.id(), update,
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+            }
+        }
+
+        @Test
+        @DisplayName("create rejects the sentinel, both credentials set, and an invalid token URL")
+        void createInvalidAuthConfigIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            // sentinel on create: nothing stored to keep
+            var withSentinel = customProviderWithAuthConfig().toBuilder()
+                    .authConfig(tokenAuthConfig().toBuilder()
+                            .credentials(List.of(
+                                    credential("client_secret", ProviderAuthConfig.SECRET_SENTINEL, true)))
+                            .build())
+                    .build();
+            llmProviderApiKeyResourceClient.createProviderApiKey(withSentinel, apiKey, workspaceName,
+                    HttpStatus.SC_UNPROCESSABLE_CONTENT);
+
+            // static key and token auth at once
+            var withBoth = customProviderWithAuthConfig().toBuilder().apiKey("static-key").build();
+            llmProviderApiKeyResourceClient.createProviderApiKey(withBoth, apiKey, workspaceName,
+                    HttpStatus.SC_UNPROCESSABLE_CONTENT);
+
+            // token URL that isn't an absolute URI
+            var withBadUrl = customProviderWithAuthConfig().toBuilder()
+                    .authConfig(tokenAuthConfig().toBuilder().tokenUrl("not a uri").build())
+                    .build();
+            llmProviderApiKeyResourceClient.createProviderApiKey(withBadUrl, apiKey, workspaceName,
+                    HttpStatus.SC_UNPROCESSABLE_CONTENT);
+        }
     }
 
     private void getAndAssertProviderApiKey(ProviderApiKey expected, String apiKey, String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Page;
 import com.comet.opik.api.ProviderApiKey;
 import com.comet.opik.api.ProviderApiKeyUpdate;
+import com.comet.opik.api.ProviderAuthCheck;
 import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
@@ -840,6 +841,186 @@ class LlmProviderApiKeyResourceTest {
                     .build();
             llmProviderApiKeyResourceClient.createProviderApiKey(withBadUrl, apiKey, workspaceName,
                     HttpStatus.SC_UNPROCESSABLE_CONTENT);
+        }
+    }
+
+    @Nested
+    @DisplayName("Auth config check endpoint:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AuthConfigCheckEndpoint {
+
+        private static final String SECRET_VALUE = "endpoint-s3cr3t";
+
+        /** unique path per test: the wiremock server is shared with the auth mocks, never reset here */
+        private String stubTokenEndpoint(String body, int status) {
+            String tokenPath = "/provider-auth-token/" + UUID.randomUUID();
+            wireMock.server().stubFor(com.github.tomakehurst.wiremock.client.WireMock.post(urlPathEqualTo(tokenPath))
+                    .willReturn(com.github.tomakehurst.wiremock.client.WireMock.aResponse()
+                            .withStatus(status)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(body)));
+            return tokenPath;
+        }
+
+        /** plain-http base: baseUrl() prefers the https port, whose self-signed cert the fetcher rejects */
+        private String tokenUrl(String tokenPath) {
+            return "http://localhost:" + wireMock.server().port() + tokenPath;
+        }
+
+        private ProviderAuthConfig recipe(String tokenUrl, String secretValue) {
+            return ProviderAuthConfig.builder()
+                    .tokenUrl(tokenUrl)
+                    .credentials(List.of(
+                            credential("grant_type", "client_credentials", false),
+                            credential("client_id", "opik-prod", false),
+                            credential("client_secret", secretValue, true)))
+                    .build();
+        }
+
+        private ProviderAuthConfig.Credential credential(String key, String value, boolean secret) {
+            return ProviderAuthConfig.Credential.builder().key(key).value(value).secret(secret).build();
+        }
+
+        private ProviderApiKey createCustomProvider(ProviderAuthConfig authConfig, String apiKey,
+                String workspaceName) {
+            var provider = factory.manufacturePojo(ProviderApiKey.class).toBuilder()
+                    .provider(LlmProvider.CUSTOM_LLM)
+                    .providerName(UUID.randomUUID().toString())
+                    .apiKey(null)
+                    .authConfig(authConfig)
+                    .build();
+            return llmProviderApiKeyResourceClient.createProviderApiKey(provider, apiKey, workspaceName,
+                    HttpStatus.SC_CREATED);
+        }
+
+        @Test
+        @DisplayName("submitted values are tested and the lifetime is reported, never the token")
+        void testWithSubmittedAuthConfig() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String tokenPath = stubTokenEndpoint("{\"access_token\": \"tok-endpoint\", \"expires_in\": 1800}", 200);
+            var request = ProviderAuthCheck.builder()
+                    .authConfig(recipe(tokenUrl(tokenPath), SECRET_VALUE))
+                    .build();
+
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+                String body = response.readEntity(String.class);
+                var result = JsonUtils.readValue(body, ProviderAuthCheck.Result.class);
+                assertThat(result.lifetimeSeconds()).isEqualTo(1800);
+                assertThat(body).doesNotContain("tok-endpoint");
+            }
+        }
+
+        @Test
+        @DisplayName("by provider id, the stored recipe is used with its real secrets, server-side")
+        void testWithStoredAuthConfig() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String tokenPath = stubTokenEndpoint("{\"access_token\": \"tok\", \"expires_in\": 60}", 200);
+            var created = createCustomProvider(recipe(tokenUrl(tokenPath), SECRET_VALUE), apiKey, workspaceName);
+
+            var request = ProviderAuthCheck.builder().providerId(created.id()).build();
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            }
+
+            wireMock.server().verify(postRequestedFor(urlPathEqualTo(tokenPath))
+                    .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock
+                            .containing("client_secret=" + SECRET_VALUE)));
+        }
+
+        @Test
+        @DisplayName("sentinels in submitted values resolve against the stored recipe when the id is given")
+        void testResolvesSentinelsAgainstStoredConfig() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String tokenPath = stubTokenEndpoint("{\"access_token\": \"tok\", \"expires_in\": 60}", 200);
+            var created = createCustomProvider(recipe(tokenUrl(tokenPath), SECRET_VALUE), apiKey, workspaceName);
+
+            var request = ProviderAuthCheck.builder()
+                    .providerId(created.id())
+                    .authConfig(recipe(tokenUrl(tokenPath), ProviderAuthConfig.SECRET_SENTINEL))
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            }
+
+            wireMock.server().verify(postRequestedFor(urlPathEqualTo(tokenPath))
+                    .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock
+                            .containing("client_secret=" + SECRET_VALUE)));
+        }
+
+        @Test
+        @DisplayName("sentinels without a provider id are rejected: there is nothing stored to resolve against")
+        void testSentinelWithoutIdIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var request = ProviderAuthCheck.builder()
+                    .authConfig(recipe("https://auth.example.com/token", ProviderAuthConfig.SECRET_SENTINEL))
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("client_secret");
+            }
+        }
+
+        @Test
+        @DisplayName("upstream auth failures surface status and body with credential values redacted")
+        void testSurfacesUpstreamErrorsRedacted() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String tokenPath = stubTokenEndpoint(
+                    "{\"error\": \"invalid_client\", \"echo\": \"%s\"}".formatted(SECRET_VALUE), 401);
+            var request = ProviderAuthCheck.builder()
+                    .authConfig(recipe(tokenUrl(tokenPath), SECRET_VALUE))
+                    .build();
+
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                String message = response.readEntity(ErrorMessage.class).getMessage();
+                assertThat(message).contains("401").contains("invalid_client").doesNotContain(SECRET_VALUE);
+            }
+        }
+
+        @Test
+        @DisplayName("a request with neither id nor auth config, or an id without a stored recipe, is rejected")
+        void testInvalidRequestsAreRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(
+                    ProviderAuthCheck.builder().build(), apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage())
+                        .contains("either provider_id or auth_config");
+            }
+
+            var staticProvider = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    createProviderApiKey(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(
+                    ProviderAuthCheck.builder().providerId(staticProvider.id()).build(),
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("no auth_config");
+            }
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.priv;
 
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Page;
 import com.comet.opik.api.ProviderApiKey;
@@ -653,13 +654,13 @@ class LlmProviderApiKeyResourceTest {
                     .provider(LlmProvider.CUSTOM_LLM)
                     .providerName(UUID.randomUUID().toString())
                     .apiKey(null)
-                    .authConfig(tokenAuthConfig())
+                    .authConfig(EncryptedAuthConfig.of(tokenAuthConfig()))
                     .build();
         }
 
         private ProviderAuthConfig storedAuthConfig(UUID id, String workspaceId) {
             return mySqlTemplate.inTransaction(READ_ONLY,
-                    handle -> handle.attach(LlmProviderApiKeyDAO.class).findById(id, workspaceId).authConfig());
+                    handle -> handle.attach(LlmProviderApiKeyDAO.class).findById(id, workspaceId).authConfig().value());
         }
 
         @Test
@@ -675,12 +676,12 @@ class LlmProviderApiKeyResourceTest {
 
             var actual = llmProviderApiKeyResourceClient.getById(created.id(), workspaceName, apiKey,
                     HttpStatus.SC_OK);
-            assertThat(actual.authConfig()).isEqualTo(tokenAuthConfig().mask());
-            assertThat(actual.authConfig().credentials().getLast().value())
+            assertThat(actual.authConfig().value()).isEqualTo(tokenAuthConfig().mask());
+            assertThat(actual.authConfig().value().credentials().getLast().value())
                     .isEqualTo(ProviderAuthConfig.SECRET_SENTINEL);
 
             var page = llmProviderApiKeyResourceClient.getAll(workspaceName, apiKey);
-            assertThat(page.content().getFirst().authConfig()).isEqualTo(tokenAuthConfig().mask());
+            assertThat(page.content().getFirst().authConfig().value()).isEqualTo(tokenAuthConfig().mask());
 
             String rawColumn = mySqlTemplate.inTransaction(READ_ONLY, handle -> handle
                     .createQuery("SELECT auth_config FROM llm_provider_api_key WHERE id = :id")
@@ -825,7 +826,7 @@ class LlmProviderApiKeyResourceTest {
 
             // create
             llmProviderApiKeyResourceClient.createProviderApiKey(
-                    createProviderApiKey().toBuilder().authConfig(tokenAuthConfig()).build(),
+                    createProviderApiKey().toBuilder().authConfig(EncryptedAuthConfig.of(tokenAuthConfig())).build(),
                     apiKey, workspaceName, HttpStatus.SC_UNPROCESSABLE_CONTENT);
 
             // update
@@ -839,6 +840,35 @@ class LlmProviderApiKeyResourceTest {
         }
 
         @Test
+        @DisplayName("update with the sentinel can't change token_url: a new destination needs full credentials")
+        void updateSentinelWithChangedTokenUrlIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig(), apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            // stored secret via the sentinel, but pointed at a different destination
+            var update = ProviderApiKeyUpdate.builder()
+                    .authConfig(tokenAuthConfig().toBuilder()
+                            .tokenUrl("https://attacker.example.com/token")
+                            .credentials(List.of(
+                                    credential("client_secret", ProviderAuthConfig.SECRET_SENTINEL, true)))
+                            .build())
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callUpdateProviderApiKey(created.id(), update,
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("token_url");
+            }
+
+            var stored = storedAuthConfig(created.id(), workspaceId);
+            assertThat(stored.tokenUrl()).isEqualTo(tokenAuthConfig().tokenUrl());
+        }
+
+        @Test
         @DisplayName("create rejects the sentinel, both credentials set, and an invalid token URL")
         void createInvalidAuthConfigIsRejected() {
             String workspaceName = UUID.randomUUID().toString();
@@ -848,10 +878,10 @@ class LlmProviderApiKeyResourceTest {
 
             // sentinel on create: nothing stored to keep
             var withSentinel = customProviderWithAuthConfig().toBuilder()
-                    .authConfig(tokenAuthConfig().toBuilder()
+                    .authConfig(EncryptedAuthConfig.of(tokenAuthConfig().toBuilder()
                             .credentials(List.of(
                                     credential("client_secret", ProviderAuthConfig.SECRET_SENTINEL, true)))
-                            .build())
+                            .build()))
                     .build();
             llmProviderApiKeyResourceClient.createProviderApiKey(withSentinel, apiKey, workspaceName,
                     HttpStatus.SC_UNPROCESSABLE_CONTENT);
@@ -863,7 +893,7 @@ class LlmProviderApiKeyResourceTest {
 
             // token URL that isn't an absolute URI
             var withBadUrl = customProviderWithAuthConfig().toBuilder()
-                    .authConfig(tokenAuthConfig().toBuilder().tokenUrl("not a uri").build())
+                    .authConfig(EncryptedAuthConfig.of(tokenAuthConfig().toBuilder().tokenUrl("not a uri").build()))
                     .build();
             llmProviderApiKeyResourceClient.createProviderApiKey(withBadUrl, apiKey, workspaceName,
                     HttpStatus.SC_UNPROCESSABLE_CONTENT);
@@ -913,7 +943,7 @@ class LlmProviderApiKeyResourceTest {
                     .provider(LlmProvider.CUSTOM_LLM)
                     .providerName(UUID.randomUUID().toString())
                     .apiKey(null)
-                    .authConfig(authConfig)
+                    .authConfig(EncryptedAuthConfig.of(authConfig))
                     .build();
             return llmProviderApiKeyResourceClient.createProviderApiKey(provider, apiKey, workspaceName,
                     HttpStatus.SC_CREATED);
@@ -987,6 +1017,29 @@ class LlmProviderApiKeyResourceTest {
         }
 
         @Test
+        @DisplayName("sentinels are refused when the submitted token_url differs from the stored one")
+        void testSentinelWithDifferentTokenUrlIsRejected() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            String tokenPath = stubTokenEndpoint("{\"access_token\": \"tok\", \"expires_in\": 60}", 200);
+            var created = createCustomProvider(recipe(tokenUrl(tokenPath), SECRET_VALUE), apiKey, workspaceName);
+
+            // a stored provider's id paired with a caller-controlled destination must not
+            // resolve the stored secret: that would exfiltrate it to the caller's server
+            var request = ProviderAuthCheck.builder()
+                    .providerId(created.id())
+                    .authConfig(recipe("https://attacker.example.com/token", ProviderAuthConfig.SECRET_SENTINEL))
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("token_url");
+            }
+        }
+
+        @Test
         @DisplayName("sentinels without a provider id are rejected: there is nothing stored to resolve against")
         void testSentinelWithoutIdIsRejected() {
             String workspaceName = UUID.randomUUID().toString();
@@ -1025,6 +1078,26 @@ class LlmProviderApiKeyResourceTest {
         }
 
         @Test
+        @DisplayName("without the provider-update permission the test endpoint denies before any token fetch")
+        void testRequiresAiProviderUpdatePermission() {
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String apiKey = UUID.randomUUID().toString();
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.AI_PROVIDER_UPDATE.getValue());
+
+            String tokenPath = stubTokenEndpoint("{\"access_token\": \"tok\", \"expires_in\": 60}", 200);
+            var request = ProviderAuthCheck.builder()
+                    .authConfig(recipe(tokenUrl(tokenPath), SECRET_VALUE))
+                    .build();
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(request, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+            }
+
+            // the denial must hold before the endpoint does anything with the credentials
+            wireMock.server().verify(0, postRequestedFor(urlPathEqualTo(tokenPath)));
+        }
+
+        @Test
         @DisplayName("a request with neither id nor auth config, or an id without a stored recipe, is rejected")
         void testInvalidRequestsAreRejected() {
             String workspaceName = UUID.randomUUID().toString();
@@ -1038,10 +1111,27 @@ class LlmProviderApiKeyResourceTest {
                 assertThat(response.readEntity(String.class)).contains("either provider_id or auth_config");
             }
 
+            // a provider type that can't hold an auth_config at all
             var staticProvider = llmProviderApiKeyResourceClient.createProviderApiKey(
                     createProviderApiKey(), apiKey, workspaceName, HttpStatus.SC_CREATED);
             try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(
                     ProviderAuthCheck.builder().providerId(staticProvider.id()).build(),
+                    apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
+                assertThat(response.readEntity(ErrorMessage.class).getMessage())
+                        .contains("auth_config is only supported");
+            }
+
+            // a supporting provider type that simply has no recipe stored
+            var keyOnlyCustom = factory.manufacturePojo(ProviderApiKey.class).toBuilder()
+                    .provider(LlmProvider.CUSTOM_LLM)
+                    .providerName(UUID.randomUUID().toString())
+                    .authConfig(null)
+                    .build();
+            var customProvider = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    keyOnlyCustom, apiKey, workspaceName, HttpStatus.SC_CREATED);
+            try (var response = llmProviderApiKeyResourceClient.callTestAuthConfig(
+                    ProviderAuthCheck.builder().providerId(customProvider.id()).build(),
                     apiKey, workspaceName)) {
                 assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_BAD_REQUEST);
                 assertThat(response.readEntity(ErrorMessage.class).getMessage()).contains("no auth_config");

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/LlmProviderApiKeyResourceTest.java
@@ -772,6 +772,32 @@ class LlmProviderApiKeyResourceTest {
         }
 
         @Test
+        @DisplayName("switching a keyed provider to token auth clears the stored static key")
+        void switchFromStaticKeyToTokenAuthClearsTheStoredKey() {
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var created = llmProviderApiKeyResourceClient.createProviderApiKey(
+                    customProviderWithAuthConfig().toBuilder()
+                            .apiKey("legacy-static-key")
+                            .authConfig(null)
+                            .build(),
+                    apiKey, workspaceName, HttpStatus.SC_CREATED);
+
+            // the dialog hides the api_key field in token mode, so the update carries none
+            var update = ProviderApiKeyUpdate.builder().authConfig(tokenAuthConfig()).build();
+            llmProviderApiKeyResourceClient.updateProviderApiKey(created.id(), update, apiKey, workspaceName,
+                    HttpStatus.SC_NO_CONTENT);
+
+            var actual = llmProviderApiKeyResourceClient.getById(created.id(), workspaceName, apiKey,
+                    HttpStatus.SC_OK);
+            assertThat(actual.authConfig()).isNotNull();
+            checkEncryption(created.id(), workspaceId, "");
+        }
+
+        @Test
         @DisplayName("setting a static key while token auth is configured is rejected")
         void updateApiKeyWhileTokenModeActiveIsRejected() {
             String workspaceName = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
@@ -43,6 +43,19 @@ class ProviderAuthConfigValidatorTest {
         assertThat(ProviderAuthConfigValidator.validationErrors(ProviderAuthConfig.builder().build())).hasSize(2);
     }
 
+    @Test
+    void duplicateCredentialKeysAreRejected() {
+        var config = AUTH_CONFIG.toBuilder()
+                .credentials(List.of(
+                        credential("client_id", "first", false),
+                        credential("client_id", "second", false),
+                        credential("client_secret", "s3cr3t", true)))
+                .build();
+
+        assertThat(ProviderAuthConfigValidator.validationErrors(config))
+                .containsExactly("auth_config.credentials contains duplicate key 'client_id'");
+    }
+
     // any single field set means "not the clear convention" — the update path must
     // route these through validationErrors(), never silently clear the stored recipe
     static Stream<Arguments> partialConfigs() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
@@ -1,0 +1,65 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.ProviderAuthConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class ProviderAuthConfigValidatorTest {
+
+    private static final ProviderAuthConfig AUTH_CONFIG = ProviderAuthConfig.builder()
+            .tokenUrl("https://auth.example.com/oauth/token")
+            .sendAs(ProviderAuthConfig.SendAs.BASIC)
+            .credentials(List.of(
+                    credential("grant_type", "client_credentials", false),
+                    credential("client_id", "opik-prod", false),
+                    credential("client_secret", "s3cr3t", true)))
+            .tokenField("access_token")
+            .expiresField("expires_in")
+            .build();
+
+    private static ProviderAuthConfig.Credential credential(String key, String value, boolean secret) {
+        return ProviderAuthConfig.Credential.builder().key(key).value(value).secret(secret).build();
+    }
+
+    @Test
+    void validationErrorsRequireTokenUrlAndCredentials() {
+        assertThat(ProviderAuthConfigValidator.validationErrors(AUTH_CONFIG)).isEmpty();
+
+        assertThat(ProviderAuthConfigValidator.validationErrors(AUTH_CONFIG.toBuilder().tokenUrl("not a uri").build()))
+                .containsExactly("auth_config.token_url must be a valid absolute URI");
+        assertThat(ProviderAuthConfigValidator
+                .validationErrors(AUTH_CONFIG.toBuilder().tokenUrl("ftp://auth.example.com/token").build()))
+                .containsExactly("auth_config.token_url must use http or https");
+        assertThat(ProviderAuthConfigValidator.validationErrors(AUTH_CONFIG.toBuilder().credentials(List.of()).build()))
+                .containsExactly("auth_config.credentials must not be empty");
+        assertThat(ProviderAuthConfigValidator.validationErrors(ProviderAuthConfig.builder().build())).hasSize(2);
+    }
+
+    // any single field set means "not the clear convention" — the update path must
+    // route these through validationErrors(), never silently clear the stored recipe
+    static Stream<Arguments> partialConfigs() {
+        return Stream.of(
+                arguments("sendAs", ProviderAuthConfig.builder().sendAs(ProviderAuthConfig.SendAs.BASIC).build()),
+                arguments("credentials", ProviderAuthConfig.builder()
+                        .credentials(List.of(credential("client_id", "opik", false)))
+                        .build()),
+                arguments("tokenField", ProviderAuthConfig.builder().tokenField("access_token").build()),
+                arguments("expiresField", ProviderAuthConfig.builder().expiresField("expires_in").build()),
+                arguments("fallbackTtlSeconds", ProviderAuthConfig.builder().fallbackTtlSeconds(60L).build()));
+    }
+
+    @ParameterizedTest(name = "only {0} set")
+    @MethodSource("partialConfigs")
+    void partialConfigsAreNotEmptySoTheyValidateInsteadOfClearing(String field, ProviderAuthConfig partial) {
+        assertThat(partial.isEmpty()).isFalse();
+        assertThat(ProviderAuthConfigValidator.validationErrors(partial)).isNotEmpty();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/validation/ProviderAuthConfigValidatorTest.java
@@ -38,6 +38,9 @@ class ProviderAuthConfigValidatorTest {
         assertThat(ProviderAuthConfigValidator
                 .validationErrors(AUTH_CONFIG.toBuilder().tokenUrl("ftp://auth.example.com/token").build()))
                 .containsExactly("auth_config.token_url must use http or https");
+        assertThat(
+                ProviderAuthConfigValidator.validationErrors(AUTH_CONFIG.toBuilder().tokenUrl("https:token").build()))
+                .containsExactly("auth_config.token_url must include a host");
         assertThat(ProviderAuthConfigValidator.validationErrors(AUTH_CONFIG.toBuilder().credentials(List.of()).build()))
                 .containsExactly("auth_config.credentials must not be empty");
         assertThat(ProviderAuthConfigValidator.validationErrors(ProviderAuthConfig.builder().build())).hasSize(2);

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/EncryptionUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/EncryptionUtilsTest.java
@@ -1,0 +1,52 @@
+package com.comet.opik.infrastructure;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class EncryptionUtilsTest {
+
+    @BeforeAll
+    static void setUpAll() {
+        var config = new OpikConfiguration();
+        config.getEncryption().setKey("0123456789abcdef");
+        EncryptionUtils.setConfig(config);
+    }
+
+    @Test
+    void gcmRoundTrip() {
+        var plaintext = "{\"credentials\":[{\"key\":\"client_secret\",\"value\":\"s3cr3t\"}]}";
+
+        var encrypted = EncryptionUtils.encryptGcm(plaintext);
+
+        assertThat(encrypted).doesNotContain("s3cr3t");
+        assertThat(EncryptionUtils.decryptGcm(encrypted)).isEqualTo(plaintext);
+    }
+
+    @Test
+    void gcmUsesARandomIvPerEncryption() {
+        var plaintext = "same plaintext";
+
+        assertThat(EncryptionUtils.encryptGcm(plaintext)).isNotEqualTo(EncryptionUtils.encryptGcm(plaintext));
+    }
+
+    @Test
+    void gcmRejectsTamperedCiphertext() {
+        byte[] payload = Base64.getDecoder().decode(EncryptionUtils.encryptGcm("payload"));
+        payload[payload.length - 1] ^= 1;
+        var tampered = Base64.getEncoder().encodeToString(payload);
+
+        assertThatThrownBy(() -> EncryptionUtils.decryptGcm(tampered)).isInstanceOf(SecurityException.class);
+    }
+
+    @Test
+    void gcmRejectsLegacyCiphertext() {
+        var legacy = EncryptionUtils.encrypt("payload");
+
+        assertThatThrownBy(() -> EncryptionUtils.decryptGcm(legacy)).isInstanceOf(SecurityException.class);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
@@ -49,6 +49,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -89,15 +91,11 @@ class LlmProviderFactoryTest {
         String workspaceId = UUID.randomUUID().toString();
         String apiKey = UUID.randomUUID().toString();
 
-        when(llmProviderApiKeyService.find(workspaceId)).thenReturn(ProviderApiKey.ProviderApiKeyPage.builder()
-                .content(List.of(ProviderApiKey.builder()
+        when(llmProviderApiKeyService.findByProviders(eq(workspaceId), anySet()))
+                .thenReturn(List.of(ProviderApiKey.builder()
                         .provider(llmProvider)
                         .apiKey(EncryptionUtils.encrypt(apiKey))
-                        .build()))
-                .total(1)
-                .page(1)
-                .size(1)
-                .build());
+                        .build()));
 
         // SUT - use config with disabled free model to not interfere with other tests
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");
@@ -163,18 +161,14 @@ class LlmProviderFactoryTest {
         String workspaceId = UUID.randomUUID().toString();
         String apiKey = UUID.randomUUID().toString();
 
-        when(llmProviderApiKeyService.find(workspaceId)).thenReturn(ProviderApiKey.ProviderApiKeyPage.builder()
-                .content(List.of(ProviderApiKey.builder()
+        when(llmProviderApiKeyService.findByProviders(eq(workspaceId), anySet()))
+                .thenReturn(List.of(ProviderApiKey.builder()
                         .provider(LlmProvider.CUSTOM_LLM)
                         .providerName(providerName)
                         .apiKey(EncryptionUtils.encrypt(apiKey))
                         .baseUrl("http://localhost:11434/v1")
                         .configuration(Map.of("models", configuredModels))
-                        .build()))
-                .total(1)
-                .page(1)
-                .size(1)
-                .build());
+                        .build()));
 
         // SUT - use config with disabled free model
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");
@@ -204,18 +198,14 @@ class LlmProviderFactoryTest {
         String workspaceId = UUID.randomUUID().toString();
         String apiKey = UUID.randomUUID().toString();
 
-        when(llmProviderApiKeyService.find(workspaceId)).thenReturn(ProviderApiKey.ProviderApiKeyPage.builder()
-                .content(List.of(ProviderApiKey.builder()
+        when(llmProviderApiKeyService.findByProviders(eq(workspaceId), anySet()))
+                .thenReturn(List.of(ProviderApiKey.builder()
                         .provider(LlmProvider.CUSTOM_LLM)
                         .providerName(providerName)
                         .apiKey(EncryptionUtils.encrypt(apiKey))
                         .baseUrl("http://localhost:11434/v1")
                         .configuration(Map.of("models", configuredModels))
-                        .build()))
-                .total(1)
-                .page(1)
-                .size(1)
-                .build());
+                        .build()));
 
         // SUT - use config with disabled free model
         var mockConfig = createMockConfigWithFreeModel(false, "gpt-4o-mini", "openai");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/LlmProviderFactoryTest.java
@@ -15,6 +15,7 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.llm.antropic.AnthropicClientGenerator;
 import com.comet.opik.infrastructure.llm.antropic.AnthropicModelName;
 import com.comet.opik.infrastructure.llm.antropic.AnthropicModule;
+import com.comet.opik.infrastructure.llm.customllm.AuthTokenProvider;
 import com.comet.opik.infrastructure.llm.customllm.CustomLlmClientGenerator;
 import com.comet.opik.infrastructure.llm.customllm.CustomLlmModule;
 import com.comet.opik.infrastructure.llm.gemini.GeminiClientGenerator;
@@ -181,7 +182,8 @@ class LlmProviderFactoryTest {
 
         // Register custom LLM service (required for getService to work)
         CustomLlmModule customLlmModule = new CustomLlmModule();
-        CustomLlmClientGenerator customLlmClientGenerator = customLlmModule.clientGenerator(llmProviderClientConfig);
+        CustomLlmClientGenerator customLlmClientGenerator = customLlmModule.clientGenerator(llmProviderClientConfig,
+                mock(AuthTokenProvider.class));
         customLlmModule.llmServiceProvider(llmProviderFactory, customLlmClientGenerator);
 
         // When & Then - Should successfully get the service
@@ -221,7 +223,8 @@ class LlmProviderFactoryTest {
 
         // Register custom LLM service (required for getService to work)
         CustomLlmModule customLlmModule = new CustomLlmModule();
-        CustomLlmClientGenerator customLlmClientGenerator = customLlmModule.clientGenerator(llmProviderClientConfig);
+        CustomLlmClientGenerator customLlmClientGenerator = customLlmModule.clientGenerator(llmProviderClientConfig,
+                mock(AuthTokenProvider.class));
         customLlmModule.llmServiceProvider(llmProviderFactory, customLlmClientGenerator);
 
         // When & Then - Should throw BadRequestException

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -355,6 +355,30 @@ class AuthTokenProviderTest {
     }
 
     @Test
+    @DisplayName("a lock-wait timeout recovers from the holder's cache write instead of fetching directly")
+    void lockTimeoutRecoversFromTheHoldersCacheWrite() {
+        stubToken("{\"access_token\": \"tok-held\", \"expires_in\": 3600}");
+        var recipe = oauthRecipe().build();
+        UUID providerId = UUID.randomUUID();
+
+        // the "holder": a normal provider sharing the same Redis, whose fetch caches tok-held
+        var holder = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE, relaxedConfig());
+        // the "waiter": its lock wait elapses (empty result), but only after the holder has
+        // written — exactly the sequence the timed-out-waiter re-read is for
+        LockService timedOutLock = org.mockito.Mockito.mock(LockService.class);
+        org.mockito.Mockito.when(timedOutLock.executeWithLockCustomExpire(
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any()))
+                .thenAnswer(invocation -> Mono.fromRunnable(() -> holder.bearer("ws", providerId, recipe))
+                        .then(Mono.empty()));
+        var waiter = new AuthTokenProvider(stringRedisClient, timedOutLock, relaxedConfig());
+
+        assertThat(waiter.bearer("ws", providerId, recipe)).isEqualTo("tok-held");
+        // one fetch total (the holder's); the waiter recovered from the cache
+        wireMock.verify(1, postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
     @DisplayName("rotating a secret changes the cache key, so a stale cached token is never served")
     void rotatedSecretChangesTheCacheKey() {
         stubToken("{\"access_token\": \"tok-rotation\", \"expires_in\": 3600}");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -322,7 +322,7 @@ class AuthTokenProviderTest {
         var recipe = oauthRecipe().build();
 
         provider.bearer("ws", providerId, recipe);
-        provider.invalidate(providerId, recipe);
+        provider.invalidateAfterGatewayRejection("ws", providerId, recipe);
         provider.bearer("ws", providerId, recipe);
 
         wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
@@ -352,6 +352,38 @@ class AuthTokenProviderTest {
                 .hasMessageContaining("access_token")
                 .hasMessageContaining("[token, ttl]")
                 .satisfies(exception -> assertThat(exception.getMessage()).doesNotContain("the-actual-token"));
+    }
+
+    @Test
+    @DisplayName("rotating a secret changes the cache key, so a stale cached token is never served")
+    void rotatedSecretChangesTheCacheKey() {
+        stubToken("{\"access_token\": \"tok-rotation\", \"expires_in\": 3600}");
+        UUID providerId = UUID.randomUUID();
+
+        provider.bearer("ws", providerId, oauthRecipe().build());
+        provider.bearer("ws", providerId, oauthRecipe().build());
+
+        var rotated = oauthRecipe()
+                .credentials(List.of(
+                        credential("grant_type", "client_credentials", false),
+                        credential("client_id", "opik-prod", false),
+                        credential("client_secret", "rotated-" + SECRET_VALUE, true)))
+                .build();
+        provider.bearer("ws", providerId, rotated);
+
+        // the hash covers unmasked values: fetch 1 (cold), cache hit, fetch 2 (rotated secret).
+        // Load-bearing — masking earlier in the chain would silently keep serving the stale token.
+        wireMock.verify(2, postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
+    @DisplayName("a non-http(s) token_url surfaces as a clear auth error, never a raw exception")
+    void nonHttpTokenUrlIsRejected() {
+        var recipe = oauthRecipe().tokenUrl("mailto:auth@example.com").build();
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), recipe))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("not a usable http(s) URL");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.EncryptionUtils;
 import com.comet.opik.infrastructure.LlmProviderTokenAuthConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.net.DestinationGuard;
 import com.comet.opik.infrastructure.redis.StringRedisClient;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -132,8 +133,13 @@ class AuthTokenProviderTest {
         opikConfiguration.getEncryption().setKey("0123456789abcdef");
         EncryptionUtils.setConfig(opikConfiguration);
 
-        provider = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE,
-                new LlmProviderTokenAuthConfig());
+        provider = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE, relaxedConfig());
+    }
+
+    private static LlmProviderTokenAuthConfig relaxedConfig() {
+        var config = new LlmProviderTokenAuthConfig();
+        config.setDestinationGuard(DestinationGuard.Mode.RELAXED);
+        return config;
     }
 
     @AfterAll
@@ -382,6 +388,19 @@ class AuthTokenProviderTest {
     }
 
     @Test
+    @DisplayName("a strict destination guard refuses the token URL before any request is made")
+    void strictGuardRefusesNonPublicTokenUrl() {
+        var strictConfig = new LlmProviderTokenAuthConfig();
+        strictConfig.setDestinationGuard(DestinationGuard.Mode.STRICT);
+        var strictProvider = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE, strictConfig);
+
+        assertThatThrownBy(() -> strictProvider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("only https");
+        wireMock.verify(exactly(0), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
     @DisplayName("a Redis outage degrades to a direct fetch instead of failing the call")
     void redisOutageDegradesToDirectFetch() {
         var flakyRedis = RedisContainerUtils.newRedisContainer();
@@ -395,7 +414,7 @@ class AuthTokenProviderTest {
         var flakyRedisson = Redisson.create(flakyConfig);
         try {
             var flakyProvider = new AuthTokenProvider(new StringRedisClient(flakyRedisson),
-                    PASSTHROUGH_LOCK_SERVICE, new LlmProviderTokenAuthConfig());
+                    PASSTHROUGH_LOCK_SERVICE, relaxedConfig());
             flakyRedis.stop();
 
             stubToken("{\"access_token\": \"tok-degraded\", \"expires_in\": 3600}");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -355,6 +355,16 @@ class AuthTokenProviderTest {
     }
 
     @Test
+    @DisplayName("an absurdly large lifetime is rejected before it can corrupt cache arithmetic")
+    void oversizedLifetimeIsRejected() {
+        stubToken("{\"access_token\": \"tok-huge\", \"expires_in\": 9223372036854775807}");
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("outside the accepted range");
+    }
+
+    @Test
     @DisplayName("a reply without a lifetime and without a fallback is a clear error")
     void missingLifetimeWithoutFallbackIsRejected() {
         stubToken("{\"access_token\": \"tok-nolife\"}");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.llm.customllm;
 
+import com.comet.opik.api.EncryptedAuthConfig;
 import com.comet.opik.api.ProviderAuthConfig;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.infrastructure.EncryptionUtils;
@@ -154,6 +155,11 @@ class AuthTokenProviderTest {
         wireMock.resetAll();
     }
 
+    /** Wraps a parsed recipe the way request-path code receives it. */
+    private static EncryptedAuthConfig wrap(ProviderAuthConfig config) {
+        return EncryptedAuthConfig.of(config);
+    }
+
     private ProviderAuthConfig.ProviderAuthConfigBuilder oauthRecipe() {
         return ProviderAuthConfig.builder()
                 .tokenUrl(wireMock.baseUrl() + TOKEN_PATH)
@@ -186,8 +192,8 @@ class AuthTokenProviderTest {
         var providerId = UUID.randomUUID();
         var recipe = oauthRecipe().build();
 
-        assertThat(provider.bearer("ws", providerId, recipe)).isEqualTo("tok-1");
-        assertThat(provider.bearer("ws", providerId, recipe)).isEqualTo("tok-1");
+        assertThat(provider.bearer("ws", providerId, wrap(recipe))).isEqualTo("tok-1");
+        assertThat(provider.bearer("ws", providerId, wrap(recipe))).isEqualTo("tok-1");
 
         wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH))
                 .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
@@ -214,7 +220,7 @@ class AuthTokenProviderTest {
                         credential("client_secret", SECRET_VALUE, true)))
                 .build();
 
-        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-basic");
+        assertThat(provider.bearer("ws", UUID.randomUUID(), wrap(recipe))).isEqualTo("tok-basic");
 
         String expectedBasic = "Basic " + Base64.getEncoder()
                 .encodeToString(("opik-prod:" + SECRET_VALUE).getBytes());
@@ -229,7 +235,7 @@ class AuthTokenProviderTest {
         stubToken("{\"access_token\": \"tok-json\", \"expires_in\": 3600}");
         var recipe = oauthRecipe().sendAs(ProviderAuthConfig.SendAs.JSON).build();
 
-        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-json");
+        assertThat(provider.bearer("ws", UUID.randomUUID(), wrap(recipe))).isEqualTo("tok-json");
 
         wireMock.verify(postRequestedFor(urlEqualTo(TOKEN_PATH))
                 .withHeader("Content-Type", equalTo("application/json"))
@@ -248,7 +254,7 @@ class AuthTokenProviderTest {
                 .fallbackTtlSeconds(90_000L)
                 .build();
 
-        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-nested");
+        assertThat(provider.bearer("ws", UUID.randomUUID(), wrap(recipe))).isEqualTo("tok-nested");
     }
 
     @Test
@@ -258,8 +264,8 @@ class AuthTokenProviderTest {
         var providerId = UUID.randomUUID();
         var recipe = oauthRecipe().fallbackTtlSeconds(0L).build();
 
-        provider.bearer("ws", providerId, recipe);
-        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, wrap(recipe));
+        provider.bearer("ws", providerId, wrap(recipe));
 
         wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
         assertThat(cachedKeys(providerId)).isEmpty();
@@ -272,8 +278,8 @@ class AuthTokenProviderTest {
         var providerId = UUID.randomUUID();
         var recipe = oauthRecipe().fallbackTtlSeconds(0L).build();
 
-        provider.bearer("ws", providerId, recipe);
-        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, wrap(recipe));
+        provider.bearer("ws", providerId, wrap(recipe));
 
         wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
         assertThat(cachedKeys(providerId)).hasSize(1);
@@ -287,12 +293,12 @@ class AuthTokenProviderTest {
         var providerId = UUID.randomUUID();
         var recipe = oauthRecipe().build();
 
-        provider.bearer("ws", providerId, recipe);
-        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, wrap(recipe));
+        provider.bearer("ws", providerId, wrap(recipe));
         wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
 
         Thread.sleep(800);
-        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, wrap(recipe));
 
         wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
     }
@@ -303,13 +309,13 @@ class AuthTokenProviderTest {
         stubToken("{\"access_token\": \"tok-cfg\", \"expires_in\": 3600}");
         var providerId = UUID.randomUUID();
 
-        provider.bearer("ws", providerId, oauthRecipe().build());
-        provider.bearer("ws", providerId, oauthRecipe()
+        provider.bearer("ws", providerId, wrap(oauthRecipe().build()));
+        provider.bearer("ws", providerId, wrap(oauthRecipe()
                 .credentials(List.of(
                         credential("grant_type", "client_credentials", false),
                         credential("client_id", "opik-prod", false),
                         credential("client_secret", "rotated-secret", true)))
-                .build());
+                .build()));
 
         wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
     }
@@ -321,9 +327,9 @@ class AuthTokenProviderTest {
         var providerId = UUID.randomUUID();
         var recipe = oauthRecipe().build();
 
-        provider.bearer("ws", providerId, recipe);
-        provider.invalidateAfterGatewayRejection("ws", providerId, recipe);
-        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, wrap(recipe));
+        provider.invalidateAfterGatewayRejection("ws", providerId, wrap(recipe));
+        provider.bearer("ws", providerId, wrap(recipe));
 
         wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
     }
@@ -335,7 +341,7 @@ class AuthTokenProviderTest {
                 .withStatus(401)
                 .withBody("{\"error\": \"invalid_client\", \"echo\": \"%s\"}".formatted(SECRET_VALUE))));
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("401")
                 .hasMessageContaining("invalid_client")
@@ -343,11 +349,35 @@ class AuthTokenProviderTest {
     }
 
     @Test
+    @DisplayName("an oversized 200 reply is refused while streaming")
+    void oversizedReplyIsRefused() {
+        stubToken("{\"access_token\": \"%s\"}".formatted("x".repeat(1_100_000)));
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("exceeds the maximum accepted size");
+    }
+
+    @Test
+    @DisplayName("a secret straddling the error-snippet boundary never leaks its prefix")
+    void secretStraddlingSnippetBoundaryIsRedacted() {
+        // the secret starts 5 chars before the 500-char cut: truncate-then-redact would leave "super"
+        wireMock.stubFor(post(urlEqualTo(TOKEN_PATH)).willReturn(aResponse()
+                .withStatus(401)
+                .withBody("x".repeat(495) + SECRET_VALUE)));
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
+                .isInstanceOf(AuthTokenException.class)
+                .satisfies(exception -> assertThat(exception.getMessage())
+                        .doesNotContain(SECRET_VALUE.substring(0, 5)));
+    }
+
+    @Test
     @DisplayName("a missing token field names the reply's top-level fields, never values")
     void missingTokenFieldListsTopLevelKeys() {
         stubToken("{\"token\": \"the-actual-token\", \"ttl\": 60}");
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("access_token")
                 .hasMessageContaining("[token, ttl]")
@@ -369,11 +399,11 @@ class AuthTokenProviderTest {
         org.mockito.Mockito.when(timedOutLock.executeWithLockCustomExpire(
                 org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
                 org.mockito.ArgumentMatchers.any()))
-                .thenAnswer(invocation -> Mono.fromRunnable(() -> holder.bearer("ws", providerId, recipe))
+                .thenAnswer(invocation -> Mono.fromRunnable(() -> holder.bearer("ws", providerId, wrap(recipe)))
                         .then(Mono.empty()));
         var waiter = new AuthTokenProvider(stringRedisClient, timedOutLock, relaxedConfig());
 
-        assertThat(waiter.bearer("ws", providerId, recipe)).isEqualTo("tok-held");
+        assertThat(waiter.bearer("ws", providerId, wrap(recipe))).isEqualTo("tok-held");
         // one fetch total (the holder's); the waiter recovered from the cache
         wireMock.verify(1, postRequestedFor(urlEqualTo(TOKEN_PATH)));
     }
@@ -384,8 +414,8 @@ class AuthTokenProviderTest {
         stubToken("{\"access_token\": \"tok-rotation\", \"expires_in\": 3600}");
         UUID providerId = UUID.randomUUID();
 
-        provider.bearer("ws", providerId, oauthRecipe().build());
-        provider.bearer("ws", providerId, oauthRecipe().build());
+        provider.bearer("ws", providerId, wrap(oauthRecipe().build()));
+        provider.bearer("ws", providerId, wrap(oauthRecipe().build()));
 
         var rotated = oauthRecipe()
                 .credentials(List.of(
@@ -393,7 +423,7 @@ class AuthTokenProviderTest {
                         credential("client_id", "opik-prod", false),
                         credential("client_secret", "rotated-" + SECRET_VALUE, true)))
                 .build();
-        provider.bearer("ws", providerId, rotated);
+        provider.bearer("ws", providerId, wrap(rotated));
 
         // the hash covers unmasked values: fetch 1 (cold), cache hit, fetch 2 (rotated secret).
         // Load-bearing — masking earlier in the chain would silently keep serving the stale token.
@@ -405,7 +435,7 @@ class AuthTokenProviderTest {
     void nonHttpTokenUrlIsRejected() {
         var recipe = oauthRecipe().tokenUrl("mailto:auth@example.com").build();
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), recipe))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(recipe)))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("not a usable http(s) URL");
     }
@@ -415,7 +445,7 @@ class AuthTokenProviderTest {
     void oversizedLifetimeIsRejected() {
         stubToken("{\"access_token\": \"tok-huge\", \"expires_in\": 9223372036854775807}");
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("outside the accepted range");
     }
@@ -425,7 +455,7 @@ class AuthTokenProviderTest {
     void missingLifetimeWithoutFallbackIsRejected() {
         stubToken("{\"access_token\": \"tok-nolife\"}");
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("expires_in")
                 .hasMessageContaining("no fallback lifetime");
@@ -438,7 +468,7 @@ class AuthTokenProviderTest {
                 .withStatus(200)
                 .withBody("<html>gateway login page</html>")));
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("non-JSON reply");
     }
@@ -448,7 +478,7 @@ class AuthTokenProviderTest {
     void unreachableTokenUrlIsRejected() {
         var recipe = oauthRecipe().tokenUrl("http://localhost:1/token").build();
 
-        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), recipe))
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), wrap(recipe)))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("could not reach");
     }
@@ -460,7 +490,7 @@ class AuthTokenProviderTest {
         strictConfig.setDestinationGuard(DestinationGuard.Mode.STRICT);
         var strictProvider = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE, strictConfig);
 
-        assertThatThrownBy(() -> strictProvider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+        assertThatThrownBy(() -> strictProvider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                 .isInstanceOf(AuthTokenException.class)
                 .hasMessageContaining("only https");
         wireMock.verify(exactly(0), postRequestedFor(urlEqualTo(TOKEN_PATH)));
@@ -485,7 +515,7 @@ class AuthTokenProviderTest {
 
             stubToken("{\"access_token\": \"tok-degraded\", \"expires_in\": 3600}");
 
-            assertThat(flakyProvider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+            assertThat(flakyProvider.bearer("ws", UUID.randomUUID(), wrap(oauthRecipe().build())))
                     .isEqualTo("tok-degraded");
             wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
         } finally {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/AuthTokenProviderTest.java
@@ -1,0 +1,410 @@
+package com.comet.opik.infrastructure.llm.customllm;
+
+import com.comet.opik.api.ProviderAuthConfig;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.infrastructure.EncryptionUtils;
+import com.comet.opik.infrastructure.LlmProviderTokenAuthConfig;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.lock.LockService;
+import com.comet.opik.infrastructure.redis.StringRedisClient;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.redis.testcontainers.RedisContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.api.options.KeysScanOptions;
+import org.redisson.config.Config;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Auth Token Provider Test")
+class AuthTokenProviderTest {
+
+    private static final String TOKEN_PATH = "/oauth/token";
+    private static final String SECRET_VALUE = "super-s3cr3t";
+
+    /**
+     * Single-flight correctness belongs to {@code RedissonLockService}'s own tests (which is also
+     * package-private); here the lock is a passthrough so the provider's orchestration is what's
+     * under test.
+     */
+    private static final LockService PASSTHROUGH_LOCK_SERVICE = new LockService() {
+        @Override
+        public <T> Mono<T> executeWithLock(Lock lock, Mono<T> action) {
+            return action;
+        }
+
+        @Override
+        public <T> Mono<T> executeWithLockCustomExpire(Lock lock, Mono<T> action, Duration duration) {
+            return action;
+        }
+
+        @Override
+        public <T> Flux<T> executeWithLock(Lock lock, Flux<T> action) {
+            return action;
+        }
+
+        @Override
+        public <T> Mono<T> bestEffortLock(Lock lock, Mono<T> action, Mono<Void> failToAcquireLockAction,
+                Duration actionTimeout, Duration lockTimeout) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> Mono<T> bestEffortLock(Lock lock, Mono<T> action, Mono<Void> failToAcquireLockAction,
+                Duration actionTimeout, Duration lockTimeout, boolean holdUntilExpiry) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<Boolean> lockUsingToken(Lock lock, Duration lockDuration) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<Void> unlockUsingToken(Lock lock) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<String> tryAcquireSlot(Lock lock, int totalSlots, Duration leaseTime) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<Boolean> refreshSlot(Lock lock, String permitId, Duration leaseTime) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<Boolean> releaseSlot(Lock lock, String permitId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Mono<Void> addSlotPermits(Lock lock, int delta) {
+            throw new UnsupportedOperationException();
+        }
+    };
+
+    private final RedisContainer redis = RedisContainerUtils.newRedisContainer();
+    private WireMockServer wireMock;
+    private RedissonClient redisson;
+    private StringRedisClient stringRedisClient;
+    private AuthTokenProvider provider;
+
+    @BeforeAll
+    void setUpAll() {
+        redis.start();
+        var redissonConfig = new Config();
+        redissonConfig.useSingleServer().setAddress(redis.getRedisURI());
+        redisson = Redisson.create(redissonConfig);
+        stringRedisClient = new StringRedisClient(redisson);
+
+        wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+
+        var opikConfiguration = new OpikConfiguration();
+        opikConfiguration.getEncryption().setKey("0123456789abcdef");
+        EncryptionUtils.setConfig(opikConfiguration);
+
+        provider = new AuthTokenProvider(stringRedisClient, PASSTHROUGH_LOCK_SERVICE,
+                new LlmProviderTokenAuthConfig());
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.stop();
+        redisson.shutdown();
+        redis.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        wireMock.resetAll();
+    }
+
+    private ProviderAuthConfig.ProviderAuthConfigBuilder oauthRecipe() {
+        return ProviderAuthConfig.builder()
+                .tokenUrl(wireMock.baseUrl() + TOKEN_PATH)
+                .credentials(List.of(
+                        credential("grant_type", "client_credentials", false),
+                        credential("client_id", "opik-prod", false),
+                        credential("client_secret", SECRET_VALUE, true)));
+    }
+
+    private ProviderAuthConfig.Credential credential(String key, String value, boolean secret) {
+        return ProviderAuthConfig.Credential.builder().key(key).value(value).secret(secret).build();
+    }
+
+    private void stubToken(String body) {
+        wireMock.stubFor(post(urlEqualTo(TOKEN_PATH)).willReturn(okJson(body)));
+    }
+
+    private List<String> cachedKeys(UUID providerId) {
+        var keys = new java.util.ArrayList<String>();
+        redisson.getKeys()
+                .getKeys(KeysScanOptions.defaults().pattern("llm_auth_token:%s:*".formatted(providerId)))
+                .forEach(keys::add);
+        return keys;
+    }
+
+    @Test
+    @DisplayName("form mode fetches, caches encrypted, and serves cache hits")
+    void formModeFetchesAndCaches() {
+        stubToken("{\"access_token\": \"tok-1\", \"expires_in\": 3600}");
+        var providerId = UUID.randomUUID();
+        var recipe = oauthRecipe().build();
+
+        assertThat(provider.bearer("ws", providerId, recipe)).isEqualTo("tok-1");
+        assertThat(provider.bearer("ws", providerId, recipe)).isEqualTo("tok-1");
+
+        wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH))
+                .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+                .withRequestBody(containing("grant_type=client_credentials"))
+                .withRequestBody(containing("client_secret=" + SECRET_VALUE)));
+
+        // the cached value is ciphertext: neither the token nor the recipe is readable in Redis
+        var keys = cachedKeys(providerId);
+        assertThat(keys).hasSize(1);
+        String rawValue = stringRedisClient.getBucket(keys.getFirst()).get();
+        assertThat(rawValue).doesNotContain("tok-1", SECRET_VALUE);
+    }
+
+    @Test
+    @DisplayName("basic mode sends id/secret in the Basic header and the remaining fields in the body")
+    void basicModeSendsBasicHeader() {
+        stubToken("{\"access_token\": \"tok-basic\", \"expires_in\": 3600}");
+        var recipe = oauthRecipe()
+                .sendAs(ProviderAuthConfig.SendAs.BASIC)
+                .credentials(List.of(
+                        credential("grant_type", "client_credentials", false),
+                        credential("scope", "data:read", false),
+                        credential("client_id", "opik-prod", false),
+                        credential("client_secret", SECRET_VALUE, true)))
+                .build();
+
+        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-basic");
+
+        String expectedBasic = "Basic " + Base64.getEncoder()
+                .encodeToString(("opik-prod:" + SECRET_VALUE).getBytes());
+        wireMock.verify(postRequestedFor(urlEqualTo(TOKEN_PATH))
+                .withHeader("Authorization", equalTo(expectedBasic))
+                .withRequestBody(equalTo("grant_type=client_credentials&scope=data%3Aread")));
+    }
+
+    @Test
+    @DisplayName("json mode sends the credentials as a JSON body")
+    void jsonModeSendsJsonBody() {
+        stubToken("{\"access_token\": \"tok-json\", \"expires_in\": 3600}");
+        var recipe = oauthRecipe().sendAs(ProviderAuthConfig.SendAs.JSON).build();
+
+        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-json");
+
+        wireMock.verify(postRequestedFor(urlEqualTo(TOKEN_PATH))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson(
+                        "{\"grant_type\": \"client_credentials\", \"client_id\": \"opik-prod\", \"client_secret\": \"%s\"}"
+                                .formatted(SECRET_VALUE))));
+    }
+
+    @Test
+    @DisplayName("dot-path token field and fallback lifetime cover the service-account shape")
+    void dotPathAndFallbackTtl() {
+        stubToken("{\"result\": {\"jwt\": \"tok-nested\"}}");
+        var recipe = oauthRecipe()
+                .tokenField("result.jwt")
+                .expiresField("result.ttl")
+                .fallbackTtlSeconds(90_000L)
+                .build();
+
+        assertThat(provider.bearer("ws", UUID.randomUUID(), recipe)).isEqualTo("tok-nested");
+    }
+
+    @Test
+    @DisplayName("a zero fallback leaves tokens uncached when the reply states no lifetime")
+    void zeroTtlFetchesPerCall() {
+        stubToken("{\"access_token\": \"tok-0\"}");
+        var providerId = UUID.randomUUID();
+        var recipe = oauthRecipe().fallbackTtlSeconds(0L).build();
+
+        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, recipe);
+
+        wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+        assertThat(cachedKeys(providerId)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a reply-stated lifetime wins over the fallback, including a zero fallback")
+    void replyLifetimeWinsOverFallback() {
+        stubToken("{\"access_token\": \"tok-authoritative\", \"expires_in\": 3600}");
+        var providerId = UUID.randomUUID();
+        var recipe = oauthRecipe().fallbackTtlSeconds(0L).build();
+
+        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, recipe);
+
+        wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+        assertThat(cachedKeys(providerId)).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("a token inside the refresh window is refetched")
+    void refreshWindowTriggersRefetch() throws InterruptedException {
+        // 1s lifetime with the default 0.25 fraction: fresh for ~750ms, inside the window after
+        stubToken("{\"access_token\": \"tok-refresh\", \"expires_in\": 1}");
+        var providerId = UUID.randomUUID();
+        var recipe = oauthRecipe().build();
+
+        provider.bearer("ws", providerId, recipe);
+        provider.bearer("ws", providerId, recipe);
+        wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+
+        Thread.sleep(800);
+        provider.bearer("ws", providerId, recipe);
+
+        wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
+    @DisplayName("editing the recipe changes the cache key, so the old token is never served")
+    void configChangeChangesCacheKey() {
+        stubToken("{\"access_token\": \"tok-cfg\", \"expires_in\": 3600}");
+        var providerId = UUID.randomUUID();
+
+        provider.bearer("ws", providerId, oauthRecipe().build());
+        provider.bearer("ws", providerId, oauthRecipe()
+                .credentials(List.of(
+                        credential("grant_type", "client_credentials", false),
+                        credential("client_id", "opik-prod", false),
+                        credential("client_secret", "rotated-secret", true)))
+                .build());
+
+        wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
+    @DisplayName("invalidate drops the cached token so the next call refetches")
+    void invalidateForcesRefetch() {
+        stubToken("{\"access_token\": \"tok-inv\", \"expires_in\": 3600}");
+        var providerId = UUID.randomUUID();
+        var recipe = oauthRecipe().build();
+
+        provider.bearer("ws", providerId, recipe);
+        provider.invalidate(providerId, recipe);
+        provider.bearer("ws", providerId, recipe);
+
+        wireMock.verify(exactly(2), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+    }
+
+    @Test
+    @DisplayName("upstream errors surface status and body with credential values redacted")
+    void upstreamErrorIsSurfacedRedacted() {
+        wireMock.stubFor(post(urlEqualTo(TOKEN_PATH)).willReturn(aResponse()
+                .withStatus(401)
+                .withBody("{\"error\": \"invalid_client\", \"echo\": \"%s\"}".formatted(SECRET_VALUE))));
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("401")
+                .hasMessageContaining("invalid_client")
+                .satisfies(exception -> assertThat(exception.getMessage()).doesNotContain(SECRET_VALUE));
+    }
+
+    @Test
+    @DisplayName("a missing token field names the reply's top-level fields, never values")
+    void missingTokenFieldListsTopLevelKeys() {
+        stubToken("{\"token\": \"the-actual-token\", \"ttl\": 60}");
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("access_token")
+                .hasMessageContaining("[token, ttl]")
+                .satisfies(exception -> assertThat(exception.getMessage()).doesNotContain("the-actual-token"));
+    }
+
+    @Test
+    @DisplayName("a reply without a lifetime and without a fallback is a clear error")
+    void missingLifetimeWithoutFallbackIsRejected() {
+        stubToken("{\"access_token\": \"tok-nolife\"}");
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("expires_in")
+                .hasMessageContaining("no fallback lifetime");
+    }
+
+    @Test
+    @DisplayName("a non-JSON reply is a clear error")
+    void nonJsonReplyIsRejected() {
+        wireMock.stubFor(post(urlEqualTo(TOKEN_PATH)).willReturn(aResponse()
+                .withStatus(200)
+                .withBody("<html>gateway login page</html>")));
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("non-JSON reply");
+    }
+
+    @Test
+    @DisplayName("an unreachable token URL is a clear error, not a hang")
+    void unreachableTokenUrlIsRejected() {
+        var recipe = oauthRecipe().tokenUrl("http://localhost:1/token").build();
+
+        assertThatThrownBy(() -> provider.bearer("ws", UUID.randomUUID(), recipe))
+                .isInstanceOf(AuthTokenException.class)
+                .hasMessageContaining("could not reach");
+    }
+
+    @Test
+    @DisplayName("a Redis outage degrades to a direct fetch instead of failing the call")
+    void redisOutageDegradesToDirectFetch() {
+        var flakyRedis = RedisContainerUtils.newRedisContainer();
+        flakyRedis.start();
+        var flakyConfig = new Config();
+        flakyConfig.useSingleServer()
+                .setAddress(flakyRedis.getRedisURI())
+                .setTimeout(500)
+                .setRetryAttempts(0)
+                .setConnectTimeout(500);
+        var flakyRedisson = Redisson.create(flakyConfig);
+        try {
+            var flakyProvider = new AuthTokenProvider(new StringRedisClient(flakyRedisson),
+                    PASSTHROUGH_LOCK_SERVICE, new LlmProviderTokenAuthConfig());
+            flakyRedis.stop();
+
+            stubToken("{\"access_token\": \"tok-degraded\", \"expires_in\": 3600}");
+
+            assertThat(flakyProvider.bearer("ws", UUID.randomUUID(), oauthRecipe().build()))
+                    .isEqualTo("tok-degraded");
+            wireMock.verify(exactly(1), postRequestedFor(urlEqualTo(TOKEN_PATH)));
+        } finally {
+            flakyRedisson.shutdown();
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientTest.java
@@ -1,9 +1,13 @@
 package com.comet.opik.infrastructure.llm.customllm;
 
+import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.http.client.HttpClient;
 import dev.langchain4j.http.client.HttpMethod;
 import dev.langchain4j.http.client.HttpRequest;
 import dev.langchain4j.http.client.SuccessfulHttpResponse;
+import dev.langchain4j.http.client.sse.ServerSentEvent;
+import dev.langchain4j.http.client.sse.ServerSentEventListener;
+import dev.langchain4j.http.client.sse.ServerSentEventParser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -14,7 +18,12 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -210,5 +219,166 @@ class InterceptingHttpClientTest {
         verify(delegate).execute(captor.capture());
         assertThat(captor.getValue().headers())
                 .containsEntry("Authorization", List.of("Bearer dummy-key"));
+    }
+
+    // --- dynamic token auth ---
+
+    private HttpRequest chatRequest() {
+        return HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .url("https://example.test/chat/completions")
+                .body("{\"model\":\"gpt-4o\"}")
+                .build();
+    }
+
+    private SuccessfulHttpResponse ok() {
+        return SuccessfulHttpResponse.builder().statusCode(200).body("{}").build();
+    }
+
+    @Test
+    void tokenIsInjectedAsBearerOnEveryRequest() {
+        when(delegate.execute(any(HttpRequest.class))).thenReturn(ok());
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok-1", () -> {
+        });
+
+        client.execute(chatRequest());
+
+        var captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(delegate).execute(captor.capture());
+        assertThat(captor.getValue().headers()).containsEntry("Authorization", List.of("Bearer tok-1"));
+    }
+
+    @Test
+    void tokenReplacesPreConfiguredStaticAuthorizationHeader() {
+        when(delegate.execute(any(HttpRequest.class))).thenReturn(ok());
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok-1", () -> {
+        });
+        var request = HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .url("https://example.test/chat/completions")
+                .addHeader("Authorization", "Bearer stale-static-key")
+                .addHeader("X-Extra", "kept")
+                .body("{}")
+                .build();
+
+        client.execute(request);
+
+        var captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(delegate).execute(captor.capture());
+        assertThat(captor.getValue().headers())
+                .containsEntry("Authorization", List.of("Bearer tok-1"))
+                .containsEntry("X-Extra", List.of("kept"));
+    }
+
+    @Test
+    void tokenGoesRawUnderConfiguredAuthHeaderName() {
+        when(delegate.execute(any(HttpRequest.class))).thenReturn(ok());
+        var configuration = Map.of("auth_header_name", "api-key");
+        var client = new InterceptingHttpClient(delegate, configuration, null, () -> "tok-1", () -> {
+        });
+        var request = HttpRequest.builder()
+                .method(HttpMethod.POST)
+                .url("https://example.test/chat/completions")
+                .addHeader("Authorization", "Bearer stale")
+                .body("{}")
+                .build();
+
+        client.execute(request);
+
+        var captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(delegate).execute(captor.capture());
+        assertThat(captor.getValue().headers())
+                .containsEntry("api-key", List.of("tok-1"))
+                .doesNotContainKey("Authorization");
+    }
+
+    @Test
+    void authFailureInvalidatesAndRetriesOnceWithAFreshToken() {
+        var tokens = new java.util.concurrent.atomic.AtomicInteger();
+        var invalidated = new java.util.concurrent.atomic.AtomicBoolean();
+        when(delegate.execute(any(HttpRequest.class)))
+                .thenThrow(new HttpException(401, "token rejected"))
+                .thenReturn(ok());
+        var client = new InterceptingHttpClient(delegate, Map.of(), null,
+                () -> "tok-" + tokens.incrementAndGet(), () -> invalidated.set(true));
+
+        client.execute(chatRequest());
+
+        assertThat(invalidated).isTrue();
+        var captor = ArgumentCaptor.forClass(HttpRequest.class);
+        verify(delegate, times(2)).execute(captor.capture());
+        assertThat(captor.getAllValues().getFirst().headers())
+                .containsEntry("Authorization", List.of("Bearer tok-1"));
+        assertThat(captor.getAllValues().getLast().headers())
+                .containsEntry("Authorization", List.of("Bearer tok-2"));
+    }
+
+    @Test
+    void authFailureIsRetriedExactlyOnce() {
+        when(delegate.execute(any(HttpRequest.class))).thenThrow(new HttpException(401, "still rejected"));
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> {
+        });
+
+        assertThatThrownBy(() -> client.execute(chatRequest()))
+                .isInstanceOf(HttpException.class);
+        verify(delegate, times(2)).execute(any(HttpRequest.class));
+    }
+
+    @Test
+    void nonAuthFailureIsNotRetried() {
+        when(delegate.execute(any(HttpRequest.class))).thenThrow(new HttpException(500, "gateway down"));
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> {
+        });
+
+        assertThatThrownBy(() -> client.execute(chatRequest()))
+                .isInstanceOf(HttpException.class);
+        verify(delegate, times(1)).execute(any(HttpRequest.class));
+    }
+
+    @Test
+    void streamedAuthFailureRetriesOnlyBeforeTheFirstDeliveredEvent() {
+        var downstream = mock(ServerSentEventListener.class);
+        var parser = mock(ServerSentEventParser.class);
+        var tokens = new java.util.concurrent.atomic.AtomicInteger();
+        var client = new InterceptingHttpClient(delegate, Map.of(), null,
+                () -> "tok-" + tokens.incrementAndGet(), () -> {
+                });
+
+        client.execute(chatRequest(), parser, downstream);
+
+        var requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+        var listenerCaptor = ArgumentCaptor.forClass(ServerSentEventListener.class);
+        verify(delegate).execute(requestCaptor.capture(), any(), listenerCaptor.capture());
+        assertThat(requestCaptor.getValue().headers()).containsEntry("Authorization", List.of("Bearer tok-1"));
+
+        // 401 arrives before any event: the wrapper retries once, straight to the downstream listener
+        listenerCaptor.getValue().onError(new HttpException(401, "token rejected"));
+
+        verify(delegate).execute(requestCaptor.capture(), any(), same(downstream));
+        assertThat(requestCaptor.getValue().headers()).containsEntry("Authorization", List.of("Bearer tok-2"));
+        verify(downstream, never()).onError(any());
+    }
+
+    @Test
+    void streamedAuthFailureAfterAnEventPropagatesWithoutRetry() {
+        var downstream = mock(ServerSentEventListener.class);
+        var parser = mock(ServerSentEventParser.class);
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> {
+        });
+
+        client.execute(chatRequest(), parser, downstream);
+
+        var listenerCaptor = ArgumentCaptor.forClass(ServerSentEventListener.class);
+        verify(delegate).execute(any(HttpRequest.class), any(), listenerCaptor.capture());
+
+        var event = new ServerSentEvent("message", "chunk");
+        listenerCaptor.getValue().onEvent(event);
+        var failure = new HttpException(401, "cut mid-stream");
+        listenerCaptor.getValue().onError(failure);
+
+        verify(downstream).onEvent(event);
+        verify(downstream).onError(failure);
+        // no second execute: content already flowed, splicing two half-responses would be worse
+        verify(delegate, times(1)).execute(any(HttpRequest.class), any(), any());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/llm/customllm/InterceptingHttpClientTest.java
@@ -314,6 +314,36 @@ class InterceptingHttpClientTest {
     }
 
     @Test
+    void a403WithATokenRejectionHintIsRetried() {
+        var invalidated = new java.util.concurrent.atomic.AtomicBoolean();
+        when(delegate.execute(any(HttpRequest.class)))
+                .thenThrow(new HttpException(403,
+                        "{\"error\": \"invalid_token\", \"error_description\": \"The access token expired\"}"))
+                .thenReturn(ok());
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> invalidated.set(true));
+
+        client.execute(chatRequest());
+
+        assertThat(invalidated).isTrue();
+        verify(delegate, times(2)).execute(any(HttpRequest.class));
+    }
+
+    @Test
+    void aPolicy403IsNotRetried() {
+        // a policy/quota/WAF 403 must not replay a non-idempotent LLM request
+        // nor invalidate the shared token cache
+        var invalidated = new java.util.concurrent.atomic.AtomicBoolean();
+        when(delegate.execute(any(HttpRequest.class)))
+                .thenThrow(new HttpException(403, "request blocked by content policy"));
+        var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> invalidated.set(true));
+
+        assertThatThrownBy(() -> client.execute(chatRequest()))
+                .isInstanceOf(HttpException.class);
+        assertThat(invalidated).isFalse();
+        verify(delegate, times(1)).execute(any(HttpRequest.class));
+    }
+
+    @Test
     void authFailureIsRetriedExactlyOnce() {
         when(delegate.execute(any(HttpRequest.class))).thenThrow(new HttpException(401, "still rejected"));
         var client = new InterceptingHttpClient(delegate, Map.of(), null, () -> "tok", () -> {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/net/DestinationGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/net/DestinationGuardTest.java
@@ -1,0 +1,74 @@
+package com.comet.opik.infrastructure.net;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Destination Guard Test")
+class DestinationGuardTest {
+
+    private final DestinationGuard strict = new DestinationGuard(DestinationGuard.Mode.STRICT);
+    private final DestinationGuard relaxed = new DestinationGuard(DestinationGuard.Mode.RELAXED);
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://public.example.com/token", // https only
+            "https://localhost/token",
+            "https://127.0.0.1/token",
+            "https://10.1.2.3/token",
+            "https://172.16.0.1/token",
+            "https://192.168.1.1/token",
+            "https://169.254.169.254/latest/meta-data", // cloud metadata endpoint
+            "https://[::1]/token",
+            "https://[fe80::1]/token",
+            "https://[fc00::1]/token", // IPv6 unique-local
+            "https://0.0.0.0/token",
+            "not a url",
+    })
+    @DisplayName("strict mode refuses non-https, private, internal and malformed destinations")
+    void strictModeRefuses(String url) {
+        assertThatThrownBy(() -> strict.validate(url)).isInstanceOf(DestinationGuardException.class);
+    }
+
+    @Test
+    @DisplayName("strict mode refuses unresolvable hosts")
+    void strictModeRefusesUnresolvableHosts() {
+        // .invalid is reserved (RFC 2606): guaranteed NXDOMAIN, no DNS flakiness
+        assertThatThrownBy(() -> strict.validate("https://token-endpoint.invalid/token"))
+                .isInstanceOf(DestinationGuardException.class)
+                .hasMessageContaining("could not be resolved");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "https://8.8.8.8/token",
+            "https://1.1.1.1/oauth/token",
+    })
+    @DisplayName("strict mode allows public https destinations")
+    void strictModeAllowsPublicHttps(String url) {
+        assertThatCode(() -> strict.validate(url)).doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://localhost:9876/token",
+            "https://10.1.2.3/token",
+            "https://169.254.169.254/latest/meta-data",
+    })
+    @DisplayName("relaxed mode is a no-op: internal gateways are legitimate self-hosted destinations")
+    void relaxedModeAllowsEverything(String url) {
+        assertThatCode(() -> relaxed.validate(url)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("refusal messages echo the user's hostname, never the resolved address")
+    void refusalNeverEchoesTheResolvedAddress() {
+        assertThatThrownBy(() -> strict.validate("https://localhost/token"))
+                .hasMessageContaining("localhost")
+                .hasMessageNotContainingAny("127.0.0.1", "::1");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyUpdateManufacturer.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/podam/manufacturer/ProviderApiKeyUpdateManufacturer.java
@@ -16,22 +16,23 @@ public class ProviderApiKeyUpdateManufacturer extends AbstractTypeManufacturer<P
     public ProviderApiKeyUpdate getType(DataProviderStrategy strategy, AttributeMetadata metadata,
             ManufacturingContext context) {
 
-        return new ProviderApiKeyUpdate(
-                RandomStringUtils.secure().nextAlphabetic(20),
-                strategy.getTypeValue(metadata, context, String.class),
-                strategy.getTypeValue(metadata, context, String.class),
-                Map.of(
+        return ProviderApiKeyUpdate.builder()
+                .apiKey(RandomStringUtils.secure().nextAlphabetic(20))
+                .name(strategy.getTypeValue(metadata, context, String.class))
+                .providerName(strategy.getTypeValue(metadata, context, String.class))
+                .headers(Map.of(
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
-                        RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5)),
-                Map.of(
+                        RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5)))
+                .configuration(Map.of(
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
                         RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5),
-                        RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5)),
-                "http://" + strategy.getTypeValue(metadata, context, String.class) + ".com");
+                        RandomStringUtils.secure().nextAlphabetic(5), RandomStringUtils.secure().nextAlphabetic(5)))
+                .baseUrl("http://" + strategy.getTypeValue(metadata, context, String.class) + ".com")
+                .build();
     }
 }

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -568,6 +568,10 @@ datasetExport:
   cleanupLockWaitTime: 1s
   cleanupBatchSize: 100
 
+# Dynamic token auth for custom LLM providers: tests hit localhost token endpoints over http
+llmProviderTokenAuth:
+  destinationGuard: "relaxed"
+
 # LLM providers client configuration
 llmProviderClient:
   # Default: 60s

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysAuthCheckMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysAuthCheckMutation.ts
@@ -1,0 +1,37 @@
+import { useMutation } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+
+import api, { PROVIDER_KEYS_REST_ENDPOINT } from "@/api/api";
+import { ProviderAuthConfig } from "@/types/providers";
+
+export type ProviderAuthCheckRequest = {
+  provider_id?: string;
+  auth_config?: ProviderAuthConfig;
+};
+
+export type ProviderAuthCheckResult = {
+  lifetime_seconds: number;
+};
+
+/**
+ * Test-connection for dynamic token auth: the backend runs the recipe once and reports the token
+ * lifetime — the token itself is never returned. Errors carry the upstream auth service's status
+ * and body (credential values redacted), meant to be shown to the user verbatim.
+ */
+const useProviderKeysAuthCheckMutation = () => {
+  return useMutation<
+    ProviderAuthCheckResult,
+    AxiosError,
+    ProviderAuthCheckRequest
+  >({
+    mutationFn: async (request: ProviderAuthCheckRequest) => {
+      const { data } = await api.post(
+        `${PROVIDER_KEYS_REST_ENDPOINT}auth-config/test`,
+        request,
+      );
+      return data;
+    },
+  });
+};
+
+export default useProviderKeysAuthCheckMutation;

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
@@ -41,9 +41,12 @@ const useProviderKeysCreateMutation = () => {
     onError: (error: AxiosError) => {
       // the backend 400s in two shapes: bean validation -> {errors: [...]},
       // service BadRequestException -> {message: "..."} (Dropwizard ErrorMessage)
+      const errors = get(error, ["response", "data", "errors"]);
       const message =
         get(error, ["response", "data", "message"]) ??
-        get(error, ["response", "data", "errors", "0"], error.message);
+        (Array.isArray(errors) && errors.length > 0
+          ? errors.join("; ")
+          : error.message);
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
@@ -31,6 +31,9 @@ const useProviderKeysCreateMutation = () => {
           configuration: providerKey.configuration,
         }),
         ...(providerKey?.headers && { headers: providerKey.headers }),
+        ...(providerKey.auth_config !== undefined && {
+          auth_config: providerKey.auth_config,
+        }),
       });
 
       return data;

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysCreateMutation.ts
@@ -39,11 +39,11 @@ const useProviderKeysCreateMutation = () => {
       return data;
     },
     onError: (error: AxiosError) => {
-      const message = get(
-        error,
-        ["response", "data", "errors", "0"],
-        error.message,
-      );
+      // the backend 400s in two shapes: bean validation -> {errors: [...]},
+      // service BadRequestException -> {message: "..."} (Dropwizard ErrorMessage)
+      const message =
+        get(error, ["response", "data", "message"]) ??
+        get(error, ["response", "data", "errors", "0"], error.message);
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
@@ -28,6 +28,10 @@ const useProviderKeysUpdateMutation = () => {
             configuration: providerKey.configuration,
           }),
           ...(providerKey?.headers && { headers: providerKey.headers }),
+          // {} clears the stored recipe, so the check is on undefined, not truthiness
+          ...(providerKey.auth_config !== undefined && {
+            auth_config: providerKey.auth_config,
+          }),
         },
       );
       return data;

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
@@ -22,7 +22,11 @@ const useProviderKeysUpdateMutation = () => {
       const { data } = await api.patch(
         `${PROVIDER_KEYS_REST_ENDPOINT}${providerKey.id}`,
         {
-          ...(providerKey.apiKey && { api_key: providerKey.apiKey }),
+          // "" clears the stored key when switching to token auth, so
+          // the check is on undefined, not truthiness
+          ...(providerKey.apiKey !== undefined && {
+            api_key: providerKey.apiKey,
+          }),
           ...(providerKey.base_url && { base_url: providerKey.base_url }),
           ...(providerKey?.configuration && {
             configuration: providerKey.configuration,
@@ -37,11 +41,11 @@ const useProviderKeysUpdateMutation = () => {
       return data;
     },
     onError: (error: AxiosError) => {
-      const message = get(
-        error,
-        ["response", "data", "errors", "0"],
-        error.message,
-      );
+      // the backend 400s in two shapes: bean validation -> {errors: [...]},
+      // service BadRequestException -> {message: "..."} (Dropwizard ErrorMessage)
+      const message =
+        get(error, ["response", "data", "message"]) ??
+        get(error, ["response", "data", "errors", "0"], error.message);
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
+++ b/apps/opik-frontend/src/api/provider-keys/useProviderKeysUpdateMutation.ts
@@ -43,9 +43,12 @@ const useProviderKeysUpdateMutation = () => {
     onError: (error: AxiosError) => {
       // the backend 400s in two shapes: bean validation -> {errors: [...]},
       // service BadRequestException -> {message: "..."} (Dropwizard ErrorMessage)
+      const errors = get(error, ["response", "data", "errors"]);
       const message =
         get(error, ["response", "data", "message"]) ??
-        get(error, ["response", "data", "errors", "0"], error.message);
+        (Array.isArray(errors) && errors.length > 0
+          ? errors.join("; ")
+          : error.message);
 
       toast({
         title: "Error",

--- a/apps/opik-frontend/src/shared/EyeInput/EyeInput.tsx
+++ b/apps/opik-frontend/src/shared/EyeInput/EyeInput.tsx
@@ -4,13 +4,16 @@ import { Eye, EyeOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/ui/button";
 
-interface EyeInputProps extends InputProps {}
+interface EyeInputProps extends InputProps {
+  revealable?: boolean;
+}
 
-const EyeInput = (props: EyeInputProps) => {
+const EyeInput = ({ revealable = true, ...props }: EyeInputProps) => {
   const [hidden, setHidden] = useState(true);
   const id = useId();
 
-  const Icon = hidden ? Eye : EyeOff;
+  const isHidden = hidden || !revealable;
+  const Icon = isHidden ? Eye : EyeOff;
 
   return (
     <div className="relative">
@@ -20,21 +23,23 @@ const EyeInput = (props: EyeInputProps) => {
         style={
           {
             ...(props?.style || {}),
-            WebkitTextSecurity: hidden ? "disc" : "none",
+            WebkitTextSecurity: isHidden ? "disc" : "none",
           } as React.CSSProperties
         }
-        className={cn(props.className, "pr-8")}
+        className={cn(props.className, revealable && "pr-8")}
       />
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon"
-        className="absolute right-0 top-1/2 -translate-y-1/2"
-        onClick={() => setHidden((h) => !h)}
-        disabled={props.disabled}
-      >
-        <Icon className="size-4 text-light-slate" />
-      </Button>
+      {revealable && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="absolute right-0 top-1/2 -translate-y-1/2"
+          onClick={() => setHidden((h) => !h)}
+          disabled={props.disabled}
+        >
+          <Icon className="size-4 text-light-slate" />
+        </Button>
+      )}
     </div>
   );
 };

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -862,6 +862,34 @@ export interface ProviderKeyConfiguration {
   openai_pipeline_mode?: OpenAiPipelineMode;
 }
 
+/** Read-back sentinel for secret credential values: the backend never returns a stored secret,
+ * it returns this marker instead. Submitting it back means "keep the stored value". */
+export const AUTH_SECRET_SENTINEL = "__SECRET__";
+
+export const AUTH_SEND_AS_VALUES = ["form", "json", "basic"] as const;
+export type AuthSendAs = (typeof AUTH_SEND_AS_VALUES)[number];
+
+export interface ProviderAuthCredential {
+  key: string;
+  value: string;
+  /** Secret values are encrypted at rest and read back masked; once true it cannot be unset. */
+  secret: boolean;
+}
+
+/** Dynamic token auth recipe (OPIK-7940): how to fetch a short-lived bearer before LLM calls.
+ * Presence on a provider means token mode; an empty object on update clears it (back to static). */
+export interface ProviderAuthConfig {
+  token_url: string;
+  send_as?: AuthSendAs;
+  credentials: ProviderAuthCredential[];
+  /** Field holding the token in the reply; dot-path for nested replies (e.g. "result.jwt"). */
+  token_field?: string;
+  /** Field holding the lifetime in seconds in the reply; dot-path supported. */
+  expires_field?: string;
+  /** Lifetime assumed when the reply doesn't state one; 0 means such tokens are not cached. */
+  fallback_ttl_seconds?: number;
+}
+
 export interface BaseProviderKey {
   id: string;
   created_at: string;
@@ -869,6 +897,7 @@ export interface BaseProviderKey {
   ui_composed_provider: COMPOSED_PROVIDER_TYPE;
   configuration: ProviderKeyConfiguration;
   headers?: Record<string, string>;
+  auth_config?: ProviderAuthConfig;
   read_only: boolean;
 }
 
@@ -896,7 +925,7 @@ export type ProviderObject =
   | OllamaProviderObject;
 
 export type PartialProviderKeyUpdate = Partial<
-  Omit<BaseProviderKey, "provider">
+  Omit<BaseProviderKey, "provider" | "auth_config">
 > & {
   id?: string;
   provider?: PROVIDER_TYPE;
@@ -904,6 +933,8 @@ export type PartialProviderKeyUpdate = Partial<
   base_url?: string;
   provider_name?: string;
   headers?: Record<string, string>;
+  /** Full recipe to set, or an empty object to clear (switch back to static key). */
+  auth_config?: ProviderAuthConfig | Record<string, never>;
 };
 
 export type ReasoningEffort =

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
@@ -217,11 +217,14 @@ const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
                         placeholder={
                           isStoredSecret ? "stored, write-only" : "Value"
                         }
-                        value={value}
+                        // Emptying a saved secret reverts to the sentinel (= keep stored).
+                        value={isStoredSecret ? "" : value}
                         onChange={(e) =>
                           form.setValue(
                             `authCredentials.${index}.value`,
-                            e.target.value,
+                            e.target.value === "" && isSaved
+                              ? AUTH_SECRET_SENTINEL
+                              : e.target.value,
                           )
                         }
                       />

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
@@ -1,0 +1,326 @@
+import React, { useCallback } from "react";
+import { UseFormReturn, useFieldArray } from "react-hook-form";
+import { v4 as uuidv4 } from "uuid";
+import get from "lodash/get";
+import { AxiosError } from "axios";
+import { Lock, LockOpen, Plus, Trash2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/ui/button";
+import { Label } from "@/ui/label";
+import { FormControl, FormField, FormItem, FormMessage } from "@/ui/form";
+import { Input } from "@/ui/input";
+import { Description } from "@/ui/description";
+import { RadioGroup, RadioGroupItem } from "@/ui/radio-group";
+import { FormFieldCard } from "@/v2/pages-shared/llm/FormFieldCard";
+import { useToast } from "@/ui/use-toast";
+import EyeInput from "@/shared/EyeInput/EyeInput";
+import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
+import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
+import { AUTH_SECRET_SENTINEL } from "@/types/providers";
+import useProviderKeysAuthCheckMutation from "@/api/provider-keys/useProviderKeysAuthCheckMutation";
+import { AIProviderFormType } from "@/v2/pages-shared/llm/ManageAIProviderDialog/schema";
+import {
+  AUTH_SECRET_KEY_PATTERN,
+  AuthMode,
+  formValuesToAuthConfig,
+  oauth2CredentialRows,
+} from "@/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig";
+
+type AuthConfigSectionProps = {
+  form: UseFormReturn<AIProviderFormType>;
+  /** The provider's static-auth fields (API key etc.), rendered only while static mode is selected. */
+  staticModeFields: React.ReactNode;
+};
+
+/**
+ * The Authentication block of the custom/Bedrock provider form: a mode selector between the
+ * classic static API key and OAuth2 client credentials (OPIK-7940). The UI surfaces only the
+ * OAuth2 flow.
+ * Secret credential values are write-only once saved — they load as the backend's sentinel and
+ * their lock cannot be removed, mirroring the API contract.
+ */
+const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
+  form,
+  staticModeFields,
+}) => {
+  const { toast } = useToast();
+  const { mutate: checkAuthConfig, isPending: isChecking } =
+    useProviderKeysAuthCheckMutation();
+
+  const authMode = form.watch("authMode") ?? "api_key";
+  const headers = form.watch("headers");
+  const hasStaticAuthorizationHeader = (headers ?? []).some(
+    (header) => header.key.trim().toLowerCase() === "authorization",
+  );
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "authCredentials",
+  });
+
+  const handleModeChange = useCallback(
+    (value: AuthMode) => {
+      form.setValue("authMode", value);
+      if (
+        value === "token" &&
+        (form.getValues("authCredentials") ?? []).length === 0
+      ) {
+        form.setValue("authCredentials", oauth2CredentialRows());
+      }
+    },
+    [form],
+  );
+
+  const handleCheckConnection = useCallback(() => {
+    const authConfig = formValuesToAuthConfig(
+      { ...form.getValues(), authMode: "token" },
+      { isEditing: false, hadAuthConfig: false },
+    );
+    const providerId = form.getValues("id");
+
+    checkAuthConfig(
+      {
+        // the id lets the backend resolve __SECRET__ sentinels against the stored recipe
+        ...(providerId && { provider_id: providerId }),
+        auth_config: authConfig as never,
+      },
+      {
+        onSuccess: (result) => {
+          toast({
+            title: "Connection successful",
+            description: `Token received, valid for ${result.lifetime_seconds} seconds.`,
+          });
+        },
+        onError: (error: AxiosError) => {
+          const message =
+            get(error, ["response", "data", "message"]) ??
+            get(error, ["response", "data", "errors", "0"], error.message);
+          toast({
+            title: "Connection failed",
+            description: String(message),
+            variant: "destructive",
+          });
+        },
+      },
+    );
+  }, [form, checkAuthConfig, toast]);
+
+  const handleCredentialKeyChange = useCallback(
+    (index: number, key: string) => {
+      form.setValue(`authCredentials.${index}.key`, key);
+      // auto-lock names that look like secrets, visibly, as the user types
+      if (
+        AUTH_SECRET_KEY_PATTERN.test(key) &&
+        !form.getValues(`authCredentials.${index}.secret`)
+      ) {
+        form.setValue(`authCredentials.${index}.secret`, true);
+      }
+    },
+    [form],
+  );
+
+  return (
+    <FormFieldCard title="Authentication" bodyClassName="flex flex-col gap-4">
+      <RadioGroup
+        value={authMode}
+        onValueChange={(value) => handleModeChange(value as AuthMode)}
+        className="flex gap-6"
+      >
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value="api_key" id="authModeApiKey" />
+          <Label htmlFor="authModeApiKey" className="cursor-pointer">
+            Static API key
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <RadioGroupItem value="token" id="authModeToken" />
+          <Label htmlFor="authModeToken" className="cursor-pointer">
+            OAuth2 client credentials
+          </Label>
+          <ExplainerIcon description="Opik requests a short-lived access token from your auth service using the OAuth2 client credentials grant and attaches it to every model call, refreshing it automatically before expiry." />
+        </div>
+      </RadioGroup>
+
+      {authMode === "api_key" && staticModeFields}
+
+      {authMode === "token" && (
+        <>
+          <FormField
+            control={form.control}
+            name="authTokenUrl"
+            render={({ field, formState }) => {
+              const validationErrors = get(formState.errors, ["authTokenUrl"]);
+              return (
+                <FormItem>
+                  <Label htmlFor="authTokenUrl">Token URL</Label>
+                  <FormControl>
+                    <Input
+                      id="authTokenUrl"
+                      type="url"
+                      inputMode="url"
+                      placeholder="https://auth.example.com/oauth/token"
+                      value={field.value ?? ""}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      className={cn({
+                        "border-destructive": Boolean(
+                          validationErrors?.message,
+                        ),
+                      })}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
+          />
+
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center gap-1">
+              <Label>Credentials</Label>
+              <ExplainerIcon description="Sent to the token URL per the OAuth2 standard: client_id and client_secret go in an HTTP Basic header, the remaining rows (e.g. scope) as a form body along with grant_type=client_credentials, which is added automatically. Locked values are encrypted at rest and can't be read back after saving, only replaced. Fields named like a secret are locked automatically." />
+            </div>
+
+            {fields.map((row, index) => {
+              const isSecret = form.watch(`authCredentials.${index}.secret`);
+              const isSaved = row.saved;
+              const value = form.watch(`authCredentials.${index}.value`);
+              const isStoredSecret = isSaved && value === AUTH_SECRET_SENTINEL;
+              const keyErrors = get(form.formState.errors, [
+                "authCredentials",
+                index,
+                "key",
+              ]);
+
+              return (
+                <div key={row.id} className="flex items-start gap-2">
+                  <div className="flex-1">
+                    <Input
+                      placeholder="Field name"
+                      value={form.watch(`authCredentials.${index}.key`)}
+                      onChange={(e) =>
+                        handleCredentialKeyChange(index, e.target.value)
+                      }
+                      className={cn({
+                        "border-destructive": Boolean(keyErrors?.message),
+                      })}
+                    />
+                    {keyErrors?.message && (
+                      <FormMessage>{String(keyErrors.message)}</FormMessage>
+                    )}
+                  </div>
+                  <div className="flex-1">
+                    {isSecret ? (
+                      <EyeInput
+                        revealable={!isStoredSecret}
+                        placeholder={
+                          isStoredSecret ? "stored, write-only" : "Value"
+                        }
+                        value={value}
+                        onChange={(e) =>
+                          form.setValue(
+                            `authCredentials.${index}.value`,
+                            e.target.value,
+                          )
+                        }
+                      />
+                    ) : (
+                      <Input
+                        placeholder="Value"
+                        value={value}
+                        onChange={(e) =>
+                          form.setValue(
+                            `authCredentials.${index}.value`,
+                            e.target.value,
+                          )
+                        }
+                      />
+                    )}
+                  </div>
+                  <TooltipWrapper
+                    content={
+                      isSaved && isSecret
+                        ? "Saved secrets stay secret; the lock cannot be removed"
+                        : isSecret
+                          ? "Stored encrypted, write-only after saving"
+                          : "Mark as secret"
+                    }
+                  >
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      disabled={isSaved && isSecret}
+                      onClick={() =>
+                        form.setValue(
+                          `authCredentials.${index}.secret`,
+                          !isSecret,
+                        )
+                      }
+                    >
+                      {isSecret ? (
+                        <Lock className="size-4 text-primary" />
+                      ) : (
+                        <LockOpen className="size-4" />
+                      )}
+                    </Button>
+                  </TooltipWrapper>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => remove(index)}
+                  >
+                    <Trash2 className="size-4" />
+                  </Button>
+                </div>
+              );
+            })}
+
+            <div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() =>
+                  append({
+                    key: "",
+                    value: "",
+                    secret: false,
+                    saved: false,
+                    id: uuidv4(),
+                  })
+                }
+              >
+                <Plus className="mr-1.5 size-3.5" /> Add credential
+              </Button>
+            </div>
+          </div>
+
+          {hasStaticAuthorizationHeader && (
+            <Description className="text-warning">
+              A custom <code>Authorization</code> header is configured below —
+              it is ignored while token auth is on; the fetched token takes
+              precedence.
+            </Description>
+          )}
+
+          <TooltipWrapper content="Runs the token fetch once, server-side, and reports the token lifetime.">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="w-full"
+              disabled={isChecking}
+              onClick={handleCheckConnection}
+            >
+              {isChecking ? "Testing…" : "Test connection"}
+            </Button>
+          </TooltipWrapper>
+        </>
+      )}
+    </FormFieldCard>
+  );
+};
+
+export default AuthConfigSection;

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
@@ -34,9 +34,10 @@ type AuthConfigSectionProps = {
 };
 
 /**
- * The Authentication block of the custom/Bedrock provider form: a mode selector between the
- * classic static API key and OAuth2 client credentials (OPIK-7940). The UI surfaces only the
- * OAuth2 flow.
+ * The Authentication block of the custom/Bedrock provider form: a mode switch between the classic
+ * static API key (rendered via {@code staticModeFields}) and dynamic token auth (OPIK-7940). Of
+ * the backend's general token-auth recipe, the UI surfaces only the OAuth2 client credentials
+ * flow — other recipe shapes remain API-only.
  * Secret credential values are write-only once saved — they load as the backend's sentinel and
  * their lock cannot be removed, mirroring the API contract.
  */

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/BedrockProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/BedrockProviderDetails.tsx
@@ -10,6 +10,7 @@ import { Input } from "@/ui/input";
 import { Description } from "@/ui/description";
 import { Button } from "@/ui/button";
 import CustomHeadersField from "./CustomHeadersField";
+import AuthConfigSection from "./AuthConfigSection";
 
 type BedrockProviderDetailsProps = {
   form: UseFormReturn<AIProviderFormType>;
@@ -82,50 +83,6 @@ const BedrockProviderDetails: React.FC<BedrockProviderDetailsProps> = ({
 
       <FormField
         control={form.control}
-        name="apiKey"
-        render={({ field, formState }) => {
-          const validationErrors = get(formState.errors, ["apiKey"]);
-
-          return (
-            <FormItem>
-              <Label htmlFor="apiKey">API key</Label>
-              <FormControl>
-                <EyeInput
-                  id="apiKey"
-                  placeholder="API key"
-                  value={field.value}
-                  onChange={(e) => field.onChange(e.target.value)}
-                  className={cn({
-                    "border-destructive": Boolean(validationErrors?.message),
-                  })}
-                />
-              </FormControl>
-              <FormMessage />
-              <Description>
-                Click{" "}
-                <Button
-                  variant="link"
-                  size="sm"
-                  asChild
-                  className="inline px-0"
-                >
-                  <a
-                    href="https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started-api-keys.html"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    here
-                  </a>
-                </Button>{" "}
-                for instructions on how to create a service account and assign
-                the correct permissions.
-              </Description>
-            </FormItem>
-          );
-        }}
-      />
-      <FormField
-        control={form.control}
         name="models"
         render={({ field, formState }) => {
           const validationErrors = get(formState.errors, ["models"]);
@@ -155,6 +112,58 @@ const BedrockProviderDetails: React.FC<BedrockProviderDetailsProps> = ({
       />
 
       <CustomHeadersField form={form} />
+
+      <AuthConfigSection
+        form={form}
+        staticModeFields={
+          <FormField
+            control={form.control}
+            name="apiKey"
+            render={({ field, formState }) => {
+              const validationErrors = get(formState.errors, ["apiKey"]);
+
+              return (
+                <FormItem>
+                  <Label htmlFor="apiKey">API key</Label>
+                  <FormControl>
+                    <EyeInput
+                      id="apiKey"
+                      placeholder="API key"
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                      className={cn({
+                        "border-destructive": Boolean(
+                          validationErrors?.message,
+                        ),
+                      })}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                  <Description>
+                    Click{" "}
+                    <Button
+                      variant="link"
+                      size="sm"
+                      asChild
+                      className="inline px-0"
+                    >
+                      <a
+                        href="https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started-api-keys.html"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        here
+                      </a>
+                    </Button>{" "}
+                    for instructions on how to create a service account and
+                    assign the correct permissions.
+                  </Description>
+                </FormItem>
+              );
+            }}
+          />
+        }
+      />
     </div>
   );
 };

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
@@ -14,6 +14,7 @@ import { Switch } from "@/ui/switch";
 import { PROVIDERS } from "@/constants/providers";
 import { PROVIDER_TYPE } from "@/types/providers";
 import CustomHeadersField from "./CustomHeadersField";
+import AuthConfigSection from "./AuthConfigSection";
 
 type CustomProviderDetailsProps = {
   form: UseFormReturn<AIProviderFormType>;
@@ -95,50 +96,6 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
 
       <FormField
         control={form.control}
-        name="apiKey"
-        render={({ field, formState }) => {
-          const validationErrors = get(formState.errors, ["apiKey"]);
-
-          return (
-            <FormItem>
-              <Label htmlFor="apiKey">API key</Label>
-              <FormControl>
-                <EyeInput
-                  id="apiKey"
-                  placeholder="API key"
-                  value={field.value}
-                  onChange={(e) => field.onChange(e.target.value)}
-                  className={cn({
-                    "border-destructive": Boolean(validationErrors?.message),
-                  })}
-                />
-              </FormControl>
-              <FormMessage />
-              <Description>
-                Custom providers may not require an API key, depending on your
-                server setup. Learn more in the{" "}
-                <Button
-                  variant="link"
-                  size="sm"
-                  asChild
-                  className="inline px-0"
-                >
-                  <a
-                    href={buildDocsUrl("/development/playground")}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    documentation
-                  </a>
-                </Button>
-                .
-              </Description>
-            </FormItem>
-          );
-        }}
-      />
-      <FormField
-        control={form.control}
         name="models"
         render={({ field, formState }) => {
           const validationErrors = get(formState.errors, ["models"]);
@@ -179,60 +136,118 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
         description="Appended to every outgoing request URL. Some gateways require a version parameter such as api-version=2024-08-01-preview."
       />
 
-      <FormField
-        control={form.control}
-        name="authHeaderName"
-        render={({ field, formState }) => {
-          const validationErrors = get(formState.errors, ["authHeaderName"]);
+      <AuthConfigSection
+        form={form}
+        staticModeFields={
+          <>
+            <FormField
+              control={form.control}
+              name="apiKey"
+              render={({ field, formState }) => {
+                const validationErrors = get(formState.errors, ["apiKey"]);
 
-          return (
-            <FormItem>
-              <Label htmlFor="authHeaderName">
-                Auth header name (optional)
-              </Label>
-              <FormControl>
-                <Input
-                  id="authHeaderName"
-                  placeholder="api-key"
-                  value={field.value ?? ""}
-                  onChange={(e) => field.onChange(e.target.value)}
-                  className={cn({
-                    "border-destructive": Boolean(validationErrors?.message),
-                  })}
-                />
-              </FormControl>
-              <FormMessage />
-              <Description>
-                If set, the API key is sent as <code>{"{name}: <key>"}</code> in
-                addition to the default <code>Authorization: Bearer</code>{" "}
-                header.
-              </Description>
-            </FormItem>
-          );
-        }}
-      />
+                return (
+                  <FormItem>
+                    <Label htmlFor="apiKey">API key</Label>
+                    <FormControl>
+                      <EyeInput
+                        id="apiKey"
+                        placeholder="API key"
+                        value={field.value}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        className={cn({
+                          "border-destructive": Boolean(
+                            validationErrors?.message,
+                          ),
+                        })}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                    <Description>
+                      Custom providers may not require an API key, depending on
+                      your server setup. Learn more in the{" "}
+                      <Button
+                        variant="link"
+                        size="sm"
+                        asChild
+                        className="inline px-0"
+                      >
+                        <a
+                          href={buildDocsUrl("/development/playground")}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          documentation
+                        </a>
+                      </Button>
+                      .
+                    </Description>
+                  </FormItem>
+                );
+              }}
+            />
 
-      <FormField
-        control={form.control}
-        name="suppressDefaultAuth"
-        render={({ field }) => (
-          <FormItem>
-            <div className="flex items-center gap-3">
-              <Switch
-                id="suppressDefaultAuth"
-                checked={Boolean(field.value)}
-                onCheckedChange={field.onChange}
-              />
-              <Label htmlFor="suppressDefaultAuth">
-                Suppress default Authorization header
-              </Label>
-            </div>
-            <Description>
-              Turn on only if your gateway rejects requests that include{" "}
-              <code>Authorization: Bearer</code>.
-            </Description>
-          </FormItem>
-        )}
+            <FormField
+              control={form.control}
+              name="authHeaderName"
+              render={({ field, formState }) => {
+                const validationErrors = get(formState.errors, [
+                  "authHeaderName",
+                ]);
+
+                return (
+                  <FormItem>
+                    <Label htmlFor="authHeaderName">
+                      Auth header name (optional)
+                    </Label>
+                    <FormControl>
+                      <Input
+                        id="authHeaderName"
+                        placeholder="api-key"
+                        value={field.value ?? ""}
+                        onChange={(e) => field.onChange(e.target.value)}
+                        className={cn({
+                          "border-destructive": Boolean(
+                            validationErrors?.message,
+                          ),
+                        })}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                    <Description>
+                      If set, the API key is sent as{" "}
+                      <code>{"{name}: <key>"}</code> in addition to the default{" "}
+                      <code>Authorization: Bearer</code> header.
+                    </Description>
+                  </FormItem>
+                );
+              }}
+            />
+
+            <FormField
+              control={form.control}
+              name="suppressDefaultAuth"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="suppressDefaultAuth"
+                      checked={Boolean(field.value)}
+                      onCheckedChange={field.onChange}
+                    />
+                    <Label htmlFor="suppressDefaultAuth">
+                      Suppress default Authorization header
+                    </Label>
+                  </div>
+                  <Description>
+                    Turn on only if your gateway rejects requests that include{" "}
+                    <code>Authorization: Bearer</code>.
+                  </Description>
+                </FormItem>
+              )}
+            />
+          </>
+        }
       />
     </div>
   );

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
@@ -350,7 +350,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
       : undefined;
     // token mode and static key are mutually exclusive on the API
     const isTokenMode = isCustomLike && form.getValues("authMode") === "token";
-    const effectiveApiKey = isTokenMode ? "" : apiKey;
+    const effectiveApiKey = isTokenMode ? "" : apiKey || undefined;
 
     if (providerKey || calculatedProviderKey) {
       updateMutate({

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/ManageAIProviderDialog.tsx
@@ -42,8 +42,12 @@ import ProviderSelectionStep from "@/v2/pages-shared/llm/SetupProviderDialog/Pro
 import ProviderConfigurationStep from "@/v2/pages-shared/llm/SetupProviderDialog/ProviderConfigurationStep";
 
 import {
+  AuthConfigFormValues,
+  EMPTY_AUTH_FORM_VALUES,
+  authConfigToFormValues,
   configStringToQueryParamsArray,
   convertHeadersForAPI,
+  formValuesToAuthConfig,
   queryParamsArrayToConfigString,
 } from "./customProviderConfig";
 
@@ -139,6 +143,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
       openaiPipelineMode: normalizeOpenAiPipelineMode(
         providerKey?.configuration?.openai_pipeline_mode,
       ),
+      ...authConfigToFormValues(providerKey?.auth_config),
     } as AIProviderFormType,
   });
 
@@ -188,6 +193,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
       authHeaderName: "",
       suppressDefaultAuth: false,
       openaiPipelineMode: DEFAULT_OPENAI_PIPELINE_MODE,
+      ...EMPTY_AUTH_FORM_VALUES,
     });
     setStep("select");
   }, [form]);
@@ -248,6 +254,15 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
         ),
       );
 
+      const authFormValues = authConfigToFormValues(providerData?.auth_config);
+      form.setValue("authMode", authFormValues.authMode);
+      form.setValue("authTokenUrl", authFormValues.authTokenUrl);
+      form.setValue("authSendAs", authFormValues.authSendAs);
+      form.setValue("authCredentials", authFormValues.authCredentials);
+      form.setValue("authTokenField", authFormValues.authTokenField);
+      form.setValue("authExpiresField", authFormValues.authExpiresField);
+      form.setValue("authFallbackTtl", authFormValues.authFallbackTtl);
+
       form.setValue("provider", providerType);
       form.setValue("composedProviderType", composedProviderType);
       form.setValue("apiKey", "");
@@ -262,7 +277,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
     resetSelectionState();
   }, [resetSelectionState]);
 
-  const cloudConfigHandler = useCallback(() => {
+  const submitProviderHandler = useCallback(() => {
     const apiKey = form.getValues("apiKey");
     const url = form.getValues("url");
     const location = form.getValues("location");
@@ -321,14 +336,31 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
       isCustomLike && !!(providerKey || calculatedProviderKey);
     const headers = convertHeadersForAPI(headersArray, isEditingCustomProvider);
 
+    const storedProvider = providerKey ?? calculatedProviderKey;
+    const authConfig = isCustomLike
+      ? // the isCustomLike guard means the union's custom member (which carries the
+        // auth fields) is the live one; TS can't narrow a union by that boolean
+        formValuesToAuthConfig(
+          form.getValues() as Partial<AuthConfigFormValues>,
+          {
+            isEditing: isEditingCustomProvider,
+            hadAuthConfig: Boolean(storedProvider?.auth_config),
+          },
+        )
+      : undefined;
+    // token mode and static key are mutually exclusive on the API
+    const isTokenMode = isCustomLike && form.getValues("authMode") === "token";
+    const effectiveApiKey = isTokenMode ? "" : apiKey;
+
     if (providerKey || calculatedProviderKey) {
       updateMutate({
         providerKey: {
           id: providerKey?.id ?? calculatedProviderKey?.id,
-          apiKey,
+          apiKey: effectiveApiKey,
           base_url: isCustomLike ? url : undefined,
           ...(configuration && { configuration }),
           ...(isCustomLike && headers !== undefined && { headers }),
+          ...(authConfig !== undefined && { auth_config: authConfig }),
         },
       });
     } else if (provider) {
@@ -338,12 +370,13 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
 
       createMutate({
         providerKey: {
-          apiKey,
+          apiKey: effectiveApiKey,
           provider,
           base_url: isCustomLike ? url : undefined,
           provider_name: isCustomLike ? providerName : undefined,
           ...(configuration && { configuration }),
           ...(isCustomLike && headers !== undefined && { headers }),
+          ...(authConfig !== undefined && { auth_config: authConfig }),
         },
       });
     }
@@ -428,7 +461,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
               <ProviderConfigurationStep
                 selectedProviderType={selectedProviderType as PROVIDER_TYPE}
                 form={form}
-                onSubmit={cloudConfigHandler}
+                onSubmit={submitProviderHandler}
                 isEdit={isEdit}
                 customProviderName={customProviderName}
               />
@@ -471,7 +504,7 @@ const ManageAIProviderDialog: React.FC<ManageAIProviderDialogProps> = ({
                 )}
                 <Button
                   type="submit"
-                  onClick={form.handleSubmit(cloudConfigHandler)}
+                  onClick={form.handleSubmit(submitProviderHandler)}
                 >
                   {buttonText}
                 </Button>

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig.test.ts
@@ -1,10 +1,14 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  authConfigToFormValues,
   configStringToQueryParamsArray,
   convertHeadersForAPI,
+  formValuesToAuthConfig,
+  oauth2CredentialRows,
   queryParamsArrayToConfigString,
 } from "./customProviderConfig";
+import { ProviderAuthConfig } from "@/types/providers";
 
 describe("customProviderConfig", () => {
   describe("queryParamsArrayToConfigString", () => {
@@ -126,6 +130,191 @@ describe("customProviderConfig", () => {
         "api-key": "secret",
         "X-Other": "value",
       });
+    });
+  });
+
+  describe("authConfigToFormValues", () => {
+    it("maps an absent config to static mode", () => {
+      const values = authConfigToFormValues(undefined);
+      expect(values.authMode).toBe("api_key");
+      expect(values.authCredentials).toEqual([]);
+    });
+
+    it("loads a stored config with rows marked as saved", () => {
+      const stored: ProviderAuthConfig = {
+        token_url: "https://auth.example.com/token",
+        send_as: "basic",
+        credentials: [
+          { key: "client_id", value: "opik", secret: false },
+          { key: "client_secret", value: "__SECRET__", secret: true },
+        ],
+        token_field: "access_token",
+        expires_field: "expires_in",
+        fallback_ttl_seconds: 3600,
+      };
+
+      const values = authConfigToFormValues(stored);
+
+      expect(values.authMode).toBe("token");
+      expect(values.authTokenUrl).toBe("https://auth.example.com/token");
+      expect(values.authSendAs).toBe("basic");
+      expect(values.authFallbackTtl).toBe("3600");
+      expect(values.authCredentials).toHaveLength(2);
+      expect(values.authCredentials.every((row) => row.saved)).toBe(true);
+      expect(values.authCredentials[1].value).toBe("__SECRET__");
+    });
+
+    it("hides the injected client_credentials grant row but keeps a custom one visible", () => {
+      const values = authConfigToFormValues({
+        token_url: "https://auth.example.com/token",
+        credentials: [
+          { key: "grant_type", value: "client_credentials", secret: false },
+          { key: "client_id", value: "opik", secret: false },
+        ],
+      });
+      expect(values.authCredentials.map((row) => row.key)).toEqual([
+        "client_id",
+      ]);
+
+      const custom = authConfigToFormValues({
+        token_url: "https://auth.example.com/token",
+        credentials: [{ key: "grant_type", value: "password", secret: false }],
+      });
+      expect(custom.authCredentials.map((row) => row.key)).toEqual([
+        "grant_type",
+      ]);
+    });
+
+    it("stringifies a zero fallback (fetch-per-call) rather than dropping it", () => {
+      const values = authConfigToFormValues({
+        token_url: "https://auth.example.com/token",
+        credentials: [],
+        fallback_ttl_seconds: 0,
+      });
+      expect(values.authFallbackTtl).toBe("0");
+    });
+  });
+
+  describe("formValuesToAuthConfig", () => {
+    const tokenValues = {
+      authMode: "token" as const,
+      authTokenUrl: " https://auth.example.com/token ",
+      authSendAs: "form" as const,
+      authCredentials: [
+        { key: "username", value: "svc", secret: false, saved: false, id: "1" },
+        { key: "password", value: "p", secret: true, saved: false, id: "2" },
+        { key: "  ", value: "dropped", secret: false, saved: false, id: "3" },
+      ],
+      authTokenField: "token",
+      authExpiresField: "",
+      authFallbackTtl: "90000",
+    };
+
+    it("builds the recipe in token mode, trimming and dropping empty-key rows", () => {
+      const config = formValuesToAuthConfig(tokenValues, {
+        isEditing: false,
+        hadAuthConfig: false,
+      });
+
+      expect(config).toEqual({
+        token_url: "https://auth.example.com/token",
+        send_as: "form",
+        credentials: [
+          { key: "grant_type", value: "client_credentials", secret: false },
+          { key: "username", value: "svc", secret: false },
+          { key: "password", value: "p", secret: true },
+        ],
+        token_field: "token",
+        fallback_ttl_seconds: 90000,
+      });
+    });
+
+    it("does not inject grant_type when the user provided their own", () => {
+      const config = formValuesToAuthConfig(
+        {
+          ...tokenValues,
+          authCredentials: [
+            {
+              key: "grant_type",
+              value: "password",
+              secret: false,
+              saved: false,
+              id: "1",
+            },
+          ],
+        },
+        { isEditing: false, hadAuthConfig: false },
+      );
+
+      expect((config as ProviderAuthConfig).credentials).toEqual([
+        { key: "grant_type", value: "password", secret: false },
+      ]);
+    });
+
+    it("defaults send_as to basic per the OAuth2 client credentials flow", () => {
+      const config = formValuesToAuthConfig(
+        { authMode: "token", authTokenUrl: "https://auth.example.com/token" },
+        { isEditing: false, hadAuthConfig: false },
+      );
+      expect(config).toMatchObject({ send_as: "basic" });
+    });
+
+    it("returns {} to clear when switching back to static on an edited provider", () => {
+      const config = formValuesToAuthConfig(
+        { ...tokenValues, authMode: "api_key" },
+        { isEditing: true, hadAuthConfig: true },
+      );
+      expect(config).toEqual({});
+    });
+
+    it("returns undefined in static mode when there is nothing to clear", () => {
+      expect(
+        formValuesToAuthConfig(
+          { ...tokenValues, authMode: "api_key" },
+          { isEditing: true, hadAuthConfig: false },
+        ),
+      ).toBeUndefined();
+      expect(
+        formValuesToAuthConfig(
+          { ...tokenValues, authMode: "api_key" },
+          { isEditing: false, hadAuthConfig: false },
+        ),
+      ).toBeUndefined();
+    });
+
+    it("round-trips a loaded config, preserving the secret sentinel for unchanged values", () => {
+      const stored: ProviderAuthConfig = {
+        token_url: "https://auth.example.com/token",
+        send_as: "basic",
+        credentials: [
+          { key: "grant_type", value: "client_credentials", secret: false },
+          { key: "client_id", value: "opik", secret: false },
+          { key: "client_secret", value: "__SECRET__", secret: true },
+        ],
+        token_field: "access_token",
+      };
+
+      const roundTripped = formValuesToAuthConfig(
+        authConfigToFormValues(stored),
+        { isEditing: true, hadAuthConfig: true },
+      );
+
+      expect(roundTripped).toEqual(stored);
+    });
+  });
+
+  describe("oauth2CredentialRows", () => {
+    it("seeds only the user-owned rows, locking the secret; grant_type is injected on save", () => {
+      expect(
+        oauth2CredentialRows().map((row) => [row.key, row.secret]),
+      ).toEqual([
+        ["client_id", false],
+        ["client_secret", true],
+      ]);
+    });
+
+    it("marks seeded rows as unsaved so their locks stay toggleable", () => {
+      expect(oauth2CredentialRows().every((row) => !row.saved)).toBe(true);
     });
   });
 });

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig.ts
@@ -1,10 +1,148 @@
 import { v4 as uuidv4 } from "uuid";
 
+import { AuthSendAs, ProviderAuthConfig } from "@/types/providers";
+
 export type KeyValueEntry = {
   key: string;
   value: string;
   id: string;
 };
+
+export const AUTH_MODE_VALUES = ["api_key", "token"] as const;
+export type AuthMode = (typeof AUTH_MODE_VALUES)[number];
+
+export type AuthCredentialEntry = {
+  key: string;
+  value: string;
+  secret: boolean;
+  saved: boolean; // Loaded from a stored provider: its lock can never be removed, per the backend contract
+  id: string;
+};
+
+export type AuthConfigFormValues = {
+  authMode: AuthMode;
+  authTokenUrl: string;
+  authSendAs: AuthSendAs;
+  authCredentials: AuthCredentialEntry[];
+  authTokenField: string;
+  authExpiresField: string;
+  authFallbackTtl: string;
+};
+
+/** Field names the backend auto-locks; mirrored here so the lock flips visibly as the user types. */
+export const AUTH_SECRET_KEY_PATTERN = /secret|password|key|token|credential/i;
+
+// The one grant the UI supports at the moment. Hidden from the credentials list and injected on save.
+// A grant_type row the user adds themselves — or one stored with a different value — wins over the
+// injected default.
+const OAUTH2_GRANT_TYPE = {
+  key: "grant_type",
+  value: "client_credentials",
+  secret: false,
+};
+
+export const EMPTY_AUTH_FORM_VALUES: AuthConfigFormValues = {
+  authMode: "api_key",
+  authTokenUrl: "",
+  authSendAs: "basic",
+  authCredentials: [],
+  authTokenField: "",
+  authExpiresField: "",
+  authFallbackTtl: "",
+};
+
+/** Loads a stored provider's auth config into form state (absent config -> static mode). */
+export function authConfigToFormValues(
+  authConfig: ProviderAuthConfig | undefined,
+): AuthConfigFormValues {
+  if (!authConfig) {
+    return { ...EMPTY_AUTH_FORM_VALUES };
+  }
+  return {
+    authMode: "token",
+    authTokenUrl: authConfig.token_url ?? "",
+    authSendAs: authConfig.send_as ?? "basic",
+    authCredentials: (authConfig.credentials ?? [])
+      .filter(
+        (credential) =>
+          credential.key !== OAUTH2_GRANT_TYPE.key ||
+          credential.value !== OAUTH2_GRANT_TYPE.value,
+      )
+      .map((credential) => ({
+        key: credential.key,
+        value: credential.value,
+        secret: credential.secret,
+        saved: true,
+        id: uuidv4(),
+      })),
+    authTokenField: authConfig.token_field ?? "",
+    authExpiresField: authConfig.expires_field ?? "",
+    authFallbackTtl:
+      authConfig.fallback_ttl_seconds !== undefined &&
+      authConfig.fallback_ttl_seconds !== null
+        ? String(authConfig.fallback_ttl_seconds)
+        : "",
+  };
+}
+
+/**
+ * Builds the auth_config payload from form state.
+ *
+ * Three cases, mirroring the headers convention:
+ * 1. Token mode -> the full recipe (empty-key rows dropped)
+ * 2. Static mode while editing a provider that had a config -> {} to clear it
+ * 3. Static mode otherwise -> undefined (field omitted)
+ */
+export function formValuesToAuthConfig(
+  formValues: Partial<AuthConfigFormValues>,
+  options: { isEditing: boolean; hadAuthConfig: boolean },
+): ProviderAuthConfig | Record<string, never> | undefined {
+  const values: AuthConfigFormValues = {
+    ...EMPTY_AUTH_FORM_VALUES,
+    ...formValues,
+  };
+  if (values.authMode !== "token") {
+    return options.isEditing && options.hadAuthConfig ? {} : undefined;
+  }
+
+  const credentials = values.authCredentials
+    .filter((credential) => credential.key.trim().length > 0)
+    .map((credential) => ({
+      key: credential.key.trim(),
+      value: credential.value,
+      secret: credential.secret,
+    }));
+  if (!credentials.some(({ key }) => key === OAUTH2_GRANT_TYPE.key)) {
+    credentials.unshift({ ...OAUTH2_GRANT_TYPE });
+  }
+
+  const fallbackTtl = values.authFallbackTtl.trim();
+  return {
+    token_url: values.authTokenUrl.trim(),
+    send_as: values.authSendAs,
+    credentials,
+    ...(values.authTokenField.trim() && {
+      token_field: values.authTokenField.trim(),
+    }),
+    ...(values.authExpiresField.trim() && {
+      expires_field: values.authExpiresField.trim(),
+    }),
+    ...(fallbackTtl && { fallback_ttl_seconds: Number(fallbackTtl) }),
+  };
+}
+
+export function oauth2CredentialRows(): AuthCredentialEntry[] {
+  return [
+    { key: "client_id", value: "", secret: false, saved: false, id: uuidv4() },
+    {
+      key: "client_secret",
+      value: "",
+      secret: true,
+      saved: false,
+      id: uuidv4(),
+    },
+  ];
+}
 
 /**
  * Converts header array from form state to API-compatible object format.

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
@@ -126,9 +126,9 @@ export const createCustomProviderDetailsFormSchema = (
       authCredentials: z
         .array(
           z.object({
-            // max mirrors the backend's @Size(max = 250) on Credential.key
+            // maxes mirror the backend's @Size(max = 250 / 2000) on Credential
             key: z.string().max(250),
-            value: z.string(),
+            value: z.string().max(2000),
             secret: z.boolean(),
             saved: z.boolean(),
             id: z.string(),
@@ -193,10 +193,14 @@ export const createCustomProviderDetailsFormSchema = (
 
         const fallbackTtl = (data.authFallbackTtl ?? "").trim();
         // digits-only implies non-negative; no separate sign/number check needed
-        if (fallbackTtl.length > 0 && !/^\d+$/.test(fallbackTtl)) {
+        if (
+          fallbackTtl.length > 0 &&
+          (!/^\d+$/.test(fallbackTtl) || Number(fallbackTtl) > 31_536_000)
+        ) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: "Fallback lifetime must be a whole number of seconds",
+            message:
+              "Fallback lifetime must be a whole number of seconds, at most 31,536,000 (one year)",
             path: ["authFallbackTtl"],
           });
         }

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
@@ -150,6 +150,12 @@ export const createCustomProviderDetailsFormSchema = (
             message: "Token URL must be a valid URL",
             path: ["authTokenUrl"],
           });
+        } else if (!/^https?:\/\//i.test(tokenUrl)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Token URL must use http or https",
+            path: ["authTokenUrl"],
+          });
         }
 
         const credentials = data.authCredentials ?? [];

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/schema.ts
@@ -2,10 +2,12 @@ import { z } from "zod";
 import uniq from "lodash/uniq";
 
 import {
+  AUTH_SEND_AS_VALUES,
   OPENAI_PIPELINE_MODE_VALUES,
   OpenAiPipelineMode,
   PROVIDER_TYPE,
 } from "@/types/providers";
+import { AUTH_MODE_VALUES } from "./customProviderConfig";
 
 export type { OpenAiPipelineMode };
 export { OPENAI_PIPELINE_MODE_VALUES };
@@ -118,8 +120,81 @@ export const createCustomProviderDetailsFormSchema = (
         .optional(),
       authHeaderName: z.string().max(150).optional(),
       suppressDefaultAuth: z.boolean().optional(),
+      authMode: z.enum(AUTH_MODE_VALUES).optional(),
+      authTokenUrl: z.string().optional(),
+      authSendAs: z.enum(AUTH_SEND_AS_VALUES).optional(),
+      authCredentials: z
+        .array(
+          z.object({
+            // max mirrors the backend's @Size(max = 250) on Credential.key
+            key: z.string().max(250),
+            value: z.string(),
+            secret: z.boolean(),
+            saved: z.boolean(),
+            id: z.string(),
+          }),
+        )
+        .optional(),
+      authTokenField: z.string().max(250).optional(),
+      authExpiresField: z.string().max(250).optional(),
+      authFallbackTtl: z.string().optional(),
     })
     .superRefine((data, ctx) => {
+      // Token-auth mode requirements: field-level rules stay optional because static mode is the
+      // default and none of these apply there.
+      if (data.authMode === "token") {
+        const tokenUrl = (data.authTokenUrl ?? "").trim();
+        if (!tokenUrl || !z.string().url().safeParse(tokenUrl).success) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Token URL must be a valid URL",
+            path: ["authTokenUrl"],
+          });
+        }
+
+        const credentials = data.authCredentials ?? [];
+        if (!credentials.some((entry) => entry.key.trim().length > 0)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "At least one credential is required",
+            path: ["authTokenUrl"],
+          });
+        }
+
+        const credentialKeys: string[] = [];
+        credentials.forEach((entry, index) => {
+          const hasKey = entry.key.trim().length > 0;
+          if (!hasKey && entry.value.trim().length > 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "Credential key is required",
+              path: ["authCredentials", index, "key"],
+            });
+          }
+          if (hasKey) {
+            const trimmedKey = entry.key.trim();
+            if (credentialKeys.includes(trimmedKey)) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: "Credential key must be unique",
+                path: ["authCredentials", index, "key"],
+              });
+            } else {
+              credentialKeys.push(trimmedKey);
+            }
+          }
+        });
+
+        const fallbackTtl = (data.authFallbackTtl ?? "").trim();
+        // digits-only implies non-negative; no separate sign/number check needed
+        if (fallbackTtl.length > 0 && !/^\d+$/.test(fallbackTtl)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "Fallback lifetime must be a whole number of seconds",
+            path: ["authFallbackTtl"],
+          });
+        }
+      }
       // Validate headers: if a header has any content, both key and value must be non-empty
       if (data.headers) {
         const headerKeys: string[] = [];

--- a/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/SetupProviderDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/SetupProviderDialog/SetupProviderDialog.tsx
@@ -20,6 +20,11 @@ import {
   AIProviderFormSchema,
   AIProviderFormType,
 } from "@/v2/pages-shared/llm/ManageAIProviderDialog/schema";
+import {
+  AuthConfigFormValues,
+  formValuesToAuthConfig,
+} from "@/v2/pages-shared/llm/ManageAIProviderDialog/customProviderConfig";
+import { ProviderAuthConfig } from "@/types/providers";
 import { convertCustomProviderModels } from "@/lib/provider";
 import { useProviderOptions } from "@/hooks/useProviderOptions";
 import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
@@ -104,6 +109,8 @@ const SetupProviderDialog: React.FC<SetupProviderDialogProps> = ({
       const isOllama = data.provider === PROVIDER_TYPE.OLLAMA;
       const isVertex = data.provider === PROVIDER_TYPE.VERTEX_AI;
 
+      const isTokenMode = "authMode" in data && data.authMode === "token";
+
       const providerKeyData: Partial<{
         provider: PROVIDER_TYPE;
         provider_name: string;
@@ -111,9 +118,10 @@ const SetupProviderDialog: React.FC<SetupProviderDialogProps> = ({
         base_url: string;
         configuration: Record<string, string>;
         headers: Record<string, string>;
+        auth_config: ProviderAuthConfig;
       }> = {
         provider: data.provider as PROVIDER_TYPE,
-        ...(data.apiKey && { apiKey: data.apiKey }),
+        ...(!isTokenMode && data.apiKey && { apiKey: data.apiKey }),
       };
 
       if (
@@ -122,6 +130,12 @@ const SetupProviderDialog: React.FC<SetupProviderDialogProps> = ({
         "models" in data &&
         "providerName" in data
       ) {
+        if (isTokenMode) {
+          providerKeyData.auth_config = formValuesToAuthConfig(
+            data as Partial<AuthConfigFormValues>,
+            { isEditing: false, hadAuthConfig: false },
+          ) as ProviderAuthConfig;
+        }
         providerKeyData.base_url = data.url;
         providerKeyData.provider_name = data.providerName;
         providerKeyData.configuration = {

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -171,6 +171,9 @@ services:
       # Ollie / Agent Insights read-only freeform SQL (default off). When true, the backend provisions the restricted
       # read-only user (provision_agent_insights_readonly_user.sh, after migrations) and connects as it.
       TOGGLE_OLLIE_ENABLED: ${TOGGLE_OLLIE_ENABLED:-"false"}
+      # Self-hosted deployments legitimately point custom-provider token auth at internal gateways;
+      # the application default is "strict" (SSRF guard) for non-self-hosted deployments.
+      LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: ${LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD:-"relaxed"}
       ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_USER:-comet_readonly_freeform_sql_user}
       ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS: ${ANALYTICS_DB_READ_ONLY_FREEFORM_SQL_PASS:-opik}
       # Traces cutover knobs (data-migrations/traces-local-v2-cutover). Default off / unset; the operator sets these

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -249,6 +249,7 @@ Call opik api on http://localhost:5173/api
 | component.backend.env.LLM_MODEL_REGISTRY_REFRESH_INTERVAL_SECONDS | string | `"300"` |  |
 | component.backend.env.LLM_MODEL_REGISTRY_REMOTE_ENABLED | string | `"false"` |  |
 | component.backend.env.LLM_MODEL_REGISTRY_REMOTE_URL | string | `""` |  |
+| component.backend.env.LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD | string | `"relaxed"` |  |
 | component.backend.env.OPIK_OTEL_SDK_ENABLED | bool | `false` |  |
 | component.backend.env.OTEL_EXPERIMENTAL_EXPORTER_OTLP_RETRY_ENABLED | bool | `true` |  |
 | component.backend.env.OTEL_EXPERIMENTAL_RESOURCE_DISABLED_KEYS | string | `"process.command_args"` |  |

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -178,6 +178,9 @@ component:
       ANALYTICS_DB_DATABASE_NAME: "opik"
       JAVA_OPTS: "-Dliquibase.propertySubstitutionEnabled=true -XX:+UseG1GC -XX:MaxRAMPercentage=80.0 -XX:MinRAMPercentage=75"
       REDIS_URL: redis://:wFSuJX9nDBdCa25sKZG7bh@opik-redis-master:6379/
+      # Self-hosted deployments legitimately point custom-provider token auth at internal gateways;
+      # the application default is "strict" (SSRF guard) for non-self-hosted deployments.
+      LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD: "relaxed"
       ANALYTICS_DB_MIGRATIONS_PASS: opik
       ANALYTICS_DB_PASS: opik
       STATE_DB_PASS: opik


### PR DESCRIPTION
## Details

Enterprise AI gateways commonly forbid static API keys and instead require short-lived bearer tokens minted via the OAuth2 client credentials grant. This PR adds a dynamic token auth mode to Custom AI providers (and Bedrock/Ollama-style custom endpoints): Opik fetches the token from the customer's auth service before LLM calls and manages its whole lifecycle, so online evaluations and the Playground work against these gateways with zero manual token handling.

- **Storage (BE)**: new `auth_config` recipe (token URL, send mode, credentials, reply field paths, fallback TTL) stored AES-GCM-encrypted in one MySQL column. Secret values are write-only: read-back masks them with a `__SECRET__` sentinel, and whole-document updates resolve sentinels against the stored recipe — only for the stored `token_url` (changing the destination requires resubmitting full credentials, so a stored secret can never be redirected to a caller-chosen endpoint). Stored recipes decrypt lazily (`EncryptedAuthConfig`): cache hits and rows filtered out during provider resolution never materialize plaintext credentials, and token replies are size-capped while streaming.
- **Token lifecycle (BE)**: Redis-cached bearer shared across pods (cache key includes a recipe hash, so any config edit is an instant cache miss), proportional refresh ahead of expiry, cross-pod single-flight via distributed lock, degradation to direct fetch on Redis failure, and a retry-once path when the gateway rejects a token (revocation/clock skew). Streaming requests retry only before the first delivered event.
- **Safety (BE)**: outbound token fetches go through a destination guard (https-only, resolve-then-decide, refuses loopback/link-local/private ranges) — `strict` by default, with `relaxed` shipped explicitly in the docker-compose and Helm distributions. OTel metrics cover token requests and fetch durations, labeled by outcome and origin (request vs test button).
- **Test connection (BE+FE)**: `POST /v1/private/llm-provider-key/auth-config/test` runs the fetch server-side (rate-limited, redacted errors) and the dialog surfaces the result with the token lifetime.
- **FE**: the provider dialog gains an Authentication card with a "Static API key" / "OAuth2 client credentials" mode switch. The OAuth2 mode exposes only the spec's fields (token URL, `client_id`, `client_secret`, optional extras like `scope`); `grant_type=client_credentials` is injected automatically. Stored secrets render write-only (no reveal, locked). The backend recipe stays fully general, so other flows can be surfaced later as UI-only changes.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7940

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: full implementation (BE + FE), built and reviewed part-by-part
  - Human verification: per-part code review of every diff, plus manual end-to-end testing against a live local stack

## Testing

Automated (all passing locally):
- BE: `mvn test` on the feature's classes — token fetcher/cache (16), intercepting HTTP client incl. streaming retry semantics (14), destination guard (19), provider key resource incl. auth-config CRUD, masking and check endpoint (13), recipe validation and encryption utils. `mvn compile` + `spotless:check` clean after rebase on latest `main`.
- FE: `npm run lint`, `npm run typecheck`, `npm run deps:validate`, and 27 vitest cases over the form↔recipe converters (sentinel round-trip, clear-vs-omit semantics, grant_type injection/hiding).

Manual, against a local stack with a mock OAuth2 token service + bearer-validating gateway (and separately a real JWT-issuing OAuth2 server):
- Configure + Test connection (success and failure toasts, redacted error messages)
- Sentinel round-trip: reopen dialog, write-only secret, update without re-entering it
- Playground streaming through the fetched bearer
- Proactive refresh inside the TTL window; reactive 401 → invalidate → refetch → transparent retry; token expiry mid-stream (stream completes, no spurious re-auth)
- Destination guard: strict mode refuses local endpoints with an actionable message; relaxed override works

Not run: full repository-wide BE test suite (targeted classes instead, per repo convention). Playwright e2e specs for these flows are ready as a follow-up stacked PR.

## Documentation

N/A — a docs page (provider setup + API-driven rotation snippet) follows in the stacked e2e/docs PR.

