### PR TITLE
[OPIK-7772] [BE] test: add the topology-aware traces DDL pattern and its reference migration

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/MigrationUtils.java
@@ -53,6 +53,22 @@ public class MigrationUtils {
     }
 
     /**
+     * Applies an arbitrary ClickHouse changelog from the test classpath, with the same parameters and ledger the real
+     * one uses. Exists so a test can apply a purpose-built migration <i>after</i> the real changelog — the way a pull
+     * request's new migration arrives — instead of having to append it to the shipped migrations directory, where every
+     * other suite would then run it too.
+     */
+    public static void runClickhouseChangelog(ClickHouseContainer container, String changeLogFile) {
+        try (var connection = container.createConnection("")) {
+            DatabaseConnection dbConnection = new JdbcConnection(
+                    new ClickHouseConnectionImpl(connection.getMetaData().getURL()));
+            runDbMigration(changeLogFile, ClickHouseContainerUtils.migrationParameters(), dbConnection);
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to run ClickHouse changelog " + changeLogFile, e);
+        }
+    }
+
+    /**
      * Applies the ClickHouse changelog only up to and including the changesets of {@code migrationFileName}, leaving
      * every later migration unrun so a caller can transform the schema mid-changelog and then resume with
      * {@link #runClickhouseDbMigration(ClickHouseContainer)}.
@@ -91,11 +107,16 @@ public class MigrationUtils {
      * not) would otherwise leave the schema short without anything throwing.
      */
     public static List<String> unrunClickhouseChangeSetIds(ClickHouseContainer container) {
+        return unrunClickhouseChangeSetIds(container, CLICKHOUSE_CHANGELOG_FILE);
+    }
+
+    /** {@link #unrunClickhouseChangeSetIds(ClickHouseContainer)} for an arbitrary changelog on the test classpath. */
+    public static List<String> unrunClickhouseChangeSetIds(ClickHouseContainer container, String changeLogFile) {
         try (var connection = container.createConnection("")) {
             DatabaseConnection dbConnection = new JdbcConnection(
                     new ClickHouseConnectionImpl(connection.getMetaData().getURL()));
             var database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(dbConnection);
-            try (var liquibase = new Liquibase(CLICKHOUSE_CHANGELOG_FILE, new ClassLoaderResourceAccessor(),
+            try (var liquibase = new Liquibase(changeLogFile, new ClassLoaderResourceAccessor(),
                     database)) {
                 ClickHouseContainerUtils.migrationParameters().forEach(liquibase::setChangeLogParameter);
                 return liquibase.listUnrunChangeSets(new Contexts(), new LabelExpression())

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TableSchema.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TableSchema.java
@@ -1,5 +1,8 @@
 package com.comet.opik.db;
 
+import lombok.Builder;
+import lombok.NonNull;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -26,15 +29,16 @@ import java.util.stream.Collectors;
  * comparing sets should go through {@link #columnNames()} / {@link #storedColumnNames()} rather than comparing the
  * lists.
  */
+@Builder(toBuilder = true)
 record TableSchema(
-        String table,
-        String engine,
-        String partitionKey,
-        String sortingKey,
-        String primaryKey,
-        List<Column> columns,
-        List<SkipIndex> skipIndices,
-        List<Projection> projections) {
+        @NonNull String table,
+        @NonNull String engine,
+        @NonNull String partitionKey,
+        @NonNull String sortingKey,
+        @NonNull String primaryKey,
+        @NonNull List<Column> columns,
+        @NonNull List<SkipIndex> skipIndices,
+        @NonNull List<Projection> projections) {
 
     /**
      * @param defaultKind {@code DEFAULT}, {@code MATERIALIZED}, {@code ALIAS}, or empty when the column simply has no
@@ -42,28 +46,33 @@ record TableSchema(
      *            named in an {@code INSERT}, so it is what separates a column the cutover backfill must carry from one
      *            the destination recomputes for itself.
      */
-    record Column(String name, String type, String defaultKind, String defaultExpression, String codec) {
+    @Builder(toBuilder = true)
+    record Column(@NonNull String name, @NonNull String type, @NonNull String defaultKind,
+            @NonNull String defaultExpression, @NonNull String codec) {
     }
 
-    record SkipIndex(String name, String typeFull, String expression, long granularity) {
+    @Builder(toBuilder = true)
+    record SkipIndex(@NonNull String name, @NonNull String typeFull, @NonNull String expression, long granularity) {
     }
 
-    record Projection(String name, String query) {
+    @Builder(toBuilder = true)
+    record Projection(@NonNull String name, @NonNull String query) {
     }
 
     private static final Set<String> COMPUTED_DEFAULT_KINDS = Set.of("MATERIALIZED", "ALIAS");
 
     static TableSchema read(Connection connection, String database, String table) throws SQLException {
         var tableRow = readTableRow(connection, database, table);
-        return new TableSchema(
-                table,
-                tableRow.get("engine_full"),
-                tableRow.get("partition_key"),
-                tableRow.get("sorting_key"),
-                tableRow.get("primary_key"),
-                readColumns(connection, database, table),
-                readSkipIndices(connection, database, table),
-                readProjections(connection, database, table));
+        return TableSchema.builder()
+                .table(table)
+                .engine(tableRow.get("engine_full"))
+                .partitionKey(tableRow.get("partition_key"))
+                .sortingKey(tableRow.get("sorting_key"))
+                .primaryKey(tableRow.get("primary_key"))
+                .columns(readColumns(connection, database, table))
+                .skipIndices(readSkipIndices(connection, database, table))
+                .projections(readProjections(connection, database, table))
+                .build();
     }
 
     /** Column names in the server's declaration order. */
@@ -134,12 +143,13 @@ record TableSchema(
         var columns = new ArrayList<Column>();
         try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
             while (resultSet.next()) {
-                columns.add(new Column(
-                        text(resultSet, "name"),
-                        text(resultSet, "type"),
-                        text(resultSet, "default_kind"),
-                        text(resultSet, "default_expression"),
-                        text(resultSet, "compression_codec")));
+                columns.add(Column.builder()
+                        .name(text(resultSet, "name"))
+                        .type(text(resultSet, "type"))
+                        .defaultKind(text(resultSet, "default_kind"))
+                        .defaultExpression(text(resultSet, "default_expression"))
+                        .codec(text(resultSet, "compression_codec"))
+                        .build());
             }
         }
         return List.copyOf(columns);
@@ -154,11 +164,12 @@ record TableSchema(
         var indices = new ArrayList<SkipIndex>();
         try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
             while (resultSet.next()) {
-                indices.add(new SkipIndex(
-                        text(resultSet, "name"),
-                        text(resultSet, "type_full"),
-                        text(resultSet, "expr"),
-                        resultSet.getLong("granularity")));
+                indices.add(SkipIndex.builder()
+                        .name(text(resultSet, "name"))
+                        .typeFull(text(resultSet, "type_full"))
+                        .expression(text(resultSet, "expr"))
+                        .granularity(resultSet.getLong("granularity"))
+                        .build());
             }
         }
         return List.copyOf(indices);
@@ -173,7 +184,10 @@ record TableSchema(
         var projections = new ArrayList<Projection>();
         try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
             while (resultSet.next()) {
-                projections.add(new Projection(text(resultSet, "name"), text(resultSet, "query")));
+                projections.add(Projection.builder()
+                        .name(text(resultSet, "name"))
+                        .query(text(resultSet, "query"))
+                        .build());
             }
         }
         return List.copyOf(projections);

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
@@ -46,8 +46,22 @@ class TracesDdlReferenceFixture {
     /** The reference field change: MATERIALIZED, so read-facing — it must reach the shard and the wrapper. */
     static final String DERIVED_COLUMN = "reference_derived";
 
+    /**
+     * The full contract the field change declares, asserted rather than merely its presence: a column of the right name
+     * but the wrong type or default kind would satisfy a name check while breaking what the migration promises.
+     */
+    static final String DERIVED_COLUMN_TYPE = "UInt64";
+    static final String DERIVED_COLUMN_DEFAULT_KIND = "MATERIALIZED";
+
     /** The reference index change: storage-only — it must reach the shard alone. */
     static final String STORAGE_INDEX = "idx_reference_storage";
+
+    /**
+     * The index's full definition. Same reasoning as the column: an index of this name with a different type,
+     * expression or granularity is not the index the migration declared.
+     */
+    static final TableSchema.SkipIndex EXPECTED_STORAGE_INDEX = new TableSchema.SkipIndex(
+            STORAGE_INDEX, "set(0)", "name", 1);
 
     /** The column the un-guarded negative control adds to {@code traces} and nothing else. */
     static final String UNGUARDED_COLUMN = "unguarded_column";

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
@@ -65,12 +65,21 @@ class TracesDdlReferenceFixture {
     /**
      * How Liquibase recorded {@code changeSetId} in the ledger, or {@code null} if it recorded nothing. The ledger lives
      * in {@code default}, not the analytics database (matching {@code ChangelogRebaselineTest}).
+     *
+     * <p>The changeset id and author are <b>bound</b>, not interpolated: they are values in a predicate, which is what
+     * {@code SKILL.md}'s SQL rule reserves for binding. (Identifiers elsewhere in these gates cannot be bound —
+     * ClickHouse accepts no parameter in a table or column position — but these two can, so they are.)
      */
     static String execType(Connection connection, String changeSetId) throws SQLException {
-        var sql = "SELECT EXECTYPE FROM default.DATABASECHANGELOG WHERE ID = '%s' AND AUTHOR = '%s'"
-                .formatted(changeSetId, FIXTURE_AUTHOR);
-        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
-            return resultSet.next() ? resultSet.getString(1) : null;
+        var sql = """
+                SELECT EXECTYPE FROM default.DATABASECHANGELOG WHERE ID = ? AND AUTHOR = ?
+                """;
+        try (var statement = connection.prepareStatement(sql)) {
+            statement.setString(1, changeSetId);
+            statement.setString(2, FIXTURE_AUTHOR);
+            try (var resultSet = statement.executeQuery()) {
+                return resultSet.next() ? resultSet.getString(1) : null;
+            }
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
@@ -1,0 +1,76 @@
+package com.comet.opik.db;
+
+import lombok.experimental.UtilityClass;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * The names and ledger vocabulary shared by the two topology gates when they apply the reference DDL fixtures.
+ *
+ * <p>{@link #CHANGELOG} is the topology-aware reference migration — two complementary precondition-guarded changesets
+ * keyed on whether {@code traces_local} exists, of which exactly one executes while the other is recorded
+ * {@code MARK_RAN}. {@link #UNGUARDED_CHANGELOG} is the negative control: the same intent written the ordinary way, as
+ * one unconditional {@code ALTER TABLE traces}, which applies cleanly on both topologies and is wrong on both.
+ *
+ * <p><b>Isolation from the shipped changelog.</b> These fixtures are deliberately kept away from anything an install
+ * runs, on three independent levels, because they do write to the Liquibase ledger:
+ * <ul>
+ *   <li>they live under {@code src/test/resources}, so the shipped changelog's {@code includeAll} over
+ *   {@code liquibase/db-app-analytics/migrations/} cannot reach them and no deployment can apply them;</li>
+ *   <li>their file names carry no migration number and their changeset author is
+ *   {@value #FIXTURE_AUTHOR}, so a ledger row from a fixture is unmistakable and can never collide with a shipped
+ *   changeset id;</li>
+ *   <li>the gates that apply them run on dedicated, non-reused containers that are stopped afterwards, and each gate
+ *   asserts the shipped changelog is still fully applied once a fixture has run — see
+ *   {@code applyingTheFixtureLeavesTheShippedChangelogIntact} in both gates.</li>
+ * </ul>
+ *
+ * <p>See {@code guides/traces-schema-ddl.md} for the playbook the reference implements.
+ */
+@UtilityClass
+class TracesDdlReferenceFixture {
+
+    static final String CHANGELOG = "liquibase/traces-ddl-reference/changelog.xml";
+    static final String UNGUARDED_CHANGELOG = "liquibase/traces-ddl-unguarded/changelog.xml";
+
+    /**
+     * The changeset author every fixture uses. Deliberately not {@code opik}: it marks a ledger row as belonging to a
+     * test fixture rather than to a shipped migration, and keeps fixture ids in their own namespace.
+     */
+    static final String FIXTURE_AUTHOR = "opik-7772-test-fixture";
+
+    static final String PRE_CUTOVER_CHANGESET = "reference_topology_aware_change_pre_cutover";
+    static final String POST_CUTOVER_CHANGESET = "reference_topology_aware_change_post_cutover";
+
+    /** The reference field change: MATERIALIZED, so read-facing — it must reach the shard and the wrapper. */
+    static final String DERIVED_COLUMN = "reference_derived";
+
+    /** The reference index change: storage-only — it must reach the shard alone. */
+    static final String STORAGE_INDEX = "idx_reference_storage";
+
+    /** The column the un-guarded negative control adds to {@code traces} and nothing else. */
+    static final String UNGUARDED_COLUMN = "unguarded_column";
+
+    /** Liquibase records a changeset whose statements ran as {@code EXECUTED}. */
+    static final String EXECUTED = "EXECUTED";
+
+    /**
+     * Liquibase records a changeset whose precondition failed with {@code onFail:MARK_RAN} as {@code MARK_RAN}: it is
+     * marked applied without its statements running, which is what lets one file serve both topologies and stay
+     * idempotent — the skipped branch is never retried on a later startup.
+     */
+    static final String MARK_RAN = "MARK_RAN";
+
+    /**
+     * How Liquibase recorded {@code changeSetId} in the ledger, or {@code null} if it recorded nothing. The ledger lives
+     * in {@code default}, not the analytics database (matching {@code ChangelogRebaselineTest}).
+     */
+    static String execType(Connection connection, String changeSetId) throws SQLException {
+        var sql = "SELECT EXECTYPE FROM default.DATABASECHANGELOG WHERE ID = '%s' AND AUTHOR = '%s'"
+                .formatted(changeSetId, FIXTURE_AUTHOR);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            return resultSet.next() ? resultSet.getString(1) : null;
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesDdlReferenceFixture.java
@@ -53,6 +53,13 @@ class TracesDdlReferenceFixture {
     static final String DERIVED_COLUMN_TYPE = "UInt64";
     static final String DERIVED_COLUMN_DEFAULT_KIND = "MATERIALIZED";
 
+    /**
+     * The expression too, not just the kind: a {@code MATERIALIZED UInt64} computing something other than what the
+     * reference declares satisfies every other assertion while producing different values on each topology — the same
+     * class of drift {@code assertPostCutoverParity} compares expressions to catch.
+     */
+    static final String DERIVED_COLUMN_EXPRESSION = "length(name)";
+
     /** The reference index change: storage-only — it must reach the shard alone. */
     static final String STORAGE_INDEX = "idx_reference_storage";
 
@@ -60,10 +67,14 @@ class TracesDdlReferenceFixture {
      * The index's full definition. Same reasoning as the column: an index of this name with a different type,
      * expression or granularity is not the index the migration declared.
      */
-    static final TableSchema.SkipIndex EXPECTED_STORAGE_INDEX = new TableSchema.SkipIndex(
-            STORAGE_INDEX, "set(0)", "name", 1);
+    static final TableSchema.SkipIndex EXPECTED_STORAGE_INDEX = TableSchema.SkipIndex.builder()
+            .name(STORAGE_INDEX)
+            .typeFull("set(0)")
+            .expression("name")
+            .granularity(1)
+            .build();
 
-    /** The column the un-guarded negative control adds to {@code traces} and nothing else. */
+    /** The column the unguarded negative control adds to {@code traces} and nothing else. */
     static final String UNGUARDED_COLUMN = "unguarded_column";
 
     /** Liquibase records a changeset whose statements ran as {@code EXECUTED}. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParity.java
@@ -1,5 +1,7 @@
 package com.comet.opik.db;
 
+import lombok.Builder;
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
 import java.io.IOException;
@@ -90,11 +92,27 @@ class TracesSchemaParity {
     static final String BACKUP = "traces_pre_cutover_backup";
 
     /**
-     * {@code is_deleted} is the successor's {@code ReplacingMergeTree} delete meta-column (000101). It is engine
-     * bookkeeping rather than trace data, which is why it has no counterpart on {@code traces} and why the cutover
-     * backfill deliberately omits it so it defaults to 0.
+     * The columns that exist on the shadow and have no counterpart on {@code traces}, pinned rather than merely named.
+     * <p>
+     * These are the one blind spot of the type comparison below: it iterates the columns of {@code traces} and looks
+     * each up on the shadow, so a shadow-only column is never reached by it. Left unpinned, {@code is_deleted} could
+     * become {@code DEFAULT 1} and every row the cutover copies would materialise as a tombstone — the backfill omits
+     * the column precisely so it takes its default, so the default is the whole contract.
      */
-    static final Set<String> SHADOW_ONLY_COLUMNS = Set.of("is_deleted");
+    static final Map<String, ShadowOnlyColumn> SHADOW_ONLY_COLUMNS = Map.of(
+            "is_deleted", ShadowOnlyColumn.builder()
+                    .type("UInt8")
+                    .defaultKind("DEFAULT")
+                    .defaultExpression("0")
+                    .reason("the ReplacingMergeTree delete meta-column (000101); the cutover backfill omits it so "
+                            + "every copied row defaults to alive")
+                    .build());
+
+    /** A shadow-only column's full declared contract. */
+    @Builder(toBuilder = true)
+    record ShadowOnlyColumn(@NonNull String type, @NonNull String defaultKind, @NonNull String defaultExpression,
+            @NonNull String reason) {
+    }
 
     /**
      * Skip indices the successor adds because its layout needs them and {@code traces} cannot use them:
@@ -115,25 +133,44 @@ class TracesSchemaParity {
      * grow into a blanket exemption.
      */
     static final Map<String, BaselineTypeDifference> BASELINE_TYPE_DIFFERENCES = Map.of(
-            "start_time", new BaselineTypeDifference("DateTime64(9, 'UTC')", "DateTime64(6, 'UTC')",
-                    "nanosecond -> microsecond precision; nothing ingested needs finer (000101)"),
-            "created_at", new BaselineTypeDifference("DateTime64(9, 'UTC')", "DateTime64(6, 'UTC')",
-                    "nanosecond -> microsecond precision; nothing ingested needs finer (000101)"),
-            "end_time", new BaselineTypeDifference("Nullable(DateTime64(9, 'UTC'))", "DateTime64(6, 'UTC')",
-                    "Nullable -> non-nullable with an epoch sentinel, dropping the null-mask overhead (000101)"),
-            "ttft", new BaselineTypeDifference("Nullable(Float64)", "Float64",
-                    "Nullable -> non-nullable with a NaN sentinel (000101)"),
-            "duration", new BaselineTypeDifference("Nullable(Float64)", "Float64",
-                    "Nullable -> non-nullable, materialized from the sentinels rather than a null check (000101)"),
-            "id_at", new BaselineTypeDifference("DateTime('UTC')", "DateTime64(0, 'UTC')",
-                    "DateTime -> DateTime64(0), honest past 2106 so a far-future UUIDv7 partitions correctly (000114)"));
+            "start_time", BaselineTypeDifference.builder()
+                    .tracesType("DateTime64(9, 'UTC')")
+                    .shadowType("DateTime64(6, 'UTC')")
+                    .reason("nanosecond -> microsecond precision; nothing ingested needs finer (000101)")
+                    .build(),
+            "created_at", BaselineTypeDifference.builder()
+                    .tracesType("DateTime64(9, 'UTC')")
+                    .shadowType("DateTime64(6, 'UTC')")
+                    .reason("nanosecond -> microsecond precision; nothing ingested needs finer (000101)")
+                    .build(),
+            "end_time", BaselineTypeDifference.builder()
+                    .tracesType("Nullable(DateTime64(9, 'UTC'))")
+                    .shadowType("DateTime64(6, 'UTC')")
+                    .reason("Nullable -> non-nullable with an epoch sentinel, dropping the null-mask overhead (000101)")
+                    .build(),
+            "ttft", BaselineTypeDifference.builder()
+                    .tracesType("Nullable(Float64)")
+                    .shadowType("Float64")
+                    .reason("Nullable -> non-nullable with a NaN sentinel (000101)")
+                    .build(),
+            "duration", BaselineTypeDifference.builder()
+                    .tracesType("Nullable(Float64)")
+                    .shadowType("Float64")
+                    .reason("Nullable -> non-nullable, materialized from the sentinels rather than a null check (000101)")
+                    .build(),
+            "id_at", BaselineTypeDifference.builder()
+                    .tracesType("DateTime('UTC')")
+                    .shadowType("DateTime64(0, 'UTC')")
+                    .reason("DateTime -> DateTime64(0), honest past 2106 so a far-future UUIDv7 partitions correctly (000114)")
+                    .build());
 
     /**
      * One allowlisted difference, pinned on <b>both</b> sides rather than merely asserted to exist. Recording only that
      * the types differ would let either side drift to an unrelated type — {@code traces.start_time} becoming
      * {@code String}, say — while still "differing" and so still being excused.
      */
-    record BaselineTypeDifference(String tracesType, String shadowType, String reason) {
+    @Builder(toBuilder = true)
+    record BaselineTypeDifference(@NonNull String tracesType, @NonNull String shadowType, @NonNull String reason) {
     }
 
     /**
@@ -167,8 +204,8 @@ class TracesSchemaParity {
                         read-facing column parity: every column on `%s` must exist on the `%s` shadow (and vice versa, \
                         beyond the documented engine meta-columns %s). A change that adds or drops a column on one \
                         without the other leaves the cutover promoting a table that does not match the live one.\
-                        """, TRACES, SHADOW, SHADOW_ONLY_COLUMNS)
-                .containsExactlyInAnyOrderElementsOf(union(traces.columnNames(), SHADOW_ONLY_COLUMNS));
+                        """, TRACES, SHADOW, SHADOW_ONLY_COLUMNS.keySet())
+                .containsExactlyInAnyOrderElementsOf(union(traces.columnNames(), SHADOW_ONLY_COLUMNS.keySet()));
 
         // Type parity for every shared column outside the documented baseline. This is the leg that catches a
         // precision narrowed on one table only, or a String quietly becoming LowCardinality(String) on one side: the
@@ -188,6 +225,26 @@ class TracesSchemaParity {
                             """,
                             name, TRACES, SHADOW)
                     .isEqualTo(column.type());
+        });
+
+        // The shadow-only columns, which the loop above cannot reach because they have no counterpart on `traces`.
+        // Nothing else checks them at all, so their declared contract is pinned here in full.
+        SHADOW_ONLY_COLUMNS.forEach((name, expected) -> {
+            var column = shadowColumns.get(name);
+            assertThat(column)
+                    .as("the `%s` shadow must carry `%s` — %s", SHADOW, name, expected.reason())
+                    .isNotNull();
+            assertThat(column.type()).as("shadow-only column `%s` type (%s)", name, expected.reason())
+                    .isEqualTo(expected.type());
+            assertThat(column.defaultKind()).as("shadow-only column `%s` default kind (%s)", name, expected.reason())
+                    .isEqualTo(expected.defaultKind());
+            assertThat(column.defaultExpression())
+                    .as("""
+                            shadow-only column `%s` default expression (%s). The cutover backfill omits this column so \
+                            it takes its default, which makes the default the entire contract: change it and every \
+                            copied row is written with the wrong value.\
+                            """, name, expected.reason())
+                    .isEqualTo(expected.defaultExpression());
         });
 
         // Each allowlisted difference is pinned on both sides. Merely requiring the types to differ would excuse an
@@ -229,8 +286,8 @@ class TracesSchemaParity {
                 .as("""
                         the `%s` shadow must accept exactly the backfilled columns plus its engine meta-columns %s \
                         (which the backfill deliberately omits so they take their defaults)\
-                        """, SHADOW, SHADOW_ONLY_COLUMNS)
-                .containsExactlyInAnyOrderElementsOf(union(backfillColumns, SHADOW_ONLY_COLUMNS));
+                        """, SHADOW, SHADOW_ONLY_COLUMNS.keySet())
+                .containsExactlyInAnyOrderElementsOf(union(backfillColumns, SHADOW_ONLY_COLUMNS.keySet()));
 
         // The column sets above say the right columns are carried; this says they are carried to the right places.
         assertBackfillInsertMatchesSelect();

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -91,9 +91,14 @@ class TracesSchemaParityPostCutoverTest {
 
     @AfterAll
     void tearDown() throws Exception {
-        connection.close();
-        clickHouse.stop();
-        zookeeper.stop();
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } finally {
+            clickHouse.stop();
+            zookeeper.stop();
+        }
     }
 
     @Test
@@ -152,7 +157,7 @@ class TracesSchemaParityPostCutoverTest {
      */
     @Test
     @Order(5)
-    @DisplayName("the reference migration takes its post-cutover branch and marks the other one run")
+    @DisplayName("the reference migration takes its post-cutover branch and records the other as MARK_RAN")
     void referenceMigrationTakesThePostCutoverBranch() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
 
@@ -241,7 +246,7 @@ class TracesSchemaParityPostCutoverTest {
      */
     @Test
     @Order(7)
-    @DisplayName("an unguarded traces migration is rejected: it only reaches the wrapper")
+    @DisplayName("an unguarded traces migration applies cleanly and leaves wrapper-only drift the gate rejects")
     void unguardedMigrationIsRejected() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -169,22 +169,55 @@ class TracesSchemaParityPostCutoverTest {
         var wrapper = TableSchema.read(connection, DATABASE_NAME, TRACES);
         var shard = TableSchema.read(connection, DATABASE_NAME, SHARD);
 
-        assertThat(shard.columnNames())
-                .as("the read-facing field must reach the shard, which stores it")
-                .contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
-        assertThat(wrapper.columnNames())
-                .as("...and the wrapper, which resolves it for reads")
-                .contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        // The full declared contract on both, not merely the name: a column of this name with the wrong type or
+        // default kind would satisfy a presence check while breaking what the migration promises.
+        assertReferenceFieldContract(shard, "the read-facing field must reach the shard, which stores it");
+        assertReferenceFieldContract(wrapper, "...and the wrapper, which resolves it for reads");
 
-        assertThat(shard.skipIndexNames())
-                .as("the storage-only index must reach the shard")
-                .contains(TracesDdlReferenceFixture.STORAGE_INDEX);
+        assertThat(shard.skipIndicesByName().get(TracesDdlReferenceFixture.STORAGE_INDEX))
+                .as("the storage-only index must reach the shard, defined as declared")
+                .isEqualTo(TracesDdlReferenceFixture.EXPECTED_STORAGE_INDEX);
         assertThat(wrapper.skipIndexNames())
                 .as("...and must NOT be attempted on the Distributed wrapper, which stores no data to index")
                 .doesNotContain(TracesDdlReferenceFixture.STORAGE_INDEX);
 
         TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
         selectColumns(List.of(TracesDdlReferenceFixture.DERIVED_COLUMN));
+        assertDerivedFieldComputesThroughTheWrapper();
+    }
+
+    private void assertReferenceFieldContract(TableSchema schema, String description) {
+        var column = schema.columnsByName().get(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        assertThat(column).as(description).isNotNull();
+        assertThat(column.type()).as("reference field type on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_TYPE);
+        assertThat(column.defaultKind()).as("reference field default kind on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_DEFAULT_KIND);
+    }
+
+    /**
+     * Resolving the column proves the wrapper can see it; it does not prove the expression behind it works. A
+     * materialized column with a valid name and a broken definition would pass every assertion above, so one row is
+     * written through the wrapper and its computed value read back — the reference migration declares
+     * {@code MATERIALIZED length(name)}, so a known name must yield its length.
+     */
+    private void assertDerivedFieldComputesThroughTheWrapper() throws Exception {
+        var traceId = java.util.UUID.randomUUID().toString();
+        var name = "reference-derived-probe";
+        execute("""
+                INSERT INTO %s.%s (id, workspace_id, project_id, name)
+                VALUES ('%s', 'ws-reference-probe', '%s', '%s')
+                """.formatted(DATABASE_NAME, TRACES, traceId, java.util.UUID.randomUUID(), name));
+
+        var sql = "SELECT %s FROM %s.%s WHERE id = '%s'"
+                .formatted(TracesDdlReferenceFixture.DERIVED_COLUMN, DATABASE_NAME, TRACES, traceId);
+        try (var statement = connection.createStatement(); var resultSet = statement.executeQuery(sql)) {
+            assertThat(resultSet.next()).as("the probe row must be readable through the wrapper").isTrue();
+            assertThat(resultSet.getLong(1))
+                    .as("`%s` is MATERIALIZED length(name), so it must compute the probe name's length",
+                            TracesDdlReferenceFixture.DERIVED_COLUMN)
+                    .isEqualTo(name.length());
+        }
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -193,6 +193,8 @@ class TracesSchemaParityPostCutoverTest {
                 .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_TYPE);
         assertThat(column.defaultKind()).as("reference field default kind on `%s`", schema.table())
                 .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_DEFAULT_KIND);
+        assertThat(column.defaultExpression()).as("reference field expression on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_EXPRESSION);
     }
 
     /**
@@ -234,17 +236,17 @@ class TracesSchemaParityPostCutoverTest {
     }
 
     /**
-     * The negative control on this topology: the un-guarded {@code ALTER TABLE traces} lands on the Distributed wrapper,
+     * The negative control on this topology: the unguarded {@code ALTER TABLE traces} lands on the Distributed wrapper,
      * which accepts it as metadata, so the column resolves on reads while no shard stores it.
      */
     @Test
     @Order(7)
-    @DisplayName("an un-guarded traces migration is rejected: it only reaches the wrapper")
+    @DisplayName("an unguarded traces migration is rejected: it only reaches the wrapper")
     void unguardedMigrationIsRejected() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
 
         assertThat(TableSchema.read(connection, DATABASE_NAME, TRACES).columnNames())
-                .as("the un-guarded ALTER reaches the wrapper, so it applies without error")
+                .as("the unguarded ALTER reaches the wrapper, so it applies without error")
                 .contains(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
         assertThat(TableSchema.read(connection, DATABASE_NAME, SHARD).columnNames())
                 .as("...and never reaches the shard that would have to store it")

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPostCutoverTest.java
@@ -145,6 +145,102 @@ class TracesSchemaParityPostCutoverTest {
     }
 
     /**
+     * The reference migration's post-cutover branch, applied to the topology it is written for — the same single file
+     * that {@link TracesSchemaParityPreCutoverTest} applies to the other one. Proves the guard selects the correct
+     * branch from the runtime topology, that the read-facing field reaches both the shard and the wrapper while the
+     * storage-only index reaches the shard alone, and that the field is genuinely readable afterwards.
+     */
+    @Test
+    @Order(5)
+    @DisplayName("the reference migration takes its post-cutover branch and marks the other one run")
+    void referenceMigrationTakesThePostCutoverBranch() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
+
+        assertThat(TracesDdlReferenceFixture.execType(connection, TracesDdlReferenceFixture.POST_CUTOVER_CHANGESET))
+                .as("on a cut-over install the post-cutover branch must run")
+                .isEqualTo(TracesDdlReferenceFixture.EXECUTED);
+        assertThat(TracesDdlReferenceFixture.execType(connection, TracesDdlReferenceFixture.PRE_CUTOVER_CHANGESET))
+                .as("""
+                        the pre-cutover branch must be recorded MARK_RAN: its statements name traces_local_v2, which no \
+                        longer exists here, so running them would fail the migration on every cut-over install\
+                        """)
+                .isEqualTo(TracesDdlReferenceFixture.MARK_RAN);
+
+        var wrapper = TableSchema.read(connection, DATABASE_NAME, TRACES);
+        var shard = TableSchema.read(connection, DATABASE_NAME, SHARD);
+
+        assertThat(shard.columnNames())
+                .as("the read-facing field must reach the shard, which stores it")
+                .contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        assertThat(wrapper.columnNames())
+                .as("...and the wrapper, which resolves it for reads")
+                .contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
+
+        assertThat(shard.skipIndexNames())
+                .as("the storage-only index must reach the shard")
+                .contains(TracesDdlReferenceFixture.STORAGE_INDEX);
+        assertThat(wrapper.skipIndexNames())
+                .as("...and must NOT be attempted on the Distributed wrapper, which stores no data to index")
+                .doesNotContain(TracesDdlReferenceFixture.STORAGE_INDEX);
+
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+        selectColumns(List.of(TracesDdlReferenceFixture.DERIVED_COLUMN));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("re-applying the reference migration is a no-op")
+    void reApplyingTheReferenceMigrationIsANoOp() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
+
+        assertThat(MigrationUtils.unrunClickhouseChangeSetIds(clickHouse, TracesDdlReferenceFixture.CHANGELOG))
+                .as("both branches stay recorded as applied, so nothing is left to run")
+                .isEmpty();
+
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The negative control on this topology: the un-guarded {@code ALTER TABLE traces} lands on the Distributed wrapper,
+     * which accepts it as metadata, so the column resolves on reads while no shard stores it.
+     */
+    @Test
+    @Order(7)
+    @DisplayName("an un-guarded traces migration is rejected: it only reaches the wrapper")
+    void unguardedMigrationIsRejected() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
+
+        assertThat(TableSchema.read(connection, DATABASE_NAME, TRACES).columnNames())
+                .as("the un-guarded ALTER reaches the wrapper, so it applies without error")
+                .contains(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+        assertThat(TableSchema.read(connection, DATABASE_NAME, SHARD).columnNames())
+                .as("...and never reaches the shard that would have to store it")
+                .doesNotContain(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+
+        execute("ALTER TABLE %s.%s DROP COLUMN %s"
+                .formatted(DATABASE_NAME, TRACES, TracesDdlReferenceFixture.UNGUARDED_COLUMN));
+        TracesSchemaParity.assertPostCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The fixtures do write Liquibase ledger rows, so this pins that they stay additive: the shipped changelog is still
+     * fully applied afterwards. Listing its unrun changesets also revalidates every recorded checksum, so a fixture
+     * that had disturbed a shipped ledger row would fail here rather than in some unrelated suite later.
+     */
+    @Test
+    @Order(8)
+    @DisplayName("applying the fixtures leaves the shipped changelog intact")
+    void applyingTheFixturesLeavesTheShippedChangelogIntact() {
+        assertThat(MigrationUtils.unrunClickhouseChangeSetIds(clickHouse))
+                .as("the shipped changelog must remain fully applied, with nothing pending or invalidated")
+                .isEmpty();
+    }
+
+    /**
      * The spike's central finding and the playbook's remedy, in one test: post-cutover a shard-only {@code ADD COLUMN}
      * applies without error and is then invisible through the wrapper, and altering the wrapper too — which it accepts as
      * a metadata-only change — makes it readable. This is the exact shape of a migration that forgets the wrapper branch,

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -150,18 +150,18 @@ class TracesSchemaParityPreCutoverTest {
     }
 
     /**
-     * The negative control that makes the pattern load-bearing: the same change written the ordinary un-guarded way
+     * The negative control that makes the pattern load-bearing: the same change written the ordinary unguarded way
      * applies without error and leaves the shadow behind, and this gate rejects it. A pull request shaped like this
      * cannot merge.
      */
     @Test
     @Order(7)
-    @DisplayName("an un-guarded traces migration is rejected: it never reaches the shadow")
+    @DisplayName("an unguarded traces migration is rejected: it never reaches the shadow")
     void unguardedMigrationIsRejected() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
 
         assertThat(TableSchema.read(connection, DATABASE_NAME, TRACES).columnNames())
-                .as("the un-guarded ALTER does reach the live table — it fails silently, which is the problem")
+                .as("the unguarded ALTER does reach the live table — it fails silently, which is the problem")
                 .contains(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
         assertThat(TableSchema.read(connection, DATABASE_NAME, SHADOW).columnNames())
                 .as("...and never reaches the shadow the cutover will promote")
@@ -395,6 +395,8 @@ class TracesSchemaParityPreCutoverTest {
                 .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_TYPE);
         assertThat(column.defaultKind()).as("reference field default kind on `%s`", schema.table())
                 .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_DEFAULT_KIND);
+        assertThat(column.defaultExpression()).as("reference field expression on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_EXPRESSION);
     }
 
     /** Likewise the index: the same name with a different type, expression or granularity is a different index. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -124,10 +124,10 @@ class TracesSchemaParityPreCutoverTest {
         // The read-facing field and the storage-only index both reach both tables pre-cutover.
         var traces = TableSchema.read(connection, DATABASE_NAME, TRACES);
         var shadow = TableSchema.read(connection, DATABASE_NAME, SHADOW);
-        assertThat(traces.columnNames()).contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
-        assertThat(shadow.columnNames()).contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
-        assertThat(traces.skipIndexNames()).contains(TracesDdlReferenceFixture.STORAGE_INDEX);
-        assertThat(shadow.skipIndexNames()).contains(TracesDdlReferenceFixture.STORAGE_INDEX);
+        assertReferenceFieldContract(traces);
+        assertReferenceFieldContract(shadow);
+        assertReferenceIndexContract(traces);
+        assertReferenceIndexContract(shadow);
 
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
@@ -378,6 +378,30 @@ class TracesSchemaParityPreCutoverTest {
 
         execute("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 0".formatted(DATABASE_NAME, SHADOW));
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The reference field must arrive as the exact column the migration declares. Presence alone would be satisfied by
+     * a {@code UInt32}, or by an {@code ALIAS} where a {@code MATERIALIZED} was intended — both of which change the
+     * read contract while passing a name check.
+     */
+    private void assertReferenceFieldContract(TableSchema schema) {
+        var column = schema.columnsByName().get(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        assertThat(column)
+                .as("`%s` must carry the reference field on `%s`", TracesDdlReferenceFixture.DERIVED_COLUMN,
+                        schema.table())
+                .isNotNull();
+        assertThat(column.type()).as("reference field type on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_TYPE);
+        assertThat(column.defaultKind()).as("reference field default kind on `%s`", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.DERIVED_COLUMN_DEFAULT_KIND);
+    }
+
+    /** Likewise the index: the same name with a different type, expression or granularity is a different index. */
+    private void assertReferenceIndexContract(TableSchema schema) {
+        assertThat(schema.skipIndicesByName().get(TracesDdlReferenceFixture.STORAGE_INDEX))
+                .as("`%s` must carry the reference index, defined as declared", schema.table())
+                .isEqualTo(TracesDdlReferenceFixture.EXPECTED_STORAGE_INDEX);
     }
 
     private boolean tableExists(String table) throws Exception {

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -100,6 +100,97 @@ class TracesSchemaParityPreCutoverTest {
     }
 
     /**
+     * The reference migration's pre-cutover branch, applied to the topology it is written for. Proves the two facts the
+     * pattern rests on: {@code liquibase-clickhouse} honours a formatted-SQL {@code sqlCheck} precondition with
+     * {@code onFail:MARK_RAN}, so one file can serve both topologies; and the branch that does run reaches both the live
+     * table and the shadow, leaving parity intact.
+     */
+    @Test
+    @Order(5)
+    @DisplayName("the reference migration takes its pre-cutover branch and marks the other one run")
+    void referenceMigrationTakesThePreCutoverBranch() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
+
+        assertThat(TracesDdlReferenceFixture.execType(connection, TracesDdlReferenceFixture.PRE_CUTOVER_CHANGESET))
+                .as("on a pre-cutover install the pre-cutover branch must run")
+                .isEqualTo(TracesDdlReferenceFixture.EXECUTED);
+        assertThat(TracesDdlReferenceFixture.execType(connection, TracesDdlReferenceFixture.POST_CUTOVER_CHANGESET))
+                .as("""
+                        the post-cutover branch must be recorded MARK_RAN, not left unrun: it is marked applied without \
+                        executing, so a later startup never retries it against the wrong topology\
+                        """)
+                .isEqualTo(TracesDdlReferenceFixture.MARK_RAN);
+
+        // The read-facing field and the storage-only index both reach both tables pre-cutover.
+        var traces = TableSchema.read(connection, DATABASE_NAME, TRACES);
+        var shadow = TableSchema.read(connection, DATABASE_NAME, SHADOW);
+        assertThat(traces.columnNames()).contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        assertThat(shadow.columnNames()).contains(TracesDdlReferenceFixture.DERIVED_COLUMN);
+        assertThat(traces.skipIndexNames()).contains(TracesDdlReferenceFixture.STORAGE_INDEX);
+        assertThat(shadow.skipIndexNames()).contains(TracesDdlReferenceFixture.STORAGE_INDEX);
+
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * Idempotency: the guarded branches are all {@code IF [NOT] EXISTS} and the skipped one is recorded {@code MARK_RAN},
+     * so a second apply — a restarting replica, a re-run after a partial failure — must be a no-op rather than an error.
+     */
+    @Test
+    @Order(6)
+    @DisplayName("re-applying the reference migration is a no-op")
+    void reApplyingTheReferenceMigrationIsANoOp() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
+
+        assertThat(MigrationUtils.unrunClickhouseChangeSetIds(clickHouse, TracesDdlReferenceFixture.CHANGELOG))
+                .as("both branches stay recorded as applied, so nothing is left to run")
+                .isEmpty();
+
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The negative control that makes the pattern load-bearing: the same change written the ordinary un-guarded way
+     * applies without error and leaves the shadow behind, and this gate rejects it. A pull request shaped like this
+     * cannot merge.
+     */
+    @Test
+    @Order(7)
+    @DisplayName("an un-guarded traces migration is rejected: it never reaches the shadow")
+    void unguardedMigrationIsRejected() throws Exception {
+        MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
+
+        assertThat(TableSchema.read(connection, DATABASE_NAME, TRACES).columnNames())
+                .as("the un-guarded ALTER does reach the live table — it fails silently, which is the problem")
+                .contains(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+        assertThat(TableSchema.read(connection, DATABASE_NAME, SHADOW).columnNames())
+                .as("...and never reaches the shadow the cutover will promote")
+                .doesNotContain(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining(TracesDdlReferenceFixture.UNGUARDED_COLUMN);
+
+        execute("ALTER TABLE %s.%s DROP COLUMN %s"
+                .formatted(DATABASE_NAME, TRACES, TracesDdlReferenceFixture.UNGUARDED_COLUMN));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
+    /**
+     * The fixtures do write Liquibase ledger rows, so this pins that they stay additive: the shipped changelog is still
+     * fully applied afterwards. Listing its unrun changesets also revalidates every recorded checksum, so a fixture
+     * that had disturbed a shipped ledger row would fail here rather than in some unrelated suite later.
+     */
+    @Test
+    @Order(8)
+    @DisplayName("applying the fixtures leaves the shipped changelog intact")
+    void applyingTheFixturesLeavesTheShippedChangelogIntact() {
+        assertThat(MigrationUtils.unrunClickhouseChangeSetIds(clickHouse))
+                .as("the shipped changelog must remain fully applied, with nothing pending or invalidated")
+                .isEmpty();
+    }
+
+    /**
      * Both directions of the same mistake — a column that reached one table and not the other — parameterized because
      * the arrange/act/assert is identical and only the target differs. Both directions are covered deliberately: a
      * migration writer is far likelier to forget the shadow, but a shadow-only change is equally broken.

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -269,6 +269,26 @@ class TracesSchemaParityPreCutoverTest {
         TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
 
+    /**
+     * The one column the type comparison structurally cannot reach — it exists on the shadow and has no counterpart on
+     * {@code traces} — and the one where the <i>default</i> is the whole contract. The cutover backfill deliberately
+     * omits {@code is_deleted} so it takes its default; flip that default to 1 and every row the cutover copies
+     * materialises as a {@code ReplacingMergeTree} tombstone, which is a silent, total data loss at swap time.
+     */
+    @Test
+    @Order(18)
+    @DisplayName("drift is caught: the shadow's is_deleted default flipped to 1")
+    void shadowOnlyColumnDefaultDriftIsCaught() throws Exception {
+        execute("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 1".formatted(DATABASE_NAME, SHADOW));
+
+        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("is_deleted");
+
+        execute("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 0".formatted(DATABASE_NAME, SHADOW));
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+    }
+
     private boolean tableExists(String table) throws Exception {
         var sql = "SELECT count() FROM system.tables WHERE database = '%s' AND name = '%s'"
                 .formatted(DATABASE_NAME, table);

--- a/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/db/TracesSchemaParityPreCutoverTest.java
@@ -19,6 +19,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 
 import java.sql.Connection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
@@ -70,9 +71,14 @@ class TracesSchemaParityPreCutoverTest {
 
     @AfterAll
     void tearDown() throws Exception {
-        connection.close();
-        clickHouse.stop();
-        zookeeper.stop();
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } finally {
+            clickHouse.stop();
+            zookeeper.stop();
+        }
     }
 
     @Test
@@ -107,7 +113,7 @@ class TracesSchemaParityPreCutoverTest {
      */
     @Test
     @Order(5)
-    @DisplayName("the reference migration takes its pre-cutover branch and marks the other one run")
+    @DisplayName("the reference migration takes its pre-cutover branch and records the other as MARK_RAN")
     void referenceMigrationTakesThePreCutoverBranch() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.CHANGELOG);
 
@@ -156,7 +162,7 @@ class TracesSchemaParityPreCutoverTest {
      */
     @Test
     @Order(7)
-    @DisplayName("an unguarded traces migration is rejected: it never reaches the shadow")
+    @DisplayName("an unguarded traces migration applies cleanly and leaves shadow drift the gate rejects")
     void unguardedMigrationIsRejected() throws Exception {
         MigrationUtils.runClickhouseChangelog(clickHouse, TracesDdlReferenceFixture.UNGUARDED_CHANGELOG);
 
@@ -206,14 +212,10 @@ class TracesSchemaParityPreCutoverTest {
     @Order(10)
     @DisplayName("drift is caught: a column added to one table but not the other")
     void oneSidedColumnIsCaught(String table, String column) throws Exception {
-        execute("ALTER TABLE %s.%s ADD COLUMN %s String".formatted(DATABASE_NAME, table, column));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining(column);
-
-        execute("ALTER TABLE %s.%s DROP COLUMN %s".formatted(DATABASE_NAME, table, column));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s ADD COLUMN %s String".formatted(DATABASE_NAME, table, column)),
+                List.of("ALTER TABLE %s.%s DROP COLUMN %s".formatted(DATABASE_NAME, table, column)),
+                column);
     }
 
     /**
@@ -233,20 +235,19 @@ class TracesSchemaParityPreCutoverTest {
     void projectionQueryDriftIsCaught() throws Exception {
         allowProjections(TRACES);
         allowProjections(SHADOW);
-        execute("ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, name ORDER BY name)"
-                .formatted(DATABASE_NAME, TRACES));
-        execute("ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, thread_id ORDER BY thread_id)"
-                .formatted(DATABASE_NAME, SHADOW));
 
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("proj_drift");
-
-        execute("ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, TRACES));
-        execute("ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, SHADOW));
-        restoreProjectionMode(TRACES);
-        restoreProjectionMode(SHADOW);
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, name ORDER BY name)"
+                        .formatted(DATABASE_NAME, TRACES),
+                        "ALTER TABLE %s.%s ADD PROJECTION proj_drift (SELECT id, thread_id ORDER BY thread_id)"
+                                .formatted(DATABASE_NAME, SHADOW)),
+                List.of("ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, TRACES),
+                        "ALTER TABLE %s.%s DROP PROJECTION proj_drift".formatted(DATABASE_NAME, SHADOW),
+                        "ALTER TABLE %s.%s RESET SETTING deduplicate_merge_projection_mode"
+                                .formatted(DATABASE_NAME, TRACES),
+                        "ALTER TABLE %s.%s RESET SETTING deduplicate_merge_projection_mode"
+                                .formatted(DATABASE_NAME, SHADOW)),
+                "proj_drift");
     }
 
     private void allowProjections(String table) throws Exception {
@@ -267,15 +268,10 @@ class TracesSchemaParityPreCutoverTest {
     @Order(15)
     @DisplayName("drift is caught: a shared column whose type changed on one table only")
     void oneSidedTypeChangeIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s MODIFY COLUMN name LowCardinality(String)".formatted(DATABASE_NAME, SHADOW));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("name")
-                .hasMessageContaining("LowCardinality");
-
-        execute("ALTER TABLE %s.%s MODIFY COLUMN name String".formatted(DATABASE_NAME, SHADOW));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN name LowCardinality(String)".formatted(DATABASE_NAME, SHADOW)),
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN name String".formatted(DATABASE_NAME, SHADOW)),
+                "name", "LowCardinality");
     }
 
     /**
@@ -287,16 +283,11 @@ class TracesSchemaParityPreCutoverTest {
     @Order(16)
     @DisplayName("drift is caught: an allowlisted column that left its documented type")
     void allowlistedColumnLeavingItsDocumentedTypeIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Nullable(Float64)".formatted(DATABASE_NAME, SHADOW));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("allowlisted column")
-                .hasMessageContaining("ttft");
-
-        execute("ALTER TABLE %s.%s MODIFY COLUMN ttft Float64 DEFAULT toFloat64('nan')"
-                .formatted(DATABASE_NAME, SHADOW));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN ttft Nullable(Float64)".formatted(DATABASE_NAME, SHADOW)),
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN ttft Float64 DEFAULT toFloat64('nan')"
+                        .formatted(DATABASE_NAME, SHADOW)),
+                "allowlisted column", "ttft");
     }
 
     /**
@@ -307,16 +298,12 @@ class TracesSchemaParityPreCutoverTest {
     @Order(17)
     @DisplayName("drift is caught: an allowlisted column that changed on traces")
     void allowlistedColumnDriftingOnTracesIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(3, 'UTC')".formatted(DATABASE_NAME, TRACES));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("allowlisted column")
-                .hasMessageContaining("start_time");
-
-        execute("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(9, 'UTC') DEFAULT now64(9)"
-                .formatted(DATABASE_NAME, TRACES));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(3, 'UTC')"
+                        .formatted(DATABASE_NAME, TRACES)),
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN start_time DateTime64(9, 'UTC') DEFAULT now64(9)"
+                        .formatted(DATABASE_NAME, TRACES)),
+                "allowlisted column", "start_time");
     }
 
     /**
@@ -349,15 +336,11 @@ class TracesSchemaParityPreCutoverTest {
     @Order(13)
     @DisplayName("drift is caught: a skip index added to traces but not to the shadow")
     void skipIndexAddedToTracesAloneIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s ADD INDEX idx_drift_name name TYPE set(0) GRANULARITY 1"
-                .formatted(DATABASE_NAME, TRACES));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("idx_drift_name");
-
-        execute("ALTER TABLE %s.%s DROP INDEX idx_drift_name".formatted(DATABASE_NAME, TRACES));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s ADD INDEX idx_drift_name name TYPE set(0) GRANULARITY 1"
+                        .formatted(DATABASE_NAME, TRACES)),
+                List.of("ALTER TABLE %s.%s DROP INDEX idx_drift_name".formatted(DATABASE_NAME, TRACES)),
+                "idx_drift_name");
     }
 
     /**
@@ -370,14 +353,10 @@ class TracesSchemaParityPreCutoverTest {
     @Order(18)
     @DisplayName("drift is caught: the shadow's is_deleted default flipped to 1")
     void shadowOnlyColumnDefaultDriftIsCaught() throws Exception {
-        execute("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 1".formatted(DATABASE_NAME, SHADOW));
-
-        assertThatThrownBy(() -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
-                .isInstanceOf(AssertionError.class)
-                .hasMessageContaining("is_deleted");
-
-        execute("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 0".formatted(DATABASE_NAME, SHADOW));
-        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
+        assertDriftIsCaught(
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 1".formatted(DATABASE_NAME, SHADOW)),
+                List.of("ALTER TABLE %s.%s MODIFY COLUMN is_deleted UInt8 DEFAULT 0".formatted(DATABASE_NAME, SHADOW)),
+                "is_deleted");
     }
 
     /**
@@ -404,6 +383,35 @@ class TracesSchemaParityPreCutoverTest {
         assertThat(schema.skipIndicesByName().get(TracesDdlReferenceFixture.STORAGE_INDEX))
                 .as("`%s` must carry the reference index, defined as declared", schema.table())
                 .isEqualTo(TracesDdlReferenceFixture.EXPECTED_STORAGE_INDEX);
+    }
+
+    /**
+     * Injects drift, asserts the guard rejects it naming {@code expectedInMessage}, and restores the schema
+     * <b>whether or not the assertion held</b>.
+     * <p>
+     * The finally is the point. These negative tests share one container with every later {@code @Order}ed test, so a
+     * failing assertion that left its drift in place would cascade: the next tests fail for a reason unrelated to what
+     * they assert, and the real failure is buried. Restoring first, then re-asserting parity, also proves the cleanup
+     * actually worked rather than assuming it.
+     */
+    private void assertDriftIsCaught(List<String> inject, List<String> restore, String... expectedInMessage)
+            throws Exception {
+        for (var sql : inject) {
+            execute(sql);
+        }
+        try {
+            var thrown = assertThatThrownBy(
+                    () -> TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME))
+                    .isInstanceOf(AssertionError.class);
+            for (var expected : expectedInMessage) {
+                thrown.hasMessageContaining(expected);
+            }
+        } finally {
+            for (var sql : restore) {
+                execute(sql);
+            }
+        }
+        TracesSchemaParity.assertPreCutoverParity(connection, DATABASE_NAME);
     }
 
     private boolean tableExists(String table) throws Exception {

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/changelog.xml
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/changelog.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The reference for the topology-aware traces DDL pattern (OPIK-7772).
+
+  This is a TEST FIXTURE, not a shipped migration: it lives on the test classpath so the pattern can be applied against
+  both topologies and proven, without adding DDL to db-app-analytics/migrations that every install would run. A real
+  traces migration copies the shape of migrations/000001_reference_topology_aware_change.sql into the shipped
+  directory; see guides/traces-schema-ddl.md for the playbook.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll relativeToChangelogFile="true" path="migrations/" endsWithFilter=".sql"/>
+
+</databaseChangeLog>

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/migrations/reference_topology_aware_change.sql
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/migrations/reference_topology_aware_change.sql
@@ -22,6 +22,12 @@
 -- Both branches are written with IF [NOT] EXISTS so a re-run, a partially-applied branch, or an install that reaches
 -- this migration from either side is idempotent.
 --
+-- ON CLUSTER. Every statement carries ON CLUSTER '{cluster}', as every shipped traces/spans ALTER does and as
+-- migrations.md requires: without it the DDL reaches only the node the migration connected to, leaving the other
+-- replicas short of the column while the changeset is recorded as applied. That matters twice over here — the guard
+-- branch is chosen from a LOCAL system.tables read, so on a divergent cluster one node can record MARK_RAN for a
+-- topology the others are not in. The macro is resolved server-side, so this stays portable across installs.
+--
 -- WHERE A CHANGE LANDS (the general rule):
 --   * Anything that changes the READ-FACING COLUMN LIST (a column, including MATERIALIZED / ALIAS) must be applied to
 --     the shard AND the Distributed wrapper. The wrapper stores nothing, but it resolves column names: a shard-only
@@ -49,24 +55,24 @@
 --comment: Pre-cutover branch — traces is the live MergeTree and traces_local_v2 is the shadow; apply to both
 --preconditions onFail:MARK_RAN onError:HALT onFailMessage:traces_local exists, so this install is post-cutover; the pre-cutover branch is skipped
 --precondition-sql-check expectedResult:0 SELECT count() FROM system.tables WHERE database = '${ANALYTICS_DB_DATABASE_NAME}' AND name = 'traces_local'
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ON CLUSTER '{cluster}' ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP INDEX IF EXISTS idx_reference_storage;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS reference_derived;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 DROP INDEX IF EXISTS idx_reference_storage;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS reference_derived;
 
 --changeset opik-7772-test-fixture:reference_topology_aware_change_post_cutover
 --comment: Post-cutover branch — traces is the Distributed wrapper over traces_local; the column goes to both, the index to the shard only
 --preconditions onFail:MARK_RAN onError:HALT onFailMessage:traces_local does not exist, so this install is pre-cutover; the post-cutover branch is skipped
 --precondition-sql-check expectedResult:1 SELECT count() FROM system.tables WHERE database = '${ANALYTICS_DB_DATABASE_NAME}' AND name = 'traces_local'
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ON CLUSTER '{cluster}' ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS reference_derived;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local DROP INDEX IF EXISTS idx_reference_storage;
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ON CLUSTER '{cluster}' DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS reference_derived;

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/migrations/reference_topology_aware_change.sql
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-reference/migrations/reference_topology_aware_change.sql
@@ -1,0 +1,72 @@
+--liquibase formatted sql
+
+-- REFERENCE MIGRATION for the topology-aware traces DDL pattern (OPIK-7772). TEST FIXTURE, NOT A SHIPPED MIGRATION.
+--
+-- ISOLATION. This file is under src/test/resources, so the shipped changelog's includeAll over
+-- liquibase/db-app-analytics/migrations/ cannot reach it and no deployment can apply it. It has no migration number and
+-- its changeset author is `opik-7772-test-fixture`, so the ledger rows it writes in a test container are unmistakable
+-- and cannot collide with a shipped changeset id. A real traces migration copies this SHAPE into the shipped
+-- migrations directory under the usual NNNNNN_ name and the `opik` author -- it does not include this file.
+--
+-- WHY THIS SHAPE. The cutover to the partitioned, sharding-ready trace table is produced by the operator runbook
+-- (data-migrations/traces-local-v2-cutover), not by Liquibase, so from the moment an install cuts over the changelog and
+-- the runtime topology disagree — and the fleet stays mixed for months (SaaS cut over; self-hosted on their own cadence;
+-- fresh installs still pre-cutover). One migration file therefore has to be correct against BOTH layouts:
+--
+--   pre-cutover:   traces        = the live MergeTree           traces_local_v2 = the empty successor (shadow)
+--   post-cutover:  traces        = a Distributed wrapper        traces_local    = the MergeTree shard beneath it
+--
+-- THE PATTERN. Ship the change as TWO complementary changesets guarded on the same fact — whether traces_local exists —
+-- so exactly one branch executes and the other is recorded MARK_RAN. The guard is a sqlCheck against system.tables
+-- rather than a tableExists precondition because it must read the *runtime* topology, which no changelog records.
+-- Both branches are written with IF [NOT] EXISTS so a re-run, a partially-applied branch, or an install that reaches
+-- this migration from either side is idempotent.
+--
+-- WHERE A CHANGE LANDS (the general rule):
+--   * Anything that changes the READ-FACING COLUMN LIST (a column, including MATERIALIZED / ALIAS) must be applied to
+--     the shard AND the Distributed wrapper. The wrapper stores nothing, but it resolves column names: a shard-only
+--     ADD COLUMN succeeds silently and is then unreadable through the wrapper (code 47).
+--   * Anything STORAGE-ONLY (skip index, codec, TTL, projection) goes to the SHARD ONLY. The Distributed wrapper holds
+--     no data, so it has nowhere to put an index and rejects the statement.
+--   * Pre-cutover the same change applies to BOTH traces and the traces_local_v2 shadow, or the cutover promotes a
+--     table that no longer matches the live one.
+--   * A PRESERVED (non-derived) column must ALSO be added to the cutover backfill's explicit column list
+--     (data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000001_backfill_traces_local_v2.sql), or the
+--     cutover copies it as its default and the data is lost. TracesSchemaParityPreCutoverTest enforces this.
+--
+-- This reference demonstrates the two cases we have historically shipped, one of each kind:
+--   * a FIELD  — reference_derived, a MATERIALIZED column, so read-facing: shard + wrapper.
+--   * an INDEX — idx_reference_storage, a data-skipping index, so storage-only: shard alone.
+-- A derived (MATERIALIZED) column is used deliberately: it is read-facing, so it exercises the wrapper branch, while
+-- needing no backfill-list entry (the destination recomputes it), which keeps this fixture from having to edit shipped
+-- cutover SQL. A preserved column would additionally need the backfill-list edit described above.
+--
+-- Structural changes (ORDER BY / PRIMARY KEY / PARTITION BY) are immutable on MergeTree and cannot be ALTERed at all;
+-- they require a table recreate, ride the successor's table definition rather than an in-window ALTER, and are to be
+-- avoided entirely during the mixed-fleet window. They are out of scope for this pattern.
+
+--changeset opik-7772-test-fixture:reference_topology_aware_change_pre_cutover
+--comment: Pre-cutover branch — traces is the live MergeTree and traces_local_v2 is the shadow; apply to both
+--preconditions onFail:MARK_RAN onError:HALT onFailMessage:traces_local exists, so this install is post-cutover; the pre-cutover branch is skipped
+--precondition-sql-check expectedResult:0 SELECT count() FROM system.tables WHERE database = '${ANALYTICS_DB_DATABASE_NAME}' AND name = 'traces_local'
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 DROP COLUMN IF EXISTS reference_derived;
+
+--changeset opik-7772-test-fixture:reference_topology_aware_change_post_cutover
+--comment: Post-cutover branch — traces is the Distributed wrapper over traces_local; the column goes to both, the index to the shard only
+--preconditions onFail:MARK_RAN onError:HALT onFailMessage:traces_local does not exist, so this install is pre-cutover; the post-cutover branch is skipped
+--precondition-sql-check expectedResult:1 SELECT count() FROM system.tables WHERE database = '${ANALYTICS_DB_DATABASE_NAME}' AND name = 'traces_local'
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local ADD INDEX IF NOT EXISTS idx_reference_storage name TYPE set(0) GRANULARITY 1;
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS reference_derived UInt64 MATERIALIZED length(name);
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS reference_derived;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local DROP INDEX IF EXISTS idx_reference_storage;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces_local DROP COLUMN IF EXISTS reference_derived;

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/changelog.xml
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/changelog.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
   The NEGATIVE control for the topology-aware traces DDL pattern (OPIK-7772): a traces migration written the ordinary,
-  un-guarded way. Test fixture; applied by the parity gates to prove the pattern is load-bearing rather than ceremony.
+  unguarded way. Test fixture; applied by the parity gates to prove the pattern is load-bearing rather than ceremony.
 -->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/changelog.xml
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/changelog.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The NEGATIVE control for the topology-aware traces DDL pattern (OPIK-7772): a traces migration written the ordinary,
+  un-guarded way. Test fixture; applied by the parity gates to prove the pattern is load-bearing rather than ceremony.
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll relativeToChangelogFile="true" path="migrations/" endsWithFilter=".sql"/>
+
+</databaseChangeLog>

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
@@ -18,8 +18,12 @@
 -- (TracesSchemaParityPreCutoverTest / TracesSchemaParityPostCutoverTest) apply this fixture and assert they reject it,
 -- which is what proves a non-conforming migration cannot merge.
 
+-- It is otherwise written correctly -- IF NOT EXISTS, ON CLUSTER '{cluster}', a real rollback -- so the precondition
+-- guard is the ONLY thing it is missing. That keeps the negative control sharp: when the gates reject it, they are
+-- rejecting the absent guard and nothing else.
+--
 --changeset opik-7772-test-fixture:unguarded_traces_change
 --comment: Deliberately un-guarded — the mistake the pattern exists to prevent
-ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS unguarded_column String DEFAULT '';
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS unguarded_column String DEFAULT '';
 
---rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS unguarded_column;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS unguarded_column;

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
@@ -23,7 +23,7 @@
 -- rejecting the absent guard and nothing else.
 --
 --changeset opik-7772-test-fixture:unguarded_traces_change
---comment: Deliberately un-guarded — the mistake the pattern exists to prevent
+--comment: Deliberately unguarded — the mistake the pattern exists to prevent
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' ADD COLUMN IF NOT EXISTS unguarded_column String DEFAULT '';
 
 --rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS unguarded_column;

--- a/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
+++ b/apps/opik-backend/src/test/resources/liquibase/traces-ddl-unguarded/migrations/unguarded_traces_change.sql
@@ -1,0 +1,25 @@
+--liquibase formatted sql
+
+-- NEGATIVE CONTROL for OPIK-7772. TEST FIXTURE, NEVER SHIPPED.
+--
+-- ISOLATION: under src/test/resources, so the shipped changelog cannot reach it; no migration number, and the
+-- `opik-7772-test-fixture` changeset author keeps its ledger rows out of the shipped id namespace.
+--
+-- This is what a traces migration looks like when it is written without the topology-aware pattern: a single
+-- unconditional ALTER against `traces`, which is how every pre-cutover migration in db-app-analytics/migrations was
+-- legitimately written before the cutover existed. It applies cleanly on BOTH topologies and is WRONG on both:
+--
+--   * pre-cutover  — it reaches the live `traces` but not the `traces_local_v2` shadow, so the next cutover promotes a
+--                    table missing this column.
+--   * post-cutover — `traces` is the Distributed wrapper, which takes the ADD COLUMN as metadata only, so the column
+--                    resolves on reads but no shard stores it.
+--
+-- Neither failure raises anything at migration time. The parity gates
+-- (TracesSchemaParityPreCutoverTest / TracesSchemaParityPostCutoverTest) apply this fixture and assert they reject it,
+-- which is what proves a non-conforming migration cannot merge.
+
+--changeset opik-7772-test-fixture:unguarded_traces_change
+--comment: Deliberately un-guarded — the mistake the pattern exists to prevent
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces ADD COLUMN IF NOT EXISTS unguarded_column String DEFAULT '';
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.traces DROP COLUMN IF EXISTS unguarded_column;


### PR DESCRIPTION
## Details

**Stack 2/4 for OPIK-7772 — base #7951, review that one first.** Establishes the shape every future `traces` schema change ships in: two complementary changesets guarded on the same runtime fact — whether `traces_local` exists — so exactly one branch executes and the other is recorded `MARK_RAN`. Both gates from #7951 now apply the same single file to their own topology and prove the correct branch ran, which is what turns the pattern from a convention into something CI can enforce.

- **Four load-bearing details**, each now asserted: a `sqlCheck` against `system.tables` rather than `tableExists`, because the guard has to read the *runtime* topology, which no changelog records; `onFail:MARK_RAN`, so the skipped branch is marked applied without executing and a later startup never retries it against the wrong topology; `onError:HALT`, so an unevaluable precondition stops rather than guesses; and `IF [NOT] EXISTS` throughout, so a re-run or partially-applied branch is idempotent.
- This also confirms `liquibase-clickhouse` 0.7.2 honours these preconditions — the fact the whole pattern rests on. A version bump that broke it now fails CI rather than production.
- **The reference migration covers the two cases we have historically shipped**, one of each kind: a read-facing field (a `MATERIALIZED` column → shard *and* wrapper) and a storage-only skip index (→ shard alone). A *derived* column is used deliberately: read-facing enough to exercise the wrapper branch, while needing no cutover-backfill entry, so the fixture never has to edit shipped cutover SQL. The preserved-column → backfill-list obligation is already covered by a negative test in #7951.
- **A negative control carries the same intent written the ordinary un-guarded way**, as one unconditional `ALTER TABLE traces`. It applies cleanly on both topologies and is wrong on both — pre-cutover it never reaches the shadow, post-cutover it only reaches the wrapper — and both gates assert they reject it. That is what makes the pattern load-bearing rather than ceremony.
- **These are reference migrations, not actual migrations, so they are test-only.** They sit under `src/test/resources`, where the shipped changelog's `includeAll` over `liquibase/db-app-analytics/migrations/` cannot reach them, so no deployment can apply them. They carry no migration number and use the changeset author `opik-7772-test-fixture`, so a ledger row from a fixture is unmistakable — and since Liquibase identity is id + author + *filename*, and the fixture path differs from the shipped one, a collision was already impossible.
- Each gate additionally asserts **the shipped changelog is still fully applied** once a fixture has run. Listing its unrun changesets revalidates every recorded checksum, so a fixture that had disturbed a shipped ledger row fails there rather than in an unrelated suite later.
- No shipped migration is added or edited.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7772

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: Test-only. Authored the two fixture changelogs and their migrations, the `TracesDdlReferenceFixture` constants/ledger helper, and the fixture tests added to both gates. The `MARK_RAN` behaviour and the fact that a `MATERIALIZED` column can be added to a `Distributed` wrapper were both verified empirically against a real container rather than assumed.
- Human verification: The author chose the test-only fixture approach over shipping a real reference migration, and pushed back on the fixture's interaction with the changelog ledger — which is what prompted the isolation notes and the "shipped changelog intact" assertions in this PR. All tests executed locally (see Testing). The author has not line-reviewed every Javadoc paragraph.

## Testing

Environment: local, Docker 29.7.2 (linux/aarch64), Corretto 25.0.3, Maven 3.9.9, from `apps/opik-backend`.

```bash
cd apps/opik-backend
mvn test -Dtest='TracesSchemaParity*Test'
```

Result: 21/21 (pre-cutover 10, post-cutover 11), ~30s per gate.

Scenarios validated:
- **Correct branch per topology** — pre-cutover the pre-cutover changeset is `EXECUTED` and the post-cutover one `MARK_RAN`; post-cutover, the reverse. Read from the `DATABASECHANGELOG` `EXECTYPE`, filtered by the fixture author.
- **Where the change landed** — pre-cutover the field and the index reach both `traces` and the shadow; post-cutover the field reaches shard *and* wrapper while the index reaches the shard *only* and is asserted absent from the wrapper.
- **Readability** — post-cutover the field is `SELECT`ed through the wrapper, so the branch is proven to have produced a working column, not just matching metadata.
- **Idempotency** — re-applying the fixture changelog leaves nothing unrun and parity intact.
- **Un-guarded negative control** — applied on both topologies; asserted that it does reach the live table (i.e. it genuinely fails silently) and does not reach the shadow / shard, and that the gate rejects it. Cleaned up and parity re-asserted afterwards.
- **Ledger isolation** — the shipped changelog is still fully applied, with nothing pending or checksum-invalidated, after both fixtures have run.

Not run: the full backend suite (unchanged by this PR; CI runs it). No video — non-visual, test-only change.

## Documentation

None in this PR. The playbook this reference implements lands in stack 4/4 as `apps/opik-backend/docs/traces-schema-ddl.md`; the fixture headers already point at it.
