### PR TITLE
[NA] [BE] feat: enable agentic-tools by default for all deployments

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1468,10 +1468,12 @@ serviceToggles:
   # Default: false
   # Description: Whether the project homepage is enabled. When false, the Ollie page is the default project page.
   projectHomepageEnabled: ${TOGGLE_PROJECT_HOMEPAGE_ENABLED:-"false"}
-  # Default: false
+  # Default: true
   # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring. When false, the
   #   inline path is used regardless of context size. Threshold lives under onlineScoring.agenticToolsThresholdTokens.
-  agenticToolsEnabled: ${TOGGLE_AGENTIC_TOOLS_ENABLED:-"false"}
+  #   On by default for every deployment, self-hosted included; set TOGGLE_AGENTIC_TOOLS_ENABLED=false to force
+  #   the inline path (e.g. to keep online scoring on a single LLM round-trip).
+  agenticToolsEnabled: ${TOGGLE_AGENTIC_TOOLS_ENABLED:-"true"}
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces/spans.
   #   When on, each evaluation produces one trace (source=evaluator) with one llm span per LLM round, so cost and

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -822,9 +822,11 @@ serviceToggles:
   #   freeform SQL path and the clickhouse-readonly-freeform-sql health check. Tests flip this on when exercising
   #   the read-only ClickHouse client.
   ollieEnabled: "false"
-  # Default: false
-  # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring.
-  agenticToolsEnabled: "false"
+  # Default: true
+  # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring. Mirrors the
+  #   shipped default in config.yml so app-booting tests exercise the path real deployments run. Tests
+  #   that need the inline path flip this off via customConfigs.
+  agenticToolsEnabled: "true"
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces.
   onlineScoringTracingEnabled: "true"


### PR DESCRIPTION
## Details

The agentic-tools path on LLM-as-judge online scoring only ever reached Comet-hosted environments, which pin `TOGGLE_AGENTIC_TOOLS_ENABLED=true` in their chart values. Self-hosted installs inherit the image's `config.yml` default, and that default was still `"false"` — so neither the docker-compose nor the helm install path ever turned the feature on. Enabling it for self-hosted was requested; this flips `serviceToggles.agenticToolsEnabled` in `apps/opik-backend/config.yml` from `"false"` to `"true"`.

- That single line covers every self-hosted install because **neither deployment path names this variable**. `deployment/docker-compose/docker-compose.yaml` sets only `TOGGLE_OLLIE_ENABLED`, `TOGGLE_OPIK_AI_ENABLED`, `TOGGLE_GUARDRAILS_ENABLED` and `TOGGLE_WELCOME_WIZARD_ENABLED`; the helm chart's `component.backend.env` does not list it either.
- `configmap-backend.yaml` only emits keys present in `component.backend.env`, so an absent key means no env var in the pod and the image default applies. Operators keep full control — adding `component.backend.env.TOGGLE_AGENTIC_TOOLS_ENABLED: "false"` still wins — while the image retains the ability to move the default, which is exactly the property a chart-pinned value would destroy. Hence **no chart change here**.
- `config-test.yml` mirrors the flip so app-booting tests exercise the path real deployments now run. Previously CI validated the inline path while we were about to ship the agentic one as the default.
- Deliberately unchanged — the frontend `DEFAULT_STATE` (`feature-toggles-provider.tsx`) stays `false`. It only applies when the backend *omits* the key, i.e. a newer FE against an older BE with no agentic support, so flipping it would enable UI affordances the backend can't honour.
- Deliberately unchanged — helm `values.yaml`, for the reason above. No `TOGGLE_*` key appears in the generated chart README for any component either, so listing just this one would be inconsistent; documenting all toggles is a separate change.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigated which deployment paths pin the toggle, authored the two-line default flip (`config.yml`, `config-test.yml`), and ran/triaged the backend test suites below.
- Human verification: Code review of the diff; the deployment-path claims (docker-compose env list, helm `component.backend.env` → `configmap-backend.yaml`) re-checked against the files in-tree.

## Testing

Backend suites run locally against the flipped `config-test.yml`, each as `mvn -Dtest=<Class> test` from `apps/opik-backend`:

| Class | Result |
|---|---|
| `TraceThreadOnlineScoringAgenticToolsE2ETest` | ✅ 1/1 |
| `TraceThreadOnlineScoringSamplerListenerIntegrationTest` | ✅ 6/6 |
| `OnlineScoringSpanSamplerIntegrationTest` | ✅ 2/2 |
| `AutomationRuleEvaluatorsResourceTest` | 135/136 — one flaky `ConditionTimeout`, see below |
| `ManualEvaluationResourceTest` | ✅ 20/20 |

Scenarios covered: the agentic path now taken by default (E2E), the sampler/listener path that routes by size, and the automation-rule and manual-evaluation resource surfaces that build scorer context.

The `AutomationRuleEvaluatorsResourceTest` failure is not attributable to this change, on three grounds:

1. It landed on a **different test each run** — `getLogsUserDefinedMetricPythonScorer`, then `getLogsTraceSkippedDueToDisabledRule` — each passing in the other run.
2. Single-method A/B runs passed with the toggle at both `false` and `true`.
3. The second failure's test creates both rules with `enabled(false)`, so no scorer is ever invoked and a flag governing scorer context-building cannot reach it.

Every failure had the shape `Expected size: N but was: 0 … within 10 seconds` — zero logs, i.e. the Awaitility window losing a race under class-level load, not a behavioural divergence (which would emit logs with diverging *content*).

Not run: frontend and SDK suites — neither is touched by a backend config default.

## Documentation

N/A — no docs or chart README reference `TOGGLE_AGENTIC_TOOLS_ENABLED` today (`grep` over `*.md`/`*.mdx`/chart values returns only the `config.yml` definition itself), so there is no documented default to correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
