### PR TITLE
docs: weekly changelog update (2026-08-24)

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-17.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-17.mdx
@@ -1,0 +1,29 @@
+## Experiment Traces Are Now a Logs Tab
+
+Experiment traces were previously reachable only through a small "Go to logs" link tucked into the metadata row, easy to miss — users who couldn't find it would conclude nothing had been logged. They're now a dedicated **Logs** tab on the experiment page, always scoped to that experiment or, when comparing, to every experiment in the comparison. Comparing experiments that live in different projects now shows an explicit message instead of silently dropping traces, since logs are read per project.
+
+The tab carries its own toolbar (just the columns selector, matching the other experiment tabs) and its own saved column/sort/filter configuration, so setting it up doesn't overwrite what you've configured in the Playground or trial overlay views. The Playground's "view trace" link on an experiment result now opens this tab directly instead of a dead-end overlay.
+
+## Bug Fixes & Improvements
+
+- **LLM-as-judge online-eval rules score more consistently** — Built-in judge prompt templates and the scoring engine disagreed on whether a judge's answer should be a flat or nested JSON object, so a rule could non-deterministically return an empty score depending on which shape the model happened to pick. The engine now accepts both shapes, correctly parses quoted numbers (`"0.8"` no longer becomes `0.0`) and common boolean spellings (yes/no, pass/fail, on/off), and reports — rather than silently drops — a score name the rule doesn't recognize. Judge prompts are also no longer HTML-escaped before being sent, which had been corrupting values like base64 data URLs assembled from template variables.
+
+- **Unsupported LLM features now return a clear 400 instead of a mysterious 500** — Requesting a capability the selected provider doesn't support (for example, requiring tool choice against a model that can't do it) previously failed with a generic server error and, for online-scoring rules, burned through the full retry budget before the message was dropped. It's now reported immediately as a 400 naming the unsupported feature, for both regular and streaming requests.
+
+- **Fixed a Vertex AI thread leak that could exhaust a backend pod** — Every LLM call routed through Vertex AI built a brand-new client whose background threads were never released, which could accumulate to thousands of threads per pod over time and eventually require a restart. The client is now created and closed per request instead.
+
+- **Optimization cost totals now include GEPA reflection spend** — LLM calls the optimizer makes internally during GEPA reflection belong to no single trial, so they were billed but excluded from a run's total cost, undercounting real spend. That spend is now traced, tagged with the run, and included in `total_optimization_cost` (`opik-optimizer` 3.2.0). Upgrade both packages together — `pip install -U "opik-optimizer>=3.2.0" "gepa>=0.1.0"` — raising `gepa` on its own breaks at runtime against the older reflection-template format that 3.2.0 no longer speaks.
+
+- **Self-hosted: per-component image registry override, and a demo-data job fix** — The Helm chart now lets you set a separate image registry for the backend, frontend, or Python backend individually, falling back to the chart-wide registry when unset. The demo-data job also now honors a component's configured image repository instead of always defaulting to `opik-python-backend`.
+
+## Performance Improvements
+
+- **Faster trace counts on projects using guardrails filters** — The traces-count query that fires on every Logs page load always joined against guardrails results and sorted every row to deduplicate, even when no guardrails filter was applied. Both are now skipped unless actually needed, cutting rows read roughly in half and cutting measured P99 latency by about 90% on production workspaces.
+
+- **Faster trace lookups by thread ID** — Filtering traces or threads by thread ID wasn't engaging an existing prefilter, so a lookup could scan a project's entire span history just to find one thread's traces. The prefilter now engages for thread-scoped lookups, cutting measured production query times from multiple seconds to under 200ms.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.2.23...2.2.29)
+
+_Releases_: `2.2.25`, `2.2.26`, `2.2.27`, `2.2.28`, `2.2.29`

--- a/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-24.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/changelog/2026-08-24.mdx
@@ -1,0 +1,50 @@
+## `evaluate_threads` Can Now Judge RAG Agents on Retrieved Context
+
+`evaluate_threads` only accepted `trace_input_transform` and `trace_output_transform`, so a thread was flattened to plain role/content messages with no way to pass along the documents each answer was grounded on — judging relevance or faithfulness for multi-turn RAG agents meant falling back to scoring individual traces instead.
+
+A new `trace_context_transform` argument receives the whole trace object and attaches the extracted context to that trace's message:
+
+```python
+from opik.evaluation import evaluate_threads
+from opik.evaluation.metrics import ConversationalCoherenceMetric
+
+evaluate_threads(
+    project_name="rag_chatbot",
+    filter_string='id = "0197ad2a"',
+    eval_project_name="rag_chatbot_evaluation",
+    metrics=[ConversationalCoherenceMetric()],
+    trace_input_transform=lambda x: x["input"],
+    trace_output_transform=lambda x: x["output"],
+    trace_context_transform=lambda trace: trace.metadata["retrieved_docs"],
+)
+```
+
+Only metrics that declare `uses_message_context = True` see the context, so every other metric's prompts and scores are unaffected. `ConversationalCoherenceMetric` is the first consumer: when context is present it also judges whether each answer is supported by it, returning an additional `conversational_groundedness_score`, while its original score is unchanged.
+
+## Bug Fixes & Improvements
+
+- **Daily briefings report "Not enough credits" instead of failing silently** — A daily report that ran out of LLM credits mid-run used to just say "Briefing failed," with the pod already allocated and the spend already burned. The trigger now checks credits up front, and a briefing that can't run for that reason shows "Not enough credits" with a direct link to add more, alongside Run again.
+
+- **Provider errors keep their real HTTP status instead of turning into a 500** — Traces and online-scoring rules calling out to an LLM provider reported a generic server error whenever the provider's response couldn't be parsed into its usual error shape — a plain-text upstream outage message, or a rate-limit response wrapped by a retry layer. The provider's actual status is now recovered from these cases too, so a caller-side or provider-side failure is no longer reported as an Opik fault.
+
+- **LLM-as-judge scoring retries on empty provider responses and no longer hangs indefinitely** — An empty structured-output response from the judge model previously fell outside the retry policy and cost the item its whole score. These are now retried, and judge calls carry an explicit timeout and retry budget so a stalled provider can no longer block scoring indefinitely.
+
+- **Silent span-conversion failures in the ADK integration are now reported** — When converting an ADK `LlmResponse` or extracting its usage failed, the span was still logged but silently missing output and usage, with nothing surfacing the failure. This is now logged as an error instead of being swallowed.
+
+- **Fixed two production NullPointerExceptions** — Deleting or batch-updating dataset items, and querying span metrics, could 500 when a filter used an operator not supported by its field, instead of returning the same 400 other endpoints already gave. Separately, a judge response with no text (for example from a content filter) could crash scoring for the whole trace instead of reporting that nothing was scored.
+
+- **Prompts no longer leak across projects with the same name** — A backward-compatibility fallback for looking up a prompt by name, when no project was specified, incorrectly matched a same-named prompt from any project in the workspace instead of only project-less legacy prompts, so a client without a `project_name` set could read, and unintentionally version, another project's prompt.
+
+- **Grouped chart series and tag colors are easier to tell apart** — Two adjacent colors in the series palette were close enough to be confused in a thin chart line; one has been replaced with a more distinct color, so any label that resolved to that palette slot now renders more legibly wherever it appears — chart series, tag chips, and feedback scores.
+
+- **Dataset item sorting by JSON fields now handles special characters correctly** — Sorting by `input.*`, `output.*`, or `metadata.*` keys built the underlying query by interpolating the key text directly, unlike `data.*` sorting, which could corrupt results for keys containing quotes or other special characters. JSON sort keys are now passed as bound parameters like everywhere else.
+
+## Performance Improvements
+
+- **Faster traces table on projects with many feedback score columns** — The traces table builds one column per feedback-score name, and every cell — editable or not — was paying the cost of wiring up inline editing. Non-editable score columns now render a lighter read-only cell, cutting a multi-second main-thread block down substantially on projects with hundreds of score columns and rows.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.2.29...2.2.36)
+
+_Releases_: `2.2.30`, `2.2.31`, `2.2.32`, `2.2.33`, `2.2.34`, `2.2.35`, `2.2.36`

--- a/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-24.mdx
+++ b/apps/opik-documentation/documentation/fern/docs/changelog/2026-08-24.mdx
@@ -1,0 +1,54 @@
+---
+canonical-url: https://www.comet.com/docs/opik/changelog
+---
+
+## `evaluate_threads` Can Now Judge RAG Agents on Retrieved Context
+
+`evaluate_threads` only accepted `trace_input_transform` and `trace_output_transform`, so a thread was flattened to plain role/content messages with no way to pass along the documents each answer was grounded on — judging relevance or faithfulness for multi-turn RAG agents meant falling back to scoring individual traces instead.
+
+A new `trace_context_transform` argument receives the whole trace object and attaches the extracted context to that trace's message:
+
+```python
+from opik.evaluation import evaluate_threads
+from opik.evaluation.metrics import ConversationalCoherenceMetric
+
+evaluate_threads(
+    project_name="rag_chatbot",
+    filter_string='id = "0197ad2a"',
+    eval_project_name="rag_chatbot_evaluation",
+    metrics=[ConversationalCoherenceMetric()],
+    trace_input_transform=lambda x: x["input"],
+    trace_output_transform=lambda x: x["output"],
+    trace_context_transform=lambda trace: trace.metadata["retrieved_docs"],
+)
+```
+
+Only metrics that declare `uses_message_context = True` see the context, so every other metric's prompts and scores are unaffected. `ConversationalCoherenceMetric` is the first consumer: when context is present it also judges whether each answer is supported by it, returning an additional `conversational_groundedness_score`, while its original score is unchanged.
+
+## Bug Fixes & Improvements
+
+- **Daily briefings report "Not enough credits" instead of failing silently** — A daily report that ran out of LLM credits mid-run used to just say "Briefing failed," with the pod already allocated and the spend already burned. The trigger now checks credits up front, and a briefing that can't run for that reason shows "Not enough credits" with a direct link to add more, alongside Run again.
+
+- **Provider errors keep their real HTTP status instead of turning into a 500** — Traces and online-scoring rules calling out to an LLM provider reported a generic server error whenever the provider's response couldn't be parsed into its usual error shape — a plain-text upstream outage message, or a rate-limit response wrapped by a retry layer. The provider's actual status is now recovered from these cases too, so a caller-side or provider-side failure is no longer reported as an Opik fault.
+
+- **LLM-as-judge scoring retries on empty provider responses and no longer hangs indefinitely** — An empty structured-output response from the judge model previously fell outside the retry policy and cost the item its whole score. These are now retried, and judge calls carry an explicit timeout and retry budget so a stalled provider can no longer block scoring indefinitely.
+
+- **Silent span-conversion failures in the ADK integration are now reported** — When converting an ADK `LlmResponse` or extracting its usage failed, the span was still logged but silently missing output and usage, with nothing surfacing the failure. This is now logged as an error instead of being swallowed.
+
+- **Fixed two production NullPointerExceptions** — Deleting or batch-updating dataset items, and querying span metrics, could 500 when a filter used an operator not supported by its field, instead of returning the same 400 other endpoints already gave. Separately, a judge response with no text (for example from a content filter) could crash scoring for the whole trace instead of reporting that nothing was scored.
+
+- **Prompts no longer leak across projects with the same name** — A backward-compatibility fallback for looking up a prompt by name, when no project was specified, incorrectly matched a same-named prompt from any project in the workspace instead of only project-less legacy prompts, so a client without a `project_name` set could read, and unintentionally version, another project's prompt.
+
+- **Grouped chart series and tag colors are easier to tell apart** — Two adjacent colors in the series palette were close enough to be confused in a thin chart line; one has been replaced with a more distinct color, so any label that resolved to that palette slot now renders more legibly wherever it appears — chart series, tag chips, and feedback scores.
+
+- **Dataset item sorting by JSON fields now handles special characters correctly** — Sorting by `input.*`, `output.*`, or `metadata.*` keys built the underlying query by interpolating the key text directly, unlike `data.*` sorting, which could corrupt results for keys containing quotes or other special characters. JSON sort keys are now passed as bound parameters like everywhere else.
+
+## Performance Improvements
+
+- **Faster traces table on projects with many feedback score columns** — The traces table builds one column per feedback-score name, and every cell — editable or not — was paying the cost of wiring up inline editing. Non-editable score columns now render a lighter read-only cell, cutting a multi-second main-thread block down substantially on projects with hundreds of score columns and rows.
+
+---
+
+And much more! 👉 [See full commit log on GitHub](https://github.com/comet-ml/opik/compare/2.2.29...2.2.36)
+
+_Releases_: `2.2.30`, `2.2.31`, `2.2.32`, `2.2.33`, `2.2.34`, `2.2.35`, `2.2.36`


### PR DESCRIPTION
## Details

Adds this week's changelog entry, leading with `evaluate_threads`' new `trace_context_transform` argument for context-aware RAG thread evaluation, followed by a consolidated Bug Fixes & Improvements section (daily-briefing credit checks, provider error status codes, LLM-judge retry/timeout bounds, ADK span-conversion reporting, two production NPEs, a cross-project prompt lookup leak, confusable chart colors, and JSON dataset-item sort key binding) and a Performance Improvements section (traces table with many feedback score columns). Also backfills the `2026-08-17` entry into `docs-v2/changelog`, which is the version actually served under "Latest" but was missing it (same gap the previous weekly-changelog PR fixed for two earlier weeks).

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude (runtime-selected)
- Scope: Authored the new changelog entries (`docs-v2/changelog/2026-08-24.mdx`, `docs/changelog/2026-08-24.mdx`) and backfilled `docs-v2/changelog/2026-08-17.mdx` from the existing legacy `docs/changelog/2026-08-17.mdx`. No application code changed.
- Human verification: Each item was cross-checked against the actual source changes in the target commits (SDK, backend, and frontend code) rather than taken from commit messages alone, to confirm shipped behavior and exact API/UI names (e.g. `trace_context_transform`, `uses_message_context`, the `purpleDark` chart color, and the "Not enough credits" UI copy).

## Testing

This is a documentation-only change (new `.mdx` changelog entries). No code was changed, so no automated test suite applies.

- Verified the new `docs-v2/changelog/2026-08-24.mdx` and `docs/changelog/2026-08-24.mdx` files are byte-identical apart from the legacy frontmatter block, matching the existing convention for prior weekly entries.
- Verified `docs-v2/changelog/2026-08-17.mdx` matches its `docs/changelog/2026-08-17.mdx` source apart from frontmatter, matching how earlier gaps (`2026-07-13`, `2026-07-20`) were backfilled in PR #7802.
- Spot-checked each changelog claim against the current codebase:
  - `trace_context_transform` / `uses_message_context` in `sdks/python/src/opik/evaluation/threads/evaluator.py` and `conversation_thread_metric.py`
  - `OUT_OF_CREDITS_FAILURE_REASON` / "Not enough credits" copy in `apps/opik-frontend/src/v2/pages/ProjectHomePage/DailyBriefing/DailyBriefingSection.tsx`
  - `getLlmProviderError` HTTP status handling in `apps/opik-backend/.../infrastructure/llm/*`
  - `purpleDark` (`#491b7e`) palette entry in `apps/opik-frontend/src/constants/colorVariants.ts`
  - JSON sort-key parameter binding in `FilterQueryBuilder`/`SortingQueryBuilder`/`DatasetItemDAO`
  - Confirmed release tags `2.2.30`–`2.2.36` exist via `git tag -l`
- Excluded from this entry: internal-only changes (the already-unreachable Opik V1 frontend deletion, the internal ClickHouse "cutover" migration tool flag, CI/build changes, automated provider-pricing syncs) since they have no user-visible effect or aren't part of the shipped product surface.

## Documentation

This PR *is* the documentation update — no further docs changes needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_016sEkXVj4AkqLPiedtNb5JA)_