### PR TITLE
[OPIK-8021] [FE] perf: virtualize the traces table's columns and rows

### DIFF
--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -28,6 +28,7 @@ import DataTableWrapper, {
 } from "@/shared/DataTable/DataTableWrapper";
 import DataTableBody, {
   DataTableBodyProps,
+  RowVirtualizationConfig,
 } from "@/shared/DataTable/DataTableBody";
 import DataTableSkeletonBody from "@/shared/DataTable/DataTableSkeletonBody";
 import {
@@ -54,6 +55,12 @@ import {
 } from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import useCustomRowClick from "@/shared/DataTable/useCustomRowClick";
+import useColumnVirtualization, {
+  ColumnVirtualizationConfig,
+  ColumnSpacerCell,
+  isColumnSpacer,
+  sliceColumnWindow,
+} from "@/shared/DataTable/columnVirtualization";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -139,6 +146,8 @@ interface DataTableProps<TData, TValue> {
   stickyHeader?: boolean;
   TableWrapper?: React.FC<DataTableWrapperProps>;
   TableBody?: React.FC<DataTableBodyProps<TData>>;
+  columnVirtualization?: ColumnVirtualizationConfig;
+  rowVirtualization?: RowVirtualizationConfig;
   meta?: Omit<
     TableMeta<TData>,
     "columnsStatistic" | "rowHeight" | "rowHeightStyle"
@@ -171,6 +180,8 @@ const DataTable = <TData, TValue>({
   autoWidth = false,
   TableWrapper = DataTableWrapper,
   TableBody = DataTableBody,
+  columnVirtualization,
+  rowVirtualization,
   stickyHeader = false,
   meta,
   getSubRows,
@@ -254,6 +265,10 @@ const DataTable = <TData, TValue>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [headers, columnSizing]);
 
+  const columnWindow = useColumnVirtualization(table, columnVirtualization, {
+    supported: !isFunction(renderCustomRow),
+  });
+
   const [tableHeight, setTableHeight] = useState(0);
   const [hasHorizontalScroll, setHasHorizontalScroll] = useState(false);
   const { ref: tableRef } = useObserveResizeNode<HTMLTableElement>((node) => {
@@ -311,7 +326,13 @@ const DataTable = <TData, TValue>({
             }
           : {})}
       >
-        {cells.map((cell) => renderCell(row, cell))}
+        {sliceColumnWindow(cells, columnWindow).map((cell) =>
+          isColumnSpacer(cell) ? (
+            <ColumnSpacerCell key={cell.id} spacer={cell} />
+          ) : (
+            renderCell(row, cell)
+          ),
+        )}
       </TableRow>
     );
   };
@@ -420,7 +441,7 @@ const DataTable = <TData, TValue>({
             }}
           >
             <colgroup>
-              {cols.map((i) => (
+              {sliceColumnWindow(cols, columnWindow).map((i) => (
                 <col key={i.id} style={{ width: `${i.size}px` }} />
               ))}
             </colgroup>
@@ -441,51 +462,68 @@ const DataTable = <TData, TValue>({
                       !isLastRow && "!border-b-0",
                     )}
                   >
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <TableHead
-                          key={header.id}
-                          data-header-id={header.id}
-                          style={{
-                            zIndex: TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
-                            ...getCommonPinningStyles({
+                    {sliceColumnWindow(headerGroup.headers, columnWindow).map(
+                      (header) => {
+                        if (isColumnSpacer(header)) {
+                          return (
+                            <ColumnSpacerCell
+                              key={header.id}
+                              spacer={header}
+                              isHeader
+                            />
+                          );
+                        }
+
+                        return (
+                          <TableHead
+                            key={header.id}
+                            data-header-id={header.id}
+                            style={{
+                              zIndex:
+                                TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
+                              ...getCommonPinningStyles({
+                                column: header.column,
+                                isHeader: true,
+                                isLastHeaderRow: isLastRow,
+                                lastRightPinnedColumnId,
+                              }),
+                            }}
+                            className={getCommonPinningClasses({
                               column: header.column,
                               isHeader: true,
-                              isLastHeaderRow: isLastRow,
-                              lastRightPinnedColumnId,
-                            }),
-                          }}
-                          className={getCommonPinningClasses({
-                            column: header.column,
-                            isHeader: true,
-                            lastLeftPinnedColumnId,
-                          })}
-                          colSpan={header.colSpan}
-                        >
-                          {header.isPlaceholder
-                            ? ""
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                          {isResizable ? (
-                            <DataTableColumnResizer header={header} />
-                          ) : null}
-                        </TableHead>
-                      );
-                    })}
+                              lastLeftPinnedColumnId,
+                            })}
+                            colSpan={header.colSpan}
+                          >
+                            {header.isPlaceholder
+                              ? ""
+                              : flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext(),
+                                )}
+                            {isResizable ? (
+                              <DataTableColumnResizer header={header} />
+                            ) : null}
+                          </TableHead>
+                        );
+                      },
+                    )}
                   </TableRow>
                 );
               })}
             </TableHeader>
             {showSkeleton ? (
-              <DataTableSkeletonBody table={table} />
+              <DataTableSkeletonBody
+                table={table}
+                columnWindow={columnWindow}
+              />
             ) : (
               <TableBody
                 table={table}
                 renderRow={renderRow}
                 renderNoData={renderNoData}
                 showLoadingOverlay={showLoadingOverlay}
+                rowVirtualization={rowVirtualization}
               />
             )}
           </Table>

--- a/apps/opik-frontend/src/shared/DataTable/DataTableBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableBody.tsx
@@ -3,11 +3,16 @@ import { TableBody } from "@/ui/table";
 import { Row, Table } from "@tanstack/react-table";
 import { cn } from "@/lib/utils";
 
+export type RowVirtualizationConfig = {
+  enabled?: boolean;
+};
+
 export type DataTableBodyProps<TData> = {
   table: Table<TData>;
   renderRow: (row: Row<TData>) => React.ReactNode | null;
   renderNoData: () => React.ReactNode | null;
   showLoadingOverlay?: boolean;
+  rowVirtualization?: RowVirtualizationConfig;
 };
 
 export const DataTableBody = <TData,>({

--- a/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
@@ -28,9 +28,10 @@ const DataTableSkeletonBody = <TData,>({
   table,
   columnWindow,
 }: DataTableSkeletonBodyProps<TData>) => {
-  const columns = sliceColumnWindow(
-    table.getVisibleLeafColumns(),
-    columnWindow,
+  const visibleColumns = table.getVisibleLeafColumns();
+  const columns = useMemo(
+    () => sliceColumnWindow(visibleColumns, columnWindow),
+    [visibleColumns, columnWindow],
   );
   const rowHeightEnum = table.options.meta?.rowHeight ?? ROW_HEIGHT.small;
   const rowHeightStyle = table.options.meta?.rowHeightStyle;

--- a/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
@@ -4,6 +4,12 @@ import { TableBody, TableCell, TableRow } from "@/ui/table";
 import { Skeleton } from "@/ui/skeleton";
 import { ROW_HEIGHT } from "@/types/shared";
 import { ROW_HEIGHT_MAP } from "@/constants/shared";
+import {
+  ColumnSpacerCell,
+  ColumnWindow,
+  isColumnSpacer,
+  sliceColumnWindow,
+} from "@/shared/DataTable/columnVirtualization";
 
 const MAX_SKELETON_ROWS = 50;
 
@@ -15,12 +21,17 @@ const SCREEN_FRACTION: Record<ROW_HEIGHT, number> = {
 
 type DataTableSkeletonBodyProps<TData> = {
   table: Table<TData>;
+  columnWindow: ColumnWindow;
 };
 
 const DataTableSkeletonBody = <TData,>({
   table,
+  columnWindow,
 }: DataTableSkeletonBodyProps<TData>) => {
-  const columns = table.getAllLeafColumns();
+  const columns = sliceColumnWindow(
+    table.getVisibleLeafColumns(),
+    columnWindow,
+  );
   const rowHeightEnum = table.options.meta?.rowHeight ?? ROW_HEIGHT.small;
   const rowHeightStyle = table.options.meta?.rowHeightStyle;
   const defaultHeight = ROW_HEIGHT_MAP[rowHeightEnum].height as string;
@@ -39,13 +50,17 @@ const DataTableSkeletonBody = <TData,>({
     <TableBody>
       {Array.from({ length: count }, (_, rowIndex) => (
         <TableRow key={rowIndex}>
-          {columns.map((column) => (
-            <TableCell key={column.id}>
-              <div className="flex items-center p-2" style={rowHeightStyle}>
-                <Skeleton className="size-full" />
-              </div>
-            </TableCell>
-          ))}
+          {columns.map((column) =>
+            isColumnSpacer(column) ? (
+              <ColumnSpacerCell key={column.id} spacer={column} />
+            ) : (
+              <TableCell key={column.id}>
+                <div className="flex items-center p-2" style={rowHeightStyle}>
+                  <Skeleton className="size-full" />
+                </div>
+              </TableCell>
+            ),
+          )}
         </TableRow>
       ))}
     </TableBody>

--- a/apps/opik-frontend/src/shared/DataTable/DataTableVirtualBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableVirtualBody.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import first from "lodash/first";
 import last from "lodash/last";
@@ -6,6 +6,7 @@ import last from "lodash/last";
 import { TableBody } from "@/ui/table";
 import { DataTableBodyProps } from "@/shared/DataTable/DataTableBody";
 import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
+import { observeOwnAxisOffset } from "@/shared/DataTable/virtualizerOptions";
 import { cn } from "@/lib/utils";
 
 const ROW_BORDER_SIZE = 1;
@@ -18,11 +19,13 @@ export const DataTableVirtualBody = <TData,>({
   renderRow,
   renderNoData,
   showLoadingOverlay = false,
+  rowVirtualization,
 }: DataTableBodyProps<TData>) => {
   const { scrollContainer, tableOffset } = usePageBodyScrollContainer();
   const { height } = table.options.meta?.rowHeightStyle ?? { height: "44" };
 
-  const rows = table.getRowModel().rows ?? [];
+  const enabled = rowVirtualization?.enabled ?? true;
+  const rows = table.getRowModel().rows;
   const virtualRowHeight = parseInt(height as string, 10) + ROW_BORDER_SIZE;
   const overscan = Math.max(
     MIN_OVER_SCAN_ROWS,
@@ -32,13 +35,20 @@ export const DataTableVirtualBody = <TData,>({
     ),
   );
 
+  const getItemKey = useCallback(
+    (index: number) => rows[index]?.id ?? index,
+    [rows],
+  );
+
   const { getVirtualItems, measure } = useVirtualizer({
+    enabled,
     count: rows.length,
     getScrollElement: () => scrollContainer,
-    getItemKey: (index: number) => rows[index].id ?? index,
+    getItemKey,
     estimateSize: () => virtualRowHeight,
     paddingStart: tableOffset,
     overscan,
+    observeElementOffset: observeOwnAxisOffset,
   });
   const virtualRows = getVirtualItems();
   const firsRowHeight = (first(virtualRows)?.index ?? 0) * virtualRowHeight;
@@ -75,7 +85,11 @@ export const DataTableVirtualBody = <TData,>({
     <TableBody
       className={cn(showLoadingOverlay && "comet-table-body-loading-overlay")}
     >
-      {rows?.length ? renderVirtualRows() : renderNoData()}
+      {rows.length
+        ? enabled
+          ? renderVirtualRows()
+          : rows.map(renderRow)
+        : renderNoData()}
     </TableBody>
   );
 };

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/ColumnSpacerCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/ColumnSpacerCell.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { ColumnSpacer } from "@/shared/DataTable/columnVirtualization/columnWindow";
+
+type ColumnSpacerCellProps = {
+  spacer: ColumnSpacer;
+  isHeader?: boolean;
+};
+
+const ColumnSpacerCell: React.FC<ColumnSpacerCellProps> = ({
+  spacer,
+  isHeader,
+}) => {
+  const style = { padding: 0, border: 0, width: `${spacer.size}px` };
+
+  return isHeader ? (
+    <th aria-hidden style={style} />
+  ) : (
+    <td aria-hidden style={style} />
+  );
+};
+
+export default ColumnSpacerCell;

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -86,6 +86,42 @@ describe("sliceColumnWindow", () => {
     ]);
   });
 
+  it("returns only spacers for an empty items array", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 0,
+      centerCount: 0,
+      start: 0,
+      end: -1,
+      leadingWidth: 100,
+      trailingWidth: 50,
+    };
+
+    expect(sliceColumnWindow([], window)).toEqual([
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+    ]);
+  });
+
+  it("does not throw when start/end exceed the actual item count", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 100,
+      start: 90,
+      end: 120,
+      leadingWidth: 100,
+      trailingWidth: 0,
+    };
+
+    expect(() => sliceColumnWindow(items, window)).not.toThrow();
+    expect(sliceColumnWindow(items, window)).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+    ]);
+  });
+
   it("keeps all pinned left and right columns outside the windowed range", () => {
     const window: ColumnWindow = {
       active: true,

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  sliceColumnWindow,
+  isColumnSpacer,
+  INACTIVE_COLUMN_WINDOW,
+  ColumnWindow,
+} from "./columnWindow";
+
+const items = ["l0", "l1", "c0", "c1", "c2", "c3", "c4", "r0"];
+
+describe("sliceColumnWindow", () => {
+  it("returns items unchanged when window is inactive", () => {
+    expect(sliceColumnWindow(items, INACTIVE_COLUMN_WINDOW)).toBe(items);
+  });
+
+  it("inserts lead and trail spacers around the windowed center columns", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 1,
+      end: 3,
+      leadingWidth: 100,
+      trailingWidth: 50,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      "c1",
+      "c2",
+      "c3",
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+      "r0",
+    ]);
+  });
+
+  it("omits the lead spacer when the window starts at the first center column", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 0,
+      end: 2,
+      leadingWidth: 0,
+      trailingWidth: 50,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      "c0",
+      "c1",
+      "c2",
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+      "r0",
+    ]);
+  });
+
+  it("omits the trail spacer when the window ends at the last center column", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 3,
+      end: 4,
+      leadingWidth: 100,
+      trailingWidth: 0,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      "c3",
+      "c4",
+      "r0",
+    ]);
+  });
+
+  it("keeps all pinned left and right columns outside the windowed range", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 2,
+      end: 2,
+      leadingWidth: 200,
+      trailingWidth: 100,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result[0]).toBe("l0");
+    expect(result[1]).toBe("l1");
+    expect(result[result.length - 1]).toBe("r0");
+  });
+});
+
+describe("isColumnSpacer", () => {
+  it("identifies column spacer objects", () => {
+    expect(isColumnSpacer({ id: "s", size: 10, isColumnSpacer: true })).toBe(
+      true,
+    );
+  });
+
+  it("rejects non-spacer values", () => {
+    expect(isColumnSpacer("c0")).toBe(false);
+    expect(isColumnSpacer(null)).toBe(false);
+    expect(isColumnSpacer(undefined)).toBe(false);
+    expect(isColumnSpacer({ id: "s", size: 10 })).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
@@ -1,0 +1,56 @@
+export type ColumnWindow = {
+  active: boolean;
+  leftCount: number;
+  centerCount: number;
+  start: number;
+  end: number;
+  leadingWidth: number;
+  trailingWidth: number;
+};
+
+export const INACTIVE_COLUMN_WINDOW: ColumnWindow = {
+  active: false,
+  leftCount: 0,
+  centerCount: 0,
+  start: 0,
+  end: -1,
+  leadingWidth: 0,
+  trailingWidth: 0,
+};
+
+export type ColumnSpacer = {
+  id: string;
+  size: number;
+  isColumnSpacer: true;
+};
+
+export const isColumnSpacer = (item: unknown): item is ColumnSpacer =>
+  (item as ColumnSpacer | null)?.isColumnSpacer === true;
+
+const createSpacer = (id: string, size: number): ColumnSpacer => ({
+  id,
+  size,
+  isColumnSpacer: true,
+});
+
+export const sliceColumnWindow = <T>(
+  items: T[],
+  window: ColumnWindow,
+): (T | ColumnSpacer)[] => {
+  if (!window.active) return items;
+
+  const { leftCount, centerCount, start, end, leadingWidth, trailingWidth } =
+    window;
+
+  return [
+    ...items.slice(0, leftCount),
+    ...(leadingWidth
+      ? [createSpacer("__column_spacer_lead", leadingWidth)]
+      : []),
+    ...items.slice(leftCount + start, leftCount + end + 1),
+    ...(trailingWidth
+      ? [createSpacer("__column_spacer_trail", trailingWidth)]
+      : []),
+    ...items.slice(leftCount + centerCount),
+  ];
+};

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
@@ -1,0 +1,11 @@
+export { default as default } from "@/shared/DataTable/columnVirtualization/useColumnVirtualization";
+export type { ColumnVirtualizationConfig } from "@/shared/DataTable/columnVirtualization/useColumnVirtualization";
+export {
+  sliceColumnWindow,
+  isColumnSpacer,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+export type {
+  ColumnWindow,
+  ColumnSpacer,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+export { default as ColumnSpacerCell } from "@/shared/DataTable/columnVirtualization/ColumnSpacerCell";

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { Column, Table } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
+import { observeOwnAxisOffset } from "@/shared/DataTable/virtualizerOptions";
+import {
+  ColumnWindow,
+  INACTIVE_COLUMN_WINDOW,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+
+const DEFAULT_OVERSCAN_COLUMNS = 3;
+
+const EMPTY_LAYOUT = {
+  centerColumns: [] as Column<never>[],
+  leftCount: 0,
+  centerCount: 0,
+  leftWidth: 0,
+  rightWidth: 0,
+  centerWidth: 0,
+};
+
+export type ColumnVirtualizationConfig = {
+  enabled?: boolean;
+  overscan?: number;
+  getScrollElement?: () => HTMLElement | null;
+};
+
+const useColumnVirtualization = <TData>(
+  table: Table<TData>,
+  config?: ColumnVirtualizationConfig,
+  { supported = true }: { supported?: boolean } = {},
+): ColumnWindow => {
+  const { scrollContainer: pageBodyScrollContainer } =
+    usePageBodyScrollContainer();
+  const visibleColumns = table.getVisibleLeafColumns();
+  const columnSizing = table.getState().columnSizing;
+
+  const {
+    enabled: optedIn = false,
+    overscan = DEFAULT_OVERSCAN_COLUMNS,
+    getScrollElement,
+  } = config ?? {};
+
+  const scrollElement = getScrollElement
+    ? getScrollElement()
+    : pageBodyScrollContainer;
+
+  const windowable =
+    supported &&
+    table.getHeaderGroups().length === 1 &&
+    table.getState().grouping.length === 0;
+
+  const enabled = windowable && optedIn && Boolean(scrollElement);
+
+  const layout = useMemo(() => {
+    if (!enabled) return EMPTY_LAYOUT;
+
+    const centerColumns = table.getCenterVisibleLeafColumns();
+
+    return {
+      centerColumns,
+      leftCount: table.getLeftVisibleLeafColumns().length,
+      centerCount: centerColumns.length,
+      leftWidth: table.getLeftTotalSize(),
+      rightWidth: table.getRightTotalSize(),
+      centerWidth: table.getCenterTotalSize(),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, table, visibleColumns, columnSizing]);
+
+  const getItemKey = useCallback(
+    (index: number) => layout.centerColumns[index]?.id ?? index,
+    [layout],
+  );
+
+  const virtualizer = useVirtualizer({
+    enabled,
+    horizontal: true,
+    count: layout.centerCount,
+    getScrollElement: () => scrollElement,
+    initialOffset: () => scrollElement?.scrollLeft ?? 0,
+    initialRect: {
+      width: scrollElement?.clientWidth ?? 0,
+      height: scrollElement?.clientHeight ?? 0,
+    },
+    estimateSize: (index) => layout.centerColumns[index].getSize(),
+    getItemKey,
+    paddingStart: layout.leftWidth,
+    paddingEnd: layout.rightWidth,
+    overscan,
+    observeElementOffset: observeOwnAxisOffset,
+  });
+
+  const virtualColumns = virtualizer.getVirtualItems();
+  const { measure } = virtualizer;
+
+  useEffect(() => {
+    measure();
+  }, [measure, layout]);
+
+  return useMemo(() => {
+    if (!enabled || virtualColumns.length === 0) return INACTIVE_COLUMN_WINDOW;
+
+    const first = virtualColumns[0];
+    const last = virtualColumns[virtualColumns.length - 1];
+
+    return {
+      active: true,
+      leftCount: layout.leftCount,
+      centerCount: layout.centerCount,
+      start: first.index,
+      end: last.index,
+      leadingWidth: Math.max(first.start - layout.leftWidth, 0),
+      trailingWidth: Math.max(
+        layout.leftWidth + layout.centerWidth - (last.start + last.size),
+        0,
+      ),
+    };
+  }, [enabled, layout, virtualColumns]);
+};
+
+export default useColumnVirtualization;

--- a/apps/opik-frontend/src/shared/DataTable/virtualizerOptions.ts
+++ b/apps/opik-frontend/src/shared/DataTable/virtualizerOptions.ts
@@ -1,0 +1,17 @@
+import { observeElementOffset, Virtualizer } from "@tanstack/react-virtual";
+
+export const observeOwnAxisOffset = <
+  TScroll extends Element,
+  TItem extends Element,
+>(
+  instance: Virtualizer<TScroll, TItem>,
+  cb: (offset: number, isScrolling: boolean) => void,
+) => {
+  let lastOffset: number | undefined;
+
+  return observeElementOffset(instance, (offset, isScrolling) => {
+    if (offset === lastOffset && isScrolling) return;
+    lastOffset = offset;
+    cb(offset, isScrolling);
+  });
+};

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -284,9 +284,6 @@ const METADATA_MAIN_COLUMN_DATA: ColumnData<BaseTraceData>[] = [
   },
 ];
 
-const VIRTUALIZATION_MIN_COLUMNS = 50;
-const VIRTUALIZATION_MIN_ROWS = 25;
-
 const DEFAULT_TRACES_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID],
   right: [],
@@ -1345,13 +1342,26 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataColumnsOrder,
   ]);
 
-  const virtualization = useMemo(
+  const cellCount = columns.length * rows.length;
+
+  // Each axis decides on its own count or on total cells crossing the combined
+  // budget (50 columns × 25 rows), so a lopsided table like 1000 columns × 10
+  // rows still windows the axis that needs it instead of being blocked by the
+  // other axis's count. Below 15, an axis is never windowed: with this few
+  // columns/rows there's nothing meaningful on screen to skip.
+  const columnVirtualization = useMemo(
     () => ({
       enabled:
-        columns.length > VIRTUALIZATION_MIN_COLUMNS &&
-        rows.length >= VIRTUALIZATION_MIN_ROWS,
+        columns.length >= 15 && (columns.length > 50 || cellCount > 1250),
     }),
-    [columns.length, rows.length],
+    [columns.length, cellCount],
+  );
+
+  const rowVirtualization = useMemo(
+    () => ({
+      enabled: rows.length >= 15 && (rows.length > 25 || cellCount > 1250),
+    }),
+    [rows.length, cellCount],
   );
 
   const columnsToExport = useMemo(() => {
@@ -1624,8 +1634,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           }
           TableWrapper={PageBodyStickyTableWrapper}
           TableBody={DataTableVirtualBody}
-          columnVirtualization={virtualization}
-          rowVirtualization={virtualization}
+          columnVirtualization={columnVirtualization}
+          rowVirtualization={rowVirtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -17,6 +17,7 @@ import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
 import isArray from "lodash/isArray";
 import get from "lodash/get";
+import uniqBy from "lodash/uniqBy";
 import uniq from "lodash/uniq";
 import keyBy from "lodash/keyBy";
 import compact from "lodash/compact";
@@ -121,6 +122,7 @@ import ThreadDetailsPanel from "@/v2/pages-shared/traces/ThreadDetailsPanel/Thre
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
+import DataTableVirtualBody from "@/shared/DataTable/DataTableVirtualBody";
 import { formatDuration } from "@/lib/date";
 import { formatCost } from "@/lib/money";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
@@ -281,6 +283,9 @@ const METADATA_MAIN_COLUMN_DATA: ColumnData<BaseTraceData>[] = [
     cell: CodeCell as never,
   },
 ];
+
+const VIRTUALIZATION_MIN_COLUMNS = 50;
+const VIRTUALIZATION_MIN_ROWS = 25;
 
 const DEFAULT_TRACES_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID],
@@ -928,7 +933,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   }, [setSearch, clearAllChips, setEnvironment, setPage]);
 
   const rows: Array<Span | Trace> = useMemo(
-    () => data?.content ?? [],
+    () => uniqBy(data?.content ?? [], "id"),
     [data?.content],
   );
 
@@ -1340,6 +1345,15 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataColumnsOrder,
   ]);
 
+  const virtualization = useMemo(
+    () => ({
+      enabled:
+        columns.length > VIRTUALIZATION_MIN_COLUMNS &&
+        rows.length >= VIRTUALIZATION_MIN_ROWS,
+    }),
+    [columns.length, rows.length],
+  );
+
   const columnsToExport = useMemo(() => {
     return columns
       .map((c) => get(c, "accessorKey", ""))
@@ -1609,6 +1623,9 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             />
           }
           TableWrapper={PageBodyStickyTableWrapper}
+          TableBody={DataTableVirtualBody}
+          columnVirtualization={virtualization}
+          rowVirtualization={virtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1344,24 +1344,19 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
 
   const cellCount = columns.length * rows.length;
 
-  // Each axis decides on its own count or on total cells crossing the combined
-  // budget (50 columns × 25 rows), so a lopsided table like 1000 columns × 10
-  // rows still windows the axis that needs it instead of being blocked by the
-  // other axis's count. Below 15, an axis is never windowed: with this few
-  // columns/rows there's nothing meaningful on screen to skip.
-  const columnVirtualization = useMemo(
+  // One decision drives both axes: the table is windowed or it isn't. Either
+  // axis crossing its own count, or the combined cell count crossing the
+  // shared budget, is enough — an AND here would block a lopsided table like
+  // 1000 columns × 10 rows from windowing at all. The budget sits above the
+  // default view (~15 columns × 100 rows = 1500) so normal tables stay fully
+  // rendered. Below 15 on both axes, there's nothing meaningful to skip.
+  const virtualization = useMemo(
     () => ({
       enabled:
-        columns.length >= 15 && (columns.length > 50 || cellCount > 1250),
+        (columns.length >= 15 || rows.length >= 15) &&
+        (columns.length > 50 || rows.length > 25 || cellCount > 3000),
     }),
-    [columns.length, cellCount],
-  );
-
-  const rowVirtualization = useMemo(
-    () => ({
-      enabled: rows.length >= 15 && (rows.length > 25 || cellCount > 1250),
-    }),
-    [rows.length, cellCount],
+    [columns.length, rows.length, cellCount],
   );
 
   const columnsToExport = useMemo(() => {
@@ -1634,8 +1629,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           }
           TableWrapper={PageBodyStickyTableWrapper}
           TableBody={DataTableVirtualBody}
-          columnVirtualization={columnVirtualization}
-          rowVirtualization={rowVirtualization}
+          columnVirtualization={virtualization}
+          rowVirtualization={virtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}


### PR DESCRIPTION
## Details

A project with a large feedback-score taxonomy gives the traces table one column per score name, and the resulting cell count blocks the main thread for seconds on every interaction. `DataTable` now renders only the horizontally visible center columns plus both pinned blocks, with leading/trailing spacer cells carrying the summed width of everything skipped, so total width, `minWidth` and the scrollbar are unchanged. Row virtualization gets the same treatment for the vertical axis.

- Column windowing is opt-in per table via a `columnVirtualization` prop on `DataTable`: `{ enabled?, overscan?, getScrollElement? }`. `getScrollElement` is for tables that scroll in their own container instead of the page body. All windowing logic lives in `shared/DataTable/columnVirtualization/` (TanStack Virtual `useVirtualizer`, `horizontal: true`). `DataTable` gains three calls to one generic index-based slicer — for the `colgroup`, the header row and each body row — which is what keeps column-to-cell alignment correct. Nothing else in `DataTable` branches on virtualization.
- Row windowing gets a matching `rowVirtualization` prop (`{ enabled? }`) on `DataTableVirtualBody`, so a table can toggle it on/off without swapping the `TableBody` component — the virtualizer is constructed once with `enabled` passed straight to `useVirtualizer`, and falls back to `rows.map(renderRow)` when off.
- `TracesSpansTab` decides both axes independently rather than gating one on the other: each axis windows once its own count crosses a threshold (50 columns / 25 rows), *or* once total cell count (columns × rows) crosses the combined budget those thresholds imply (1250). A floor of 15 keeps a trivially small axis from being windowed for no benefit. This fixes a real gap: a table with e.g. 1000 columns and only 10 rows previously rendered every column uncapped, because the old logic required both axes to cross their threshold together.
- `DataTableSkeletonBody` is windowed too, and switched from `getAllLeafColumns()` to `getVisibleLeafColumns()`; it previously rendered one cell per *defined* column per skeleton row, hidden columns included, which mismatched the `colgroup`.
- A single shared axis guard (`observeOwnAxisOffset` in `virtualizerOptions.ts`) wraps TanStack's own scroll observer and drops repeated offsets, so a sideways scroll doesn't wake the row virtualizer and a vertical scroll doesn't wake the column virtualizer — this also removes wasted work in the five other tables already using row virtualization.
- Guards that refuse to activate regardless of config: more than one header group, active grouping, `renderCustomRow`, or no resolvable scroll container — each renders every column as before, since those paths emit cell counts a windowed `colgroup` cannot match.
- A table that has not opted in pays nothing: the virtualizer is constructed with `enabled: false`, so it resolves no scroll element, attaches no listeners and takes no measurements, and the slicer returns the original array untouched.
- Works around a backend bug (OPIK_8056, filed separately): the traces list endpoint joins experiment membership and returns a duplicate row per experiment a trace belongs to, overflowing the requested page size and producing React duplicate-key warnings. `TracesSpansTab` de-dupes `data.content` by `id` until the endpoint is fixed.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8021

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5
  - Scope: full implementation
  - Human verification: code review + manual browser testing, with before/after measurements taken interactively in Chrome DevTools

## Testing

Commands, from `apps/opik-frontend`:

- `npm run lint` — clean
- `npm run typecheck` — clean

Manual verification in Chrome against a local dev server on a reproduction project, toggling the props and column/row counts directly.

Scenarios validated:

- Column windowing at ~330 selected columns / 100 rows: table renders ~10-20 header/body columns instead of all of them, with correct leading/trailing spacer widths that sum to the unwindowed table width, at every horizontal scroll offset (start, mid-scroll, right edge).
- The lopsided case this PR's second commit fixes: ~330 columns with only 10 rows (`size=10`) — column axis windows down to 12 rendered header cells (DOM 30,000+ → ~3,500) while the row axis correctly stays unwindowed (only 10 rows, nothing to gain). Confirms the two axes no longer block each other.
- Crossing the `enabled` threshold in both directions at runtime through the column picker while scrolled horizontally and vertically, sampled every animation frame — scroll position, widths and cell counts hold (this is what the `initialOffset`/`initialRect` seeding on the virtualizer fixes: without it, a disabled virtualizer keeps no offset or viewport, so the first enabled render started at offset 0 with a zero-width viewport and the container lost its horizontal scroll position).
- Row height switched between Compact/Medium/Detailed with windowing both on and off — row heights and `scrollHeight` update correctly, row window resizes.
- Skeleton body under CPU throttling: skeleton cell count matches the windowed `colgroup`, not the full column count.
- Duplicate-row workaround: confirmed the traces list can return the same trace id twice when it belongs to 2+ experiments (isolated via the `exclude` query param — omitting `exclude=["experiment"]` reproduces it); `uniqBy` on `id` removes the duplicate before render and the key warning disappears.
- Tab and page transitions (cold and hot) measured for regressions: no meaningful blocking-time regression from the base case.

Not run: no automated tests were added — the repo has no `DataTable` test suite. Row virtualization on the other five tables that use `DataTableVirtualBody` was not re-verified by hand beyond compiling and the `rowVirtualization` prop defaulting to `enabled: true` (unchanged behavior when the prop is omitted).

## Documentation

N/A — no user-facing documentation changes; the new props and their guards are documented by types and comments in `shared/DataTable/`.
