### PR TITLE
[OPIK-7891] [BE] fix: count distinct item ids when sizing a dataset version

### DIFF
--- a/.agents/skills/opik-backend/testing.md
+++ b/.agents/skills/opik-backend/testing.md
@@ -284,6 +284,31 @@ assertThat(actual)
 `containsExactly` asserts size and content together — `hasSize` plus per-index checks does not,
 and lets an extra element through.
 
+`hasSize` **on its own** is weaker still: it asserts a count and nothing about identity, so any
+bug that preserves the count passes. This bites hardest on de-duplication, merge, and upsert
+tests, where the count is exactly the thing a bug is most likely to keep right:
+
+```java
+// ❌ BAD - passes if the wrong revision survived, or if the duplicate was kept
+// and the distinct row dropped. Both keep the size at 2.
+assertThat(stored).hasSize(2);
+assertThat(version.itemsTotal()).isEqualTo(stored.size());
+
+// ✅ GOOD - names the rows that must survive, so a wrong-winner bug fails
+assertThat(stored)
+    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+    .containsExactlyInAnyOrder(winningDuplicate, distinctItem);
+assertThat(version.itemsTotal()).isEqualTo(stored.size());
+```
+
+Asserting a derived counter against `stored.size()` is good — it ties the counter to reality
+rather than to a literal — but it is only as strong as the assertion on `stored` itself. Pin the
+contents first, then tie the counter to them.
+
+Reuse the shared ignore-field constants (`IGNORED_FIELDS_DATA_ITEM` and friends) rather than
+declaring a local list: they already encode which server-generated fields are not part of the
+contract, and a local copy silently drifts from them.
+
 These `containsExactly*` variants compare elements with the element type's own `equals`, which is
 what you want for exact-valued models. When the elements carry `BigDecimal` or `double`, the same
 exception that justifies a comparator on a single object applies per element — otherwise a

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3683,7 +3683,15 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
         // Note: ClickHouse with async inserts returns 0 immediately before commit.
         // We return the count of items we're inserting instead of relying on getRowsUpdated.
-        long itemCount = items.size();
+        //
+        // Count DISTINCT stable ids, not rows handed in (OPIK-7891): reads collapse a repeated
+        // dataset_item_id to one row via LIMIT 1 BY, so counting the raw list inflates every
+        // version total derived from this value. Callers set datasetItemId before inserting;
+        // fall back to id so an unnormalized item still counts as itself rather than as null.
+        long itemCount = items.stream()
+                .map(item -> item.datasetItemId() != null ? item.datasetItemId() : item.id())
+                .distinct()
+                .count();
 
         return asyncTemplate.nonTransaction(connection -> {
             Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "insert_delta_items");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3686,10 +3686,11 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
         //
         // Count DISTINCT stable ids, not rows handed in (OPIK-7891): reads collapse a repeated
         // dataset_item_id to one row via LIMIT 1 BY, so counting the raw list inflates every
-        // version total derived from this value. Callers set datasetItemId before inserting;
-        // fall back to id so an unnormalized item still counts as itself rather than as null.
+        // version total derived from this value. Counting the same field the INSERT binds below
+        // keeps one definition of identity -- every caller normalizes datasetItemId first, and a
+        // null would fail at the bind regardless, so there is nothing to fall back to.
         long itemCount = items.stream()
-                .map(item -> item.datasetItemId() != null ? item.datasetItemId() : item.id())
+                .map(DatasetItem::datasetItemId)
                 .distinct()
                 .count();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -3796,21 +3796,14 @@ class DatasetVersionResourceTest {
             var datasetId = createDataset(UUID.randomUUID().toString());
 
             // The SDK's parallel upload sends every batch under one batch_group_id. The batch that
-            // arrives first CREATES the version, and that path derives itemsTotal from insertItems,
-            // which returns items.size() -- the raw list length, deliberately not a DB row count
-            // (ClickHouse async inserts report 0 before commit). A stable id repeated inside that
-            // first batch is therefore counted twice, while ClickHouse collapses it to one row.
+            // arrives first CREATES the version, and that path derives itemsTotal from insertItems.
+            // That used to return items.size() -- the raw list length, deliberately not a DB row count
+            // (ClickHouse async inserts report 0 before commit) -- so a stable id repeated inside the
+            // first batch was counted twice while ClickHouse collapsed it to one row. It now counts
+            // distinct dataset_item_ids, which is what this test pins.
             var duplicatedId = TestIdGeneratorFactory.create().generateId();
             var distinctId = TestIdGeneratorFactory.create().generateId();
 
-            // The repeated id wins with its LAST submitted content: ClickHouse keeps one row per
-            // dataset_item_id and reads take the newest, so "second" survives and "first" does not.
-            var winningDuplicate = DatasetItem.builder()
-                    .id(duplicatedId)
-                    .datasetItemId(duplicatedId)
-                    .source(DatasetItemSource.SDK)
-                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
-                    .build();
             var distinctItem = DatasetItem.builder()
                     .id(distinctId)
                     .datasetItemId(distinctId)
@@ -3824,7 +3817,11 @@ class DatasetVersionResourceTest {
                             .source(DatasetItemSource.SDK)
                             .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
                             .build(),
-                    winningDuplicate,
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
+                            .build(),
                     distinctItem);
 
             datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
@@ -3834,15 +3831,23 @@ class DatasetVersionResourceTest {
                     .build(), TEST_WORKSPACE, API_KEY);
 
             var version = getLatestVersion(datasetId);
-
-            // Assert on the rows themselves, not just how many: a bug that kept the wrong revision
-            // of the duplicate, or dropped the distinct item and kept both duplicates, would leave
-            // the count at 2 and slip through a size-only check.
             var stored = datasetResourceClient.getDatasetItems(
                     datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
+
+            // Which revision of the repeated id survives is deliberately NOT asserted: every row in a
+            // batch is written with the same now64(9), and the read dedupes with
+            // `ORDER BY dataset_item_id DESC, last_updated_at DESC LIMIT 1 BY dataset_item_id` -- no
+            // tie-breaker, so either payload may win. Pinning "second" would be asserting an accident.
+            // What is guaranteed, and what the fix is about: exactly one row per distinct id, and a
+            // counter that agrees with it.
+            assertThat(stored).extracting(DatasetItem::id)
+                    .containsExactlyInAnyOrder(duplicatedId, distinctId);
             assertThat(stored)
-                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
-                    .containsExactlyInAnyOrder(winningDuplicate, distinctItem);
+                    .filteredOn(item -> distinctId.equals(item.id()))
+                    .singleElement()
+                    .usingRecursiveComparison()
+                    .ignoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .isEqualTo(distinctItem);
 
             // items_total must agree with what is actually stored.
             assertThat(version.itemsTotal()).isEqualTo(stored.size());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -3791,6 +3791,96 @@ class DatasetVersionResourceTest {
     class BatchVersioningTests {
 
         @Test
+        @DisplayName("Success: Duplicate stable id in the version-creating batch counts once (OPIK-7891)")
+        void putItems__whenCreatingBatchRepeatsStableId__thenCountedOnce() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            // The SDK's parallel upload sends every batch under one batch_group_id. The batch that
+            // arrives first CREATES the version, and that path derives itemsTotal from insertItems,
+            // which returns items.size() -- the raw list length, deliberately not a DB row count
+            // (ClickHouse async inserts report 0 before commit). A stable id repeated inside that
+            // first batch is therefore counted twice, while ClickHouse collapses it to one row.
+            var duplicatedId = TestIdGeneratorFactory.create().generateId();
+            var items = List.of(
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
+                            .build(),
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
+                            .build(),
+                    DatasetItem.builder()
+                            .id(TestIdGeneratorFactory.create().generateId())
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"third\"")))
+                            .build());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(UUID.randomUUID())
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version = getLatestVersion(datasetId);
+
+            // Two distinct ids went in, so the version holds two rows.
+            var stored = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
+            assertThat(stored).hasSize(2);
+
+            // items_total must agree with what is actually stored.
+            assertThat(version.itemsTotal()).isEqualTo(stored.size());
+        }
+
+        @Test
+        @DisplayName("Success: Duplicate stable id across batches in one group counts once (OPIK-7891)")
+        void putItems__whenDuplicateStableIdSpansBatchesInGroup__thenCountedOnce() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // Mirrors the SDK's parallel upload: several batches under one batch_group_id fold into
+            // one version. The first batch creates it, later batches append. A stable id present in
+            // both must contribute exactly one item to the total.
+            var sharedId = TestIdGeneratorFactory.create().generateId();
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(batchGroupId)
+                    .items(List.of(
+                            DatasetItem.builder()
+                                    .id(sharedId)
+                                    .source(DatasetItemSource.SDK)
+                                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
+                                    .build(),
+                            DatasetItem.builder()
+                                    .id(TestIdGeneratorFactory.create().generateId())
+                                    .source(DatasetItemSource.SDK)
+                                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"other\"")))
+                                    .build()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(batchGroupId)
+                    .items(List.of(DatasetItem.builder()
+                            .id(sharedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"updated\"")))
+                            .build()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version = getLatestVersion(datasetId);
+            var stored = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
+
+            assertThat(stored).hasSize(2);
+            assertThat(version.itemsTotal()).isEqualTo(stored.size());
+        }
+
+        @Test
         @DisplayName("Success: Multiple INSERT batches with same batch_group_id create single version")
         void putItems_whenSameBatchId_thenSingleVersion() {
             // Given - Create dataset

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -3801,22 +3801,31 @@ class DatasetVersionResourceTest {
             // (ClickHouse async inserts report 0 before commit). A stable id repeated inside that
             // first batch is therefore counted twice, while ClickHouse collapses it to one row.
             var duplicatedId = TestIdGeneratorFactory.create().generateId();
+            var distinctId = TestIdGeneratorFactory.create().generateId();
+
+            // The repeated id wins with its LAST submitted content: ClickHouse keeps one row per
+            // dataset_item_id and reads take the newest, so "second" survives and "first" does not.
+            var winningDuplicate = DatasetItem.builder()
+                    .id(duplicatedId)
+                    .datasetItemId(duplicatedId)
+                    .source(DatasetItemSource.SDK)
+                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
+                    .build();
+            var distinctItem = DatasetItem.builder()
+                    .id(distinctId)
+                    .datasetItemId(distinctId)
+                    .source(DatasetItemSource.SDK)
+                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"third\"")))
+                    .build();
+
             var items = List.of(
                     DatasetItem.builder()
                             .id(duplicatedId)
                             .source(DatasetItemSource.SDK)
                             .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
                             .build(),
-                    DatasetItem.builder()
-                            .id(duplicatedId)
-                            .source(DatasetItemSource.SDK)
-                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
-                            .build(),
-                    DatasetItem.builder()
-                            .id(TestIdGeneratorFactory.create().generateId())
-                            .source(DatasetItemSource.SDK)
-                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"third\"")))
-                            .build());
+                    winningDuplicate,
+                    distinctItem);
 
             datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
                     .datasetId(datasetId)
@@ -3826,10 +3835,14 @@ class DatasetVersionResourceTest {
 
             var version = getLatestVersion(datasetId);
 
-            // Two distinct ids went in, so the version holds two rows.
+            // Assert on the rows themselves, not just how many: a bug that kept the wrong revision
+            // of the duplicate, or dropped the distinct item and kept both duplicates, would leave
+            // the count at 2 and slip through a size-only check.
             var stored = datasetResourceClient.getDatasetItems(
                     datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
-            assertThat(stored).hasSize(2);
+            assertThat(stored)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactlyInAnyOrder(winningDuplicate, distinctItem);
 
             // items_total must agree with what is actually stored.
             assertThat(version.itemsTotal()).isEqualTo(stored.size());
@@ -3845,6 +3858,14 @@ class DatasetVersionResourceTest {
             // one version. The first batch creates it, later batches append. A stable id present in
             // both must contribute exactly one item to the total.
             var sharedId = TestIdGeneratorFactory.create().generateId();
+            var otherId = TestIdGeneratorFactory.create().generateId();
+
+            var otherItem = DatasetItem.builder()
+                    .id(otherId)
+                    .datasetItemId(otherId)
+                    .source(DatasetItemSource.SDK)
+                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"other\"")))
+                    .build();
 
             datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
                     .datasetId(datasetId)
@@ -3855,28 +3876,31 @@ class DatasetVersionResourceTest {
                                     .source(DatasetItemSource.SDK)
                                     .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
                                     .build(),
-                            DatasetItem.builder()
-                                    .id(TestIdGeneratorFactory.create().generateId())
-                                    .source(DatasetItemSource.SDK)
-                                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"other\"")))
-                                    .build()))
+                            otherItem))
                     .build(), TEST_WORKSPACE, API_KEY);
+
+            // The second batch re-sends the shared id with new content, so it is an update:
+            // one row, holding the later revision.
+            var updatedShared = DatasetItem.builder()
+                    .id(sharedId)
+                    .datasetItemId(sharedId)
+                    .source(DatasetItemSource.SDK)
+                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"updated\"")))
+                    .build();
 
             datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
                     .datasetId(datasetId)
                     .batchGroupId(batchGroupId)
-                    .items(List.of(DatasetItem.builder()
-                            .id(sharedId)
-                            .source(DatasetItemSource.SDK)
-                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"updated\"")))
-                            .build()))
+                    .items(List.of(updatedShared))
                     .build(), TEST_WORKSPACE, API_KEY);
 
             var version = getLatestVersion(datasetId);
             var stored = datasetResourceClient.getDatasetItems(
                     datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
 
-            assertThat(stored).hasSize(2);
+            assertThat(stored)
+                    .usingRecursiveFieldByFieldElementComparatorIgnoringFields(IGNORED_FIELDS_DATA_ITEM)
+                    .containsExactlyInAnyOrder(updatedShared, otherItem);
             assertThat(version.itemsTotal()).isEqualTo(stored.size());
         }
 


### PR DESCRIPTION
## Details

> **Stacked on #7705** (OPIK-7707). Base branch is `danield/OPIK-7707-make-the-version-count-update-atomic`, so this PR's diff shows only the OPIK-7891 fix. Merge #7705 first; this retargets to `main` automatically once it lands.

<img width="986" height="1502" alt="image" src="https://github.com/user-attachments/assets/0db2782e-cd09-44e2-8202-f4c3512faabf" />

`DatasetItemVersionDAO.insertItems` returned `items.size()` — the raw list length. That is deliberate, not an oversight: ClickHouse async inserts report 0 rows before commit, so the code returns the count of what it handed in rather than trusting `getRowsUpdated`. But reads collapse a repeated `dataset_item_id` to a single row via `LIMIT 1 BY`, so a stable id appearing twice in one batch made the stored version total one higher than the rows the version actually holds.

Every version total flows through that return value — `createFirstVersion` feeds it straight into `itemsTotal`, and `applyDelta` sums added + edited + copied — so the fix belongs at the source: count distinct stable ids, matching what the storage engine keeps.

- Counts `DISTINCT` `datasetItemId` in `insertItems` — the same field the `INSERT` below binds, so counting and writing share one definition of item identity. (An earlier revision added an `item.id()` fallback for a null `datasetItemId`; it was removed after review. The `INSERT` binds `datasetItemId().toString()` with no null check, so a null cannot survive to be counted either way, and every caller normalizes the field first.)
- Fixes all four call sites at once rather than patching one caller and leaving the others inflated.

### This corrects the mechanism recorded on the ticket

The ticket described this as asynchronous ClickHouse visibility racing concurrent batches on the *append* path, reachable only via `num_threads>1`. Investigation shows it is none of those things:

| Reported | Actual |
|---|---|
| A race between concurrent batches | Deterministic; one single-threaded request reproduces it |
| Requires `num_threads>1` | Parallelism is irrelevant to the defect |
| In the append path (`countExistingItemIds`) | In the version-**creating** path (`insertItems` → `createFirstVersion`) |

The append path is genuinely correct — `countExistingItemIds` classifies a cross-batch duplicate as an update. A test in this PR covers that case and passes both with and without the fix, which is what rules the append path out.

`num_threads` was a red herring: the SDK's content-hash dedup drops same-content duplicates before batching, so a duplicate id only survives into a request when the content differs. The reporter's parallel runs were simply the ones where such an id landed in the version-creating batch.

## Change checklist
- [x] User facing
- [x] Documentation update

User-facing: the "Item count" in **Datasets → _dataset_ → Version history** (and `dataset_items_count` in the SDK) now agrees with the rows the version holds. No API shape change.

## Issues

- Resolves #
- OPIK-7891

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Traced the call graph, wrote the fix and both tests, ran the suites and the with/without-fix comparisons below.
- Human verification: Pending author review.

## Testing

```
mvn test -Dtest='DatasetVersionResourceTest*'                       # 127/127 pass
mvn test -Dtest='DatasetsResourceTest$CreateDatasetItems,...'       # 45/45 pass
mvn spotless:check                                                  # clean
```

Two tests added, deliberately covering both shapes, and each was run with and without the fix:

| Scenario | Without fix | With fix |
|---|---|---|
| Duplicate stable id **inside the version-creating batch** | **FAILS** — `items_total` 3, rows stored 2 | passes |
| Duplicate stable id **spanning two batches** in one `batch_group_id` | passes | passes |

The first is the regression test. The second is a negative control: it pins the append path's existing correct behaviour and is the evidence that the reported async-visibility mechanism is not the cause. Both assert `items_total` against the rows actually returned for the version, rather than against a hardcoded number, so a future change that breaks one but not the other still fails.

Not verified:

- No measurement of production impact on already-drifted datasets. This prevents new inflation; it does not reconcile a version whose `items_total` is already wrong. Reconciliation is tracked separately under OPIK_7804.
- The original report was against a deployed environment; the reproduction here is a local integration test. The mechanism is confirmed in code and by test, but I have not re-run the reporter's exact 1,200-item scenario.

## Documentation

N/A — internal counter correctness fix with no API or configuration surface.
