### PR TITLE
[OPIK-7978] fix: verify Ollie navigation lands on the target project's route

### DIFF
--- a/tests_end_to_end/e2e/pom/ollie.page.ts
+++ b/tests_end_to_end/e2e/pom/ollie.page.ts
@@ -14,9 +14,19 @@ export class OlliePage {
   async goto(): Promise<void> {
     return test.step('open the Ollie page', async () => {
       const env = loadEnvConfig();
-      await this.page.goto(
-        `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/ollie`,
-      );
+      const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/ollie`;
+      const onTarget = new RegExp(`/projects/${this.projectId}/ollie(?:$|[/?#])`);
+
+      await this.page.goto(url);
+      // A redirect away from this project's /ollie route (e.g. the project
+      // isn't provisioned yet) otherwise fails silently here and only
+      // surfaces later as an opaque iframe/readiness timeout. Re-navigate
+      // once in case the first load raced a redirect, then fail loudly if
+      // it still isn't on the target project's Ollie page.
+      if (!onTarget.test(this.page.url())) {
+        await this.page.goto(url);
+      }
+      await expect(this.page).toHaveURL(onTarget);
     });
   }
 


### PR DESCRIPTION
## Details
`OlliePage.goto()` navigated to a project's Ollie page with a bare `page.goto()` and never verified the result, so a redirect (e.g. the project not being fully provisioned yet) left the test on the wrong screen while silently continuing — this only surfaced later as an opaque iframe/readiness timeout in `ollie-smoke.spec.ts`, as seen in a recent nightly regression run. `goto()` now asserts the browser landed on the target project's `/ollie` route, retrying the navigation once before failing loudly if it's still on the wrong page.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7978

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation
- Human verification: code review pending

## Testing
Diagnosed via a failing nightly E2E run (`comet-ml/comet-automation-tests` Actions run #32208714407) where `ollie-smoke.spec.ts` timed out waiting for the Ollie iframe's "Send message" button; the failure video showed navigation landing on the wrong project screen. No repo-configured lint/typecheck hook applies to `tests_end_to_end/e2e/` (`pre-commit run` on the changed file shows all hooks skipped as not applicable). Not run against a live environment as part of this PR — the actual E2E suite requires a deployed Opik instance.

## Documentation
N/A
