### PR TITLE
[OPIK-8021] [FE] perf: make the score cell read-only unless the column is editable

### DIFF
--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -63,7 +63,6 @@ declare module "@tanstack/react-table" {
     rowHeightStyle: React.CSSProperties;
     onCommentsReply?: (row: TData, idx?: number) => void;
     aggregationMap?: Record<string, unknown>;
-    enableUserFeedbackEditing?: boolean;
     projectId?: string;
     projectName?: string;
   }

--- a/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/FeedbackScoreCell.tsx
@@ -19,27 +19,24 @@ import { BaseTraceData } from "@/types/traces";
 import useFeedbackScoreInlineEdit from "@/hooks/useFeedbackScoreInlineEdit";
 import { isObjectSpan, isObjectThread } from "@/lib/traces";
 import { ROW_HEIGHT } from "@/types/shared";
+import { USER_FEEDBACK_NAME } from "@/constants/shared";
 
-const FeedbackScoreCell = (context: CellContext<unknown, unknown>) => {
-  const feedbackScore = context.getValue() as TraceFeedbackScore | undefined;
+type FeedbackScoreCellContentProps = {
+  context: CellContext<unknown, unknown>;
+  feedbackScore?: TraceFeedbackScore;
+  isUserFeedbackColumn?: boolean;
+  onValueChange?: (name: string, value: number) => void;
+};
+
+const FeedbackScoreCellContent = ({
+  context,
+  feedbackScore,
+  isUserFeedbackColumn = false,
+  onValueChange,
+}: FeedbackScoreCellContentProps) => {
   const reason = feedbackScore?.reason;
-  const row = context.row.original as BaseTraceData | Thread | Span;
-
-  const {
-    projectId,
-    projectName,
-    rowHeight = ROW_HEIGHT.small,
-    enableUserFeedbackEditing = false,
-  } = (context.table.options.meta ?? {}) as TableMeta<unknown>;
-
-  const { handleValueChange } = useFeedbackScoreInlineEdit({
-    id: row.id,
-    isThread: isObjectThread(row),
-    isSpan: isObjectSpan(row),
-    feedbackScore,
-    projectId,
-    projectName,
-  });
+  const { rowHeight = ROW_HEIGHT.small } = (context.table.options.meta ??
+    {}) as TableMeta<unknown>;
 
   const reasons = useMemo(() => {
     if (getIsMultiValueFeedbackScore(feedbackScore?.value_by_author)) {
@@ -62,11 +59,6 @@ const FeedbackScoreCell = (context: CellContext<unknown, unknown>) => {
     feedbackScore?.last_updated_at,
   ]);
 
-  // Editing is now enabled for all threads regardless of status
-  const isEditingEnabled = enableUserFeedbackEditing;
-
-  const isUserFeedbackColumn =
-    isEditingEnabled && context.column.id === "feedback_scores_User feedback";
   const isCompact =
     rowHeight === ROW_HEIGHT.small || rowHeight === ROW_HEIGHT.medium;
 
@@ -85,7 +77,7 @@ const FeedbackScoreCell = (context: CellContext<unknown, unknown>) => {
       <FeedbackScoreCellValue
         feedbackScore={feedbackScore}
         isUserFeedbackColumn={isUserFeedbackColumn}
-        onValueChange={handleValueChange}
+        onValueChange={onValueChange}
         size={isCompact ? "sm" : "md"}
       />
 
@@ -104,6 +96,48 @@ const FeedbackScoreCell = (context: CellContext<unknown, unknown>) => {
     </CellWrapper>
   );
 };
+
+// The default cell is read-only, so a table only pays for the inline-edit
+// hooks on the one column that can actually be edited (see
+// EditableFeedbackScoreCell and resolveFeedbackScoreCell).
+const FeedbackScoreCell = (context: CellContext<unknown, unknown>) => (
+  <FeedbackScoreCellContent
+    context={context}
+    feedbackScore={context.getValue() as TraceFeedbackScore | undefined}
+  />
+);
+
+export const EditableFeedbackScoreCell = (
+  context: CellContext<unknown, unknown>,
+) => {
+  const feedbackScore = context.getValue() as TraceFeedbackScore | undefined;
+  const row = context.row.original as BaseTraceData | Thread | Span;
+  const { projectId, projectName } = (context.table.options.meta ??
+    {}) as TableMeta<unknown>;
+
+  const { handleValueChange } = useFeedbackScoreInlineEdit({
+    id: row.id,
+    isThread: isObjectThread(row),
+    isSpan: isObjectSpan(row),
+    feedbackScore,
+    projectId,
+    projectName,
+  });
+
+  return (
+    <FeedbackScoreCellContent
+      context={context}
+      feedbackScore={feedbackScore}
+      isUserFeedbackColumn
+      onValueChange={handleValueChange}
+    />
+  );
+};
+
+export const resolveFeedbackScoreCell = (scoreName: string) =>
+  scoreName === USER_FEEDBACK_NAME
+    ? EditableFeedbackScoreCell
+    : FeedbackScoreCell;
 
 type CustomMeta = {
   accessorFn?: string;

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -39,12 +39,7 @@ const CompareExperimentsFeedbackScoreCellContent = ({
   const { rowHeight = ROW_HEIGHT.small } = (context.table.options.meta ??
     {}) as TableMeta<ExperimentsCompare>;
 
-  // a split cell shows several experiments at once, so there is no single
-  // trace to write the score back to
-  const isUserFeedbackColumn =
-    editable &&
-    Boolean(onValueChange) &&
-    experimentCompare.experiment_items.length === 1;
+  const canEditUserFeedback = editable && Boolean(onValueChange);
   const isCompact =
     rowHeight === ROW_HEIGHT.small || rowHeight === ROW_HEIGHT.medium;
 
@@ -56,7 +51,7 @@ const CompareExperimentsFeedbackScoreCellContent = ({
     if (!feedbackScore) {
       return (
         <div className="flex items-center gap-1">
-          {isUserFeedbackColumn && onValueChange && (
+          {canEditUserFeedback && onValueChange && (
             <FeedbackScoreEditDropdown
               feedbackScore={feedbackScore}
               onValueChange={onValueChange}
@@ -91,13 +86,13 @@ const CompareExperimentsFeedbackScoreCellContent = ({
           isCompact
             ? "h-4 items-center"
             : "flex-col items-end justify-start overflow-hidden",
-          isUserFeedbackColumn && "group",
+          canEditUserFeedback && "group",
         )}
       >
         <FeedbackScoreCellValue
           feedbackScore={feedbackScore}
           color={color}
-          isUserFeedbackColumn={isUserFeedbackColumn}
+          isUserFeedbackColumn={canEditUserFeedback}
           onValueChange={onValueChange}
           size={isCompact ? "sm" : "md"}
           footer={
@@ -142,16 +137,19 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
   <CompareExperimentsFeedbackScoreCellContent context={context} />
 );
 
-export const EditableCompareExperimentsFeedbackScoreCell: React.FC<
-  CellContext<ExperimentsCompare, unknown>
-> = (context) => {
+const EditableCell = ({
+  context,
+  traceId,
+}: {
+  context: CellContext<ExperimentsCompare, unknown>;
+  traceId: string;
+}) => {
   const { custom } = context.column.columnDef.meta ?? {};
   const { scoreName } = (custom ?? {}) as CustomMeta & FeedbackScoreCustomMeta;
   const experimentItem = context.row.original.experiment_items[0];
-  const traceId = experimentItem?.trace_id;
 
   const { handleValueChange } = useFeedbackScoreInlineEdit({
-    id: traceId!, // TODO: handle case where traceId is not found
+    id: traceId,
     feedbackScore: experimentItem?.feedback_scores?.find(
       (f) => f.name === scoreName,
     ),
@@ -163,6 +161,22 @@ export const EditableCompareExperimentsFeedbackScoreCell: React.FC<
       editable
       onValueChange={handleValueChange}
     />
+  );
+};
+
+// A split cell shows several experiments at once, and an experiment item can
+// carry no trace, so in both cases there is nothing to write the score back to.
+export const EditableCompareExperimentsFeedbackScoreCell: React.FC<
+  CellContext<ExperimentsCompare, unknown>
+> = (context) => {
+  const experimentItems = context.row.original.experiment_items;
+  const traceId =
+    experimentItems.length === 1 ? experimentItems[0]?.trace_id : undefined;
+
+  return traceId ? (
+    <EditableCell context={context} traceId={traceId} />
+  ) : (
+    <CompareExperimentsFeedbackScoreCellContent context={context} />
   );
 };
 

--- a/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell.tsx
@@ -18,35 +18,33 @@ import useFeedbackScoreInlineEdit from "@/hooks/useFeedbackScoreInlineEdit";
 import { cn } from "@/lib/utils";
 import FeedbackScoreEditDropdown from "@/shared/DataTableCells/FeedbackScoreEditDropdown";
 import { ROW_HEIGHT } from "@/types/shared";
+import { USER_FEEDBACK_NAME } from "@/constants/shared";
 
-const CompareExperimentsFeedbackScoreCell: React.FC<
-  CellContext<ExperimentsCompare, unknown>
-> = (context) => {
+type CompareExperimentsFeedbackScoreCellProps = {
+  context: CellContext<ExperimentsCompare, unknown>;
+  editable?: boolean;
+  onValueChange?: (name: string, value: number) => void;
+};
+
+const CompareExperimentsFeedbackScoreCellContent = ({
+  context,
+  editable = false,
+  onValueChange,
+}: CompareExperimentsFeedbackScoreCellProps) => {
   const experimentCompare = context.row.original;
   const { custom } = context.column.columnDef.meta ?? {};
   const { scoreName, colorMap } = (custom ?? {}) as CustomMeta &
     FeedbackScoreCustomMeta;
-  const experimentItem = experimentCompare.experiment_items[0];
 
-  const feedbackScore = experimentItem?.feedback_scores?.find(
-    (f) => f.name === scoreName,
-  );
+  const { rowHeight = ROW_HEIGHT.small } = (context.table.options.meta ??
+    {}) as TableMeta<ExperimentsCompare>;
 
-  const traceId = experimentItem?.trace_id;
-
-  const { handleValueChange } = useFeedbackScoreInlineEdit({
-    id: traceId!, // TODO: handle case where traceId is not found
-    feedbackScore,
-  });
-
-  const { enableUserFeedbackEditing = false, rowHeight = ROW_HEIGHT.small } =
-    (context.table.options.meta ?? {}) as TableMeta<ExperimentsCompare>;
-
-  const isEditingEnabled =
-    experimentCompare.experiment_items.length === 1 &&
-    enableUserFeedbackEditing;
+  // a split cell shows several experiments at once, so there is no single
+  // trace to write the score back to
   const isUserFeedbackColumn =
-    isEditingEnabled && context.column.id === "feedback_scores_User feedback";
+    editable &&
+    Boolean(onValueChange) &&
+    experimentCompare.experiment_items.length === 1;
   const isCompact =
     rowHeight === ROW_HEIGHT.small || rowHeight === ROW_HEIGHT.medium;
 
@@ -58,10 +56,10 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
     if (!feedbackScore) {
       return (
         <div className="flex items-center gap-1">
-          {isUserFeedbackColumn && (
+          {isUserFeedbackColumn && onValueChange && (
             <FeedbackScoreEditDropdown
               feedbackScore={feedbackScore}
-              onValueChange={handleValueChange}
+              onValueChange={onValueChange}
               size={isCompact ? "sm" : "md"}
             />
           )}
@@ -100,7 +98,7 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
           feedbackScore={feedbackScore}
           color={color}
           isUserFeedbackColumn={isUserFeedbackColumn}
-          onValueChange={handleValueChange}
+          onValueChange={onValueChange}
           size={isCompact ? "sm" : "md"}
           footer={
             isAggregatedScore(feedbackScore)
@@ -135,5 +133,44 @@ const CompareExperimentsFeedbackScoreCell: React.FC<
     />
   );
 };
+
+// Read-only by default: only the User feedback column needs the inline-edit
+// hooks, and a table with many score columns would otherwise build them per cell
+const CompareExperimentsFeedbackScoreCell: React.FC<
+  CellContext<ExperimentsCompare, unknown>
+> = (context) => (
+  <CompareExperimentsFeedbackScoreCellContent context={context} />
+);
+
+export const EditableCompareExperimentsFeedbackScoreCell: React.FC<
+  CellContext<ExperimentsCompare, unknown>
+> = (context) => {
+  const { custom } = context.column.columnDef.meta ?? {};
+  const { scoreName } = (custom ?? {}) as CustomMeta & FeedbackScoreCustomMeta;
+  const experimentItem = context.row.original.experiment_items[0];
+  const traceId = experimentItem?.trace_id;
+
+  const { handleValueChange } = useFeedbackScoreInlineEdit({
+    id: traceId!, // TODO: handle case where traceId is not found
+    feedbackScore: experimentItem?.feedback_scores?.find(
+      (f) => f.name === scoreName,
+    ),
+  });
+
+  return (
+    <CompareExperimentsFeedbackScoreCellContent
+      context={context}
+      editable
+      onValueChange={handleValueChange}
+    />
+  );
+};
+
+export const resolveCompareExperimentsFeedbackScoreCell = (
+  scoreName: string,
+) =>
+  scoreName === USER_FEEDBACK_NAME
+    ? EditableCompareExperimentsFeedbackScoreCell
+    : CompareExperimentsFeedbackScoreCell;
 
 export default CompareExperimentsFeedbackScoreCell;

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -31,7 +31,7 @@ import SearchInput from "@/shared/SearchInput/SearchInput";
 import IdCell from "@/shared/DataTableCells/IdCell";
 import AutodetectCell from "@/shared/DataTableCells/AutodetectCell";
 import CompareExperimentsOutputCell from "@/v2/pages-shared/experiments/CompareExperimentsOutputCell/CompareExperimentsOutputCell";
-import CompareExperimentsFeedbackScoreCell from "@/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell";
+import { resolveCompareExperimentsFeedbackScoreCell } from "@/v2/pages-shared/experiments/CompareExperimentsFeedbackScoreCell/CompareExperimentsFeedbackScoreCell";
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import CompareExperimentsPanel from "@/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel";
 import CompareExperimentsActionsPanel from "@/v2/pages/CompareExperimentsPage/CompareExperimentsActionsPanel";
@@ -366,7 +366,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
           label,
           type: columnType,
           header: FeedbackScoreHeader as never,
-          cell: CompareExperimentsFeedbackScoreCell as never,
+          cell: resolveCompareExperimentsFeedbackScoreCell(label) as never,
           statisticKey: `${COLUMN_FEEDBACK_SCORES_ID}.${label}`,
           statisticDataFormater: formatScoreDisplay,
           supportsPercentiles: true,
@@ -617,7 +617,6 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         setExpandedCommentSections([String(idx)]);
       },
       columnsStatistic,
-      enableUserFeedbackEditing: true,
     }),
     [handleRowClick, setExpandedCommentSections, columnsStatistic],
   );

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -78,7 +78,7 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
 import { formatScoreDisplay } from "@/lib/feedback-scores";
 import DataTableStateHandler from "@/shared/DataTableStateHandler/DataTableStateHandler";
-import FeedbackScoreCell from "@/shared/DataTableCells/FeedbackScoreCell";
+import { resolveFeedbackScoreCell } from "@/shared/DataTableCells/FeedbackScoreCell";
 import useThreadsFeedbackScoresNames from "@/api/traces/useThreadsFeedbackScoresNames";
 import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
@@ -661,7 +661,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
           label,
           type: columnType,
           header: FeedbackScoreHeader as never,
-          cell: FeedbackScoreCell as never,
+          cell: resolveFeedbackScoreCell(label) as never,
           accessorFn: (row) =>
             row.feedback_scores?.find((f) => f.name === label),
           statisticKey: `${COLUMN_FEEDBACK_SCORES_ID}.${label}`,
@@ -739,7 +739,6 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
     () => ({
       projectId,
       projectName,
-      enableUserFeedbackEditing: true,
     }),
     [projectId, projectName],
   );

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -108,7 +108,9 @@ import {
   buildSpanDurationTarget,
   buildSpanErrorTarget,
 } from "@/v2/pages/LogsPage/TracesSpansTab/explainTargets";
-import FeedbackScoreCell from "@/shared/DataTableCells/FeedbackScoreCell";
+import FeedbackScoreCell, {
+  resolveFeedbackScoreCell,
+} from "@/shared/DataTableCells/FeedbackScoreCell";
 import PrettyCell from "@/shared/DataTableCells/PrettyCell";
 import CommentsCell from "@/shared/DataTableCells/CommentsCell";
 import FeedbackScoreHeader from "@/shared/DataTableHeaders/FeedbackScoreHeader";
@@ -1034,7 +1036,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           label,
           type: columnType,
           header: FeedbackScoreHeader as never,
-          cell: FeedbackScoreCell as never,
+          cell: resolveFeedbackScoreCell(label) as never,
           accessorFn: (row) =>
             row.feedback_scores?.find((f) => f.name === label),
           statisticKey: `${COLUMN_FEEDBACK_SCORES_ID}.${label}`,
@@ -1151,7 +1153,6 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       onCommentsReply: (row?: Trace | Span) => {
         handleRowClick(row, DetailsActionSection.Comments);
       },
-      enableUserFeedbackEditing: true,
     }),
     [handleRowClick],
   );


### PR DESCRIPTION
## Details

Tables that show feedback scores build one column per score name, so a project with a large score taxonomy renders tens of thousands of score cells. Every one of those cells called `useFeedbackScoreInlineEdit` — four react-query mutations plus a store subscription — and then threw the result away, because only the "User feedback" column is editable. This splits the cell into a read-only and an editable variant over a shared presenter and picks between them per column, which is worth about half of the render cost on a wide table.

- `FeedbackScoreCell` keeps its name and becomes the read-only cell, so every table rendering score columns benefits without a change of its own; editing moves to `EditableFeedbackScoreCell`, chosen by `resolveFeedbackScoreCell` when the column is defined.
- `CompareExperimentsFeedbackScoreCell` gets the same split for the experiments comparison table.
- The three tables that used `enableUserFeedbackEditing` — traces, threads, experiment items — now select the editable cell per column, so the table-level flag and the hardcoded `feedback_scores_User feedback` column id are both gone.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8021

Partial delivery: this PR covers the feedback-score cell only. Table virtualization for the same ticket follows in a separate PR.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: investigation, implementation and measurement
- Human verification: code review, plus manual checks in the dev UI

## Testing

Commands run, both clean:

- `npm run lint`
- `npm run typecheck`

Measured with Chrome DevTools against a dev project with 330 columns and 100 rows, main-thread blocking on a single pagination click, dev build: ~19s before, ~9s after. Measurement was repeated across reloads; dev-build absolutes are inflated, the ratio held.

Not verified: the editable path against real data. The reproduction project has no "User feedback" score column, so only the read-only branch rendered during measurement. The editable branch is the previous code path unchanged, and the column-id selection was confirmed by inspecting the generated column ids, but it deserves a click-through on a project that has such a score before merge.

No video: the change has no visual difference, only timing.

## Documentation

N/A — internal performance change with no behaviour or API change.
