### PR TITLE
[OPIK-8045] [QA] Proposed e2e spec from the #7949 online-scoring exploration

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
@@ -157,6 +157,18 @@ public interface AgenticScoringService {
     boolean supportsToolCalling(LlmProvider provider);
 
     /**
+     * Tool choice for the FIRST call of the agentic loop. {@link ToolChoice#REQUIRED} is what stops an
+     * OpenAI judge from answering straight from visible context (see {@link SupportedJudgeProvider} for
+     * the empirical asymmetry), but langchain4j's {@code VertexAiGeminiChatModel} rejects any explicit
+     * tool choice with {@code UnsupportedFeatureException} — and since that is terminal, forcing it there
+     * failed the evaluation outright instead of scoring it. Vertex therefore gets
+     * {@link ToolChoice#AUTO}: the model may skip the tool loop, which the loop already handles (a first
+     * response with no tool-execution requests finishes it), so a possibly-tool-less evaluation replaces
+     * a guaranteed failure.
+     */
+    ToolChoice firstRoundToolChoice(LlmProvider provider);
+
+    /**
      * Attach the tool specs from the registered {@link ToolRegistry} and the given {@code toolChoice} to
      * {@code request}'s parameters. Tool specs live inside {@link ChatRequestParameters}, so we copy the
      * existing parameters via {@code overrideWith} and layer tool specs on top — setting
@@ -436,6 +448,18 @@ class AgenticScoringServiceImpl implements AgenticScoringService {
         return switch (provider) {
             case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, VERTEX_AI, BEDROCK -> true;
             case OLLAMA, CUSTOM_LLM, OPIK_FREE -> false;
+        };
+    }
+
+    @Override
+    public ToolChoice firstRoundToolChoice(@NonNull LlmProvider provider) {
+        return switch (provider) {
+            // VertexAiGeminiChatModel.validate() throws UnsupportedFeatureException on any toolChoice.
+            case VERTEX_AI -> ToolChoice.AUTO;
+            case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, BEDROCK -> ToolChoice.REQUIRED;
+            // Unreachable while callers gate on supportsToolCalling first; AUTO keeps a caller that
+            // forgets the gate on the harmless side.
+            case OLLAMA, CUSTOM_LLM, OPIK_FREE -> ToolChoice.AUTO;
         };
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -17,12 +17,10 @@ import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateParseUtils;
 import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.JsonPath;
 import dev.langchain4j.data.message.AudioContent;
@@ -885,23 +883,31 @@ public class OnlineScoringEngine {
             }
         }
 
-        Map<String, Object> forcedObject;
+        Object forcedObject;
         try {
             // JsonPath didn't work with JsonNode, even explicitly using
-            // JacksonJsonProvider, so we convert to a Map
-            forcedObject = OBJECT_MAPPER.convertValue(json, new TypeReference<>() {
-            });
-        } catch (InvalidArgumentException e) {
+            // JacksonJsonProvider, so we convert to a plain Object: a Map for an object node, a List for
+            // an array node, and the scalar itself for anything else. Converting straight to
+            // Map<String, Object> instead threw MismatchedInputException (wrapped in
+            // IllegalArgumentException) whenever the section was NOT an object — e.g. a trace whose
+            // output is the bare string "how can I help?" — and that escaped prepareLlmRequest and failed
+            // the whole evaluation before the LLM was ever called.
+            forcedObject = OBJECT_MAPPER.convertValue(json, Object.class);
+        } catch (IllegalArgumentException e) {
             log.warn("failed to parse json, json={}", json, e);
             return null;
         }
 
         try {
+            // JsonPath.parse rejects a non-container (a scalar section has no nested path to walk), which
+            // lands on the fallback below rather than propagating.
             var value = JsonPath.parse(forcedObject).read(path);
             return value != null ? serializeToJsonString(value) : null;
         } catch (Exception e) {
             log.warn("couldn't find path inside json, trying flat structure, path={}, json={}", path, json, e);
-            return Optional.ofNullable(forcedObject.get(path.replace("$.", "")))
+            return Optional.ofNullable(forcedObject)
+                    .filter(Map.class::isInstance)
+                    .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
                     .map(OnlineScoringEngine::serializeToJsonString)
                     .orElseGet(() -> {
                         log.info("couldn't find flat or nested path in json, path={}, json={}", path, json);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -33,7 +33,6 @@ import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -483,8 +482,10 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 // for the empirical asymmetry. Follow-up rounds in handleToolCalls switch to
                 // AUTO so the model can decide when it has enough info to stop investigating;
                 // a uniform REQUIRED would loop forever because the wrap-up turn would also
-                // be forced to call a tool.
-                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                // be forced to call a tool. Providers that reject a forced choice outright get
+                // AUTO here too — see firstRoundToolChoice.
+                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                        agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
             }
 
             // summarizeRequest is cheap (no per-message toString streaming since the chars-count

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -24,7 +24,6 @@ import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import lombok.Builder;
@@ -311,8 +310,10 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                 llmProviderFactory.getStructuredOutputStrategy(modelName),
                 onlineScoringConfig.getMaxPromptFieldChars(), drillDownHint, spanStructureJson);
         // REQUIRED on the first call only forces ≥1 tool call; follow-ups switch to AUTO in
-        // handleToolCalls so the model can decide when to stop investigating.
-        scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+        // handleToolCalls so the model can decide when to stop investigating. Providers that reject
+        // a forced choice outright get AUTO here too — see firstRoundToolChoice.
+        scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
         return LlmRequests.builder().score(scoreRequest).structured(structuredRequest).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -28,7 +28,6 @@ import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
@@ -439,7 +438,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 // REQUIRED on the first call only — same reasoning as the trace scorer: forces
                 // ≥1 tool call before the model can answer from skeleton alone. Follow-up rounds
                 // switch to AUTO so the wrap-up turn can emit JSON without invoking a tool.
-                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                // Providers that reject a forced choice outright get AUTO here too — see
+                // firstRoundToolChoice.
+                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                        agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
             }
 
             // summarizeRequest is cheap (no per-message toString streaming). At INFO to mirror

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
@@ -22,9 +25,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -112,28 +117,45 @@ class AgenticScoringServiceTest {
         assertThat(emitted.get()).isLessThan(5);
     }
 
-    @Test
-    @DisplayName("firstRoundToolChoice forces a tool call except on providers that reject a forced choice")
-    void firstRoundToolChoicePerProvider() {
-        // Vertex AI's langchain4j model throws UnsupportedFeatureException on any explicit tool choice,
-        // which is terminal — it failed the evaluation instead of scoring it.
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.VERTEX_AI)).isEqualTo(ToolChoice.AUTO);
+    /**
+     * One row per {@link LlmProvider} — deliberately explicit rather than derived from
+     * {@code supportsToolCalling}, so adding a provider fails
+     * {@link #firstRoundToolChoiceCoversEveryProvider()} until its tool choice is decided here
+     * instead of silently inheriting a default.
+     */
+    static Stream<Arguments> firstRoundToolChoices() {
+        return Stream.of(
+                // langchain4j's ChatRequestValidationUtils.validate throws
+                // UnsupportedFeatureException for any tool choice other than AUTO, and Vertex's
+                // model calls it — a forced choice failed the evaluation instead of scoring it.
+                arguments(LlmProvider.VERTEX_AI, ToolChoice.AUTO),
+                arguments(LlmProvider.OPEN_AI, ToolChoice.REQUIRED),
+                arguments(LlmProvider.ANTHROPIC, ToolChoice.REQUIRED),
+                arguments(LlmProvider.GEMINI, ToolChoice.REQUIRED),
+                arguments(LlmProvider.OPEN_ROUTER, ToolChoice.REQUIRED),
+                arguments(LlmProvider.BEDROCK, ToolChoice.REQUIRED),
+                // No tool support at all: callers gate these out, and AUTO keeps a caller that
+                // forgets the gate on the harmless side.
+                arguments(LlmProvider.OLLAMA, ToolChoice.AUTO),
+                arguments(LlmProvider.CUSTOM_LLM, ToolChoice.AUTO),
+                arguments(LlmProvider.OPIK_FREE, ToolChoice.AUTO));
+    }
 
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_AI)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.ANTHROPIC)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.GEMINI)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_ROUTER)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.BEDROCK)).isEqualTo(ToolChoice.REQUIRED);
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("firstRoundToolChoices")
+    @DisplayName("firstRoundToolChoice forces a tool call except where the provider rejects one")
+    void firstRoundToolChoicePerProvider(LlmProvider provider, ToolChoice expected) {
+        assertThat(agenticScoringService.firstRoundToolChoice(provider)).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("firstRoundToolChoice never forces a choice on a provider that has no tool support")
-    void firstRoundToolChoiceOnNonToolCallingProviders() {
-        Stream.of(LlmProvider.values())
-                .filter(provider -> !agenticScoringService.supportsToolCalling(provider))
-                .forEach(provider -> assertThat(agenticScoringService.firstRoundToolChoice(provider))
-                        .as("provider %s", provider)
-                        .isEqualTo(ToolChoice.AUTO));
+    @DisplayName("firstRoundToolChoice has a case for every LlmProvider")
+    void firstRoundToolChoiceCoversEveryProvider() {
+        var covered = firstRoundToolChoices()
+                .map(arguments -> (LlmProvider) arguments.get()[0])
+                .collect(Collectors.toSet());
+
+        assertThat(covered).containsExactlyInAnyOrder(LlmProvider.values());
     }
 
     private static Span spanWithInput(String payload) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
@@ -8,6 +9,7 @@ import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.TestIdGeneratorFactory;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.utils.JsonUtils;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -107,6 +110,30 @@ class AgenticScoringServiceTest {
         assertThat(result.spans()).isEmpty();
         // Cancelled almost immediately — a handful of elements at most, not the unbounded stream.
         assertThat(emitted.get()).isLessThan(5);
+    }
+
+    @Test
+    @DisplayName("firstRoundToolChoice forces a tool call except on providers that reject a forced choice")
+    void firstRoundToolChoicePerProvider() {
+        // Vertex AI's langchain4j model throws UnsupportedFeatureException on any explicit tool choice,
+        // which is terminal — it failed the evaluation instead of scoring it.
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.VERTEX_AI)).isEqualTo(ToolChoice.AUTO);
+
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_AI)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.ANTHROPIC)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.GEMINI)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_ROUTER)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.BEDROCK)).isEqualTo(ToolChoice.REQUIRED);
+    }
+
+    @Test
+    @DisplayName("firstRoundToolChoice never forces a choice on a provider that has no tool support")
+    void firstRoundToolChoiceOnNonToolCallingProviders() {
+        Stream.of(LlmProvider.values())
+                .filter(provider -> !agenticScoringService.supportsToolCalling(provider))
+                .forEach(provider -> assertThat(agenticScoringService.firstRoundToolChoice(provider))
+                        .as("provider %s", provider)
+                        .isEqualTo(ToolChoice.AUTO));
     }
 
     private static Span spanWithInput(String payload) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
@@ -1,0 +1,109 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Variable extraction out of a trace's input/output/metadata section. Pure static functions, so no
+ * containers here — see {@link OnlineScoringEngineTest} for the end-to-end scoring flow.
+ * <p>
+ * The scalar-section cases are the regression: a trace whose section is a bare JSON string (or array)
+ * used to blow up {@code toReplacements} with a {@code MismatchedInputException}, which propagated out
+ * of {@code prepareLlmRequest} and failed the whole evaluation before the LLM was ever called.
+ */
+@DisplayName("OnlineScoringEngine variable extraction")
+class OnlineScoringEngineExtractFromJsonTest {
+
+    private static Trace traceWithOutput(String outputJson) {
+        return Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("project")
+                .projectId(UUID.randomUUID())
+                .createdBy("user")
+                .output(JsonUtils.getJsonNodeFromString(outputJson))
+                .build();
+    }
+
+    @Test
+    @DisplayName("nested path against a bare-string section drops the variable instead of throwing")
+    void nestedPathOnStringSection() {
+        var trace = traceWithOutput("\"Motor, elektrik, vites veya gövde?\"");
+        var variables = Map.of("answer", "output.answer");
+
+        assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, trace)).doesNotThrowAnyException();
+        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("answer");
+    }
+
+    @Test
+    @DisplayName("whole-section mapping of a bare-string section still resolves")
+    void wholeSectionOnStringSection() {
+        var trace = traceWithOutput("\"just a string\"");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("output", "output"), trace);
+
+        assertThat(replacements).containsEntry("output", "\"just a string\"");
+    }
+
+    @Test
+    @DisplayName("nested path against a numeric section drops the variable instead of throwing")
+    void nestedPathOnNumericSection() {
+        var trace = traceWithOutput("42");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("score", "output.score"), trace);
+
+        assertThat(replacements).doesNotContainKey("score");
+    }
+
+    @Test
+    @DisplayName("indexed path against an array section resolves the element")
+    void indexedPathOnArraySection() {
+        var trace = traceWithOutput("[{\"name\": \"first\"}, {\"name\": \"second\"}]");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.[0].name"), trace);
+
+        assertThat(replacements).containsEntry("name", "first");
+    }
+
+    @Test
+    @DisplayName("field path against an array section drops the variable instead of throwing")
+    void fieldPathOnArraySection() {
+        var trace = traceWithOutput("[\"a\", \"b\"]");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.name"), trace);
+
+        assertThat(replacements).doesNotContainKey("name");
+    }
+
+    @Test
+    @DisplayName("nested and flat paths against an object section keep working")
+    void objectSectionStillResolves() {
+        var trace = traceWithOutput("""
+                {
+                    "answer": "42",
+                    "details": {"unit": "meters"},
+                    "flat.key": "flat value"
+                }
+                """);
+
+        var replacements = OnlineScoringEngine.toReplacements(
+                Map.of(
+                        "answer", "output.answer",
+                        "unit", "output.details.unit",
+                        "flat", "output.flat.key"),
+                trace);
+
+        assertThat(replacements).containsEntry("answer", "42");
+        assertThat(replacements).containsEntry("unit", "meters");
+        // JsonPath reads "$.flat.key" as a nested miss, then the flat-structure fallback finds the
+        // literal "flat.key" property.
+        assertThat(replacements).containsEntry("flat", "flat value");
+    }
+}

--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -82,8 +82,22 @@ class CodeExecutorBase(ABC):
     def parse_execution_result(self, result: ExecutionResult) -> dict:
         """Parse execution result into API response format."""
         if result.exit_code == 0:
-            last_line = result.output.decode("utf-8").strip().splitlines()[-1]
-            return json.loads(last_line)
+            lines = result.output.decode("utf-8").strip().splitlines()
+            if not lines:
+                # Exit code 0 with no output at all: the client's metric ran to completion without
+                # printing its result line. Indexing [-1] here raised IndexError, which
+                # run_scoring's catch-all reported as an opaque "An unexpected error occurred" 500 —
+                # retried by the caller and counted against us. The executed code is the client's,
+                # so this is a 400 like every other way their metric can be wrong.
+                logger.warning("Execution returned exit code 0 with no output")
+                return {"code": 400, "error": "Execution failed: the metric produced no output"}
+            try:
+                return json.loads(lines[-1])
+            except json.JSONDecodeError as e:
+                # Same reasoning: exit code 0 whose last line is not the result JSON means the
+                # client's metric printed something else last, not that the server misbehaved.
+                logger.warning(f"Failed to parse execution result as JSON: {e}")
+                return {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
         else:
             logger.warning(f"Execution failed (Code: {result.exit_code}):\n{result.output.decode('utf-8')}")
             try:

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -474,14 +474,21 @@ class DockerExecutor(CodeExecutorBase):
                 # Parse result and track outcome
                 parsed_result = self.parse_execution_result(exec_result)
 
-                # Determine outcome status based on result
-                if exec_result.exit_code == 0:
+                # Determine outcome status from the parsed result, not from the exit code alone: a
+                # metric can exit 0 and still fail to produce a usable result line, which
+                # parse_execution_result reports as a 4xx. Keying telemetry on the exit code
+                # counted those as successes while the caller was handed an error.
+                result_code = parsed_result.get("code") if isinstance(parsed_result, dict) else None
+                if exec_result.exit_code == 0 and result_code is None:
                     outcome_status = "success"
                 else:
                     outcome_status = "invalid_code"
-                    span.set_status(Status(StatusCode.ERROR, f"Execution failed with exit_code={exec_result.exit_code}"))
+                    span.set_status(Status(StatusCode.ERROR,
+                            f"Execution failed with exit_code={exec_result.exit_code}, result_code={result_code}"))
                     span.set_attribute("error.type", "invalid_code")
                     span.set_attribute("error.exit_code", exec_result.exit_code)
+                    if result_code is not None:
+                        span.set_attribute("error.result_code", result_code)
 
                 self._record_execution_outcome(outcome_status, payload_type)
                 return parsed_result

--- a/apps/opik-python-backend/tests/unit/test_executor_docker_outcome.py
+++ b/apps/opik-python-backend/tests/unit/test_executor_docker_outcome.py
@@ -1,0 +1,76 @@
+"""Execution-outcome telemetry of DockerExecutor.run_scoring.
+
+The outcome recorded on the ``execution_outcome_counter`` metric must match what
+the caller is actually handed. A metric can exit 0 and still fail to produce a
+usable result line — parse_execution_result reports that as a 4xx and the HTTP
+layer aborts with it — so keying the outcome on the exit code alone counted those
+runs as successes.
+
+The Docker daemon is not required: ``docker.from_env`` is mocked, pool pre-warming
+and the pool monitor are stubbed, and a container whose ``exec_run`` returns a
+canned result is injected into the pool.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opik_backend.executor_docker import DockerExecutor
+
+DATA = {"output": "x", "reference": "x"}
+
+
+@pytest.fixture
+def executor():
+    with (
+        patch("opik_backend.executor_docker.docker.from_env", return_value=MagicMock()),
+        patch("opik_backend.executor_docker.DockerExecutor._pre_warm_container_pool"),
+        patch("opik_backend.executor_docker.DockerExecutor._start_pool_monitor"),
+    ):
+        instance = DockerExecutor()
+        yield instance
+        instance.stop_event.set()
+
+
+def run_with_result(executor, exit_code, output: bytes):
+    """Run scoring against a container returning a canned exec result."""
+    container = MagicMock()
+    container.exec_run.return_value = MagicMock(exit_code=exit_code, output=output)
+    with patch.object(executor, "get_container", return_value=container):
+        with patch.object(executor, "_record_execution_outcome") as record:
+            response = executor.run_scoring(code="<unused>", data=DATA)
+    return response, [call.args[0] for call in record.call_args_list]
+
+
+def test_scores_payload_records_success(executor):
+    payload = {"scores": [{"name": "m", "value": 1.0}]}
+
+    response, outcomes = run_with_result(executor, 0, json.dumps(payload).encode("utf-8"))
+
+    assert response == payload
+    assert outcomes == ["success"]
+
+
+def test_exit_zero_without_output_is_not_recorded_as_success(executor):
+    response, outcomes = run_with_result(executor, 0, b"")
+
+    assert response["code"] == 400
+    assert outcomes == ["invalid_code"]
+
+
+def test_exit_zero_with_error_payload_is_not_recorded_as_success(executor):
+    # The sandbox runner catches a failing metric and prints its own 400 payload
+    # while still exiting 0; the HTTP layer aborts with that code.
+    body = {"code": 400, "error": "boom"}
+
+    response, outcomes = run_with_result(executor, 0, json.dumps(body).encode("utf-8"))
+
+    assert response == body
+    assert outcomes == ["invalid_code"]
+
+
+def test_nonzero_exit_records_invalid_code(executor):
+    response, outcomes = run_with_result(executor, 1, json.dumps({"error": "bad metric"}).encode("utf-8"))
+
+    assert response == {"code": 400, "error": "bad metric"}
+    assert outcomes == ["invalid_code"]

--- a/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
+++ b/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
@@ -1,0 +1,54 @@
+"""Tests for CodeExecutorBase.parse_execution_result"""
+import json
+
+from opik_backend.executor import CodeExecutorBase, ExecutionResult
+
+
+class _Executor(CodeExecutorBase):
+    """parse_execution_result lives on the base class; run_scoring is abstract but unused here."""
+
+    def run_scoring(self, code, data, payload_type=None):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+
+def parse(exit_code: int, output: bytes) -> dict:
+    return _Executor().parse_execution_result(ExecutionResult(exit_code=exit_code, output=output))
+
+
+def test_success_returns_last_line_payload():
+    payload = {"scores": [{"name": "m", "value": 1.0}]}
+    result = parse(0, b"some stdout noise\n" + json.dumps(payload).encode("utf-8"))
+
+    assert result == payload
+
+
+def test_success_with_no_output_reports_a_client_error():
+    # Used to raise IndexError from splitlines()[-1], which run_scoring's catch-all reported as
+    # "An unexpected error occurred" with HTTP 500 — retried by the caller and blamed on us.
+    result = parse(0, b"")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric produced no output"}
+
+
+def test_success_with_whitespace_only_output_reports_a_client_error():
+    result = parse(0, b"   \n\n  ")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric produced no output"}
+
+
+def test_success_with_non_json_last_line_reports_a_client_error():
+    result = parse(0, b"not json at all")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
+
+
+def test_failure_surfaces_the_user_error_as_400():
+    result = parse(1, json.dumps({"error": "bad metric"}).encode("utf-8"))
+
+    assert result == {"code": 400, "error": "bad metric"}
+
+
+def test_failure_with_no_output_falls_back_to_the_invalid_metric_message():
+    result = parse(1, b"")
+
+    assert result == {"code": 400, "error": "Execution failed: Python code contains an invalid metric"}

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -473,6 +473,11 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.service.type | string | `"ClusterIP"` |  |
 | component.python-backend.serviceAccount.create | bool | `true` |  |
 | component.python-backend.serviceAccount.name | string | `"opik-python-backend"` |  |
+| component.python-backend.startupProbe.failureThreshold | int | `60` |  |
+| component.python-backend.startupProbe.httpGet.path | string | `"/health/liveness"` |  |
+| component.python-backend.startupProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.startupProbe.periodSeconds | int | `5` |  |
+| component.python-backend.startupProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.waitForRedis.enabled | bool | `true` |  |
 | component.python-backend.waitForRedis.image.registry | string | `"docker.io"` |  |
 | component.python-backend.waitForRedis.image.repository | string | `"busybox"` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -445,11 +445,24 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.ingress.tls.enabled | bool | `false` |  |
 | component.python-backend.ingress.tls.hosts | list | `[]` |  |
 | component.python-backend.ingress.tls.secretName | string | `""` |  |
+| component.python-backend.lifecycle.preStop.exec.command[0] | string | `"/bin/sh"` |  |
+| component.python-backend.lifecycle.preStop.exec.command[1] | string | `"-c"` |  |
+| component.python-backend.lifecycle.preStop.exec.command[2] | string | `"sleep 5"` |  |
+| component.python-backend.livenessProbe.failureThreshold | int | `3` |  |
+| component.python-backend.livenessProbe.httpGet.path | string | `"/health/liveness"` |  |
+| component.python-backend.livenessProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.livenessProbe.periodSeconds | int | `15` |  |
+| component.python-backend.livenessProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.metrics.enabled | bool | `false` |  |
 | component.python-backend.networkPolicy.additionalRules | list | `[]` |  |
 | component.python-backend.networkPolicy.annotations | object | `{}` |  |
 | component.python-backend.networkPolicy.enabled | bool | `false` |  |
 | component.python-backend.podDisruptionBudget.enabled | bool | `false` |  |
+| component.python-backend.readinessProbe.failureThreshold | int | `3` |  |
+| component.python-backend.readinessProbe.httpGet.path | string | `"/health/readiness"` |  |
+| component.python-backend.readinessProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.readinessProbe.periodSeconds | int | `10` |  |
+| component.python-backend.readinessProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.replicaCount | int | `1` |  |
 | component.python-backend.secretRefs | list | `[]` |  |
 | component.python-backend.securityContext.privileged | bool | `true` |  |

--- a/deployment/helm_chart/opik/tests/component_probes_test.yaml
+++ b/deployment/helm_chart/opik/tests/component_probes_test.yaml
@@ -60,6 +60,25 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 3
 
+  - it: python-backend gates liveness behind a startup probe with room to boot
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      # 5s x 60 = five minutes, enough for entrypoint.sh to wait on dockerd and
+      # load the sandbox executor image before gunicorn binds. Kubernetes holds
+      # liveness and readiness until this passes, so the tighter liveness timings
+      # below can never restart a pod that is merely still starting.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 60
+
   - it: python-backend liveness uses the app's liveness endpoint
     documentSelector:
       path: metadata.name

--- a/deployment/helm_chart/opik/tests/component_probes_test.yaml
+++ b/deployment/helm_chart/opik/tests/component_probes_test.yaml
@@ -1,0 +1,107 @@
+suite: probes shipped per component
+
+# What each component's probes actually resolve to with default values — the
+# deployed contract, as opposed to tests/probe_test.yaml, which exercises the
+# `opik.probe` helper's own modes and defaults.
+#
+# Worth pinning per component because the consequences differ: backend's probes
+# gate the API's rollout, python-backend's keep a starting pod out of the
+# Service's endpoints (without them a rolling update made the backend's
+# evaluator calls fail with "connection refused"), and frontend deliberately has
+# none — asserting that keeps the helper suite's clean-slate vehicle honest.
+templates:
+  - templates/deployment.yaml
+
+tests:
+  # ---- backend --------------------------------------------------------------
+  - it: backend probes point at the dropwizard health-check endpoints
+    documentSelector:
+      path: metadata.name
+      value: opik-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health-check?name=all&type=alive
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health-check?name=all&type=ready
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
+      # Readiness waits for the app to boot; liveness has no delay of its own.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 20
+
+  # ---- python-backend -------------------------------------------------------
+  - it: python-backend readiness gates the endpoint on the app answering
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
+      # taken out of the endpoint list.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+
+  - it: python-backend liveness uses the app's liveness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+
+  - it: python-backend drains before exiting so terminating pods leave the endpoints
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 5
+
+  # ---- frontend -------------------------------------------------------------
+  - it: frontend ships no probes
+    documentSelector:
+      path: metadata.name
+      value: opik-frontend
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -198,7 +198,10 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *pyb
+    # frontend, not python-backend: the latter ships a startupProbe of its own.
+    documentSelector:
+      path: metadata.name
+      value: opik-frontend
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
@@ -206,6 +209,9 @@ tests:
   - it: startupProbe renders in simplified mode
     set:
       component.python-backend.startupProbe:
+        # Cleared so the assertion below sees the helper's default, not the
+        # periodSeconds python-backend ships.
+        periodSeconds: null
         path: /healthcheck
         port: 8000
         failureThreshold: 30

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,26 +7,28 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Tests target the `python-backend` component: it has NO probe defined in
-# values.yaml, so each test's `set` is a clean probe spec rather than a deep
-# merge over a pre-existing httpGet default (which would leak into full-mode
-# assertions). The deployment renders one document per enabled component, so we
-# select the python-backend deployment by name and read its single container.
+# Tests target the `frontend` component: it is the only one with NO probe
+# defined in values.yaml, so each test's `set` is a clean probe spec rather than
+# a deep merge over a pre-existing httpGet default (which would leak into
+# full-mode assertions). The deployment renders one document per enabled
+# component, so we select the frontend deployment by name and read its first
+# container. The probes that `backend` and `python-backend` ship by default are
+# asserted at the bottom of this suite instead.
 templates:
   - templates/deployment.yaml
 
-documentSelector: &pyb
+documentSelector: &frontend
   path: metadata.name
-  value: opik-python-backend
+  value: opik-frontend
 
 tests:
   # ---- Simplified mode: only path/port set ----------------------------------
   - it: simplified mode renders httpGet with the Accept header
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -42,10 +44,10 @@ tests:
 
   - it: simplified mode fills in the hard-coded timing defaults
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
@@ -62,10 +64,10 @@ tests:
 
   - it: simplified mode defaults initialDelaySeconds to 0 when unset
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -73,11 +75,11 @@ tests:
 
   - it: simplified mode honors initialDelaySeconds when set
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
         initialDelaySeconds: 20
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -85,14 +87,14 @@ tests:
 
   - it: simplified mode honors overridden timing fields
     set:
-      component.python-backend.readinessProbe:
+      component.frontend.readinessProbe:
         path: /healthcheck
         port: 8000
         timeoutSeconds: 5
         periodSeconds: 30
         successThreshold: 3
         failureThreshold: 6
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
@@ -110,7 +112,7 @@ tests:
   # ---- Full-definition mode: spec emitted verbatim --------------------------
   - it: full httpGet definition is emitted verbatim and not overwritten
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         httpGet:
           path: /custom/health
           port: 9999
@@ -120,7 +122,7 @@ tests:
         timeoutSeconds: 7
         periodSeconds: 11
         failureThreshold: 4
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -143,14 +145,14 @@ tests:
 
   - it: full exec definition is emitted verbatim
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
             - curl -f http://localhost:8000/healthcheck
         initialDelaySeconds: 15
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
@@ -166,11 +168,11 @@ tests:
 
   - it: full tcpSocket definition is emitted verbatim
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         tcpSocket:
           port: 8000
         periodSeconds: 20
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
@@ -183,18 +185,18 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
   - it: startupProbe renders in simplified mode
     set:
-      component.python-backend.startupProbe:
+      component.frontend.startupProbe:
         path: /healthcheck
         port: 8000
         failureThreshold: 30
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -217,13 +219,13 @@ tests:
 
   - it: startupProbe renders in full-definition mode
     set:
-      component.python-backend.startupProbe:
+      component.frontend.startupProbe:
         httpGet:
           path: /startup
           port: 8000
         periodSeconds: 5
         failureThreshold: 60
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -234,3 +236,57 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
+
+  # ---- Shipped defaults: probes the chart configures out of the box ---------
+  # python-backend previously had none, so a rolling update put pods into the
+  # Service's endpoints before gunicorn was listening and the backend's
+  # evaluator calls got "connection refused".
+  - it: python-backend ships a readiness probe on the app's readiness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
+      # taken out of the endpoint list.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+
+  - it: python-backend ships a liveness probe on the app's liveness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 15
+
+  - it: python-backend ships a preStop sleep so terminating pods drain
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 5

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,13 +7,17 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Tests target the `frontend` component: it is the only one with NO probe
-# defined in values.yaml, so each test's `set` is a clean probe spec rather than
-# a deep merge over a pre-existing httpGet default (which would leak into
-# full-mode assertions). The deployment renders one document per enabled
-# component, so we select the frontend deployment by name and read its first
-# container. The probes that `backend` and `python-backend` ship by default are
-# asserted at the bottom of this suite instead.
+# Two groups, because the helper behaves differently depending on what the
+# component already has in values.yaml:
+#   * `frontend` has NO probe, so each `set` is a clean spec — the right vehicle
+#     for asserting the helper's own modes and defaults in isolation.
+#   * `python-backend` DOES ship probes, so a `set` deep-merges over them. That
+#     is the operator-facing path (overriding a shipped probe) and it has its own
+#     group below, including the explicit nulls an override needs.
+# The deployment renders one document per enabled component, so each test selects
+# its component's deployment by name and reads the first container. What each
+# component ships by default is a separate concern, asserted in
+# tests/component_probes_test.yaml.
 templates:
   - templates/deployment.yaml
 
@@ -237,56 +241,86 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
 
-  # ---- Shipped defaults: probes the chart configures out of the box ---------
-  # python-backend previously had none, so a rolling update put pods into the
-  # Service's endpoints before gunicorn was listening and the backend's
-  # evaluator calls got "connection refused".
-  - it: python-backend ships a readiness probe on the app's readiness endpoint
+  # ---- Overriding a component that already ships probes ---------------------
+  # values.yaml merges, so an override inherits whatever the component ships
+  # unless the inherited keys are explicitly nulled. These cover that path for
+  # python-backend, which ships httpGet + timings.
+  - it: partial override merges over the shipped probe rather than replacing it
+    set:
+      component.python-backend.readinessProbe:
+        periodSeconds: 30
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
+      # The shipped endpoint survives — only the named field changes.
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /health/readiness
       - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: 8000
-      - equal:
           path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 10
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
-          value: 3
-      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
-      # taken out of the endpoint list.
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
-          value: 3
+          value: 30
 
-  - it: python-backend ships a liveness probe on the app's liveness endpoint
+  - it: nulling the shipped keys returns the probe to simplified mode
+    set:
+      component.python-backend.livenessProbe:
+        httpGet: null
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
+        path: /healthcheck
+        port: 8000
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /health/liveness
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: 8000
+          value: /healthcheck
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders
+          content:
+            name: Accept
+            value: application/json
+      # Helper defaults apply again, not the shipped periodSeconds 15 / timeout 3.
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.periodSeconds
-          value: 15
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 2
 
-  - it: python-backend ships a preStop sleep so terminating pods drain
+  - it: a full-definition override drops the shipped httpGet when it is nulled
+    set:
+      component.python-backend.livenessProbe:
+        httpGet: null
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - curl -f http://localhost:8000/healthcheck
+        initialDelaySeconds: 15
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
           value:
             - /bin/sh
             - -c
-            - sleep 5
+            - curl -f http://localhost:8000/healthcheck
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 15
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      # Full mode emits the spec verbatim — no simplified-mode defaults injected.
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.successThreshold

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,32 +7,32 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Two groups, because the helper behaves differently depending on what the
-# component already has in values.yaml:
-#   * `frontend` has NO probe, so each `set` is a clean spec — the right vehicle
-#     for asserting the helper's own modes and defaults in isolation.
-#   * `python-backend` DOES ship probes, so a `set` deep-merges over them. That
-#     is the operator-facing path (overriding a shipped probe) and it has its own
-#     group below, including the explicit nulls an override needs.
+# Tests target the `python-backend` component. It ships probes of its own, so a
+# `set` deep-merges over them: the three tests whose assertions would otherwise
+# see an inherited value null the specific keys they need cleared (simplified
+# mode ignores an inherited httpGet, since it builds its own from path/port, but
+# full mode emits the whole map verbatim). A small `frontend` group at the bottom
+# pins the same helper behaviour on a component with nothing to inherit, and one
+# python-backend test covers the merge itself. What each component ships by
+# default is a separate concern, asserted in tests/component_probes_test.yaml.
+#
 # The deployment renders one document per enabled component, so each test selects
-# its component's deployment by name and reads the first container. What each
-# component ships by default is a separate concern, asserted in
-# tests/component_probes_test.yaml.
+# its component's deployment by name and reads the first container.
 templates:
   - templates/deployment.yaml
 
-documentSelector: &frontend
+documentSelector: &pyb
   path: metadata.name
-  value: opik-frontend
+  value: opik-python-backend
 
 tests:
   # ---- Simplified mode: only path/port set ----------------------------------
   - it: simplified mode renders httpGet with the Accept header
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -48,10 +48,15 @@ tests:
 
   - it: simplified mode fills in the hard-coded timing defaults
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Cleared so the assertions below see the helper's defaults rather than
+        # the timings python-backend ships.
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
@@ -68,10 +73,10 @@ tests:
 
   - it: simplified mode defaults initialDelaySeconds to 0 when unset
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -79,11 +84,11 @@ tests:
 
   - it: simplified mode honors initialDelaySeconds when set
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
         initialDelaySeconds: 20
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -91,14 +96,14 @@ tests:
 
   - it: simplified mode honors overridden timing fields
     set:
-      component.frontend.readinessProbe:
+      component.python-backend.readinessProbe:
         path: /healthcheck
         port: 8000
         timeoutSeconds: 5
         periodSeconds: 30
         successThreshold: 3
         failureThreshold: 6
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
@@ -116,7 +121,7 @@ tests:
   # ---- Full-definition mode: spec emitted verbatim --------------------------
   - it: full httpGet definition is emitted verbatim and not overwritten
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         httpGet:
           path: /custom/health
           port: 9999
@@ -126,7 +131,7 @@ tests:
         timeoutSeconds: 7
         periodSeconds: 11
         failureThreshold: 4
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -149,14 +154,16 @@ tests:
 
   - it: full exec definition is emitted verbatim
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Full mode emits the map verbatim, so the shipped httpGet has to go.
+        httpGet: null
         exec:
           command:
             - /bin/sh
             - -c
             - curl -f http://localhost:8000/healthcheck
         initialDelaySeconds: 15
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
@@ -172,11 +179,13 @@ tests:
 
   - it: full tcpSocket definition is emitted verbatim
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Full mode emits the map verbatim, so the shipped httpGet has to go.
+        httpGet: null
         tcpSocket:
           port: 8000
         periodSeconds: 20
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
@@ -189,18 +198,18 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
   - it: startupProbe renders in simplified mode
     set:
-      component.frontend.startupProbe:
+      component.python-backend.startupProbe:
         path: /healthcheck
         port: 8000
         failureThreshold: 30
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -223,13 +232,13 @@ tests:
 
   - it: startupProbe renders in full-definition mode
     set:
-      component.frontend.startupProbe:
+      component.python-backend.startupProbe:
         httpGet:
           path: /startup
           port: 8000
         periodSeconds: 5
         failureThreshold: 60
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -241,86 +250,70 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
 
-  # ---- Overriding a component that already ships probes ---------------------
-  # values.yaml merges, so an override inherits whatever the component ships
-  # unless the inherited keys are explicitly nulled. These cover that path for
-  # python-backend, which ships httpGet + timings.
-  - it: partial override merges over the shipped probe rather than replacing it
+  # ---- The same helper on a component with nothing to inherit ---------------
+  # frontend defines no probe in values.yaml, so these need none of the nulls
+  # above — which is what separates helper behaviour from merge behaviour.
+  - it: simplified mode on a probe-less component needs no clearing
     set:
-      component.python-backend.readinessProbe:
-        periodSeconds: 30
-    documentSelector:
-      path: metadata.name
-      value: opik-python-backend
-    asserts:
-      # The shipped endpoint survives — only the named field changes.
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /health/readiness
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 30
-
-  - it: nulling the shipped keys returns the probe to simplified mode
-    set:
-      component.python-backend.livenessProbe:
-        httpGet: null
-        periodSeconds: null
-        timeoutSeconds: null
-        failureThreshold: null
+      component.frontend.livenessProbe:
         path: /healthcheck
-        port: 8000
-    documentSelector:
+        port: 5173
+    documentSelector: &frontend
       path: metadata.name
-      value: opik-python-backend
+      value: opik-frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /healthcheck
-      - contains:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders
-          content:
-            name: Accept
-            value: application/json
-      # Helper defaults apply again, not the shipped periodSeconds 15 / timeout 3.
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
-          value: 10
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 5173
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 2
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 10
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 2
 
-  - it: a full-definition override drops the shipped httpGet when it is nulled
+  - it: full definition on a probe-less component carries no inherited httpGet
     set:
-      component.python-backend.livenessProbe:
-        httpGet: null
-        periodSeconds: null
-        timeoutSeconds: null
-        failureThreshold: null
+      component.frontend.livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
-            - curl -f http://localhost:8000/healthcheck
+            - curl -f http://localhost:5173/
         initialDelaySeconds: 15
-    documentSelector:
-      path: metadata.name
-      value: opik-python-backend
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
           value:
             - /bin/sh
             - -c
-            - curl -f http://localhost:8000/healthcheck
+            - curl -f http://localhost:5173/
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 15
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe.httpGet
-      # Full mode emits the spec verbatim — no simplified-mode defaults injected.
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe.successThreshold
+
+  # ---- The merge itself, for a component that ships probes ------------------
+  - it: a partial override merges over the shipped probe rather than replacing it
+    set:
+      component.python-backend.readinessProbe:
+        periodSeconds: 30
+    documentSelector: *pyb
+    asserts:
+      # Only the named field changes; the shipped endpoint survives.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 30

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -270,12 +270,16 @@ component:
         path: /health/liveness
         port: 8000
       periodSeconds: 15
+      # Above the 1s Kubernetes default: gunicorn under load can take longer than
+      # a second to answer, and a probe timeout counts as a failure.
+      timeoutSeconds: 3
       failureThreshold: 3
     readinessProbe:
       httpGet:
         path: /health/readiness
         port: 8000
       periodSeconds: 10
+      timeoutSeconds: 3
       failureThreshold: 3
     lifecycle:
       preStop:

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -259,6 +259,28 @@ component:
           selectPolicy: Max
     backendConfigMap:
       enabled: true
+    # Without a readiness probe a pod joins the Service's endpoints as soon as its container
+    # starts, so during a rollout the backend's evaluator calls reach a gunicorn that is not
+    # listening yet and get "connection refused" (HttpHostConnectException) — the backend's four
+    # retries span only ~3.5s, less than a pod takes to boot. Readiness gates the endpoint on the
+    # app actually answering; the preStop sleep covers the other side of the race, giving
+    # kube-proxy time to drop a terminating pod from the endpoint list before the process exits.
+    livenessProbe:
+      httpGet:
+        path: /health/liveness
+        port: 8000
+      periodSeconds: 15
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health/readiness
+        port: 8000
+      periodSeconds: 10
+      failureThreshold: 3
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 5"]
     podDisruptionBudget:
       enabled: false
     # Init container that blocks startup until Redis is reachable. Rendered only

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -265,6 +265,23 @@ component:
     # retries span only ~3.5s, less than a pod takes to boot. Readiness gates the endpoint on the
     # app actually answering; the preStop sleep covers the other side of the race, giving
     # kube-proxy time to drop a terminating pod from the endpoint list before the process exits.
+    #
+    # Overriding any of these replaces only the keys you set — Helm merges the rest of the map in
+    # from here. Set every field you care about, or null the ones you want gone
+    # (`httpGet: null`, `periodSeconds: null`, ...).
+    #
+    # The startup probe is what makes the liveness probe safe: with
+    # PYTHON_CODE_EXECUTOR_STRATEGY=docker, entrypoint.sh waits up to 30s for dockerd and then
+    # loads the sandbox executor image before gunicorn binds, so liveness alone (15s x 3) could
+    # restart the pod before it ever finished starting. Kubernetes suppresses both liveness and
+    # readiness until the startup probe passes, and 5s x 60 gives startup five minutes.
+    startupProbe:
+      httpGet:
+        path: /health/liveness
+        port: 8000
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 60
     livenessProbe:
       httpGet:
         path: /health/liveness

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -629,11 +629,12 @@ areas:
       - online-evaluation/online-evaluation-smoke.spec.ts
       - online-evaluation/online-evaluation-delete-rule.spec.ts
       - online-evaluation/online-evaluation-enable-disable-rule.spec.ts
+      - online-evaluation/online-evaluation-non-object-output-mapping.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
       llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
       create-python-rule:      { covered: true,  tier: t1-smoke }
-      python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0" }
+      python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0; non-object-output-mapping adds the variable-mapping half at t2-cuj — object/string/array/number/array-of-objects sections against output.answer and output.[0].name" }
       scores-in-trace-panel:   { covered: true,  tier: t1-smoke }
       list-rules:              { covered: false }
       rule-scope-thread-span:  { covered: false, note: "span/thread scope flags" }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -88,6 +88,13 @@ export interface TraceDetail {
    * collapse them.
    */
   input: Record<string, unknown> | null;
+  /**
+   * The trace's `output` payload. Deliberately *not* narrowed to a record the
+   * way `input` is: the column is a `JsonNode`, so a bare string, an array or a
+   * number are all legitimate values, and a record type would make the shapes
+   * a variable-mapping test exists to drive unrepresentable.
+   */
+  output: unknown;
 }
 
 /** One conversation thread as `GET /v1/private/traces/threads/retrieve` answers it. */
@@ -102,6 +109,22 @@ export interface AutomationRuleRef {
   name: string;
   projectIds: string[];
   enabled: boolean;
+}
+
+/**
+ * One line of `GET /v1/private/automations/evaluators/{id}/logs` — the
+ * automation log a user reads to find out why a trace was or wasn't scored.
+ *
+ * `traceId` is lifted out of the line's `markers` map because that is the only
+ * thing that ties a log line to a trace: the message text carries the id too,
+ * but only as a substring of free-form prose. `level` is kept as the raw string
+ * the backend sends rather than a union, so an unexpected level fails an
+ * assertion loudly instead of being narrowed away at the boundary.
+ */
+export interface AutomationRuleLogItem {
+  level: string;
+  message: string;
+  traceId: string | null;
 }
 
 export interface AnnotationQueueReviewerRef {
@@ -252,6 +275,7 @@ export function makeBackendClient(apiKey: string | null = null) {
           source: String(fs.source),
         })),
         input: (t.input as Record<string, unknown> | undefined) ?? null,
+        output: (t.output as unknown) ?? null,
       };
     } catch (err) {
       if (isNotFoundError(err)) return null;
@@ -575,6 +599,74 @@ export function makeBackendClient(apiKey: string | null = null) {
     },
 
     /**
+     * Create a `user_defined_metric_python` rule with an explicit variable
+     * mapping and return its id.
+     *
+     * The create-rule dialog is the only path the existing online-evaluation
+     * specs use, and it can't express this: `arguments` is where the trace
+     * section a variable resolves against is chosen (`output.answer`,
+     * `output.[0].name`), which is exactly what a mapping test has to own.
+     *
+     * The id comes from a read-back rather than the write, because
+     * `POST /v1/private/automations/evaluators` answers 201 with no body.
+     */
+    async createPythonMetricRule(args: {
+      projectId: string;
+      name: string;
+      /** Python source declaring one BaseMetric subclass. */
+      metric: string;
+      /** Metric kwarg name -> trace JSON path, e.g. `{ answer: 'output.answer' }`. */
+      arguments: Record<string, string>;
+      samplingRate?: number;
+    }): Promise<string> {
+      await opik.api.automationRuleEvaluators.createAutomationRuleEvaluator({
+        type: 'user_defined_metric_python',
+        action: 'evaluator',
+        name: args.name,
+        projectIds: [args.projectId],
+        samplingRate: args.samplingRate ?? 1.0,
+        enabled: true,
+        code: { metric: args.metric, arguments: args.arguments },
+      });
+
+      const page = await opik.api.automationRuleEvaluators.findEvaluators({
+        projectId: args.projectId,
+        name: args.name,
+        size: 500,
+      });
+      const created = (page.content ?? []).filter((r) => r.name === args.name);
+      if (created.length !== 1) {
+        throw new Error(
+          `createPythonMetricRule: expected exactly 1 rule named "${args.name}" in project ` +
+            `${args.projectId} after creating it, found ${created.length}`,
+        );
+      }
+      return String(created[0].id);
+    },
+
+    /**
+     * Every line of a rule's automation log, newest first (the order the
+     * backend returns and the automation-logs page renders).
+     *
+     * `size` is deliberately large: the log is what proves a scoring run
+     * produced no errors, and a truncated page would turn a missing ERROR line
+     * into a silent pass.
+     */
+    async getAutomationRuleLogs(
+      ruleId: string,
+      opts: { size?: number } = {},
+    ): Promise<AutomationRuleLogItem[]> {
+      const page = await opik.api.automationRuleEvaluators.getEvaluatorLogsById(ruleId, {
+        size: opts.size ?? 1000,
+      });
+      return (page.content ?? []).map((item) => ({
+        level: String(item.level ?? ''),
+        message: item.message ?? '',
+        traceId: item.markers?.trace_id ?? null,
+      }));
+    },
+
+    /**
      * One page of `GET /v1/private/traces/threads` — the exact read the Threads
      * view issues, including its `filters` and time window.
      *
@@ -715,6 +807,71 @@ export function makeBackendClient(apiKey: string | null = null) {
         ...(args.input ? { input: args.input } : {}),
         ...(args.output ? { output: args.output } : {}),
       });
+      return args.id;
+    },
+
+    /**
+     * Create a completed trace whose `output` is an arbitrary JSON value — a
+     * bare string, an array, a number — and not only the object shape every
+     * other seeding path in this suite produces.
+     *
+     * `output` is a `JsonNode` on the wire and the backend accepts any JSON
+     * value there, but no route this suite already has can say so:
+     *
+     *  - the Python SDK bridge wraps a decorated function's return as
+     *    `{"output": ...}`, so everything it seeds is an object;
+     *  - `createTraceWithSource` types `output` as a record;
+     *  - the pinned TS SDK's own `traces.createTrace` narrows it to
+     *    `object | object[] | string` and *validates that at runtime*, so a
+     *    cast doesn't help — `["a","b"]` and `42` are rejected client-side
+     *    before a request is made.
+     *
+     * Hence the raw fetch, the same escape hatch `getProjectStats` above takes
+     * for the same reason. Switch to the typed call once the SDK's `output`
+     * type admits a whole JsonNode.
+     *
+     * `end_time` is always sent: `OnlineScoringSampler.onTracesCreated` drops
+     * traces with no end time as partial, so a trace seeded without one is
+     * never scored at all and every downstream assertion would time out on a
+     * score that was never coming.
+     */
+    async createTraceWithJsonOutput(args: {
+      id: string;
+      projectName: string;
+      name: string;
+      input: Record<string, unknown>;
+      output: unknown;
+      startTime?: Date;
+    }): Promise<string> {
+      const startTime = args.startTime ?? new Date();
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'Comet-Workspace': env.workspace,
+      };
+      const key = apiKey ?? env.apiKey;
+      if (key) headers['Authorization'] = key;
+
+      const res = await fetch(`${env.apiBaseUrl}/v1/private/traces`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          id: args.id,
+          project_name: args.projectName,
+          name: args.name,
+          source: 'sdk',
+          start_time: startTime.toISOString(),
+          end_time: new Date(startTime.getTime() + 1_000).toISOString(),
+          input: args.input,
+          output: args.output,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `POST /v1/private/traces -> ${res.status}: ${(await res.text()).slice(0, 300)}`,
+        );
+      }
       return args.id;
     },
 

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -12,6 +12,7 @@ export {
   type FeedbackScoreRef,
   type TraceDetail,
   type AutomationRuleRef,
+  type AutomationRuleLogItem,
   type AnnotationQueueDetail,
   type AnnotationQueueReviewerRef,
   type ThreadRowRef,

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './evaluated-thread.fixture';
+export { test, expect } from './python-metric-rule.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -65,4 +65,10 @@ export type {
   ThreadEvaluationRunRef,
   EvaluatedThreadFixtures,
 } from './evaluated-thread.fixture';
+export type {
+  PythonMetricRuleRef,
+  PythonMetricRuleFactory,
+  PythonMetricRuleFixtures,
+  CreatePythonMetricRuleSeed,
+} from './python-metric-rule.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/python-metric-rule.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/python-metric-rule.fixture.ts
@@ -1,0 +1,98 @@
+import { test as baseTest } from './evaluated-thread.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface PythonMetricRuleRef {
+  id: string;
+  /** The rule's name, as the Online evaluation list renders it. */
+  name: string;
+  /**
+   * The name the metric stamps on its `ScoreResult`, which is the name the
+   * feedback score lands under. The engine ignores the rule name here, so the
+   * two are tracked separately and both are needed to assert on a scored trace.
+   */
+  scoreName: string;
+}
+
+export interface CreatePythonMetricRuleSeed {
+  /** Suffix appended to the test namespace; keep it short and unique per rule. */
+  suffix: string;
+  /**
+   * Metric kwarg name -> the trace JSON path it resolves against, e.g.
+   * `{ q: 'input.x', answer: 'output.answer' }`. This is the mapping the
+   * Online evaluation rule form calls "variables".
+   */
+  arguments: Record<string, string>;
+  /**
+   * Python source for the rule, given the score name to stamp on its
+   * `ScoreResult`. Exactly one `BaseMetric` subclass may be declared: the
+   * python_evaluator backend picks the first subclass in the module
+   * alphabetically, so an extra import would shadow it.
+   */
+  buildMetric(scoreName: string): string;
+  samplingRate?: number;
+}
+
+export interface PythonMetricRuleFactory {
+  create(seed: CreatePythonMetricRuleSeed): Promise<PythonMetricRuleRef>;
+}
+
+export interface PythonMetricRuleFixtures {
+  pythonMetricRules: PythonMetricRuleFactory;
+}
+
+/**
+ * Creates `user_defined_metric_python` online-evaluation rules on the fixture
+ * project, over the REST write rather than the create-rule dialog — the dialog
+ * cannot set a rule's variable mapping, which is the thing a mapping test owns.
+ *
+ * A factory rather than a single rule because the interesting scenarios need
+ * two or more rules scoring the same traces, and every rule has to exist
+ * *before* its traces are seeded: the sampler only ever sees trace-created and
+ * trace-updated events, so a rule created afterwards never backfills.
+ *
+ * Teardown is here rather than in a trailing `test.step`: automation rules do
+ * not cascade when their project is deleted and `global-teardown`'s run-prefix
+ * sweep does not know about them, so a rule left behind by a failing test
+ * outlives the run. A step at the end of the test is skipped the moment an
+ * earlier step throws — which is exactly when the leak happens.
+ */
+export const test = baseTest.extend<PythonMetricRuleFixtures>({
+  pythonMetricRules: async ({ project, backendClient, testNamespace }, use, testInfo) => {
+    const created: PythonMetricRuleRef[] = [];
+
+    const factory: PythonMetricRuleFactory = {
+      async create(seed) {
+        const name = `${testNamespace}-${seed.suffix}`;
+        const id = await backendClient.createPythonMetricRule({
+          projectId: project.id,
+          name,
+          metric: seed.buildMetric(name),
+          arguments: seed.arguments,
+          samplingRate: seed.samplingRate,
+        });
+        const ref: PythonMetricRuleRef = { id, name, scoreName: name };
+        created.push(ref);
+        return ref;
+      },
+    };
+
+    await use(factory);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      for (const rule of created) {
+        try {
+          await backendClient.deleteAutomationRule(project.id, rule.id);
+        } catch (err) {
+          console.warn(`[pythonMetricRules fixture] delete warning for ${rule.name}:`, err);
+        }
+      }
+    } else {
+      await testInfo.attach('opik.pythonMetricRules', {
+        body: JSON.stringify(created, null, 2),
+        contentType: 'application/json',
+      });
+    }
+  },
+});
+
+export { expect } from './evaluated-thread.fixture';

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-non-object-output-mapping.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-non-object-output-mapping.spec.ts
@@ -1,0 +1,297 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+import { uuid7 } from '@e2e/core/backend';
+
+/**
+ * A rule variable maps to a path inside a trace section (`output.answer`). When
+ * the section is not a JSON object — a bare string, an array, a number — the
+ * path cannot resolve. The contract is that the variable is simply dropped and
+ * the metric still runs on whatever else resolved; the regression this covers
+ * is the whole evaluation aborting instead, which a user only ever sees as a
+ * trace that silently never got a score.
+ *
+ * Two rules run over the same five traces so both halves of the contract are
+ * asserted on the same data: `output.answer` resolves only against the object
+ * output, and `output.[0].name` resolves only against the array-of-objects one.
+ * Every other pairing is an unresolvable path over a section of some other
+ * shape, and every one of them must still produce a score.
+ */
+
+/** The metric's answer when its `answer` kwarg resolved. */
+const RESOLVED = 1.0;
+/** The metric's answer when `answer` was dropped and defaulted. */
+const DROPPED = 0.5;
+
+interface OutputShape {
+  /** Suffix for the trace name; also the key results are collated under. */
+  key: string;
+  output: unknown;
+  /** What `output.answer` resolves to for this shape, or null if it cannot. */
+  nestedAnswer: string | null;
+  /** What `output.[0].name` resolves to for this shape, or null if it cannot. */
+  indexedAnswer: string | null;
+}
+
+const OUTPUT_SHAPES: OutputShape[] = [
+  { key: 'object', output: { answer: 'forty two' }, nestedAnswer: 'forty two', indexedAnswer: null },
+  { key: 'bare-string', output: 'how can I help?', nestedAnswer: null, indexedAnswer: null },
+  { key: 'string-array', output: ['a', 'b'], nestedAnswer: null, indexedAnswer: null },
+  { key: 'number', output: 42, nestedAnswer: null, indexedAnswer: null },
+  {
+    key: 'object-array',
+    output: [{ name: 'first' }, { name: 'second' }],
+    nestedAnswer: null,
+    indexedAnswer: 'first',
+  },
+];
+
+const INPUT = { x: 'seed-question' };
+
+/**
+ * A metric that reports which of its two mapped variables actually arrived.
+ *
+ * `answer` carries a default so a dropped variable is a *value* the metric can
+ * report rather than a `TypeError` — the reason string is what turns "scored
+ * 0.5" into "scored 0.5 because `answer` never resolved", which is the whole
+ * claim of this test. A metric that declared `answer` with no default would
+ * fail instead, and that boundary belongs to a different test.
+ *
+ * Only one `BaseMetric` subclass is declared and nothing else is imported:
+ * `get_metric_class` in the python_evaluator backend takes the first subclass
+ * in the module alphabetically, so an extra import would shadow this one.
+ */
+function buildMappingProbeMetric(scoreName: string): string {
+  return `from typing import Any
+from opik.evaluation.metrics import base_metric, score_result
+
+SCORE_NAME = ${JSON.stringify(scoreName)}
+
+class MappingProbe(base_metric.BaseMetric):
+    def __init__(self, name: str = SCORE_NAME):
+        self.name = name
+
+    def score(self, q: str = "<unmapped>", answer: Any = None, **ignored_kwargs: Any) -> score_result.ScoreResult:
+        value = ${RESOLVED} if answer is not None else ${DROPPED}
+        return score_result.ScoreResult(value=value, name=self.name, reason=f"q={q!r} answer={answer!r}")`;
+}
+
+/** The reason string `MappingProbe` stamps for a given resolved `answer`. */
+function expectedReason(answer: string | null): string {
+  const rendered = answer === null ? 'None' : `'${answer}'`;
+  return `q='${INPUT.x}' answer=${rendered}`;
+}
+
+test.describe(
+  'Online Evaluation — variable mapping over non-object trace sections',
+  { tag: ['@t2-cuj', '@area:online-evaluation'] },
+  () => {
+    test(
+      'A Python rule scores every trace whether or not its mapped path resolves, and drops only the unresolvable variable',
+      { tag: ['@cap:online-evaluation.python-rule-scores'] },
+      async ({ project, backendClient, pythonMetricRules, page }) => {
+        // Two async waits dominate: the scores poll (120s) and the log poll
+        // (60s). The ceiling sits above their sum so a stall fails inside the
+        // step that stalled, naming the trace and the scores actually seen,
+        // rather than as an opaque test timeout. Runs in ~40-60s in practice.
+        test.setTimeout(300_000);
+
+        // Both rules must exist before any trace is seeded: the sampler only
+        // sees trace-created/updated events, so a rule created afterwards never
+        // scores what already landed.
+        const nestedRule = await test.step(
+          'Create a rule mapping answer -> output.answer',
+          async () =>
+            pythonMetricRules.create({
+              suffix: 'nested',
+              arguments: { q: 'input.x', answer: 'output.answer' },
+              buildMetric: buildMappingProbeMetric,
+            }),
+        );
+
+        const indexedRule = await test.step(
+          'Create a rule mapping answer -> output.[0].name',
+          async () =>
+            pythonMetricRules.create({
+              suffix: 'indexed',
+              arguments: { q: 'input.x', answer: 'output.[0].name' },
+              buildMetric: buildMappingProbeMetric,
+            }),
+        );
+
+        const traceIds = new Map<string, string>();
+        await test.step(
+          'Seed five traces with the same input and five differently-shaped outputs',
+          async () => {
+            await Promise.all(
+              OUTPUT_SHAPES.map(async (shape) => {
+                const id = uuid7();
+                await backendClient.createTraceWithJsonOutput({
+                  id,
+                  projectName: project.name,
+                  name: `${nestedRule.name}-${shape.key}`,
+                  input: INPUT,
+                  output: shape.output,
+                });
+                traceIds.set(shape.key, id);
+              }),
+            );
+          },
+        );
+
+        await test.step(
+          'The seeded outputs really are the shapes this test needs',
+          async () => {
+            // A fixture that silently normalised `42` or `"how can I help?"`
+            // into an object would leave every assertion below passing against
+            // the one shape that was never in question.
+            for (const shape of OUTPUT_SHAPES) {
+              const stored = await backendClient.getTrace(traceIds.get(shape.key)!);
+              expect(stored, `trace for ${shape.key} was written`).not.toBeNull();
+              expect(stored!.output, `stored output for ${shape.key}`).toEqual(shape.output);
+            }
+          },
+        );
+
+        // scores[shapeKey][scoreName] = { value, reason }
+        const scores = new Map<string, Map<string, { value: number; reason: string | null }>>();
+        await test.step(
+          'Poll every trace for both rules, in parallel (120s budget each)',
+          async () => {
+            await Promise.all(
+              OUTPUT_SHAPES.map(async (shape) => {
+                const traceId = traceIds.get(shape.key)!;
+                const [nested, indexed] = await Promise.all([
+                  backendClient.pollTraceForFeedbackScore(traceId, nestedRule.scoreName, {
+                    timeoutMs: 120_000,
+                  }),
+                  backendClient.pollTraceForFeedbackScore(traceId, indexedRule.scoreName, {
+                    timeoutMs: 120_000,
+                  }),
+                ]);
+                scores.set(
+                  shape.key,
+                  new Map([
+                    [nestedRule.scoreName, { value: nested.value, reason: nested.reason }],
+                    [indexedRule.scoreName, { value: indexed.value, reason: indexed.reason }],
+                  ]),
+                );
+              }),
+            );
+          },
+        );
+
+        await test.step(
+          'Every trace is scored by both rules — a non-object section must not abort the evaluation',
+          async () => {
+            // The regression is total absence of a score, so the count is the
+            // assertion: naming the shapes that did score would pass on a run
+            // where four of five were silently skipped.
+            expect(
+              [...scores.keys()].sort(),
+              'all five shapes produced scores',
+            ).toEqual(OUTPUT_SHAPES.map((s) => s.key).sort());
+            for (const shape of OUTPUT_SHAPES) {
+              expect(
+                [...scores.get(shape.key)!.keys()].sort(),
+                `both rules scored the ${shape.key} trace`,
+              ).toEqual([nestedRule.scoreName, indexedRule.scoreName].sort());
+            }
+          },
+        );
+
+        await test.step(
+          'Each rule resolves its variable for exactly the shape it can address, and drops it everywhere else',
+          async () => {
+            for (const shape of OUTPUT_SHAPES) {
+              const byRule = scores.get(shape.key)!;
+
+              const nested = byRule.get(nestedRule.scoreName)!;
+              expect(nested.value, `output.answer over ${shape.key}`).toBe(
+                shape.nestedAnswer === null ? DROPPED : RESOLVED,
+              );
+              expect(nested.reason, `output.answer reason over ${shape.key}`).toBe(
+                expectedReason(shape.nestedAnswer),
+              );
+
+              const indexed = byRule.get(indexedRule.scoreName)!;
+              expect(indexed.value, `output.[0].name over ${shape.key}`).toBe(
+                shape.indexedAnswer === null ? DROPPED : RESOLVED,
+              );
+              expect(indexed.reason, `output.[0].name reason over ${shape.key}`).toBe(
+                expectedReason(shape.indexedAnswer),
+              );
+            }
+          },
+        );
+
+        await test.step(
+          'Neither rule logged an error for any of the five traces',
+          async () => {
+            for (const rule of [nestedRule, indexedRule]) {
+              // The log is written on its own path, so a line can still be in
+              // flight when the score has landed. Wait until every seeded trace
+              // is represented before reading levels off it — otherwise "no
+              // ERROR line" is satisfied by a log that is merely empty.
+              await expect
+                .poll(
+                  async () => {
+                    const logs = await backendClient.getAutomationRuleLogs(rule.id);
+                    const seen = new Set(logs.map((l) => l.traceId));
+                    return [...traceIds.values()].filter((id) => seen.has(id)).length;
+                  },
+                  {
+                    message: `rule ${rule.name} logged a line for each of the 5 seeded traces`,
+                    timeout: 60_000,
+                  },
+                )
+                .toBe(OUTPUT_SHAPES.length);
+
+              const logs = await backendClient.getAutomationRuleLogs(rule.id);
+              const seededIds = new Set(traceIds.values());
+              const errors = logs.filter(
+                (l) => l.level === 'ERROR' && l.traceId !== null && seededIds.has(l.traceId),
+              );
+              expect(
+                errors.map((l) => `${l.traceId}: ${l.message}`),
+                `rule ${rule.name} must score every shape without erroring`,
+              ).toEqual([]);
+            }
+          },
+        );
+
+        await test.step(
+          'The trace panel renders the same values the API reported',
+          async () => {
+            const logs = new LogsPage(page);
+            await logs.goto(project.id);
+            await logs.waitForReady();
+
+            // The bare-string trace is the shape that used to score nothing at
+            // all, and the object-array trace is the one whose indexed path
+            // resolves — the negative and positive halves of the fix.
+            for (const key of ['bare-string', 'object-array']) {
+              const shape = OUTPUT_SHAPES.find((s) => s.key === key)!;
+              const panel = await logs.openTraceById(traceIds.get(key)!);
+              await panel.waitForFullyLoaded();
+              await panel.openFeedbackScoresTab();
+
+              for (const [rule, answer] of [
+                [nestedRule, shape.nestedAnswer],
+                [indexedRule, shape.indexedAnswer],
+              ] as const) {
+                await expect(
+                  panel.feedbackScoreRow(rule.scoreName),
+                  `${key}: exactly one ${rule.scoreName} row`,
+                ).toHaveCount(1);
+                expect(
+                  await panel.readFeedbackScoreValue(rule.scoreName),
+                  `${key}: ${rule.scoreName} in the panel`,
+                ).toBe(answer === null ? DROPPED : RESOLVED);
+              }
+            }
+          },
+        );
+      },
+    );
+  },
+);


### PR DESCRIPTION
> **Generated by the release QA side flow (release-test-proposal).** It is a
> **draft** and needs human review before merge. Nothing here has been reviewed
> by a person yet.

## Where this came from

Exploratory testing of **#7949 — `[OPIK-8045] [BE] fix: four online-scoring failures seen in production`**,
driven by hand against that PR's own deployed environment
(`https://pr-7949.dev.comet.com`, build `2.2.37-7949-merge-3035` — a fresh OSS
install, workspace `default`, no provider keys). The flow below was verified
manually there first; this PR turns the one strong candidate into a permanent
spec.

## Base branch — this targets #7949's branch, not `main`

`--base thiagoh/online-scoring-failure-fixes`, deliberately.

The spec asserts that a rule variable pointing into a **non-object** trace
section is dropped while the metric still runs. On `main` that path still throws
`IllegalArgumentException` out of `extractFromJson` past a `catch` naming the
wrong class, so the evaluation aborts and the trace is never scored — this spec
would fail there, on the very bug #7949 fixes. It belongs on top of the change
it tests. Written and run against **7619ed60df1c6e592726ac6221870d3039c09a49**,
that PR's head at the time.

Once #7949 merges, this can be rebased onto `main` unchanged.

## The spec

`tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-non-object-output-mapping.spec.ts`
— one test, `@t2-cuj @area:online-evaluation @cap:online-evaluation.python-rule-scores`.

**What it asserts.** Two `user_defined_metric_python` rules are created over
REST with explicit variable mappings — `answer -> output.answer` and
`answer -> output.[0].name` — and both score the same five traces, which share
an input and differ only in the shape of `output`:

| `output` | `output.answer` | `output.[0].name` |
|---|---|---|
| `{"answer": "forty two"}` | resolves → 1.0 | dropped → 0.5 |
| `"how can I help?"` | dropped → 0.5 | dropped → 0.5 |
| `["a", "b"]` | dropped → 0.5 | dropped → 0.5 |
| `42` | dropped → 0.5 | dropped → 0.5 |
| `[{"name":"first"}, {"name":"second"}]` | dropped → 0.5 | resolves → 1.0 |

Each rule's metric defaults its `answer` kwarg and reports what it received in
the score reason, so the spec asserts the exact `reason` string, not just the
value — `answer='forty two'` vs `answer=None` is the difference between "the
variable resolved" and "the variable was dropped but the metric still ran".

The regression being guarded is **total absence of a score**, so the spec
asserts the whole matrix (all five shapes × both rules) rather than picking its
rows out of a larger set: a run where four of five were silently skipped fails
on the collection comparison. It then asserts neither rule logged an `ERROR`
line for any seeded trace id — after polling until every trace is represented in
the log, so "no ERROR" can't be satisfied by a log that is merely empty — and
finally opens the bare-string and array-of-objects traces in the trace panel and
checks the rendered Feedback scores match the API.

`output.[0].name` resolving against an array-of-objects is worth calling out
separately: that is not an error being suppressed, it is a mapping shape that
was unreachable before, because the conversion threw before JsonPath ever ran.

**Verification.** Passed. Run twice against `https://pr-7949.dev.comet.com`:

```bash
cd tests_end_to_end/e2e
OPIK_DEPLOYMENT=oss OPIK_WORKSPACE=default OPIK_BASE_URL=https://pr-7949.dev.comet.com \
  npx playwright test tests/online-evaluation/online-evaluation-non-object-output-mapping.spec.ts --reporter=list
# 1 passed (10.0s) ... 1 passed (12.1s)
```

Also green: `npx tsc --noEmit`, and
`python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end`
→ `40 specs checked, 1 exempt, 0 problem(s)`. `online-evaluation-delete-rule.spec.ts`
was run alongside as a regression check on the shared fixture chain — also green.

<sub>One environment note, not a spec concern: that host ends in `comet.com`, so
the TS SDK demands an API key even though the install has no auth. The runs
above passed a placeholder `OPIK_API_KEY`. On a normal OSS target
(`http://localhost:5173`) no such variable is needed.</sub>

## Supporting changes

- **`backendClient.createTraceWithJsonOutput`** — seeds a trace whose `output`
  is an arbitrary JSON value. Needed because neither existing route can express
  one: the Python SDK bridge always wraps a decorated return as
  `{"output": ...}`, and the pinned TS SDK narrows `output` to
  `object | object[] | string` **and validates it at runtime**, rejecting
  `["a","b"]` and `42` client-side. Hence a raw fetch, the same escape hatch
  `getProjectStats` already takes. It always sends `end_time`, because
  `OnlineScoringSampler.onTracesCreated` drops end-time-less traces as partial
  and they are then never scored at all.
- **`backendClient.createPythonMetricRule` / `getAutomationRuleLogs`** — the
  create-rule dialog the existing specs drive cannot set a rule's `arguments`,
  which is the whole subject here.
- **`pythonMetricRules` fixture** (`fixtures/python-metric-rule.fixture.ts`) — a
  factory, because the scenario needs two rules and every rule must exist before
  its traces are seeded (the sampler never backfills). Teardown lives in the
  fixture rather than a trailing `test.step`: automation rules do not cascade
  with their project and `global-teardown`'s run-prefix sweep does not know
  about them, so a rule leaks exactly when an earlier step threw. Honours
  `OPIK_LEAVE_FAILURES`.
- **`TraceDetail.output`** — the spec asserts the seeded shapes really survived
  the write before trusting anything downstream. A fixture that had silently
  normalised `42` into an object would otherwise leave every later assertion
  passing against the one shape that was never in question.
- **`taxonomy.yaml`** — spec added to `online-evaluation`'s `specs:` list, and
  the `python-rule-scores` note extended. That capability was already
  `covered: true` at `t1-smoke`, so nothing is flipped: the tier stays at the
  stricter t1, and the note records that the variable-mapping half now has
  t2-cuj coverage. `online-evaluation-smoke.spec.ts` seeds through the SDK,
  which always produces an object `output`, so its `output -> output.output`
  mapping only ever lands on an object — the non-object branch was untested
  despite the green capability.

## What I deliberately did not write

Four candidates came out of the exploration; **three were dropped.**

1. **"A metric error surfaces as an actionable line on the automation-logs
   page"** (`@cap:online-evaluation.automation-logs`, currently `covered: false`).
   Verified working, and it is genuinely uncovered — but the exploration graded
   it **weak** and the skill's rule is to skip weak candidates when a strong one
   exists. Two reasons it is weak: it sits *adjacent* to this PR rather than on
   it (the PR changes what lands in the log, not the log surface), and its
   assertion would be a log **message string**, a much more brittle contract
   than a score. Worth writing as its own change, by someone who can decide how
   tightly to pin that string.
2. **python-backend `parse_execution_result` returning 400 for exit-code-0 with
   no/unparseable output** — not reachable. That environment runs the *process*
   executor, whose `run_scoring` never calls `parse_execution_result`; only
   `executor_docker` does, and that needs `PYTHON_CODE_EXECUTOR_STRATEGY=docker`,
   which neither compose nor helm defaults to. Covered by this PR's own unit
   tests.
3. **`AgenticScoringService.firstRoundToolChoice` returning `AUTO` for
   `VERTEX_AI`** — needs GCP credentials and a Vertex provider key; the target
   is a fresh OSS install with none. (The helm startup-probe change was also on
   the list and is deployment-only — not observable from a running instance.)

Nothing was skipped for being hard to write. Nothing was `.skip`ped to make the
run look clean.

---

Related: #7949

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-8045]: https://comet-ml.atlassian.net/browse/OPIK-8045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ