### PR TITLE
[NA] [SDK] fix: respect search wait timeouts

### DIFF
--- a/sdks/typescript/src/opik/utils/searchHelpers.ts
+++ b/sdks/typescript/src/opik/utils/searchHelpers.ts
@@ -13,7 +13,7 @@ export async function searchTracesWithFilters(
   filters: OpikApi.TraceFilterPublic[] | null,
   maxResults: number,
   truncate: boolean,
-  exclude?: OpikApi.TraceSearchStreamRequestPublicExcludeItem[]
+  exclude?: OpikApi.TraceSearchStreamRequestPublicExcludeItem[],
 ): Promise<OpikApi.TracePublic[]> {
   const streamResponse = await apiClient.traces.searchTraces({
     projectName,
@@ -26,7 +26,7 @@ export async function searchTracesWithFilters(
   const traces = await parseNdjsonStreamToArray<OpikApi.TracePublic>(
     streamResponse,
     serialization.TracePublic,
-    maxResults
+    maxResults,
   );
 
   return traces;
@@ -39,7 +39,7 @@ export async function searchAndWaitForDone<T>(
   searchFn: () => Promise<T[]>,
   waitForAtLeast: number,
   waitForTimeout: number,
-  sleepTime: number
+  sleepTime: number,
 ): Promise<T[]> {
   const startTime = Date.now();
   let result: T[] = [];
@@ -60,8 +60,10 @@ export async function searchAndWaitForDone<T>(
       return result;
     }
 
-    // Sleep before next attempt
-    await new Promise((resolve) => setTimeout(resolve, sleepTime));
+    // Sleep only for the time remaining in the caller's timeout budget.
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(sleepTime, waitForTimeout - elapsedTime)),
+    );
   }
 }
 
@@ -73,7 +75,7 @@ export async function searchThreadsWithFilters(
   projectName: string,
   filters: OpikApi.TraceThreadFilter[] | null,
   maxResults: number,
-  truncate: boolean
+  truncate: boolean,
 ): Promise<OpikApi.TraceThread[]> {
   const streamResponse = await apiClient.traces.searchTraceThreads({
     projectName,
@@ -85,7 +87,7 @@ export async function searchThreadsWithFilters(
   const threads = await parseNdjsonStreamToArray<OpikApi.TraceThread>(
     streamResponse,
     serialization.TraceThread,
-    maxResults
+    maxResults,
   );
 
   return threads;
@@ -97,7 +99,7 @@ export async function searchThreadsWithFilters(
 function parseFilterStringGeneric<TFilter, TOperator>(
   filterString: string | undefined,
   operatorCast: (op: string) => TOperator,
-  oqlFactory: (filterString: string) => OpikQueryLanguage
+  oqlFactory: (filterString: string) => OpikQueryLanguage,
 ): TFilter[] | null {
   if (!filterString) {
     return null;
@@ -134,7 +136,7 @@ function parseFilterStringGeneric<TFilter, TOperator>(
  * Parses a filter string using OpikQueryLanguage and converts to TraceFilterPublic format
  */
 export function parseFilterString(
-  filterString?: string
+  filterString?: string,
 ): OpikApi.TraceFilterPublic[] | null {
   return parseFilterStringGeneric<
     OpikApi.TraceFilterPublic,
@@ -142,7 +144,7 @@ export function parseFilterString(
   >(
     filterString,
     (op) => op as OpikApi.TraceFilterPublicOperator,
-    OpikQueryLanguage.forTraces
+    OpikQueryLanguage.forTraces,
   );
 }
 
@@ -150,7 +152,7 @@ export function parseFilterString(
  * Parses a filter string using OpikQueryLanguage and converts to TraceThreadFilter format
  */
 export function parseThreadFilterString(
-  filterString?: string
+  filterString?: string,
 ): OpikApi.TraceThreadFilter[] | null {
   return parseFilterStringGeneric<
     OpikApi.TraceThreadFilter,
@@ -158,7 +160,7 @@ export function parseThreadFilterString(
   >(
     filterString,
     (op) => op as OpikApi.TraceThreadFilterOperator,
-    OpikQueryLanguage.forThreads
+    OpikQueryLanguage.forThreads,
   );
 }
 
@@ -171,7 +173,7 @@ export async function searchSpansWithFilters(
   filters: OpikApi.SpanFilterPublic[] | null,
   maxResults: number,
   truncate: boolean,
-  exclude?: OpikApi.SpanSearchStreamRequestPublicExcludeItem[]
+  exclude?: OpikApi.SpanSearchStreamRequestPublicExcludeItem[],
 ): Promise<OpikApi.SpanPublic[]> {
   const streamResponse = await apiClient.spans.searchSpans({
     projectName,
@@ -184,7 +186,7 @@ export async function searchSpansWithFilters(
   const spans = await parseNdjsonStreamToArray<OpikApi.SpanPublic>(
     streamResponse,
     serialization.SpanPublic,
-    maxResults
+    maxResults,
   );
 
   return spans;
@@ -194,7 +196,7 @@ export async function searchSpansWithFilters(
  * Parses a filter string using OpikQueryLanguage and converts to SpanFilterPublic format
  */
 export function parseSpanFilterString(
-  filterString?: string
+  filterString?: string,
 ): OpikApi.SpanFilterPublic[] | null {
   return parseFilterStringGeneric<
     OpikApi.SpanFilterPublic,
@@ -202,6 +204,6 @@ export function parseSpanFilterString(
   >(
     filterString,
     (op) => op as OpikApi.SpanFilterPublicOperator,
-    OpikQueryLanguage.forSpans
+    OpikQueryLanguage.forSpans,
   );
 }

--- a/sdks/typescript/tests/unit/utils/searchHelpers.test.ts
+++ b/sdks/typescript/tests/unit/utils/searchHelpers.test.ts
@@ -69,7 +69,7 @@ describe("searchHelpers", () => {
       });
 
       const feedbackResult = parseFilterString(
-        'feedback_scores."Answer Relevance" < 0.8'
+        'feedback_scores."Answer Relevance" < 0.8',
       );
       expect(feedbackResult![0]).toMatchObject({
         field: "feedback_scores",
@@ -81,7 +81,7 @@ describe("searchHelpers", () => {
 
     it("should parse complex queries with multiple conditions", () => {
       const result = parseFilterString(
-        'name = "test" and duration > 100 and thread_id = "thread-123"'
+        'name = "test" and duration > 100 and thread_id = "thread-123"',
       );
 
       expect(result).toHaveLength(3);
@@ -93,7 +93,7 @@ describe("searchHelpers", () => {
     it("should throw error for invalid OQL syntax", () => {
       expect(() => parseFilterString("invalid syntax ===")).toThrow();
       expect(() => parseFilterString('invalid_field = "test"')).toThrow(
-        /is not supported/
+        /is not supported/,
       );
     });
   });
@@ -168,6 +168,26 @@ describe("searchHelpers", () => {
       await promise;
     });
 
+    it("should not sleep past the timeout when the poll interval is longer", async () => {
+      const mockSearchFn = vi.fn().mockResolvedValue([]);
+      const promise = searchAndWaitForDone(mockSearchFn, 1, 100, 5000);
+      let settled = false;
+      const trackedPromise = promise.then((result) => {
+        settled = true;
+        return result;
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      try {
+        expect(settled).toBe(true);
+        await expect(trackedPromise).resolves.toEqual([]);
+        expect(mockSearchFn).toHaveBeenCalledTimes(2);
+      } finally {
+        await vi.runAllTimersAsync();
+      }
+    });
+
     it("should propagate search function errors", async () => {
       const mockSearchFn = vi
         .fn()
@@ -205,7 +225,7 @@ describe("searchHelpers", () => {
 
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.traces, "searchTraces").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       const filters: OpikApi.TraceFilterPublic[] = [
@@ -217,7 +237,7 @@ describe("searchHelpers", () => {
         "test-project",
         filters,
         100,
-        true
+        true,
       );
 
       expect(mockApiClient.traces.searchTraces).toHaveBeenCalledWith({
@@ -232,7 +252,7 @@ describe("searchHelpers", () => {
     it("should handle null filters and pass as undefined to API", async () => {
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.traces, "searchTraces").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       await searchTracesWithFilters(
@@ -240,20 +260,20 @@ describe("searchHelpers", () => {
         "test-project",
         null,
         100,
-        true
+        true,
       );
 
       expect(mockApiClient.traces.searchTraces).toHaveBeenCalledWith(
         expect.objectContaining({
           filters: undefined,
-        })
+        }),
       );
     });
 
     it("should handle complex filters with metadata and feedback keys", async () => {
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.traces, "searchTraces").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       const filters: OpikApi.TraceFilterPublic[] = [
@@ -276,7 +296,7 @@ describe("searchHelpers", () => {
         "test-project",
         filters,
         100,
-        true
+        true,
       );
 
       const call = (
@@ -333,7 +353,7 @@ describe("searchHelpers", () => {
       });
 
       const feedbackResult = parseSpanFilterString(
-        'feedback_scores."quality" > 0.8'
+        'feedback_scores."quality" > 0.8',
       );
       expect(feedbackResult![0]).toMatchObject({
         field: "feedback_scores",
@@ -345,7 +365,7 @@ describe("searchHelpers", () => {
 
     it("should parse complex queries with multiple conditions", () => {
       const result = parseSpanFilterString(
-        'model = "gpt-4" and provider = "openai" and type = "llm"'
+        'model = "gpt-4" and provider = "openai" and type = "llm"',
       );
 
       expect(result).toHaveLength(3);
@@ -396,7 +416,7 @@ describe("searchHelpers", () => {
 
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.spans, "searchSpans").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       const filters: OpikApi.SpanFilterPublic[] = [
@@ -408,7 +428,7 @@ describe("searchHelpers", () => {
         "test-project",
         filters,
         100,
-        true
+        true,
       );
 
       expect(mockApiClient.spans.searchSpans).toHaveBeenCalledWith({
@@ -423,7 +443,7 @@ describe("searchHelpers", () => {
     it("should handle null filters and pass as undefined to API", async () => {
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.spans, "searchSpans").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       await searchSpansWithFilters(
@@ -431,20 +451,20 @@ describe("searchHelpers", () => {
         "test-project",
         null,
         100,
-        true
+        true,
       );
 
       expect(mockApiClient.spans.searchSpans).toHaveBeenCalledWith(
         expect.objectContaining({
           filters: undefined,
-        })
+        }),
       );
     });
 
     it("should handle complex filters with metadata and feedback keys", async () => {
       const mockStream = {} as AsyncIterable<Uint8Array>;
       vi.spyOn(mockApiClient.spans, "searchSpans").mockResolvedValue(
-        mockStream as never
+        mockStream as never,
       );
 
       const filters: OpikApi.SpanFilterPublic[] = [
@@ -472,12 +492,11 @@ describe("searchHelpers", () => {
         "test-project",
         filters,
         100,
-        true
+        true,
       );
 
-      const call = (
-        mockApiClient.spans.searchSpans as ReturnType<typeof vi.fn>
-      ).mock.calls[0][0];
+      const call = (mockApiClient.spans.searchSpans as ReturnType<typeof vi.fn>)
+        .mock.calls[0][0];
       expect(call.filters).toEqual(filters);
     });
   });


### PR DESCRIPTION
## Details
`searchAndWaitForDone` currently sleeps for the full polling interval even when less time remains in the caller-provided timeout. This can make a short timeout wait for several seconds longer than requested. The polling sleep is now capped to the remaining timeout budget, with a fake-timer regression covering a poll interval longer than the timeout.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #7936
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: AI coding assistant
- Model(s): not disclosed
- Scope: implementation and regression-test drafting
- Human verification: contributor reviewed the final diff and ran the repository's TypeScript unit, lint, formatting, and diff checks.

## Testing

- `./node_modules/.bin/vitest run tests/unit/utils/searchHelpers.test.ts` — 28 passed
- `./node_modules/.bin/eslint src/opik/utils/searchHelpers.ts tests/unit/utils/searchHelpers.test.ts` — passed
- `./node_modules/.bin/prettier --check src/opik/utils/searchHelpers.ts tests/unit/utils/searchHelpers.test.ts` — passed
- `git diff --check origin/main...HEAD` — passed
- The full TypeScript SDK test suite was not run; this PR is limited to the polling helper and its focused unit coverage.

## Documentation

No documentation changes are needed for this internal timeout-boundary fix.