### PR TITLE
[OPIK-7940] [FE] [CI] test: e2e coverage for OAuth2 dynamic token auth

### DIFF
--- a/.github/workflows/e2e_tests_post_merge_v2.yml
+++ b/.github/workflows/e2e_tests_post_merge_v2.yml
@@ -159,6 +159,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           ALLURE_LAUNCH_NAME: "Opik v2 Post-Merge ${{ github.event.inputs.tier || 't1' }} - ${{ github.run_id }}"
           TIER: ${{ github.event.inputs.tier || 't1' }}
+          # The dockerized backend reaches the host-run mock token service via the docker0 host IP
+          MOCK_AUTH_URL_FOR_BACKEND: http://172.17.0.1:9878
         run: |
           echo "========================================"
           echo "🧪 Running v2 tier: $TIER"

--- a/.github/workflows/end2end_suites_v2.yml
+++ b/.github/workflows/end2end_suites_v2.yml
@@ -106,6 +106,8 @@ jobs:
         env:
           TIER: ${{ github.event.inputs.tier || 't1' }}
           ALLURE_LAUNCH_NAME: "Opik v2 E2E ${{ github.event.inputs.tier || 't1' }} - ${{ github.run_id }}"
+          # The dockerized backend reaches the host-run mock token service via the docker0 host IP
+          MOCK_AUTH_URL_FOR_BACKEND: http://172.17.0.1:9878
         run: |
           # Point both the allure-playwright reporter and allurectl at the same
           # absolute results dir, then stream results to TestOps via allurectl watch.

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/AuthConfigSection.tsx
@@ -194,9 +194,14 @@ const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
               ]);
 
               return (
-                <div key={row.id} className="flex items-start gap-2">
+                <div
+                  key={row.id}
+                  data-testid="auth-credential-row"
+                  className="flex items-start gap-2"
+                >
                   <div className="flex-1">
                     <Input
+                      data-testid="auth-credential-key"
                       placeholder="Field name"
                       value={form.watch(`authCredentials.${index}.key`)}
                       onChange={(e) =>
@@ -213,6 +218,7 @@ const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
                   <div className="flex-1">
                     {isSecret ? (
                       <EyeInput
+                        data-testid="auth-credential-value"
                         revealable={!isStoredSecret}
                         placeholder={
                           isStoredSecret ? "stored, write-only" : "Value"
@@ -230,6 +236,7 @@ const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
                       />
                     ) : (
                       <Input
+                        data-testid="auth-credential-value"
                         placeholder="Value"
                         value={value}
                         onChange={(e) =>
@@ -252,6 +259,7 @@ const AuthConfigSection: React.FC<AuthConfigSectionProps> = ({
                   >
                     <Button
                       type="button"
+                      data-testid="auth-credential-lock"
                       variant="ghost"
                       size="icon"
                       disabled={isSaved && isSecret}

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -740,8 +740,9 @@ areas:
     label: Configuration
     nav_group: Workspace
     routes: ["/$workspaceName/configuration"]
-    specs: []
-    # A configuration.page.ts POM exists with no spec using it — half-built surface.
+    specs:
+      - ai-providers/token-auth-dialog.spec.ts
+      - ai-providers/token-auth-refetch.spec.ts
     # Split per-tab: the page has 5 distinct tabs (CONFIGURATION_TABS), each with
     # its own CRUD surface, so one capability per tab was too coarse. Capabilities
     # below are read off the tab components on origin/main.
@@ -759,10 +760,10 @@ areas:
       environment-delete:       { covered: false }
       # -- AI providers tab --
       ai-provider-list:         { covered: false }
-      ai-provider-add:          { covered: false, note: "exercised indirectly by playground provider setup (configuration.page.ts), never asserted here" }
-      ai-provider-edit:         { covered: false }
-      ai-provider-delete:       { covered: false }
-      ai-provider-token-refetch: { covered: false, note: "OAuth2 token auth (OPIK-7940): gateway-revoked bearer is refetched and the request retried transparently" }
+      ai-provider-add:          { covered: true,  tier: t1-smoke }
+      ai-provider-edit:         { covered: true,  tier: t1-smoke }
+      ai-provider-delete:       { covered: false, note: "exercised as spec teardown (token-auth-dialog.spec.ts), never asserted" }
+      ai-provider-token-refetch: { covered: true,  tier: t1-smoke, note: "OAuth2 token auth (OPIK-7940): gateway-revoked bearer is refetched and the request retried transparently" }
       # -- Workspace preferences tab --
       pref-thread-timeout:      { covered: false, note: "EditThreadTimeoutDialog" }
       pref-truncation-toggle:   { covered: false, note: "EditTruncationToggleDialog" }

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -762,6 +762,7 @@ areas:
       ai-provider-add:          { covered: false, note: "exercised indirectly by playground provider setup (configuration.page.ts), never asserted here" }
       ai-provider-edit:         { covered: false }
       ai-provider-delete:       { covered: false }
+      ai-provider-token-refetch: { covered: false, note: "OAuth2 token auth (OPIK-7940): gateway-revoked bearer is refetched and the request retried transparently" }
       # -- Workspace preferences tab --
       pref-thread-timeout:      { covered: false, note: "EditThreadTimeoutDialog" }
       pref-truncation-toggle:   { covered: false, note: "EditTruncationToggleDialog" }

--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -26,15 +26,12 @@ export const MOCK_AUTH_CLIENT_SECRET = 'opik-secret';
 export const mockTokenUrlForBackend = `${mockAuthBaseUrlForBackend}/oauth/token`;
 export const mockGatewayUrlForBackend = `${mockAuthBaseUrlForBackend}/v1`;
 
-export interface MockAuthStats {
-  tokens_issued?: number;
-  token_refused?: number;
-  chat_ok?: number;
-  chat_refused_missing?: number;
-  chat_refused_unknown?: number;
-  chat_refused_expired?: number;
-  revocations?: number;
-}
+/**
+ * Counter map from /stats. Global outcome counters (tokens_issued, chat_ok,
+ * chat_refused_unknown, ...) plus model-scoped variants (`chat_ok:<model>`) so
+ * parallel specs can assert on their own traffic via unique model names.
+ */
+export type MockAuthStats = Record<string, number>;
 
 export async function mockAuthStats(): Promise<MockAuthStats> {
   const response = await fetch(`${mockAuthBaseUrl}/stats`);

--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -1,0 +1,48 @@
+/**
+ * Endpoints of the mock OAuth2 token service + bearer-validating gateway
+ * (services/mock-token-auth/), which Playwright's webServer spawns for the run.
+ *
+ * Two views of the same service, because the test process and the Opik backend
+ * may live on different network planes:
+ *  - `mockAuthBaseUrl`           — as reached from THIS process (specs poking /stats, /revoke).
+ *  - `mockAuthBaseUrlForBackend` — as reached from the OPIK BACKEND, which is what goes into
+ *    the provider config (token URL, base URL). Locally the backend is a host process, so the
+ *    default is the same localhost; when the backend runs inside docker-compose, set
+ *    MOCK_AUTH_URL_FOR_BACKEND=http://host.docker.internal:9878 (and make sure the backend
+ *    runs with LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed, as the compose file ships).
+ */
+export const MOCK_AUTH_PORT = parseInt(process.env.MOCK_AUTH_PORT ?? '9878', 10);
+
+export const mockAuthBaseUrl =
+  process.env.MOCK_AUTH_URL ?? `http://localhost:${MOCK_AUTH_PORT}`;
+
+export const mockAuthBaseUrlForBackend =
+  process.env.MOCK_AUTH_URL_FOR_BACKEND ?? mockAuthBaseUrl;
+
+/** Fixed identities the mock accepts (see mock_token_auth_service.py). */
+export const MOCK_AUTH_CLIENT_ID = 'opik-test';
+export const MOCK_AUTH_CLIENT_SECRET = 'opik-secret';
+
+export const mockTokenUrlForBackend = `${mockAuthBaseUrlForBackend}/oauth/token`;
+export const mockGatewayUrlForBackend = `${mockAuthBaseUrlForBackend}/v1`;
+
+export interface MockAuthStats {
+  tokens_issued?: number;
+  token_refused?: number;
+  chat_ok?: number;
+  chat_refused_missing?: number;
+  chat_refused_unknown?: number;
+  chat_refused_expired?: number;
+  revocations?: number;
+}
+
+export async function mockAuthStats(): Promise<MockAuthStats> {
+  const response = await fetch(`${mockAuthBaseUrl}/stats`);
+  if (!response.ok) throw new Error(`mock-auth /stats returned ${response.status}`);
+  return (await response.json()) as MockAuthStats;
+}
+
+export async function mockAuthRevokeAll(): Promise<void> {
+  const response = await fetch(`${mockAuthBaseUrl}/revoke`, { method: 'POST' });
+  if (!response.ok) throw new Error(`mock-auth /revoke returned ${response.status}`);
+}

--- a/tests_end_to_end/e2e/core/provider-keys.ts
+++ b/tests_end_to_end/e2e/core/provider-keys.ts
@@ -1,0 +1,100 @@
+/**
+ * Thin fetch-based helpers for the LLM provider-key REST endpoints.
+ *
+ * Stopgap: the suite's TS SDK predates the `auth_config` field (OPIK-7940), so the token-auth
+ * specs read and clean up provider keys through the public REST surface directly.
+ *
+ * TODO: once the SDK is regenerated with `auth_config`, migrate these to
+ * `opik.api.llmProviderKeys.*` on the backend client (core/backend/client.ts) and delete
+ * this module.
+ * Provider keys are WORKSPACE-GLOBAL — every spec must use a testNamespace-prefixed
+ * provider_name and delete what it creates, or parallel runs will trample each other.
+ */
+import { loadEnvConfig } from '../config/env.config';
+
+export interface ProviderAuthCredential {
+  key: string;
+  value: string;
+  secret: boolean;
+}
+
+export interface ProviderAuthConfig {
+  token_url?: string;
+  send_as?: string;
+  credentials?: ProviderAuthCredential[];
+  token_field?: string;
+  expires_field?: string;
+  fallback_ttl_seconds?: number;
+}
+
+export interface ProviderKeyRef {
+  id: string;
+  provider: string;
+  provider_name?: string;
+  base_url?: string;
+  auth_config?: ProviderAuthConfig;
+}
+
+function restHeaders(): Record<string, string> {
+  const env = loadEnvConfig();
+  return {
+    'Content-Type': 'application/json',
+    ...(env.apiKey ? { authorization: env.apiKey } : {}),
+    ...(env.workspace ? { 'Comet-Workspace': env.workspace } : {}),
+  };
+}
+
+function endpoint(path = ''): string {
+  const env = loadEnvConfig();
+  return `${env.apiBaseUrl}/v1/private/llm-provider-key${path}`;
+}
+
+export async function findProviderKeyByName(providerName: string): Promise<ProviderKeyRef | null> {
+  const response = await fetch(endpoint(), { headers: restHeaders() });
+  if (!response.ok) throw new Error(`list provider keys returned ${response.status}`);
+  const body = (await response.json()) as { content: ProviderKeyRef[] };
+  return body.content.find((key) => key.provider_name === providerName) ?? null;
+}
+
+export async function createProviderKey(payload: {
+  provider: string;
+  provider_name: string;
+  base_url: string;
+  configuration?: Record<string, string>;
+  auth_config?: ProviderAuthConfig;
+}): Promise<void> {
+  const response = await fetch(endpoint(), {
+    method: 'POST',
+    headers: restHeaders(),
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`create provider key returned ${response.status}: ${await response.text()}`);
+  }
+}
+
+export async function deleteProviderKeyByName(providerName: string): Promise<void> {
+  const found = await findProviderKeyByName(providerName);
+  if (!found) return;
+  const response = await fetch(endpoint('/delete'), {
+    method: 'POST',
+    headers: restHeaders(),
+    body: JSON.stringify({ ids: [found.id] }),
+  });
+  if (!response.ok) {
+    throw new Error(`delete provider key returned ${response.status}`);
+  }
+}
+
+/** Server-side connection check; resolves __SECRET__ sentinels via provider_id. */
+export async function checkProviderAuthConfig(providerId: string): Promise<{ lifetime_seconds: number }> {
+  const response = await fetch(endpoint('/auth-config/test'), {
+    method: 'POST',
+    headers: restHeaders(),
+    body: JSON.stringify({ provider_id: providerId }),
+  });
+  if (!response.ok) {
+    throw new Error(`auth-config check returned ${response.status}: ${await response.text()}`);
+  }
+  return (await response.json()) as { lifetime_seconds: number };
+}

--- a/tests_end_to_end/e2e/data/playground-models.yaml
+++ b/tests_end_to_end/e2e/data/playground-models.yaml
@@ -49,6 +49,32 @@ providers:
         options:
           temperature: 0
           max_tokens: 128
+  # Hermetic entries against the suite's mock gateway (services/mock-token-auth/,
+  # spawned by Playwright's webServer). No external keys: `api_key`/`auth` are the
+  # mock's fixed identities. The oauth entry covers OPIK-7940 dynamic token auth.
+  mock-custom-static:
+    display_name: "Mock gateway (Custom, static key)"
+    provider_type: "custom"
+    provider_name: "mock-static"
+    base_url: "http://localhost:9878/v1"
+    api_key: "mock-static-key"
+    models:
+      - name: "mock-model-static"
+        ui_selector: "mock-model-static"
+        enabled: true
+  mock-custom-oauth:
+    display_name: "Mock gateway (Custom, OAuth2 token auth)"
+    provider_type: "custom"
+    provider_name: "mock-oauth-sanity"
+    base_url: "http://localhost:9878/v1"
+    auth:
+      token_url: "http://localhost:9878/oauth/token"
+      client_id: "opik-test"
+      client_secret: "opik-secret"
+    models:
+      - name: "mock-model-oauth"
+        ui_selector: "mock-model-oauth"
+        enabled: true
 test_config:
   test_prompt: "Explain what is an LLM in one paragraph."
   response_timeout_seconds: 60

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,9 @@
-export { test, expect } from './automation-rules.fixture';
+export { test, expect } from './provider-key.fixture';
+export type {
+  OauthProviderSeed,
+  ProviderKeysFixture,
+  ProviderKeyFixtures,
+} from './provider-key.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {

--- a/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
@@ -1,0 +1,79 @@
+import { test as baseTest } from './automation-rules.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import {
+  MOCK_AUTH_CLIENT_ID,
+  MOCK_AUTH_CLIENT_SECRET,
+  mockGatewayUrlForBackend,
+  mockTokenUrlForBackend,
+} from '../core/mock-auth';
+import { createProviderKey, deleteProviderKeyByName } from '../core/provider-keys';
+
+export interface OauthProviderSeed {
+  providerName: string;
+  /** Model the mock gateway will echo; unique per test so parallel specs never collide. */
+  modelName?: string;
+}
+
+export interface ProviderKeysFixture {
+  /**
+   * REST-seeds a Custom provider in OAuth2 token-auth mode against the suite's mock
+   * token service; registered for teardown deletion.
+   */
+  createOauth(seed: OauthProviderSeed): Promise<void>;
+  /**
+   * Registers a provider name for teardown deletion without seeding — for tests where
+   * UI creation is itself the behavior under test. Cleanup runs even when the test fails.
+   */
+  register(providerName: string): void;
+}
+
+export interface ProviderKeyFixtures {
+  providerKeys: ProviderKeysFixture;
+}
+
+/**
+ * Provider keys are WORKSPACE-GLOBAL, so every spec must use testNamespace-prefixed
+ * names and delete what it creates — this fixture owns the delete half.
+ */
+export const test = baseTest.extend<ProviderKeyFixtures>({
+  // eslint-disable-next-line no-empty-pattern
+  providerKeys: async ({}, use, testInfo) => {
+    const registered: string[] = [];
+
+    await use({
+      async createOauth({ providerName, modelName = 'mock-model' }) {
+        registered.push(providerName);
+        await createProviderKey({
+          provider: 'custom-llm',
+          provider_name: providerName,
+          base_url: mockGatewayUrlForBackend,
+          configuration: { models: `custom-llm/${providerName}/${modelName}` },
+          auth_config: {
+            token_url: mockTokenUrlForBackend,
+            send_as: 'basic',
+            credentials: [
+              { key: 'grant_type', value: 'client_credentials', secret: false },
+              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
+              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
+            ],
+          },
+        });
+      },
+      register(providerName) {
+        registered.push(providerName);
+      },
+    });
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      for (const name of registered) {
+        try {
+          await deleteProviderKeyByName(name);
+        } catch (err) {
+          console.warn(`[provider-key fixture] delete warning for ${name}:`, err);
+        }
+      }
+    }
+  },
+});
+
+export { expect } from './automation-rules.fixture';

--- a/tests_end_to_end/e2e/playwright.config.ts
+++ b/tests_end_to_end/e2e/playwright.config.ts
@@ -62,5 +62,18 @@ export default defineConfig({
         OPIK_WORKSPACE: env.workspace,
       },
     },
+    {
+      // Mock OAuth2 token service + bearer-validating LLM gateway for the
+      // dynamic token auth specs (OPIK-7940). Hermetic: no external keys.
+      // In CI the backend runs inside docker-compose, so the mock binds 0.0.0.0 and the
+      // backend reaches it through the host (MOCK_AUTH_URL_FOR_BACKEND, set by the workflow).
+      command: `uv run --no-project python mock_token_auth_service.py --port ${process.env.MOCK_AUTH_PORT ?? '9878'} --host ${process.env.CI ? '0.0.0.0' : '127.0.0.1'}`,
+      cwd: 'services/mock-token-auth',
+      url: `http://localhost:${process.env.MOCK_AUTH_PORT ?? '9878'}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 15_000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
   ],
 });

--- a/tests_end_to_end/e2e/pom/configuration.page.ts
+++ b/tests_end_to_end/e2e/pom/configuration.page.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import { test, expect } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
@@ -30,14 +30,30 @@ const PROVIDER_TYPE_MAP: Record<ProviderName, string> = {
 /** data-provider value for the Custom (vLLM / OpenAI-compatible) option. */
 const CUSTOM_PROVIDER_TYPE = 'custom-llm';
 
+/**
+ * OAuth2 client-credentials auth for a Custom provider (OPIK-7940). When present,
+ * the provider is configured in "OAuth2 client credentials" mode instead of a
+ * static API key: Opik fetches a short-lived bearer from `tokenUrl` before LLM calls.
+ */
+export interface CustomProviderAuthConfig {
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  /** Optional extra `scope` credential row (e.g. "ttl:10" against the mock service). */
+  scope?: string;
+}
+
 export interface CustomProviderConfig {
   /** Unique provider_name (e.g. "openrouter"). Used to dedupe in the providers table. */
   providerName: string;
   /** Base URL of the OpenAI-compatible endpoint (e.g. "https://openrouter.ai/api/v1"). */
   baseUrl: string;
-  apiKey: string;
+  /** Static API key. Ignored when `auth` is set (the field is hidden in OAuth2 mode). */
+  apiKey?: string;
   /** Comma-separated model ids the gateway exposes (e.g. "openai/gpt-4o-mini"). */
   models: string;
+  /** OAuth2 client credentials mode instead of a static API key. */
+  auth?: CustomProviderAuthConfig;
 }
 
 /**
@@ -161,34 +177,17 @@ export class ConfigurationPage {
     return test.step(`ensure custom provider "${config.providerName}" is configured`, async () => {
       if (await this.hasCustomProvider(config.providerName)) return true;
 
-      const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
-      const toolbarButton = tabpanel
-        .getByRole('button', { name: 'Add configuration', exact: true })
-        .first();
-      await toolbarButton.click();
-      const dialog = this.page.getByTestId('add-provider-dialog');
-      await dialog.waitFor({ state: 'visible' });
-
-      const providerButton = dialog
-        .getByTestId('add-provider-dialog-option')
-        .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`))
-        .first();
-
-      const offered = await providerButton
-        .waitFor({ state: 'visible', timeout: 2_000 })
-        .then(() => true)
-        .catch(() => false);
-      if (!offered) {
-        await this.page.keyboard.press('Escape');
-        await dialog.waitFor({ state: 'hidden' });
-        return false;
-      }
-      await providerButton.click();
+      const dialog = await this.openAddCustomProviderDialog();
+      if (dialog === null) return false;
 
       await dialog.getByRole('textbox', { name: 'Provider name' }).fill(config.providerName);
-      await dialog.getByRole('textbox', { name: 'URL' }).fill(config.baseUrl);
-      await dialog.getByRole('textbox', { name: 'API key' }).fill(config.apiKey);
+      await dialog.getByRole('textbox', { name: 'URL', exact: true }).fill(config.baseUrl);
       await dialog.getByRole('textbox', { name: 'Models list' }).fill(config.models);
+      if (config.auth) {
+        await this.fillAuthSection(dialog, config.auth);
+      } else {
+        await dialog.getByRole('textbox', { name: 'API key' }).fill(config.apiKey ?? '');
+      }
 
       await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
       await dialog.waitFor({ state: 'hidden' });
@@ -210,6 +209,149 @@ export class ConfigurationPage {
    * redundant write invalidates the provider-key query right as dependent pages
    * (Playground, Online evaluation) are opening their model pickers.
    */
+  /**
+   * Open the add-provider dialog with the Custom option selected. Returns the
+   * dialog locator, or null when the deployment doesn't offer the Custom option
+   * (its feature toggle is off) — mirroring `ensureProviderConfigured`.
+   */
+  async openAddCustomProviderDialog(): Promise<Locator | null> {
+    return test.step('open the add-provider dialog (Custom)', async () => {
+      const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
+      await tabpanel
+        .getByRole('button', { name: 'Add configuration', exact: true })
+        .first()
+        .click();
+      const dialog = this.page.getByTestId('add-provider-dialog');
+      await dialog.waitFor({ state: 'visible' });
+
+      // Each already-configured custom instance gets its own tile (opens EDIT for
+      // that instance, marked with a "Configured" tag) — pick the generic add-new tile.
+      const providerButton = dialog
+        .getByTestId('add-provider-dialog-option')
+        .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`))
+        .filter({ hasNot: this.page.getByText('Configured', { exact: true }) })
+        .first();
+
+      const offered = await providerButton
+        .waitFor({ state: 'visible', timeout: 2_000 })
+        .then(() => true)
+        .catch(() => false);
+      if (!offered) {
+        await this.page.keyboard.press('Escape');
+        await dialog.waitFor({ state: 'hidden' });
+        return null;
+      }
+      await providerButton.click();
+      return dialog;
+    });
+  }
+
+  /**
+   * Fill the Authentication card in "OAuth2 client credentials" mode. Selecting
+   * the mode seeds two credential rows (client_id, client_secret); their value
+   * inputs are filled by matching each row's key input, so row order never matters.
+   */
+  async fillAuthSection(dialog: Locator, auth: CustomProviderAuthConfig): Promise<void> {
+    return test.step('fill the OAuth2 client credentials auth section', async () => {
+      await dialog.getByRole('radio', { name: 'OAuth2 client credentials' }).click();
+      await dialog.getByRole('textbox', { name: 'Token URL' }).fill(auth.tokenUrl);
+      await this.fillCredentialValue(dialog, 'client_id', auth.clientId);
+      await this.fillCredentialValue(dialog, 'client_secret', auth.clientSecret);
+      if (auth.scope !== undefined) {
+        await dialog.getByRole('button', { name: 'Add credential' }).click();
+        const newRow = dialog.getByTestId('auth-credential-row').last();
+        await newRow.getByTestId('auth-credential-key').fill('scope');
+        await newRow.getByTestId('auth-credential-value').fill(auth.scope);
+      }
+    });
+  }
+
+  /**
+   * The credential row whose key input currently holds `key`. Scans by input
+   * value (a DOM property — controlled React inputs never update the `value`
+   * attribute, so a CSS attribute filter would not match). Throws when absent.
+   */
+  async credentialRow(dialog: Locator, key: string): Promise<Locator> {
+    const rows = dialog.getByTestId('auth-credential-row');
+    await rows.first().waitFor({ state: 'visible' });
+    const count = await rows.count();
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(i);
+      if ((await row.getByTestId('auth-credential-key').inputValue()) === key) {
+        return row;
+      }
+    }
+    throw new Error(`no credential row with key "${key}"`);
+  }
+
+  /** The keys of every credential row currently in the dialog, in display order. */
+  async credentialKeys(dialog: Locator): Promise<string[]> {
+    const keys = dialog.getByTestId('auth-credential-key');
+    const count = await keys.count();
+    const values: string[] = [];
+    for (let i = 0; i < count; i++) {
+      values.push(await keys.nth(i).inputValue());
+    }
+    return values;
+  }
+
+  private async fillCredentialValue(dialog: Locator, key: string, value: string): Promise<void> {
+    const row = await this.credentialRow(dialog, key);
+    await row.getByTestId('auth-credential-value').fill(value);
+  }
+
+  /** Click "Test connection" in the auth section; assertions on the toast belong to the caller. */
+  async clickTestConnection(dialog: Locator): Promise<void> {
+    return test.step('click Test connection', async () => {
+      await dialog.getByRole('button', { name: 'Test connection' }).click();
+    });
+  }
+
+  /** Open the edit dialog for a Custom provider row and return the dialog locator. */
+  async openCustomProviderEdit(providerName: string): Promise<Locator> {
+    return test.step(`open edit dialog for custom provider "${providerName}"`, async () => {
+      const row = await this.customProviderRow(providerName);
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Edit' }).click();
+      const dialog = this.page.getByRole('dialog', { name: 'Edit provider configuration' });
+      await dialog.waitFor({ state: 'visible' });
+      return dialog;
+    });
+  }
+
+  /** Delete a Custom provider row through its actions menu. Used for spec teardown. */
+  async deleteCustomProvider(providerName: string): Promise<void> {
+    return test.step(`delete custom provider "${providerName}"`, async () => {
+      const row = await this.customProviderRow(providerName);
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Delete' }).click();
+      await this.page
+        .getByRole('button', { name: 'Delete configuration', exact: true })
+        .click();
+      await expect
+        .poll(async () => this.hasCustomProvider(providerName), {
+          timeout: 15_000,
+          intervals: [500, 1000],
+        })
+        .toBe(false);
+    });
+  }
+
+  private async customProviderRow(providerName: string): Promise<Locator> {
+    await this.waitForProvidersTableSettled();
+    const row = this.page
+      .locator('tr')
+      .filter({
+        has: this.page
+          .getByTestId('ai-provider-row-cell')
+          .and(this.page.locator(`[data-provider="${CUSTOM_PROVIDER_TYPE}"]`)),
+      })
+      .filter({ has: this.page.getByText(providerName, { exact: true }) })
+      .first();
+    await row.waitFor({ state: 'visible' });
+    return row;
+  }
+
   private async waitForProvidersTableSettled(): Promise<void> {
     const tabpanel = this.page.getByTestId('ai-providers-tabpanel');
     const firstRowCell = this.page.getByTestId('ai-provider-row-cell').first();
@@ -229,7 +371,7 @@ export class ConfigurationPage {
    * (data-provider=custom-llm, name cell text === providerName). The first
    * cell in each row contains the provider_name.
    */
-  private async hasCustomProvider(providerName: string): Promise<boolean> {
+  async hasCustomProvider(providerName: string): Promise<boolean> {
     await this.waitForProvidersTableSettled();
     const customCells = this.page
       .getByTestId('ai-provider-row-cell')

--- a/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
+++ b/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
@@ -154,11 +154,23 @@ class Handler(BaseHTTPRequestHandler):
         })
 
     def _handle_chat(self, raw_body):
+        try:
+            request = json.loads(raw_body)
+        except Exception:
+            request = {}
+        model = request.get("model", "mock-model")
+
+        # counters are kept globally AND per model: parallel specs use unique model
+        # names, so the model-scoped counters let each spec assert on its own traffic
+        def count(outcome):
+            STATS[outcome] += 1
+            STATS[f"{outcome}:{model}"] += 1
+
         auth = self.headers.get("Authorization") or ""
         token = auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else None
         if token is None:
-            STATS["chat_refused_missing"] += 1
-            log("chat request REFUSED: missing bearer token")
+            count("chat_refused_missing")
+            log(f"chat request REFUSED: missing bearer token (model={model})")
             self._reply(401, {"error": {"message": "missing bearer token", "type": "invalid_request_error"}})
             return
         if token == STATIC_API_KEY:
@@ -166,24 +178,19 @@ class Handler(BaseHTTPRequestHandler):
         else:
             expiry = ISSUED_TOKENS.get(token)
         if expiry is None:
-            STATS["chat_refused_unknown"] += 1
-            log("chat request REFUSED: unknown bearer token")
+            count("chat_refused_unknown")
+            log(f"chat request REFUSED: unknown bearer token (model={model})")
             self._reply(401, {"error": {"message": "invalid bearer token", "type": "invalid_request_error"}})
             return
         if expiry < time.time():
-            STATS["chat_refused_expired"] += 1
-            log(f"chat request REFUSED: expired token ...{token[-8:]}")
+            count("chat_refused_expired")
+            log(f"chat request REFUSED: expired token ...{token[-8:]} (model={model})")
             self._reply(401, {"error": {"message": "token expired", "type": "invalid_request_error"}})
             return
 
-        try:
-            request = json.loads(raw_body)
-        except Exception:
-            request = {}
-        model = request.get("model", "mock-model")
         content = json.dumps(synthesize_reply(request))
         usage = {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20}
-        STATS["chat_ok"] += 1
+        count("chat_ok")
 
         if request.get("stream"):
             log(f"chat request OK (streaming) with token ...{token[-8:]}")

--- a/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
+++ b/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""OAuth2 client-credentials mock for the OPIK-7940 e2e suite (dynamic token auth).
+
+One process, two roles:
+
+  POST /oauth/token           OAuth2 token endpoint. Requires HTTP Basic
+                              (CLIENT_ID/CLIENT_SECRET) and a form body with
+                              grant_type=client_credentials, per the spec.
+                              Returns {access_token, token_type, expires_in}.
+                              A credential row "scope: ttl:<N>" overrides the
+                              token lifetime for that request only.
+  POST /v1/chat/completions   OpenAI-compatible gateway (sync + SSE streaming).
+                              Accepts only bearers this process issued (or the
+                              static API key), so a missing/stale bearer fails
+                              loudly instead of silently passing.
+
+Test hooks:
+
+  GET  /health                Liveness for Playwright's webServer probe.
+  GET  /stats                 Counters (tokens_issued, chat_ok, chat_refused_*)
+                              for clock-free refetch assertions.
+  POST /revoke                Invalidate every issued token (reactive-retry path).
+
+Spawned automatically by the suite's `webServer` config; run by hand with
+    python3 mock_token_auth_service.py --port 9878 --ttl 3600
+"""
+
+import argparse
+import base64
+import json
+import secrets
+import sys
+import time
+from collections import Counter
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs
+
+CLIENT_ID = "opik-test"
+CLIENT_SECRET = "opik-secret"
+STATIC_API_KEY = "mock-static-key"  # accepted as a bearer, for the static-auth provider entry
+
+TTL_SECONDS = 3600
+ISSUED_TOKENS = {}  # token -> expiry epoch seconds
+STATS = Counter()
+
+
+def log(message):
+    print(f"[mock-auth {time.strftime('%H:%M:%S')}] {message}", file=sys.stderr, flush=True)
+
+
+def _value_for(schema):
+    kind = schema.get("type")
+    if kind == "object":
+        return {name: _value_for(prop) for name, prop in (schema.get("properties") or {}).items()}
+    if kind in ("number", "integer"):
+        return 1
+    if kind == "boolean":
+        return True
+    if kind == "array":
+        return []
+    return "mock gateway accepted the bearer token"
+
+
+def synthesize_reply(request):
+    """Builds content matching the response_format JSON schema when the caller sends one
+    (the LLM-as-judge path does), so online scoring can parse the reply."""
+    schema = (((request.get("response_format") or {}).get("json_schema") or {}).get("schema")) or {}
+    if schema.get("properties"):
+        return _value_for(schema)
+    return {"score": 1.0, "reason": "mock gateway accepted the bearer token"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # silence default access log; we log ourselves
+        pass
+
+    def _reply(self, status, payload):
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self._reply(200, {"status": "ok"})
+        elif self.path == "/stats":
+            self._reply(200, dict(STATS))
+        else:
+            self._reply(404, {"error": "not_found", "path": self.path})
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw_body = self.rfile.read(length) if length else b""
+
+        if self.path == "/oauth/token":
+            self._handle_token(raw_body)
+        elif self.path == "/revoke":
+            count = len(ISSUED_TOKENS)
+            ISSUED_TOKENS.clear()
+            STATS["revocations"] += 1
+            log(f"REVOKED all {count} issued tokens (gateway will 401 until a fresh fetch)")
+            self._reply(200, {"revoked": count})
+        elif self.path.endswith("/chat/completions"):
+            self._handle_chat(raw_body)
+        else:
+            self._reply(404, {"error": "not_found", "path": self.path})
+
+    def _handle_token(self, raw_body):
+        auth = self.headers.get("Authorization") or ""
+        if not auth.startswith("Basic "):
+            STATS["token_refused"] += 1
+            log("token request REFUSED: no HTTP Basic header")
+            self._reply(401, {"error": "invalid_client",
+                              "error_description": "expected client_id/client_secret via HTTP Basic"})
+            return
+        try:
+            client_id, client_secret = (
+                base64.b64decode(auth.removeprefix("Basic ")).decode().split(":", 1))
+        except Exception:
+            STATS["token_refused"] += 1
+            self._reply(401, {"error": "invalid_client"})
+            return
+        if (client_id, client_secret) != (CLIENT_ID, CLIENT_SECRET):
+            STATS["token_refused"] += 1
+            log(f"token request REFUSED: bad credentials for client_id='{client_id}'")
+            self._reply(401, {"error": "invalid_client"})
+            return
+
+        form = parse_qs(raw_body.decode())
+        grant_type = (form.get("grant_type") or [""])[0]
+        if grant_type != "client_credentials":
+            STATS["token_refused"] += 1
+            log(f"token request REFUSED: grant_type='{grant_type}'")
+            self._reply(400, {"error": "unsupported_grant_type",
+                              "error_description": f"got grant_type='{grant_type}'"})
+            return
+
+        scope = (form.get("scope") or [""])[0]
+        ttl = TTL_SECONDS
+        if scope.startswith("ttl:"):  # per-provider TTL override, e.g. scope=ttl:10
+            ttl = int(scope.split(":", 1)[1])
+
+        token = secrets.token_urlsafe(24)
+        ISSUED_TOKENS[token] = time.time() + ttl
+        STATS["tokens_issued"] += 1
+        log(f"token ISSUED (ttl={ttl}s, scope='{scope}'): ...{token[-8:]}")
+        self._reply(200, {
+            "access_token": token,
+            "token_type": "Bearer",
+            "expires_in": ttl,
+            **({"scope": scope} if scope else {}),
+        })
+
+    def _handle_chat(self, raw_body):
+        auth = self.headers.get("Authorization") or ""
+        token = auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else None
+        if token is None:
+            STATS["chat_refused_missing"] += 1
+            log("chat request REFUSED: missing bearer token")
+            self._reply(401, {"error": {"message": "missing bearer token", "type": "invalid_request_error"}})
+            return
+        if token == STATIC_API_KEY:
+            expiry = float("inf")
+        else:
+            expiry = ISSUED_TOKENS.get(token)
+        if expiry is None:
+            STATS["chat_refused_unknown"] += 1
+            log("chat request REFUSED: unknown bearer token")
+            self._reply(401, {"error": {"message": "invalid bearer token", "type": "invalid_request_error"}})
+            return
+        if expiry < time.time():
+            STATS["chat_refused_expired"] += 1
+            log(f"chat request REFUSED: expired token ...{token[-8:]}")
+            self._reply(401, {"error": {"message": "token expired", "type": "invalid_request_error"}})
+            return
+
+        try:
+            request = json.loads(raw_body)
+        except Exception:
+            request = {}
+        model = request.get("model", "mock-model")
+        content = json.dumps(synthesize_reply(request))
+        usage = {"prompt_tokens": 10, "completion_tokens": 10, "total_tokens": 20}
+        STATS["chat_ok"] += 1
+
+        if request.get("stream"):
+            log(f"chat request OK (streaming) with token ...{token[-8:]}")
+            self._reply_sse(model, content, usage)
+            return
+
+        log(f"chat request OK with token ...{token[-8:]}")
+        self._reply(200, {
+            "id": "chatcmpl-mock",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": content},
+            }],
+            "usage": usage,
+        })
+
+    def _reply_sse(self, model, content, usage):
+        def chunk(delta, finish_reason=None, **extra):
+            return {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion.chunk",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish_reason}],
+                **extra,
+            }
+
+        events = [
+            chunk({"role": "assistant"}),
+            chunk({"content": content}),
+            chunk({}, finish_reason="stop", usage=usage),
+        ]
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        for event in events:
+            self.wfile.write(f"data: {json.dumps(event)}\n\n".encode())
+            self.wfile.flush()
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+
+def main():
+    global TTL_SECONDS
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=9878)
+    parser.add_argument("--host", default="127.0.0.1",
+                        help="bind address; CI uses 0.0.0.0 so the dockerized backend can reach the mock via the host")
+    parser.add_argument("--ttl", type=int, default=3600, help="default token lifetime (expires_in) in seconds")
+    args = parser.parse_args()
+    TTL_SECONDS = args.ttl
+
+    log(f"listening on http://{args.host}:{args.port} "
+        f"(token URL /oauth/token, gateway /v1/chat/completions, ttl={TTL_SECONDS}s)")
+    log(f"client_id={CLIENT_ID} client_secret={CLIENT_SECRET} static_api_key={STATIC_API_KEY}")
+    ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
+++ b/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
@@ -243,7 +243,8 @@ def main():
 
     log(f"listening on http://{args.host}:{args.port} "
         f"(token URL /oauth/token, gateway /v1/chat/completions, ttl={TTL_SECONDS}s)")
-    log(f"client_id={CLIENT_ID} client_secret={CLIENT_SECRET} static_api_key={STATIC_API_KEY}")
+    # fake, hardcoded test identities — still redacted so CodeQL's clear-text-logging check stays green
+    log(f"client_id={CLIENT_ID} client_secret=[see CLIENT_SECRET constant] static_api_key=[see STATIC_API_KEY constant]")
     ThreadingHTTPServer((args.host, args.port), Handler).serve_forever()
 
 

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
@@ -1,0 +1,232 @@
+import { test, expect } from '@e2e/fixtures';
+import { ConfigurationPage } from '@e2e/pom/configuration.page';
+import {
+  MOCK_AUTH_CLIENT_ID,
+  MOCK_AUTH_CLIENT_SECRET,
+  mockGatewayUrlForBackend,
+  mockTokenUrlForBackend,
+} from '@e2e/core/mock-auth';
+import {
+  checkProviderAuthConfig,
+  deleteProviderKeyByName,
+  createProviderKey,
+  findProviderKeyByName,
+} from '@e2e/core/provider-keys';
+
+const SECRET_SENTINEL = '__SECRET__';
+
+/**
+ * Dialog contracts of the OAuth2 client-credentials auth mode (OPIK-7940),
+ * against the suite's hermetic mock token service — no external keys involved.
+ * Provider keys are workspace-global: every test uses a namespaced provider_name
+ * and deletes it in a finally block.
+ */
+test.describe('AI Providers — OAuth2 token auth', { tag: ['@t1-smoke', '@area:ai-providers'] }, () => {
+  test('configure with test connection, persist the recipe masked', { tag: ['@cap:configuration.ai-provider-add'] }, async ({
+    page,
+    testNamespace,
+  }) => {
+    const providerName = `${testNamespace}-oauth-create`;
+    const configuration = new ConfigurationPage(page);
+
+    try {
+      const dialog = await test.step('Open the add-provider dialog (Custom)', async () => {
+        await configuration.gotoAiProviders();
+        return configuration.openAddCustomProviderDialog();
+      });
+      test.skip(dialog === null, 'Custom provider option not offered by this deployment');
+      if (dialog === null) return;
+
+      await test.step('Fill the provider with OAuth2 client credentials', async () => {
+        await dialog.getByRole('textbox', { name: 'Provider name' }).fill(providerName);
+        await dialog.getByRole('textbox', { name: 'URL', exact: true }).fill(mockGatewayUrlForBackend);
+        await dialog.getByRole('textbox', { name: 'Models list' }).fill('mock-model');
+        await configuration.fillAuthSection(dialog, {
+          tokenUrl: mockTokenUrlForBackend,
+          clientId: MOCK_AUTH_CLIENT_ID,
+          clientSecret: MOCK_AUTH_CLIENT_SECRET,
+        });
+      });
+
+      await test.step('Test connection succeeds and reports the token lifetime', async () => {
+        await configuration.clickTestConnection(dialog);
+        await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
+        await expect(page.getByText(/valid for 3600 seconds/).first()).toBeVisible();
+      });
+
+      await test.step('Save and verify the provider row appears', async () => {
+        await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
+        await dialog.waitFor({ state: 'hidden' });
+        await expect
+          .poll(async () => configuration.hasCustomProvider(providerName), {
+            timeout: 15_000,
+            intervals: [500, 1000],
+          })
+          .toBe(true);
+      });
+
+      await test.step('Backend stores the full recipe with the secret masked', async () => {
+        const stored = await findProviderKeyByName(providerName);
+        expect(stored).not.toBeNull();
+        expect(stored!.auth_config?.token_url).toBe(mockTokenUrlForBackend);
+        expect(stored!.auth_config?.send_as).toBe('basic');
+
+        const byKey = Object.fromEntries(
+          (stored!.auth_config?.credentials ?? []).map((c) => [c.key, c]),
+        );
+        // grant_type is injected by the FE (hidden from the dialog) per the OAuth2 spec
+        expect(byKey.grant_type).toMatchObject({ value: 'client_credentials', secret: false });
+        expect(byKey.client_id).toMatchObject({ value: MOCK_AUTH_CLIENT_ID, secret: false });
+        // the secret is write-only: read-back must return the sentinel, never the value
+        expect(byKey.client_secret).toMatchObject({ value: SECRET_SENTINEL, secret: true });
+      });
+    } finally {
+      await deleteProviderKeyByName(providerName);
+    }
+  });
+
+  test('sentinel round-trip: reopen shows a write-only secret and updating keeps it', { tag: ['@cap:configuration.ai-provider-edit'] }, async ({
+    page,
+    testNamespace,
+  }) => {
+    const providerName = `${testNamespace}-oauth-edit`;
+    const configuration = new ConfigurationPage(page);
+
+    try {
+      await test.step('Seed an OAuth2 provider via REST', async () => {
+        await createProviderKey({
+          provider: 'custom-llm',
+          provider_name: providerName,
+          base_url: mockGatewayUrlForBackend,
+          configuration: { models: `custom-llm/${providerName}/mock-model` },
+          auth_config: {
+            token_url: mockTokenUrlForBackend,
+            send_as: 'basic',
+            credentials: [
+              { key: 'grant_type', value: 'client_credentials', secret: false },
+              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
+              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
+            ],
+          },
+        });
+      });
+
+      const dialog = await test.step('Open the edit dialog', async () => {
+        await configuration.gotoAiProviders();
+        return configuration.openCustomProviderEdit(providerName);
+      });
+
+      await test.step('OAuth2 mode is preselected with stored values; the secret is write-only', async () => {
+        await expect(dialog.getByRole('radio', { name: 'OAuth2 client credentials' })).toBeChecked();
+        await expect(dialog.getByRole('textbox', { name: 'Token URL' })).toHaveValue(
+          mockTokenUrlForBackend,
+        );
+
+        // grant_type stays hidden — only user-owned rows are listed
+        expect(await configuration.credentialKeys(dialog)).not.toContain('grant_type');
+        const idRow = await configuration.credentialRow(dialog, 'client_id');
+        await expect(idRow.getByTestId('auth-credential-value')).toHaveValue(MOCK_AUTH_CLIENT_ID);
+
+        const secretRow = await configuration.credentialRow(dialog, 'client_secret');
+        await expect(secretRow.getByTestId('auth-credential-value')).toHaveValue(SECRET_SENTINEL);
+        // stored secrets stay masked: no reveal (eye) affordance, and the lock can't be removed.
+        // Row buttons are [eye?, lock, remove] — exactly 2 means the eye is absent.
+        await expect(secretRow.getByRole('button')).toHaveCount(2);
+        await expect(secretRow.getByTestId('auth-credential-lock')).toBeDisabled();
+      });
+
+      await test.step('Test connection resolves the stored secret server-side', async () => {
+        await configuration.clickTestConnection(dialog);
+        await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
+      });
+
+      await test.step('Update without changes; the stored secret survives the sentinel round-trip', async () => {
+        await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
+        await dialog.waitFor({ state: 'hidden' });
+
+        const stored = await findProviderKeyByName(providerName);
+        expect(stored).not.toBeNull();
+        // still masked on read-back, and still usable: the server-side check
+        // fetches a token with the stored (decrypted) secret
+        const secret = stored!.auth_config?.credentials?.find((c) => c.key === 'client_secret');
+        expect(secret?.value).toBe(SECRET_SENTINEL);
+        const check = await checkProviderAuthConfig(stored!.id);
+        expect(check.lifetime_seconds).toBe(3600);
+      });
+    } finally {
+      await deleteProviderKeyByName(providerName);
+    }
+  });
+
+  test('switching back to a static API key clears the stored recipe', { tag: ['@cap:configuration.ai-provider-edit'] }, async ({
+    page,
+    testNamespace,
+  }) => {
+    const providerName = `${testNamespace}-oauth-clear`;
+    const configuration = new ConfigurationPage(page);
+
+    try {
+      await test.step('Seed an OAuth2 provider via REST', async () => {
+        await createProviderKey({
+          provider: 'custom-llm',
+          provider_name: providerName,
+          base_url: mockGatewayUrlForBackend,
+          configuration: { models: `custom-llm/${providerName}/mock-model` },
+          auth_config: {
+            token_url: mockTokenUrlForBackend,
+            send_as: 'basic',
+            credentials: [
+              { key: 'grant_type', value: 'client_credentials', secret: false },
+              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
+              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
+            ],
+          },
+        });
+      });
+
+      await test.step('Switch the auth mode to Static API key and save', async () => {
+        await configuration.gotoAiProviders();
+        const dialog = await configuration.openCustomProviderEdit(providerName);
+        await dialog.getByRole('radio', { name: 'Static API key' }).click();
+        await dialog.getByRole('textbox', { name: 'API key' }).fill('mock-static-key');
+        await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
+        await dialog.waitFor({ state: 'hidden' });
+      });
+
+      await test.step('The stored recipe is cleared', async () => {
+        const stored = await findProviderKeyByName(providerName);
+        expect(stored).not.toBeNull();
+        expect(stored!.auth_config).toBeFalsy();
+      });
+    } finally {
+      await deleteProviderKeyByName(providerName);
+    }
+  });
+
+  test('failed test connection surfaces a redacted error', { tag: ['@cap:configuration.ai-provider-add'] }, async ({ page, testNamespace }) => {
+    const configuration = new ConfigurationPage(page);
+    const wrongSecret = `wrong-secret-${testNamespace}`;
+
+    await configuration.gotoAiProviders();
+    const dialog = await configuration.openAddCustomProviderDialog();
+    test.skip(dialog === null, 'Custom provider option not offered by this deployment');
+    if (dialog === null) return;
+
+    await test.step('Fill auth with a wrong client secret and test the connection', async () => {
+      await configuration.fillAuthSection(dialog, {
+        tokenUrl: mockTokenUrlForBackend,
+        clientId: MOCK_AUTH_CLIENT_ID,
+        clientSecret: wrongSecret,
+      });
+      await configuration.clickTestConnection(dialog);
+    });
+
+    await test.step('The failure toast names the upstream 401 and never the secret', async () => {
+      await expect(page.getByText('Connection failed', { exact: true })).toBeVisible();
+      await expect(page.getByText(/401/).first()).toBeVisible();
+      await expect(page.getByText(wrongSecret)).toHaveCount(0);
+    });
+
+    await page.keyboard.press('Escape');
+  });
+});

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
@@ -21,7 +21,7 @@ const SECRET_SENTINEL = '__SECRET__';
  * Provider keys are workspace-global: every test uses a namespaced provider_name
  * and deletes it in a finally block.
  */
-test.describe('AI Providers — OAuth2 token auth', { tag: ['@t1-smoke', '@area:ai-providers'] }, () => {
+test.describe('AI Providers — OAuth2 token auth', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
   test('configure with test connection, persist the recipe masked', { tag: ['@cap:configuration.ai-provider-add'] }, async ({
     page,
     testNamespace,

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
@@ -8,8 +8,6 @@ import {
 } from '@e2e/core/mock-auth';
 import {
   checkProviderAuthConfig,
-  deleteProviderKeyByName,
-  createProviderKey,
   findProviderKeyByName,
 } from '@e2e/core/provider-keys';
 
@@ -18,189 +16,154 @@ const SECRET_SENTINEL = '__SECRET__';
 /**
  * Dialog contracts of the OAuth2 client-credentials auth mode (OPIK-7940),
  * against the suite's hermetic mock token service — no external keys involved.
- * Provider keys are workspace-global: every test uses a namespaced provider_name
- * and deletes it in a finally block.
+ * Provider keys are workspace-global: every test uses a namespaced provider_name,
+ * seeded and torn down by the providerKeys fixture.
  */
 test.describe('AI Providers — OAuth2 token auth', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
   test('configure with test connection, persist the recipe masked', { tag: ['@cap:configuration.ai-provider-add'] }, async ({
     page,
     testNamespace,
+    providerKeys,
   }) => {
     const providerName = `${testNamespace}-oauth-create`;
+    // UI creation is the behavior under test, so only cleanup is delegated to the fixture
+    providerKeys.register(providerName);
     const configuration = new ConfigurationPage(page);
 
-    try {
-      const dialog = await test.step('Open the add-provider dialog (Custom)', async () => {
-        await configuration.gotoAiProviders();
-        return configuration.openAddCustomProviderDialog();
-      });
-      test.skip(dialog === null, 'Custom provider option not offered by this deployment');
-      if (dialog === null) return;
+    const dialog = await test.step('Open the add-provider dialog (Custom)', async () => {
+      await configuration.gotoAiProviders();
+      return configuration.openAddCustomProviderDialog();
+    });
+    test.skip(dialog === null, 'Custom provider option not offered by this deployment');
+    if (dialog === null) return;
 
-      await test.step('Fill the provider with OAuth2 client credentials', async () => {
-        await dialog.getByRole('textbox', { name: 'Provider name' }).fill(providerName);
-        await dialog.getByRole('textbox', { name: 'URL', exact: true }).fill(mockGatewayUrlForBackend);
-        await dialog.getByRole('textbox', { name: 'Models list' }).fill('mock-model');
-        await configuration.fillAuthSection(dialog, {
-          tokenUrl: mockTokenUrlForBackend,
-          clientId: MOCK_AUTH_CLIENT_ID,
-          clientSecret: MOCK_AUTH_CLIENT_SECRET,
-        });
+    await test.step('Fill the provider with OAuth2 client credentials', async () => {
+      await dialog.getByRole('textbox', { name: 'Provider name' }).fill(providerName);
+      await dialog.getByRole('textbox', { name: 'URL', exact: true }).fill(mockGatewayUrlForBackend);
+      await dialog.getByRole('textbox', { name: 'Models list' }).fill('mock-model');
+      await configuration.fillAuthSection(dialog, {
+        tokenUrl: mockTokenUrlForBackend,
+        clientId: MOCK_AUTH_CLIENT_ID,
+        clientSecret: MOCK_AUTH_CLIENT_SECRET,
       });
+    });
 
-      await test.step('Test connection succeeds and reports the token lifetime', async () => {
-        await configuration.clickTestConnection(dialog);
-        await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
-        await expect(page.getByText(/valid for 3600 seconds/).first()).toBeVisible();
-      });
+    await test.step('Test connection succeeds and reports the token lifetime', async () => {
+      await configuration.clickTestConnection(dialog);
+      await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
+      await expect(page.getByText(/valid for 3600 seconds/).first()).toBeVisible();
+    });
 
-      await test.step('Save and verify the provider row appears', async () => {
-        await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
-        await dialog.waitFor({ state: 'hidden' });
-        await expect
-          .poll(async () => configuration.hasCustomProvider(providerName), {
-            timeout: 15_000,
-            intervals: [500, 1000],
-          })
-          .toBe(true);
-      });
+    await test.step('Save and verify the provider row appears', async () => {
+      await dialog.getByRole('button', { name: 'Add provider', exact: true }).click();
+      await dialog.waitFor({ state: 'hidden' });
+      await expect
+        .poll(async () => configuration.hasCustomProvider(providerName), {
+          timeout: 15_000,
+          intervals: [500, 1000],
+        })
+        .toBe(true);
+    });
 
-      await test.step('Backend stores the full recipe with the secret masked', async () => {
-        const stored = await findProviderKeyByName(providerName);
-        expect(stored).not.toBeNull();
-        expect(stored!.auth_config?.token_url).toBe(mockTokenUrlForBackend);
-        expect(stored!.auth_config?.send_as).toBe('basic');
+    await test.step('Backend stores the full recipe with the secret masked', async () => {
+      const stored = await findProviderKeyByName(providerName);
+      expect(stored).not.toBeNull();
+      expect(stored!.auth_config?.token_url).toBe(mockTokenUrlForBackend);
+      expect(stored!.auth_config?.send_as).toBe('basic');
 
-        const byKey = Object.fromEntries(
-          (stored!.auth_config?.credentials ?? []).map((c) => [c.key, c]),
-        );
-        // grant_type is injected by the FE (hidden from the dialog) per the OAuth2 spec
-        expect(byKey.grant_type).toMatchObject({ value: 'client_credentials', secret: false });
-        expect(byKey.client_id).toMatchObject({ value: MOCK_AUTH_CLIENT_ID, secret: false });
-        // the secret is write-only: read-back must return the sentinel, never the value
-        expect(byKey.client_secret).toMatchObject({ value: SECRET_SENTINEL, secret: true });
-      });
-    } finally {
-      await deleteProviderKeyByName(providerName);
-    }
+      const byKey = Object.fromEntries(
+        (stored!.auth_config?.credentials ?? []).map((c) => [c.key, c]),
+      );
+      // grant_type is injected by the FE (hidden from the dialog) per the OAuth2 spec
+      expect(byKey.grant_type).toMatchObject({ value: 'client_credentials', secret: false });
+      expect(byKey.client_id).toMatchObject({ value: MOCK_AUTH_CLIENT_ID, secret: false });
+      // the secret is write-only: read-back must return the sentinel, never the value
+      expect(byKey.client_secret).toMatchObject({ value: SECRET_SENTINEL, secret: true });
+    });
   });
 
   test('sentinel round-trip: reopen shows a write-only secret and updating keeps it', { tag: ['@cap:configuration.ai-provider-edit'] }, async ({
     page,
     testNamespace,
+    providerKeys,
   }) => {
     const providerName = `${testNamespace}-oauth-edit`;
     const configuration = new ConfigurationPage(page);
 
-    try {
-      await test.step('Seed an OAuth2 provider via REST', async () => {
-        await createProviderKey({
-          provider: 'custom-llm',
-          provider_name: providerName,
-          base_url: mockGatewayUrlForBackend,
-          configuration: { models: `custom-llm/${providerName}/mock-model` },
-          auth_config: {
-            token_url: mockTokenUrlForBackend,
-            send_as: 'basic',
-            credentials: [
-              { key: 'grant_type', value: 'client_credentials', secret: false },
-              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
-              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
-            ],
-          },
-        });
-      });
+    await providerKeys.createOauth({ providerName });
 
-      const dialog = await test.step('Open the edit dialog', async () => {
-        await configuration.gotoAiProviders();
-        return configuration.openCustomProviderEdit(providerName);
-      });
+    const dialog = await test.step('Open the edit dialog', async () => {
+      await configuration.gotoAiProviders();
+      return configuration.openCustomProviderEdit(providerName);
+    });
 
-      await test.step('OAuth2 mode is preselected with stored values; the secret is write-only', async () => {
-        await expect(dialog.getByRole('radio', { name: 'OAuth2 client credentials' })).toBeChecked();
-        await expect(dialog.getByRole('textbox', { name: 'Token URL' })).toHaveValue(
-          mockTokenUrlForBackend,
-        );
+    await test.step('OAuth2 mode is preselected with stored values; the secret is write-only', async () => {
+      await expect(dialog.getByRole('radio', { name: 'OAuth2 client credentials' })).toBeChecked();
+      await expect(dialog.getByRole('textbox', { name: 'Token URL' })).toHaveValue(
+        mockTokenUrlForBackend,
+      );
 
-        // grant_type stays hidden — only user-owned rows are listed
-        expect(await configuration.credentialKeys(dialog)).not.toContain('grant_type');
-        const idRow = await configuration.credentialRow(dialog, 'client_id');
-        await expect(idRow.getByTestId('auth-credential-value')).toHaveValue(MOCK_AUTH_CLIENT_ID);
+      // grant_type stays hidden — only user-owned rows are listed
+      expect(await configuration.credentialKeys(dialog)).not.toContain('grant_type');
+      const idRow = await configuration.credentialRow(dialog, 'client_id');
+      await expect(idRow.getByTestId('auth-credential-value')).toHaveValue(MOCK_AUTH_CLIENT_ID);
 
-        const secretRow = await configuration.credentialRow(dialog, 'client_secret');
-        await expect(secretRow.getByTestId('auth-credential-value')).toHaveValue(SECRET_SENTINEL);
-        // stored secrets stay masked: no reveal (eye) affordance, and the lock can't be removed.
-        // Row buttons are [eye?, lock, remove] — exactly 2 means the eye is absent.
-        await expect(secretRow.getByRole('button')).toHaveCount(2);
-        await expect(secretRow.getByTestId('auth-credential-lock')).toBeDisabled();
-      });
+      const secretRow = await configuration.credentialRow(dialog, 'client_secret');
+      // a stored secret DISPLAYS empty (the sentinel would be editable text otherwise);
+      // the "stored, write-only" placeholder is the visible cue that a value exists
+      const secretValueInput = secretRow.getByTestId('auth-credential-value');
+      await expect(secretValueInput).toHaveValue('');
+      await expect(secretValueInput).toHaveAttribute('placeholder', 'stored, write-only');
+      // no reveal (eye) affordance, and the lock can't be removed.
+      // Row buttons are [eye?, lock, remove] — exactly 2 means the eye is absent.
+      await expect(secretRow.getByRole('button')).toHaveCount(2);
+      await expect(secretRow.getByTestId('auth-credential-lock')).toBeDisabled();
+    });
 
-      await test.step('Test connection resolves the stored secret server-side', async () => {
-        await configuration.clickTestConnection(dialog);
-        await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
-      });
+    await test.step('Test connection resolves the stored secret server-side', async () => {
+      await configuration.clickTestConnection(dialog);
+      await expect(page.getByText('Connection successful', { exact: true })).toBeVisible();
+    });
 
-      await test.step('Update without changes; the stored secret survives the sentinel round-trip', async () => {
-        await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
-        await dialog.waitFor({ state: 'hidden' });
+    await test.step('Update without changes; the stored secret survives the sentinel round-trip', async () => {
+      await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
+      await dialog.waitFor({ state: 'hidden' });
 
-        const stored = await findProviderKeyByName(providerName);
-        expect(stored).not.toBeNull();
-        // still masked on read-back, and still usable: the server-side check
-        // fetches a token with the stored (decrypted) secret
-        const secret = stored!.auth_config?.credentials?.find((c) => c.key === 'client_secret');
-        expect(secret?.value).toBe(SECRET_SENTINEL);
-        const check = await checkProviderAuthConfig(stored!.id);
-        expect(check.lifetime_seconds).toBe(3600);
-      });
-    } finally {
-      await deleteProviderKeyByName(providerName);
-    }
+      const stored = await findProviderKeyByName(providerName);
+      expect(stored).not.toBeNull();
+      // still masked on read-back, and still usable: the server-side check
+      // fetches a token with the stored (decrypted) secret
+      const secret = stored!.auth_config?.credentials?.find((c) => c.key === 'client_secret');
+      expect(secret?.value).toBe(SECRET_SENTINEL);
+      const check = await checkProviderAuthConfig(stored!.id);
+      expect(check.lifetime_seconds).toBe(3600);
+    });
   });
 
   test('switching back to a static API key clears the stored recipe', { tag: ['@cap:configuration.ai-provider-edit'] }, async ({
     page,
     testNamespace,
+    providerKeys,
   }) => {
     const providerName = `${testNamespace}-oauth-clear`;
     const configuration = new ConfigurationPage(page);
 
-    try {
-      await test.step('Seed an OAuth2 provider via REST', async () => {
-        await createProviderKey({
-          provider: 'custom-llm',
-          provider_name: providerName,
-          base_url: mockGatewayUrlForBackend,
-          configuration: { models: `custom-llm/${providerName}/mock-model` },
-          auth_config: {
-            token_url: mockTokenUrlForBackend,
-            send_as: 'basic',
-            credentials: [
-              { key: 'grant_type', value: 'client_credentials', secret: false },
-              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
-              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
-            ],
-          },
-        });
-      });
+    await providerKeys.createOauth({ providerName });
 
-      await test.step('Switch the auth mode to Static API key and save', async () => {
-        await configuration.gotoAiProviders();
-        const dialog = await configuration.openCustomProviderEdit(providerName);
-        await dialog.getByRole('radio', { name: 'Static API key' }).click();
-        await dialog.getByRole('textbox', { name: 'API key' }).fill('mock-static-key');
-        await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
-        await dialog.waitFor({ state: 'hidden' });
-      });
+    await test.step('Switch the auth mode to Static API key and save', async () => {
+      await configuration.gotoAiProviders();
+      const dialog = await configuration.openCustomProviderEdit(providerName);
+      await dialog.getByRole('radio', { name: 'Static API key' }).click();
+      await dialog.getByRole('textbox', { name: 'API key' }).fill('mock-static-key');
+      await dialog.getByRole('button', { name: 'Update configuration', exact: true }).click();
+      await dialog.waitFor({ state: 'hidden' });
+    });
 
-      await test.step('The stored recipe is cleared', async () => {
-        const stored = await findProviderKeyByName(providerName);
-        expect(stored).not.toBeNull();
-        expect(stored!.auth_config).toBeFalsy();
-      });
-    } finally {
-      await deleteProviderKeyByName(providerName);
-    }
+    await test.step('The stored recipe is cleared', async () => {
+      const stored = await findProviderKeyByName(providerName);
+      expect(stored).not.toBeNull();
+      expect(stored!.auth_config).toBeFalsy();
+    });
   });
 
   test('failed test connection surfaces a redacted error', { tag: ['@cap:configuration.ai-provider-add'] }, async ({ page, testNamespace }) => {

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@e2e/fixtures';
+import { PlaygroundPage } from '@e2e/pom/playground.page';
+import {
+  MOCK_AUTH_CLIENT_ID,
+  MOCK_AUTH_CLIENT_SECRET,
+  mockAuthRevokeAll,
+  mockAuthStats,
+  mockGatewayUrlForBackend,
+  mockTokenUrlForBackend,
+} from '@e2e/core/mock-auth';
+import { createProviderKey, deleteProviderKeyByName } from '@e2e/core/provider-keys';
+
+/**
+ * Reactive token refetch (OPIK-7940): when the gateway rejects a cached bearer
+ * (revoked server-side while still fresh in Opik's cache), the backend must
+ * invalidate, fetch a new token, and retry once — invisibly to the user.
+ *
+ * Clock-free by design: revocation is forced via the mock's /revoke hook and the
+ * refetch is asserted through /stats deltas (counts, not timing). The mock's
+ * counters are global across the run, so assertions are >= deltas.
+ */
+test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smoke', '@area:ai-providers'] }, () => {
+  test('a revoked token is transparently refetched and the request retried', async ({
+    page,
+    project,
+    testNamespace,
+  }) => {
+    test.setTimeout(180_000);
+
+    const providerName = `${testNamespace}-oauth-refetch`;
+    // unique model name so parallel specs can't collide in the model selector
+    const modelName = `${testNamespace}-mock-model`;
+
+    try {
+      await test.step('Seed an OAuth2 provider via REST', async () => {
+        await createProviderKey({
+          provider: 'custom-llm',
+          provider_name: providerName,
+          base_url: mockGatewayUrlForBackend,
+          configuration: { models: `custom-llm/${providerName}/${modelName}` },
+          auth_config: {
+            token_url: mockTokenUrlForBackend,
+            send_as: 'basic',
+            credentials: [
+              { key: 'grant_type', value: 'client_credentials', secret: false },
+              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
+              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
+            ],
+          },
+        });
+      });
+
+      const playground = new PlaygroundPage(page, project.id);
+
+      await test.step('First Playground run fetches a token and succeeds', async () => {
+        await playground.goto();
+        await playground.waitForReady();
+        const result = await playground.runSimplePromptAndAwaitResponse({
+          modelDisplayName: modelName,
+          prompt: 'Say hello.',
+          timeoutMs: 60_000,
+        });
+        expect(result.isError, 'no error indicator').toBe(false);
+        expect(result.outputText.length, 'non-empty response').toBeGreaterThan(0);
+      });
+
+      const before = await test.step('Revoke every issued token at the gateway', async () => {
+        const stats = await mockAuthStats();
+        await mockAuthRevokeAll();
+        return stats;
+      });
+
+      await test.step('Second run still succeeds — Opik retried with a fresh token', async () => {
+        // fresh navigation: rerunning on the same page can satisfy the output wait
+        // with the previous run's still-rendered response, skipping the request
+        await playground.goto();
+        await playground.waitForReady();
+        const result = await playground.runSimplePromptAndAwaitResponse({
+          modelDisplayName: modelName,
+          prompt: 'Say hello again.',
+          timeoutMs: 60_000,
+        });
+        expect(result.isError, 'no error indicator after revocation').toBe(false);
+        expect(result.outputText.length, 'non-empty response after revocation').toBeGreaterThan(0);
+      });
+
+      await test.step('The gateway saw the stale bearer refused and a new token issued', async () => {
+        // poll: the SSE stream can render before the mock finishes accounting
+        await expect
+          .poll(async () => (await mockAuthStats()).chat_refused_unknown ?? 0, {
+            timeout: 10_000,
+          })
+          .toBeGreaterThan(before.chat_refused_unknown ?? 0);
+        const after = await mockAuthStats();
+        expect(after.tokens_issued ?? 0).toBeGreaterThan(before.tokens_issued ?? 0);
+        expect(after.chat_ok ?? 0).toBeGreaterThan(before.chat_ok ?? 0);
+      });
+    } finally {
+      await deleteProviderKeyByName(providerName);
+    }
+  });
+});

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
@@ -19,8 +19,8 @@ import { createProviderKey, deleteProviderKeyByName } from '@e2e/core/provider-k
  * refetch is asserted through /stats deltas (counts, not timing). The mock's
  * counters are global across the run, so assertions are >= deltas.
  */
-test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smoke', '@area:ai-providers'] }, () => {
-  test('a revoked token is transparently refetched and the request retried', async ({
+test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
+  test('a revoked token is transparently refetched and the request retried', { tag: ['@cap:configuration.ai-provider-token-refetch'] }, async ({
     page,
     project,
     testNamespace,

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
@@ -1,14 +1,6 @@
 import { test, expect } from '@e2e/fixtures';
 import { PlaygroundPage } from '@e2e/pom/playground.page';
-import {
-  MOCK_AUTH_CLIENT_ID,
-  MOCK_AUTH_CLIENT_SECRET,
-  mockAuthRevokeAll,
-  mockAuthStats,
-  mockGatewayUrlForBackend,
-  mockTokenUrlForBackend,
-} from '@e2e/core/mock-auth';
-import { createProviderKey, deleteProviderKeyByName } from '@e2e/core/provider-keys';
+import { mockAuthRevokeAll, mockAuthStats } from '@e2e/core/mock-auth';
 
 /**
  * Reactive token refetch (OPIK-7940): when the gateway rejects a cached bearer
@@ -16,14 +8,17 @@ import { createProviderKey, deleteProviderKeyByName } from '@e2e/core/provider-k
  * invalidate, fetch a new token, and retry once — invisibly to the user.
  *
  * Clock-free by design: revocation is forced via the mock's /revoke hook and the
- * refetch is asserted through /stats deltas (counts, not timing). The mock's
- * counters are global across the run, so assertions are >= deltas.
+ * refetch is asserted through /stats deltas (counts, not timing), scoped to this
+ * test's unique model name so parallel specs sharing the mock can't interfere.
+ * /revoke itself is global, which is benign: a concurrent spec swept up by it just
+ * exercises the same transparent retry and still passes.
  */
 test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
   test('a revoked token is transparently refetched and the request retried', { tag: ['@cap:configuration.ai-provider-token-refetch'] }, async ({
     page,
     project,
     testNamespace,
+    providerKeys,
   }) => {
     test.setTimeout(180_000);
 
@@ -31,46 +26,34 @@ test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smo
     // unique model name so parallel specs can't collide in the model selector
     const modelName = `${testNamespace}-mock-model`;
 
-    try {
-      await test.step('Seed an OAuth2 provider via REST', async () => {
-        await createProviderKey({
-          provider: 'custom-llm',
-          provider_name: providerName,
-          base_url: mockGatewayUrlForBackend,
-          configuration: { models: `custom-llm/${providerName}/${modelName}` },
-          auth_config: {
-            token_url: mockTokenUrlForBackend,
-            send_as: 'basic',
-            credentials: [
-              { key: 'grant_type', value: 'client_credentials', secret: false },
-              { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
-              { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
-            ],
-          },
-        });
+    await providerKeys.createOauth({ providerName, modelName });
+
+    const playground = new PlaygroundPage(page, project.id);
+
+    await test.step('First Playground run fetches a token and succeeds', async () => {
+      await playground.goto();
+      await playground.waitForReady();
+      const result = await playground.runSimplePromptAndAwaitResponse({
+        modelDisplayName: modelName,
+        prompt: 'Say hello.',
+        timeoutMs: 60_000,
       });
+      expect(result.isError, 'no error indicator').toBe(false);
+      expect(result.outputText.length, 'non-empty response').toBeGreaterThan(0);
+    });
 
-      const playground = new PlaygroundPage(page, project.id);
+    const refusedKey = `chat_refused_unknown:${modelName}`;
 
-      await test.step('First Playground run fetches a token and succeeds', async () => {
-        await playground.goto();
-        await playground.waitForReady();
-        const result = await playground.runSimplePromptAndAwaitResponse({
-          modelDisplayName: modelName,
-          prompt: 'Say hello.',
-          timeoutMs: 60_000,
-        });
-        expect(result.isError, 'no error indicator').toBe(false);
-        expect(result.outputText.length, 'non-empty response').toBeGreaterThan(0);
-      });
-
-      const before = await test.step('Revoke every issued token at the gateway', async () => {
-        const stats = await mockAuthStats();
+    // Under parallel load the backend may legitimately degrade to a direct, uncached
+    // token fetch (Redis lock contention) — then a revocation has no cached bearer to
+    // expose and no refusal occurs even though behavior is correct. Retry the
+    // revoke -> prompt cycle until a run genuinely presents a stale bearer.
+    let observedRefusal = false;
+    for (let cycle = 1; cycle <= 3 && !observedRefusal; cycle++) {
+      observedRefusal = await test.step(`Revoke, rerun, and check for a refused stale bearer (cycle ${cycle})`, async () => {
+        const before = (await mockAuthStats())[refusedKey] ?? 0;
         await mockAuthRevokeAll();
-        return stats;
-      });
 
-      await test.step('Second run still succeeds — Opik retried with a fresh token', async () => {
         // fresh navigation: rerunning on the same page can satisfy the output wait
         // with the previous run's still-rendered response, skipping the request
         await playground.goto();
@@ -82,21 +65,22 @@ test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smo
         });
         expect(result.isError, 'no error indicator after revocation').toBe(false);
         expect(result.outputText.length, 'non-empty response after revocation').toBeGreaterThan(0);
-      });
 
-      await test.step('The gateway saw the stale bearer refused and a new token issued', async () => {
         // poll: the SSE stream can render before the mock finishes accounting
-        await expect
-          .poll(async () => (await mockAuthStats()).chat_refused_unknown ?? 0, {
-            timeout: 10_000,
-          })
-          .toBeGreaterThan(before.chat_refused_unknown ?? 0);
-        const after = await mockAuthStats();
-        expect(after.tokens_issued ?? 0).toBeGreaterThan(before.tokens_issued ?? 0);
-        expect(after.chat_ok ?? 0).toBeGreaterThan(before.chat_ok ?? 0);
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline) {
+          if (((await mockAuthStats())[refusedKey] ?? 0) > before) {
+            return true;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 250));
+        }
+        return false;
       });
-    } finally {
-      await deleteProviderKeyByName(providerName);
     }
+
+    expect(
+      observedRefusal,
+      'a revoked bearer was presented, refused, and transparently retried within 3 cycles',
+    ).toBe(true);
   });
 });

--- a/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
+++ b/tests_end_to_end/e2e/tests/playground/playground-providers.spec.ts
@@ -26,7 +26,12 @@ interface CustomProviderEntry {
   provider_type: 'custom';
   provider_name: string;
   base_url: string;
-  api_key_env_var: string;
+  /** Env var holding the static API key (external gateways). */
+  api_key_env_var?: string;
+  /** Literal static API key (hermetic mock entries only — never real secrets). */
+  api_key?: string;
+  /** OAuth2 client credentials mode (OPIK-7940) instead of a static key. */
+  auth?: { token_url: string; client_id: string; client_secret: string };
   models: ModelEntry[];
 }
 
@@ -61,8 +66,11 @@ test.describe('Playground — provider sanity', { tag: ['@provider-sanity', '@ar
     }) => {
       test.setTimeout(180_000);
 
-      const apiKey = process.env[provider.api_key_env_var];
-      test.skip(!apiKey, `${provider.api_key_env_var} not set in this env`);
+      const auth = provider.provider_type === 'custom' ? provider.auth : undefined;
+      const apiKey =
+        ('api_key' in provider ? provider.api_key : undefined) ??
+        (provider.api_key_env_var ? process.env[provider.api_key_env_var] : undefined);
+      test.skip(!apiKey && !auth, `${provider.api_key_env_var} not set in this env`);
 
       const offered = await test.step(
         `Ensure ${provider.provider_name} provider key is configured`,
@@ -73,8 +81,15 @@ test.describe('Playground — provider sanity', { tag: ['@provider-sanity', '@ar
             return cfg.ensureCustomProviderConfigured({
               providerName: provider.provider_name,
               baseUrl: provider.base_url,
-              apiKey: apiKey!,
+              apiKey,
               models: provider.models.map((m) => m.name).join(','),
+              ...(auth && {
+                auth: {
+                  tokenUrl: auth.token_url,
+                  clientId: auth.client_id,
+                  clientSecret: auth.client_secret,
+                },
+              }),
             });
           }
           return cfg.ensureProviderConfigured(provider.provider_name, apiKey!);


### PR DESCRIPTION
## Details

Stacked on #7910. Hermetic Playwright e2e coverage for the OAuth2 client-credentials token auth mode — no external API keys involved: a mock OAuth2 token service + bearer-validating gateway (`services/mock-token-auth/`) is spawned automatically by Playwright's `webServer`, and rejects any missing/stale bearer so specs fail loudly instead of passing vacuously.

- **`tests/ai-providers/token-auth-dialog.spec.ts`** (`@t1-smoke`, 4 tests): UI configure + Test connection + save with backend read-back asserting the masked recipe (regression test for a dropped-`auth_config` save bug caught during manual testing); sentinel round-trip (OAuth2 mode preselected on reopen, hidden `grant_type`, write-only secret with no reveal affordance and a non-removable lock, update-without-changes keeps the stored secret usable); switching back to Static API key clears the stored recipe; failed Test connection surfaces the upstream 401 with the secret never echoed.
- **`tests/ai-providers/token-auth-refetch.spec.ts`** (`@t1-smoke`): a token revoked at the gateway (via the mock's `/revoke` hook) is transparently refetched and the request retried — asserted through `/stats` count deltas, fully clock-free.
- **Playground provider-sanity parametrization**: `playground-models.yaml` entries gain optional `api_key` (literal) and `auth` blocks; two new hermetic entries (`mock-custom-static`, `mock-custom-oauth`) run the existing provision → prompt → completion journey once per auth mode. Existing entries and their code path are untouched.
- **POM**: `ConfigurationPage` gains OAuth2 auth-section methods, edit/delete flows, and a fix to the add-dialog tile selection (it previously could pick an already-configured Custom instance tile, opening Edit instead of Add). Four `data-testid`s added to the credential rows in `AuthConfigSection`.
- **CI**: both e2e workflows export `MOCK_AUTH_URL_FOR_BACKEND=http://172.17.0.1:9878` and the mock binds `0.0.0.0` under CI, so the dockerized backend can reach the host-run mock (docker-compose already ships the destination guard as `relaxed`). Specs are tagged `@t1-smoke`, so they run in this PR's e2e workflow (triggered by `tests_end_to_end/e2e/**` changes) and on every post-merge t1 run.

`core/provider-keys.ts` is a documented stopgap (fetch-based REST helpers) until the TS SDK is regenerated with `auth_config`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7940 (e2e acceptance criterion; feature implemented in #7910)

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: full implementation, reviewed file-by-file
  - Human verification: code review + repeated local runs against the live stack

## Testing

- `npx playwright test tests/ai-providers/ tests/playground/playground-providers.spec.ts` (hermetic entries) — 7/7 passing, verified across 5+ consecutive local runs including fully parallel execution (4 workers) to shake out cross-spec interference; two real flake sources found and fixed during development (configured-tile selection, same-page playground rerun).
- Suite `tsc --noEmit` clean; `pre-commit` (eslint, typecheck, actionlint, zizmor) passing on all changed files.
- Local runs target the vite dev server (`OPIK_BASE_URL=http://localhost:5174`); CI runs against the docker-compose stack — the `172.17.0.1` host-bridge leg is exercised for the first time by this PR's own e2e workflow run.

## Documentation

N/A — the feature docs page follows separately.
