### PR TITLE
docs(online-evaluation): document Agent as a Judge

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -37,7 +37,7 @@ When creating a new rule, you will be presented with the following options:
 2. **Sampling rate:** The percentage of traces to score. When set to `100%`, all traces will be scored.
 3. **Model:** The model to use to run the LLM as a Judge metric. For evaluating traces with images, make sure to select a model that supports vision capabilities.
 4. **Prompt:** The LLM as a Judge prompt to use. Opik provides a set of base prompts (Hallucination, Moderation, Answer Relevance) that you can use or you can define your own. Variables in the prompt should be in `{{variable_name}}` format.
-5. **Variable mapping:** Where each prompt variable reads from in the trace. Not needed when you use Agent as a Judge — see [Giving the judge your trace data](#giving-the-judge-your-trace-data).
+5. **Variable mapping:** Where each prompt variable reads from in the trace. Not needed when you use Agent as a Judge — see [Writing your own LLM as a Judge metric](#writing-your-own-llm-as-a-judge-metric).
 6. **Score definition:** This is the format of the output of the LLM as a Judge metric. By adding more than one score, you can define LLM as a Judge metrics that score an LLM output along different dimensions.
 
 ### Opik's built-in LLM as a Judge metrics
@@ -63,14 +63,9 @@ We typically recommend that you experiment with LLM as a Judge metrics during de
   <img src="/img/production/online_evaluation_custom_judge.png" />
 </Frame>
 When writing your own LLM as a Judge metric you will need to specify the prompt variables using the mustache syntax, ie.
-`{{ variable_name }}`. How Opik fills those variables in is covered in
-[Giving the judge your trace data](#giving-the-judge-your-trace-data) below.
+`{{ variable_name }}`. You control the scores it returns with the `Scoring definition` parameter. Under the hood, we will use this definition in conjunction with the [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) functionality to ensure that the LLM as a Judge metric always returns trace scores.
 
-You can control the format of the output using the `Scoring definition` parameter. This is where you can define the scores you want the LLM as a Judge metric to return. Under the hood, we will use this definition in conjunction with the [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) functionality to ensure that the LLM as a Judge metric always returns trace scores.
-
-### Giving the judge your trace data
-
-For trace and span rules there are two ways to give a judge what it needs. Both work with the built-in metrics and with your own.
+That leaves one decision: where the judge gets its data. For trace and span rules there are two ways, and both work with the built-in metrics as well as your own.
 
 - **Agent as a Judge** — start here. No mapping to fill in, works on any trace shape, handles nesting and attachments. Best while you are still exploring what to measure.
 - **Variable mapping** — use when the judge should see exactly one field, every time.

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -88,9 +88,9 @@ For a span-scope rule, use `{{span}}` instead. To inject the trace's spans as pl
   Agent as a Judge needs a model that supports tool calling. On a model that does not, the rule falls back to a single call with a truncated trace.
 </Note>
 
-Cost scales with trace size. A small trace fits in the prompt and the judge answers in one call. A larger trace is truncated in the prompt, and the judge makes extra tool calls to read the rest.
+Agent as a Judge is built to keep the cost bounded. Opik truncates the trace it puts in the prompt and points the judge at targeted reads instead of loading everything up front. A small trace fits in the prompt and the judge answers in a single call. On a larger one, the judge reads only the parts it needs.
 
-Use **Max cost per evaluation (USD)** to cap that spend. Once an evaluation reaches the cap, the judge wraps up and returns the scores it has. Leave it empty for no limit.
+You can also set a hard limit with **Max cost per evaluation (USD)**. Once an evaluation reaches it, the judge wraps up and returns the scores it has. Leave it empty for no limit.
 
 ### Evaluating traces with images
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -70,10 +70,12 @@ You can control the format of the output using the `Scoring definition` paramete
 
 ### Giving the judge your trace data
 
-There are two ways to give a judge what it needs. Both work with the built-in metrics and with your own.
+For trace and span rules there are two ways to give a judge what it needs. Both work with the built-in metrics and with your own.
 
 - **Agent as a Judge** — start here. No mapping to fill in, works on any trace shape, handles nesting and attachments. Best while you are still exploring what to measure.
 - **Variable mapping** — use when the judge should see exactly one field, every time.
+
+Thread rules have no mapping to choose. They always use `{{context}}`, which reads the conversation the same way — see [Online thread evaluation rules](#online-thread-evaluation-rules).
 
 #### Agent as a Judge
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -81,6 +81,16 @@ Thread rules have no mapping to choose. They always use `{{context}}`, which rea
 
 Add `{{trace}}` to the prompt. There is nothing to map, so the same rule works whatever shape your traces have.
 
+Prompt:
+
+```
+Read the trace below and decide whether the assistant answered the user's question.
+
+{{trace}}
+```
+
+Variable mapping: nothing to fill in.
+
 The judge reads the trace itself, using these tools:
 
 - `read` — read the trace or one of its spans
@@ -101,7 +111,19 @@ You can also set a hard limit with **Max cost per evaluation (USD)**. Once an ev
 
 #### Variable mapping
 
-Point each prompt variable at a field in the trace, for example `output.messages[0].parts[0].content`. The judge then receives that field and nothing else.
+Point each prompt variable at a field in the trace. The judge then receives that field and nothing else.
+
+Prompt:
+
+```
+Decide whether the answer below is helpful.
+
+{{answer}}
+```
+
+Variable mapping:
+
+- `answer` → `output.messages[0].parts[0].content`
 
 Use it when a metric should score the same field on every trace. Because the input is fixed, the scores stay comparable over time, and each evaluation is a single call with no drill-down.
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -37,7 +37,7 @@ When creating a new rule, you will be presented with the following options:
 2. **Sampling rate:** The percentage of traces to score. When set to `100%`, all traces will be scored.
 3. **Model:** The model to use to run the LLM as a Judge metric. For evaluating traces with images, make sure to select a model that supports vision capabilities.
 4. **Prompt:** The LLM as a Judge prompt to use. Opik provides a set of base prompts (Hallucination, Moderation, Answer Relevance) that you can use or you can define your own. Variables in the prompt should be in `{{variable_name}}` format.
-5. **Variable mapping:** This is the mapping of the variables in the prompt to the values from the trace.
+5. **Variable mapping:** Where each prompt variable reads from in the trace. Not needed when you use Agent as a Judge — see [Giving the judge your trace data](#giving-the-judge-your-trace-data).
 6. **Score definition:** This is the format of the output of the LLM as a Judge metric. By adding more than one score, you can define LLM as a Judge metrics that score an LLM output along different dimensions.
 
 ### Opik's built-in LLM as a Judge metrics
@@ -63,18 +63,23 @@ We typically recommend that you experiment with LLM as a Judge metrics during de
   <img src="/img/production/online_evaluation_custom_judge.png" />
 </Frame>
 When writing your own LLM as a Judge metric you will need to specify the prompt variables using the mustache syntax, ie.
-`{{ variable_name }}`. You can then map these variables to your trace data using the `variable_mapping` parameter. When the
-rule is executed, Opik will replace the variables with the values from the trace data.
+`{{ variable_name }}`. How Opik fills those variables in is covered in
+[Giving the judge your trace data](#giving-the-judge-your-trace-data) below.
 
 You can control the format of the output using the `Scoring definition` parameter. This is where you can define the scores you want the LLM as a Judge metric to return. Under the hood, we will use this definition in conjunction with the [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) functionality to ensure that the LLM as a Judge metric always returns trace scores.
 
-### Agent as a Judge
+### Giving the judge your trace data
 
-An LLM as a Judge metric only sees the fields you map. An agent as a judge receives the trace and reads the rest of it itself.
+There are two ways to give a judge what it needs. Both work with the built-in metrics and with your own.
 
-Add `{{trace}}` to the prompt. There is no variable mapping to fill in, so the same rule works whatever shape your traces have.
+- **Agent as a Judge** — start here. No mapping to fill in, works on any trace shape, handles nesting and attachments. Best while you are still exploring what to measure.
+- **Variable mapping** — use when the judge should see exactly one field, every time.
 
-The judge gets these tools:
+#### Agent as a Judge
+
+Add `{{trace}}` to the prompt. There is nothing to map, so the same rule works whatever shape your traces have.
+
+The judge reads the trace itself, using these tools:
 
 - `read` — read the trace or one of its spans
 - `jq` — pull out a specific path
@@ -84,13 +89,21 @@ The judge gets these tools:
 
 For a span-scope rule, use `{{span}}` instead. To inject the trace's spans as plain JSON without giving the judge any tools, use `{{spans}}`.
 
+Agent as a Judge is built to keep the cost bounded. Opik truncates the trace it puts in the prompt and points the judge at targeted reads instead of loading everything up front. A small trace fits in the prompt and the judge answers in a single call. On a larger one, the judge reads only the parts it needs.
+
+You can also set a hard limit with **Max cost per evaluation (USD)**. Once an evaluation reaches it, the judge wraps up and returns the scores it has. Leave it empty for no limit.
+
 <Note>
   Agent as a Judge needs a model that supports tool calling. On a model that does not, the rule falls back to a single call with a truncated trace.
 </Note>
 
-Agent as a Judge is built to keep the cost bounded. Opik truncates the trace it puts in the prompt and points the judge at targeted reads instead of loading everything up front. A small trace fits in the prompt and the judge answers in a single call. On a larger one, the judge reads only the parts it needs.
+#### Variable mapping
 
-You can also set a hard limit with **Max cost per evaluation (USD)**. Once an evaluation reaches it, the judge wraps up and returns the scores it has. Leave it empty for no limit.
+Point each prompt variable at a field in the trace, for example `output.messages[0].parts[0].content`. The judge then receives that field and nothing else.
+
+Use it when a metric should score the same field on every trace. Because the input is fixed, the scores stay comparable over time, and each evaluation is a single call with no drill-down.
+
+The trade-off is that the path has to match your traces. A rule mapped to your application's traces will not read traces logged in a different shape, such as the ones the playground writes when you run an experiment. Use Agent as a Judge when one rule has to cover both.
 
 ### Evaluating traces with images
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -118,11 +118,13 @@ Prompt:
 ```
 Decide whether the answer below is helpful.
 
-{{answer}}
+Question: {{question}}
+Answer: {{answer}}
 ```
 
 Variable mapping:
 
+- `question` → `input.messages[0].content`
 - `answer` → `output.messages[0].parts[0].content`
 
 Use it when a metric should score the same field on every trace. Because the input is fixed, the scores stay comparable over time, and each evaluation is a single call with no drill-down.

--- a/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/production/online-evaluation/rules.mdx
@@ -68,6 +68,30 @@ rule is executed, Opik will replace the variables with the values from the trace
 
 You can control the format of the output using the `Scoring definition` parameter. This is where you can define the scores you want the LLM as a Judge metric to return. Under the hood, we will use this definition in conjunction with the [structured outputs](https://platform.openai.com/docs/guides/structured-outputs) functionality to ensure that the LLM as a Judge metric always returns trace scores.
 
+### Agent as a Judge
+
+An LLM as a Judge metric only sees the fields you map. An agent as a judge receives the trace and reads the rest of it itself.
+
+Add `{{trace}}` to the prompt. There is no variable mapping to fill in, so the same rule works whatever shape your traces have.
+
+The judge gets these tools:
+
+- `read` — read the trace or one of its spans
+- `jq` — pull out a specific path
+- `search` — find text anywhere in the trace
+- `get_trace_spans` — list the trace's spans
+- `get_attachment` — fetch an attached file as image, audio or text
+
+For a span-scope rule, use `{{span}}` instead. To inject the trace's spans as plain JSON without giving the judge any tools, use `{{spans}}`.
+
+<Note>
+  Agent as a Judge needs a model that supports tool calling. On a model that does not, the rule falls back to a single call with a truncated trace.
+</Note>
+
+Cost scales with trace size. A small trace fits in the prompt and the judge answers in one call. A larger trace is truncated in the prompt, and the judge makes extra tool calls to read the rest.
+
+Use **Max cost per evaluation (USD)** to cap that spend. Once an evaluation reaches the cap, the judge wraps up and returns the scores it has. Leave it empty for no limit.
+
 ### Evaluating traces with images
 
 LLM as a Judge metrics can evaluate traces that contain images when using vision-capable models. This is useful for:


### PR DESCRIPTION
## Why

The online evaluation rules page documents variable mapping, but never mentions the agentic path. `{{trace}}`, `{{span}}` and `{{spans}}` are not documented anywhere in the docs — only in two changelog entries ([2026-06-23](https://www.comet.com/docs/opik/changelog/2026-06-23), [2026-07-13](https://www.comet.com/docs/opik/changelog/2026-07-13)).

Came out of [OPIK-8040](https://comet-ml.atlassian.net/browse/OPIK-8040), where a customer needs a judge that works on traces of two different shapes. `{{trace}}` is the answer today, and there was nowhere to point them.

## What

One new section, `### Agent as a Judge`, on `docs-v2/production/online-evaluation/rules.mdx`, after "Writing your own LLM as a Judge metric":

- Add `{{trace}}` to the prompt, no variable mapping to fill in
- The five tools the judge gets: `read`, `jq`, `search`, `get_trace_spans`, `get_attachment`
- `{{span}}` for span scope, `{{spans}}` to inject spans as plain JSON without tools
- Needs a tool-calling model; falls back to a single call with a truncated trace otherwise
- Cost scales with trace size, and **Max cost per evaluation (USD)** caps it

## Not included

- `docs/production/rules.mdx` (the `v1` version) is unchanged — new feature docs do not seem to get backported there.
- The section does not mention that `TOGGLE_AGENTIC_TOOLS_ENABLED` defaults to `false` in `apps/opik-backend/config.yml`. Worth deciding: a self-hosted reader following these steps gets an unfilled variable and a validation error rather than an agentic judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OPIK-8040]: https://comet-ml.atlassian.net/browse/OPIK-8040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ