### PR TITLE
[NA] [DOCS] docs: address Cost Intelligence docs review feedback

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/macos-app.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/macos-app.mdx
@@ -24,7 +24,7 @@ The data landing in Opik is the same as the plugin produces. What differs is how
 | --- | --- | --- |
 | How traffic arrives | Agent is pointed at a local port | The OS diverts the flows |
 | Captures | Claude Code CLI | CLI **and** the Claude Code desktop app |
-| Configuration touches | The agent's settings | The app only — the agent is untouched |
+| Configuration touches | The agent's settings | Certificate trust only, set up by the app |
 | Delivered via | MDM or Claude managed settings | MDM |
 | TLS | Not intercepted | Terminated locally |
 | Platforms | macOS, Linux, Windows | macOS only |

--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/mdm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/mdm.mdx
@@ -174,6 +174,6 @@ Then, on each device, `opik-cipx uninstall` removes the hook, stops the daemon, 
     icon="fa-regular fa-shield-halved"
     href="/cost-intelligence/install/macos-app"
   >
-    Transparent capture when no client configuration can be delivered.
+    Transparent capture of every user, including the Claude Code desktop app.
   </Card>
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/overview.mdx
@@ -50,7 +50,7 @@ Which one fits:
 | **Platforms** | macOS, Linux, Windows | macOS, Linux, Windows | macOS only |
 | **Who receives it** | Whichever devices or groups you target | Every authenticated user in the org | Targeted devices |
 | **Staged / pilot rollout** | Yes | No, all users at once | Yes |
-| **Agent config needed** | Yes (delivered for you) | Yes (delivered for you) | None — the agent is untouched |
+| **Agent config needed** | Yes (delivered for you) | Yes (delivered for you) | None to deliver — cert trust set up on-device |
 | **Intercepts TLS** | No | No | Yes, locally |
 | **User can disable it** | No, enforced | No, enforced | No, enforced |
 | **Effort** | Low | Lowest | Highest |

--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/overview.mdx
@@ -22,7 +22,7 @@ Cost Intelligence closes that gap. It captures every coding-agent API call on th
 
 ## How it works
 
-Each developer machine runs its own local `opik-cipx` daemon. The coding agent talks to it over the loopback interface, and the daemon forwards every call to the provider unchanged — there is no shared collector, and none of your traffic routes through Comet. What ships to your Opik workspace is a separate, asynchronous stream of metadata-only spans: token counts, costs, and structure, [never content](/cost-intelligence/data-privacy-security).
+Each developer machine runs its own local `opik-cipx` daemon. The coding agent talks to it over the loopback interface, and the daemon forwards every call to the provider unchanged — there is no shared collector, and none of your traffic routes through Comet. What ships to your Opik workspace is a separate, asynchronous stream of metadata-only spans: token counts, costs, and structure, [never content](/cost-intelligence/data-privacy-security). The diagram shows Claude Code on the plugin path, the most common setup; see [Installation](/cost-intelligence/install/overview) for the other agents and rollout paths.
 
 <Frame>
   <img src="/img/v2/cost-intelligence/architecture.svg" alt="Cost Intelligence architecture: a local opik-cipx daemon on each developer machine forwards Claude Code traffic unchanged to Anthropic and ships metadata-only spans to Opik" />

--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/reduce-agent-spend.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/reduce-agent-spend.mdx
@@ -22,7 +22,7 @@ Cost Intelligence closes that loop. It shows you where the money went, prices wh
 The loop below works at any scale, but you don't have to run it fleet-wide on day one. The lowest-risk way in is staged:
 
 1. **Observe first.** Roll out to a pilot group and collect data only — no policies yet. You learn where the money goes before anything changes.
-2. **Apply to the pilot.** Review the recommendations priced from the pilot's own traffic and apply the ones you approve, to that group only.
+2. **Apply to the pilot.** Review the recommendations priced from the pilot's own traffic and apply the ones you approve. Policies only reach machines where Cost Intelligence is installed, so while only the pilot is rolled out, the changes land on the pilot's machines alone.
 3. **Widen.** Expand observability and the approved policies to the whole organization.
 4. **Tune per user.** Use [user policies](/cost-intelligence/roll-out-cost-policies) to handle the heaviest spenders and the teams that genuinely need different settings.
 
@@ -88,7 +88,7 @@ A recommendation that cuts spend by making the agent worse is not a saving, so e
 
 **Against benchmarks.** We evaluate agent performance on open and private benchmarks — TerminalBench among them — before and after each change, so a method that degrades what the agent can do never becomes a recommendation.
 
-**Against real sessions.** We maintain a body of tens of thousands of real, labeled coding-agent sessions that are replayable inside Opik. Every method is tuned against it offline, in large experiments, and monitored online with LLM-as-a-judge evaluation of real outcomes. As agents and usage patterns evolve, the same loop keeps the recommendations current.
+**Against real sessions.** We maintain a body of tens of thousands of real, labeled coding-agent sessions — drawn from our own internal usage and from customers who explicitly opt in — that are replayable inside Opik. Every method is tuned against it offline, in large experiments, and monitored online with LLM-as-a-judge evaluation of real outcomes. As agents and usage patterns evolve, the same loop keeps the recommendations current.
 
 ## Next steps
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/roll-out-cost-policies.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/roll-out-cost-policies.mdx
@@ -29,11 +29,13 @@ Delivery is automatic once you are set up. Bootstrap configuration (workspace, A
 
 <Note>
   **Disabling a skill doesn't take it away.** The most common recommendation —
-  turning off unused skills and MCP servers — only keeps them out of the
+  turning off unused skills and MCP servers — removes their weight from the
   context that ships with every request. Nothing is uninstalled, and a disabled
   skill stays callable: when a developer asks for it by name, Claude Code
-  re-enables it and uses it. The saving comes from the thousands of requests
-  that never needed it, not from taking capability away.
+  re-enables it and uses it. A denied MCP server does stay off until the policy
+  changes, which is why the recommendation only targets servers nobody has been
+  using. The saving comes from the thousands of requests that never needed
+  them.
 </Note>
 
 ## Grant exceptions per user


### PR DESCRIPTION
## Details
Follow-up to #7904 (merged), addressing the review comments left on it. Prose-only accuracy fixes across the Cost Intelligence docs:

- **Reduce coding agent spend**: the pilot stage no longer promises group-scoped policy — scoping comes from where Cost Intelligence is installed; the validation corpus is identified as internal usage plus customers who explicitly opt in.
- **Roll out cost policies**: the skills/MCP note now distinguishes the two — a disabled skill re-enables when called by name, while a denied MCP server stays off until the policy changes.
- **macOS app + install overview**: "the agent is untouched" corrected — the app sets up certificate trust in the agent; comparison rows updated on both pages.
- **Overview**: the "How it works" flow is scoped to Claude Code on the plugin path, with a pointer to Installation for other agents.
- **MDM page**: the macOS app card dropped the stale "when no client configuration can be delivered" framing.

Review comments on the SVG diagrams were intentionally not addressed (graphics excluded from this pass).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5
  - Scope: full implementation (docs prose)
  - Human verification: fixes directed by review comments; content reviewed by author

## Testing
- Prose-only changes to six existing MDX pages; no routing, code, or component changes. The Fern preview build on the PR verifies rendering and links.

## Documentation
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/overview.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/reduce-agent-spend.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/roll-out-cost-policies.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/overview.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/macos-app.mdx`
- `apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/install/mdm.mdx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
