### PR TITLE
[OPIK-7025] [QA] docs: a spec's area is its taxonomy area, not its directory name

### DIFF
--- a/tests_end_to_end/TESTING-TAGS.md
+++ b/tests_end_to_end/TESTING-TAGS.md
@@ -68,8 +68,11 @@ opt-out of the ladder (`playground-providers.spec.ts` does this).
 
 ### area and cap — coverage
 
-`@area:` must match the spec's directory name. `@cap:` must be
-`<area>.<capability>` and both halves must exist in `coverage/taxonomy.yaml`.
+`@area:` is the area whose capabilities the spec asserts — read it from
+`coverage/taxonomy.yaml`, **not** from the spec's directory name (see
+"Where a spec lives" below). `@cap:` must be `<area>.<capability>` and both halves
+must exist in that file. Only the `@cap:`-matches-`@area:` rule is enforced by
+`tag_lint.py`.
 
 ```ts
 // tests/datasets/dataset-items.spec.ts
@@ -134,7 +137,22 @@ test('Editing an item field commits as a new version and round-trips to the SDK'
 test('click edit then save then check')
 ```
 
-**Directory = area.** `tests/<area>/` and `@area:<area>` must match. Enforced.
+## Where a spec lives
+
+**`@area:` is not derivable from the directory.** Read the area's `spec_dir` in
+`coverage/taxonomy.yaml` — a directory is named after the product surface, and one
+directory can hold more than one area. Both real cases today:
+
+| Directory | Areas it holds | Why |
+|---|---|---|
+| `trace-explore/` | `@area:traces`, `@area:threads` | both areas declare `spec_dir: trace-explore`; the UI calls the surface "Logs" |
+| `prompts/` | `@area:prompts`, `@area:playground` | four prompt→playground journey specs, grouped by the flow they exercise rather than by area |
+
+So two different `@area:` values in one directory is expected, not a mistake, and
+a cross-area journey spec lives with the flow it tests.
+
+When adding a spec: put it where its flow's neighbours are, tag the area whose
+capabilities it asserts, and add it to that area's `specs:` list.
 
 ---
 


### PR DESCRIPTION
## Details

`TESTING-TAGS.md` asserted, twice:

> **Directory = area.** `tests/<area>/` and `@area:<area>` must match. Enforced.

Neither half is true.

**Two directories deliberately hold more than one area:**

| Directory | Areas | Why |
|---|---|---|
| `trace-explore/` | `@area:traces`, `@area:threads` | both declare `spec_dir: trace-explore` — the UI calls the surface "Logs", so neither area name matches the directory |
| `prompts/` | `@area:prompts`, `@area:playground` | four prompt→playground journey specs, grouped by the flow they exercise |

**And it is not enforced.** `tag_lint.py` checks that each `@cap:` matches the spec's declared `@area:`; it never compares `@area:` to the path. The linter is right — the doc was wrong.

## Why it matters

A review of #7908 read that sentence, concluded a `@area:threads` spec in `trace-explore/` was misplaced, and proposed creating a `tests/threads/` directory. That would have split the threads specs across two directories and made the estate *less* consistent. The spec was already exactly where it belonged.

Anything reading this file to decide where a spec goes is being pointed the wrong way — including the agents that now generate specs, which are instructed to follow it.

## Issues

OPIK-7025 (follow-up from the #7908 review).

## Testing

`tag_lint.py` — 38 specs checked, 1 exempt, 0 problems. Docs-only change; no spec or taxonomy edits.

The two shared directories were verified by enumeration, not assumption:

\`\`\`
for d in tests_end_to_end/e2e/tests/*/; do
  echo "\$(basename \$d) → \$(grep -rhoE '@area:[a-z-]+' \$d | sort -u | tr '\n' ' ')"
done
\`\`\`

## Documentation

This PR *is* the documentation change.

## Change checklist

- [x] Docs corrected to match the estate's actual conventions
- [ ] Tests added — n/a, docs only
- [ ] Breaking change — no