### PR TITLE
Update guardrails documentation with default threshold

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/guardrails/guardrails.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/guardrails/guardrails.mdx
@@ -61,7 +61,7 @@ Detects sensitive personal information such as names, addresses, email addresses
 **What you configure**
 
 - **Personal data to block** — which categories to look for. The UI offers the categories that come up most often; the underlying detector supports a [much longer list](https://microsoft.github.io/presidio/supported_entities/).
-- **Threshold** — the confidence at or above which a detection counts. Lower is stricter.
+- **Threshold** — the confidence at or above which a detection counts. Lower is stricter. Default is 0.5.
 
 _The method used here leverages traditional NLP models for tokenization and named entity recognition._
 


### PR DESCRIPTION
Added default value for the threshold configuration in guardrails documentation.

## Details
<!--
Added default value for the threshold configuration in guardrails documentation.
-->

## Change checklist
- [ ] User facing
- [X] Documentation update

## Issues

- Resolves #
- OPIK-

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: [yes|no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
<!--
REPLACE ME WITH:

How you tested

Include:
- Exact commands run (for example: `mvn test`, `npm run lint && npm run test`, `pytest ...`)
- Scenarios validated (happy path, edge cases, regressions)
- Environment/context used (local process mode vs Docker, OS/browser when relevant)
- Any tests not run, with reason
- Relevant logs/artifacts links if available

Video evidence:
- External contributors: include a short recording for all contributions where possible.
- Internal contributors: include a short recording for complex changes where possible.
-->

## Documentation
