### PR TITLE
[OPIK-7707] [QA] Proposed e2e specs: dataset version counters on the delete path

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1780,13 +1780,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @param workspaceId The workspace ID
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
-        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
-
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1745,36 +1745,25 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     /**
      * Updates version counts after inserting items into an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * Only the new items move the total; re-sent items count as modifications.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
      * @param newItemsCount Number of new items inserted
      * @param updatedItemsCount Number of items updated
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForInsert(UUID versionId, String workspaceId, int newItemsCount,
             int updatedItemsCount, String userName) {
-        template.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(DatasetVersionDAO.class);
-
-            // Only increment total by new items (not updates)
-            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
-                    workspaceId, userName);
-
-            if (updated == 0) {
-                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
-            }
-            return null;
-        });
+        updateVersionCounts(versionId, workspaceId, newItemsCount, newItemsCount, updatedItemsCount, 0, userName);
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
      * <p>
-     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
-     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
-     * both callers fetch the version for their own purposes regardless.
+     * Unlike the insert path this saves no round-trip: both callers fetch the version for their own purposes
+     * regardless. What it buys is that the arithmetic no longer depends on that snapshot still being current.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
@@ -1783,10 +1772,23 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        updateVersionCounts(versionId, workspaceId, -deletedCount, 0, 0, deletedCount, userName);
+    }
+
+    /**
+     * Applies signed counter deltas to a version in a single atomic statement, so the arithmetic does not depend on
+     * {@code withDatasetVersionLock} for mutual exclusion. A zero affected-row count means the version was removed or
+     * belongs to another workspace.
+     *
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
+     */
+    private void updateVersionCounts(UUID versionId, String workspaceId, int totalDelta, int addedDelta,
+            int modifiedDelta, int deletedDelta, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
 
-            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+            int updated = dao.incrementCounts(versionId, totalDelta, addedDelta, modifiedDelta, deletedDelta,
+                    workspaceId, userName);
 
             if (updated == 0) {
                 throw new NotFoundException("Version not found: '%s'".formatted(versionId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1662,7 +1662,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         UUID latestVersionId = latestVersion.get().id();
         log.info("Inserting '{}' items into existing version '{}'", batch.items().size(), latestVersionId);
 
-        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName);
+        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName).then(Mono.empty());
     }
 
     /**
@@ -1670,14 +1670,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * Handles validation, classification of new vs updated items, and count updates.
      * Used by mutateLatestVersionWithInsert and handleGroupedInsertion.
      *
+     * Completes empty: no caller reads the resulting version, so the counters are applied with a single atomic
+     * increment and the row is not read back.
+     *
      * @param batch the batch of items to insert
      * @param datasetId the dataset ID
      * @param versionId the version ID to insert into
      * @param workspaceId the workspace ID
      * @param userName the username
-     * @return Mono emitting the updated dataset version
+     * @return Mono completing when the items are inserted and the counts updated
      */
-    private Mono<DatasetVersion> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+    private Mono<Void> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         // Validate and prepare items
         List<DatasetItem> validatedItems = addIdIfAbsent(batch);
@@ -1730,11 +1733,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     // Insert items directly into the existing version
                                     return versionDao
                                             .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
-                                            .then(Mono.fromCallable(() -> {
-                                                updateVersionCountsForInsert(versionId, workspaceId, finalNewItemsCount,
-                                                        finalUpdatedItemsCount, userName);
-                                                return versionService.getVersionById(workspaceId, datasetId, versionId);
-                                            }).subscribeOn(Schedulers.boundedElastic()));
+                                            .then(Mono.fromRunnable(() -> updateVersionCountsForInsert(versionId,
+                                                    workspaceId, finalNewItemsCount, finalUpdatedItemsCount, userName))
+                                                    .subscribeOn(Schedulers.boundedElastic()))
+                                            .then();
                                 });
                     }));
         }).contextWrite(c -> c.put(RequestContext.WORKSPACE_ID, workspaceId)
@@ -1755,43 +1757,36 @@ class DatasetItemServiceImpl implements DatasetItemService {
             int updatedItemsCount, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            var currentVersion = dao.findById(versionId, workspaceId)
-                    .orElseThrow(() -> new NotFoundException(
-                            "Version not found: '%s'".formatted(versionId)));
 
             // Only increment total by new items (not updates)
-            int newTotal = currentVersion.itemsTotal() + newItemsCount;
-            int newAdded = currentVersion.itemsAdded() + newItemsCount;
-            int newModified = currentVersion.itemsModified() + updatedItemsCount;
+            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
+                    workspaceId, userName);
 
-            dao.updateCounts(versionId, newTotal, newAdded, newModified,
-                    currentVersion.itemsDeleted(), workspaceId, userName);
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * <p>
+     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
+     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
+     * both callers fetch the version for their own purposes regardless.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
-     * @param currentVersion The current version before deletion
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
      */
-    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, DatasetVersion currentVersion,
-            int deletedCount, String userName) {
-        int newTotal = currentVersion.itemsTotal() - deletedCount;
-        int newDeleted = currentVersion.itemsDeleted() + deletedCount;
-
-        log.info("deleteItemsFromExistingVersion: updating counts - newTotal='{}', newDeleted='{}'",
-                newTotal, newDeleted);
+    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
 
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.updateCounts(versionId, newTotal, currentVersion.itemsAdded(),
-                    currentVersion.itemsModified(), newDeleted, workspaceId, userName);
+            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
             return null;
         });
     }
@@ -2186,8 +2181,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2231,8 +2225,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2357,7 +2350,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
+                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
+                                .then(Mono.<DatasetVersion>empty());
                     } else {
                         // No version with this batch_group_id - create new one
                         log.info("Creating new version with batch_group_id '{}' for dataset '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -539,22 +539,26 @@ public interface DatasetVersionDAO {
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 
+    /**
+     * Applies signed deltas to the version counters in a single statement, so the arithmetic happens in the database
+     * rather than as a read-modify-write in the application. Correct under concurrent callers without an external lock.
+     */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = :items_total,
-                items_added = :items_added,
-                items_modified = :items_modified,
-                items_deleted = :items_deleted,
+            SET items_total = items_total + :items_total_delta,
+                items_added = items_added + :items_added_delta,
+                items_modified = items_modified + :items_modified_delta,
+                items_deleted = items_deleted + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id
               AND workspace_id = :workspace_id
             """)
-    void updateCounts(@Bind("version_id") UUID versionId,
-            @Bind("items_total") int itemsTotal,
-            @Bind("items_added") int itemsAdded,
-            @Bind("items_modified") int itemsModified,
-            @Bind("items_deleted") int itemsDeleted,
+    int incrementCounts(@Bind("version_id") UUID versionId,
+            @Bind("items_total_delta") int itemsTotalDelta,
+            @Bind("items_added_delta") int itemsAddedDelta,
+            @Bind("items_modified_delta") int itemsModifiedDelta,
+            @Bind("items_deleted_delta") int itemsDeletedDelta,
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -545,10 +545,10 @@ public interface DatasetVersionDAO {
      */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = items_total + :items_total_delta,
-                items_added = items_added + :items_added_delta,
-                items_modified = items_modified + :items_modified_delta,
-                items_deleted = items_deleted + :items_deleted_delta,
+            SET items_total = COALESCE(items_total, 0) + :items_total_delta,
+                items_added = COALESCE(items_added, 0) + :items_added_delta,
+                items_modified = COALESCE(items_modified, 0) + :items_modified_delta,
+                items_deleted = COALESCE(items_deleted, 0) + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -77,6 +77,7 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5204,6 +5206,152 @@ class DatasetVersionResourceTest {
                     datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
             assertThat(latestItems).hasSize(1);
             assertThat(latestItems.getFirst().description()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Atomic version count updates (OPIK-7707):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AtomicVersionCountUpdates {
+
+        private int incrementCounts(UUID versionId, int total, int added, int modified, int deleted) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(versionId, total, added, modified, deleted, WORKSPACE_ID, USER));
+        }
+
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException | TimeoutException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Test
+        @DisplayName("Success: single-batch append accumulates the full counter triple")
+        void insertItems__whenAppendingToExistingVersion__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 3);
+
+            var seed = getLatestVersion(datasetId);
+            assertThat(seed.itemsTotal()).isEqualTo(3);
+            assertThat(seed.itemsAdded()).isEqualTo(3);
+            assertThat(seed.itemsModified()).isZero();
+
+            // 2 brand-new items plus a re-send of an existing one: only the new items move itemsTotal.
+            var existingItem = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+            var items = new ArrayList<>(generateDatasetItems(2));
+            items.add(existingItem);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(5); // 3 + 2 new (the update doesn't count)
+            assertThat(updated.itemsAdded()).isEqualTo(5);
+            assertThat(updated.itemsModified()).isEqualTo(1);
+            assertThat(updated.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: multi-batch append via batch_group_id accumulates the full counter triple")
+        void insertItems__whenAppendingViaBatchGroupId__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // First batch creates the version; the next two append into it via the batch_group_id path.
+            for (int i = 0; i < 3; i++) {
+                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                        .datasetId(datasetId)
+                        .batchGroupId(batchGroupId)
+                        .items(generateDatasetItems(2))
+                        .build(), TEST_WORKSPACE, API_KEY);
+            }
+
+            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).content()).hasSize(1);
+
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(6);
+            assertThat(version.itemsAdded()).isEqualTo(6);
+            assertThat(version.itemsModified()).isZero();
+            assertThat(version.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: concurrent increments are exact without the per-dataset lock")
+        void incrementCounts__whenConcurrentWritersBypassTheLock__thenCountersAreExact() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Hit the DAO directly so withDatasetVersionLock is out of the picture entirely: this is what
+            // proves the arithmetic itself is atomic rather than merely serialized by the lock. The old
+            // read-modify-write would lose updates here.
+            int writers = 8;
+            int incrementsPerWriter = 25;
+
+            ExecutorService executor = Executors.newFixedThreadPool(writers);
+            CyclicBarrier barrier = new CyclicBarrier(writers);
+            try {
+                IntStream.range(0, writers)
+                        .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                            awaitBarrier(barrier);
+                            for (int n = 0; n < incrementsPerWriter; n++) {
+                                incrementCounts(versionId, 1, 1, 2, 0);
+                            }
+                        }, executor))
+                        .toList()
+                        .forEach(CompletableFuture::join);
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            int expectedIncrements = writers * incrementsPerWriter;
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsAdded()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsModified()).isEqualTo(2 * expectedIncrements);
+        }
+
+        @Test
+        @DisplayName("Success: negative deltas on the delete path decrement total and raise deleted")
+        void incrementCounts__whenNegativeDelta__thenTotalDecrements() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var seed = getLatestVersion(datasetId);
+            var itemToDelete = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+
+            datasetResourceClient.deleteDatasetItems(DatasetItemsDelete.builder()
+                    .itemIds(Set.of(itemToDelete.datasetItemId()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(4);
+            assertThat(updated.itemsDeleted()).isEqualTo(1);
+            // The delete path leaves added/modified untouched.
+            assertThat(updated.itemsAdded()).isEqualTo(seed.itemsAdded());
+            assertThat(updated.itemsModified()).isEqualTo(seed.itemsModified());
+        }
+
+        @Test
+        @DisplayName("Success: increment against an unknown version affects no rows")
+        void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
+            assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5349,6 +5349,36 @@ class DatasetVersionResourceTest {
         }
 
         @Test
+        @DisplayName("Success: NULL counters are treated as zero rather than staying NULL")
+        void incrementCounts__whenCountersAreNull__thenTreatedAsZero() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // The counter columns are `INT DEFAULT 0` -- nullable, since DEFAULT only applies when the
+            // column is omitted on INSERT. A bare `col + :delta` would leave NULL as NULL, which then
+            // unboxes to an NPE on the Integer-typed record. The absolute update this replaced happened
+            // to repair a NULL by overwriting it, so the increment has to COALESCE explicitly.
+            int nulled = mySqlTemplate.inTransaction(WRITE, handle -> handle.createUpdate("""
+                    UPDATE dataset_versions
+                    SET items_total = NULL, items_added = NULL, items_modified = NULL, items_deleted = NULL
+                    WHERE id = :version_id AND workspace_id = :workspace_id
+                    """)
+                    .bind("version_id", versionId.toString())
+                    .bind("workspace_id", WORKSPACE_ID)
+                    .execute());
+            assertThat(nulled).isOne();
+
+            assertThat(incrementCounts(versionId, 3, 3, 1, 0)).isOne();
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded,
+                            DatasetVersion::itemsModified, DatasetVersion::itemsDeleted)
+                    .containsExactly(3, 3, 1, 0);
+        }
+
+        @Test
         @DisplayName("Success: increment against an unknown version affects no rows")
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5353,6 +5353,22 @@ class DatasetVersionResourceTest {
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
+
+        @Test
+        @DisplayName("Success: increment scoped to another workspace affects no rows")
+        void incrementCounts__whenVersionBelongsToAnotherWorkspace__thenNoRowsAffected() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            var seed = getLatestVersion(datasetId);
+
+            // Real version id, wrong workspace: the workspace predicate must keep the update from matching, which is
+            // what lets both count-update helpers detect a missing/foreign version from the affected-row count alone.
+            int updated = mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(seed.id(), 1, 1, 0, 0, UUID.randomUUID().toString(), USER));
+
+            assertThat(updated).isZero();
+            assertThat(getLatestVersion(datasetId).itemsTotal()).isEqualTo(seed.itemsTotal());
+        }
     }
 
     @Nested

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -422,6 +422,7 @@ areas:
     specs:
       - datasets/dataset-crud-smoke.spec.ts
       - datasets/dataset-items.spec.ts
+      - datasets/dataset-version-delete-counters.spec.ts
     capabilities:
       list-datasets:          { covered: true,  tier: t1-smoke }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }
@@ -432,7 +433,7 @@ areas:
       bulk-delete-items:      { covered: true,  tier: t3-nightly }
       search-items:           { covered: true,  tier: t3-nightly }
       sdk-round-trip:         { covered: true,  tier: t1-smoke }
-      version-history-view:   { covered: false }
+      version-history-view:   { covered: true,  tier: t2-cuj, note: "ungrouped writes only (no batch_group_id, so the latest version is mutated in place); asserts the counter quadruple against the items actually held and the Item count / Changes summary cells that render it" }
       export-dataset:         { covered: false, note: "DATASET_EXPORT_ENABLED" }
       import-huggingface:     { covered: false }
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -29,6 +29,31 @@ export interface DatasetItemRef {
   data: Record<string, unknown>;
 }
 
+/**
+ * One row of a dataset's version history. `itemsTotal` is what the Version
+ * history tab renders as "Item count"; added/modified/deleted are the `+ / ~ /
+ * −` tags of its "Changes summary" column.
+ *
+ * `id` is carried so a caller can assert that a write *mutated* the latest
+ * version rather than cutting a new one — an ungrouped write (no
+ * `batchGroupId`) must never change it.
+ */
+export interface DatasetVersionRef {
+  id: string;
+  versionName: string;
+  itemsTotal: number;
+  itemsAdded: number;
+  itemsModified: number;
+  itemsDeleted: number;
+  isLatest: boolean;
+}
+
+/** One item of a write batch. Re-sending an existing `id` is an upsert. */
+export interface DatasetItemWriteRef {
+  id?: string;
+  data: Record<string, unknown>;
+}
+
 export interface ExperimentRefDetail {
   id: string;
   name: string;
@@ -227,6 +252,79 @@ export function makeBackendClient(apiKey: string | null = null) {
         id: String(item.id),
         data: (item.data ?? {}) as Record<string, unknown>,
       }));
+    },
+
+    async getDatasetVersions(datasetId: string): Promise<DatasetVersionRef[]> {
+      const page = await opik.api.datasets.listDatasetVersions(datasetId, { size: 100 });
+      const content = page.content ?? [];
+      return content.map((v) => ({
+        id: String(v.id ?? ''),
+        versionName: String(v.versionName ?? ''),
+        itemsTotal: Number(v.itemsTotal ?? 0),
+        itemsAdded: Number(v.itemsAdded ?? 0),
+        itemsModified: Number(v.itemsModified ?? 0),
+        itemsDeleted: Number(v.itemsDeleted ?? 0),
+        isLatest: Boolean(v.isLatest),
+      }));
+    },
+
+    /**
+     * Every item id actually stored in the dataset, paged out in full. This is
+     * the ground truth a version's `items_total` is supposed to agree with, so
+     * it must not be capped at a page — hence the loop. `truncate` drops the
+     * item payloads we don't need, keeping the read cheap.
+     */
+    async listDatasetItemIds(datasetId: string): Promise<string[]> {
+      const pageSize = 1000;
+      const ids: string[] = [];
+      for (let page = 1; ; page++) {
+        const result = await opik.api.datasets.getDatasetItems(datasetId, {
+          page,
+          size: pageSize,
+          truncate: true,
+        });
+        const content = result.content ?? [];
+        ids.push(...content.map((item) => String(item.id)));
+        if (content.length < pageSize) return ids;
+      }
+    },
+
+    /**
+     * Writes items into the dataset's *latest* version — `PUT /v1/private/
+     * datasets/items` with no `batch_group_id`, which mutates that version in
+     * place instead of cutting a new one. An item carrying an existing `id` is
+     * an update (counts as modified), one without is an addition.
+     *
+     * This is deliberately the ungrouped form. The grouped form (a
+     * `batch_group_id`, which is what the Python SDK's `insert()` sends) is a
+     * separate contract with different version semantics, and a caller that
+     * wants it must not reach for this helper.
+     */
+    async upsertDatasetItemsIntoLatestVersion(args: {
+      datasetId: string;
+      items: DatasetItemWriteRef[];
+    }): Promise<void> {
+      await opik.api.datasets.createOrUpdateDatasetItems({
+        datasetId: args.datasetId,
+        items: args.items.map((item) => ({
+          ...(item.id ? { id: item.id } : {}),
+          source: 'manual' as const,
+          data: item.data,
+        })),
+      });
+    },
+
+    /**
+     * Deletes dataset items by id, again ungrouped so the latest version is
+     * mutated in place. Returns the HTTP status rather than void: deleting ids
+     * that are already gone is specified to be a no-op 204, and a caller
+     * checking that needs to tell it from a 404.
+     */
+    async deleteDatasetItemsByIds(itemIds: string[]): Promise<number> {
+      const { rawResponse } = await opik.api.datasets
+        .deleteDatasetItems({ itemIds })
+        .withRawResponse();
+      return rawResponse.status;
     },
 
     async findExperimentByName(name: string): Promise<ExperimentRefDetail | null> {

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -4,6 +4,8 @@ export {
   type ProjectRef,
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
+  type DatasetItemWriteRef,
+  type DatasetVersionRef,
   type ExperimentRefDetail,
   type TestSuiteRef as BackendTestSuiteRef,
   type TestSuiteItemRef,

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -2,6 +2,17 @@ import { test } from '@playwright/test';
 import type { Page, Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
+export type DatasetVersionChange = 'added' | 'modified' | 'deleted';
+
+/** U+2212 MINUS SIGN — what VersionChangeSummaryCell prints, not a hyphen. */
+const DELETED_TAG_SYMBOL = '−';
+
+const CHANGE_TAG_SYMBOL: Record<DatasetVersionChange, string> = {
+  added: '+',
+  modified: '~',
+  deleted: DELETED_TAG_SYMBOL,
+};
+
 export class DatasetItemsPage {
   constructor(
     private readonly page: Page,
@@ -51,6 +62,65 @@ export class DatasetItemsPage {
 
   itemRowById(id: string): Locator {
     return this.itemsTableBody.locator(`tr[data-row-id="${id}"]`);
+  }
+
+  /** Second tab of the dataset page: one row per version, with its counters. */
+  async openVersionHistory(): Promise<void> {
+    return test.step('Open the Version history tab', async () => {
+      await this.page.getByRole('tab', { name: 'Version history' }).click();
+      const realRow = this.versionsTableBody.locator('tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No version history yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  versionHistoryRow(versionName: string): Locator {
+    return this.versionsTableBody
+      .locator('tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name: versionName, exact: true }) });
+  }
+
+  /**
+   * The "Item count" cell of a version row, as rendered — thousands-separated
+   * ("1,800"), because the column formats through toLocaleString().
+   *
+   * Addressed by the table's own `data-cell-id` (`<rowId>_<columnId>`) rather
+   * than a positional nth(): the version table has no per-cell testid, and
+   * column order is user-configurable, so position is not stable.
+   */
+  versionItemCount(versionName: string): Locator {
+    return this.versionHistoryRow(versionName).locator('[data-cell-id$="_items_total"]');
+  }
+
+  /**
+   * The "Changes summary" cell of a version row. It renders one tag per
+   * non-zero counter — `+ N` added, `~ N` modified, `− N` deleted (U+2212, not
+   * a hyphen) — and a single "-" when every counter is zero.
+   */
+  versionChangeSummary(versionName: string): Locator {
+    return this.versionHistoryRow(versionName).locator('[data-cell-id$="_change_summary"]');
+  }
+
+  /**
+   * Every change tag in that cell. The regex matches the tag elements only —
+   * their container's text is the tags run together, which never matches —
+   * so a caller can assert the exact set and catch a tag that should not be
+   * there, not just the ones it expected.
+   */
+  versionChangeTags(versionName: string): Locator {
+    return this.versionChangeSummary(versionName).getByText(
+      new RegExp(`^\\s*[+~${DELETED_TAG_SYMBOL}]\\s*\\d+\\s*$`),
+    );
+  }
+
+  versionChangeTag(versionName: string, change: DatasetVersionChange, count: number): Locator {
+    return this.versionChangeSummary(versionName).getByText(
+      `${CHANGE_TAG_SYMBOL[change]} ${count}`,
+      { exact: true },
+    );
   }
 
   async clickAddItem(): Promise<void> {
@@ -212,6 +282,10 @@ export class DatasetItemsPage {
 
   private get itemsTableBody(): Locator {
     return this.page.getByRole('tabpanel', { name: 'Records' }).locator('tbody');
+  }
+
+  private get versionsTableBody(): Locator {
+    return this.page.getByRole('tabpanel', { name: 'Version history' }).locator('tbody');
   }
 
   /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */

--- a/tests_end_to_end/e2e/tests/datasets/dataset-version-delete-counters.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-version-delete-counters.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+import type { BackendClient, DatasetVersionRef } from '@e2e/core/backend';
+
+/**
+ * A dataset version stores its own item counters — items_total / items_added /
+ * items_modified / items_deleted. The Version history tab renders items_total
+ * as "Item count" and the other three as the `+ / ~ / −` tags of its "Changes
+ * summary" column, so a wrong counter is silent wrongness on a page users read.
+ *
+ * OPIK-7707 (#7705) put both write paths behind one signed-delta UPDATE:
+ * `updateVersionCountsForInsert` and `updateVersionCountsForDelete` now funnel
+ * through `updateVersionCounts(versionId, workspace, totalDelta, addedDelta,
+ * modifiedDelta, deletedDelta, user)` — six positional ints, where a sign or an
+ * argument slip would hide. Nothing covers the *delete* side of that:
+ * `dataset-items.spec.ts` bulk-deletes but counts rendered rows and SDK items,
+ * never a counter, so an items_total that kept climbing after a delete would
+ * leave the whole suite green.
+ *
+ * Both specs drive the **ungrouped** write path — no `batch_group_id`, which
+ * mutates the latest version in place rather than cutting a new one — and after
+ * every operation assert three things together: the exact counter quadruple,
+ * that the version was mutated and not replaced, and that items_total agrees
+ * with the item ids the dataset actually holds. Then they read the same numbers
+ * back off the Version history tab, which is the surface that has to agree with
+ * the API.
+ */
+
+/** The four counters of a version, asserted as one value so a diff is legible. */
+interface VersionCounters {
+  total: number;
+  added: number;
+  modified: number;
+  deleted: number;
+}
+
+/**
+ * Dataset item ids must be UUIDv7; the backend rejects any other version. Ids
+ * are minted here rather than read back after each write so that what a step
+ * asserts about the stored set is independent of what the API reports.
+ */
+function uuidV7(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  const millis = Date.now();
+  bytes[0] = (millis / 2 ** 40) & 0xff;
+  bytes[1] = (millis / 2 ** 32) & 0xff;
+  bytes[2] = (millis / 2 ** 24) & 0xff;
+  bytes[3] = (millis / 2 ** 16) & 0xff;
+  bytes[4] = (millis / 2 ** 8) & 0xff;
+  bytes[5] = millis & 0xff;
+  bytes[6] = 0x70 | (bytes[6] & 0x0f);
+  bytes[8] = 0x80 | (bytes[8] & 0x3f);
+  const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function newItems(count: number, revision: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: uuidV7(),
+    data: { input: `${revision} input ${index}`, expected_output: `${revision} output ${index}` },
+  }));
+}
+
+/**
+ * Asserts the dataset's whole version state at once.
+ *
+ * `expectedItemIds` is the full set the dataset should hold, not a subset: a
+ * delete that removed the wrong rows leaves the count right and the contents
+ * wrong, and a check that only looked for the survivors it expected would pass
+ * over a leak.
+ */
+async function expectVersionState(
+  backendClient: BackendClient,
+  datasetId: string,
+  expected: { versionId: string; counters: VersionCounters; itemIds: string[] },
+): Promise<void> {
+  const versions = await backendClient.getDatasetVersions(datasetId);
+  // An ungrouped write must never cut a version. If one appeared, every
+  // assertion below would be reading the wrong row — fail here instead.
+  expect(versions).toHaveLength(1);
+  const version = versions[0];
+  expect(version.isLatest).toBe(true);
+  expect(version.id).toBe(expected.versionId);
+
+  expect({
+    total: version.itemsTotal,
+    added: version.itemsAdded,
+    modified: version.itemsModified,
+    deleted: version.itemsDeleted,
+  }).toEqual(expected.counters);
+
+  const storedIds = await backendClient.listDatasetItemIds(datasetId);
+  expect([...storedIds].sort()).toEqual([...expected.itemIds].sort());
+  // The counter is only worth rendering if it agrees with the items stored.
+  expect(version.itemsTotal).toBe(expected.itemIds.length);
+}
+
+/** The dataset's sole version, read before any of the writes under test. */
+async function readSeededVersion(
+  backendClient: BackendClient,
+  datasetId: string,
+): Promise<{ version: DatasetVersionRef; itemIds: string[] }> {
+  const versions = await backendClient.getDatasetVersions(datasetId);
+  expect(versions).toHaveLength(1);
+  return { version: versions[0], itemIds: await backendClient.listDatasetItemIds(datasetId) };
+}
+
+test.describe('Dataset version counters — deletes and interleaved writes', { tag: ['@area:datasets'] }, () => {
+  /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test(
+    'Deleting items moves only the total and deleted counters of the version it mutates, and the Version history tab renders them',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ dataset, project, backendClient, page }) => {
+      const seeded = await test.step('Read the counters the seeded version starts from', async () => {
+        const { version, itemIds } = await readSeededVersion(backendClient, dataset.id);
+        expect(itemIds).toHaveLength(dataset.items.length);
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: version.id,
+          counters: { total: 3, added: 3, modified: 0, deleted: 0 },
+          itemIds,
+        });
+        return { versionId: version.id, itemIds };
+      });
+
+      const afterInsert = await test.step('Adding three items raises total and added, in the same version', async () => {
+        const added = newItems(3, 'added');
+        await backendClient.upsertDatasetItemsIntoLatestVersion({
+          datasetId: dataset.id,
+          items: added,
+        });
+        const itemIds = [...seeded.itemIds, ...added.map((item) => item.id)];
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 6, added: 6, modified: 0, deleted: 0 },
+          itemIds,
+        });
+        return itemIds;
+      });
+
+      const survivors = afterInsert.slice(2);
+      const removed = afterInsert.slice(0, 2);
+
+      await test.step('Deleting two items drops total by two and raises deleted by two — added and modified untouched', async () => {
+        expect(await backendClient.deleteDatasetItemsByIds(removed)).toBe(204);
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 4, added: 6, modified: 0, deleted: 2 },
+          itemIds: survivors,
+        });
+      });
+
+      await test.step('Re-sending the same delete is a no-op 204, not a 404, and moves no counter', async () => {
+        // The `deletedCount == 0` short-circuit has to fire before the counter
+        // update, or a repeated delete writes a phantom delta.
+        expect(await backendClient.deleteDatasetItemsByIds(removed)).toBe(204);
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 4, added: 6, modified: 0, deleted: 2 },
+          itemIds: survivors,
+        });
+      });
+
+      await test.step('The Version history tab renders the reduced count and the deleted figure', async () => {
+        const datasets = new DatasetsPage(page);
+        await datasets.goto(project.id);
+        await datasets.waitForReady();
+        const items = await datasets.openDatasetByName(dataset.name);
+        await items.waitForReady();
+        await items.openVersionHistory();
+
+        await expect(items.versionItemCount('v1')).toHaveText('4');
+        // Exactly two tags: nothing was modified, so a `~` tag appearing here
+        // is the disagreement worth failing on.
+        await expect(items.versionChangeTags('v1')).toHaveCount(2);
+        await expect(items.versionChangeTag('v1', 'added', 6)).toBeVisible();
+        await expect(items.versionChangeTag('v1', 'deleted', 2)).toBeVisible();
+      });
+    },
+  );
+
+  test(
+    'Interleaved inserts, upserts and deletes keep the version counters equal to the items the dataset holds',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ dataset, project, backendClient, page }) => {
+      // A single operation cannot catch a delta applied to the wrong column:
+      // after one write the numbers still look plausible. A sequence that mixes
+      // both signs and touches all three change counters can.
+      const seeded = await test.step('Read the counters the seeded version starts from', async () => {
+        const { version, itemIds } = await readSeededVersion(backendClient, dataset.id);
+        expect(itemIds).toHaveLength(dataset.items.length);
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: version.id,
+          counters: { total: 3, added: 3, modified: 0, deleted: 0 },
+          itemIds,
+        });
+        return { versionId: version.id, itemIds };
+      });
+
+      let held = seeded.itemIds;
+
+      const firstBatch = newItems(4, 'first');
+      await test.step('Insert four items', async () => {
+        await backendClient.upsertDatasetItemsIntoLatestVersion({
+          datasetId: dataset.id,
+          items: firstBatch,
+        });
+        held = [...held, ...firstBatch.map((item) => item.id)];
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 7, added: 7, modified: 0, deleted: 0 },
+          itemIds: held,
+        });
+      });
+
+      await test.step('Delete two of them', async () => {
+        const removed = firstBatch.slice(0, 2).map((item) => item.id);
+        expect(await backendClient.deleteDatasetItemsByIds(removed)).toBe(204);
+        held = held.filter((id) => !removed.includes(id));
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 5, added: 7, modified: 0, deleted: 2 },
+          itemIds: held,
+        });
+      });
+
+      await test.step('Insert three more', async () => {
+        const secondBatch = newItems(3, 'second');
+        await backendClient.upsertDatasetItemsIntoLatestVersion({
+          datasetId: dataset.id,
+          items: secondBatch,
+        });
+        held = [...held, ...secondBatch.map((item) => item.id)];
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 8, added: 10, modified: 0, deleted: 2 },
+          itemIds: held,
+        });
+      });
+
+      await test.step('Re-send two stored ids with new content — an upsert, which moves modified only', async () => {
+        await backendClient.upsertDatasetItemsIntoLatestVersion({
+          datasetId: dataset.id,
+          items: held.slice(0, 2).map((id) => ({ id, data: { input: 'edited', expected_output: 'edited' } })),
+        });
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 8, added: 10, modified: 2, deleted: 2 },
+          itemIds: held,
+        });
+      });
+
+      await test.step('Delete one more', async () => {
+        const removed = held.slice(-1);
+        expect(await backendClient.deleteDatasetItemsByIds(removed)).toBe(204);
+        held = held.filter((id) => !removed.includes(id));
+        await expectVersionState(backendClient, dataset.id, {
+          versionId: seeded.versionId,
+          counters: { total: 7, added: 10, modified: 2, deleted: 3 },
+          itemIds: held,
+        });
+      });
+
+      await test.step('The Version history tab renders all three change tags with the API figures', async () => {
+        const datasets = new DatasetsPage(page);
+        await datasets.goto(project.id);
+        await datasets.waitForReady();
+        const items = await datasets.openDatasetByName(dataset.name);
+        await items.waitForReady();
+        await items.openVersionHistory();
+
+        await expect(items.versionItemCount('v1')).toHaveText('7');
+        await expect(items.versionChangeTags('v1')).toHaveCount(3);
+        await expect(items.versionChangeTag('v1', 'added', 10)).toBeVisible();
+        await expect(items.versionChangeTag('v1', 'modified', 2)).toBeVisible();
+        await expect(items.versionChangeTag('v1', 'deleted', 3)).toBeVisible();
+      });
+    },
+  );
+});


### PR DESCRIPTION
> **Generated by the release QA side flow (`release-test-proposal`). Not reviewed by a human. Draft on purpose — please review before promoting.**

## Where these came from

Exploratory testing of **#7705 — `[OPIK-7707] [BE] perf: make dataset version count updates atomic`**, run by hand against that PR's own deployed environment (`pr-7705.dev.comet.com`, serving `2.2.14-7705-merge-3043`; fresh OSS install, workspace `default`). Every flow below was reached and verified manually there before any spec was written.

**This PR targets `danield/OPIK-7707-make-the-version-count-update-atomic`, not `main`** — it is branched from that PR's head, `7ad36cf35490e454fb93810311c374361354a67f`. The specs assert the counter arithmetic the way #7705 implements it (one signed-delta `UPDATE` shared by the insert and delete paths), so they belong on top of the change they test rather than ahead of it. Merge #7705 first; this then rides in with it.

## What was uncovered

`updateVersionCountsForInsert` and `updateVersionCountsForDelete` now funnel through `updateVersionCounts(versionId, workspace, totalDelta, addedDelta, modifiedDelta, deletedDelta, user)` — six positional ints, which is where a sign or argument slip would hide. Nothing in the suite reads a version counter on the **delete** side: `dataset-items.spec.ts` bulk-deletes but counts rendered table rows and SDK items, so an `items_total` that kept climbing after a delete would leave every existing spec green, while the Version history tab showed users the wrong Item count.

`datasets.version-history-view` was `covered: false` in the taxonomy at this branch point.

## The specs

Both live in `tests_end_to_end/e2e/tests/datasets/dataset-version-delete-counters.spec.ts`, both `@t2-cuj @area:datasets @cap:datasets.version-history-view`, and both drive the **ungrouped** write path (no `batch_group_id`, so the latest version is mutated in place instead of a new one being cut). Writes go through the backend client; the figures are then read back off the UI — the disagreement between the two surfaces is the thing worth catching.

### 1. `Deleting items moves only the total and deleted counters of the version it mutates, and the Version history tab renders them`

Seeds via the `dataset` fixture (3 items, `v1`), adds 3 more, deletes 2 by id, then re-sends the identical delete. After every step it asserts the exact quadruple, that the version id did not change and no second version appeared, and that `items_total` equals the item ids the dataset actually holds — `{3,3,0,0}` → `{6,6,0,0}` → `{4,6,0,2}`, unchanged on the repeat. The repeat also asserts `204`, not `404`: the `deletedCount == 0` short-circuit has to fire before the counter update, or a repeated delete writes a phantom delta. Finally the Version history tab must render Item count `4` and **exactly two** change tags, `+ 6` and `− 2` — a `~` tag appearing there is a failure.

**Result: passed.**

### 2. `Interleaved inserts, upserts and deletes keep the version counters equal to the items the dataset holds`

A single operation can't catch a delta applied to the wrong column — after one write the numbers still look plausible. This drives insert 4 → delete 2 → insert 3 → upsert 2 stored ids with new content → delete 1, all into `v1`, asserting the full quadruple and the stored id set after each: `{3,3,0,0}` → `{7,7,0,0}` → `{5,7,0,2}` → `{8,10,0,2}` → `{8,10,2,2}` → `{7,10,2,3}`. Then the tab must show Item count `7` and exactly three tags, `+ 10 ~ 2 − 3`.

**Result: passed.**

## Verification

```bash
cd tests_end_to_end/e2e
npx tsc --noEmit                                          # clean
python3 ../coverage/tag_lint.py --taxonomy ../coverage/taxonomy.yaml --estate ..
                                                          # 27 specs checked, 0 problem(s)
npx playwright test tests/datasets/ --reporter=list        # 7 passed (31.9s)
```

Run against `https://pr-7705.dev.comet.com` (`OPIK_DEPLOYMENT=oss`, workspace `default`). The whole `tests/datasets/` directory was run, not just the new file, because `DatasetItemsPage` is shared — the 5 pre-existing specs still pass.

Two things a reviewer should know about that run:

- The suite's `makeBackendClient` requires an API key for any non-localhost host, so the run passed a placeholder `OPIK_API_KEY` at an OSS install that has no auth. That's a property of running the OSS suite against a *remote* OSS deployment, not something the specs need.
- To prove the UI assertions can actually discriminate rather than passing vacuously, the expected Item count was temporarily mutated from `4` to `5` and the spec failed at exactly that line. Reverted before committing.

## What I deliberately did not write

One candidate was dropped: **concurrent batch inserts and deletes into one version** (8 workers × 5 batches × 10 items → `items_total` exactly 401; concurrent insert+delete → 401/441/0/40). It passed by hand on the PR environment, but it was marked weak by the exploration and I agree: `withDatasetVersionLock` still serialises these API paths, so the assertion would be about end-to-end exactness rather than the lock-free property the PR claims — the DAO-level proof is the PR's own unit test — and a wall-clock-sensitive fan-out is a flake risk the suite shouldn't take on for that. If the team wants a single-threaded stand-in with similar value, the deterministic one is a >1000-row CSV upload (`csvBatchSize` is 1000), which drives several sequential increments into one version through a real product path.

Also not proposed: the `COALESCE(col, 0)` NULL-counter guard (not producible through the API — every `INSERT INTO dataset_versions` names the columns and every `DatasetVersion.builder()` sets them; the PR's own unit test forces it with raw SQL), and a second `datasets.bulk-delete-items` spec (already covered at t3-nightly; the counter assertions belong under the uncovered capability instead).

## Supporting changes

- `core/backend/client.ts` — `getDatasetVersions`, `listDatasetItemIds`, `upsertDatasetItemsIntoLatestVersion`, `deleteDatasetItemsByIds`. The delete helper returns the HTTP status rather than `void` so a caller can tell a specified no-op `204` from a `404`.
- `pom/dataset-items.page.ts` — Version history tab: `openVersionHistory`, `versionHistoryRow`, `versionItemCount`, `versionChangeSummary`, `versionChangeTags`, `versionChangeTag`. Cells are addressed by the shared `DataTable`'s `data-cell-id`, not by position, because column order is user-configurable.
- `coverage/taxonomy.yaml` — spec added to the area's `specs:` list, `datasets.version-history-view` flipped to `covered: true, tier: t2-cuj` with a note on what it does and does not assert.

### One merge note

`main` has moved on since this branch point: it now carries `datasets/dataset-version-counters.spec.ts`, which covers the **insert** side of the same capability (multi-batch and multi-threaded `insert()`, adds/modified), and already has `version-history-view` flipped to covered. That spec and this one are complementary — nothing here re-asserts the insert path — and the filenames deliberately don't collide. Expect small textual conflicts in `taxonomy.yaml` (the `specs:` list, the capability line) and in `core/backend/client.ts` / `pom/dataset-items.page.ts`, where `main` has near-identical versions of `getDatasetVersions`, `listDatasetItemIds`, `openVersionHistory` and `versionItemCount`; take `main`'s and keep the additions here that it lacks (`DatasetVersionRef.id`, the write/delete helpers, the change-summary locators).

---

Generated by the release QA side flow. Needs human review before merge.


[OPIK-7707]: https://comet-ml.atlassian.net/browse/OPIK-7707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ