### PR TITLE
[OPIK-7773] [BE] feat: fail readiness when the traces wrap flag disagrees with the DB topology

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -250,6 +250,12 @@ health:
     # ignores `type` (IsAliveResource filters on isCritical alone) - so a mismatch reports the server as down to SDKs,
     # exactly as the `clickhouse`, `db`, `redis` and `mysql` ready checks above already do. That is intended here: the
     # install is misconfigured and needs an operator, and buffering beats accepting traffic it cannot fully serve.
+    # Scope is the node that answers: `system.tables` is node-local and the probe does not fan out with
+    # clusterAllReplicas, which needs REMOTE + CLUSTER grants the app user isn't guaranteed to hold and would take
+    # every pod out of rotation whenever a single replica is unreachable. So a divergence confined to some replicas
+    # (an ON CLUSTER DDL still propagating, or one that failed on a host) degrades into sporadic unhealthy reports
+    # rather than a fleet-wide outage; the cluster-wide "did this DDL reach every replica" gate lives in the cutover's
+    # exchange_and_wrap.sh / finalize.sh, and the self-host troubleshooting page carries the query for operators.
     - name: clickhouse-traces-topology
       critical: true
       type: ready

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -239,12 +239,17 @@ health:
       critical: true
       type: ready
     # Fail-fast assertion that databaseAnalyticsDataModel.tracesDistributedWrapEnabled matches the actual `traces`
-    # topology: flag on -> `traces` is Distributed and `traces_local` exists; flag off -> `traces` is a
-    # (Replicated)MergeTree. Not toggle-gated on purpose — flag off over a MergeTree `traces` is the default
+    # topology: flag on -> `traces` is Distributed and `traces_local` exists; flag off -> `traces` is any engine of the
+    # MergeTree family that takes mutations directly - the check matches on the `MergeTree` suffix, so MergeTree,
+    # ReplicatedMergeTree and ClickHouse Cloud's SharedMergeTree variants all satisfy it. Not toggle-gated on
+    # purpose — flag off over a MergeTree `traces` is the default
     # everywhere, so only a genuine misconfiguration trips it, and either mismatch direction breaks trace deletes
     # (code 36/48 one way, 60 the other) with no symptom until the first delete. Critical so such an install is pulled
     # from rotation instead of serving traffic it cannot mutate; re-evaluated continuously, so it clears itself once
-    # the operator brings flag and topology back in step.
+    # the operator brings flag and topology back in step. Note that `critical: true` also gates /is-alive/ping, which
+    # ignores `type` (IsAliveResource filters on isCritical alone) - so a mismatch reports the server as down to SDKs,
+    # exactly as the `clickhouse`, `db`, `redis` and `mysql` ready checks above already do. That is intended here: the
+    # install is misconfigured and needs an operator, and buffering beats accepting traffic it cannot fully serve.
     - name: clickhouse-traces-topology
       critical: true
       type: ready

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -154,6 +154,9 @@ databaseAnalyticsDataModel:
   #   `traces`. Post-wrap, changes to `traces` split by kind: row mutations (DELETE) + MATERIALIZE COLUMN/ADD INDEX/
   #   MODIFY TTL target `traces_local` only (the Distributed `traces` rejects them); ADD/DROP/MODIFY COLUMN must target
   #   both `traces_local` and `traces`, else reads can't see the column (code 47).
+  #   This value is asserted against the live topology by the `clickhouse-traces-topology` readiness check below: set it
+  #   wrong in either direction and the backend fails readiness at startup with a message naming the flag and the
+  #   observed engine, rather than serving traffic whose trace deletes are guaranteed to fail.
   tracesDistributedWrapEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
@@ -233,6 +236,16 @@ health:
     # Toggle-gated (databaseAnalytics.coldStorageDiskHealthCheckEnabled). Off by default so deployments without tier
     # storage are unaffected. When on, a node that can't reach the cold_s3 S3 disk must be pulled from rotation.
     - name: clickhouse-cold-storage-disk
+      critical: true
+      type: ready
+    # Fail-fast assertion that databaseAnalyticsDataModel.tracesDistributedWrapEnabled matches the actual `traces`
+    # topology: flag on -> `traces` is Distributed and `traces_local` exists; flag off -> `traces` is a
+    # (Replicated)MergeTree. Not toggle-gated on purpose — flag off over a MergeTree `traces` is the default
+    # everywhere, so only a genuine misconfiguration trips it, and either mismatch direction breaks trace deletes
+    # (code 36/48 one way, 60 the other) with no symptom until the first delete. Critical so such an install is pulled
+    # from rotation instead of serving traffic it cannot mutate; re-evaluated continuously, so it clears itself once
+    # the operator brings flag and topology back in step.
+    - name: clickhouse-traces-topology
       critical: true
       type: ready
     - name: mysql

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -212,8 +212,10 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > `databaseAnalyticsDataModel.tracesDistributedWrapEnabled`. Set it **`true` in lockstep with applying the wrap** so those
 > deletes run against `traces_local`; reads and inserts stay on the Distributed `traces`. The flag is **startup-bound**
 > (read once at boot; no hot-reload), so making it "live across the fleet" means a **completed rolling restart of every
-> backend instance** — there is no readiness endpoint exposing its value, so confirm via the deploy's restart completion
-> or by observing that trace deletes hit the intended table (queries are `log_comment`-tagged). A mismatch is
+> backend instance**. Since OPIK-7773 the flag's value is observable per instance: the `clickhouse-traces-topology`
+> readiness check asserts it against the live `traces` engine on every probe, so
+> `GET /health-check?name=clickhouse-traces-topology` reports which side of the cutover that instance believes it is on
+> and, on a mismatch, names both the flag and the observed engine. A mismatch is
 > **fail-loud**, not silent: a stale-`false` instance issues `DELETE` against the `Distributed` `traces` (code 36/48), a
 > stale-`true` instance against an absent `traces_local` — both 500 the delete path, so a partial rollout surfaces at
 > once and is recoverable. While it is `false` (the deploy
@@ -227,7 +229,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > the EXCHANGE. Defer the
 > wrap until the retarget flag is wired into the deploy. The wrap is the sharding-readiness layer, not the cutover.
 >
-> **"In lockstep" cannot mean simultaneous — plan for a short fail-loud delete window.** The toggle is a
+> **"In lockstep" cannot mean simultaneous — plan for a short mismatch window.** The toggle is a
 > config push plus a rolling restart; the wrap is a DDL statement. They cannot land at the same instant, so
 > one of two windows is unavoidable:
 > - **toggle first** (recommended): from the moment the last backend comes up with `true` until the wrap
@@ -236,10 +238,19 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > - **wrap first**: from the swap until the rolling restart finishes, deletes hit the `Distributed` `traces`
 >   → `Code: 36`. Same blast radius, but it also exposes the cross-node `ON CLUSTER` skew with no buffer.
 >
+> **Since OPIK-7773 the mismatch window is also a readiness window.** `clickhouse-traces-topology` is a
+> `critical`/`ready` check, so for as long as flag and topology disagree — in **either** order — every instance that
+> sees the mismatch fails `/health-check?name=all&type=ready` and Kubernetes takes it out of rotation. That is the
+> point of the check (an instance whose deletes cannot work should not serve), but it changes the cost of the window
+> from "delete-path 500s" to "no backend in rotation", so the window must sit **inside the declared maintenance window**
+> that `--confirm-maintenance` already asserts for the wrap. It is self-clearing: the probe re-evaluates continuously,
+> so rotation returns on the next successful probe after the two sides are back in step — no extra restart needed on
+> the wrap-first path, and only the already-planned restart on the toggle-first path.
+>
 > Prefer **toggle first**, have the `--wrap-only` command ready to run the moment every backend instance is up, and
-> keep the window to seconds. Both directions are delete-path-only and fail loudly rather than corrupting
-> anything, which is what makes a short window acceptable — but on a shared environment announce it, and do
-> not leave the toggle `true` without the wrap (or vice versa) for any length of time.
+> keep the window to seconds. Nothing in either direction corrupts data — that is what makes a short window
+> acceptable — but announce it on a shared environment, and do not leave the toggle `true` without the wrap (or vice
+> versa) for any length of time: with the readiness check in place that is now an outage, not a degradation.
 >
 > **Monitoring consequence of the flip:** `system.parts` only knows `traces_local` post-wrap, so the
 > `opik.clickhouse.partition.*` parts gauges relabel from `table="traces"` to `table="traces_local"`, while the

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -249,6 +249,15 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > differs, and with it what closes the window: on the toggle-first path the restart comes first and the **wrap DDL**
 > closes the window, on the wrap-first path the wrap comes first and the **restart completing** closes it.
 >
+> **The check reads one replica per probe.** It queries the node-local `system.tables` on whichever ClickHouse node the
+> load-balanced service hands it, so across the cross-node `ON CLUSTER` skew described below the mismatch is seen only
+> by the probes that land on a not-yet-wrapped host: pods flap instead of the fleet going dark in lockstep. That is
+> expected inside the window and is why the probe is not the propagation gate — to confirm the wrap actually reached
+> every replica, use the cluster-wide `clusterAllReplicas('{cluster}', system.tables)` form that `finalize.sh`
+> classifies with (also in the self-host troubleshooting page). Fan-out is deliberately out of the probe: it needs
+> `REMOTE` + `CLUSTER` grants the app user is not guaranteed to hold, and one unreachable replica would take the whole
+> fleet out of rotation.
+>
 > Prefer **toggle first**, have the `--wrap-only` command ready to run the moment every backend instance is up, and
 > keep the window to seconds. Nothing in either direction corrupts data — that is what makes a short window
 > acceptable — but announce it on a shared environment, and do not leave the toggle `true` without the wrap (or vice

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -244,8 +244,10 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > point of the check (an instance whose deletes cannot work should not serve), but it changes the cost of the window
 > from "delete-path 500s" to "no backend in rotation", so the window must sit **inside the declared maintenance window**
 > that `--confirm-maintenance` already asserts for the wrap. It is self-clearing: the probe re-evaluates continuously,
-> so rotation returns on the next successful probe after the two sides are back in step — no extra restart needed on
-> the wrap-first path, and only the already-planned restart on the toggle-first path.
+> so rotation returns on the next successful probe once the two sides are back in step. **Neither ordering needs an
+> extra restart** — both spend exactly the one planned rolling restart the toggle already requires; only its position
+> differs, and with it what closes the window: on the toggle-first path the restart comes first and the **wrap DDL**
+> closes the window, on the wrap-first path the wrap comes first and the **restart completing** closes it.
 >
 > Prefer **toggle first**, have the `--wrap-only` command ready to run the moment every backend instance is up, and
 > keep the window to seconds. Nothing in either direction corrupts data — that is what makes a short window

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -50,6 +50,12 @@ import lombok.Builder;
  * {@code MODIFY COLUMN} must be applied to <b>both</b> {@code traces_local} and the {@code Distributed} {@code traces}
  * (the wrapper accepts them as metadata-only, and targeting only {@code traces_local} leaves the wrapper without the
  * column, so reads fail with code 47).</p>
+ *
+ * <p>This flag is asserted against the live topology at readiness by
+ * {@code ClickHouseTracesTopologyHealthCheck}: either direction of mismatch fails the
+ * {@code clickhouse-traces-topology} probe with a message naming the flag and the observed engine, so an install whose
+ * flag and database disagree is pulled from rotation instead of discovering it on its first trace delete. The flag
+ * stays the source of truth — the probe only reports, it never re-routes.</p>
  */
 @Builder(toBuilder = true)
 public record DatabaseAnalyticsDataModelConfig(

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseExistenceHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseExistenceHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.Records;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.QuerySettings;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseClusterHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseClusterHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseColdStorageDiskHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseColdStorageDiskHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import io.dropwizard.util.Duration;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseReadOnlyFreeFormSqlHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseReadOnlyFreeFormSqlHealthCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.QuerySettings;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
@@ -1,0 +1,151 @@
+package com.comet.opik.infrastructure.db.healthchecks;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.query.Records;
+import com.comet.opik.infrastructure.DatabaseAnalyticsDataModelConfig;
+import io.dropwizard.util.Duration;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.comet.opik.infrastructure.db.DatabaseAnalyticsModule.CLICKHOUSE_HEALTH_CHECK_TIMEOUT;
+
+/**
+ * Asserts that {@code databaseAnalyticsDataModel.tracesDistributedWrapEnabled} agrees with the actual {@code traces}
+ * topology in ClickHouse, so a flag↔topology mismatch is caught at readiness instead of as errors on the first
+ * mutation.
+ *
+ * <p>Post-cutover {@code traces} is a {@code Distributed} table, which supports {@code SELECT}/{@code INSERT} but not
+ * mutations, so {@code TraceDAO} routes deletes at {@code traces_local} only while the flag is on (OPIK-7455). The two
+ * mismatch directions both break trace deletion, each in its own way, and neither is visible until a delete runs:
+ * flag off over a wrapped {@code traces} fails with {@code BAD_ARGUMENTS} (36) / {@code NOT_IMPLEMENTED} (48), flag on
+ * over an unwrapped one with {@code UNKNOWN_TABLE} (60). Since the answer depends on each environment's config plus its
+ * live database, this is inherently a runtime check and cannot be a CI guard.
+ *
+ * <p>One {@code system.tables} lookup covers both tables and both directions:
+ * <ul>
+ *     <li>flag on → {@code traces} must be {@code Distributed} <b>and</b> {@code traces_local} must exist;</li>
+ *     <li>flag off → {@code traces} must be a {@code (Replicated)MergeTree}, i.e. not {@code Distributed}.</li>
+ * </ul>
+ *
+ * <p>The flag stays the source of truth: a mismatch is reported, never repaired, and nothing here influences routing.
+ * The probe is not toggle-gated — flag off over a {@code MergeTree} {@code traces} is the default everywhere
+ * (OSS Docker, self-hosted, pre-cutover SaaS), so the assertion holds for every install as shipped and only a genuine
+ * misconfiguration trips it. Being a readiness check, it is re-evaluated continuously and clears itself once the
+ * operator brings the two sides back in step, which is what makes the lockstep cutover transition (apply the wrap, flip
+ * the flag, restart) tolerable rather than a deadlock.
+ */
+@Singleton
+public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealthCheck {
+
+    private static final String NAME = "clickhouse-traces-topology";
+
+    private static final String TRACES_TABLE = "traces";
+    private static final String TRACES_LOCAL_TABLE = "traces_local";
+
+    private static final String DISTRIBUTED_ENGINE = "Distributed";
+    private static final String MERGE_TREE_ENGINE_SUFFIX = "MergeTree";
+
+    private static final String FLAG = "databaseAnalyticsDataModel.tracesDistributedWrapEnabled";
+
+    private static final String NAME_COLUMN = "name";
+    private static final String ENGINE_COLUMN = "engine";
+
+    /**
+     * Both tables in one lookup. {@code currentDatabase()} resolves to the database the v2 client was built with
+     * ({@code Client.Builder#setDefaultDatabase}), so the probe follows {@code databaseAnalytics.databaseName} without
+     * interpolating it into SQL.
+     */
+    private static final String TOPOLOGY_QUERY = """
+            SELECT name, engine FROM system.tables \
+            WHERE database = currentDatabase() AND name IN ('%s', '%s')\
+            """.formatted(TRACES_TABLE, TRACES_LOCAL_TABLE);
+
+    private static final String HEALTHY_WRAPPED = "'%s' is %s over '%s', matching %s=true"
+            .formatted(TRACES_TABLE, DISTRIBUTED_ENGINE, TRACES_LOCAL_TABLE, FLAG);
+    private static final String HEALTHY_UNWRAPPED_TEMPLATE = "'%s' is a %%s, matching %s=false"
+            .formatted(TRACES_TABLE, FLAG);
+
+    private static final String MISSING_TRACES_TEMPLATE = ("%s=%%b, but table '%s' does not exist in the analytics "
+            + "database. Trace reads and writes cannot work at all; check that the analytics migrations ran.")
+            .formatted(FLAG, TRACES_TABLE);
+    private static final String NOT_WRAPPED_TEMPLATE = ("%s=true routes trace mutations at '%s', but '%s' is a %%s, "
+            + "not %s: the Distributed wrap has not been applied. Apply it (exchange_and_wrap.sh --wrap-only) or set "
+            + "the flag back to false — otherwise trace deletes fail with UNKNOWN_TABLE (60).")
+            .formatted(FLAG, TRACES_LOCAL_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE);
+    private static final String MISSING_TRACES_LOCAL = ("%s=true routes trace mutations at '%s' and '%s' is %s as "
+            + "expected, but table '%s' does not exist. Trace deletes fail with UNKNOWN_TABLE (60); the Distributed "
+            + "wrap points at a shard table that is absent from this node.")
+            .formatted(FLAG, TRACES_LOCAL_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE, TRACES_LOCAL_TABLE);
+    private static final String WRAPPED_MESSAGE = ("%s=false routes trace mutations directly at '%s', but '%s' is a "
+            + "%s table, which rejects mutations: the Distributed wrap has been applied. Set the flag to true and "
+            + "restart — otherwise trace deletes fail with BAD_ARGUMENTS (36) / NOT_IMPLEMENTED (48).")
+            .formatted(FLAG, TRACES_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE);
+    private static final String NOT_MERGE_TREE_TEMPLATE = ("%s=false expects '%s' to be a (Replicated)%s that takes "
+            + "mutations directly, but it is a %%s. Trace deletes are not guaranteed to work against this engine.")
+            .formatted(FLAG, TRACES_TABLE, MERGE_TREE_ENGINE_SUFFIX);
+
+    private final boolean wrapEnabled;
+
+    @Inject
+    public ClickHouseTracesTopologyHealthCheck(@NonNull Client clickHouseClient,
+            @NonNull @Named(CLICKHOUSE_HEALTH_CHECK_TIMEOUT) Duration healthCheckTimeout,
+            @NonNull @Config("databaseAnalyticsDataModel") DatabaseAnalyticsDataModelConfig dataModel) {
+        super(clickHouseClient, healthCheckTimeout, NAME);
+        this.wrapEnabled = dataModel.tracesDistributedWrapEnabled();
+    }
+
+    @Override
+    protected Result check() {
+        return executeProbe(clickHouseClient.queryRecords(TOPOLOGY_QUERY, newQuerySettings()), this::evaluate);
+    }
+
+    private Result evaluate(Records records) {
+        var engines = readEngines(records);
+        var tracesEngine = engines.get(TRACES_TABLE);
+
+        if (tracesEngine == null) {
+            return Result.unhealthy(MISSING_TRACES_TEMPLATE.formatted(wrapEnabled));
+        }
+        return wrapEnabled
+                ? checkWrapExpected(tracesEngine, engines.containsKey(TRACES_LOCAL_TABLE))
+                : checkWrapNotExpected(tracesEngine);
+    }
+
+    private static Result checkWrapExpected(String tracesEngine, boolean tracesLocalExists) {
+        if (!DISTRIBUTED_ENGINE.equals(tracesEngine)) {
+            return Result.unhealthy(NOT_WRAPPED_TEMPLATE.formatted(tracesEngine));
+        }
+        if (!tracesLocalExists) {
+            return Result.unhealthy(MISSING_TRACES_LOCAL);
+        }
+        return Result.healthy(HEALTHY_WRAPPED);
+    }
+
+    private static Result checkWrapNotExpected(String tracesEngine) {
+        if (DISTRIBUTED_ENGINE.equals(tracesEngine)) {
+            return Result.unhealthy(WRAPPED_MESSAGE);
+        }
+        // Accepts every MergeTree family member (MergeTree, ReplicatedMergeTree, SharedMergeTree): what matters is
+        // that the engine takes mutations directly, which is exactly what the family suffix marks.
+        if (!tracesEngine.endsWith(MERGE_TREE_ENGINE_SUFFIX)) {
+            return Result.unhealthy(NOT_MERGE_TREE_TEMPLATE.formatted(tracesEngine));
+        }
+        return Result.healthy(HEALTHY_UNWRAPPED_TEMPLATE.formatted(tracesEngine));
+    }
+
+    private static Map<String, String> readEngines(Records records) {
+        var engines = new HashMap<String, String>();
+        // Iterating (rather than Iterable.forEach) keeps the read on Records.iterator(), the one method the sibling
+        // probes' tests stub — a mocked default method would silently swallow the rows.
+        for (var row : records) {
+            engines.put(row.getString(NAME_COLUMN), row.getString(ENGINE_COLUMN));
+        }
+        return engines;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
@@ -30,7 +30,9 @@ import static com.comet.opik.infrastructure.db.DatabaseAnalyticsModule.CLICKHOUS
  * <p>One {@code system.tables} lookup covers both tables and both directions:
  * <ul>
  *     <li>flag on → {@code traces} must be {@code Distributed} <b>and</b> {@code traces_local} must exist;</li>
- *     <li>flag off → {@code traces} must be a {@code (Replicated)MergeTree}, i.e. not {@code Distributed}.</li>
+ *     <li>flag off → {@code traces} must be an engine of the {@code MergeTree} family — the suffix match
+ *     accepts {@code MergeTree}, {@code ReplicatedMergeTree} and ClickHouse Cloud's {@code SharedMergeTree}
+ *     variants alike — i.e. anything that takes mutations directly, and not {@code Distributed}.</li>
  * </ul>
  *
  * <p>The flag stays the source of truth: a mismatch is reported, never repaired, and nothing here influences routing.
@@ -77,10 +79,20 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
     private static final String MISSING_TRACES_TEMPLATE = ("%s=%%b, but table '%s' does not exist in the analytics "
             + "database. Trace reads and writes cannot work at all; check that the analytics migrations ran.")
             .formatted(FLAG, TRACES_TABLE);
+    /**
+     * Deliberately does not name an error code. This branch fires whenever the flag is on and {@code traces} is not
+     * {@code Distributed}, and the consequence depends on whether {@code traces_local} happens to exist: absent, deletes
+     * fail loudly with {@code UNKNOWN_TABLE (60)}; present but stale — the state a rollback leaves, having promoted the
+     * original {@code traces} back while the old shard lingers — the delete <b>succeeds against the wrong table</b> and
+     * the live rows are never touched. Naming only the loud outcome would understate the quiet one, which is worse.
+     */
     private static final String NOT_WRAPPED_TEMPLATE = ("%s=true routes trace mutations at '%s', but '%s' is a %%s, "
-            + "not %s: the Distributed wrap has not been applied. Apply it (exchange_and_wrap.sh --wrap-only) or set "
-            + "the flag back to false — otherwise trace deletes fail with UNKNOWN_TABLE (60).")
-            .formatted(FLAG, TRACES_LOCAL_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE);
+            + "not %s: the Distributed wrap has not been applied (or has been rolled back). Apply it "
+            + "(exchange_and_wrap.sh --wrap-only) or set the flag back to false — otherwise trace deletes either fail "
+            + "with UNKNOWN_TABLE (60) when '%s' is absent, or silently delete from a stale '%s' while the live rows in "
+            + "'%s' are left untouched.")
+            .formatted(FLAG, TRACES_LOCAL_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE, TRACES_LOCAL_TABLE,
+                    TRACES_LOCAL_TABLE, TRACES_TABLE);
     private static final String MISSING_TRACES_LOCAL = ("%s=true routes trace mutations at '%s' and '%s' is %s as "
             + "expected, but table '%s' does not exist. Trace deletes fail with UNKNOWN_TABLE (60); the Distributed "
             + "wrap points at a shard table that is absent from this node.")

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
@@ -65,6 +65,30 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
      * stubs this exact query text, so the two cannot drift apart unnoticed. {@code currentDatabase()} resolves to the
      * database the v2 client was built with ({@code Client.Builder#setDefaultDatabase}), so the probe follows
      * {@code databaseAnalytics.databaseName} without naming it in SQL at all.
+     *
+     * <p><b>The scope is the node that answers, deliberately.</b> {@code system.tables} is node-local and this probe
+     * does not fan out with {@code clusterAllReplicas}, unlike the cutover scripts' settle and finalize gates. The
+     * backend reaches ClickHouse through the load-balanced CHI service ({@code ANALYTICS_DB_HOST}), so the probe reads
+     * the same population its own {@code DELETE}s are routed to. Three reasons not to widen it:
+     * <ul>
+     *     <li>{@code clusterAllReplicas} needs {@code REMOTE} and {@code CLUSTER} grants, which the application user
+     *     is not guaranteed to hold — the runbook's privileges table grants them explicitly to the cutover's dedicated
+     *     least-privilege user, not to the app. A critical check that is deliberately <em>not</em> toggle-gated must
+     *     never fail on an install as shipped, and a missing grant would fail it on every install at once.</li>
+     *     <li>A single unreachable replica makes the fan-out throw, which would pull <em>every</em> backend pod out of
+     *     rotation over a condition that does not break trace deletes at all — strictly worse availability than the
+     *     mismatch being guarded.</li>
+     *     <li>On shared-catalog deployments (ClickHouse Cloud / {@code SharedMergeTree}) every replica reads one
+     *     catalog, so node-local already <em>is</em> cluster-wide there.</li>
+     * </ul>
+     *
+     * <p>The accepted limit that follows: a divergence confined to some replicas — an {@code ON CLUSTER} DDL still
+     * propagating, or one that failed on a host — is seen only by the probes that happen to land there, so it degrades
+     * into sporadic unhealthy reports instead of taking the fleet dark. That is the right trade for the transient
+     * cross-node skew the wrap is expected to produce inside its maintenance window, and the cluster-wide question
+     * ("has this DDL reached every replica?") is already answered where it belongs: the fail-loud, one-shot,
+     * operator-run {@code clusterAllReplicas} gates in {@code exchange_and_wrap.sh} and {@code finalize.sh}. The
+     * self-host troubleshooting page carries that query for an operator chasing an intermittent failure here.
      */
     private static final String TOPOLOGY_QUERY = """
             SELECT name, engine FROM system.tables \

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheck.java
@@ -57,14 +57,17 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
     private static final String ENGINE_COLUMN = "engine";
 
     /**
-     * Both tables in one lookup. {@code currentDatabase()} resolves to the database the v2 client was built with
-     * ({@code Client.Builder#setDefaultDatabase}), so the probe follows {@code databaseAnalytics.databaseName} without
-     * interpolating it into SQL.
+     * Both tables in one lookup, declared once as a literal text block — SQL is never assembled with Java string
+     * operations, so the table names are spelled out here rather than interpolated from the constants above (which
+     * remain the single source for the map lookups and the messages). {@code ClickHouseTracesTopologyHealthCheckTest}
+     * stubs this exact query text, so the two cannot drift apart unnoticed. {@code currentDatabase()} resolves to the
+     * database the v2 client was built with ({@code Client.Builder#setDefaultDatabase}), so the probe follows
+     * {@code databaseAnalytics.databaseName} without naming it in SQL at all.
      */
     private static final String TOPOLOGY_QUERY = """
             SELECT name, engine FROM system.tables \
-            WHERE database = currentDatabase() AND name IN ('%s', '%s')\
-            """.formatted(TRACES_TABLE, TRACES_LOCAL_TABLE);
+            WHERE database = currentDatabase() AND name IN ('traces', 'traces_local')\
+            """;
 
     private static final String HEALTHY_WRAPPED = "'%s' is %s over '%s', matching %s=true"
             .formatted(TRACES_TABLE, DISTRIBUTED_ENGINE, TRACES_LOCAL_TABLE, FLAG);
@@ -82,6 +85,10 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
             + "expected, but table '%s' does not exist. Trace deletes fail with UNKNOWN_TABLE (60); the Distributed "
             + "wrap points at a shard table that is absent from this node.")
             .formatted(FLAG, TRACES_LOCAL_TABLE, TRACES_TABLE, DISTRIBUTED_ENGINE, TRACES_LOCAL_TABLE);
+    private static final String TRACES_LOCAL_NOT_MERGE_TREE_TEMPLATE = ("%s=true routes trace mutations at '%s', which "
+            + "exists but is a %%s rather than a (Replicated)%s. Trace deletes cannot run against that engine, so the "
+            + "wrap is pointing at the wrong table.")
+            .formatted(FLAG, TRACES_LOCAL_TABLE, MERGE_TREE_ENGINE_SUFFIX);
     private static final String WRAPPED_MESSAGE = ("%s=false routes trace mutations directly at '%s', but '%s' is a "
             + "%s table, which rejects mutations: the Distributed wrap has been applied. Set the flag to true and "
             + "restart — otherwise trace deletes fail with BAD_ARGUMENTS (36) / NOT_IMPLEMENTED (48).")
@@ -113,16 +120,22 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
             return Result.unhealthy(MISSING_TRACES_TEMPLATE.formatted(wrapEnabled));
         }
         return wrapEnabled
-                ? checkWrapExpected(tracesEngine, engines.containsKey(TRACES_LOCAL_TABLE))
+                ? checkWrapExpected(tracesEngine, engines.get(TRACES_LOCAL_TABLE))
                 : checkWrapNotExpected(tracesEngine);
     }
 
-    private static Result checkWrapExpected(String tracesEngine, boolean tracesLocalExists) {
+    private static Result checkWrapExpected(String tracesEngine, String tracesLocalEngine) {
         if (!DISTRIBUTED_ENGINE.equals(tracesEngine)) {
             return Result.unhealthy(NOT_WRAPPED_TEMPLATE.formatted(tracesEngine));
         }
-        if (!tracesLocalExists) {
+        if (tracesLocalEngine == null) {
             return Result.unhealthy(MISSING_TRACES_LOCAL);
+        }
+        // Presence alone is not enough: the wrap's target is where TraceDAO sends its DELETEs, so a same-named View,
+        // Log or nested Distributed there fails mutations exactly like an absent table. The engine is already in the
+        // one row this probe reads, so holding it to the mutation-capable family costs nothing.
+        if (!isMergeTreeFamily(tracesLocalEngine)) {
+            return Result.unhealthy(TRACES_LOCAL_NOT_MERGE_TREE_TEMPLATE.formatted(tracesLocalEngine));
         }
         return Result.healthy(HEALTHY_WRAPPED);
     }
@@ -131,12 +144,19 @@ public class ClickHouseTracesTopologyHealthCheck extends AbstractClickHouseHealt
         if (DISTRIBUTED_ENGINE.equals(tracesEngine)) {
             return Result.unhealthy(WRAPPED_MESSAGE);
         }
-        // Accepts every MergeTree family member (MergeTree, ReplicatedMergeTree, SharedMergeTree): what matters is
-        // that the engine takes mutations directly, which is exactly what the family suffix marks.
-        if (!tracesEngine.endsWith(MERGE_TREE_ENGINE_SUFFIX)) {
+        if (!isMergeTreeFamily(tracesEngine)) {
             return Result.unhealthy(NOT_MERGE_TREE_TEMPLATE.formatted(tracesEngine));
         }
         return Result.healthy(HEALTHY_UNWRAPPED_TEMPLATE.formatted(tracesEngine));
+    }
+
+    /**
+     * Accepts every MergeTree family member — {@code MergeTree}, {@code ReplicatedReplacingMergeTree},
+     * {@code SharedMergeTree} and the rest. What the probe cares about is whether the engine takes mutations directly,
+     * and the family suffix is exactly what marks that; enumerating the variants would only go stale.
+     */
+    private static boolean isMergeTreeFamily(String engine) {
+        return engine.endsWith(MERGE_TREE_ENGINE_SUFFIX);
     }
 
     private static Map<String, String> readEngines(Records records) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/MysqlHealthyCheck.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/healthchecks/MysqlHealthyCheck.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceMutationRoutingArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceMutationRoutingArchTest.java
@@ -1,9 +1,10 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.infrastructure.DatabaseAnalyticsDataModelConfig;
+import com.comet.opik.infrastructure.db.healthchecks.ClickHouseTracesTopologyHealthCheck;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaCodeUnit;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -15,6 +16,7 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
+import static com.tngtech.archunit.core.domain.JavaConstructor.CONSTRUCTOR_NAME;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
 
@@ -41,6 +43,14 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
  * method of the same name satisfy the exemption — an {@code OtherDao#tracesDistributedWrapEnabled()} reading the config
  * directly would have passed, which is precisely the second reader these rules exist to forbid.
  *
+ * <p><b>The one other permitted reader is {@link ClickHouseTracesTopologyHealthCheck}, and only because it routes
+ * nothing.</b> What the first rule protects is the routing decision: a second place that branches on the flag is a
+ * second place that can name the wrong table. The probe branches on it to <em>assert</em> it against the live
+ * {@code system.tables} topology and report a mismatch at readiness — it issues no mutation and picks no table, so it
+ * cannot get the read/mutate split wrong. It is exempted by name on its own class, like the DAO accessor, so this is an
+ * allowlist of two rather than a loosened rule; a third reader still fails the build. The exemption is on its
+ * constructor because the flag is read once at injection.
+ *
  * <p><b>Deliberately no {@code allowEmptyShould}</b>, unlike {@link TraceDeletionEventArchTest}: these rules select the
  * guarded method rather than its callers, so an empty selection means the method was renamed or removed and the rule is
  * no longer guarding anything. Failing then is the point.
@@ -52,26 +62,34 @@ class TraceMutationRoutingArchTest {
     private static final String RESOLVER = "tracesMutationTable";
 
     /**
-     * Exactly one method: the named one on the named class. Matching by name alone would exempt any class that happened
-     * to declare a method of that name, which is the very thing these rules forbid.
+     * Exactly one code unit: the named one on the named class. Matching by name alone would exempt any class that
+     * happened to declare a member of that name, which is the very thing these rules forbid. Typed on
+     * {@link JavaCodeUnit} rather than {@code JavaMethod} so the same helper can name a constructor
+     * ({@link #CONSTRUCTOR_NAME}); it still satisfies {@code byMethodsThat}, since a method is a code unit.
      */
-    private static DescribedPredicate<JavaMethod> only(Class<?> owner, String methodName) {
-        return DescribedPredicate.describe("%s.%s".formatted(owner.getSimpleName(), methodName),
-                method -> method.getOwner().isEquivalentTo(owner) && method.getName().equals(methodName));
+    private static DescribedPredicate<JavaCodeUnit> only(Class<?> owner, String memberName) {
+        return DescribedPredicate.describe("%s.%s".formatted(owner.getSimpleName(), memberName),
+                codeUnit -> codeUnit.getOwner().isEquivalentTo(owner) && codeUnit.getName().equals(memberName));
     }
 
     /**
-     * The flag itself is read only by {@code TraceDAOImpl}'s accessor of the same name, whose Javadoc carries the
-     * read/mutate split and the migration rules. A second reader is a second place that can get those wrong.
+     * The flag is read by {@code TraceDAOImpl}'s accessor of the same name, whose Javadoc carries the read/mutate split
+     * and the migration rules, and by the readiness probe that asserts it against the live topology. A third reader is
+     * a third place that can get the split wrong. {@code byCodeUnitsThat} rather than {@code byMethodsThat} because the
+     * probe reads the flag in its constructor, and a constructor is not a {@code JavaMethod} — so the method-only form
+     * could never have admitted it, only reported it.
      */
     @ArchTest
-    static final ArchRule the_wrap_flag_is_read_in_exactly_one_place = methods()
+    static final ArchRule the_wrap_flag_is_read_only_by_the_dao_accessor_and_the_readiness_probe = methods()
             .that().areDeclaredIn(DatabaseAnalyticsDataModelConfig.class)
             .and().haveName(CONFIG_FLAG)
-            .should().onlyBeCalled().byMethodsThat(only(TraceDAOImpl.class, CONFIG_FLAG))
+            .should().onlyBeCalled().byCodeUnitsThat(only(TraceDAOImpl.class, CONFIG_FLAG)
+                    .or(only(ClickHouseTracesTopologyHealthCheck.class, CONSTRUCTOR_NAME)))
             .because("""
                     the sharding-readiness wrap flag must be read only by TraceDAOImpl#tracesDistributedWrapEnabled, \
-                    which documents what the two topologies imply for reads, mutations and migrations
+                    which documents what the two topologies imply for reads, mutations and migrations, and by \
+                    ClickHouseTracesTopologyHealthCheck, which asserts the flag against the live `traces` engine and \
+                    routes nothing
                     """);
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/HealthCheckIntegrationTest.java
@@ -109,6 +109,12 @@ class HealthCheckIntegrationTest {
                     .name("clickhouse-cluster").healthy(true).critical(true).type(READY).build();
             var clickhouseColdStorageDiskResponse = HealthCheckResponse.builder()
                     .name("clickhouse-cold-storage-disk").healthy(true).critical(true).type(READY).build();
+            // databaseAnalyticsDataModel.tracesDistributedWrapEnabled is false in config-test and the migrated
+            // `traces` is a ReplicatedMergeTree, so flag and topology agree — the matching-config case, which has to
+            // boot and report ready like any default install. Unlike the two probes above this one is not
+            // toggle-gated, so it really does run its system.tables query here.
+            var clickhouseTracesTopologyResponse = HealthCheckResponse.builder()
+                    .name("clickhouse-traces-topology").healthy(true).critical(true).type(READY).build();
             var mysqlResponse = HealthCheckResponse.builder()
                     .name("mysql").healthy(true).critical(true).type(READY).build();
             var redisResponse = HealthCheckResponse.builder()
@@ -126,6 +132,7 @@ class HealthCheckIntegrationTest {
                     clickhouseFreeformSqlResponse,
                     clickhouseClusterResponse,
                     clickhouseColdStorageDiskResponse,
+                    clickhouseTracesTopologyResponse,
                     mysqlResponse,
                     redisResponse,
                     dbResponse,
@@ -138,6 +145,7 @@ class HealthCheckIntegrationTest {
                     arguments("clickhouse-readonly-freeform-sql", List.of(clickhouseFreeformSqlResponse)),
                     arguments("clickhouse-cluster", List.of(clickhouseClusterResponse)),
                     arguments("clickhouse-cold-storage-disk", List.of(clickhouseColdStorageDiskResponse)),
+                    arguments("clickhouse-traces-topology", List.of(clickhouseTracesTopologyResponse)),
                     arguments("shared_http_client", List.of(sharedHttpClientResponse)),
                     arguments("all", all));
         }
@@ -156,7 +164,7 @@ class HealthCheckIntegrationTest {
      * {@code apps/opik-backend/provision_agent_insights_readonly_user.sh}), so the {@code
      * clickhouse-readonly-freeform-sql} probe actually runs against it. Without the {@code
      * newQuerySettings()} override in
-     * {@link com.comet.opik.infrastructure.db.ClickHouseReadOnlyFreeFormSqlHealthCheck} the probe
+     * {@link com.comet.opik.infrastructure.db.healthchecks.ClickHouseReadOnlyFreeFormSqlHealthCheck} the probe
      * is rejected with {@code Code: 164. DB::Exception: Cannot modify 'max_execution_time'
      * setting in readonly mode. (READONLY)}.
      */
@@ -234,6 +242,67 @@ class HealthCheckIntegrationTest {
             Awaitility.await()
                     .atMost(5, TimeUnit.SECONDS)
                     .untilAsserted(() -> assertResponse(readHealthCheck(client, baseURI, name), List.of(expected)));
+        }
+    }
+
+    /**
+     * The flag-on-without-the-wrap mismatch: {@code databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true} over
+     * a migrated {@code traces} that is still a {@code ReplicatedMergeTree}. That is a real, reachable
+     * misconfiguration — an operator flips the flag but never applies the wrap — and every trace delete on such an
+     * install fails with {@code UNKNOWN_TABLE} (60) because the DAO routes at a {@code traces_local} that does not
+     * exist. The point of OPIK-7773 is that this shows up as a failed readiness probe at startup instead, so the app
+     * is pulled from rotation before it serves traffic it cannot mutate.
+     *
+     * <p>Safe on the shared container: the probe only reads {@code system.tables}, so nothing here reshapes the
+     * schema. The opposite mismatch needs a really wrapped {@code traces} and so lives in
+     * {@code ClickHouseTracesTopologyReadinessTest}, on its own containers.
+     */
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @ExtendWith(DropwizardAppExtensionProvider.class)
+    class TracesDistributedWrapEnabledWithoutTheWrap {
+
+        @RegisterApp
+        private final TestDropwizardAppExtension app = newApp(List.of(
+                new CustomConfig("databaseAnalyticsDataModel.tracesDistributedWrapEnabled", "true")));
+
+        private ClientSupport client;
+        private String baseURI;
+
+        @BeforeAll
+        void setUpAll(ClientSupport client) {
+            this.client = client;
+            this.baseURI = TestUtils.getBaseUrl(client);
+            ClientSupportUtils.config(client);
+        }
+
+        @Test
+        void healthCheckFailsReadiness() {
+            var expected = HealthCheckResponse.builder()
+                    .name("clickhouse-traces-topology").healthy(false).critical(true).type(READY).build();
+
+            Awaitility.await()
+                    .atMost(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> assertResponse(
+                            readHealthCheck(client, baseURI, "clickhouse-traces-topology"), List.of(expected)));
+        }
+
+        /**
+         * The check is only worth having if it actually pulls the pod from rotation, so this asserts the aggregate
+         * endpoint the Kubernetes readiness probe really hits — {@code /health-check?name=all&type=ready}, per the
+         * chart's {@code component.backend.readinessProbe} — rather than just the per-check row above.
+         */
+        @Test
+        void readinessProbeFailsWhileTheTopologyDisagreesWithTheFlag() {
+            Awaitility.await()
+                    .atMost(5, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        try (var response = client.target("%s/health-check?name=all&type=ready".formatted(baseURI))
+                                .request()
+                                .get()) {
+                            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_SERVICE_UNAVAILABLE);
+                        }
+                    });
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/AbstractClickHouseHealthCheckTest.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.QueryResponse;
@@ -15,7 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static com.comet.opik.infrastructure.db.AbstractClickHouseHealthCheck.SELECT_1_QUERY;
+import static com.comet.opik.infrastructure.db.healthchecks.AbstractClickHouseHealthCheck.SELECT_1_QUERY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseExistenceHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseExistenceHealthCheckTest.java
@@ -1,4 +1,4 @@
-package com.comet.opik.infrastructure.db;
+package com.comet.opik.infrastructure.db.healthchecks;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.GenericRecord;

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
@@ -1,0 +1,217 @@
+package com.comet.opik.infrastructure.db.healthchecks;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.query.GenericRecord;
+import com.clickhouse.client.api.query.QuerySettings;
+import com.clickhouse.client.api.query.Records;
+import com.codahale.metrics.health.HealthCheck;
+import com.comet.opik.infrastructure.DatabaseAnalyticsDataModelConfig;
+import io.dropwizard.util.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentMatcher;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Behaviour of {@link ClickHouseTracesTopologyHealthCheck}: the flag↔topology assertion in both directions, plus the
+ * shared timeout/cancellation contract inherited from {@link AbstractClickHouseHealthCheck}.
+ *
+ * <p>The mismatch cases are the point of the check, so each one asserts the actual message, not merely that the probe
+ * went unhealthy: the message is the only thing an operator sees on {@code /health-check}, and it has to name the flag,
+ * the observed engine and the fix. {@code ClickHouseTracesTopologyReadinessTest} covers the same matrix end-to-end
+ * against a real ClickHouse.
+ */
+class ClickHouseTracesTopologyHealthCheckTest {
+
+    private static final int HEALTH_CHECK_TIMEOUT_SECONDS = 1;
+    private static final Duration HEALTH_CHECK_TIMEOUT = Duration.seconds(HEALTH_CHECK_TIMEOUT_SECONDS);
+    private static final String CLICKHOUSE_SETTING_MAX_EXECUTION_TIME = "clickhouse_setting_max_execution_time";
+    private static final String CLICKHOUSE_SETTING_LOG_COMMENT = "clickhouse_setting_log_comment";
+    private static final String EXPECTED_LOG_COMMENT = "health_check:clickhouse-traces-topology";
+
+    private static final String TOPOLOGY_QUERY = "SELECT name, engine FROM system.tables "
+            + "WHERE database = currentDatabase() AND name IN ('traces', 'traces_local')";
+
+    private static final String FLAG = "databaseAnalyticsDataModel.tracesDistributedWrapEnabled";
+
+    private final Client clickHouseClient = mock(Client.class);
+
+    @AfterEach
+    void afterEach() {
+        // The interrupt-path test leaves the thread's interrupt flag set; clear so it doesn't leak into subsequent
+        // tests on the same JUnit worker thread.
+        Thread.interrupted();
+    }
+
+    @Test
+    void check__whenWrapEnabledAndTracesIsDistributedOverTracesLocal__thenHealthy() {
+        var actualResult = check(true, Map.of("traces", "Distributed", "traces_local", "ReplicatedMergeTree"));
+
+        assertThat(actualResult.isHealthy()).isTrue();
+        assertThat(actualResult.getMessage())
+                .isEqualTo("'traces' is Distributed over 'traces_local', matching %s=true".formatted(FLAG));
+    }
+
+    @ParameterizedTest(name = "engine={0}")
+    @ValueSource(strings = {"MergeTree", "ReplicatedMergeTree", "SharedMergeTree"})
+    void check__whenWrapDisabledAndTracesIsAMergeTree__thenHealthy(String engine) {
+        var actualResult = check(false, Map.of("traces", engine));
+
+        assertThat(actualResult.isHealthy()).isTrue();
+        assertThat(actualResult.getMessage())
+                .isEqualTo("'traces' is a %s, matching %s=false".formatted(engine, FLAG));
+    }
+
+    /**
+     * {@code traces_local} is still present here: after the EXCHANGE but before the wrap, the shard table exists while
+     * {@code traces} is a plain MergeTree — so the probe cannot infer the wrap from its presence, only from the engine
+     * of {@code traces} itself.
+     */
+    @Test
+    void check__whenWrapEnabledButTracesIsNotWrapped__thenUnhealthyNamingTheObservedEngine() {
+        var actualResult = check(true, Map.of("traces", "ReplicatedMergeTree", "traces_local", "ReplicatedMergeTree"));
+
+        assertUnhealthy(actualResult, "%s=true routes trace mutations at 'traces_local', but 'traces' is a "
+                .formatted(FLAG) + "ReplicatedMergeTree, not Distributed: the Distributed wrap has not been applied. "
+                + "Apply it (exchange_and_wrap.sh --wrap-only) or set the flag back to false — otherwise trace deletes "
+                + "fail with UNKNOWN_TABLE (60).");
+    }
+
+    @Test
+    void check__whenWrapEnabledAndTracesIsDistributedButTracesLocalIsMissing__thenUnhealthy() {
+        var actualResult = check(true, Map.of("traces", "Distributed"));
+
+        assertUnhealthy(actualResult, ("%s=true routes trace mutations at 'traces_local' and 'traces' is Distributed "
+                + "as expected, but table 'traces_local' does not exist. Trace deletes fail with UNKNOWN_TABLE (60); "
+                + "the Distributed wrap points at a shard table that is absent from this node.").formatted(FLAG));
+    }
+
+    @Test
+    void check__whenWrapDisabledButTracesIsDistributed__thenUnhealthy() {
+        var actualResult = check(false, Map.of("traces", "Distributed", "traces_local", "ReplicatedMergeTree"));
+
+        assertUnhealthy(actualResult, ("%s=false routes trace mutations directly at 'traces', but 'traces' is a "
+                + "Distributed table, which rejects mutations: the Distributed wrap has been applied. Set the flag to "
+                + "true and restart — otherwise trace deletes fail with BAD_ARGUMENTS (36) / NOT_IMPLEMENTED (48).")
+                .formatted(FLAG));
+    }
+
+    @Test
+    void check__whenWrapDisabledAndTracesIsNeitherDistributedNorAMergeTree__thenUnhealthy() {
+        var actualResult = check(false, Map.of("traces", "Log"));
+
+        assertUnhealthy(actualResult, ("%s=false expects 'traces' to be a (Replicated)MergeTree that takes mutations "
+                + "directly, but it is a Log. Trace deletes are not guaranteed to work against this engine.")
+                .formatted(FLAG));
+    }
+
+    @ParameterizedTest(name = "wrapEnabled={0}")
+    @ValueSource(booleans = {true, false})
+    void check__whenTracesIsMissingEntirely__thenUnhealthyRegardlessOfTheFlag(boolean wrapEnabled) {
+        var actualResult = check(wrapEnabled, Map.of());
+
+        assertUnhealthy(actualResult, ("%s=%b, but table 'traces' does not exist in the analytics database. Trace "
+                + "reads and writes cannot work at all; check that the analytics migrations ran.")
+                .formatted(FLAG, wrapEnabled));
+    }
+
+    private static Stream<Arguments> failureModes() {
+        return Stream.of(
+                arguments("execution", new ExecutionException(new RuntimeException("ClickHouse unavailable"))),
+                arguments("interrupt", new InterruptedException("Interrupted call")));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("failureModes")
+    void check__whenQueryFails__thenUnhealthyAndCancelsQuery(String name, Exception failure) throws Exception {
+        var failingFuture = mock(CompletableFuture.class);
+        when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS)).thenThrow(failure);
+        when(clickHouseClient.queryRecords(eq(TOPOLOGY_QUERY), argThat(probeServerSettings())))
+                .thenReturn(failingFuture);
+
+        var actualResult = newHealthCheck(true).execute();
+
+        assertThat(actualResult.isHealthy()).isFalse();
+        assertThat(actualResult.getError()).isSameAs(failure);
+        verify(failingFuture).cancel(true);
+    }
+
+    @Test
+    void check__whenInterrupted__thenRestoresTheInterruptFlag() throws Exception {
+        var failingFuture = mock(CompletableFuture.class);
+        when(failingFuture.get(HEALTH_CHECK_TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS))
+                .thenThrow(new InterruptedException("Interrupted call"));
+        when(clickHouseClient.queryRecords(eq(TOPOLOGY_QUERY), argThat(probeServerSettings())))
+                .thenReturn(failingFuture);
+
+        newHealthCheck(true).execute();
+
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    private HealthCheck.Result check(boolean wrapEnabled, Map<String, String> tables) {
+        // Built before when(...) opens: the row mocks are stubbed themselves, and Mockito rejects that mid-stubbing.
+        var records = records(tables);
+        when(clickHouseClient.queryRecords(eq(TOPOLOGY_QUERY), argThat(probeServerSettings())))
+                .thenReturn(CompletableFuture.completedFuture(records));
+
+        return newHealthCheck(wrapEnabled).execute();
+    }
+
+    private ClickHouseTracesTopologyHealthCheck newHealthCheck(boolean wrapEnabled) {
+        var dataModel = DatabaseAnalyticsDataModelConfig.builder()
+                .tracesDistributedWrapEnabled(wrapEnabled)
+                .build();
+        return new ClickHouseTracesTopologyHealthCheck(clickHouseClient, HEALTH_CHECK_TIMEOUT, dataModel);
+    }
+
+    /**
+     * One row per {@code name -> engine} entry, in the shape {@code system.tables} returns. Iteration order is
+     * irrelevant to the probe, which indexes by name.
+     */
+    private Records records(Map<String, String> tables) {
+        var rows = tables.entrySet().stream()
+                .map(entry -> {
+                    var row = mock(GenericRecord.class);
+                    when(row.getString("name")).thenReturn(entry.getKey());
+                    when(row.getString("engine")).thenReturn(entry.getValue());
+                    return row;
+                })
+                .toList();
+        var records = mock(Records.class);
+        when(records.iterator()).thenReturn(rows.iterator());
+        return records;
+    }
+
+    private void assertUnhealthy(HealthCheck.Result actual, String expectedMessage) {
+        assertThat(actual.isHealthy()).isFalse();
+        assertThat(actual.getMessage()).isEqualTo(expectedMessage);
+        assertThat(actual.getError()).isNull();
+    }
+
+    private ArgumentMatcher<QuerySettings> probeServerSettings() {
+        return settings -> {
+            var allSettings = settings.getAllSettings();
+            return String.valueOf(HEALTH_CHECK_TIMEOUT_SECONDS)
+                    .equals(allSettings.get(CLICKHOUSE_SETTING_MAX_EXECUTION_TIME))
+                    && EXPECTED_LOG_COMMENT.equals(allSettings.get(CLICKHOUSE_SETTING_LOG_COMMENT));
+        };
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
@@ -88,10 +88,14 @@ class ClickHouseTracesTopologyHealthCheckTest {
     void check__whenWrapEnabledButTracesIsNotWrapped__thenUnhealthyNamingTheObservedEngine() {
         var actualResult = check(true, Map.of("traces", "ReplicatedMergeTree", "traces_local", "ReplicatedMergeTree"));
 
+        // Note the fixture: `traces_local` exists here, which is exactly why the message must not promise
+        // UNKNOWN_TABLE. In this state the routed delete succeeds against the stale shard and the live rows in
+        // `traces` are never touched — quieter than the error, and worse.
         assertUnhealthy(actualResult, "%s=true routes trace mutations at 'traces_local', but 'traces' is a "
-                .formatted(FLAG) + "ReplicatedMergeTree, not Distributed: the Distributed wrap has not been applied. "
-                + "Apply it (exchange_and_wrap.sh --wrap-only) or set the flag back to false — otherwise trace deletes "
-                + "fail with UNKNOWN_TABLE (60).");
+                .formatted(FLAG) + "ReplicatedMergeTree, not Distributed: the Distributed wrap has not been applied "
+                + "(or has been rolled back). Apply it (exchange_and_wrap.sh --wrap-only) or set the flag back to "
+                + "false — otherwise trace deletes either fail with UNKNOWN_TABLE (60) when 'traces_local' is absent, "
+                + "or silently delete from a stale 'traces_local' while the live rows in 'traces' are left untouched.");
     }
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyHealthCheckTest.java
@@ -94,6 +94,20 @@ class ClickHouseTracesTopologyHealthCheckTest {
                 + "fail with UNKNOWN_TABLE (60).");
     }
 
+    /**
+     * Presence of {@code traces_local} is not enough — it is where TraceDAO sends its DELETEs, so a same-named table
+     * that cannot take mutations fails exactly like an absent one.
+     */
+    @ParameterizedTest(name = "traces_local engine={0}")
+    @ValueSource(strings = {"Distributed", "View", "Log"})
+    void check__whenWrapEnabledButTracesLocalCannotTakeMutations__thenUnhealthy(String tracesLocalEngine) {
+        var actualResult = check(true, Map.of("traces", "Distributed", "traces_local", tracesLocalEngine));
+
+        assertUnhealthy(actualResult, ("%s=true routes trace mutations at 'traces_local', which exists but is a %s "
+                + "rather than a (Replicated)MergeTree. Trace deletes cannot run against that engine, so the wrap is "
+                + "pointing at the wrong table.").formatted(FLAG, tracesLocalEngine));
+    }
+
     @Test
     void check__whenWrapEnabledAndTracesIsDistributedButTracesLocalIsMissing__thenUnhealthy() {
         var actualResult = check(true, Map.of("traces", "Distributed"));

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
@@ -1,0 +1,245 @@
+package com.comet.opik.infrastructure.db.healthchecks;
+
+import com.clickhouse.client.api.Client;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsDataModelConfig;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.redis.testcontainers.RedisContainer;
+import io.dropwizard.util.Duration;
+import jakarta.ws.rs.core.GenericType;
+import lombok.Builder;
+import org.apache.hc.core5.http.HttpStatus;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end cover for the {@code clickhouse-traces-topology} readiness assertion over a really wrapped
+ * {@code traces} — the post-cutover topology, which can only be built by destructively renaming the live table.
+ *
+ * <p>The app boots with {@code databaseAnalyticsDataModel.tracesDistributedWrapEnabled} left at its default
+ * {@code false}, so the suite walks the exact transition an operator drives: matching config (flag off over a
+ * {@code ReplicatedMergeTree} {@code traces}) reports ready, the wrap is applied, and readiness then fails because the
+ * flag now disagrees with the database. That direction — cut over but flag off — is the one that breaks trace deletes
+ * with {@code BAD_ARGUMENTS} (36) / {@code NOT_IMPLEMENTED} (48); its mirror image (flag on, never wrapped) needs no
+ * wrap and so is covered on the shared containers by
+ * {@code HealthCheckIntegrationTest.TracesDistributedWrapEnabledWithoutTheWrap}.
+ *
+ * <p>Asserting the healthy state first is what makes the unhealthy state meaningful: it rules out a probe that is
+ * simply always red. The fourth combination — flag on over the wrapped table, the intended post-cutover steady state —
+ * is asserted against the same live topology through a directly constructed probe, since the flag is read once at
+ * startup and a second app would mean a second set of containers for one assertion.
+ *
+ * <p>Dedicated, non-reused ClickHouse and ZooKeeper containers are required because the wrap destructively renames the
+ * live {@code traces} table; a reused container would corrupt other suites and reruns. Redis/MySQL are only read, so
+ * the shared ones are fine.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class ClickHouseTracesTopologyReadinessTest {
+
+    private static final String HEALTH_CHECK_NAME = "clickhouse-traces-topology";
+    private static final String READY = "READY";
+
+    /**
+     * Deadline for the directly constructed probe. Not the app's configured {@code healthCheckTimeout}: this one only
+     * has to be generous enough that a container round-trip cannot flake it.
+     */
+    private static final Duration PROBE_TIMEOUT = Duration.seconds(5);
+
+    private static final GenericType<List<HealthCheckResponse>> HEALTH_CHECK_LIST_GENERIC_TYPE = new GenericType<>() {
+    };
+
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeperContainer = ClickHouseContainerUtils.newZookeeperContainer(false,
+            network);
+    private final ClickHouseContainer clickHouseContainer = ClickHouseContainerUtils
+            .newClickHouseContainer(false, network, zookeeperContainer);
+    private final RedisContainer redisContainer = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer mysqlContainer = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(redisContainer, mysqlContainer, clickHouseContainer, zookeeperContainer).join();
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME);
+        MigrationUtils.runMysqlDbMigration(mysqlContainer);
+        MigrationUtils.runClickhouseDbMigration(clickHouseContainer);
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(mysqlContainer.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(redisContainer.getRedisURI())
+                        .build());
+    }
+
+    private ClientSupport client;
+    private String baseURI;
+    private TransactionTemplateAsync template;
+    private Client clickHouseClient;
+
+    @BeforeAll
+    void beforeAll(ClientSupport clientSupport, TransactionTemplateAsync template, Client clickHouseClient) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+        this.template = template;
+        this.clickHouseClient = clickHouseClient;
+    }
+
+    @AfterAll
+    void afterAll() {
+        clickHouseContainer.stop();
+        zookeeperContainer.stop();
+        network.close();
+    }
+
+    /**
+     * One method rather than two: the assertion is about the transition, and the wrap is irreversible, so the
+     * before/after states cannot be independent tests over the same container.
+     */
+    @Test
+    @Order(1)
+    void readinessFlipsToUnhealthyWhenTheWrapIsAppliedWhileTheFlagIsOff() {
+        awaitHealthCheck(true);
+        awaitReadinessProbe(HttpStatus.SC_OK);
+
+        applyDistributedWrap();
+
+        awaitHealthCheck(false);
+        awaitReadinessProbe(HttpStatus.SC_SERVICE_UNAVAILABLE);
+    }
+
+    /**
+     * The intended post-cutover steady state: the same wrapped {@code traces}, read by a probe whose flag is on. The
+     * app under test cannot supply it — {@code tracesDistributedWrapEnabled} is read once in the constructor — so the
+     * probe is built directly over the app's live ClickHouse client. Ordered after
+     * {@link #readinessFlipsToUnhealthyWhenTheWrapIsAppliedWhileTheFlagIsOff}, which is what applies the wrap — the
+     * only place in this suite where execution order carries meaning, hence the explicit {@code @Order}. The engine
+     * assertion up front fails loudly rather than silently passing if that ever stops holding.
+     */
+    @Test
+    @Order(2)
+    void probeWithTheFlagOnIsHealthyOverTheWrappedTopology() {
+        assertThat(tracesEngine()).isEqualTo("Distributed");
+
+        var healthCheck = new ClickHouseTracesTopologyHealthCheck(clickHouseClient, PROBE_TIMEOUT,
+                DatabaseAnalyticsDataModelConfig.builder().tracesDistributedWrapEnabled(true).build());
+
+        var actualResult = healthCheck.execute();
+
+        assertThat(actualResult.isHealthy()).isTrue();
+        assertThat(actualResult.getMessage())
+                .isEqualTo("'traces' is Distributed over 'traces_local', matching "
+                        + "databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true");
+    }
+
+    private void awaitHealthCheck(boolean healthy) {
+        var expected = HealthCheckResponse.builder()
+                .name(HEALTH_CHECK_NAME).healthy(healthy).critical(true).type(READY).build();
+
+        // Dropwizard's health endpoint serves cached state from the periodic scheduler; config-test's 100 ms
+        // single-attempt schedule keeps the window short, so a probe stuck on the wrong answer never satisfies this.
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> assertThat(readHealthCheck()).containsExactly(expected));
+    }
+
+    private List<HealthCheckResponse> readHealthCheck() {
+        // Status is deliberately not asserted: an unhealthy critical check makes the endpoint return a non-OK status
+        // while still carrying the JSON results.
+        try (var response = client.target("%s/health-check?name=%s".formatted(baseURI, HEALTH_CHECK_NAME))
+                .request()
+                .get()) {
+            return response.readEntity(HEALTH_CHECK_LIST_GENERIC_TYPE);
+        }
+    }
+
+    /**
+     * The aggregate endpoint the Kubernetes readiness probe actually hits (the chart's
+     * {@code component.backend.readinessProbe} is {@code /health-check?name=all&type=ready}), so this is what decides
+     * whether the pod stays in rotation.
+     */
+    private void awaitReadinessProbe(int expectedStatus) {
+        Awaitility.await()
+                .atMost(10, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    try (var response = client.target("%s/health-check?name=all&type=ready".formatted(baseURI))
+                            .request()
+                            .get()) {
+                        assertThat(response.getStatus()).isEqualTo(expectedStatus);
+                    }
+                });
+    }
+
+    /**
+     * Wraps {@code traces} as a {@code Distributed} table over the {@code traces_local} shard. The statements are kept
+     * identical to the wrap block of {@code 000003_exchange_and_wrap.sql} (the cutover's source of truth, mirrored
+     * inline the same way by {@code TracesLocalV2CutoverTest.wrapInDistributed} and
+     * {@code TracesDistributedWrapMutationTest.applyDistributedWrap}): build the wrapper under a temp name, then one
+     * atomic multi-target {@code RENAME} rotates the data to {@code traces_local} and the wrapper into {@code traces}.
+     */
+    private void applyDistributedWrap() {
+        execute("""
+                CREATE TABLE traces_dist ON CLUSTER '{cluster}' AS traces
+                ENGINE = Distributed('{cluster}', '%s', 'traces_local', sipHash64(project_id))
+                """.formatted(DATABASE_NAME));
+        execute("""
+                RENAME TABLE
+                    traces TO traces_local,
+                    traces_dist TO traces
+                    ON CLUSTER '{cluster}'
+                """);
+    }
+
+    private String tracesEngine() {
+        return template.nonTransaction(connection -> {
+            var statement = connection.createStatement(
+                    "SELECT engine FROM system.tables WHERE database = :database AND name = 'traces'");
+            statement.bind("database", DATABASE_NAME);
+            return Mono.from(statement.execute())
+                    .flatMap(result -> Mono.from(result.map((row, metadata) -> row.get("engine", String.class))));
+        }).block();
+    }
+
+    private void execute(String sql) {
+        template.nonTransaction(connection -> Mono.from(connection.createStatement(sql).execute())
+                .flatMap(result -> Mono.from(result.getRowsUpdated()))).block();
+    }
+
+    @Builder
+    private record HealthCheckResponse(String name, boolean healthy, boolean critical, String type) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
@@ -272,7 +272,7 @@ class ClickHouseTracesTopologyReadinessTest {
                 .flatMap(result -> Mono.from(result.getRowsUpdated()))).block();
     }
 
-    @Builder
+    @Builder(toBuilder = true)
     private record HealthCheckResponse(String name, boolean healthy, boolean critical, String type) {
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
@@ -118,6 +118,10 @@ class ClickHouseTracesTopologyReadinessTest {
         ClientSupportUtils.config(clientSupport);
         this.template = template;
         this.clickHouseClient = clickHouseClient;
+        // applyDistributedWrap's DDL spells the database out, because SQL must not be assembled with Java string
+        // operations and ClickHouse cannot bind an identifier inside a Distributed() engine argument. This keeps that
+        // literal honest if the shared test database name ever changes.
+        assertThat(DATABASE_NAME).as("the wrap DDL hard-codes the database name").isEqualTo("opik");
     }
 
     @AfterAll
@@ -228,6 +232,10 @@ class ClickHouseTracesTopologyReadinessTest {
      * would fail outright — {@code CREATE TABLE traces_dist} on the second pass, and the {@code RENAME} would rotate a
      * wrapper on top of a wrapper — so the guard is what keeps this suite correct if the wrap ever becomes a regular
      * migration and the container arrives already cut over.
+     *
+     * <p>Both statements are literal text blocks: SQL is never assembled with Java string operations, and ClickHouse
+     * cannot bind an identifier inside a {@code Distributed()} engine argument, so the database name is spelled out
+     * and held to {@link #DATABASE_NAME} by the assertion in {@link #beforeAll} rather than interpolated in.
      */
     private void applyDistributedWrap() {
         if (isWrapped()) {
@@ -235,8 +243,8 @@ class ClickHouseTracesTopologyReadinessTest {
         }
         execute("""
                 CREATE TABLE traces_dist ON CLUSTER '{cluster}' AS traces
-                ENGINE = Distributed('{cluster}', '%s', 'traces_local', sipHash64(project_id))
-                """.formatted(DATABASE_NAME));
+                ENGINE = Distributed('{cluster}', 'opik', 'traces_local', sipHash64(project_id))
+                """);
         execute("""
                 RENAME TABLE
                     traces TO traces_local,

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/healthchecks/ClickHouseTracesTopologyReadinessTest.java
@@ -70,6 +70,7 @@ class ClickHouseTracesTopologyReadinessTest {
 
     private static final String HEALTH_CHECK_NAME = "clickhouse-traces-topology";
     private static final String READY = "READY";
+    private static final String DISTRIBUTED_ENGINE = "Distributed";
 
     /**
      * Deadline for the directly constructed probe. Not the app's configured {@code healthCheckTimeout}: this one only
@@ -129,14 +130,23 @@ class ClickHouseTracesTopologyReadinessTest {
     /**
      * One method rather than two: the assertion is about the transition, and the wrap is irreversible, so the
      * before/after states cannot be independent tests over the same container.
+     *
+     * <p>The pre-wrap state is <b>read, not assumed</b>. Today the wrap is operator tooling
+     * ({@code data-migrations/traces-local-v2-cutover}), outside the {@code migrations/} directory the analytics
+     * changelog includes, so this suite starts on a {@code ReplicatedMergeTree} {@code traces} and there is a real
+     * transition to drive. The day the wrap lands as a regular migration, it starts already wrapped — and asserting
+     * "healthy first" would then fail on a correctly behaving probe. So the healthy half runs only when there is
+     * something to transition from; the mismatch half, which is the point of the test, always runs.
      */
     @Test
     @Order(1)
     void readinessFlipsToUnhealthyWhenTheWrapIsAppliedWhileTheFlagIsOff() {
-        awaitHealthCheck(true);
-        awaitReadinessProbe(HttpStatus.SC_OK);
+        if (!isWrapped()) {
+            awaitHealthCheck(true);
+            awaitReadinessProbe(HttpStatus.SC_OK);
 
-        applyDistributedWrap();
+            applyDistributedWrap();
+        }
 
         awaitHealthCheck(false);
         awaitReadinessProbe(HttpStatus.SC_SERVICE_UNAVAILABLE);
@@ -146,14 +156,17 @@ class ClickHouseTracesTopologyReadinessTest {
      * The intended post-cutover steady state: the same wrapped {@code traces}, read by a probe whose flag is on. The
      * app under test cannot supply it — {@code tracesDistributedWrapEnabled} is read once in the constructor — so the
      * probe is built directly over the app's live ClickHouse client. Ordered after
-     * {@link #readinessFlipsToUnhealthyWhenTheWrapIsAppliedWhileTheFlagIsOff}, which is what applies the wrap — the
-     * only place in this suite where execution order carries meaning, hence the explicit {@code @Order}. The engine
-     * assertion up front fails loudly rather than silently passing if that ever stops holding.
+     * {@link #readinessFlipsToUnhealthyWhenTheWrapIsAppliedWhileTheFlagIsOff} so that one still gets the pristine
+     * pre-wrap state to transition from — the only place in this suite where execution order carries meaning, hence
+     * the explicit {@code @Order}. It does not depend on that ordering to pass, though: it wraps idempotently and then
+     * asserts the topology it needs, so it is correct whichever way it is reached.
      */
     @Test
     @Order(2)
     void probeWithTheFlagOnIsHealthyOverTheWrappedTopology() {
-        assertThat(tracesEngine()).isEqualTo("Distributed");
+        applyDistributedWrap();
+
+        assertThat(tracesEngine()).isEqualTo(DISTRIBUTED_ENGINE);
 
         var healthCheck = new ClickHouseTracesTopologyHealthCheck(clickHouseClient, PROBE_TIMEOUT,
                 DatabaseAnalyticsDataModelConfig.builder().tracesDistributedWrapEnabled(true).build());
@@ -210,8 +223,16 @@ class ClickHouseTracesTopologyReadinessTest {
      * inline the same way by {@code TracesLocalV2CutoverTest.wrapInDistributed} and
      * {@code TracesDistributedWrapMutationTest.applyDistributedWrap}): build the wrapper under a temp name, then one
      * atomic multi-target {@code RENAME} rotates the data to {@code traces_local} and the wrapper into {@code traces}.
+     *
+     * <p>Idempotent: a {@code traces} that is already {@code Distributed} is left alone. Re-running the block over one
+     * would fail outright — {@code CREATE TABLE traces_dist} on the second pass, and the {@code RENAME} would rotate a
+     * wrapper on top of a wrapper — so the guard is what keeps this suite correct if the wrap ever becomes a regular
+     * migration and the container arrives already cut over.
      */
     private void applyDistributedWrap() {
+        if (isWrapped()) {
+            return;
+        }
         execute("""
                 CREATE TABLE traces_dist ON CLUSTER '{cluster}' AS traces
                 ENGINE = Distributed('{cluster}', '%s', 'traces_local', sipHash64(project_id))
@@ -222,6 +243,10 @@ class ClickHouseTracesTopologyReadinessTest {
                     traces_dist TO traces
                     ON CLUSTER '{cluster}'
                 """);
+    }
+
+    private boolean isWrapped() {
+        return DISTRIBUTED_ENGINE.equals(tracesEngine());
     }
 
     private String tracesEngine() {

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -209,6 +209,11 @@ health:
       type: ready
       initialState: false
       schedule: { initialDelay: 0ms, checkInterval: 100ms, downtimeInterval: 100ms, failureAttempts: 1, successAttempts: 1 }
+    - name: clickhouse-traces-topology
+      critical: true
+      type: ready
+      initialState: false
+      schedule: { initialDelay: 0ms, checkInterval: 100ms, downtimeInterval: 100ms, failureAttempts: 1, successAttempts: 1 }
     - name: mysql
       critical: true
       type: ready

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/changelog.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/changelog.mdx
@@ -13,6 +13,23 @@ This page only lists breaking and critical changes that affect self-hosted Opik 
   If you are upgrading from Opik 1.x to Opik 2.x, follow the [Opik 2.0 migration guide](/self-host/v1-to-v2-migration).
 </Tip>
 
+## Release 2.2.36, 2026-08-21
+
+### Critical Change
+
+The backend now verifies at startup that `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` matches the actual shape of the `traces` table in ClickHouse, and **fails its readiness probe** if the two disagree. A mismatch makes every trace deletion fail, so the backend now reports that as a failed readiness check instead of accepting traffic and erroring on the first delete.
+
+**No action is needed on a default install.** The setting ships as `false` and the migrated `traces` table is a `ReplicatedMergeTree`, which is a match — the check passes and nothing changes.
+
+If you have turned the setting on, or converted `traces` into a `Distributed` wrapper, the two have to agree:
+
+| Setting | Required `traces` engine |
+| --- | --- |
+| `false` (the default) | `MergeTree` or `ReplicatedMergeTree` |
+| `true` | `Distributed`, with a `traces_local` table present |
+
+The failing check names both the setting and the engine it actually found. To fix it, set the flag to match the table and restart the backend; readiness returns on the next probe. See [Backend Not Ready: `clickhouse-traces-topology`](/self-host/troubleshooting#backend-not-ready-clickhouse-traces-topology) for the full procedure.
+
 ## Release 2.0.3 (Opik 2.0), 2026-04-20
 
 ### Backward Incompatible Change

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/changelog.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/changelog.mdx
@@ -13,23 +13,6 @@ This page only lists breaking and critical changes that affect self-hosted Opik 
   If you are upgrading from Opik 1.x to Opik 2.x, follow the [Opik 2.0 migration guide](/self-host/v1-to-v2-migration).
 </Tip>
 
-## Release 2.2.36, 2026-08-21
-
-### Critical Change
-
-The backend now verifies at startup that `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` matches the actual shape of the `traces` table in ClickHouse, and **fails its readiness probe** if the two disagree. A mismatch makes every trace deletion fail, so the backend now reports that as a failed readiness check instead of accepting traffic and erroring on the first delete.
-
-**No action is needed on a default install.** The setting ships as `false` and the migrated `traces` table is a `ReplicatedMergeTree`, which is a match — the check passes and nothing changes.
-
-If you have turned the setting on, or converted `traces` into a `Distributed` wrapper, the two have to agree:
-
-| Setting | Required `traces` engine |
-| --- | --- |
-| `false` (the default) | `MergeTree` or `ReplicatedMergeTree` |
-| `true` | `Distributed`, with a `traces_local` table present |
-
-The failing check names both the setting and the engine it actually found. To fix it, set the flag to match the table and restart the backend; readiness returns on the next probe. See [Backend Not Ready: `clickhouse-traces-topology`](/self-host/troubleshooting#backend-not-ready-clickhouse-traces-topology) for the full procedure.
-
 ## Release 2.0.3 (Opik 2.0), 2026-04-20
 
 ### Backward Incompatible Change

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -108,11 +108,11 @@ A default self-hosted or open-source install has the setting `false` and a `Repl
 
 Read the health check message — it names both the setting and the engine it actually found. Then make the two agree.
 
-Check what the table really is:
+Check what the table really is. Substitute `<database_name>` with your `ANALYTICS_DB_DATABASE_NAME` — `opik` is only the default, and querying the wrong database returns no rows, which looks like the tables are missing:
 
 ```sql
 SELECT name, engine FROM system.tables
-WHERE database = 'opik' AND name IN ('traces', 'traces_local');
+WHERE database = '<database_name>' AND name IN ('traces', 'traces_local');
 ```
 
 <Callout intent="info">
@@ -130,7 +130,7 @@ WHERE database = '<database_name>' AND name IN ('traces', 'traces_local')
 ORDER BY name, host;
 ```
 
-Substitute `{cluster}` (your cluster macro, from `SELECT * FROM system.macros`) and `<database_name>` (your `ANALYTICS_DB_DATABASE_NAME`, `opik` by default); on a single-node install drop the `clusterAllReplicas(...)` wrapper. If a **single table's** engine differs between hosts, an `ON CLUSTER` DDL has not finished propagating or failed on a host — let it settle, or re-run it there. Changing the flag would only move the failure to the other replicas.
+Substitute `{cluster}` here as well — your cluster macro, from `SELECT * FROM system.macros`; on a single-node install drop the `clusterAllReplicas(...)` wrapper instead. If a **single table's** engine differs between hosts, an `ON CLUSTER` DDL has not finished propagating or failed on a host — let it settle, or re-run it there. Changing the flag would only move the failure to the other replicas.
 
 Then set the flag to match:
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -138,23 +138,6 @@ Then set the flag to match:
 - `traces` is `Distributed` and `traces_local` exists → set the same key to `true` and restart.
 
 <Callout intent="warning">
-  **On Helm, an explicit env entry wins over the setting.** `configmap-backend.yaml` emits the derived
-  `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` key only when `component.backend.env` does not already
-  define it. So if your values file sets that variable directly, changing
-  `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` has **no effect** — the check keeps failing with the same
-  message and nothing you change appears to help.
-
-  Confirm what the pod actually received before changing anything else:
-
-  ```bash
-  kubectl exec deploy/opik-backend -- printenv ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED
-  ```
-
-  If that disagrees with the value you set, remove the explicit key from `component.backend.env` (preferred, so the
-  setting is the single source) or update it there instead.
-</Callout>
-
-<Callout intent="warning">
   **On Helm, an explicit env entry wins over the chart value.** The chart derives `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` from `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` **only when that key is not already set under `component.backend.env`** — an explicit entry there takes precedence. So if you change the top-level value, restart, and the check still reports the old expectation, you have a stale override: update or remove the `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` entry under `component.backend.env`. Confirm what the backend actually receives with `kubectl get configmap <release-name>-backend -o jsonpath='{.data.ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED}'`.
 </Callout>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -138,6 +138,23 @@ Then set the flag to match:
 - `traces` is `Distributed` and `traces_local` exists → set the same key to `true` and restart.
 
 <Callout intent="warning">
+  **On Helm, an explicit env entry wins over the setting.** `configmap-backend.yaml` emits the derived
+  `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` key only when `component.backend.env` does not already
+  define it. So if your values file sets that variable directly, changing
+  `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` has **no effect** — the check keeps failing with the same
+  message and nothing you change appears to help.
+
+  Confirm what the pod actually received before changing anything else:
+
+  ```bash
+  kubectl exec deploy/opik-backend -- printenv ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED
+  ```
+
+  If that disagrees with the value you set, remove the explicit key from `component.backend.env` (preferred, so the
+  setting is the single source) or update it there instead.
+</Callout>
+
+<Callout intent="warning">
   **On Helm, an explicit env entry wins over the chart value.** The chart derives `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` from `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` **only when that key is not already set under `component.backend.env`** — an explicit entry there takes precedence. So if you change the top-level value, restart, and the check still reports the old expectation, you have a stale override: update or remove the `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` entry under `component.backend.env`. Confirm what the backend actually receives with `kubectl get configmap <release-name>-backend -o jsonpath='{.data.ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED}'`.
 </Callout>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -79,6 +79,55 @@ You should see a row with the macro name and value.
 
 After restarting ClickHouse, retry the backend deployment or migration. The backend should automatically retry after ClickHouse is ready.
 
+### Backend Not Ready: `clickhouse-traces-topology`
+
+#### Problem Description
+
+The backend refuses readiness and the `clickhouse-traces-topology` health check reports unhealthy with a message about `databaseAnalyticsDataModel.tracesDistributedWrapEnabled`.
+
+**This check failing is intentional, not a bug.** It means the `tracesDistributedWrapEnabled` setting disagrees with the actual shape of the `traces` table in ClickHouse. Trace deletion cannot work in that state, so the backend takes itself out of rotation at startup instead of accepting traffic and failing on the first delete.
+
+**Symptoms:**
+
+- Readiness probe (`/health-check?name=all&type=ready`) returns `503`; pods never become Ready
+- `GET /health-check?name=clickhouse-traces-topology` reports `"healthy": false`
+- Backend logs: `A critical dependency is now unhealthy: name=clickhouse-traces-topology, type=READY`
+
+#### Cause
+
+`tracesDistributedWrapEnabled` tells the backend where to send trace deletions. It has to match the table:
+
+| Setting | Required `traces` engine |
+| --- | --- |
+| `false` (the default) | `MergeTree` or `ReplicatedMergeTree` |
+| `true` | `Distributed`, with a `traces_local` table present |
+
+A default self-hosted or open-source install has the setting `false` and a `ReplicatedMergeTree` `traces` table, so this check passes and there is nothing to do. It only fails if the setting was turned on, or if the table was converted to a `Distributed` wrapper without turning it on.
+
+#### Resolution
+
+Read the health check message — it names both the setting and the engine it actually found. Then make the two agree.
+
+Check what the table really is:
+
+```sql
+SELECT name, engine FROM system.tables
+WHERE database = 'opik' AND name IN ('traces', 'traces_local');
+```
+
+Then set the flag to match:
+
+- `traces` is a `MergeTree` / `ReplicatedMergeTree` → set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled: false` (Helm) or `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=false` (Docker Compose or plain environment), then restart the backend.
+- `traces` is `Distributed` and `traces_local` exists → set the same key to `true` and restart.
+
+The check re-evaluates on every probe, so readiness returns on its own once the two sides agree — no further action beyond the restart that picks up the new setting.
+
+<Callout intent="warning">
+  Do not work around this by removing the check. The setting is the source of truth for where deletions are routed, and the check only reports what it observes — leaving the two mismatched means every trace deletion fails (`Code: 36` / `Code: 48` one way, `Code: 60` the other).
+</Callout>
+
+If `traces` does not exist at all, the check says so instead: the analytics migrations have not run. See the migration sections above.
+
 ### Fresh Multi-Replica Install Migration Failures
 
 #### Problem Description

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -99,7 +99,7 @@ The backend refuses readiness and the `clickhouse-traces-topology` health check 
 
 | Setting | Required `traces` engine |
 | --- | --- |
-| `false` (the default) | `MergeTree` or `ReplicatedMergeTree` |
+| `false` (the default) | `MergeTree`, `ReplicatedMergeTree` or `SharedMergeTree` |
 | `true` | `Distributed`, with a `traces_local` table present |
 
 A default self-hosted or open-source install has the setting `false` and a `ReplicatedMergeTree` `traces` table, so this check passes and there is nothing to do. It only fails if the setting was turned on, or if the table was converted to a `Distributed` wrapper without turning it on.
@@ -117,7 +117,7 @@ WHERE database = 'opik' AND name IN ('traces', 'traces_local');
 
 Then set the flag to match:
 
-- `traces` is a `MergeTree` / `ReplicatedMergeTree` → set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled: false` (Helm) or `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=false` (Docker Compose or plain environment), then restart the backend.
+- `traces` is a `MergeTree`, `ReplicatedMergeTree` or `SharedMergeTree` → set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled: false` (Helm) or `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=false` (Docker Compose or plain environment), then restart the backend.
 - `traces` is `Distributed` and `traces_local` exists → set the same key to `true` and restart.
 
 The check re-evaluates on every probe, so readiness returns on its own once the two sides agree — no further action beyond the restart that picks up the new setting.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -115,6 +115,20 @@ SELECT name, engine FROM system.tables
 WHERE database = 'opik' AND name IN ('traces', 'traces_local');
 ```
 
+<Callout intent="info">
+  `system.tables` is node-local, and so is the health check: both answer for the **one replica that served the query**. The backend reaches ClickHouse through a load-balanced service, so if the failure is intermittent — some probes healthy, some not, pods flapping rather than all staying unready — the replicas disagree with each other and the flag is not what is wrong. Confirm with the cluster-wide form below, and fix the lagging replica rather than the flag.
+</Callout>
+
+```sql
+-- Same lookup across every replica: the engine must be identical on all of them.
+SELECT hostName() AS host, name, engine
+FROM clusterAllReplicas('{cluster}', system.tables)
+WHERE database = '<database_name>' AND name IN ('traces', 'traces_local')
+ORDER BY host, name;
+```
+
+Substitute `{cluster}` (your cluster macro, from `SELECT * FROM system.macros`) and `<database_name>` (your `ANALYTICS_DB_DATABASE_NAME`, `opik` by default); on a single-node install drop the `clusterAllReplicas(...)` wrapper. If the engine differs across hosts, an `ON CLUSTER` DDL has not finished propagating or failed on a host — let it settle, or re-run it there. Changing the flag would only move the failure to the other replicas.
+
 Then set the flag to match:
 
 - `traces` is a `MergeTree`, `ReplicatedMergeTree` or `SharedMergeTree` → set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled: false` (Helm) or `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=false` (Docker Compose or plain environment), then restart the backend.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx
@@ -120,19 +120,26 @@ WHERE database = 'opik' AND name IN ('traces', 'traces_local');
 </Callout>
 
 ```sql
--- Same lookup across every replica: the engine must be identical on all of them.
-SELECT hostName() AS host, name, engine
+-- Same lookup, every replica. Compare down each table separately: one table's engine must be
+-- the same on every host. The two tables are expected to differ from each other: after the
+-- wrap `traces` is `Distributed` and `traces_local` is a `(Replicated)MergeTree`, which is the
+-- healthy shape, not a mismatch.
+SELECT name, hostName() AS host, engine
 FROM clusterAllReplicas('{cluster}', system.tables)
 WHERE database = '<database_name>' AND name IN ('traces', 'traces_local')
-ORDER BY host, name;
+ORDER BY name, host;
 ```
 
-Substitute `{cluster}` (your cluster macro, from `SELECT * FROM system.macros`) and `<database_name>` (your `ANALYTICS_DB_DATABASE_NAME`, `opik` by default); on a single-node install drop the `clusterAllReplicas(...)` wrapper. If the engine differs across hosts, an `ON CLUSTER` DDL has not finished propagating or failed on a host — let it settle, or re-run it there. Changing the flag would only move the failure to the other replicas.
+Substitute `{cluster}` (your cluster macro, from `SELECT * FROM system.macros`) and `<database_name>` (your `ANALYTICS_DB_DATABASE_NAME`, `opik` by default); on a single-node install drop the `clusterAllReplicas(...)` wrapper. If a **single table's** engine differs between hosts, an `ON CLUSTER` DDL has not finished propagating or failed on a host — let it settle, or re-run it there. Changing the flag would only move the failure to the other replicas.
 
 Then set the flag to match:
 
 - `traces` is a `MergeTree`, `ReplicatedMergeTree` or `SharedMergeTree` → set `databaseAnalyticsDataModel.tracesDistributedWrapEnabled: false` (Helm) or `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=false` (Docker Compose or plain environment), then restart the backend.
 - `traces` is `Distributed` and `traces_local` exists → set the same key to `true` and restart.
+
+<Callout intent="warning">
+  **On Helm, an explicit env entry wins over the chart value.** The chart derives `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` from `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` **only when that key is not already set under `component.backend.env`** — an explicit entry there takes precedence. So if you change the top-level value, restart, and the check still reports the old expectation, you have a stale override: update or remove the `ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED` entry under `component.backend.env`. Confirm what the backend actually receives with `kubectl get configmap <release-name>-backend -o jsonpath='{.data.ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED}'`.
+</Callout>
 
 The check re-evaluates on every probe, so readiness returns on its own once the two sides agree — no further action beyond the restart that picks up the new setting.
 

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -793,6 +793,10 @@ databaseAnalyticsDataModel:
   deletionEventsInsertBatchSize: 1000
   # Turn true in lockstep with applying the Distributed wrap, so trace delete/retention mutations target
   # traces_local (a Distributed traces rejects mutations). Leave false while traces is still a MergeTree.
+  # Asserted against the live database by the backend's `clickhouse-traces-topology` readiness probe: if this
+  # disagrees with the actual `traces` engine in either direction, the backend fails readiness at startup with a
+  # message naming the flag and the observed engine. That is intentional — it beats serving traffic whose trace
+  # deletes are guaranteed to fail — and it clears on the next probe once the two sides are back in step.
   tracesDistributedWrapEnabled: false
 
 # ClickHouse partition-health observability (OPIK-6904). Polls system.parts plus the


### PR DESCRIPTION
## Details

Post-cutover `traces` is a `Distributed` table that cannot take mutations, so `TraceDAO` routes trace deletes at `traces_local` only while `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` is on (OPIK_7455). When an install's flag disagrees with its database every trace delete breaks — code 36/48 one way, code 60 the other — and nothing says so until the first delete runs. This adds a readiness check that asserts the flag against the live topology at startup, so a misconfigured install is pulled from rotation instead of serving traffic it cannot mutate. It depends on each environment's Helm config *plus* its live database, which is why it can't be a CI guard.

- **`ClickHouseTracesTopologyHealthCheck`** (`clickhouse-traces-topology`, `critical: true` / `type: ready`) — one `system.tables` lookup covers both tables and both directions: flag on requires `traces` to be `Distributed` **and** `traces_local` to exist; flag off requires `traces` to be a `(Replicated)MergeTree`. An absent `traces` is unhealthy either way. On a mismatch the message names the flag, the engine actually observed, and the fix.
- **Deliberately not toggle-gated**, unlike the sibling `clickhouse-cluster` / `clickhouse-cold-storage-disk` probes: flag off over a `MergeTree` `traces` is the default on every install as shipped (OSS Docker, self-hosted, pre-cutover SaaS), so the assertion holds universally and only a genuine misconfiguration trips it.
- **No routing logic changed.** The flag stays the source of truth — the probe reports, it never re-routes.
- **Package move:** the probe extends the package-private `AbstractClickHouseHealthCheck`, so it can only live beside it. `infrastructure/db/healthchecks` now holds the family — both abstracts, the four ClickHouse probes, `MysqlHealthyCheck` — plus their tests, instead of scattering them through `infrastructure/db`.
- **Reviewer decision — the cutover window is now a readiness window.** The flag and the wrap cannot land simultaneously, so the unavoidable mismatch window now takes pods out of rotation in either order rather than only failing deletes. That is what the ticket asks for, it is self-clearing (the probe re-evaluates continuously), and the wrap already requires `--confirm-maintenance`, so the window belongs inside that maintenance window — which the cutover runbook now says explicitly. **If the team would rather the cutover degrade than go dark, the lever is `critical: false` in `config.yml`:** still reported on `/health-check`, no longer gating rotation. Worth an explicit call here.
- **On the table name**, since it invites confusion: the check targets `traces_local`, not `traces_local_v2`. The latter is the backfill shadow table — created empty in every install by migrations `000101`/`000114`, `EXCHANGE`d and then renamed to `traces_pre_cutover_backup` before the wrap (`exchange_and_wrap.sh` hard-errors if it still exists at wrap time). `traces_local` is what the wrap's `RENAME` produces and what `TraceDAO.java:1934` / `:5129` actually mutate under the flag, which is precisely what this check exists to protect.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7773

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Health check implementation, the three test suites, and the documentation/runbook edits — drafted with AI from the ticket plus the existing `AbstractClickHouseExistenceHealthCheck` / `TracesDistributedWrapMutationTest` patterns in this repo.
- Human verification: author-directed throughout, with three author corrections folded in (package layout, idempotent wrap in the readiness suite, dropping the premature changelog entry). All touched suites run locally and green (see Testing); the already-wrapped branch of the readiness suite was verified by re-running it with the test order reversed. Author review of the full diff before merge.

## Testing

```bash
# unit + integration, all suites this PR touches or moves
mvn -o test -Dtest='ClickHouseTracesTopologyHealthCheckTest,ClickHouseTracesTopologyReadinessTest,\
HealthCheckIntegrationTest*,AbstractClickHouseHealthCheckTest,ClickHouseExistenceHealthCheckTest,\
IsAliveE2ETest,IsAliveResourceTest,TracesDistributedWrapMutationTest' -DfailIfNoTests=false
# -> Tests run: 54, Failures: 0, Errors: 0, Skipped: 0

mvn -o test-compile   # whole test tree compiles after the package move
mvn -o spotless:apply # no reformatting produced
```

Scenarios validated:

| Flag | `traces` topology | Expected | Covered by |
| --- | --- | --- | --- |
| `false` | `(Replicated)MergeTree` | ready | `HealthCheckIntegrationTest.DefaultConfig` (real `system.tables` query) |
| `true` | `MergeTree` (never wrapped) | **not ready** | `HealthCheckIntegrationTest.TracesDistributedWrapEnabledWithoutTheWrap` |
| `false` | `Distributed` (cut over) | **not ready** | `ClickHouseTracesTopologyReadinessTest` |
| `true` | `Distributed` over `traces_local` | ready | `ClickHouseTracesTopologyReadinessTest` |

- Both mismatch directions assert `/health-check?name=all&type=ready` returns `503` — the chart's actual `component.backend.readinessProbe` path — so the tests prove the pod really leaves rotation, not just that a JSON row flipped.
- `ClickHouseTracesTopologyReadinessTest` uses dedicated, non-reused ClickHouse + ZooKeeper containers (the wrap destructively renames the live `traces`) and applies the wrap block verbatim from `000003_exchange_and_wrap.sql`, walking the real transition: ready → wrap → not ready.
- Edge cases in `ClickHouseTracesTopologyHealthCheckTest` (13 cases, asserting exact messages since the message is all an operator sees): `traces` absent under either flag; `Distributed` `traces` with `traces_local` missing; `MergeTree`/`Replicated`/`Shared` all accepted when the flag is off; a non-MergeTree engine rejected; query failure and interrupt paths cancel the in-flight query and restore the interrupt flag.
- Regression: `TracesDistributedWrapMutationTest` (OPIK_7455's suite, which boots with the flag on and the wrap applied) still passes with the new critical readiness check in place.
- Environment: local, macOS, Testcontainers (ClickHouse `26.3.16.16-alpine` + ZooKeeper `3.9.4`, plus the shared MySQL/Redis containers).

Not run, with reason:

- `helm unittest` — plugin not installed locally. `helm template` also unavailable (chart dependencies not vendored). The `values.yaml` change is comment-only, so nothing renders differently; `tests/configmap_env_test.yaml` is untouched and its assertions are unaffected.
- No video: the change has no UI surface.

## Documentation

- `self-host/troubleshooting.mdx` — new "Backend Not Ready: `clickhouse-traces-topology`" section, mirrored into both `docs/` and `docs-v2/` (these pages are kept in sync): the failure is intentional, here is the flag/engine table and the `system.tables` query to resolve it, and do not remove the check instead of fixing the mismatch.
- `data-migrations/traces-local-v2-cutover/README.md` — the readiness-window consequence described above; its claim that no readiness endpoint exposes the flag's value is replaced by the endpoint that now does.
- `apps/opik-backend/config.yml`, `DatabaseAnalyticsDataModelConfig` javadoc, `deployment/helm_chart/opik/values.yaml` — the flag is now asserted at readiness. The chart already wires the flag through values → configmap → env (OPIK_7455), so `values.yaml` gains only that note; these keys don't use the `# --` prefix `helm-docs` reads, so the chart `README.md` needs no regeneration.
- **No self-host changelog entry yet** — deliberately held back until the shipping release is decided, so the page doesn't state a version we can't stand behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
