### PR TITLE
feat(ui): bulk annotate traces and spans from the selection bar

### DIFF
--- a/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
@@ -1,0 +1,63 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import chunk from "lodash/chunk";
+import { AxiosError } from "axios";
+
+import api, { SPANS_KEY, SPANS_REST_ENDPOINT, TRACE_KEY } from "@/api/api";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import { useToast } from "@/ui/use-toast";
+import { extractErrorMessage } from "@/lib/errors";
+import {
+  FeedbackScoreBatchEntry,
+  MAX_FEEDBACK_SCORES_PER_BATCH,
+} from "@/lib/feedback-scores";
+
+type UseSpanFeedbackScoreBatchSetMutationParams = {
+  projectName: string;
+  scores: FeedbackScoreBatchEntry[];
+};
+
+const useSpanFeedbackScoreBatchSetMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      projectName,
+      scores,
+    }: UseSpanFeedbackScoreBatchSetMutationParams) => {
+      for (const scoresChunk of chunk(scores, MAX_FEEDBACK_SCORES_PER_BATCH)) {
+        await api.put(`${SPANS_REST_ENDPOINT}feedback-scores`, {
+          scores: scoresChunk.map((score) => ({
+            id: score.id,
+            // The backend groups the batch by project name and derives project_id from it,
+            // falling back to the default project when it is blank, so it has to be sent.
+            project_name: projectName,
+            name: score.name,
+            category_name: score.categoryName,
+            value: score.value,
+            reason: score.reason,
+            source: FEEDBACK_SCORE_TYPE.ui,
+          })),
+        });
+      }
+    },
+    onError: (error: AxiosError) => {
+      toast({
+        title: "Error",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: async () => {
+      // Mirror the span branch of useTraceFeedbackScoreSetMutation: refresh the spans list,
+      // its columns/statistics and the trace details panel, which shows the aggregated span
+      // scores. The batch only carries span ids, so the trace cache is invalidated broadly.
+      await queryClient.invalidateQueries({ queryKey: [SPANS_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["spans-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
+      await queryClient.invalidateQueries({ queryKey: [TRACE_KEY] });
+    },
+  });
+};
+
+export default useSpanFeedbackScoreBatchSetMutation;

--- a/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useSpanFeedbackScoreBatchSetMutation.ts
@@ -2,7 +2,13 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import chunk from "lodash/chunk";
 import { AxiosError } from "axios";
 
-import api, { SPANS_KEY, SPANS_REST_ENDPOINT, TRACE_KEY } from "@/api/api";
+import api, {
+  COMPARE_EXPERIMENTS_KEY,
+  SPANS_KEY,
+  SPANS_REST_ENDPOINT,
+  TRACE_KEY,
+  TRACES_KEY,
+} from "@/api/api";
 import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
 import { extractErrorMessage } from "@/lib/errors";
@@ -49,13 +55,25 @@ const useSpanFeedbackScoreBatchSetMutation = () => {
       });
     },
     onSettled: async () => {
-      // Mirror the span branch of useTraceFeedbackScoreSetMutation: refresh the spans list,
-      // its columns/statistics and the trace details panel, which shows the aggregated span
-      // scores. The batch only carries span ids, so the trace cache is invalidated broadly.
+      // Span scores also roll up onto traces and experiment views — same keys as
+      // useTraceFeedbackScoreSetMutation's span branch + its always-on set.
       await queryClient.invalidateQueries({ queryKey: [SPANS_KEY] });
       await queryClient.invalidateQueries({ queryKey: ["spans-columns"] });
       await queryClient.invalidateQueries({ queryKey: ["spans-statistic"] });
       await queryClient.invalidateQueries({ queryKey: [TRACE_KEY] });
+      await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["experiment-items-statistic"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["experiments-columns"],
+      });
+      await queryClient.invalidateQueries({ queryKey: ["experiment"] });
+      await queryClient.invalidateQueries({
+        queryKey: [COMPARE_EXPERIMENTS_KEY],
+      });
     },
   });
 };

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
@@ -1,0 +1,70 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import chunk from "lodash/chunk";
+import { AxiosError } from "axios";
+
+import api, { TRACE_KEY, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+import { useToast } from "@/ui/use-toast";
+import { extractErrorMessage } from "@/lib/errors";
+import {
+  FeedbackScoreBatchEntry,
+  MAX_FEEDBACK_SCORES_PER_BATCH,
+} from "@/lib/feedback-scores";
+
+type UseTraceFeedbackScoreBatchSetMutationParams = {
+  projectName: string;
+  scores: FeedbackScoreBatchEntry[];
+};
+
+const useTraceFeedbackScoreBatchSetMutation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({
+      projectName,
+      scores,
+    }: UseTraceFeedbackScoreBatchSetMutationParams) => {
+      for (const scoresChunk of chunk(scores, MAX_FEEDBACK_SCORES_PER_BATCH)) {
+        await api.put(`${TRACES_REST_ENDPOINT}feedback-scores`, {
+          scores: scoresChunk.map((score) => ({
+            id: score.id,
+            // The backend groups the batch by project name and derives project_id from it,
+            // falling back to the default project when it is blank, so it has to be sent.
+            project_name: projectName,
+            name: score.name,
+            category_name: score.categoryName,
+            value: score.value,
+            reason: score.reason,
+            source: FEEDBACK_SCORE_TYPE.ui,
+          })),
+        });
+      }
+    },
+    onError: (error: AxiosError) => {
+      toast({
+        title: "Error",
+        description: extractErrorMessage(error),
+        variant: "destructive",
+      });
+    },
+    onSettled: async (data, error, variables) => {
+      // Mirror useTraceFeedbackScoreSetMutation: the scores feed the traces list, its
+      // columns/statistics and the per-trace details panel.
+      await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
+      await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+
+      const traceIds = [...new Set(variables.scores.map((score) => score.id))];
+      await Promise.all(
+        traceIds.map((traceId) =>
+          queryClient.invalidateQueries({
+            queryKey: [TRACE_KEY, { traceId }],
+          }),
+        ),
+      );
+    },
+  });
+};
+
+export default useTraceFeedbackScoreBatchSetMutation;

--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreBatchSetMutation.ts
@@ -2,7 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import chunk from "lodash/chunk";
 import { AxiosError } from "axios";
 
-import api, { TRACE_KEY, TRACES_KEY, TRACES_REST_ENDPOINT } from "@/api/api";
+import api, {
+  COMPARE_EXPERIMENTS_KEY,
+  TRACE_KEY,
+  TRACES_KEY,
+  TRACES_REST_ENDPOINT,
+} from "@/api/api";
 import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
 import { useToast } from "@/ui/use-toast";
 import { extractErrorMessage } from "@/lib/errors";
@@ -49,11 +54,20 @@ const useTraceFeedbackScoreBatchSetMutation = () => {
       });
     },
     onSettled: async (data, error, variables) => {
-      // Mirror useTraceFeedbackScoreSetMutation: the scores feed the traces list, its
-      // columns/statistics and the per-trace details panel.
+      // Same invalidation set as useTraceFeedbackScoreSetMutation.
       await queryClient.invalidateQueries({ queryKey: [TRACES_KEY] });
       await queryClient.invalidateQueries({ queryKey: ["traces-columns"] });
       await queryClient.invalidateQueries({ queryKey: ["traces-statistic"] });
+      await queryClient.invalidateQueries({
+        queryKey: ["experiment-items-statistic"],
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ["experiments-columns"],
+      });
+      await queryClient.invalidateQueries({ queryKey: ["experiment"] });
+      await queryClient.invalidateQueries({
+        queryKey: [COMPARE_EXPERIMENTS_KEY],
+      });
 
       const traceIds = [...new Set(variables.scores.map((score) => score.id))];
       await Promise.all(

--- a/apps/opik-frontend/src/lib/feedback-scores.tsx
+++ b/apps/opik-frontend/src/lib/feedback-scores.tsx
@@ -637,3 +637,18 @@ export const combineExperimentScoresAsMap = (row: {
 
   return result;
 };
+
+// A single entry of the traces/spans batch feedback score payload: the entity id plus the
+// score to set on it.
+export type FeedbackScoreBatchEntry = {
+  id: string;
+  name: string;
+  value: number;
+  categoryName?: string;
+  reason?: string;
+};
+
+// The backend caps a feedback score batch at 1000 items
+// (FeedbackScoreBatchContainer: `@Size(min = 1, max = 1000)`), and annotating a selection
+// produces `rows * scores` entries, so larger payloads have to be split.
+export const MAX_FEEDBACK_SCORES_PER_BATCH = 1000;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.test.tsx
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { TooltipProvider } from "@/ui/tooltip";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { Span, Trace } from "@/types/traces";
+import { UpdateFeedbackScoreData } from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/types";
+import AddAnnotationDialog from "./AddAnnotationDialog";
+
+const mockSetTraceFeedbackScores = vi.fn();
+const mockSetSpanFeedbackScores = vi.fn();
+
+vi.mock("@/api/traces/useTraceFeedbackScoreBatchSetMutation", () => ({
+  default: () => ({
+    mutateAsync: mockSetTraceFeedbackScores,
+    isPending: false,
+  }),
+}));
+vi.mock("@/api/traces/useSpanFeedbackScoreBatchSetMutation", () => ({
+  default: () => ({
+    mutateAsync: mockSetSpanFeedbackScores,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+type StubFeedbackScoresEditorProps = {
+  onUpdateFeedbackScore: (update: UpdateFeedbackScoreData) => void;
+  onDeleteFeedbackScore: (name: string) => void;
+};
+
+vi.mock(
+  "@/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor",
+  () => {
+    const Stub = ({
+      onUpdateFeedbackScore,
+      onDeleteFeedbackScore,
+    }: StubFeedbackScoresEditorProps) => (
+      <div data-testid="feedback-scores-editor">
+        <button
+          onClick={() =>
+            onUpdateFeedbackScore({
+              name: "Relevance",
+              value: 1,
+              categoryName: "Yes",
+              reason: "looks good",
+            })
+          }
+        >
+          set-score
+        </button>
+        <button onClick={() => onDeleteFeedbackScore("Relevance")}>
+          clear-score
+        </button>
+      </div>
+    );
+    Stub.displayName = "FeedbackScoresEditorStub";
+    const StubHeader = () => null;
+    StubHeader.displayName = "FeedbackScoresEditorHeaderStub";
+    const StubFooter = () => null;
+    StubFooter.displayName = "FeedbackScoresEditorFooterStub";
+    Stub.Header = StubHeader;
+    Stub.Footer = StubFooter;
+    return { default: Stub };
+  },
+);
+
+describe("AddAnnotationDialog", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+    mockSetTraceFeedbackScores.mockResolvedValue(undefined);
+    mockSetSpanFeedbackScores.mockResolvedValue(undefined);
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+
+  const mockTrace: Trace = {
+    id: "row-1",
+    name: "Test Trace",
+    input: { prompt: "test input" },
+    output: { response: "test output" },
+    start_time: "2024-01-01T00:00:00Z",
+    end_time: "2024-01-01T00:00:01Z",
+    duration: 1000,
+    created_at: "2024-01-01T00:00:00Z",
+    last_updated_at: "2024-01-01T00:00:01Z",
+    tags: [],
+    metadata: {},
+    feedback_scores: [],
+    comments: [],
+    project_id: "project-1",
+  };
+
+  const ROWS: Array<Trace | Span> = [mockTrace, { ...mockTrace, id: "row-2" }];
+
+  const renderDialog = (type: TRACE_DATA_TYPE) =>
+    render(
+      <AddAnnotationDialog
+        rows={ROWS}
+        open
+        setOpen={vi.fn()}
+        projectName="project-name"
+        type={type}
+      />,
+      { wrapper },
+    );
+
+  const EXPECTED_SCORES = [
+    {
+      id: "row-1",
+      name: "Relevance",
+      value: 1,
+      categoryName: "Yes",
+      reason: "looks good",
+    },
+    {
+      id: "row-2",
+      name: "Relevance",
+      value: 1,
+      categoryName: "Yes",
+      reason: "looks good",
+    },
+  ];
+
+  it("sends one batch of trace scores, carrying the project name", async () => {
+    renderDialog(TRACE_DATA_TYPE.traces);
+
+    fireEvent.click(screen.getByRole("button", { name: "set-score" }));
+    fireEvent.click(screen.getByTestId("apply-annotation-button"));
+
+    await waitFor(() =>
+      expect(mockSetTraceFeedbackScores).toHaveBeenCalledTimes(1),
+    );
+    expect(mockSetTraceFeedbackScores).toHaveBeenCalledWith({
+      projectName: "project-name",
+      scores: EXPECTED_SCORES,
+    });
+    expect(mockSetSpanFeedbackScores).not.toHaveBeenCalled();
+  });
+
+  it("routes span selections to the spans endpoint, not the traces one", async () => {
+    renderDialog(TRACE_DATA_TYPE.spans);
+
+    fireEvent.click(screen.getByRole("button", { name: "set-score" }));
+    fireEvent.click(screen.getByTestId("apply-annotation-button"));
+
+    await waitFor(() =>
+      expect(mockSetSpanFeedbackScores).toHaveBeenCalledTimes(1),
+    );
+    expect(mockSetSpanFeedbackScores).toHaveBeenCalledWith({
+      projectName: "project-name",
+      scores: EXPECTED_SCORES,
+    });
+    expect(mockSetTraceFeedbackScores).not.toHaveBeenCalled();
+  });
+
+  it("enables apply only while at least one score is set", () => {
+    renderDialog(TRACE_DATA_TYPE.traces);
+
+    expect(screen.getByTestId("apply-annotation-button")).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "set-score" }));
+    expect(screen.getByTestId("apply-annotation-button")).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "clear-score" }));
+    expect(screen.getByTestId("apply-annotation-button")).toBeDisabled();
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog.tsx
@@ -1,0 +1,163 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  FEEDBACK_SCORE_TYPE,
+  Span,
+  Trace,
+  TraceFeedbackScore,
+} from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { useToast } from "@/ui/use-toast";
+import FeedbackScoresEditor from "@/v2/pages-shared/traces/FeedbackScoresEditor/FeedbackScoresEditor";
+import { UpdateFeedbackScoreData } from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/types";
+import useTraceFeedbackScoreBatchSetMutation from "@/api/traces/useTraceFeedbackScoreBatchSetMutation";
+import useSpanFeedbackScoreBatchSetMutation from "@/api/traces/useSpanFeedbackScoreBatchSetMutation";
+
+const ENTITY_COPY: Record<TRACE_DATA_TYPE, { one: string; many: string }> = {
+  [TRACE_DATA_TYPE.traces]: { one: "trace", many: "traces" },
+  [TRACE_DATA_TYPE.spans]: { one: "span", many: "spans" },
+};
+
+type AddAnnotationDialogProps = {
+  rows: Array<Trace | Span>;
+  open: boolean | number;
+  setOpen: (open: boolean | number) => void;
+  projectName: string;
+  type: TRACE_DATA_TYPE;
+};
+
+const AddAnnotationDialog: React.FunctionComponent<
+  AddAnnotationDialogProps
+> = ({ rows, open, setOpen, projectName, type }) => {
+  const { toast } = useToast();
+  const [pendingScores, setPendingScores] = useState<
+    Record<string, TraceFeedbackScore>
+  >({});
+
+  const { mutateAsync: setTraceFeedbackScores, isPending: isTracePending } =
+    useTraceFeedbackScoreBatchSetMutation();
+  const { mutateAsync: setSpanFeedbackScores, isPending: isSpanPending } =
+    useSpanFeedbackScoreBatchSetMutation();
+
+  const isPending = isTracePending || isSpanPending;
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    setPendingScores({});
+  }, [setOpen]);
+
+  const onUpdateFeedbackScore = useCallback(
+    (update: UpdateFeedbackScoreData) => {
+      setPendingScores((scores) => ({
+        ...scores,
+        [update.name]: {
+          name: update.name,
+          value: update.value,
+          category_name: update.categoryName,
+          reason: update.reason,
+          source: FEEDBACK_SCORE_TYPE.ui,
+        },
+      }));
+    },
+    [],
+  );
+
+  const onDeleteFeedbackScore = useCallback((name: string) => {
+    setPendingScores((scores) => {
+      const nextScores = { ...scores };
+      delete nextScores[name];
+      return nextScores;
+    });
+  }, []);
+
+  const feedbackScores = useMemo(
+    () => Object.values(pendingScores),
+    [pendingScores],
+  );
+
+  const entityCopy = ENTITY_COPY[type];
+  const entityLabel = rows.length === 1 ? entityCopy.one : entityCopy.many;
+
+  const handleApply = async () => {
+    const scores = rows.flatMap((row) =>
+      feedbackScores.map((score) => ({
+        id: row.id,
+        name: score.name,
+        value: score.value,
+        categoryName: score.category_name,
+        reason: score.reason,
+      })),
+    );
+
+    try {
+      if (type === TRACE_DATA_TYPE.traces) {
+        await setTraceFeedbackScores({ projectName, scores });
+      } else {
+        await setSpanFeedbackScores({ projectName, scores });
+      }
+
+      toast({
+        title: "Feedback scores applied",
+        description: `${feedbackScores.length} ${
+          feedbackScores.length === 1 ? "score" : "scores"
+        } applied to ${rows.length} ${entityLabel}`,
+      });
+      handleClose();
+    } catch {
+      // Error handling is done by the mutation hook
+    }
+  };
+
+  return (
+    <Dialog
+      open={Boolean(open)}
+      onOpenChange={(nextOpen) => !nextOpen && handleClose()}
+    >
+      <DialogContent className="outline-none sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>
+            Annotate {rows.length} {entityLabel}
+          </DialogTitle>
+          <DialogDescription className="mt-2">
+            Set feedback scores to apply to all selected {entityLabel}.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-80 overflow-y-auto py-2">
+          <FeedbackScoresEditor
+            feedbackScores={feedbackScores}
+            onUpdateFeedbackScore={onUpdateFeedbackScore}
+            onDeleteFeedbackScore={onDeleteFeedbackScore}
+            header={<FeedbackScoresEditor.Header title="Feedback scores" />}
+            footer={
+              <FeedbackScoresEditor.Footer entityCopy={entityCopy.many} />
+            }
+          />
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleApply}
+            disabled={feedbackScores.length === 0 || isPending}
+            data-testid="apply-annotation-button"
+          >
+            Apply to {rows.length} {entityLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddAnnotationDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash } from "lucide-react";
+import { PenLine, Tag, Trash } from "lucide-react";
 import slugify from "slugify";
 import { cn } from "@/lib/utils";
 import { Button, ButtonProps } from "@/ui/button";
@@ -12,6 +12,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/v2/pages-shared/traces/AddTagDialog/AddTagDialog";
+import AddAnnotationDialog from "@/v2/pages-shared/traces/AddAnnotationDialog/AddAnnotationDialog";
 import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
 import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
@@ -70,7 +71,11 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
   const {
-    permissions: { canDeleteTraces, canLogTraceSpanThread },
+    permissions: {
+      canAnnotateTraceSpanThread,
+      canDeleteTraces,
+      canLogTraceSpanThread,
+    },
   } = usePermissions();
 
   const showEvaluate =
@@ -143,6 +148,16 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           isLoading={isRulesLoading}
         />
       )}
+      {canAnnotateTraceSpanThread && (
+        <AddAnnotationDialog
+          key={`annotate-${resetKeyRef.current}`}
+          rows={selectedRows}
+          open={open === 5}
+          setOpen={setOpen}
+          projectName={projectName}
+          type={type}
+        />
+      )}
       <AddToDropdown
         getDataForExport={getDataForExport}
         selectedRows={selectedRows}
@@ -164,6 +179,23 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           >
             <Tag className={leadIconClassName} />
             <span>Manage tags</span>
+          </Button>
+        </TooltipWrapper>
+      )}
+      {canAnnotateTraceSpanThread && (
+        <TooltipWrapper content="Annotate">
+          <Button
+            variant={buttonVariant}
+            size={buttonSize}
+            onClick={() => {
+              setOpen(5);
+              resetKeyRef.current = resetKeyRef.current + 1;
+            }}
+            disabled={disabled}
+            data-testid="traces-bulk-annotate-button"
+          >
+            <PenLine className={leadIconClassName} />
+            <span>Annotate</span>
           </Button>
         </TooltipWrapper>
       )}


### PR DESCRIPTION
/claim #1010

Fixes #1010

Adds bulk annotation to the v2 traces and LLM-calls selection bar using FeedbackScoresEditor. Feedback scores use chunked batch PUT requests with project names, are gated by canAnnotateTraceSpanThread, and route spans and traces to their respective endpoints.

This follows #7066 and is not #7680, which targets v1.