### PR TITLE
fix(alerts): accept window_in_seconds as the threshold window

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.Instant;
 import java.util.Map;
@@ -25,7 +27,7 @@ public record AlertTriggerConfig(
                 Alert.View.Write.class}) @NotNull AlertTriggerConfigType type,
 
         @JsonView({Alert.View.Public.class,
-                Alert.View.Write.class}) Map<String, String> configValue,
+                Alert.View.Write.class}) @Schema(description = "Trigger configuration map. Threshold configs accept both 'window' and 'window_in_seconds'; 'window' takes precedence when both are provided. A blank 'window' falls back to 'window_in_seconds'.") Map<String, String> configValue,
 
         @JsonView({Alert.View.Public.class,
                 Alert.View.Write.class}) @Schema(description = "Groups configs within a trigger: same group_index means AND between configs, different group_index means OR between groups. Null means a legacy/singleton group of one config. Always null for scope:project configs.") Integer groupIndex,
@@ -50,11 +52,24 @@ public record AlertTriggerConfig(
     // Comma-separated GuardrailType names (e.g. "PII,TOPIC"); empty/absent means all types.
     public static final String GUARDRAIL_TYPES_CONFIG_KEY = "guardrail_types";
 
-    public static String resolveWindow(Map<String, String> configValue) {
+    @Nullable public static String resolveWindow(@Nullable Map<String, String> configValue) {
         if (configValue == null) {
             return null;
         }
-        String window = configValue.get(WINDOW_CONFIG_KEY);
-        return window != null ? window : configValue.get(WINDOW_IN_SECONDS_CONFIG_KEY);
+        String window = StringUtils.trimToNull(configValue.get(WINDOW_CONFIG_KEY));
+        if (window != null) {
+            return window;
+        }
+        return StringUtils.trimToNull(configValue.get(WINDOW_IN_SECONDS_CONFIG_KEY));
+    }
+
+    public static String requireWindow(@Nullable Map<String, String> configValue, AlertTriggerConfigType type) {
+        String window = resolveWindow(configValue);
+        if (window == null) {
+            throw new IllegalArgumentException(
+                    "Missing config value for key '%s' or '%s' in trigger of type '%s'"
+                            .formatted(WINDOW_CONFIG_KEY, WINDOW_IN_SECONDS_CONFIG_KEY, type));
+        }
+        return window;
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
@@ -43,8 +43,18 @@ public record AlertTriggerConfig(
     public static final String PROJECT_IDS_CONFIG_KEY = "project_ids";
     public static final String THRESHOLD_CONFIG_KEY = "threshold";
     public static final String WINDOW_CONFIG_KEY = "window";
+    // Documented REST alias for WINDOW_CONFIG_KEY; stored configs may use either spelling.
+    public static final String WINDOW_IN_SECONDS_CONFIG_KEY = "window_in_seconds";
     public static final String NAME_CONFIG_KEY = "name";
     public static final String OPERATOR_CONFIG_KEY = "operator";
     // Comma-separated GuardrailType names (e.g. "PII,TOPIC"); empty/absent means all types.
     public static final String GUARDRAIL_TYPES_CONFIG_KEY = "guardrail_types";
+
+    public static String resolveWindow(Map<String, String> configValue) {
+        if (configValue == null) {
+            return null;
+        }
+        String window = configValue.get(WINDOW_CONFIG_KEY);
+        return window != null ? window : configValue.get(WINDOW_IN_SECONDS_CONFIG_KEY);
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
@@ -59,6 +59,7 @@ import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.resolveWindow;
 
 /**
  * Scheduled job for processing metrics-based alerts.
@@ -425,7 +426,7 @@ public class MetricsAlertJob extends Job implements InterruptableJob {
         }
         BigDecimal threshold = new BigDecimal(thresholdString);
 
-        var windowString = config.configValue().get(WINDOW_CONFIG_KEY);
+        var windowString = resolveWindow(config.configValue());
         if (windowString == null) {
             throw new IllegalArgumentException(
                     "Missing config value for key '%s' in trigger of type '%s'"

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
@@ -58,8 +58,7 @@ import java.util.stream.Collectors;
 import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
-import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
-import static com.comet.opik.api.AlertTriggerConfig.resolveWindow;
+import static com.comet.opik.api.AlertTriggerConfig.requireWindow;
 
 /**
  * Scheduled job for processing metrics-based alerts.
@@ -426,13 +425,7 @@ public class MetricsAlertJob extends Job implements InterruptableJob {
         }
         BigDecimal threshold = new BigDecimal(thresholdString);
 
-        var windowString = resolveWindow(config.configValue());
-        if (windowString == null) {
-            throw new IllegalArgumentException(
-                    "Missing config value for key '%s' in trigger of type '%s'"
-                            .formatted(WINDOW_CONFIG_KEY, thresholdConfigType));
-        }
-        long windowSeconds = Long.parseLong(windowString);
+        long windowSeconds = Long.parseLong(requireWindow(config.configValue(), thresholdConfigType));
 
         String name = null;
         Operator operator = Operator.GREATER_THAN;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/AlertTriggerConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/AlertTriggerConfigTest.java
@@ -1,0 +1,75 @@
+package com.comet.opik.api;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.WINDOW_IN_SECONDS_CONFIG_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AlertTriggerConfigTest {
+
+    @Test
+    void resolveWindowWhenConfigValueIsNullReturnsNull() {
+        assertThat(AlertTriggerConfig.resolveWindow(null)).isNull();
+    }
+
+    @Test
+    void resolveWindowWhenBothKeysAbsentReturnsNull() {
+        assertThat(AlertTriggerConfig.resolveWindow(Map.of(THRESHOLD_CONFIG_KEY, "2"))).isNull();
+    }
+
+    @Test
+    void resolveWindowWhenCanonicalWindowPresentReturnsCanonical() {
+        assertThat(AlertTriggerConfig.resolveWindow(Map.of(
+                WINDOW_CONFIG_KEY, "300",
+                WINDOW_IN_SECONDS_CONFIG_KEY, "999"))).isEqualTo("300");
+    }
+
+    @Test
+    void resolveWindowWhenOnlyAliasPresentReturnsAlias() {
+        assertThat(AlertTriggerConfig.resolveWindow(Map.of(WINDOW_IN_SECONDS_CONFIG_KEY, "300")))
+                .isEqualTo("300");
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t", "  \n"})
+    void resolveWindowWhenCanonicalWindowBlankFallsBackToAlias(String blankWindow) {
+        Map<String, String> configValue = new HashMap<>();
+        configValue.put(WINDOW_CONFIG_KEY, blankWindow);
+        configValue.put(WINDOW_IN_SECONDS_CONFIG_KEY, "300");
+
+        assertThat(AlertTriggerConfig.resolveWindow(configValue)).isEqualTo("300");
+    }
+
+    @Test
+    void resolveWindowWhenCanonicalWindowHasSurroundingWhitespaceReturnsTrimmedValue() {
+        assertThat(AlertTriggerConfig.resolveWindow(Map.of(WINDOW_CONFIG_KEY, "  300  ")))
+                .isEqualTo("300");
+    }
+
+    @Test
+    void requireWindowWhenBothKeysMissingMentionsBothAcceptedKeys() {
+        assertThatThrownBy(() -> AlertTriggerConfig.requireWindow(
+                Map.of(THRESHOLD_CONFIG_KEY, "2"), AlertTriggerConfigType.THRESHOLD_ERRORS))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(WINDOW_CONFIG_KEY)
+                .hasMessageContaining(WINDOW_IN_SECONDS_CONFIG_KEY);
+    }
+
+    @Test
+    void requireWindowWhenConfigValueIsNullMentionsBothAcceptedKeys() {
+        assertThatThrownBy(() -> AlertTriggerConfig.requireWindow(null, AlertTriggerConfigType.THRESHOLD_COST))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(WINDOW_CONFIG_KEY)
+                .hasMessageContaining(WINDOW_IN_SECONDS_CONFIG_KEY);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,6 +33,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
@@ -229,6 +231,33 @@ class MetricsAlertJobTest {
         assertThat(payload.get("conditions").get(1).get("threshold").asText()).isEqualTo("0.6000");
     }
 
+    @ParameterizedTest
+    @MethodSource("windowConfigKeys")
+    void firesTraceErrorsWhenWindowProvidedUnderCanonicalOrDocumentedAlias(String windowKey) {
+        Alert alert = alertWithErrorThreshold(windowKey, "2", "300");
+
+        when(projectMetricsDAO.getTotalTraceErrors(anyList(), any(Instant.class), any(Instant.class)))
+                .thenReturn(Mono.just(new BigDecimal("3")));
+        when(alertService.findAllByWorkspaceAndEventTypes(null,
+                MetricsAlertJob.SUPPORTED_EVENT_TYPES)).thenReturn(List.of(alert));
+
+        job.doJob(null);
+
+        ArgumentCaptor<List<String>> payloadCaptor = listCaptor();
+        verify(alertWebhookSender, timeout(ASYNC_TIMEOUT_MS)).createAndSendWebhook(
+                any(), eq(WORKSPACE_ID), anyString(), eq(AlertEventType.TRACE_ERRORS), anyList(),
+                payloadCaptor.capture(), anyList());
+
+        JsonNode payload = JsonUtils.readValue(payloadCaptor.getValue().getFirst(), JsonNode.class);
+        assertThat(payload.get("window_seconds").asLong()).isEqualTo(300L);
+        assertThat(payload.get("metric_value").asText()).isEqualTo("3");
+        assertThat(payload.get("threshold").asText()).isEqualTo("2");
+    }
+
+    static Stream<String> windowConfigKeys() {
+        return Stream.of(WINDOW_CONFIG_KEY, "window_in_seconds");
+    }
+
     @Test
     void doesNotEvaluateWhenInterrupted() throws org.quartz.UnableToInterruptJobException {
         job.interrupt();
@@ -261,6 +290,30 @@ class MetricsAlertJobTest {
                 .triggerConfigs(List.of(
                         feedbackConfig(operator, threshold1, groupIndex),
                         feedbackConfig(operator, threshold2, groupIndex)))
+                .build();
+
+        return Alert.builder()
+                .id(UUID.randomUUID())
+                .name("test-alert")
+                .enabled(true)
+                .webhook(Webhook.builder().url("http://example/hook").build())
+                .triggers(List.of(trigger))
+                .projectId(PROJECT_ID)
+                .workspaceId(WORKSPACE_ID)
+                .build();
+    }
+
+    private static Alert alertWithErrorThreshold(String windowKey, String threshold, String window) {
+        AlertTrigger trigger = AlertTrigger.builder()
+                .id(UUID.randomUUID())
+                .eventType(AlertEventType.TRACE_ERRORS)
+                .triggerConfigs(List.of(AlertTriggerConfig.builder()
+                        .id(UUID.randomUUID())
+                        .type(AlertTriggerConfigType.THRESHOLD_ERRORS)
+                        .configValue(Map.of(
+                                THRESHOLD_CONFIG_KEY, threshold,
+                                windowKey, window))
+                        .build()))
                 .build();
 
         return Alert.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
@@ -30,6 +31,7 @@ import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -39,6 +41,7 @@ import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.WINDOW_IN_SECONDS_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -231,13 +234,48 @@ class MetricsAlertJobTest {
         assertThat(payload.get("conditions").get(1).get("threshold").asText()).isEqualTo("0.6000");
     }
 
-    @ParameterizedTest
-    @MethodSource("windowConfigKeys")
-    void firesTraceErrorsWhenWindowProvidedUnderCanonicalOrDocumentedAlias(String windowKey) {
-        Alert alert = alertWithErrorThreshold(windowKey, "2", "300");
+    @ParameterizedTest(name = "{0} with {2}")
+    @MethodSource("windowAliasMatrix")
+    void firesWhenWindowProvidedUnderCanonicalOrDocumentedAlias(
+            AlertEventType eventType, AlertTriggerConfigType configType, String windowKey) {
+        Alert alert = alertWithThreshold(eventType, configType, thresholdConfig(eventType, windowKey, "300"));
+        stubMetricAboveThreshold(eventType);
+        when(alertService.findAllByWorkspaceAndEventTypes(null,
+                MetricsAlertJob.SUPPORTED_EVENT_TYPES)).thenReturn(List.of(alert));
 
-        when(projectMetricsDAO.getTotalTraceErrors(anyList(), any(Instant.class), any(Instant.class)))
-                .thenReturn(Mono.just(new BigDecimal("3")));
+        job.doJob(null);
+
+        ArgumentCaptor<List<String>> payloadCaptor = listCaptor();
+        verify(alertWebhookSender, timeout(ASYNC_TIMEOUT_MS)).createAndSendWebhook(
+                any(), eq(WORKSPACE_ID), anyString(), eq(eventType), anyList(),
+                payloadCaptor.capture(), anyList());
+
+        JsonNode payload = JsonUtils.readValue(payloadCaptor.getValue().getFirst(), JsonNode.class);
+        assertThat(payload.get("window_seconds").asLong()).isEqualTo(300L);
+        assertThat(payload.get("metric_value").asText()).isEqualTo("3");
+        assertThat(payload.get("threshold").asText()).isEqualTo("2");
+    }
+
+    static Stream<Arguments> windowAliasMatrix() {
+        return Stream.of(WINDOW_CONFIG_KEY, WINDOW_IN_SECONDS_CONFIG_KEY)
+                .flatMap(windowKey -> Stream.of(
+                        Arguments.of(AlertEventType.TRACE_ERRORS, AlertTriggerConfigType.THRESHOLD_ERRORS, windowKey),
+                        Arguments.of(AlertEventType.TRACE_COST, AlertTriggerConfigType.THRESHOLD_COST, windowKey),
+                        Arguments.of(AlertEventType.TRACE_LATENCY, AlertTriggerConfigType.THRESHOLD_LATENCY, windowKey),
+                        Arguments.of(AlertEventType.TRACE_FEEDBACK_SCORE,
+                                AlertTriggerConfigType.THRESHOLD_FEEDBACK_SCORE, windowKey),
+                        Arguments.of(AlertEventType.TRACE_THREAD_FEEDBACK_SCORE,
+                                AlertTriggerConfigType.THRESHOLD_FEEDBACK_SCORE, windowKey)));
+    }
+
+    @Test
+    void prefersCanonicalWindowWhenBothWindowKeysPresent() {
+        Map<String, String> configValue = thresholdConfig(AlertEventType.TRACE_ERRORS, WINDOW_CONFIG_KEY, "300");
+        configValue.put(WINDOW_IN_SECONDS_CONFIG_KEY, "999");
+        Alert alert = alertWithThreshold(AlertEventType.TRACE_ERRORS, AlertTriggerConfigType.THRESHOLD_ERRORS,
+                configValue);
+
+        stubMetricAboveThreshold(AlertEventType.TRACE_ERRORS);
         when(alertService.findAllByWorkspaceAndEventTypes(null,
                 MetricsAlertJob.SUPPORTED_EVENT_TYPES)).thenReturn(List.of(alert));
 
@@ -250,12 +288,28 @@ class MetricsAlertJobTest {
 
         JsonNode payload = JsonUtils.readValue(payloadCaptor.getValue().getFirst(), JsonNode.class);
         assertThat(payload.get("window_seconds").asLong()).isEqualTo(300L);
-        assertThat(payload.get("metric_value").asText()).isEqualTo("3");
-        assertThat(payload.get("threshold").asText()).isEqualTo("2");
     }
 
-    static Stream<String> windowConfigKeys() {
-        return Stream.of(WINDOW_CONFIG_KEY, "window_in_seconds");
+    @Test
+    void fallsBackToAliasWhenCanonicalWindowIsBlank() {
+        Map<String, String> configValue = thresholdConfig(AlertEventType.TRACE_ERRORS, WINDOW_CONFIG_KEY, "   ");
+        configValue.put(WINDOW_IN_SECONDS_CONFIG_KEY, "300");
+        Alert alert = alertWithThreshold(AlertEventType.TRACE_ERRORS, AlertTriggerConfigType.THRESHOLD_ERRORS,
+                configValue);
+
+        stubMetricAboveThreshold(AlertEventType.TRACE_ERRORS);
+        when(alertService.findAllByWorkspaceAndEventTypes(null,
+                MetricsAlertJob.SUPPORTED_EVENT_TYPES)).thenReturn(List.of(alert));
+
+        job.doJob(null);
+
+        ArgumentCaptor<List<String>> payloadCaptor = listCaptor();
+        verify(alertWebhookSender, timeout(ASYNC_TIMEOUT_MS)).createAndSendWebhook(
+                any(), eq(WORKSPACE_ID), anyString(), eq(AlertEventType.TRACE_ERRORS), anyList(),
+                payloadCaptor.capture(), anyList());
+
+        JsonNode payload = JsonUtils.readValue(payloadCaptor.getValue().getFirst(), JsonNode.class);
+        assertThat(payload.get("window_seconds").asLong()).isEqualTo(300L);
     }
 
     @Test
@@ -303,16 +357,47 @@ class MetricsAlertJobTest {
                 .build();
     }
 
-    private static Alert alertWithErrorThreshold(String windowKey, String threshold, String window) {
+    private void stubMetricAboveThreshold(AlertEventType eventType) {
+        switch (eventType) {
+            case TRACE_COST -> when(projectMetricsDAO.getTotalCost(anyList(), any(Instant.class), any(Instant.class)))
+                    .thenReturn(Mono.just(new BigDecimal("3")));
+            case TRACE_LATENCY ->
+                when(projectMetricsDAO.getAverageDuration(anyList(), any(Instant.class), any(Instant.class)))
+                        .thenReturn(Mono.just(new BigDecimal("3000")));
+            case TRACE_ERRORS ->
+                when(projectMetricsDAO.getTotalTraceErrors(anyList(), any(Instant.class), any(Instant.class)))
+                        .thenReturn(Mono.just(new BigDecimal("3")));
+            case TRACE_FEEDBACK_SCORE -> when(projectMetricsDAO.getAverageFeedbackScore(
+                    anyList(), any(Instant.class), any(Instant.class), eq(EntityType.TRACE), eq(FEEDBACK_NAME)))
+                    .thenReturn(Mono.just(new BigDecimal("3")));
+            case TRACE_THREAD_FEEDBACK_SCORE -> when(projectMetricsDAO.getAverageFeedbackScore(
+                    anyList(), any(Instant.class), any(Instant.class), eq(EntityType.THREAD), eq(FEEDBACK_NAME)))
+                    .thenReturn(Mono.just(new BigDecimal("3")));
+            default -> throw new IllegalArgumentException("Unsupported event type: " + eventType);
+        }
+    }
+
+    private static Map<String, String> thresholdConfig(AlertEventType eventType, String windowKey, String window) {
+        Map<String, String> configValue = new HashMap<>();
+        configValue.put(THRESHOLD_CONFIG_KEY, "2");
+        configValue.put(windowKey, window);
+        if (eventType == AlertEventType.TRACE_FEEDBACK_SCORE
+                || eventType == AlertEventType.TRACE_THREAD_FEEDBACK_SCORE) {
+            configValue.put(NAME_CONFIG_KEY, FEEDBACK_NAME);
+            configValue.put(OPERATOR_CONFIG_KEY, ">");
+        }
+        return configValue;
+    }
+
+    private static Alert alertWithThreshold(AlertEventType eventType, AlertTriggerConfigType configType,
+            Map<String, String> configValue) {
         AlertTrigger trigger = AlertTrigger.builder()
                 .id(UUID.randomUUID())
-                .eventType(AlertEventType.TRACE_ERRORS)
+                .eventType(eventType)
                 .triggerConfigs(List.of(AlertTriggerConfig.builder()
                         .id(UUID.randomUUID())
-                        .type(AlertTriggerConfigType.THRESHOLD_ERRORS)
-                        .configValue(Map.of(
-                                THRESHOLD_CONFIG_KEY, threshold,
-                                windowKey, window))
+                        .type(configType)
+                        .configValue(configValue)
                         .build()))
                 .build();
 

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.test.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.test.ts
@@ -136,6 +136,133 @@ describe("alertTriggersToFormTriggers", () => {
   });
 });
 
+describe("window_in_seconds alias", () => {
+  it("loads simple threshold window from window_in_seconds when canonical window is absent", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_errors,
+        trigger_configs: [
+          {
+            type: ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
+            config_value: { threshold: "2", window_in_seconds: "300" },
+          },
+        ],
+      },
+    ]);
+
+    expect(trigger.window).toBe("300");
+    expect(trigger.threshold).toBe("2");
+  });
+
+  it("prefers canonical window over window_in_seconds on simple thresholds", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_cost,
+        trigger_configs: [
+          {
+            type: ALERT_TRIGGER_CONFIG_TYPE["threshold:cost"],
+            config_value: {
+              threshold: "2",
+              window: "300",
+              window_in_seconds: "999",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(trigger.window).toBe("300");
+  });
+
+  it("falls back to window_in_seconds when canonical window is blank", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_latency,
+        trigger_configs: [
+          {
+            type: ALERT_TRIGGER_CONFIG_TYPE["threshold:latency"],
+            config_value: {
+              threshold: "2",
+              window: "   ",
+              window_in_seconds: "300",
+            },
+          },
+        ],
+      },
+    ]);
+
+    expect(trigger.window).toBe("300");
+  });
+
+  it("loads grouped feedback-score window from window_in_seconds", () => {
+    const [trigger] = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_feedback_score,
+        trigger_configs: [
+          fbScore(
+            {
+              name: "a",
+              operator: ">",
+              threshold: "0.7",
+              window_in_seconds: "3600",
+            },
+            0,
+          ),
+        ],
+      },
+    ]);
+
+    expect(trigger.groups?.[0].conditions[0].window).toBe("3600");
+  });
+
+  it("serializes the resolved window as canonical window so alias-only alerts stay editable", () => {
+    const form = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_errors,
+        trigger_configs: [
+          {
+            type: ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
+            config_value: { threshold: "2", window_in_seconds: "300" },
+          },
+        ],
+      },
+    ]);
+    const back = formTriggersToAlertTriggers(form);
+
+    expect(back[0].trigger_configs).toHaveLength(1);
+    expect(back[0].trigger_configs?.[0].config_value).toEqual({
+      threshold: "2",
+      window: "300",
+    });
+  });
+
+  it("round-trips grouped alias-only configs without dropping trigger_configs", () => {
+    const form = alertTriggersToFormTriggers([
+      {
+        event_type: ALERT_EVENT_TYPE.trace_thread_feedback_score,
+        trigger_configs: [
+          fbScore(
+            {
+              name: "a",
+              operator: ">",
+              threshold: "0.7",
+              window_in_seconds: "3600",
+            },
+            0,
+          ),
+        ],
+      },
+    ]);
+    const back = formTriggersToAlertTriggers(form);
+
+    expect(back[0].trigger_configs).toHaveLength(1);
+    expect(back[0].trigger_configs?.[0].config_value.window).toBe("3600");
+    expect(
+      back[0].trigger_configs?.[0].config_value.window_in_seconds,
+    ).toBeUndefined();
+  });
+});
+
 describe("formTriggersToAlertTriggers", () => {
   it("flattens groups and stamps group_index per group", () => {
     const [trigger] = formTriggersToAlertTriggers([

--- a/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages/AlertsPage/AddEditAlertPage/helpers.ts
@@ -113,6 +113,14 @@ const SIMPLE_THRESHOLD_CONFIG_TYPE: Partial<
     ALERT_TRIGGER_CONFIG_TYPE["threshold:errors"],
 };
 
+const resolveWindowConfig = (configValue?: Record<string, string>): string => {
+  const window = configValue?.window?.trim();
+  if (window) {
+    return window;
+  }
+  return configValue?.window_in_seconds?.trim() || "";
+};
+
 const getThresholdFromTriggerConfigs = (
   configType: ALERT_TRIGGER_CONFIG_TYPE,
   triggerConfigs?: AlertTriggerConfig[],
@@ -129,7 +137,7 @@ const getThresholdFromTriggerConfigs = (
   if (thresholdConfig?.config_value) {
     return {
       threshold: thresholdConfig.config_value.threshold,
-      window: thresholdConfig.config_value.window,
+      window: resolveWindowConfig(thresholdConfig.config_value),
       name: thresholdConfig.config_value.name,
       operator: thresholdConfig.config_value.operator,
     };
@@ -161,7 +169,7 @@ const getAllThresholdConditionGroupsFromTriggerConfigs = (
     const rawOperator = config.config_value.operator;
     const condition: FeedbackScoreConditionType = {
       threshold: config.config_value.threshold || "",
-      window: config.config_value.window || "",
+      window: resolveWindowConfig(config.config_value),
       name: config.config_value.name || "",
       operator: rawOperator === "<" ? "<" : ">",
     };


### PR DESCRIPTION
## Summary

- `threshold:errors` configs stored as `window_in_seconds` (the documented REST spelling) were accepted with 201, then every `MetricsAlertJob` run failed looking for `window`.
- `AlertTriggerConfig.resolveWindow()` prefers `window`, then `window_in_seconds`. Canonical `window` is unchanged.
- Fixes the verified Part 1 of #7862. Does not change Part 2 (alert still not firing after the key is corrected).

## Test plan

- [x] RED then GREEN: `window_in_seconds` fires the same `TRACE_ERRORS` webhook as `window`
- [x] `window` still works
- [x] `mvn test -Dtest=MetricsAlertJobTest` — 13 passed