### PR TITLE
[OPIK-8023] Fix ClickHouse SQL injection in dataset-item JSON sort keys (CWE-89)

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortableFields.java
@@ -51,9 +51,9 @@ public class SortableFields {
     public static final String INSTRUCTIONS = "instructions";
     public static final String WEBHOOK_URL = "webhook_url";
     public static final String DATA = "data.*"; // Truly dynamic - uses Map with parameter binding
-    public static final String OUTPUT_WILDCARD = "output.*"; // JSON fields - use JSONExtractRaw, not parameter binding
-    public static final String INPUT_WILDCARD = "input.*"; // JSON fields - use JSONExtractRaw, not parameter binding
-    public static final String METADATA_WILDCARD = "metadata.*"; // JSON fields - use JSONExtractRaw, not parameter binding (metadata field already exists above)
+    public static final String OUTPUT_WILDCARD = "output.*"; // JSON fields - use JSONExtractRaw with the key bound as a parameter
+    public static final String INPUT_WILDCARD = "input.*"; // JSON fields - use JSONExtractRaw with the key bound as a parameter
+    public static final String METADATA_WILDCARD = "metadata.*"; // JSON fields - use JSONExtractRaw with the key bound as a parameter (metadata field already exists above)
     public static final String COMMENTS = "comments";
     public static final String EXPERIMENT_ID = "experiment_id";
     public static final String PASS_RATE = "pass_rate";

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
@@ -26,9 +26,6 @@ import static com.comet.opik.api.sorting.SortableFields.OUTPUT_WILDCARD;
 import static com.comet.opik.api.sorting.SortableFields.TAGS;
 import static com.comet.opik.api.sorting.SortableFields.TOTAL_ESTIMATED_COST;
 import static com.comet.opik.api.sorting.SortableFields.USAGE;
-import static com.comet.opik.domain.filter.FilterQueryBuilder.INPUT_FIELD_PREFIX;
-import static com.comet.opik.domain.filter.FilterQueryBuilder.METADATA_FIELD_PREFIX;
-import static com.comet.opik.domain.filter.FilterQueryBuilder.OUTPUT_FIELD_PREFIX;
 
 public class SortingFactoryDatasets extends SortingFactory {
 
@@ -97,18 +94,9 @@ public class SortingFactoryDatasets extends SortingFactory {
     }
 
     private SortingField ensureBindKeyParam(SortingField sortingField) {
-        String field = sortingField.field();
-
-        // JSON fields (output.*, input.*, metadata.*) should NOT be treated as dynamic
-        // because they use JSONExtractRaw with literal keys in DatasetItemDAO
-        if (field.startsWith(OUTPUT_FIELD_PREFIX) || field.startsWith(INPUT_FIELD_PREFIX)
-                || field.startsWith(METADATA_FIELD_PREFIX)) {
-            return sortingField.toBuilder()
-                    .bindKeyParam(null)
-                    .build();
-        }
-
-        // Only dynamic fields need bindKeyParam
+        // Only dynamic fields need bindKeyParam. JSON fields (output.*, input.*, metadata.*) are
+        // dynamic as well: their key is bound as a query parameter via JSONExtractRaw(col, :param)
+        // in DatasetItemDAO, so they follow the same bindKeyParam path as data.*.
         if (!sortingField.isDynamic()) {
             return sortingField;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingFactoryDatasets.java
@@ -1,11 +1,9 @@
 package com.comet.opik.api.sorting;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 import static com.comet.opik.api.sorting.SortableFields.COMMENTS;
 import static com.comet.opik.api.sorting.SortableFields.CREATED_AT;
@@ -85,32 +83,6 @@ public class SortingFactoryDatasets extends SortingFactory {
         return false;
     }
 
-    @Override
-    protected List<SortingField> processFields(List<SortingField> sorting) {
-        // Ensure dynamic fields have bindKeyParam set (needed after JSON deserialization)
-        return sorting.stream()
-                .map(this::ensureBindKeyParam)
-                .toList();
-    }
-
-    private SortingField ensureBindKeyParam(SortingField sortingField) {
-        // Only dynamic fields need bindKeyParam. JSON fields (output.*, input.*, metadata.*) are
-        // dynamic as well: their key is bound as a query parameter via JSONExtractRaw(col, :param)
-        // in DatasetItemDAO, so they follow the same bindKeyParam path as data.*.
-        if (!sortingField.isDynamic()) {
-            return sortingField;
-        }
-
-        // If bindKeyParam is already set, return as-is
-        String bindKeyParam = sortingField.bindKeyParam();
-        if (StringUtils.isNotBlank(bindKeyParam)) {
-            return sortingField;
-        }
-
-        // Generate UUID for dynamic field
-        bindKeyParam = UUID.randomUUID().toString().replace("-", "");
-        return sortingField.toBuilder()
-                .bindKeyParam(bindKeyParam)
-                .build();
-    }
+    // Note: bindKeyParam is generated in SortingField's canonical constructor (a safe identifier for
+    // dynamic fields), so no factory-side normalization is needed here.
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
@@ -18,9 +19,9 @@ public record SortingField(
         Direction direction,
         // bindKeyParam feeds a SQL parameter placeholder name (see bindKey()), so it is an internal
         // value derived server-side only: @JsonIgnore keeps it off the JSON API surface entirely (neither
-        // serialized nor deserialized), and it is always (re)generated as a safe identifier in the
-        // canonical constructor.
-        @JsonIgnore String bindKeyParam) {
+        // serialized nor deserialized). It is null for static (non-dynamic) fields and a server-generated
+        // safe identifier for dynamic fields (see the canonical constructor).
+        @JsonIgnore @Nullable String bindKeyParam) {
 
     private static final Pattern SAFE_BIND_KEY_PARAM = Pattern.compile("[A-Za-z0-9_]+");
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
@@ -1,7 +1,7 @@
 package com.comet.opik.api.sorting;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
@@ -16,10 +16,11 @@ import java.util.regex.Pattern;
 public record SortingField(
         @NotBlank String field,
         Direction direction,
-        // bindKeyParam feeds a SQL parameter placeholder name (see bindKey()), so it must be derived
-        // server-side only: it is never accepted from client input (READ_ONLY) and is always
-        // (re)generated as a safe identifier in the canonical constructor.
-        @JsonProperty(access = JsonProperty.Access.READ_ONLY) String bindKeyParam) {
+        // bindKeyParam feeds a SQL parameter placeholder name (see bindKey()), so it is an internal
+        // value derived server-side only: @JsonIgnore keeps it off the JSON API surface entirely (neither
+        // serialized nor deserialized), and it is always (re)generated as a safe identifier in the
+        // canonical constructor.
+        @JsonIgnore String bindKeyParam) {
 
     private static final Pattern SAFE_BIND_KEY_PARAM = Pattern.compile("[A-Za-z0-9_]+");
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/sorting/SortingField.java
@@ -1,12 +1,14 @@
 package com.comet.opik.api.sorting;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Builder(toBuilder = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -14,12 +16,19 @@ import java.util.UUID;
 public record SortingField(
         @NotBlank String field,
         Direction direction,
-        String bindKeyParam) {
+        // bindKeyParam feeds a SQL parameter placeholder name (see bindKey()), so it must be derived
+        // server-side only: it is never accepted from client input (READ_ONLY) and is always
+        // (re)generated as a safe identifier in the canonical constructor.
+        @JsonProperty(access = JsonProperty.Access.READ_ONLY) String bindKeyParam) {
 
-    // Canonical constructor with auto-generation of bindKeyParam for dynamic fields
+    private static final Pattern SAFE_BIND_KEY_PARAM = Pattern.compile("[A-Za-z0-9_]+");
+
+    // Canonical constructor. bindKeyParam is rendered into a SQL placeholder name, so for dynamic
+    // fields it must always be a server-generated safe identifier. Regenerate it whenever it is
+    // missing or is not a safe identifier, so no client-influenced value can reach the SQL.
     public SortingField {
-        // Auto-generate bindKeyParam for dynamic fields if not provided
-        if (bindKeyParam == null && field != null && field.contains(".")) {
+        if (field != null && field.contains(".")
+                && (bindKeyParam == null || !SAFE_BIND_KEY_PARAM.matcher(bindKeyParam).matches())) {
             bindKeyParam = UUID.randomUUID().toString().replace("-", "");
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -1392,8 +1392,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                             }
 
                             var hasDynamicKeys = datasetItemSearchCriteria.sortingFields() != null
-                                    && sortingQueryBuilder.hasDynamicKeys(datasetItemSearchCriteria.sortingFields(),
-                                            itemFieldMapping);
+                                    && sortingQueryBuilder.hasDynamicKeys(datasetItemSearchCriteria.sortingFields());
 
                             var selectStatement = connection.createStatement(finalTemplate.render())
                                     .bind("datasetId", datasetItemSearchCriteria.datasetId())
@@ -1411,7 +1410,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
                             // Bind dynamic sorting keys if present
                             if (hasDynamicKeys) {
                                 selectStatement = sortingQueryBuilder.bindDynamicKeys(selectStatement,
-                                        datasetItemSearchCriteria.sortingFields(), itemFieldMapping);
+                                        datasetItemSearchCriteria.sortingFields());
                             }
 
                             bindSearchCriteria(datasetItemSearchCriteria, selectStatement);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -1398,8 +1398,8 @@ public class FilterQueryBuilder {
     /**
      * Builds field mapping for DatasetItem JSON fields (output, input, metadata).
      * These fields are stored as JSON strings in ClickHouse, so we need to use JSONExtractRaw
-     * instead of bracket notation. We use literal keys instead of bind parameters
-     * to avoid the dynamic field tuple wrapping.
+     * instead of bracket notation. The JSON key is bound as a query parameter rather than
+     * interpolated, consistent with the data.* sort path.
      * <p>
      * This is used for sorting DatasetItem fields.
      *

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -53,7 +53,10 @@ public class FilterQueryBuilder {
 
     public static final String JSONPATH_ROOT = "$";
 
-    private static final String JSON_EXTRACT_RAW_TEMPLATE = "JSONExtractRaw(%s, '%s')";
+    // The JSON key is passed as a bound query parameter (:sorting_param_xxx) rather than interpolated,
+    // consistent with the data.* sort path and robust to keys containing special characters.
+    // See buildDatasetItemFieldMapping.
+    private static final String JSON_EXTRACT_RAW_TEMPLATE = "JSONExtractRaw(%s, :%s)";
     public static final String OUTPUT_FIELD_PREFIX = "output.";
     public static final String INPUT_FIELD_PREFIX = "input.";
     public static final String METADATA_FIELD_PREFIX = "metadata.";
@@ -1409,20 +1412,20 @@ public class FilterQueryBuilder {
         for (SortingField field : sortingFields) {
             String fieldName = field.field();
 
-            // Check if this is a JSON field (output, input, or metadata)
-            // Use literal keys instead of bind parameters to avoid dynamic field handling
+            // Check if this is a JSON field (output, input, or metadata).
+            // The JSON key is bound as a query parameter (field.bindKey() -> :sorting_param_xxx) rather
+            // than interpolated into the SQL. The key VALUE (field.dynamicKey()) is bound later in
+            // SortingQueryBuilder.bindDynamicKeys(), consistent with the data.* path, so keys containing
+            // special characters are handled correctly.
             if (fieldName.startsWith(OUTPUT_FIELD_PREFIX)) {
-                String key = fieldName.substring(OUTPUT_FIELD_PREFIX.length());
                 fieldMapping.put(fieldName,
-                        JSON_EXTRACT_RAW_TEMPLATE.formatted("output", key));
+                        JSON_EXTRACT_RAW_TEMPLATE.formatted("output", field.bindKey()));
             } else if (fieldName.startsWith(INPUT_FIELD_PREFIX)) {
-                String key = fieldName.substring(INPUT_FIELD_PREFIX.length());
                 fieldMapping.put(fieldName,
-                        JSON_EXTRACT_RAW_TEMPLATE.formatted("input", key));
+                        JSON_EXTRACT_RAW_TEMPLATE.formatted("input", field.bindKey()));
             } else if (fieldName.startsWith(METADATA_FIELD_PREFIX)) {
-                String key = fieldName.substring(METADATA_FIELD_PREFIX.length());
                 fieldMapping.put(fieldName,
-                        JSON_EXTRACT_RAW_TEMPLATE.formatted("metadata", key));
+                        JSON_EXTRACT_RAW_TEMPLATE.formatted("metadata", field.bindKey()));
             }
             // For other fields (including feedback_scores, data, etc.), use default dbField()
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/filter/FilterQueryBuilder.java
@@ -1417,6 +1417,9 @@ public class FilterQueryBuilder {
             // than interpolated into the SQL. The key VALUE (field.dynamicKey()) is bound later in
             // SortingQueryBuilder.bindDynamicKeys(), consistent with the data.* path, so keys containing
             // special characters are handled correctly.
+            // Note: dynamicKey() is everything after the first dot, i.e. a single top-level JSON key
+            // ("output.a.b" looks up the key "a.b"); nested traversal is not performed. This matches the
+            // previous behavior.
             if (fieldName.startsWith(OUTPUT_FIELD_PREFIX)) {
                 fieldMapping.put(fieldName,
                         JSON_EXTRACT_RAW_TEMPLATE.formatted("output", field.bindKey()));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/sorting/SortingQueryBuilder.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/sorting/SortingQueryBuilder.java
@@ -70,28 +70,18 @@ public class SortingQueryBuilder {
     }
 
     public boolean hasDynamicKeys(@NonNull List<SortingField> sorting) {
-        return hasDynamicKeys(sorting, null);
-    }
-
-    public boolean hasDynamicKeys(@NonNull List<SortingField> sorting, Map<String, String> fieldMapping) {
-        // Only fields with bindKeyParam need dynamic binding.
-        // Fields in the fieldMapping use literal SQL expressions (e.g. JSONExtractRaw), so no bind param exists.
+        // A dynamic field is bound whenever it carries a bindKeyParam. This covers JSON fields
+        // (output/input/metadata), whose key is bound via JSONExtractRaw(col, :param), as well as
+        // map-style fields such as data[:param] and experiment_scores_agg[:param].
         return sorting.stream()
                 .filter(SortingField::isDynamic)
-                .filter(field -> field.bindKeyParam() != null)
-                .anyMatch(field -> fieldMapping == null || !fieldMapping.containsKey(field.field()));
+                .anyMatch(field -> field.bindKeyParam() != null);
     }
 
-    public Statement bindDynamicKeys(Statement statement, List<SortingField> sorting) {
-        return bindDynamicKeys(statement, sorting, null);
-    }
-
-    public Statement bindDynamicKeys(Statement statement, List<SortingField> sorting,
-            Map<String, String> fieldMapping) {
+    public Statement bindDynamicKeys(Statement statement, @NonNull List<SortingField> sorting) {
         sorting.stream()
                 .filter(SortingField::isDynamic)
                 .filter(sortingField -> sortingField.bindKeyParam() != null)
-                .filter(sortingField -> fieldMapping == null || !fieldMapping.containsKey(sortingField.field()))
                 .forEach(sortingField -> {
                     try {
                         statement.bind(sortingField.bindKey(), sortingField.dynamicKey());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -78,6 +78,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -3508,6 +3509,83 @@ class DatasetVersionResourceTest {
                             datasetItems.get(2).id(),
                             datasetItems.get(1).id(),
                             datasetItems.get(0).id());
+        }
+
+        @Test
+        @DisplayName("should sort versioned experiment items by a JSON output key through the push-top-limit path")
+        void sortByJsonOutputKey__whenAscendingAndDescending__thenReturnSortedByKey() {
+            var datasetName = UUID.randomUUID().toString();
+            var datasetId = createDataset(datasetName);
+            createDatasetItems(datasetId, 3);
+
+            var version = getLatestVersion(datasetId);
+            var datasetItems = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
+
+            var projectName = UUID.randomUUID().toString();
+
+            // One trial per dataset item; each trace's output carries a distinct value under a key that
+            // contains special characters. Sorting by output.* routes through the push-top-limit path, whose
+            // JSON expression binds the key as a parameter (JSONExtractRaw(argMax(...), :param)).
+            int count = 3;
+            String jsonKey = "score's";
+            var traceIds = IntStream.range(0, count)
+                    .mapToObj(i -> {
+                        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                                .projectName(projectName)
+                                .output(JsonUtils.valueToTree(Map.of(jsonKey, (i + 1) * 10)))
+                                .build();
+                        traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
+                        return trace.id();
+                    })
+                    .toList();
+
+            var experiment = experimentResourceClient.createPartialExperiment()
+                    .datasetName(datasetName)
+                    .datasetVersionId(version.id())
+                    .build();
+            var experimentId = experimentResourceClient.create(experiment, API_KEY, TEST_WORKSPACE);
+
+            IntStream.range(0, count).forEach(i -> {
+                var item = factory.manufacturePojo(ExperimentItem.class).toBuilder()
+                        .experimentId(experimentId)
+                        .datasetItemId(datasetItems.get(i).id())
+                        .traceId(traceIds.get(i))
+                        .build();
+                experimentResourceClient.createExperimentItem(Set.of(item), API_KEY, TEST_WORKSPACE);
+            });
+
+            String sortField = "output." + jsonKey;
+
+            // Baseline fetch (no sorting) captures the full objects as returned; the assertions below only test order.
+            var baseline = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                    datasetId, List.of(experimentId), null, null, null, API_KEY, TEST_WORKSPACE).content();
+            assertThat(baseline).hasSize(count);
+
+            Map<UUID, Integer> valueByItemId = IntStream.range(0, count).boxed()
+                    .collect(Collectors.toMap(i -> datasetItems.get(i).id(), i -> (i + 1) * 10));
+
+            var expectedAsc = baseline.stream()
+                    .sorted(Comparator.comparingInt(item -> valueByItemId.get(item.id())))
+                    .toList();
+            var expectedDesc = baseline.stream()
+                    .sorted(Comparator.comparingInt((DatasetItem item) -> valueByItemId.get(item.id())).reversed())
+                    .toList();
+
+            // Compare the whole DatasetItem objects, in order - not just their ids.
+            var asc = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                    datasetId, List.of(experimentId), null, null,
+                    List.of(new SortingField(sortField, Direction.ASC)), API_KEY, TEST_WORKSPACE);
+            assertThat(asc.content())
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactlyElementsOf(expectedAsc);
+
+            var desc = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                    datasetId, List.of(experimentId), null, null,
+                    List.of(new SortingField(sortField, Direction.DESC)), API_KEY, TEST_WORKSPACE);
+            assertThat(desc.content())
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactlyElementsOf(expectedDesc);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -78,7 +78,6 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -3511,12 +3510,26 @@ class DatasetVersionResourceTest {
                             datasetItems.get(0).id());
         }
 
-        @Test
-        @DisplayName("should sort versioned experiment items by a JSON output key through the push-top-limit path")
-        void sortByJsonOutputKey__whenAscendingAndDescending__thenReturnSortedByKey() {
+        static Stream<Arguments> sortByJsonKeyThroughPushTopLimit() {
+            // namespace, JSON key (with special characters), direction, expected item-index order
+            return Stream.of(
+                    Arguments.of("output", "score's", Direction.ASC, List.of(0, 1, 2)),
+                    Arguments.of("output", "score's", Direction.DESC, List.of(2, 1, 0)),
+                    Arguments.of("input", "in\"put", Direction.ASC, List.of(0, 1, 2)),
+                    Arguments.of("input", "in\"put", Direction.DESC, List.of(2, 1, 0)),
+                    Arguments.of("metadata", "me\\ta", Direction.ASC, List.of(0, 1, 2)),
+                    Arguments.of("metadata", "me\\ta", Direction.DESC, List.of(2, 1, 0)));
+        }
+
+        @ParameterizedTest
+        @MethodSource
+        @DisplayName("should sort versioned experiment items by a JSON key (output/input/metadata) through the push-top-limit path")
+        void sortByJsonKeyThroughPushTopLimit(String namespace, String jsonKey, Direction direction,
+                List<Integer> expectedIndexOrder) {
             var datasetName = UUID.randomUUID().toString();
             var datasetId = createDataset(datasetName);
-            createDatasetItems(datasetId, 3);
+            int count = 3;
+            createDatasetItems(datasetId, count);
 
             var version = getLatestVersion(datasetId);
             var datasetItems = datasetResourceClient.getDatasetItems(
@@ -3524,17 +3537,21 @@ class DatasetVersionResourceTest {
 
             var projectName = UUID.randomUUID().toString();
 
-            // One trial per dataset item; each trace's output carries a distinct value under a key that
-            // contains special characters. Sorting by output.* routes through the push-top-limit path, whose
-            // JSON expression binds the key as a parameter (JSONExtractRaw(argMax(...), :param)).
-            int count = 3;
-            String jsonKey = "score's";
+            // One trial per dataset item; each trace carries a distinct value under the requested key (which
+            // contains special characters) in the requested namespace. Sorting by <namespace>.<key> routes
+            // through the push-top-limit path, whose JSON expression binds the key as a parameter
+            // (JSONExtractRaw(argMax(...), :param)).
             var traceIds = IntStream.range(0, count)
                     .mapToObj(i -> {
-                        var trace = factory.manufacturePojo(Trace.class).toBuilder()
-                                .projectName(projectName)
-                                .output(JsonUtils.valueToTree(Map.of(jsonKey, (i + 1) * 10)))
-                                .build();
+                        var value = JsonUtils.valueToTree(Map.of(jsonKey, (i + 1) * 10));
+                        var builder = factory.manufacturePojo(Trace.class).toBuilder().projectName(projectName);
+                        switch (namespace) {
+                            case "output" -> builder.output(value);
+                            case "input" -> builder.input(value);
+                            case "metadata" -> builder.metadata(value);
+                            default -> throw new IllegalStateException("Unexpected namespace: " + namespace);
+                        }
+                        var trace = builder.build();
                         traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
                         return trace.id();
                     })
@@ -3555,37 +3572,25 @@ class DatasetVersionResourceTest {
                 experimentResourceClient.createExperimentItem(Set.of(item), API_KEY, TEST_WORKSPACE);
             });
 
-            String sortField = "output." + jsonKey;
-
-            // Baseline fetch (no sorting) captures the full objects as returned; the assertions below only test order.
+            // Baseline fetch (no sorting) captures the full objects as returned; the assertion only tests order.
             var baseline = datasetResourceClient.getDatasetItemsWithExperimentItems(
                     datasetId, List.of(experimentId), null, null, null, API_KEY, TEST_WORKSPACE).content();
             assertThat(baseline).hasSize(count);
 
-            Map<UUID, Integer> valueByItemId = IntStream.range(0, count).boxed()
-                    .collect(Collectors.toMap(i -> datasetItems.get(i).id(), i -> (i + 1) * 10));
+            Map<UUID, DatasetItem> baselineById = baseline.stream()
+                    .collect(Collectors.toMap(DatasetItem::id, item -> item));
+            List<DatasetItem> expected = expectedIndexOrder.stream()
+                    .map(i -> baselineById.get(datasetItems.get(i).id()))
+                    .toList();
 
-            var expectedAsc = baseline.stream()
-                    .sorted(Comparator.comparingInt(item -> valueByItemId.get(item.id())))
-                    .toList();
-            var expectedDesc = baseline.stream()
-                    .sorted(Comparator.comparingInt((DatasetItem item) -> valueByItemId.get(item.id())).reversed())
-                    .toList();
+            var sorting = List.of(SortingField.builder().field(namespace + "." + jsonKey).direction(direction).build());
+            var sorted = datasetResourceClient.getDatasetItemsWithExperimentItems(
+                    datasetId, List.of(experimentId), null, null, sorting, API_KEY, TEST_WORKSPACE);
 
             // Compare the whole DatasetItem objects, in order - not just their ids.
-            var asc = datasetResourceClient.getDatasetItemsWithExperimentItems(
-                    datasetId, List.of(experimentId), null, null,
-                    List.of(new SortingField(sortField, Direction.ASC)), API_KEY, TEST_WORKSPACE);
-            assertThat(asc.content())
+            assertThat(sorted.content())
                     .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
-                    .containsExactlyElementsOf(expectedAsc);
-
-            var desc = datasetResourceClient.getDatasetItemsWithExperimentItems(
-                    datasetId, List.of(experimentId), null, null,
-                    List.of(new SortingField(sortField, Direction.DESC)), API_KEY, TEST_WORKSPACE);
-            assertThat(desc.content())
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
-                    .containsExactlyElementsOf(expectedDesc);
+                    .containsExactlyElementsOf(expected);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -8760,8 +8760,8 @@ class DatasetsResourceTest {
                 "metadata.m\\path",
                 "output.o';"
         })
-        @DisplayName("when sorting by a JSON key containing special characters, then return items unaffected")
-        void findDatasetItemsWithExperimentItems__whenSortingKeyContainsSpecialCharacters__thenReturnItems(
+        @DisplayName("when sorting by a JSON key containing special characters, then items are sorted by that key")
+        void findDatasetItemsWithExperimentItems__whenSortingByJsonKeyWithSpecialCharacters__thenSortedByThatKey(
                 String jsonKeyField) {
 
             String workspaceName = UUID.randomUUID().toString();
@@ -8773,11 +8773,28 @@ class DatasetsResourceTest {
             var dataset = buildDataset().toBuilder().id(null).build();
             var datasetId = createAndAssert(dataset, apiKey, workspaceName);
 
+            // Namespace (output/input/metadata) and the JSON key (with special characters) being sorted on.
+            String namespace = jsonKeyField.substring(0, jsonKeyField.indexOf('.'));
+            String jsonKey = jsonKeyField.substring(jsonKeyField.indexOf('.') + 1);
+
+            // Seed each trace with a DISTINCT, sortable value stored under exactly that key, so the
+            // assertions below prove the key is actually used for ordering (not ignored/missing/constant).
+            // Values 10..50 are assigned to item indices 0..4 (equal-length numeric strings sort in
+            // numeric order under JSONExtractRaw's raw-string comparison).
             String projectName = GENERATOR.generate().toString();
-            List<Trace> traces = IntStream.range(0, 5)
-                    .mapToObj(i -> factory.manufacturePojo(Trace.class).toBuilder()
-                            .projectName(projectName)
-                            .build())
+            int count = 5;
+            List<Trace> traces = IntStream.range(0, count)
+                    .mapToObj(i -> {
+                        var value = JsonUtils.valueToTree(Map.of(jsonKey, (i + 1) * 10));
+                        var builder = factory.manufacturePojo(Trace.class).toBuilder().projectName(projectName);
+                        switch (namespace) {
+                            case "output" -> builder.output(value);
+                            case "input" -> builder.input(value);
+                            case "metadata" -> builder.metadata(value);
+                            default -> throw new IllegalStateException("Unexpected namespace: " + namespace);
+                        }
+                        return builder.build();
+                    })
                     .toList();
 
             traces.forEach(trace -> createAndAssert(trace, workspaceName, apiKey));
@@ -8812,20 +8829,59 @@ class DatasetsResourceTest {
 
             createAndAssert(new ExperimentItemsBatch(experimentItems), apiKey, workspaceName);
 
-            var sorting = SortingField.builder().field(jsonKeyField).direction(Direction.DESC).build();
-            var sortingParam = URLEncoder.encode(JsonUtils.writeValueAsString(List.of(sorting)),
-                    StandardCharsets.UTF_8);
             var experimentIdsParam = JsonUtils.writeValueAsString(List.of(experiment.id()));
 
-            // The JSON key is bound as a JSONExtractRaw parameter value, so a key containing special
-            // characters is treated as data: the request succeeds and returns all items unaffected.
-            try (var actualResponse = client.target(BASE_RESOURCE_URI.formatted(baseURI))
+            // Baseline fetch (no sorting) to capture the full DatasetItem objects exactly as the API returns them.
+            List<DatasetItem> baselineItems = fetchDatasetItems(datasetId, experimentIdsParam, null, null,
+                    apiKey, workspaceName);
+            assertThat(baselineItems).hasSize(count);
+
+            // Item index i was seeded with value (i+1)*10; order the full objects by that value.
+            Map<UUID, Integer> valueByItemId = IntStream.range(0, count).boxed()
+                    .collect(Collectors.toMap(i -> datasetItemBatch.items().get(i).id(), i -> (i + 1) * 10));
+
+            List<DatasetItem> expectedAsc = baselineItems.stream()
+                    .sorted(Comparator.comparingInt(item -> valueByItemId.get(item.id())))
+                    .toList();
+            List<DatasetItem> expectedDesc = baselineItems.stream()
+                    .sorted(Comparator.comparingInt((DatasetItem item) -> valueByItemId.get(item.id())).reversed())
+                    .toList();
+
+            assertSortedByKey(datasetId, experimentIdsParam, jsonKeyField, Direction.ASC, apiKey, workspaceName,
+                    expectedAsc);
+            assertSortedByKey(datasetId, experimentIdsParam, jsonKeyField, Direction.DESC, apiKey, workspaceName,
+                    expectedDesc);
+        }
+
+        private void assertSortedByKey(UUID datasetId, String experimentIdsParam, String sortField,
+                Direction direction, String apiKey, String workspaceName, List<DatasetItem> expectedItems) {
+            List<DatasetItem> actualItems = fetchDatasetItems(datasetId, experimentIdsParam, sortField, direction,
+                    apiKey, workspaceName);
+
+            // Compare the whole DatasetItem objects, in order - not just their ids - so the assertion proves
+            // the bound key actually drives the ordering. Volatile/derived fields are ignored per suite convention.
+            assertThat(actualItems)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactlyElementsOf(expectedItems);
+        }
+
+        private List<DatasetItem> fetchDatasetItems(UUID datasetId, String experimentIdsParam, String sortField,
+                Direction direction, String apiKey, String workspaceName) {
+            var target = client.target(BASE_RESOURCE_URI.formatted(baseURI))
                     .path(datasetId.toString())
                     .path(DATASET_ITEMS_WITH_EXPERIMENT_ITEMS_PATH)
                     .queryParam("page", 1)
                     .queryParam("size", 10)
-                    .queryParam("experiment_ids", experimentIdsParam)
-                    .queryParam("sorting", sortingParam)
+                    .queryParam("experiment_ids", experimentIdsParam);
+
+            if (sortField != null) {
+                var sorting = SortingField.builder().field(sortField).direction(direction).build();
+                var sortingParam = URLEncoder.encode(JsonUtils.writeValueAsString(List.of(sorting)),
+                        StandardCharsets.UTF_8);
+                target = target.queryParam("sorting", sortingParam);
+            }
+
+            try (var actualResponse = target
                     .request()
                     .header(HttpHeaders.AUTHORIZATION, apiKey)
                     .header(WORKSPACE_HEADER, workspaceName)
@@ -8834,8 +8890,7 @@ class DatasetsResourceTest {
                 assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
                 assertThat(actualResponse.hasEntity()).isTrue();
 
-                var actualPage = actualResponse.readEntity(DatasetItemPage.class);
-                assertThat(actualPage.content()).hasSize(5);
+                return actualResponse.readEntity(DatasetItemPage.class).content();
             }
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceTest.java
@@ -8752,6 +8752,93 @@ class DatasetsResourceTest {
             assertThat(firstFetchIds).containsExactlyElementsOf(secondFetchIds);
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "output.x'",
+                "output.a'b",
+                "input.k\"v",
+                "metadata.m\\path",
+                "output.o';"
+        })
+        @DisplayName("when sorting by a JSON key containing special characters, then return items unaffected")
+        void findDatasetItemsWithExperimentItems__whenSortingKeyContainsSpecialCharacters__thenReturnItems(
+                String jsonKeyField) {
+
+            String workspaceName = UUID.randomUUID().toString();
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var dataset = buildDataset().toBuilder().id(null).build();
+            var datasetId = createAndAssert(dataset, apiKey, workspaceName);
+
+            String projectName = GENERATOR.generate().toString();
+            List<Trace> traces = IntStream.range(0, 5)
+                    .mapToObj(i -> factory.manufacturePojo(Trace.class).toBuilder()
+                            .projectName(projectName)
+                            .build())
+                    .toList();
+
+            traces.forEach(trace -> createAndAssert(trace, workspaceName, apiKey));
+
+            var datasetItemBatch = DatasetResourceClient.buildDatasetItemBatch(factory).toBuilder()
+                    .datasetId(datasetId)
+                    .items(traces.stream()
+                            .map(trace -> DatasetResourceClient.buildDatasetItem(factory).toBuilder()
+                                    .datasetId(datasetId)
+                                    .traceId(trace.id())
+                                    .spanId(null)
+                                    .source(DatasetItemSource.TRACE)
+                                    .build())
+                            .toList())
+                    .build();
+
+            putAndAssert(datasetItemBatch, workspaceName, apiKey);
+
+            var experiment = experimentResourceClient.createPartialExperiment()
+                    .datasetName(dataset.name())
+                    .build();
+
+            createAndAssert(experiment, apiKey, workspaceName);
+
+            var experimentItems = IntStream.range(0, traces.size())
+                    .mapToObj(i -> factory.manufacturePojo(ExperimentItem.class).toBuilder()
+                            .experimentId(experiment.id())
+                            .datasetItemId(datasetItemBatch.items().get(i).id())
+                            .traceId(traces.get(i).id())
+                            .build())
+                    .collect(Collectors.toSet());
+
+            createAndAssert(new ExperimentItemsBatch(experimentItems), apiKey, workspaceName);
+
+            var sorting = SortingField.builder().field(jsonKeyField).direction(Direction.DESC).build();
+            var sortingParam = URLEncoder.encode(JsonUtils.writeValueAsString(List.of(sorting)),
+                    StandardCharsets.UTF_8);
+            var experimentIdsParam = JsonUtils.writeValueAsString(List.of(experiment.id()));
+
+            // The JSON key is bound as a JSONExtractRaw parameter value, so a key containing special
+            // characters is treated as data: the request succeeds and returns all items unaffected.
+            try (var actualResponse = client.target(BASE_RESOURCE_URI.formatted(baseURI))
+                    .path(datasetId.toString())
+                    .path(DATASET_ITEMS_WITH_EXPERIMENT_ITEMS_PATH)
+                    .queryParam("page", 1)
+                    .queryParam("size", 10)
+                    .queryParam("experiment_ids", experimentIdsParam)
+                    .queryParam("sorting", sortingParam)
+                    .request()
+                    .header(HttpHeaders.AUTHORIZATION, apiKey)
+                    .header(WORKSPACE_HEADER, workspaceName)
+                    .get()) {
+
+                assertThat(actualResponse.getStatusInfo().getStatusCode()).isEqualTo(200);
+                assertThat(actualResponse.hasEntity()).isTrue();
+
+                var actualPage = actualResponse.readEntity(DatasetItemPage.class);
+                assertThat(actualPage.content()).hasSize(5);
+            }
+        }
+
         private Stream<Arguments> findDatasetItemsWithExperimentItems__whenSorting__thenReturnItemsSortedByValidFields() {
             return Stream.of(
                     // ID field sorting

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
@@ -61,4 +61,22 @@ class SortingFactoryTest {
         assertThatCode(() -> datasetsFactory.newSorting("[{\"direction\":\"DESC\"}]")).doesNotThrowAnyException();
         assertThat(datasetsFactory.newSorting("[{\"direction\":\"DESC\"}]")).isEmpty();
     }
+
+    @Test
+    @DisplayName("bindKeyParam is generated server-side for dynamic fields and not taken from input")
+    void newSorting__generatesBindKeyParamServerSide() {
+        var datasetsFactory = new SortingFactoryDatasets();
+
+        // bindKeyParam is an internal value that builds the SQL parameter placeholder name (bindKey()).
+        // A value supplied in the request JSON must be ignored: the placeholder name must always be a
+        // safe, server-generated identifier.
+        var result = datasetsFactory
+                .newSorting("[{\"field\":\"output.foo\",\"bind_key_param\":\"clientProvided123\"}]");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).bindKeyParam())
+                .isNotEqualTo("clientProvided123")
+                .matches("[A-Za-z0-9_]+");
+        assertThat(result.get(0).bindKey()).matches("sorting_param_[A-Za-z0-9_]+");
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/sorting/SortingFactoryTest.java
@@ -54,8 +54,8 @@ class SortingFactoryTest {
 
     @Test
     void newSorting__whenNullFieldOnDatasetsFactory__ignoresItWithoutThrowing() {
-        // Regression: the null field reaches SortingFactoryDatasets.processFields -> ensureBindKeyParam,
-        // which called field.startsWith(...) and NPE'd before the validity filter ran.
+        // Regression: a null/blank field must be dropped by newSorting's blank-field filter before any
+        // per-field processing, so it never reaches field.startsWith(...) / field.contains(...).
         var datasetsFactory = new SortingFactoryDatasets();
 
         assertThatCode(() -> datasetsFactory.newSorting("[{\"direction\":\"DESC\"}]")).doesNotThrowAnyException();


### PR DESCRIPTION
## Details

Fixes a ClickHouse SQL injection (**CWE-89**) in the dataset-item sorting path.
Sorting by `output.*` / `input.*` / `metadata.*` interpolated the JSON key
**literally** into a `JSONExtractRaw(<col>, '<key>')` expression rendered into the
`ORDER BY` of the raw SQL. The sort-field validator checked only the field prefix,
never the key content — so a key containing a single quote broke out of the string
literal and injected attacker-controlled SQL into the executed query. Reachable via
`GET /v1/private/datasets/{id}/items/experiments/items?sorting=…` (and the
`DatasetItemVersionDAO` call site).

- **Severity:** Medium — CVSS:3.1 `AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` = **6.5**
  (authenticated workspace user; confidentiality-only, no writes/DDL — the injection
  sits in `ORDER BY`).
- **Fixed in release:** **[2.2.35](https://github.com/comet-ml/opik/releases/tag/2.2.35)**
  (affected: ≤ 2.2.34).

**Fix:** bind the JSON sort key as a ClickHouse query parameter — the exact path
`data.*` already uses — instead of interpolating it into a quoted literal. Applied to
both the `DatasetItemDAO` and `DatasetItemVersionDAO` call sites.

- `FilterQueryBuilder`: template uses a bound placeholder (`JSONExtractRaw(col, :param)`);
  key bound via `field.bindKey()`
- `SortingFactoryDatasets`: JSON fields go through the standard dynamic `bindKeyParam` path
- `SortingQueryBuilder`: bind all dynamic keys; removed now-unused overloads
- `DatasetItemDAO`: single-arg `hasDynamicKeys` / `bindDynamicKeys`

## Credit

Responsibly disclosed by **Santosh Kumar Puppala**
([@Santoshkumarpuppala](https://github.com/Santoshkumarpuppala)) via coordinated
disclosure. Thank you for the report and for holding details until the fix shipped. 🙏

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-8023

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus
- Scope: Implemented the parameter-binding change and the added integration test
- Human verification: Reviewed the full diff; ran spotless and the dataset-item sorting integration suite locally (35/35 pass)

## Testing
- `mvn -o test -Dtest='DatasetsResourceTest$FindDatasetItemsWithExperimentItemsSortingTest'`
  — 35/35 pass (existing valid-field sort cases + new cases for JSON keys containing
  special characters / injection payloads)
- `mvn -o spotless:check` — clean
- Environment: local Maven, Testcontainers (ClickHouse / MySQL / Redis)

## Documentation
N/A — no user-facing or documented behavior change for valid sort keys.
