### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -7032,7 +7032,11 @@ paths:
       tags:
       - Prompts
       summary: Retrieve prompt version
-      description: Retrieve prompt version
+      description: "Retrieve prompt version. When project_name is supplied the lookup\
+        \ is scoped to that project: a prompt belonging to a different project is\
+        \ never matched, and an unknown project name returns 404. Legacy prompts with\
+        \ no project are still resolved as a deprecated fallback, signalled by the\
+        \ X-Opik-Deprecation response header."
       operationId: retrievePromptVersion
       requestBody:
         content:
@@ -7042,6 +7046,14 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-Opik-Deprecation:
+              description: "Present only when the prompt was resolved through the\
+                \ deprecated workspace-wide fallback, i.e. it has no project. Absent\
+                \ for project-scoped prompts."
+              style: simple
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -20517,7 +20529,11 @@ components:
         project_name:
           pattern: (?s)^\s*(\S.*\S|\S)\s*$
           type: string
-          description: "If provided, scopes the search to the specified project"
+          description: "If provided, scopes the search to the specified project; prompts\
+            \ belonging to other projects are never matched, and an unknown project\
+            \ name returns 404. Legacy prompts that are not scoped to any project\
+            \ are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation\
+            \ response header."
     PromptVersionIdsRequest_Detail:
       required:
       - ids

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -7032,7 +7032,11 @@ paths:
       tags:
       - Prompts
       summary: Retrieve prompt version
-      description: Retrieve prompt version
+      description: "Retrieve prompt version. When project_name is supplied the lookup\
+        \ is scoped to that project: a prompt belonging to a different project is\
+        \ never matched, and an unknown project name returns 404. Legacy prompts with\
+        \ no project are still resolved as a deprecated fallback, signalled by the\
+        \ X-Opik-Deprecation response header."
       operationId: retrievePromptVersion
       requestBody:
         content:
@@ -7042,6 +7046,14 @@ paths:
       responses:
         "200":
           description: OK
+          headers:
+            X-Opik-Deprecation:
+              description: "Present only when the prompt was resolved through the\
+                \ deprecated workspace-wide fallback, i.e. it has no project. Absent\
+                \ for project-scoped prompts."
+              style: simple
+              schema:
+                type: string
           content:
             application/json:
               schema:
@@ -20517,7 +20529,11 @@ components:
         project_name:
           pattern: (?s)^\s*(\S.*\S|\S)\s*$
           type: string
-          description: "If provided, scopes the search to the specified project"
+          description: "If provided, scopes the search to the specified project; prompts\
+            \ belonging to other projects are never matched, and an unknown project\
+            \ name returns 404. Legacy prompts that are not scoped to any project\
+            \ are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation\
+            \ response header."
     PromptVersionIdsRequest_Detail:
       required:
       - ids

--- a/sdks/python/src/opik/rest_api/prompts/client.py
+++ b/sdks/python/src/opik/rest_api/prompts/client.py
@@ -597,7 +597,7 @@ class PromptsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PromptVersionDetail:
         """
-        Retrieve prompt version
+        Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         Parameters
         ----------
@@ -612,7 +612,7 @@ class PromptsClient:
             If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment
 
         project_name : typing.Optional[str]
-            If provided, scopes the search to the specified project
+            If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -1325,7 +1325,7 @@ class AsyncPromptsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> PromptVersionDetail:
         """
-        Retrieve prompt version
+        Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         Parameters
         ----------
@@ -1340,7 +1340,7 @@ class AsyncPromptsClient:
             If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment
 
         project_name : typing.Optional[str]
-            If provided, scopes the search to the specified project
+            If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.

--- a/sdks/python/src/opik/rest_api/prompts/raw_client.py
+++ b/sdks/python/src/opik/rest_api/prompts/raw_client.py
@@ -988,7 +988,7 @@ class RawPromptsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> HttpResponse[PromptVersionDetail]:
         """
-        Retrieve prompt version
+        Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         Parameters
         ----------
@@ -1003,7 +1003,7 @@ class RawPromptsClient:
             If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment
 
         project_name : typing.Optional[str]
-            If provided, scopes the search to the specified project
+            If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.
@@ -2164,7 +2164,7 @@ class AsyncRawPromptsClient:
         request_options: typing.Optional[RequestOptions] = None,
     ) -> AsyncHttpResponse[PromptVersionDetail]:
         """
-        Retrieve prompt version
+        Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         Parameters
         ----------
@@ -2179,7 +2179,7 @@ class AsyncRawPromptsClient:
             If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment
 
         project_name : typing.Optional[str]
-            If provided, scopes the search to the specified project
+            If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
 
         request_options : typing.Optional[RequestOptions]
             Request-specific configuration.

--- a/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/Client.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/Client.ts
@@ -1185,7 +1185,7 @@ export class PromptsClient {
     }
 
     /**
-     * Retrieve prompt version
+     * Retrieve prompt version. When project_name is supplied the lookup is scoped to that project: a prompt belonging to a different project is never matched, and an unknown project name returns 404. Legacy prompts with no project are still resolved as a deprecated fallback, signalled by the X-Opik-Deprecation response header.
      *
      * @param {OpikApi.PromptVersionRetrieveDetail} request
      * @param {PromptsClient.RequestOptions} requestOptions - Request-specific configuration.

--- a/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/PromptVersionRetrieveDetail.ts
+++ b/sdks/typescript/src/opik/rest_api/api/resources/prompts/client/requests/PromptVersionRetrieveDetail.ts
@@ -13,6 +13,6 @@ export interface PromptVersionRetrieveDetail {
     environment?: string;
     /** If provided, resolves to the version with this sequential number (e.g. v3); mutually exclusive with commit and environment */
     versionNumber?: string;
-    /** If provided, scopes the search to the specified project */
+    /** If provided, scopes the search to the specified project; prompts belonging to other projects are never matched, and an unknown project name returns 404. Legacy prompts that are not scoped to any project are still matched as a deprecated fallback, signalled by the X-Opik-Deprecation response header. */
     projectName?: string;
 }


### PR DESCRIPTION
## Details
Automated daily update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate