### PR TITLE
[OPIK-7772] [BE] test: guard traces DDL across pre/post-cutover topologies in CI

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
@@ -1,6 +1,9 @@
 package com.comet.opik.api.resources.utils;
 
+import liquibase.Contexts;
+import liquibase.LabelExpression;
 import liquibase.Liquibase;
+import liquibase.changelog.ChangeSet;
 import liquibase.database.DatabaseConnection;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
@@ -14,6 +17,7 @@ import org.testcontainers.mysql.MySQLContainer;
 import ru.yandex.clickhouse.ClickHouseConnectionImpl;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
 
 @UtilityClass
@@ -46,6 +50,82 @@ public class MigrationUtils {
         } catch (SQLException e) {
             throw new RuntimeException("Failed to run ClickHouse DB migration", e);
         }
+    }
+
+    /**
+     * Applies the ClickHouse changelog only up to and including the changesets of {@code migrationFileName}, leaving
+     * every later migration unrun so a caller can transform the schema mid-changelog and then resume with
+     * {@link #runClickhouseDbMigration(ClickHouseContainer)}.
+     * <p>
+     * This exists for the post-cutover topology gate: the cutover's {@code EXCHANGE} + {@code Distributed} wrap is
+     * produced by the operator runbook rather than by Liquibase, so the only way to run the later migrations against
+     * the topology they will really meet in production is to stop the changelog at the shadow-table migration, splice
+     * the transform in, and carry on. The cut is expressed as a migration <i>file name</i> rather than a changeset
+     * count so appending migrations never silently moves it.
+     *
+     * @param migrationFileName the migration file the apply stops after, e.g.
+     *            {@code 000114_recreate_traces_local_v2_id_at_datetime64.sql}
+     */
+    public static void runClickhouseDbMigrationThrough(ClickHouseContainer container, String migrationFileName) {
+        try (var connection = container.createConnection("")) {
+            DatabaseConnection dbConnection = new JdbcConnection(
+                    new ClickHouseConnectionImpl(connection.getMetaData().getURL()));
+            var database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(dbConnection);
+            try (var liquibase = new Liquibase(CLICKHOUSE_CHANGELOG_FILE, new ClassLoaderResourceAccessor(),
+                    database)) {
+                ClickHouseContainerUtils.migrationParameters().forEach(liquibase::setChangeLogParameter);
+                liquibase.update(countChangeSetsThrough(liquibase, migrationFileName), new Contexts(),
+                        new LabelExpression());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to run ClickHouse DB migration", e);
+        } catch (LiquibaseException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
+
+    /**
+     * Identifiers of the ClickHouse changesets the database has <b>not</b> applied. Empty means the changelog is fully
+     * applied — which is the assertion a topology gate needs after resuming a spliced apply, because a changeset the
+     * extension skipped (a precondition evaluating to {@code MARK_RAN} is recorded as run; an unsupported statement is
+     * not) would otherwise leave the schema short without anything throwing.
+     */
+    public static List<String> unrunClickhouseChangeSetIds(ClickHouseContainer container) {
+        try (var connection = container.createConnection("")) {
+            DatabaseConnection dbConnection = new JdbcConnection(
+                    new ClickHouseConnectionImpl(connection.getMetaData().getURL()));
+            var database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(dbConnection);
+            try (var liquibase = new Liquibase(CLICKHOUSE_CHANGELOG_FILE, new ClassLoaderResourceAccessor(),
+                    database)) {
+                ClickHouseContainerUtils.migrationParameters().forEach(liquibase::setChangeLogParameter);
+                return liquibase.listUnrunChangeSets(new Contexts(), new LabelExpression())
+                        .stream()
+                        .map(ChangeSet::getId)
+                        .toList();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to list unrun ClickHouse changesets", e);
+        } catch (LiquibaseException e) {
+            throw new UnexpectedLiquibaseException(e);
+        }
+    }
+
+    /**
+     * Number of changesets from the start of the changelog through the last one declared in {@code migrationFileName}.
+     * The changelog is a single {@code includeAll}, so this is the file's position in lexicographic order; counting the
+     * parsed changesets rather than the files keeps it right for a migration that declares more than one.
+     */
+    private static int countChangeSetsThrough(Liquibase liquibase, String migrationFileName)
+            throws LiquibaseException {
+        var changeSets = liquibase.getDatabaseChangeLog().getChangeSets();
+        for (int i = changeSets.size() - 1; i >= 0; i--) {
+            if (changeSets.get(i).getFilePath().endsWith(migrationFileName)) {
+                return i + 1;
+            }
+        }
+        throw new IllegalArgumentException(
+                "No changeset found for migration file '%s' in %s".formatted(migrationFileName,
+                        CLICKHOUSE_CHANGELOG_FILE));
     }
 
     private static void runDbMigration(String changeLogFile, Map<String, String> parameters,

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TableSchema.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TableSchema.java
@@ -1,0 +1,187 @@
+package com.comet.opik.db;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@code SHOW CREATE}-level snapshot of one ClickHouse table, read from the {@code system} tables so it reflects the
+ * schema the server actually holds rather than the DDL someone believes it applied.
+ *
+ * <p>It carries every aspect a schema change can touch — columns (with their type, DEFAULT/MATERIALIZED kind and
+ * expression, and compression codec), data-skipping indices, the sorting / primary / partition keys, projections, and
+ * the engine — so a guard comparing two tables can assert on all of them instead of on column names alone. Parsing
+ * {@code SHOW CREATE TABLE} text would carry the same information but compare formatting as well as substance; the
+ * {@code system} tables give the same facts already decomposed.
+ *
+ * <p>{@code columns} keeps the server's declaration order ({@code system.columns.position}), which matters because two
+ * tables can hold the same column set in a different order — the trace shard and its shadow do exactly that. Callers
+ * comparing sets should go through {@link #columnNames()} / {@link #storedColumnNames()} rather than comparing the
+ * lists.
+ */
+record TableSchema(
+        String table,
+        String engine,
+        String partitionKey,
+        String sortingKey,
+        String primaryKey,
+        List<Column> columns,
+        List<SkipIndex> skipIndices,
+        List<Projection> projections) {
+
+    /**
+     * @param defaultKind {@code DEFAULT}, {@code MATERIALIZED}, {@code ALIAS}, or empty when the column simply has no
+     *            default. The distinction is load-bearing: only a non-{@code MATERIALIZED}/{@code ALIAS} column can be
+     *            named in an {@code INSERT}, so it is what separates a column the cutover backfill must carry from one
+     *            the destination recomputes for itself.
+     */
+    record Column(String name, String type, String defaultKind, String defaultExpression, String codec) {
+    }
+
+    record SkipIndex(String name, String typeFull, String expression, long granularity) {
+    }
+
+    record Projection(String name, String query) {
+    }
+
+    private static final Set<String> COMPUTED_DEFAULT_KINDS = Set.of("MATERIALIZED", "ALIAS");
+
+    static TableSchema read(Connection connection, String database, String table) throws SQLException {
+        var tableRow = readTableRow(connection, database, table);
+        return new TableSchema(
+                table,
+                tableRow.get("engine_full"),
+                tableRow.get("partition_key"),
+                tableRow.get("sorting_key"),
+                tableRow.get("primary_key"),
+                readColumns(connection, database, table),
+                readSkipIndices(connection, database, table),
+                readProjections(connection, database, table));
+    }
+
+    /** Column names in the server's declaration order. */
+    List<String> columnNames() {
+        return columns.stream().map(Column::name).toList();
+    }
+
+    /**
+     * The columns an {@code INSERT} can name — everything except {@code MATERIALIZED} / {@code ALIAS}, which the server
+     * computes and refuses to accept a value for.
+     */
+    Set<String> storedColumnNames() {
+        return columns.stream()
+                .filter(column -> !COMPUTED_DEFAULT_KINDS.contains(column.defaultKind()))
+                .map(Column::name)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    Map<String, Column> columnsByName() {
+        var byName = new LinkedHashMap<String, Column>();
+        columns.forEach(column -> byName.put(column.name(), column));
+        return byName;
+    }
+
+    Map<String, SkipIndex> skipIndicesByName() {
+        var byName = new LinkedHashMap<String, SkipIndex>();
+        skipIndices.forEach(index -> byName.put(index.name(), index));
+        return byName;
+    }
+
+    Set<String> skipIndexNames() {
+        return skipIndicesByName().keySet();
+    }
+
+    Set<String> projectionNames() {
+        var names = new LinkedHashSet<String>();
+        projections.forEach(projection -> names.add(projection.name()));
+        return names;
+    }
+
+    boolean isDistributed() {
+        return engine.startsWith("Distributed");
+    }
+
+    private static Map<String, String> readTableRow(Connection connection, String database, String table)
+            throws SQLException {
+        var sql = """
+                SELECT engine_full, partition_key, sorting_key, primary_key
+                FROM system.tables WHERE database = '%s' AND name = '%s'
+                """.formatted(database, table);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            if (!resultSet.next()) {
+                throw new IllegalStateException("Table '%s.%s' does not exist".formatted(database, table));
+            }
+            return Map.of(
+                    "engine_full", text(resultSet, "engine_full"),
+                    "partition_key", text(resultSet, "partition_key"),
+                    "sorting_key", text(resultSet, "sorting_key"),
+                    "primary_key", text(resultSet, "primary_key"));
+        }
+    }
+
+    private static List<Column> readColumns(Connection connection, String database, String table) throws SQLException {
+        var sql = """
+                SELECT name, type, default_kind, default_expression, compression_codec
+                FROM system.columns WHERE database = '%s' AND table = '%s' ORDER BY position
+                """.formatted(database, table);
+        var columns = new ArrayList<Column>();
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                columns.add(new Column(
+                        text(resultSet, "name"),
+                        text(resultSet, "type"),
+                        text(resultSet, "default_kind"),
+                        text(resultSet, "default_expression"),
+                        text(resultSet, "compression_codec")));
+            }
+        }
+        return List.copyOf(columns);
+    }
+
+    private static List<SkipIndex> readSkipIndices(Connection connection, String database, String table)
+            throws SQLException {
+        var sql = """
+                SELECT name, type_full, expr, granularity
+                FROM system.data_skipping_indices WHERE database = '%s' AND table = '%s' ORDER BY name
+                """.formatted(database, table);
+        var indices = new ArrayList<SkipIndex>();
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                indices.add(new SkipIndex(
+                        text(resultSet, "name"),
+                        text(resultSet, "type_full"),
+                        text(resultSet, "expr"),
+                        resultSet.getLong("granularity")));
+            }
+        }
+        return List.copyOf(indices);
+    }
+
+    private static List<Projection> readProjections(Connection connection, String database, String table)
+            throws SQLException {
+        var sql = """
+                SELECT name, query FROM system.projections
+                WHERE database = '%s' AND table = '%s' ORDER BY name
+                """.formatted(database, table);
+        var projections = new ArrayList<Projection>();
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                projections.add(new Projection(text(resultSet, "name"), text(resultSet, "query")));
+            }
+        }
+        return List.copyOf(projections);
+    }
+
+    /** ClickHouse returns an absent String as {@code ""}; normalise the JDBC {@code null} case to match. */
+    private static String text(ResultSet resultSet, String column) throws SQLException {
+        var value = resultSet.getString(column);
+        return value == null ? "" : value;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
@@ -7,9 +7,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +53,25 @@ import static org.assertj.core.api.Assertions.assertThat;
  * default and codec differences to the suites that own them ({@code TracesLocalV2TableTest} round-trips the types and
  * sentinels, {@code TracesLocalV2BenchmarkTest} pins the codecs, {@code TracesLocalV2PartitioningTest} pins the
  * partition expression). Comparing types here would re-assert those baseline differences as failures on every run.
+ *
+ * <p><b>What "parity" covers, and what it does not.</b> Column <b>names</b> and <b>types</b>, and the <b>select and
+ * expression definitions</b> built on them — the backfill's {@code INSERT}/{@code SELECT} column mapping, projection
+ * queries, and {@code DEFAULT}/{@code MATERIALIZED} expressions where a baseline permits comparing them. It is
+ * deliberately <b>not</b> about the data: no row counts, checksums or value comparisons live here (the cutover's data
+ * fidelity is {@code TracesLocalV2CutoverTest}'s job, and its full-volume rehearsal the QA gate's). Nor does it cover
+ * data <i>lifecycle</i> — table TTL and storage policy are neither names, types nor selects, and the changelog sets
+ * neither on the trace tables; the tiered-storage policy is attached by an environment-gated migration outside this
+ * changelog, so a guard over the changelog could not meaningfully assert it.
+ *
+ * <p><b>Why DEFAULT/MATERIALIZED expressions are compared post-cutover but not pre-cutover.</b> The asymmetry is not an
+ * oversight. Pre-cutover the two tables differ in expression by design and in most columns: {@code end_time} defaults to
+ * an epoch sentinel on the shadow and is {@code Nullable} with no default on {@code traces}; {@code ttft} likewise uses
+ * a {@code NaN} sentinel; {@code duration} is materialized from a sentinel comparison rather than a null check; several
+ * columns gained an explicit {@code ''} / {@code []} default only on the successor. Requiring equality there would mean
+ * an allowlist covering most of the table — exactly the bulk tolerance this guard avoids — and those semantics are
+ * already round-tripped by {@code TracesLocalV2TableTest}. Post-cutover there is no such baseline: the
+ * {@code Distributed} wrapper is created {@code AS} the shard, so any expression divergence is drift, and
+ * {@link #assertPostCutoverParity} compares expressions strictly.
  */
 @UtilityClass
 class TracesSchemaParity {
@@ -92,6 +114,9 @@ class TracesSchemaParity {
 
     private static final String COLUMN_NAME_PATTERN = "[a-z_][a-z0-9_]*";
 
+    /** A trailing {@code AS <column>} alias on a SELECT projection entry, naming that entry's destination column. */
+    private static final Pattern SELECT_ALIAS = Pattern.compile("(?i)\\bAS\\s+([a-z_][a-z0-9_]*)\\s*$");
+
     /**
      * Asserts the pre-cutover invariant: the live table, the shadow it will be replaced by, and the backfill column
      * list that moves the data between them all agree.
@@ -130,6 +155,9 @@ class TracesSchemaParity {
                         """, SHADOW, SHADOW_ONLY_COLUMNS)
                 .containsExactlyInAnyOrderElementsOf(union(backfillColumns, SHADOW_ONLY_COLUMNS));
 
+        // The column sets above say the right columns are carried; this says they are carried to the right places.
+        assertBackfillInsertMatchesSelect();
+
         assertThat(shadow.skipIndexNames())
                 .as("""
                         skip-index parity: an index added to `%s` must also be added to the `%s` shadow, or the \
@@ -143,10 +171,15 @@ class TracesSchemaParity {
                 .as("skip index `%s` must be defined identically on `%s` and the `%s` shadow", name, TRACES, SHADOW)
                 .isEqualTo(index));
 
-        assertThat(shadow.projectionNames())
-                .as("projection parity: a projection is storage-only, but pre-cutover both tables must carry it so "
-                        + "the successor keeps it after the swap")
-                .containsExactlyInAnyOrderElementsOf(traces.projectionNames());
+        // Compared by full definition, not just by name: two projections sharing a name but not a query would leave the
+        // successor computing something different after the swap, and a name-only check cannot see that.
+        assertThat(shadow.projections())
+                .as("""
+                        projection parity: a projection is storage-only, but pre-cutover both tables must carry it — \
+                        with the same query — so the successor keeps it, and keeps it meaning the same thing, after the \
+                        swap\
+                        """)
+                .containsExactlyInAnyOrderElementsOf(traces.projections());
 
         assertThat(shadow.sortingKey())
                 .as("the successor's sorting key is the dedup key the backfill relies on; it must match `%s`", TRACES)
@@ -187,6 +220,11 @@ class TracesSchemaParity {
                         """, TRACES, SHARD)
                 .isEqualTo(shard.columnNames());
 
+        // Strict per column here — type, default kind AND the DEFAULT/MATERIALIZED expression — because the wrapper is
+        // created `AS` the shard, so it starts as an exact copy and has no legitimate reason to diverge. (The opposite of
+        // pre-cutover, where the shadow deliberately differs; see the class Javadoc.) Without the expression check, a
+        // MATERIALIZED column added to the shard with one expression and to the wrapper with another would satisfy every
+        // name and type assertion while computing something different on each side.
         var shardColumns = shard.columnsByName();
         wrapper.columnsByName().forEach((name, column) -> {
             var shardColumn = shardColumns.get(name);
@@ -197,24 +235,32 @@ class TracesSchemaParity {
                     .as("column `%s` must have the same default kind on the Distributed `%s` and on `%s`", name,
                             TRACES, SHARD)
                     .isEqualTo(shardColumn.defaultKind());
+            assertThat(column.defaultExpression())
+                    .as("""
+                            column `%s` must have the same DEFAULT/MATERIALIZED expression on the Distributed `%s` and \
+                            on `%s`; the wrapper is created AS the shard, so a divergence here means one side was \
+                            altered on its own\
+                            """, name, TRACES, SHARD)
+                    .isEqualTo(shardColumn.defaultExpression());
         });
     }
 
     /**
-     * Every column the shipped cutover backfill names in its {@code INSERT INTO ... (...)} list.
+     * Every column the shipped cutover backfill names in its {@code INSERT INTO ... (...)} list, <b>in order</b>, with
+     * duplicates rejected.
+     *
+     * <p>Order and uniqueness matter even though the parity comparisons that consume this are set-based: ClickHouse maps
+     * {@code INSERT (...) SELECT ...} by <i>position</i>, so a duplicated or reordered entry changes which destination
+     * column a value lands in, and a set would hide both. {@link #assertBackfillInsertMatchesSelect} uses the order this
+     * preserves.
      *
      * <p>Line comments are stripped before the statement is located because the file's header prose mentions
      * {@code INSERT} and carries parentheses; the reference SQL contains no string literal holding {@code --}, so the
      * naive strip is safe here. Each parsed entry is checked to be a bare column name, so a future edit that puts an
      * expression or a nested parenthesis in the list fails loudly instead of being silently mis-parsed.
      */
-    static Set<String> backfillColumnList() throws IOException {
-        assertThat(BACKFILL_SQL)
-                .as("the shipped cutover backfill must be readable at %s (relative to apps/opik-backend); if it moved, "
-                        + "update this guard rather than dropping the assertion", BACKFILL_SQL)
-                .isRegularFile();
-
-        var sql = stripLineComments(Files.readString(BACKFILL_SQL));
+    static List<String> backfillColumnList() throws IOException {
+        var sql = readBackfillSql();
 
         int insertAt = sql.indexOf("INSERT INTO");
         assertThat(insertAt).as("no INSERT INTO statement found in %s", BACKFILL_SQL).isNotNegative();
@@ -227,15 +273,141 @@ class TracesSchemaParity {
         var columns = Arrays.stream(sql.substring(open + 1, close).split(","))
                 .map(String::trim)
                 .filter(entry -> !entry.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .toList();
 
         assertThat(columns)
                 .as("the backfill column list must hold bare column names; an expression here means this parse is "
                         + "reading the wrong parentheses")
                 .isNotEmpty()
                 .allMatch(column -> column.matches(COLUMN_NAME_PATTERN));
+        assertThat(columns)
+                .as("""
+                        the backfill column list must not repeat a column: ClickHouse maps INSERT (...) SELECT ... by \
+                        position, so a duplicate silently shifts every later value into the wrong destination column\
+                        """)
+                .doesNotHaveDuplicates();
 
         return columns;
+    }
+
+    /**
+     * Asserts the backfill's {@code INSERT} column list and its {@code SELECT} projection line up position by position.
+     *
+     * <p>ClickHouse pairs the two by position, not by name, so a column added to one list and not the other — or added at
+     * a different offset — sends every subsequent value to the wrong destination column. Nothing about that is a syntax
+     * error, and both tables stay perfectly consistent with each other, so no amount of table-to-table comparison can
+     * see it: the mapping between them has to be checked directly.
+     *
+     * <p>Each projection entry must therefore name its destination — a bare column, or an expression carrying an
+     * {@code AS <name>} alias, as {@code coalesce(end_time, ...) AS end_time} does. An unaliased expression is legal SQL
+     * and would still map positionally, but it leaves the mapping unverifiable, so one fails here. The shipped SQL
+     * already aliases every expression, so this pins an existing convention rather than demanding a change.
+     */
+    static void assertBackfillInsertMatchesSelect() throws IOException {
+        var insertColumns = backfillColumnList();
+        var selectTargets = backfillSelectTargets();
+
+        assertThat(selectTargets)
+                .as("""
+                        cutover backfill select parity: the SELECT projection of %s must line up with its INSERT column \
+                        list position by position, because ClickHouse pairs them by position and not by name. A mismatch \
+                        here writes values into the wrong destination columns at cutover time, without any error.\
+                        """,
+                        BACKFILL_SQL.getFileName())
+                .containsExactlyElementsOf(insertColumns);
+    }
+
+    /**
+     * The destination column each entry of the backfill's {@code SELECT} projection targets: the alias when the entry is
+     * an expression, the column name when it is bare.
+     */
+    private static List<String> backfillSelectTargets() throws IOException {
+        var sql = readBackfillSql();
+
+        int selectAt = sql.indexOf("SELECT", sql.indexOf("INSERT INTO"));
+        assertThat(selectAt).as("no SELECT found after the INSERT column list in %s", BACKFILL_SQL).isNotNegative();
+
+        int fromAt = indexOfTopLevelFrom(sql, selectAt + "SELECT".length());
+        assertThat(fromAt).as("no top-level FROM found after SELECT in %s", BACKFILL_SQL).isNotNegative();
+
+        return splitTopLevel(sql.substring(selectAt + "SELECT".length(), fromAt)).stream()
+                .map(TracesSchemaParity::destinationColumnOf)
+                .toList();
+    }
+
+    private static String destinationColumnOf(String projectionEntry) {
+        var aliased = SELECT_ALIAS.matcher(projectionEntry);
+        if (aliased.find()) {
+            return aliased.group(1);
+        }
+        assertThat(projectionEntry)
+                .as("""
+                        every entry of the backfill SELECT projection must name its destination — a bare column, or an \
+                        expression with an `AS <column>` alias — so its positional mapping to the INSERT column list can \
+                        be verified\
+                        """)
+                .matches(COLUMN_NAME_PATTERN);
+        return projectionEntry;
+    }
+
+    /** Index of the {@code FROM} keyword at paren depth 0 and outside a string literal, or {@code -1}. */
+    private static int indexOfTopLevelFrom(String sql, int from) {
+        int depth = 0;
+        boolean inString = false;
+        for (int i = from; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            if (c == '\'') {
+                inString = !inString;
+            } else if (!inString && c == '(') {
+                depth++;
+            } else if (!inString && c == ')') {
+                depth--;
+            } else
+                if (!inString && depth == 0 && sql.startsWith("FROM", i)
+                        && !Character.isLetterOrDigit(sql.charAt(i - 1))) {
+                            return i;
+                        }
+        }
+        return -1;
+    }
+
+    /** Splits on commas at paren depth 0 and outside a string literal, so nested call arguments stay intact. */
+    private static List<String> splitTopLevel(String projection) {
+        var entries = new ArrayList<String>();
+        var current = new StringBuilder();
+        int depth = 0;
+        boolean inString = false;
+        for (int i = 0; i < projection.length(); i++) {
+            char c = projection.charAt(i);
+            if (c == '\'') {
+                inString = !inString;
+            } else if (!inString && c == '(') {
+                depth++;
+            } else if (!inString && c == ')') {
+                depth--;
+            } else if (!inString && depth == 0 && c == ',') {
+                entries.add(normalizeWhitespace(current.toString()));
+                current.setLength(0);
+                continue;
+            }
+            current.append(c);
+        }
+        if (!current.toString().isBlank()) {
+            entries.add(normalizeWhitespace(current.toString()));
+        }
+        return entries;
+    }
+
+    private static String normalizeWhitespace(String entry) {
+        return entry.trim().replaceAll("\\s+", " ");
+    }
+
+    private static String readBackfillSql() throws IOException {
+        assertThat(BACKFILL_SQL)
+                .as("the shipped cutover backfill must be readable at %s (relative to apps/opik-backend); if it moved, "
+                        + "update this guard rather than dropping the assertion", BACKFILL_SQL)
+                .isRegularFile();
+        return stripLineComments(Files.readString(BACKFILL_SQL));
     }
 
     private static String stripLineComments(String sql) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
@@ -1,0 +1,256 @@
+package com.comet.opik.db;
+
+import lombok.experimental.UtilityClass;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The trace physical-layer schema invariant, in one place, for both topologies the mixed fleet runs.
+ *
+ * <p><b>Why this exists.</b> The cutover to the partitioned, sharding-ready trace table is produced by the operator
+ * runbook ({@code data-migrations/traces-local-v2-cutover}), not by Liquibase, so the changelog and the runtime
+ * topology diverge the moment an install cuts over — and they stay diverged for as long as the fleet is mixed (SaaS cut
+ * over; self-hosted on their own cadence; fresh installs still pre-cutover). A single {@code traces} schema change
+ * must therefore be correct against <b>two</b> different physical layouts, and the failure mode is silent: a shard-only
+ * {@code ADD COLUMN} applies without error post-cutover but is <i>not readable</i> through the {@code Distributed}
+ * wrapper, and a migration that alters {@code traces} but forgets the shadow leaves the next cutover copying a table
+ * that no longer matches. Both are invisible until a customer hits them.
+ *
+ * <p><b>The invariant.</b> Every trace physical table stays schema-consistent for any change:
+ * <ul>
+ *   <li><b>Pre-cutover</b> — {@code traces} (live) and {@code traces_local_v2} (the shadow the cutover will promote)
+ *   carry the same read-facing columns and the same storage-only attributes, and the cutover backfill's explicit
+ *   column list carries every column that must survive the copy. The shadow's documented, deliberate extras are
+ *   enumerated in {@link #SHADOW_ONLY_COLUMNS} / {@link #SHADOW_ONLY_SKIP_INDICES} and nothing else may differ.</li>
+ *   <li><b>Post-cutover</b> — the {@code Distributed} {@code traces} wrapper exposes exactly the columns its
+ *   {@code traces_local} shard holds, so every read-facing change reached both.</li>
+ * </ul>
+ *
+ * <p><b>Where a change lands.</b> Anything that changes the read-facing column list (columns, including
+ * materialized/alias) must be applied to the shard <b>and</b> the {@code Distributed} wrapper; everything storage-only
+ * (skip indexes, codecs, TTL, projections) is shard-only, because the wrapper stores nothing. Pre-cutover the same
+ * change applies to {@code traces} and the shadow, and a <i>preserved</i> column must additionally be added to the
+ * backfill column list or the cutover drops it.
+ *
+ * <p><b>Baseline differences are enumerated, not tolerated in bulk.</b> The shadow deliberately differs from
+ * {@code traces} in ways a schema-change guard must not flag — narrower timestamp precision, sentinel-based
+ * non-nullable columns instead of {@code Nullable}, explicit codecs throughout, a weekly partition key, and a
+ * different column order. So this guard compares the aspects a <i>schema change</i> moves — the column name set, the
+ * insertable column set, skip indices, projections, and the sorting/primary keys — and leaves the per-column type,
+ * default and codec differences to the suites that own them ({@code TracesLocalV2TableTest} round-trips the types and
+ * sentinels, {@code TracesLocalV2BenchmarkTest} pins the codecs, {@code TracesLocalV2PartitioningTest} pins the
+ * partition expression). Comparing types here would re-assert those baseline differences as failures on every run.
+ */
+@UtilityClass
+class TracesSchemaParity {
+
+    /** The live read/insert-facing table name in both topologies: a {@code MergeTree} before the cutover, a {@code Distributed} wrapper after. */
+    static final String TRACES = "traces";
+
+    /** The empty successor the cutover promotes; exists only pre-cutover (the cutover renames it away). */
+    static final String SHADOW = "traces_local_v2";
+
+    /** The shard the {@code Distributed} wrapper fronts; exists only post-cutover. */
+    static final String SHARD = "traces_local";
+
+    /** The parked pre-cutover data, retained through the soak; exists only post-cutover. */
+    static final String BACKUP = "traces_pre_cutover_backup";
+
+    /**
+     * {@code is_deleted} is the successor's {@code ReplacingMergeTree} delete meta-column (000101). It is engine
+     * bookkeeping rather than trace data, which is why it has no counterpart on {@code traces} and why the cutover
+     * backfill deliberately omits it so it defaults to 0.
+     */
+    static final Set<String> SHADOW_ONLY_COLUMNS = Set.of("is_deleted");
+
+    /**
+     * Skip indices the successor adds because its layout needs them and {@code traces} cannot use them:
+     * {@code idx_traces_id_at} indexes the partition-input column {@code id_at}, which {@code traces} does not
+     * partition on, and {@code idx_traces_id_minmax} prunes the id-range predicates the retention path issues against
+     * the weekly partitions. Both are storage-only, so post-cutover they live on the shard alone.
+     */
+    static final Set<String> SHADOW_ONLY_SKIP_INDICES = Set.of("idx_traces_id_at", "idx_traces_id_minmax");
+
+    /**
+     * The shipped cutover backfill, read rather than restated: this guard's whole point is that the backfill column
+     * list cannot drift from the tables, so asserting against a copy of it here would assert nothing. The path is
+     * relative to the Maven module directory ({@code apps/opik-backend}), which is the working directory both locally
+     * and in CI.
+     */
+    private static final Path BACKFILL_SQL = Path
+            .of("data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql");
+
+    private static final String COLUMN_NAME_PATTERN = "[a-z_][a-z0-9_]*";
+
+    /**
+     * Asserts the pre-cutover invariant: the live table, the shadow it will be replaced by, and the backfill column
+     * list that moves the data between them all agree.
+     */
+    static void assertPreCutoverParity(Connection connection, String database) throws SQLException, IOException {
+        var traces = TableSchema.read(connection, database, TRACES);
+        var shadow = TableSchema.read(connection, database, SHADOW);
+
+        assertThat(traces.isDistributed())
+                .as("pre-cutover `%s` must still be the local MergeTree, not a Distributed wrapper", TRACES)
+                .isFalse();
+
+        assertThat(shadow.columnNames())
+                .as("""
+                        read-facing column parity: every column on `%s` must exist on the `%s` shadow (and vice versa, \
+                        beyond the documented engine meta-columns %s). A change that adds or drops a column on one \
+                        without the other leaves the cutover promoting a table that does not match the live one.\
+                        """, TRACES, SHADOW, SHADOW_ONLY_COLUMNS)
+                .containsExactlyInAnyOrderElementsOf(union(traces.columnNames(), SHADOW_ONLY_COLUMNS));
+
+        var backfillColumns = backfillColumnList();
+
+        assertThat(traces.storedColumnNames())
+                .as("""
+                        cutover backfill parity: the backfill's explicit INSERT column list must name exactly the \
+                        insertable columns of `%s`. A new preserved column added to the tables but not to %s is \
+                        silently dropped at the cutover; a column removed from the tables but left in the list fails \
+                        the backfill.\
+                        """, TRACES, BACKFILL_SQL.getFileName())
+                .containsExactlyInAnyOrderElementsOf(backfillColumns);
+
+        assertThat(shadow.storedColumnNames())
+                .as("""
+                        the `%s` shadow must accept exactly the backfilled columns plus its engine meta-columns %s \
+                        (which the backfill deliberately omits so they take their defaults)\
+                        """, SHADOW, SHADOW_ONLY_COLUMNS)
+                .containsExactlyInAnyOrderElementsOf(union(backfillColumns, SHADOW_ONLY_COLUMNS));
+
+        assertThat(shadow.skipIndexNames())
+                .as("""
+                        skip-index parity: an index added to `%s` must also be added to the `%s` shadow, or the \
+                        successor silently loses the pruning the read path was tuned for. The shadow's own extras are \
+                        %s.\
+                        """, TRACES, SHADOW, SHADOW_ONLY_SKIP_INDICES)
+                .containsExactlyInAnyOrderElementsOf(union(traces.skipIndexNames(), SHADOW_ONLY_SKIP_INDICES));
+
+        var shadowIndices = shadow.skipIndicesByName();
+        traces.skipIndicesByName().forEach((name, index) -> assertThat(shadowIndices.get(name))
+                .as("skip index `%s` must be defined identically on `%s` and the `%s` shadow", name, TRACES, SHADOW)
+                .isEqualTo(index));
+
+        assertThat(shadow.projectionNames())
+                .as("projection parity: a projection is storage-only, but pre-cutover both tables must carry it so "
+                        + "the successor keeps it after the swap")
+                .containsExactlyInAnyOrderElementsOf(traces.projectionNames());
+
+        assertThat(shadow.sortingKey())
+                .as("the successor's sorting key is the dedup key the backfill relies on; it must match `%s`", TRACES)
+                .isEqualTo(traces.sortingKey());
+        assertThat(shadow.primaryKey())
+                .as("the successor's primary key must match `%s`", TRACES)
+                .isEqualTo(traces.primaryKey());
+
+        // The partition keys differ by design (that is the point of the successor); the expression itself is pinned by
+        // TracesLocalV2PartitioningTest, so this only holds the shapes apart.
+        assertThat(traces.partitionKey()).as("`%s` is unpartitioned pre-cutover", TRACES).isEmpty();
+        assertThat(shadow.partitionKey()).as("the `%s` successor is weekly-partitioned", SHADOW).isNotEmpty();
+    }
+
+    /**
+     * Asserts the post-cutover invariant: the {@code Distributed} wrapper exposes exactly the shard's columns.
+     *
+     * <p>This is the assertion that catches the silent failure the spike measured — a shard-only {@code ADD COLUMN}
+     * succeeds, but the column is unreadable through the wrapper (ClickHouse code 47), so the feature that added it is
+     * broken on every cut-over install while CI stays green.
+     */
+    static void assertPostCutoverParity(Connection connection, String database) throws SQLException {
+        var wrapper = TableSchema.read(connection, database, TRACES);
+        var shard = TableSchema.read(connection, database, SHARD);
+
+        assertThat(wrapper.isDistributed())
+                .as("post-cutover `%s` must be the Distributed wrapper; found engine `%s`", TRACES, wrapper.engine())
+                .isTrue();
+        assertThat(shard.isDistributed())
+                .as("`%s` must be the local MergeTree shard; found engine `%s`", SHARD, shard.engine())
+                .isFalse();
+
+        assertThat(wrapper.columnNames())
+                .as("""
+                        wrapper column parity: the Distributed `%s` must expose exactly the columns `%s` holds, in the \
+                        same order. A read-facing change applied only to the shard leaves the wrapper unable to see it \
+                        (code 47); one applied only to the wrapper leaves reads referencing a column no shard stores.\
+                        """, TRACES, SHARD)
+                .isEqualTo(shard.columnNames());
+
+        var shardColumns = shard.columnsByName();
+        wrapper.columnsByName().forEach((name, column) -> {
+            var shardColumn = shardColumns.get(name);
+            assertThat(column.type())
+                    .as("column `%s` must have the same type on the Distributed `%s` and on `%s`", name, TRACES, SHARD)
+                    .isEqualTo(shardColumn.type());
+            assertThat(column.defaultKind())
+                    .as("column `%s` must have the same default kind on the Distributed `%s` and on `%s`", name,
+                            TRACES, SHARD)
+                    .isEqualTo(shardColumn.defaultKind());
+        });
+    }
+
+    /**
+     * Every column the shipped cutover backfill names in its {@code INSERT INTO ... (...)} list.
+     *
+     * <p>Line comments are stripped before the statement is located because the file's header prose mentions
+     * {@code INSERT} and carries parentheses; the reference SQL contains no string literal holding {@code --}, so the
+     * naive strip is safe here. Each parsed entry is checked to be a bare column name, so a future edit that puts an
+     * expression or a nested parenthesis in the list fails loudly instead of being silently mis-parsed.
+     */
+    static Set<String> backfillColumnList() throws IOException {
+        assertThat(BACKFILL_SQL)
+                .as("the shipped cutover backfill must be readable at %s (relative to apps/opik-backend); if it moved, "
+                        + "update this guard rather than dropping the assertion", BACKFILL_SQL)
+                .isRegularFile();
+
+        var sql = stripLineComments(Files.readString(BACKFILL_SQL));
+
+        int insertAt = sql.indexOf("INSERT INTO");
+        assertThat(insertAt).as("no INSERT INTO statement found in %s", BACKFILL_SQL).isNotNegative();
+
+        int open = sql.indexOf('(', insertAt);
+        int close = sql.indexOf(')', open);
+        assertThat(open).as("no column list found after INSERT INTO in %s", BACKFILL_SQL).isNotNegative();
+        assertThat(close).as("unterminated column list in %s", BACKFILL_SQL).isNotNegative();
+
+        var columns = Arrays.stream(sql.substring(open + 1, close).split(","))
+                .map(String::trim)
+                .filter(entry -> !entry.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        assertThat(columns)
+                .as("the backfill column list must hold bare column names; an expression here means this parse is "
+                        + "reading the wrong parentheses")
+                .isNotEmpty()
+                .allMatch(column -> column.matches(COLUMN_NAME_PATTERN));
+
+        return columns;
+    }
+
+    private static String stripLineComments(String sql) {
+        return sql.lines()
+                .map(line -> {
+                    int comment = line.indexOf("--");
+                    return comment < 0 ? line : line.substring(0, comment);
+                })
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static Set<String> union(Iterable<String> first, Set<String> second) {
+        var union = new LinkedHashSet<String>();
+        first.forEach(union::add);
+        union.addAll(second);
+        return union;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
@@ -114,14 +114,27 @@ class TracesSchemaParity {
      * this map is not stale — an entry whose columns no longer differ must be removed — so the allowlist cannot quietly
      * grow into a blanket exemption.
      */
-    static final Map<String, String> BASELINE_TYPE_DIFFERENCES = Map.of(
-            "start_time", "nanosecond -> microsecond precision; nothing ingested needs finer (000101)",
-            "created_at", "nanosecond -> microsecond precision; nothing ingested needs finer (000101)",
-            "end_time", "Nullable -> non-nullable with an epoch sentinel, dropping the null-mask overhead (000101)",
-            "ttft", "Nullable -> non-nullable with a NaN sentinel (000101)",
-            "duration", "Nullable -> non-nullable, materialized from the sentinels rather than a null check (000101)",
-            "id_at",
-            "DateTime -> DateTime64(0), honest past 2106 so a far-future UUIDv7 partitions correctly (000114)");
+    static final Map<String, BaselineTypeDifference> BASELINE_TYPE_DIFFERENCES = Map.of(
+            "start_time", new BaselineTypeDifference("DateTime64(9, 'UTC')", "DateTime64(6, 'UTC')",
+                    "nanosecond -> microsecond precision; nothing ingested needs finer (000101)"),
+            "created_at", new BaselineTypeDifference("DateTime64(9, 'UTC')", "DateTime64(6, 'UTC')",
+                    "nanosecond -> microsecond precision; nothing ingested needs finer (000101)"),
+            "end_time", new BaselineTypeDifference("Nullable(DateTime64(9, 'UTC'))", "DateTime64(6, 'UTC')",
+                    "Nullable -> non-nullable with an epoch sentinel, dropping the null-mask overhead (000101)"),
+            "ttft", new BaselineTypeDifference("Nullable(Float64)", "Float64",
+                    "Nullable -> non-nullable with a NaN sentinel (000101)"),
+            "duration", new BaselineTypeDifference("Nullable(Float64)", "Float64",
+                    "Nullable -> non-nullable, materialized from the sentinels rather than a null check (000101)"),
+            "id_at", new BaselineTypeDifference("DateTime('UTC')", "DateTime64(0, 'UTC')",
+                    "DateTime -> DateTime64(0), honest past 2106 so a far-future UUIDv7 partitions correctly (000114)"));
+
+    /**
+     * One allowlisted difference, pinned on <b>both</b> sides rather than merely asserted to exist. Recording only that
+     * the types differ would let either side drift to an unrelated type — {@code traces.start_time} becoming
+     * {@code String}, say — while still "differing" and so still being excused.
+     */
+    record BaselineTypeDifference(String tracesType, String shadowType, String reason) {
+    }
 
     /**
      * The shipped cutover backfill, read rather than restated: this guard's whole point is that the backfill column
@@ -177,8 +190,10 @@ class TracesSchemaParity {
                     .isEqualTo(column.type());
         });
 
-        // The allowlist must not outlive the differences it excuses, or it silently becomes a blanket exemption.
-        BASELINE_TYPE_DIFFERENCES.forEach((name, reason) -> {
+        // Each allowlisted difference is pinned on both sides. Merely requiring the types to differ would excuse an
+        // unrelated drift on either table, and an entry whose columns have converged is a dead exemption that must be
+        // removed rather than left covering a column nothing checks.
+        BASELINE_TYPE_DIFFERENCES.forEach((name, expected) -> {
             var tracesColumn = traces.columnsByName().get(name);
             var shadowColumn = shadowColumns.get(name);
             assertThat(tracesColumn).as("BASELINE_TYPE_DIFFERENCES names `%s`, which must exist on `%s`", name, TRACES)
@@ -187,10 +202,16 @@ class TracesSchemaParity {
                     .isNotNull();
             assertThat(tracesColumn.type())
                     .as("""
-                            stale allowlist entry: `%s` no longer differs between `%s` and `%s` (%s). Remove the entry \
-                            so the column is type-checked like every other.\
-                            """, name, TRACES, SHADOW, reason)
-                    .isNotEqualTo(shadowColumn.type());
+                            allowlisted column `%s` must still be exactly the documented type on `%s` (%s). If it \
+                            changed, either the change is wrong or the allowlist entry needs updating — and if the two \
+                            have converged, delete the entry so the column is type-checked like every other.\
+                            """, name, TRACES, expected.reason())
+                    .isEqualTo(expected.tracesType());
+            assertThat(shadowColumn.type())
+                    .as("""
+                            allowlisted column `%s` must still be exactly the documented type on the `%s` shadow (%s)\
+                            """, name, SHADOW, expected.reason())
+                    .isEqualTo(expected.shadowType());
         });
 
         var backfillColumns = backfillColumnList();
@@ -271,7 +292,7 @@ class TracesSchemaParity {
         assertThat(wrapper.engine())
                 .as("""
                         the Distributed `%s` must front `%s` on the '{cluster}' cluster in the same database, sharded on \
-                        sipHash64(project_id) — the wrap the runbook applies. A wrapper over a different target reads \
+                        sipHash64(project_id) — the wrap applied by the runbook. A wrapper over a different target reads \
                         the wrong data while looking structurally identical.\
                         """,
                         TRACES, SHARD)

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -104,6 +105,25 @@ class TracesSchemaParity {
     static final Set<String> SHADOW_ONLY_SKIP_INDICES = Set.of("idx_traces_id_at", "idx_traces_id_minmax");
 
     /**
+     * The <b>only</b> columns whose type may differ between {@code traces} and the shadow, each with the reason it does.
+     * Six of thirty-one shared columns — a small, enumerable set, which is why type parity is asserted for every other
+     * column rather than skipped wholesale.
+     * <p>
+     * An entry is a claim that the difference is deliberate and that the cutover converts it safely (the backfill
+     * carries the corresponding {@code coalesce(...)} where one is needed). {@link #assertPreCutoverParity} also asserts
+     * this map is not stale — an entry whose columns no longer differ must be removed — so the allowlist cannot quietly
+     * grow into a blanket exemption.
+     */
+    static final Map<String, String> BASELINE_TYPE_DIFFERENCES = Map.of(
+            "start_time", "nanosecond -> microsecond precision; nothing ingested needs finer (000101)",
+            "created_at", "nanosecond -> microsecond precision; nothing ingested needs finer (000101)",
+            "end_time", "Nullable -> non-nullable with an epoch sentinel, dropping the null-mask overhead (000101)",
+            "ttft", "Nullable -> non-nullable with a NaN sentinel (000101)",
+            "duration", "Nullable -> non-nullable, materialized from the sentinels rather than a null check (000101)",
+            "id_at",
+            "DateTime -> DateTime64(0), honest past 2106 so a far-future UUIDv7 partitions correctly (000114)");
+
+    /**
      * The shipped cutover backfill, read rather than restated: this guard's whole point is that the backfill column
      * list cannot drift from the tables, so asserting against a copy of it here would assert nothing. The path is
      * relative to the Maven module directory ({@code apps/opik-backend}), which is the working directory both locally
@@ -136,6 +156,42 @@ class TracesSchemaParity {
                         without the other leaves the cutover promoting a table that does not match the live one.\
                         """, TRACES, SHADOW, SHADOW_ONLY_COLUMNS)
                 .containsExactlyInAnyOrderElementsOf(union(traces.columnNames(), SHADOW_ONLY_COLUMNS));
+
+        // Type parity for every shared column outside the documented baseline. This is the leg that catches a
+        // precision narrowed on one table only, or a String quietly becoming LowCardinality(String) on one side: the
+        // name sets still match, so nothing above would notice.
+        var shadowColumns = shadow.columnsByName();
+        traces.columnsByName().forEach((name, column) -> {
+            var shadowColumn = shadowColumns.get(name);
+            if (shadowColumn == null || BASELINE_TYPE_DIFFERENCES.containsKey(name)) {
+                return;
+            }
+            assertThat(shadowColumn.type())
+                    .as("""
+                            column type parity: `%s` must have the same type on `%s` and the `%s` shadow. A type that \
+                            differs on one side only is converted at the cutover — silently truncating, or changing the \
+                            read/write contract. If the difference is deliberate, add it to BASELINE_TYPE_DIFFERENCES \
+                            with its reason.\
+                            """,
+                            name, TRACES, SHADOW)
+                    .isEqualTo(column.type());
+        });
+
+        // The allowlist must not outlive the differences it excuses, or it silently becomes a blanket exemption.
+        BASELINE_TYPE_DIFFERENCES.forEach((name, reason) -> {
+            var tracesColumn = traces.columnsByName().get(name);
+            var shadowColumn = shadowColumns.get(name);
+            assertThat(tracesColumn).as("BASELINE_TYPE_DIFFERENCES names `%s`, which must exist on `%s`", name, TRACES)
+                    .isNotNull();
+            assertThat(shadowColumn).as("BASELINE_TYPE_DIFFERENCES names `%s`, which must exist on `%s`", name, SHADOW)
+                    .isNotNull();
+            assertThat(tracesColumn.type())
+                    .as("""
+                            stale allowlist entry: `%s` no longer differs between `%s` and `%s` (%s). Remove the entry \
+                            so the column is type-checked like every other.\
+                            """, name, TRACES, SHADOW, reason)
+                    .isNotEqualTo(shadowColumn.type());
+        });
 
         var backfillColumns = backfillColumnList();
 
@@ -208,6 +264,21 @@ class TracesSchemaParity {
         assertThat(wrapper.isDistributed())
                 .as("post-cutover `%s` must be the Distributed wrapper; found engine `%s`", TRACES, wrapper.engine())
                 .isTrue();
+
+        // Being *a* Distributed table is not enough: one pointed at another cluster, database, shard table or sharding
+        // key would expose the same column list and pass every assertion below. Pinning the parameters also keeps the
+        // spliced statements honest against the shipped 000003_exchange_and_wrap.sql they mirror.
+        assertThat(wrapper.engine())
+                .as("""
+                        the Distributed `%s` must front `%s` on the '{cluster}' cluster in the same database, sharded on \
+                        sipHash64(project_id) — the wrap the runbook applies. A wrapper over a different target reads \
+                        the wrong data while looking structurally identical.\
+                        """,
+                        TRACES, SHARD)
+                .contains("Distributed")
+                .contains("'" + database + "'")
+                .contains("'" + SHARD + "'")
+                .contains("sipHash64(project_id)");
         assertThat(shard.isDistributed())
                 .as("`%s` must be the local MergeTree shard; found engine `%s`", SHARD, shard.engine())
                 .isFalse();

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -39,9 +39,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * <p><b>The failure this catches is silent.</b> Post-cutover, a shard-only {@code ADD COLUMN} succeeds — ClickHouse
  * raises nothing — but the column is not readable through the wrapper, so the feature that added it is broken on every
  * cut-over install while the migration, and every test that does not look at the wrapper, stays green.
- * {@link #shardOnlyColumnIsUnreadableThroughTheWrapper()} pins that behaviour and
- * {@link #alteringBothTablesMakesTheColumnReadable()} pins the remedy, so the playbook's "read-facing changes go to
- * both" rule is backed by an executable demonstration rather than by assertion.
+ * {@link #shardOnlyColumnIsUnreadableUntilTheWrapperIsAlteredToo()} pins both that behaviour and its remedy, so the
+ * playbook's "read-facing changes go to both" rule is backed by an executable demonstration rather than by assertion.
  *
  * <p><b>Splice, not a rewritten changelog.</b> The spliced statements mirror the shipped reference SQL
  * ({@code data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql}) and the
@@ -146,13 +145,20 @@ class TracesSchemaParityPostCutoverTest {
     }
 
     /**
-     * The spike's central finding, pinned: post-cutover a shard-only {@code ADD COLUMN} applies without error and is
-     * then invisible through the wrapper. This is the exact shape of a migration that forgets the wrapper branch.
+     * The spike's central finding and the playbook's remedy, in one test: post-cutover a shard-only {@code ADD COLUMN}
+     * applies without error and is then invisible through the wrapper, and altering the wrapper too — which it accepts as
+     * a metadata-only change — makes it readable. This is the exact shape of a migration that forgets the wrapper branch,
+     * followed by the fix.
+     *
+     * <p>Kept as one test rather than an ordered pair on purpose: the "after" half only means anything on the state the
+     * "before" half leaves behind, and handing mutated schema between two {@code @Order}ed tests would let a failure in
+     * the first leave the shard drifted for everything after it. One test owns the column from {@code ADD} to
+     * {@code DROP}.
      */
     @Test
     @Order(10)
-    @DisplayName("drift is caught: a column added to the shard alone is unreadable through the wrapper")
-    void shardOnlyColumnIsUnreadableThroughTheWrapper() throws Exception {
+    @DisplayName("drift is caught: a shard-only column is unreadable until the wrapper is altered too")
+    void shardOnlyColumnIsUnreadableUntilTheWrapperIsAlteredToo() throws Exception {
         execute("ALTER TABLE %s.%s ADD COLUMN drift_shard_only String".formatted(DATABASE_NAME, SHARD));
 
         assertThatThrownBy(() -> TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME))
@@ -162,17 +168,8 @@ class TracesSchemaParityPostCutoverTest {
         // Not merely absent from the wrapper's metadata — unresolvable, so any read referencing it fails at runtime.
         assertThatThrownBy(() -> selectColumns(List.of("drift_shard_only")))
                 .hasMessageContaining("drift_shard_only");
-    }
 
-    /**
-     * The remedy the playbook prescribes, demonstrated: the wrapper takes the same {@code ADD COLUMN} as a metadata-only
-     * change, after which parity holds and the column reads. Runs immediately after the negative case and shares its
-     * drift column, so the pair reads as one before/after.
-     */
-    @Test
-    @Order(11)
-    @DisplayName("altering both the shard and the wrapper makes the column readable")
-    void alteringBothTablesMakesTheColumnReadable() throws Exception {
+        // The remedy: the wrapper takes the same ADD COLUMN as metadata only, and the column then reads.
         execute("ALTER TABLE %s.%s ADD COLUMN drift_shard_only String".formatted(DATABASE_NAME, TRACES));
 
         TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
@@ -180,6 +177,29 @@ class TracesSchemaParityPostCutoverTest {
 
         execute("ALTER TABLE %s.%s DROP COLUMN drift_shard_only".formatted(DATABASE_NAME, TRACES));
         execute("ALTER TABLE %s.%s DROP COLUMN drift_shard_only".formatted(DATABASE_NAME, SHARD));
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * A subtler drift that names and types alone cannot see: the same materialized column present on both sides, with
+     * the same type, computing something different. The wrapper is created {@code AS} the shard, so the expressions start
+     * identical and can only diverge by one side being altered on its own.
+     */
+    @Test
+    @Order(11)
+    @DisplayName("drift is caught: a materialized column whose expression differs between shard and wrapper")
+    void materializedExpressionDriftIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_expression UInt64 MATERIALIZED length(name)"
+                .formatted(DATABASE_NAME, SHARD));
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_expression UInt64 MATERIALIZED length(thread_id)"
+                .formatted(DATABASE_NAME, TRACES));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("drift_expression");
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_expression".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_expression".formatted(DATABASE_NAME, SHARD));
         TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -1,0 +1,256 @@
+package com.comet.opik.db;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.Connection;
+import java.util.List;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.db.TracesSchemaParity.BACKUP;
+import static com.comet.opik.db.TracesSchemaParity.SHADOW;
+import static com.comet.opik.db.TracesSchemaParity.SHARD;
+import static com.comet.opik.db.TracesSchemaParity.TRACES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The post-cutover half of the trace DDL topology guard, and the reason the guard exists: it applies the real changelog
+ * against the topology a cut-over install actually runs.
+ *
+ * <p><b>How the topology is reached.</b> The cutover is operator work, not a migration, so no changelog apply can
+ * produce it. This test stops the changelog after the shadow-table migration ({@link #CUTOVER_SPLICE_POINT}), splices
+ * in the runbook's {@code EXCHANGE} + {@code Distributed} wrap, then resumes the changelog. Every migration after the
+ * splice point — including whichever one a pull request is adding — therefore runs against the live post-cutover
+ * layout: {@code traces} a {@code Distributed} wrapper, {@code traces_local} the partitioned shard beneath it.
+ *
+ * <p><b>The failure this catches is silent.</b> Post-cutover, a shard-only {@code ADD COLUMN} succeeds — ClickHouse
+ * raises nothing — but the column is not readable through the wrapper, so the feature that added it is broken on every
+ * cut-over install while the migration, and every test that does not look at the wrapper, stays green.
+ * {@link #shardOnlyColumnIsUnreadableThroughTheWrapper()} pins that behaviour and
+ * {@link #alteringBothTablesMakesTheColumnReadable()} pins the remedy, so the playbook's "read-facing changes go to
+ * both" rule is backed by an executable demonstration rather than by assertion.
+ *
+ * <p><b>Splice, not a rewritten changelog.</b> The spliced statements mirror the shipped reference SQL
+ * ({@code data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql}) and the
+ * inline statements {@code TracesLocalV2CutoverTest} already validates end to end; this test asserts what the resulting
+ * <i>schema</i> looks like to later migrations, not that the cutover moves data correctly, which is that test's job.
+ *
+ * <p><b>Dedicated, non-reused containers</b> because the splice destructively swaps the live {@code traces} table, and
+ * the negative tests then drift it further. A container reused across suites (CI sets
+ * {@code TESTCONTAINERS_REUSE_ENABLE}) would hand a post-cutover {@code traces} to whatever ran next.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Traces Schema Parity - Post-cutover")
+class TracesSchemaParityPostCutoverTest {
+
+    /**
+     * The migration the changelog stops after so the cutover transform lands where it does in production: the last
+     * migration that shapes the shadow table, and therefore the last one that runs pre-cutover on an install that then
+     * cuts over. Everything after it must tolerate both topologies.
+     */
+    private static final String CUTOVER_SPLICE_POINT = "000114_recreate_traces_local_v2_id_at_datetime64.sql";
+
+    /** The temp name the gapless wrap builds the wrapper under before the atomic rotation. */
+    private static final String TEMP_WRAPPER = "traces_dist";
+
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeper = ClickHouseContainerUtils.newZookeeperContainer(false, network);
+    private final ClickHouseContainer clickHouse = ClickHouseContainerUtils.newClickHouseContainer(false, network,
+            zookeeper);
+
+    private Connection connection;
+
+    {
+        Startables.deepStart(zookeeper, clickHouse).join();
+    }
+
+    @BeforeAll
+    void migrateAcrossTheCutover() throws Exception {
+        MigrationUtils.runClickhouseDbMigrationThrough(clickHouse, CUTOVER_SPLICE_POINT);
+        connection = clickHouse.createConnection("");
+
+        exchangeTables();
+        wrapInDistributed();
+
+        // Resume: every remaining migration now runs against the post-cutover topology.
+        MigrationUtils.runClickhouseDbMigration(clickHouse);
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        connection.close();
+        clickHouse.stop();
+        zookeeper.stop();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("the spliced cutover leaves the post-cutover topology")
+    void spliceLeavesPostCutoverTopology() throws Exception {
+        assertThat(tableExists(TRACES)).as("`%s` must exist as the wrapper", TRACES).isTrue();
+        assertThat(tableExists(SHARD)).as("`%s` must exist as the shard", SHARD).isTrue();
+        assertThat(tableExists(BACKUP)).as("the parked pre-cutover data `%s` must be retained", BACKUP).isTrue();
+
+        // The shadow name is consumed by the cutover: EXCHANGE moves the old data under it and the follow-up RENAME
+        // parks it as the backup. A shadow still present here means the splice did not complete.
+        assertThat(tableExists(SHADOW)).as("`%s` is renamed away by the cutover", SHADOW).isFalse();
+        assertThat(tableExists(TEMP_WRAPPER)).as("the temp wrapper `%s` must be rotated away", TEMP_WRAPPER).isFalse();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("the whole changelog applies cleanly on the post-cutover topology")
+    void changelogAppliesCleanlyOnPostCutoverTopology() {
+        assertThat(MigrationUtils.unrunClickhouseChangeSetIds(clickHouse))
+                .as("""
+                        every changeset must be applied after resuming across the cutover; an unrun one means a \
+                        migration cannot run on the post-cutover topology and a cut-over install would be left behind\
+                        """)
+                .isEmpty();
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("the Distributed wrapper exposes exactly the shard's columns")
+    void wrapperExposesShardColumns() throws Exception {
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * Column-list parity read from {@code system.columns} is necessary but not sufficient: it is the wrapper's ability
+     * to actually resolve each column that the product depends on. Selecting every column the shard holds through the
+     * wrapper proves the parity the previous test measures is the parity that matters.
+     */
+    @Test
+    @Order(4)
+    @DisplayName("every shard column is readable through the wrapper")
+    void everyShardColumnIsReadableThroughTheWrapper() throws Exception {
+        var shardColumns = TableSchema.read(connection, DATABASE_NAME, SHARD).columnNames();
+
+        assertThat(shardColumns).as("the shard must have columns to read").isNotEmpty();
+        selectColumns(shardColumns);
+    }
+
+    /**
+     * The spike's central finding, pinned: post-cutover a shard-only {@code ADD COLUMN} applies without error and is
+     * then invisible through the wrapper. This is the exact shape of a migration that forgets the wrapper branch.
+     */
+    @Test
+    @Order(10)
+    @DisplayName("drift is caught: a column added to the shard alone is unreadable through the wrapper")
+    void shardOnlyColumnIsUnreadableThroughTheWrapper() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_shard_only String".formatted(DATABASE_NAME, SHARD));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("drift_shard_only");
+
+        // Not merely absent from the wrapper's metadata — unresolvable, so any read referencing it fails at runtime.
+        assertThatThrownBy(() -> selectColumns(List.of("drift_shard_only")))
+                .hasMessageContaining("drift_shard_only");
+    }
+
+    /**
+     * The remedy the playbook prescribes, demonstrated: the wrapper takes the same {@code ADD COLUMN} as a metadata-only
+     * change, after which parity holds and the column reads. Runs immediately after the negative case and shares its
+     * drift column, so the pair reads as one before/after.
+     */
+    @Test
+    @Order(11)
+    @DisplayName("altering both the shard and the wrapper makes the column readable")
+    void alteringBothTablesMakesTheColumnReadable() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_shard_only String".formatted(DATABASE_NAME, TRACES));
+
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+        selectColumns(List.of("drift_shard_only"));
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_shard_only".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_shard_only".formatted(DATABASE_NAME, SHARD));
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The mirror-image drift: a read-facing change applied to the wrapper alone. The wrapper accepts it, so reads
+     * resolve the column and then fail at the shard, which stores nothing under that name.
+     */
+    @Test
+    @Order(12)
+    @DisplayName("drift is caught: a column added to the wrapper alone")
+    void wrapperOnlyColumnIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_wrapper_only String".formatted(DATABASE_NAME, TRACES));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("drift_wrapper_only");
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_wrapper_only".formatted(DATABASE_NAME, TRACES));
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /** Cutover step 3, exchange block — mirrors 000003_exchange_and_wrap.sql. */
+    private void exchangeTables() throws Exception {
+        execute("EXCHANGE TABLES %s.%s AND %s.%s ON CLUSTER '{cluster}'"
+                .formatted(DATABASE_NAME, TRACES, DATABASE_NAME, SHADOW));
+        execute("RENAME TABLE %s.%s TO %s.%s ON CLUSTER '{cluster}'"
+                .formatted(DATABASE_NAME, SHADOW, DATABASE_NAME, BACKUP));
+    }
+
+    /**
+     * Cutover step 3, wrap block — mirrors 000003_exchange_and_wrap.sql. Gapless: the wrapper is built under a temp
+     * name first (its {@code traces_local} target need not exist yet, as Distributed resolves it lazily), then a single
+     * atomic multi-target RENAME rotates the data to {@code traces_local} and the wrapper into {@code traces}.
+     */
+    private void wrapInDistributed() throws Exception {
+        execute("""
+                CREATE TABLE %s.%s ON CLUSTER '{cluster}' AS %s.%s
+                ENGINE = Distributed('{cluster}', '%s', '%s', sipHash64(project_id))
+                """.formatted(DATABASE_NAME, TEMP_WRAPPER, DATABASE_NAME, TRACES, DATABASE_NAME, SHARD));
+        execute("""
+                RENAME TABLE
+                    %s.%s TO %s.%s,
+                    %s.%s TO %s.%s
+                    ON CLUSTER '{cluster}'
+                """.formatted(DATABASE_NAME, TRACES, DATABASE_NAME, SHARD,
+                DATABASE_NAME, TEMP_WRAPPER, DATABASE_NAME, TRACES));
+    }
+
+    /**
+     * Reads the given columns through the wrapper. {@code LIMIT 0} keeps it a pure name-resolution check — the point is
+     * whether the wrapper can resolve every column, not what the (empty) table holds.
+     */
+    private void selectColumns(List<String> columns) throws Exception {
+        var sql = "SELECT %s FROM %s.%s LIMIT 0".formatted(String.join(", ", columns), DATABASE_NAME, TRACES);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).as("LIMIT 0 returns no rows").isFalse();
+        }
+    }
+
+    private boolean tableExists(String table) throws Exception {
+        var sql = "SELECT count() FROM system.tables WHERE database = '%s' AND name = '%s'"
+                .formatted(DATABASE_NAME, table);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getLong(1) > 0;
+        }
+    }
+
+    private void execute(String sql) throws Exception {
+        try (var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -168,6 +168,47 @@ class TracesSchemaParityPreCutoverTest {
     }
 
     /**
+     * Type drift on a shared column: both tables still list `name`, so every column-name comparison passes, and the
+     * cutover would then convert `String` to `LowCardinality(String)` on the way across. This is the leg the documented
+     * BASELINE_TYPE_DIFFERENCES allowlist deliberately does not cover.
+     */
+    @Test
+    @Order(15)
+    @DisplayName("drift is caught: a shared column whose type changed on one table only")
+    void oneSidedTypeChangeIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s MODIFY COLUMN name LowCardinality(String)".formatted(DATABASE_NAME, SHADOW));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("name")
+                .hasMessageContaining("LowCardinality");
+
+        execute("ALTER TABLE %s.%s MODIFY COLUMN name String".formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * And the allowlist itself is held honest: if a baseline difference is ever removed — the shadow's `ttft` made
+     * Nullable again, say — the entry excusing it becomes a blanket exemption for a column nothing checks. Bringing the
+     * types into line must therefore fail until the entry is deleted.
+     */
+    @Test
+    @Order(16)
+    @DisplayName("a stale type-allowlist entry is caught")
+    void staleTypeAllowlistEntryIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Nullable(Float64)".formatted(DATABASE_NAME, SHADOW));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("stale allowlist entry")
+                .hasMessageContaining("ttft");
+
+        execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Float64 DEFAULT toFloat64('nan')"
+                .formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
      * The third leg, and the one no table-to-table comparison can catch: a preserved column added correctly to both
      * tables but never added to the cutover backfill's column list is copied as its default, so the cutover silently
      * loses the data.

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -188,23 +188,43 @@ class TracesSchemaParityPreCutoverTest {
     }
 
     /**
-     * And the allowlist itself is held honest: if a baseline difference is ever removed — the shadow's `ttft` made
-     * Nullable again, say — the entry excusing it becomes a blanket exemption for a column nothing checks. Bringing the
-     * types into line must therefore fail until the entry is deleted.
+     * The allowlist is pinned on both sides, so an allowlisted column drifting away from its documented type fails even
+     * though it still "differs" from its counterpart. Making the shadow's `ttft` Nullable again exercises both halves at
+     * once: the entry no longer describes reality, and the difference it excused has gone.
      */
     @Test
     @Order(16)
-    @DisplayName("a stale type-allowlist entry is caught")
-    void staleTypeAllowlistEntryIsCaught() throws Exception {
+    @DisplayName("drift is caught: an allowlisted column that left its documented type")
+    void allowlistedColumnLeavingItsDocumentedTypeIsCaught() throws Exception {
         execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Nullable(Float64)".formatted(DATABASE_NAME, SHADOW));
 
         assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("stale allowlist entry")
+                .hasMessageContaining("allowlisted column")
                 .hasMessageContaining("ttft");
 
         execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Float64 DEFAULT toFloat64('nan')"
                 .formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The other side of the same pin: an allowlisted column drifting on `traces` rather than on the shadow. The two
+     * types still differ, so a "they must differ" check would pass this.
+     */
+    @Test
+    @Order(17)
+    @DisplayName("drift is caught: an allowlisted column that changed on traces")
+    void allowlistedColumnDriftingOnTracesIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(3, 'UTC')".formatted(DATABASE_NAME, TRACES));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("allowlisted column")
+                .hasMessageContaining("start_time");
+
+        execute("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(9, 'UTC') DEFAULT now64(9)"
+                .formatted(DATABASE_NAME, TRACES));
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -1,0 +1,181 @@
+package com.comet.opik.db;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+
+import java.sql.Connection;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.db.TracesSchemaParity.SHADOW;
+import static com.comet.opik.db.TracesSchemaParity.TRACES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The pre-cutover half of the trace DDL topology guard: applies the real changelog the way a fresh install does, then
+ * asserts the {@link TracesSchemaParity} invariant across {@code traces}, the {@code traces_local_v2} shadow, and the
+ * shipped cutover backfill's column list.
+ *
+ * <p><b>This is the branch that catches a forgotten shadow alter.</b> A migration that alters {@code traces} alone
+ * applies cleanly and every existing test stays green — the shadow is empty, so nothing reads it until the cutover
+ * copies into it, at which point the mismatch surfaces as an operator-facing failure (or, worse, as a column silently
+ * dropped from the copy). The three parity legs here turn that into a merge-blocking CI failure instead.
+ *
+ * <p><b>The negative tests are the point.</b> A parity assertion that never fires is indistinguishable from one that
+ * cannot fire, so each leg is followed by a test that injects the exact drift a careless migration would produce and
+ * asserts this guard rejects it. They run after the positive assertions ({@code @Order}) because they deliberately
+ * leave and then remove schema drift on a live table.
+ *
+ * <p><b>Dedicated, non-reused containers</b> because those negative tests mutate {@code traces}: a container reused
+ * across suites (CI sets {@code TESTCONTAINERS_REUSE_ENABLE}) would hand the drift to whatever ran next. Mirrors
+ * {@link ChangelogRebaselineTest}, which mutates the changelog ledger for the same reason.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Traces Schema Parity - Pre-cutover")
+class TracesSchemaParityPreCutoverTest {
+
+    private final Network network = Network.newNetwork();
+    private final GenericContainer<?> zookeeper = ClickHouseContainerUtils.newZookeeperContainer(false, network);
+    private final ClickHouseContainer clickHouse = ClickHouseContainerUtils.newClickHouseContainer(false, network,
+            zookeeper);
+
+    private Connection connection;
+
+    {
+        Startables.deepStart(zookeeper, clickHouse).join();
+    }
+
+    @BeforeAll
+    void migrate() throws Exception {
+        MigrationUtils.runClickhouseDbMigration(clickHouse);
+        connection = clickHouse.createConnection("");
+    }
+
+    @AfterAll
+    void tearDown() throws Exception {
+        connection.close();
+        clickHouse.stop();
+        zookeeper.stop();
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("a fresh changelog apply leaves the pre-cutover topology")
+    void freshApplyLeavesPreCutoverTopology() throws Exception {
+        assertThat(tableExists(TRACES)).as("`%s` must exist", TRACES).isTrue();
+        assertThat(tableExists(SHADOW)).as("the `%s` shadow must exist", SHADOW).isTrue();
+
+        // A fresh install has never run the runbook, so neither post-cutover table may be present. If one is, the
+        // post-cutover assertions below would be measuring the wrong topology.
+        assertThat(tableExists(TracesSchemaParity.SHARD))
+                .as("`%s` is created by the cutover runbook, never by the changelog", TracesSchemaParity.SHARD)
+                .isFalse();
+        assertThat(tableExists(TracesSchemaParity.BACKUP))
+                .as("`%s` is created by the cutover runbook, never by the changelog", TracesSchemaParity.BACKUP)
+                .isFalse();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("traces, the shadow, and the cutover backfill column list all agree")
+    void tracesShadowAndBackfillAgree() throws Exception {
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("drift is caught: a column added to traces but not to the shadow")
+    void columnAddedToTracesAloneIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_on_traces String".formatted(DATABASE_NAME, TRACES));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("drift_on_traces");
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_on_traces".formatted(DATABASE_NAME, TRACES));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("drift is caught: a column added to the shadow but not to traces")
+    void columnAddedToShadowAloneIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_on_shadow String".formatted(DATABASE_NAME, SHADOW));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("drift_on_shadow");
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_on_shadow".formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The third leg, and the one no table-to-table comparison can catch: a preserved column added correctly to both
+     * tables but never added to the cutover backfill's column list is copied as its default, so the cutover silently
+     * loses the data.
+     */
+    @Test
+    @Order(12)
+    @DisplayName("drift is caught: a preserved column added to both tables but not to the backfill column list")
+    void columnMissingFromBackfillListIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_unbackfilled String".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s ADD COLUMN drift_unbackfilled String".formatted(DATABASE_NAME, SHADOW));
+
+        assertThat(TracesSchemaParity.backfillColumnList())
+                .as("the injected column is deliberately absent from the shipped backfill list")
+                .doesNotContain("drift_unbackfilled");
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("backfill")
+                .hasMessageContaining("drift_unbackfilled");
+
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_unbackfilled".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s DROP COLUMN drift_unbackfilled".formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    @Test
+    @Order(13)
+    @DisplayName("drift is caught: a skip index added to traces but not to the shadow")
+    void skipIndexAddedToTracesAloneIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s ADD INDEX idx_drift_name name TYPE set(0) GRANULARITY 1"
+                .formatted(DATABASE_NAME, TRACES));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("idx_drift_name");
+
+        execute("ALTER TABLE %s.%s DROP INDEX idx_drift_name".formatted(DATABASE_NAME, TRACES));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    private boolean tableExists(String table) throws Exception {
+        var sql = "SELECT count() FROM system.tables WHERE database = '%s' AND name = '%s'"
+                .formatted(DATABASE_NAME, table);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getLong(1) > 0;
+        }
+    }
+
+    private void execute(String sql) throws Exception {
+        try (var statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -10,12 +10,16 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 
 import java.sql.Connection;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.db.TracesSchemaParity.SHADOW;
@@ -95,32 +99,72 @@ class TracesSchemaParityPreCutoverTest {
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
 
-    @Test
+    /**
+     * Both directions of the same mistake — a column that reached one table and not the other — parameterized because
+     * the arrange/act/assert is identical and only the target differs. Both directions are covered deliberately: a
+     * migration writer is far likelier to forget the shadow, but a shadow-only change is equally broken.
+     */
+    static Stream<Arguments> oneSidedColumns() {
+        return Stream.of(
+                Arguments.of(TRACES, "drift_on_traces"),
+                Arguments.of(SHADOW, "drift_on_shadow"));
+    }
+
+    @ParameterizedTest(name = "added to {0} alone")
+    @MethodSource("oneSidedColumns")
     @Order(10)
-    @DisplayName("drift is caught: a column added to traces but not to the shadow")
-    void columnAddedToTracesAloneIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s ADD COLUMN drift_on_traces String".formatted(DATABASE_NAME, TRACES));
+    @DisplayName("drift is caught: a column added to one table but not the other")
+    void oneSidedColumnIsCaught(String table, String column) throws Exception {
+        execute("ALTER TABLE %s.%s ADD COLUMN %s String".formatted(DATABASE_NAME, table, column));
 
         assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("drift_on_traces");
+                .hasMessageContaining(column);
 
-        execute("ALTER TABLE %s.%s DROP COLUMN drift_on_traces".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s DROP COLUMN %s".formatted(DATABASE_NAME, table, column));
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
 
+    /**
+     * Projections are compared by definition, not just by name, so a projection present on both tables under the same
+     * name but computing something different is drift too — the successor would keep the name and lose the meaning. A
+     * projection missing from one table entirely is caught by the same comparison; this pins the harder case.
+     *
+     * <p>Both trace tables are {@code ReplacingMergeTree}, which refuses {@code ADD PROJECTION} outright while
+     * {@code deduplicate_merge_projection_mode} is at its default {@code throw} (ClickHouse code 344) — so a projection
+     * cannot in fact be added to these tables today without a deliberate per-table setting change. The setting is
+     * relaxed here only to make the guard's projection leg reachable, and restored afterwards; that a real projection
+     * would need the same decision is itself worth knowing.
+     */
     @Test
-    @Order(11)
-    @DisplayName("drift is caught: a column added to the shadow but not to traces")
-    void columnAddedToShadowAloneIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s ADD COLUMN drift_on_shadow String".formatted(DATABASE_NAME, SHADOW));
+    @Order(14)
+    @DisplayName("drift is caught: same-named projections with different queries")
+    void projectionQueryDriftIsCaught() throws Exception {
+        allowProjections(TRACES);
+        allowProjections(SHADOW);
+        execute("ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, name ORDER BY name)"
+                .formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, thread_id ORDER BY thread_id)"
+                .formatted(DATABASE_NAME, SHADOW));
 
         assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
                 .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("drift_on_shadow");
+                .hasMessageContaining("proj_drift");
 
-        execute("ALTER TABLE %s.%s DROP COLUMN drift_on_shadow".formatted(DATABASE_NAME, SHADOW));
+        execute("ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, TRACES));
+        execute("ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, SHADOW));
+        restoreProjectionMode(TRACES);
+        restoreProjectionMode(SHADOW);
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    private void allowProjections(String table) throws Exception {
+        execute("ALTER TABLE %s.%s MODIFY SETTING deduplicate_merge_projection_mode = 'rebuild'"
+                .formatted(DATABASE_NAME, table));
+    }
+
+    private void restoreProjectionMode(String table) throws Exception {
+        execute("ALTER TABLE %s.%s RESET SETTING deduplicate_merge_projection_mode".formatted(DATABASE_NAME, table));
     }
 
     /**


### PR DESCRIPTION
## Details

**Stack 1/4 for OPIK-7772 — base `main`.** The traces cutover is produced by the operator runbook, not by Liquibase, so from the moment an install cuts over the changelog and the runtime topology disagree, and the fleet stays mixed for months. A `traces` schema change must therefore be correct against two physical layouts, and both ways of getting it wrong are silent — they raise nothing at migration time. This adds the CI guard that turns them into merge-blocking failures.

- The two silent failures: post-cutover a shard-only `ADD COLUMN` applies without error but is unreadable through the `Distributed` wrapper (code 47); and a migration that alters `traces` but forgets the shadow also passes, because the shadow is empty and nothing reads it until the cutover copies into it.
- `TracesSchemaParityPreCutoverTest` applies the real changelog as a fresh install does, then asserts three-way parity: `traces` ≅ the `traces_local_v2` shadow ≅ the shipped cutover backfill's `INSERT` column list.
- `TracesSchemaParityPostCutoverTest` stops the changelog after the shadow-table migration (`000114`), splices in the runbook's `EXCHANGE` + `Distributed` wrap, then resumes — so every later migration, including whichever one a PR is adding, runs on the live post-cutover topology.
- The backfill column list is **read from the reference SQL**, not restated, so it cannot drift from the tables. It turns out to be exactly `traces`'s insertable columns, and the shadow's are those plus `is_deleted`, so all three legs are exact assertions rather than fuzzy allowances.
- Six negative tests inject the drift a careless migration produces (a column or skip index on one table alone, a preserved column missing from the backfill list, a shard-only and a wrapper-only column), so no parity leg can quietly stop firing. The shard-only case also pins the unreadability itself and its counterpart pins the remedy, giving the "read-facing changes go to both" rule an executable demonstration.
- Parity deliberately compares only the aspects a schema change moves (column sets, insertable columns, skip indices, projections, sorting/primary keys) and enumerates the shadow's intended extras. The baseline type/codec/partition differences stay owned by `TracesLocalV2TableTest`, `TracesLocalV2BenchmarkTest` and `TracesLocalV2PartitioningTest` — comparing them here would fail on every run.
- No shipped migration is edited (append-only). Dedicated non-reused containers, because the post-cutover splice destructively swaps `traces` and the negative tests drift it further.

> Note: the spike branch `andrescrz/NA-cutover-liquibase-reconciliation-spike` no longer exists on origin, so `SCHEMA_DRIFT_SPIKE_FINDINGS.md` and the two spike tests were not retrievable. Both proven facts are re-derived from scratch inside these gates rather than ported — they are now pinned by CI instead of recorded in a document.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7772

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: Test-only. Authored both gate classes, the `TableSchema` system-table snapshot helper, the shared `TracesSchemaParity` invariant, and the partial-apply / unrun-changeset helpers added to `MigrationUtils`. The parity model was derived from the real schemas by dumping `system.columns` / `system.data_skipping_indices` / `system.tables` from a migrated container first, not assumed. The spliced `EXCHANGE` + wrap statements mirror the shipped `000003_exchange_and_wrap.sql` and the already-validated inline statements in `TracesLocalV2CutoverTest`.
- Human verification: Ticket scope, PR sequencing and the review boundary were directed by the author. All tests were executed locally (see Testing) and every negative test was confirmed to fail on injected drift before being committed green. The author has not line-reviewed every Javadoc paragraph.

## Testing

Environment: local, Docker 29.7.2 (linux/aarch64), Corretto 25.0.3, Maven 3.9.9, from `apps/opik-backend`.

```bash
cd apps/opik-backend
mvn test -Dtest=TracesSchemaParityPreCutoverTest
mvn test -Dtest=TracesSchemaParityPostCutoverTest
mvn test -Dtest=ChangelogRebaselineTest   # regression: shares MigrationUtils
```

Results: pre-cutover 6/6, post-cutover 7/7 at the time of this commit, `ChangelogRebaselineTest` 2/2 unchanged. Roughly 30s per gate.

Scenarios validated:
- **Happy path, both topologies** — full changelog applies cleanly pre-cutover; and post-cutover with nothing left unrun after resuming across the splice, confirming every migration after `000114` tolerates the wrapped layout.
- **Three-way pre-cutover parity** — columns, insertable columns vs the backfill list, skip indices (names and definitions), projections, sorting/primary keys.
- **Post-cutover wrapper parity** — column list, per-column type and default kind, plus a `SELECT` of every shard column through the wrapper to prove the measured parity is the parity that matters.
- **Negative controls (6)** — each injects drift, asserts the guard rejects it with the offending name in the message, then removes it and re-asserts parity is green.
- **Positive control** — altering both shard and wrapper makes the column readable, pinning the documented remedy.

Not run: the full backend suite (unchanged by this PR; CI runs it). No video — non-visual, test-only change.

## Documentation

None in this PR. The playbook these gates enforce is documented in stack 4/4, which also adds a pointer from `apps/opik-backend/AGENTS.md`.
