### PR TITLE
[OPIK-7891] [QA] Proposed e2e spec from the #7966 exploration: dataset version item counts with a repeated item id

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1780,13 +1780,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @param workspaceId The workspace ID
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
-        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
-
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1745,36 +1745,25 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
     /**
      * Updates version counts after inserting items into an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * Only the new items move the total; re-sent items count as modifications.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
      * @param newItemsCount Number of new items inserted
      * @param updatedItemsCount Number of items updated
      * @param userName The user performing the update
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForInsert(UUID versionId, String workspaceId, int newItemsCount,
             int updatedItemsCount, String userName) {
-        template.inTransaction(WRITE, handle -> {
-            var dao = handle.attach(DatasetVersionDAO.class);
-
-            // Only increment total by new items (not updates)
-            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
-                    workspaceId, userName);
-
-            if (updated == 0) {
-                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
-            }
-            return null;
-        });
+        updateVersionCounts(versionId, workspaceId, newItemsCount, newItemsCount, updatedItemsCount, 0, userName);
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
      * <p>
-     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
-     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
-     * both callers fetch the version for their own purposes regardless.
+     * Unlike the insert path this saves no round-trip: both callers fetch the version for their own purposes
+     * regardless. What it buys is that the arithmetic no longer depends on that snapshot still being current.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
@@ -1783,10 +1772,23 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * @throws NotFoundException if the version no longer exists or does not belong to the workspace
      */
     private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        updateVersionCounts(versionId, workspaceId, -deletedCount, 0, 0, deletedCount, userName);
+    }
+
+    /**
+     * Applies signed counter deltas to a version in a single atomic statement, so the arithmetic does not depend on
+     * {@code withDatasetVersionLock} for mutual exclusion. A zero affected-row count means the version was removed or
+     * belongs to another workspace.
+     *
+     * @throws NotFoundException if the version no longer exists or does not belong to the workspace
+     */
+    private void updateVersionCounts(UUID versionId, String workspaceId, int totalDelta, int addedDelta,
+            int modifiedDelta, int deletedDelta, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
 
-            int updated = dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
+            int updated = dao.incrementCounts(versionId, totalDelta, addedDelta, modifiedDelta, deletedDelta,
+                    workspaceId, userName);
 
             if (updated == 0) {
                 throw new NotFoundException("Version not found: '%s'".formatted(versionId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1662,7 +1662,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         UUID latestVersionId = latestVersion.get().id();
         log.info("Inserting '{}' items into existing version '{}'", batch.items().size(), latestVersionId);
 
-        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName);
+        return insertItemsIntoVersion(batch, datasetId, latestVersionId, workspaceId, userName).then(Mono.empty());
     }
 
     /**
@@ -1670,14 +1670,17 @@ class DatasetItemServiceImpl implements DatasetItemService {
      * Handles validation, classification of new vs updated items, and count updates.
      * Used by mutateLatestVersionWithInsert and handleGroupedInsertion.
      *
+     * Completes empty: no caller reads the resulting version, so the counters are applied with a single atomic
+     * increment and the row is not read back.
+     *
      * @param batch the batch of items to insert
      * @param datasetId the dataset ID
      * @param versionId the version ID to insert into
      * @param workspaceId the workspace ID
      * @param userName the username
-     * @return Mono emitting the updated dataset version
+     * @return Mono completing when the items are inserted and the counts updated
      */
-    private Mono<DatasetVersion> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+    private Mono<Void> insertItemsIntoVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         // Validate and prepare items
         List<DatasetItem> validatedItems = addIdIfAbsent(batch);
@@ -1730,11 +1733,10 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     // Insert items directly into the existing version
                                     return versionDao
                                             .insertItems(datasetId, versionId, normalizedItems, workspaceId, userName)
-                                            .then(Mono.fromCallable(() -> {
-                                                updateVersionCountsForInsert(versionId, workspaceId, finalNewItemsCount,
-                                                        finalUpdatedItemsCount, userName);
-                                                return versionService.getVersionById(workspaceId, datasetId, versionId);
-                                            }).subscribeOn(Schedulers.boundedElastic()));
+                                            .then(Mono.fromRunnable(() -> updateVersionCountsForInsert(versionId,
+                                                    workspaceId, finalNewItemsCount, finalUpdatedItemsCount, userName))
+                                                    .subscribeOn(Schedulers.boundedElastic()))
+                                            .then();
                                 });
                     }));
         }).contextWrite(c -> c.put(RequestContext.WORKSPACE_ID, workspaceId)
@@ -1755,43 +1757,36 @@ class DatasetItemServiceImpl implements DatasetItemService {
             int updatedItemsCount, String userName) {
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            var currentVersion = dao.findById(versionId, workspaceId)
-                    .orElseThrow(() -> new NotFoundException(
-                            "Version not found: '%s'".formatted(versionId)));
 
             // Only increment total by new items (not updates)
-            int newTotal = currentVersion.itemsTotal() + newItemsCount;
-            int newAdded = currentVersion.itemsAdded() + newItemsCount;
-            int newModified = currentVersion.itemsModified() + updatedItemsCount;
+            int updated = dao.incrementCounts(versionId, newItemsCount, newItemsCount, updatedItemsCount, 0,
+                    workspaceId, userName);
 
-            dao.updateCounts(versionId, newTotal, newAdded, newModified,
-                    currentVersion.itemsDeleted(), workspaceId, userName);
+            if (updated == 0) {
+                throw new NotFoundException("Version not found: '%s'".formatted(versionId));
+            }
             return null;
         });
     }
 
     /**
      * Updates version counts after deleting items from an existing version.
-     * Extracted to reduce complexity and improve testability.
+     * <p>
+     * Applies the deltas atomically rather than writing back totals computed from a caller-supplied snapshot, so the
+     * result no longer depends on that snapshot still being current. Unlike the insert path this saves no round-trip:
+     * both callers fetch the version for their own purposes regardless.
      *
      * @param versionId The version ID to update
      * @param workspaceId The workspace ID
-     * @param currentVersion The current version before deletion
      * @param deletedCount Number of items deleted
      * @param userName The user performing the update
      */
-    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, DatasetVersion currentVersion,
-            int deletedCount, String userName) {
-        int newTotal = currentVersion.itemsTotal() - deletedCount;
-        int newDeleted = currentVersion.itemsDeleted() + deletedCount;
-
-        log.info("deleteItemsFromExistingVersion: updating counts - newTotal='{}', newDeleted='{}'",
-                newTotal, newDeleted);
+    private void updateVersionCountsForDelete(UUID versionId, String workspaceId, int deletedCount, String userName) {
+        log.info("deleteItemsFromExistingVersion: updating counts - deletedCount='{}'", deletedCount);
 
         template.inTransaction(WRITE, handle -> {
             var dao = handle.attach(DatasetVersionDAO.class);
-            dao.updateCounts(versionId, newTotal, currentVersion.itemsAdded(),
-                    currentVersion.itemsModified(), newDeleted, workspaceId, userName);
+            dao.incrementCounts(versionId, -deletedCount, 0, 0, deletedCount, workspaceId, userName);
             return null;
         });
     }
@@ -2186,8 +2181,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2231,8 +2225,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
 
                         // Update version counts in MySQL
                         return Mono.fromCallable(() -> {
-                            updateVersionCountsForDelete(versionId, workspaceId, currentVersion,
-                                    deletedCount.intValue(), userName);
+                            updateVersionCountsForDelete(versionId, workspaceId, deletedCount.intValue(), userName);
                             log.info("Deleted '{}' items from version '{}', new total '{}'",
                                     deletedCount, versionId, currentVersion.itemsTotal() - deletedCount.intValue());
                             return null;
@@ -2357,7 +2350,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
+                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
+                                .then(Mono.<DatasetVersion>empty());
                     } else {
                         // No version with this batch_group_id - create new one
                         log.info("Creating new version with batch_group_id '{}' for dataset '{}'",

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3502,10 +3502,11 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
         //
         // Count DISTINCT stable ids, not rows handed in (OPIK-7891): reads collapse a repeated
         // dataset_item_id to one row via LIMIT 1 BY, so counting the raw list inflates every
-        // version total derived from this value. Callers set datasetItemId before inserting;
-        // fall back to id so an unnormalized item still counts as itself rather than as null.
+        // version total derived from this value. Counting the same field the INSERT binds below
+        // keeps one definition of identity -- every caller normalizes datasetItemId first, and a
+        // null would fail at the bind regardless, so there is nothing to fall back to.
         long itemCount = items.stream()
-                .map(item -> item.datasetItemId() != null ? item.datasetItemId() : item.id())
+                .map(DatasetItem::datasetItemId)
                 .distinct()
                 .count();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3499,7 +3499,15 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
         // Note: ClickHouse with async inserts returns 0 immediately before commit.
         // We return the count of items we're inserting instead of relying on getRowsUpdated.
-        long itemCount = items.size();
+        //
+        // Count DISTINCT stable ids, not rows handed in (OPIK-7891): reads collapse a repeated
+        // dataset_item_id to one row via LIMIT 1 BY, so counting the raw list inflates every
+        // version total derived from this value. Callers set datasetItemId before inserting;
+        // fall back to id so an unnormalized item still counts as itself rather than as null.
+        long itemCount = items.stream()
+                .map(item -> item.datasetItemId() != null ? item.datasetItemId() : item.id())
+                .distinct()
+                .count();
 
         return asyncTemplate.nonTransaction(connection -> {
             Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "insert_delta_items");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -539,22 +539,26 @@ public interface DatasetVersionDAO {
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 
+    /**
+     * Applies signed deltas to the version counters in a single statement, so the arithmetic happens in the database
+     * rather than as a read-modify-write in the application. Correct under concurrent callers without an external lock.
+     */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = :items_total,
-                items_added = :items_added,
-                items_modified = :items_modified,
-                items_deleted = :items_deleted,
+            SET items_total = items_total + :items_total_delta,
+                items_added = items_added + :items_added_delta,
+                items_modified = items_modified + :items_modified_delta,
+                items_deleted = items_deleted + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id
               AND workspace_id = :workspace_id
             """)
-    void updateCounts(@Bind("version_id") UUID versionId,
-            @Bind("items_total") int itemsTotal,
-            @Bind("items_added") int itemsAdded,
-            @Bind("items_modified") int itemsModified,
-            @Bind("items_deleted") int itemsDeleted,
+    int incrementCounts(@Bind("version_id") UUID versionId,
+            @Bind("items_total_delta") int itemsTotalDelta,
+            @Bind("items_added_delta") int itemsAddedDelta,
+            @Bind("items_modified_delta") int itemsModifiedDelta,
+            @Bind("items_deleted_delta") int itemsDeletedDelta,
             @Bind("workspace_id") String workspaceId,
             @Bind("last_updated_by") String lastUpdatedBy);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetVersionDAO.java
@@ -545,10 +545,10 @@ public interface DatasetVersionDAO {
      */
     @SqlUpdate("""
             UPDATE dataset_versions
-            SET items_total = items_total + :items_total_delta,
-                items_added = items_added + :items_added_delta,
-                items_modified = items_modified + :items_modified_delta,
-                items_deleted = items_deleted + :items_deleted_delta,
+            SET items_total = COALESCE(items_total, 0) + :items_total_delta,
+                items_added = COALESCE(items_added, 0) + :items_added_delta,
+                items_modified = COALESCE(items_modified, 0) + :items_modified_delta,
+                items_deleted = COALESCE(items_deleted, 0) + :items_deleted_delta,
                 last_updated_at = NOW(),
                 last_updated_by = :last_updated_by
             WHERE id = :version_id

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -77,6 +77,7 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +90,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -5204,6 +5206,152 @@ class DatasetVersionResourceTest {
                     datasetId, 1, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
             assertThat(latestItems).hasSize(1);
             assertThat(latestItems.getFirst().description()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Atomic version count updates (OPIK-7707):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class AtomicVersionCountUpdates {
+
+        private int incrementCounts(UUID versionId, int total, int added, int modified, int deleted) {
+            return mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(versionId, total, added, modified, deleted, WORKSPACE_ID, USER));
+        }
+
+        private void awaitBarrier(CyclicBarrier barrier) {
+            try {
+                barrier.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(e);
+            } catch (BrokenBarrierException | TimeoutException e) {
+                throw new IllegalStateException(e);
+            }
+        }
+
+        @Test
+        @DisplayName("Success: single-batch append accumulates the full counter triple")
+        void insertItems__whenAppendingToExistingVersion__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 3);
+
+            var seed = getLatestVersion(datasetId);
+            assertThat(seed.itemsTotal()).isEqualTo(3);
+            assertThat(seed.itemsAdded()).isEqualTo(3);
+            assertThat(seed.itemsModified()).isZero();
+
+            // 2 brand-new items plus a re-send of an existing one: only the new items move itemsTotal.
+            var existingItem = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+            var items = new ArrayList<>(generateDatasetItems(2));
+            items.add(existingItem);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(5); // 3 + 2 new (the update doesn't count)
+            assertThat(updated.itemsAdded()).isEqualTo(5);
+            assertThat(updated.itemsModified()).isEqualTo(1);
+            assertThat(updated.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: multi-batch append via batch_group_id accumulates the full counter triple")
+        void insertItems__whenAppendingViaBatchGroupId__thenCountersAccumulate() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // First batch creates the version; the next two append into it via the batch_group_id path.
+            for (int i = 0; i < 3; i++) {
+                datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                        .datasetId(datasetId)
+                        .batchGroupId(batchGroupId)
+                        .items(generateDatasetItems(2))
+                        .build(), TEST_WORKSPACE, API_KEY);
+            }
+
+            assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).content()).hasSize(1);
+
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(6);
+            assertThat(version.itemsAdded()).isEqualTo(6);
+            assertThat(version.itemsModified()).isZero();
+            assertThat(version.itemsDeleted()).isZero();
+        }
+
+        @Test
+        @DisplayName("Success: concurrent increments are exact without the per-dataset lock")
+        void incrementCounts__whenConcurrentWritersBypassTheLock__thenCountersAreExact() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 1);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // Hit the DAO directly so withDatasetVersionLock is out of the picture entirely: this is what
+            // proves the arithmetic itself is atomic rather than merely serialized by the lock. The old
+            // read-modify-write would lose updates here.
+            int writers = 8;
+            int incrementsPerWriter = 25;
+
+            ExecutorService executor = Executors.newFixedThreadPool(writers);
+            CyclicBarrier barrier = new CyclicBarrier(writers);
+            try {
+                IntStream.range(0, writers)
+                        .mapToObj(i -> CompletableFuture.runAsync(() -> {
+                            awaitBarrier(barrier);
+                            for (int n = 0; n < incrementsPerWriter; n++) {
+                                incrementCounts(versionId, 1, 1, 2, 0);
+                            }
+                        }, executor))
+                        .toList()
+                        .forEach(CompletableFuture::join);
+            } finally {
+                executor.shutdown();
+                try {
+                    executor.awaitTermination(30, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            int expectedIncrements = writers * incrementsPerWriter;
+            var version = getLatestVersion(datasetId);
+            assertThat(version.itemsTotal()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsAdded()).isEqualTo(1 + expectedIncrements);
+            assertThat(version.itemsModified()).isEqualTo(2 * expectedIncrements);
+        }
+
+        @Test
+        @DisplayName("Success: negative deltas on the delete path decrement total and raise deleted")
+        void incrementCounts__whenNegativeDelta__thenTotalDecrements() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var seed = getLatestVersion(datasetId);
+            var itemToDelete = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 10, seed.versionHash(), API_KEY, TEST_WORKSPACE).content().getFirst();
+
+            datasetResourceClient.deleteDatasetItems(DatasetItemsDelete.builder()
+                    .itemIds(Set.of(itemToDelete.datasetItemId()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated.id()).isEqualTo(seed.id());
+            assertThat(updated.itemsTotal()).isEqualTo(4);
+            assertThat(updated.itemsDeleted()).isEqualTo(1);
+            // The delete path leaves added/modified untouched.
+            assertThat(updated.itemsAdded()).isEqualTo(seed.itemsAdded());
+            assertThat(updated.itemsModified()).isEqualTo(seed.itemsModified());
+        }
+
+        @Test
+        @DisplayName("Success: increment against an unknown version affects no rows")
+        void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
+            assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -3558,6 +3558,96 @@ class DatasetVersionResourceTest {
     class BatchVersioningTests {
 
         @Test
+        @DisplayName("Success: Duplicate stable id in the version-creating batch counts once (OPIK-7891)")
+        void putItems__whenCreatingBatchRepeatsStableId__thenCountedOnce() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            // The SDK's parallel upload sends every batch under one batch_group_id. The batch that
+            // arrives first CREATES the version, and that path derives itemsTotal from insertItems,
+            // which returns items.size() -- the raw list length, deliberately not a DB row count
+            // (ClickHouse async inserts report 0 before commit). A stable id repeated inside that
+            // first batch is therefore counted twice, while ClickHouse collapses it to one row.
+            var duplicatedId = TestIdGeneratorFactory.create().generateId();
+            var items = List.of(
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
+                            .build(),
+                    DatasetItem.builder()
+                            .id(duplicatedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"second\"")))
+                            .build(),
+                    DatasetItem.builder()
+                            .id(TestIdGeneratorFactory.create().generateId())
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"third\"")))
+                            .build());
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(UUID.randomUUID())
+                    .items(items)
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version = getLatestVersion(datasetId);
+
+            // Two distinct ids went in, so the version holds two rows.
+            var stored = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
+            assertThat(stored).hasSize(2);
+
+            // items_total must agree with what is actually stored.
+            assertThat(version.itemsTotal()).isEqualTo(stored.size());
+        }
+
+        @Test
+        @DisplayName("Success: Duplicate stable id across batches in one group counts once (OPIK-7891)")
+        void putItems__whenDuplicateStableIdSpansBatchesInGroup__thenCountedOnce() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            var batchGroupId = UUID.randomUUID();
+
+            // Mirrors the SDK's parallel upload: several batches under one batch_group_id fold into
+            // one version. The first batch creates it, later batches append. A stable id present in
+            // both must contribute exactly one item to the total.
+            var sharedId = TestIdGeneratorFactory.create().generateId();
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(batchGroupId)
+                    .items(List.of(
+                            DatasetItem.builder()
+                                    .id(sharedId)
+                                    .source(DatasetItemSource.SDK)
+                                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"first\"")))
+                                    .build(),
+                            DatasetItem.builder()
+                                    .id(TestIdGeneratorFactory.create().generateId())
+                                    .source(DatasetItemSource.SDK)
+                                    .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"other\"")))
+                                    .build()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .batchGroupId(batchGroupId)
+                    .items(List.of(DatasetItem.builder()
+                            .id(sharedId)
+                            .source(DatasetItemSource.SDK)
+                            .data(Map.of("value", JsonUtils.getJsonNodeFromString("\"updated\"")))
+                            .build()))
+                    .build(), TEST_WORKSPACE, API_KEY);
+
+            var version = getLatestVersion(datasetId);
+            var stored = datasetResourceClient.getDatasetItems(
+                    datasetId, 1, 100, version.versionHash(), API_KEY, TEST_WORKSPACE).content();
+
+            assertThat(stored).hasSize(2);
+            assertThat(version.itemsTotal()).isEqualTo(stored.size());
+        }
+
+        @Test
         @DisplayName("Success: Multiple INSERT batches with same batch_group_id create single version")
         void putItems_whenSameBatchId_thenSingleVersion() {
             // Given - Create dataset

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5349,6 +5349,36 @@ class DatasetVersionResourceTest {
         }
 
         @Test
+        @DisplayName("Success: NULL counters are treated as zero rather than staying NULL")
+        void incrementCounts__whenCountersAreNull__thenTreatedAsZero() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            UUID versionId = getLatestVersion(datasetId).id();
+
+            // The counter columns are `INT DEFAULT 0` -- nullable, since DEFAULT only applies when the
+            // column is omitted on INSERT. A bare `col + :delta` would leave NULL as NULL, which then
+            // unboxes to an NPE on the Integer-typed record. The absolute update this replaced happened
+            // to repair a NULL by overwriting it, so the increment has to COALESCE explicitly.
+            int nulled = mySqlTemplate.inTransaction(WRITE, handle -> handle.createUpdate("""
+                    UPDATE dataset_versions
+                    SET items_total = NULL, items_added = NULL, items_modified = NULL, items_deleted = NULL
+                    WHERE id = :version_id AND workspace_id = :workspace_id
+                    """)
+                    .bind("version_id", versionId.toString())
+                    .bind("workspace_id", WORKSPACE_ID)
+                    .execute());
+            assertThat(nulled).isOne();
+
+            assertThat(incrementCounts(versionId, 3, 3, 1, 0)).isOne();
+
+            var updated = getLatestVersion(datasetId);
+            assertThat(updated)
+                    .extracting(DatasetVersion::itemsTotal, DatasetVersion::itemsAdded,
+                            DatasetVersion::itemsModified, DatasetVersion::itemsDeleted)
+                    .containsExactly(3, 3, 1, 0);
+        }
+
+        @Test
         @DisplayName("Success: increment against an unknown version affects no rows")
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5353,6 +5353,22 @@ class DatasetVersionResourceTest {
         void incrementCounts__whenVersionDoesNotExist__thenNoRowsAffected() {
             assertThat(incrementCounts(UUID.randomUUID(), 1, 1, 0, 0)).isZero();
         }
+
+        @Test
+        @DisplayName("Success: increment scoped to another workspace affects no rows")
+        void incrementCounts__whenVersionBelongsToAnotherWorkspace__thenNoRowsAffected() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 2);
+            var seed = getLatestVersion(datasetId);
+
+            // Real version id, wrong workspace: the workspace predicate must keep the update from matching, which is
+            // what lets both count-update helpers detect a missing/foreign version from the affected-row count alone.
+            int updated = mySqlTemplate.inTransaction(WRITE, handle -> handle.attach(DatasetVersionDAO.class)
+                    .incrementCounts(seed.id(), 1, 1, 0, 0, UUID.randomUUID().toString(), USER));
+
+            assertThat(updated).isZero();
+            assertThat(getLatestVersion(datasetId).itemsTotal()).isEqualTo(seed.itemsTotal());
+        }
     }
 
     @Nested

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -422,6 +422,7 @@ areas:
     specs:
       - datasets/dataset-crud-smoke.spec.ts
       - datasets/dataset-items.spec.ts
+      - datasets/dataset-version-duplicate-ids.spec.ts
     capabilities:
       list-datasets:          { covered: true,  tier: t1-smoke }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }
@@ -432,7 +433,7 @@ areas:
       bulk-delete-items:      { covered: true,  tier: t3-nightly }
       search-items:           { covered: true,  tier: t3-nightly }
       sdk-round-trip:         { covered: true,  tier: t1-smoke }
-      version-history-view:   { covered: false }
+      version-history-view:   { covered: true,  tier: t2-cuj, note: "items_total on both version-creating paths (createFirstVersion / applyDelta) when a batch repeats an item id, plus the Item count column; the un-versioned PUT path (no batch_group_id) is NOT covered" }
       export-dataset:         { covered: false, note: "DATASET_EXPORT_ENABLED" }
       import-huggingface:     { covered: false }
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -29,6 +29,15 @@ export interface DatasetItemRef {
   data: Record<string, unknown>;
 }
 
+export interface DatasetVersionRef {
+  versionName: string;
+  itemsTotal: number;
+  itemsAdded: number;
+  itemsModified: number;
+  itemsDeleted: number;
+  isLatest: boolean;
+}
+
 export interface ExperimentRefDetail {
   id: string;
   name: string;
@@ -227,6 +236,40 @@ export function makeBackendClient(apiKey: string | null = null) {
         id: String(item.id),
         data: (item.data ?? {}) as Record<string, unknown>,
       }));
+    },
+
+    async getDatasetVersions(datasetId: string): Promise<DatasetVersionRef[]> {
+      const page = await opik.api.datasets.listDatasetVersions(datasetId, { size: 100 });
+      const content = page.content ?? [];
+      return content.map((v) => ({
+        versionName: String(v.versionName ?? ''),
+        itemsTotal: Number(v.itemsTotal ?? 0),
+        itemsAdded: Number(v.itemsAdded ?? 0),
+        itemsModified: Number(v.itemsModified ?? 0),
+        itemsDeleted: Number(v.itemsDeleted ?? 0),
+        isLatest: Boolean(v.isLatest),
+      }));
+    },
+
+    /**
+     * Every item id actually stored in the dataset, paged out in full. This is
+     * the ground truth a version's `items_total` is supposed to agree with, so
+     * it must not be capped at a page — hence the loop. `truncate` drops the
+     * item payloads we don't need, keeping a few-thousand-item read cheap.
+     */
+    async listDatasetItemIds(datasetId: string): Promise<string[]> {
+      const pageSize = 1000;
+      const ids: string[] = [];
+      for (let page = 1; ; page++) {
+        const result = await opik.api.datasets.getDatasetItems(datasetId, {
+          page,
+          size: pageSize,
+          truncate: true,
+        });
+        const content = result.content ?? [];
+        ids.push(...content.map((item) => String(item.id)));
+        if (content.length < pageSize) return ids;
+      }
     },
 
     async findExperimentByName(name: string): Promise<ExperimentRefDetail | null> {

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -4,6 +4,7 @@ export {
   type ProjectRef,
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
+  type DatasetVersionRef,
   type ExperimentRefDetail,
   type TestSuiteRef as BackendTestSuiteRef,
   type TestSuiteItemRef,
@@ -13,4 +14,5 @@ export {
   type AnnotationQueueDetail,
   type AnnotationQueueReviewerRef,
 } from './client';
+export { uuid7 } from './uuid7';
 export { type PollFeedbackScoreOpts } from './poll-feedback-score';

--- a/tests_end_to_end/e2e/core/backend/uuid7.ts
+++ b/tests_end_to_end/e2e/core/backend/uuid7.ts
@@ -1,0 +1,41 @@
+import { randomBytes } from 'node:crypto';
+
+/**
+ * Build a UUIDv7 whose embedded timestamp is `moment` (default: now).
+ *
+ * Opik ids are version 7 and the backend reads the creation instant back out of
+ * them — time-windowed reads window on the id's timestamp, not on `start_time`.
+ * So a test that needs a trace to sit provably inside or outside a rolling
+ * window has to control the id, and a test that needs to assert on exact ids
+ * has to mint them up front (the REST writes answer 204 with no body).
+ *
+ * Bit layout, per RFC 9562: 48-bit big-endian millisecond timestamp, 4-bit
+ * version 7, 12 random bits, 2-bit variant, 62 random bits. This mirrors
+ * `_uuid7_at` in the SDK driver, which exists for the same reason on the Python
+ * side.
+ */
+export function uuid7(moment: Date = new Date()): string {
+  const bytes = randomBytes(16);
+  const millis = moment.getTime();
+
+  // 48-bit timestamp, most significant byte first.
+  bytes[0] = (millis / 2 ** 40) & 0xff;
+  bytes[1] = (millis / 2 ** 32) & 0xff;
+  bytes[2] = (millis / 2 ** 24) & 0xff;
+  bytes[3] = (millis / 2 ** 16) & 0xff;
+  bytes[4] = (millis / 2 ** 8) & 0xff;
+  bytes[5] = millis & 0xff;
+
+  // Version 7 in the high nibble of byte 6; RFC 4122 variant in byte 8.
+  bytes[6] = (bytes[6] & 0x0f) | 0x70;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+  const hex = bytes.toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -49,6 +49,18 @@ export interface PythonSdkClient {
     items?: Array<Record<string, unknown>>;
     workspace?: string;
   }): Promise<{ id: string; name: string }>;
+  /**
+   * One `Dataset.insert(...)` into an existing dataset — and therefore exactly
+   * one new dataset version, however many 1000-item batches the SDK splits the
+   * payload into. `num_threads` > 1 uploads those batches in parallel.
+   */
+  insertDatasetItems(args: {
+    dataset_name: string;
+    project_name: string;
+    items: Array<Record<string, unknown>>;
+    num_threads?: number;
+    workspace?: string;
+  }): Promise<{ dataset_id: string; inserted: number }>;
   evaluateExperiment(args: {
     project_name: string;
     dataset_name: string;
@@ -181,10 +193,12 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     method: 'GET' | 'POST' | 'DELETE',
     path: string,
     body?: unknown,
+    opts: { timeoutMs?: number } = {},
   ): Promise<TResponse> {
     const endpoint = `${method} ${path}`;
+    const timeoutMs = opts.timeoutMs ?? REQUEST_TIMEOUT_MS;
     const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
     try {
       const headers: Record<string, string> = {};
       if (body !== undefined) headers['content-type'] = 'application/json';
@@ -206,7 +220,7 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
             status: 0,
             endpoint,
             detail: 'client-timeout',
-            message: `opik-sdk-driver ${endpoint} aborted after ${REQUEST_TIMEOUT_MS}ms (client-side timeout — the bridge or backend did not respond in time)`,
+            message: `opik-sdk-driver ${endpoint} aborted after ${timeoutMs}ms (client-side timeout — the bridge or backend did not respond in time)`,
           });
         }
         throw err;
@@ -258,6 +272,17 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
     },
     async createDataset(args) {
       return request<{ id: string; name: string }>('POST', '/datasets', args);
+    },
+    async insertDatasetItems(args) {
+      // Multi-batch inserts against a cloud backend outlive the default budget
+      // when the workspace is being rate-limited, and a client-side abort here
+      // would leave a half-written dataset behind.
+      return request<{ dataset_id: string; inserted: number }>(
+        'POST',
+        '/datasets/insert-items',
+        args,
+        { timeoutMs: 180_000 },
+      );
     },
     async compareSeed(args) {
       return request<{

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -110,6 +110,37 @@ export class DatasetItemsPage {
     });
   }
 
+  /** Second tab of the dataset page: one row per committed version. */
+  async openVersionHistory(): Promise<void> {
+    return test.step('Open the Version history tab', async () => {
+      await this.page.getByRole('tab', { name: 'Version history' }).click();
+      const realRow = this.versionsTableBody.locator('tr[data-row-id]').first();
+      const emptyState = this.page.getByText('No version history yet');
+      await Promise.race([
+        realRow.waitFor({ state: 'visible' }),
+        emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  versionHistoryRow(versionName: string): Locator {
+    return this.versionsTableBody
+      .locator('tr[data-row-id]')
+      .filter({ has: this.page.getByRole('cell', { name: versionName, exact: true }) });
+  }
+
+  /**
+   * The "Item count" cell of a version row, as rendered — thousands-separated
+   * ("1,800"), because the column formats through toLocaleString().
+   *
+   * Addressed by the table's own `data-cell-id` (`<rowId>_<columnId>`) rather
+   * than a positional nth(): the version table has no per-cell testid, and
+   * column order is user-configurable, so position is not stable.
+   */
+  versionItemCount(versionName: string): Locator {
+    return this.versionHistoryRow(versionName).locator('[data-cell-id$="_items_total"]');
+  }
+
   async search(term: string): Promise<void> {
     return test.step(`Search items for "${term}"`, async () => {
       await this.page.getByTestId('search-input').fill(term);
@@ -212,6 +243,10 @@ export class DatasetItemsPage {
 
   private get itemsTableBody(): Locator {
     return this.page.getByRole('tabpanel', { name: 'Records' }).locator('tbody');
+  }
+
+  private get versionsTableBody(): Locator {
+    return this.page.getByRole('tabpanel', { name: 'Version history' }).locator('tbody');
   }
 
   /** Panel stays mounted; open/closed is animated via CSS transform, not display/visibility. */

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -3,7 +3,12 @@ import atexit
 from fastapi import APIRouter, Header
 
 from ..opik_factory import make_opik_client
-from ..schemas import DatasetCreate, DatasetResponse
+from ..schemas import (
+    DatasetCreate,
+    DatasetInsertItemsRequest,
+    DatasetInsertItemsResponse,
+    DatasetResponse,
+)
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 
@@ -31,3 +36,34 @@ def create_dataset(
         atexit.unregister(client.end)
 
     return DatasetResponse(id=str(dataset.id), name=dataset.name)
+
+
+@router.post(
+    "/insert-items",
+    response_model=DatasetInsertItemsResponse,
+    status_code=200,
+)
+def insert_dataset_items(
+    body: DatasetInsertItemsRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> DatasetInsertItemsResponse:
+    """Insert items into an existing dataset by name, as ONE dataset version.
+
+    Mirrors test-suites/insert-items: resolves the dataset within the caller's
+    `project_name` scope, since same-named datasets can exist across projects.
+    Each call is one `Dataset.insert(...)`, which is the unit a version is cut
+    on — the SDK splits the items into batches of 1000 internally, and those
+    batches must not become versions of their own.
+    """
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        dataset = client.get_dataset(
+            name=body.dataset_name, project_name=body.project_name
+        )
+        dataset.insert(body.items, num_threads=body.num_threads)
+        dataset_id = str(dataset.id)
+    finally:
+        client.end(flush=True)
+        atexit.unregister(client.end)
+
+    return DatasetInsertItemsResponse(dataset_id=dataset_id, inserted=len(body.items))

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -126,6 +126,26 @@ class DatasetResponse(BaseModel):
     name: str
 
 
+class DatasetInsertItemsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    project_name: str
+    items: list[dict[str, Any]]
+    # Worker threads Dataset.insert uses to upload this call's batches. 1 (the
+    # SDK default) uploads them sequentially; >1 uploads them in parallel, and
+    # both paths must land in ONE dataset version with identical counters.
+    # Parallel upload needs a backend >= MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
+    # (2.2.8); against an older one the SDK silently falls back to sequential.
+    num_threads: int = 1
+    workspace: str | None = None
+
+
+class DatasetInsertItemsResponse(BaseModel):
+    dataset_id: str
+    inserted: int
+
+
 class ExperimentItemSeed(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests_end_to_end/e2e/tests/datasets/dataset-version-duplicate-ids.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-version-duplicate-ids.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+import { uuid7 } from '@e2e/core/backend';
+
+/**
+ * A dataset version sizes itself from the batch it was cut on, and renders that
+ * size as the "Item count" column of the Version history tab (and as the
+ * datasets list's item count). One batch may legitimately carry the SAME
+ * dataset_item_id more than once — two rows with different content collapse to
+ * one stored item — so the version has to count DISTINCT ids, not rows.
+ *
+ * The existing counter coverage seeds only unique ids, so nothing catches the
+ * failure this covers: a version reporting more items than the dataset holds.
+ * That is silent wrongness — the rows are right, the number above them is not,
+ * and a user has no way to tell.
+ *
+ * Both version-creating paths are exercised, because they size the version
+ * independently:
+ *  - `createFirstVersion`, when the batch lands on a dataset with no version;
+ *  - `applyDelta`, when it lands on a dataset that already has one.
+ */
+
+/** Rows in the seed batch, and how many distinct ids they carry. */
+const FIRST_BATCH_ROWS = 5;
+const FIRST_BATCH_DISTINCT = 4;
+const DELTA_BATCH_ROWS = 3;
+const DELTA_BATCH_DISTINCT = 2;
+
+/**
+ * A batch that carries `distinct` ids across `rows` rows: the last id is
+ * repeated to make up the difference, each repeat with different content.
+ *
+ * The differing content matters — the Python SDK dedupes items whose payloads
+ * hash identically before it ever sends them, so identical repeats would never
+ * reach the backend and the batch would prove nothing.
+ */
+function batchWithRepeatedId(
+  ids: string[],
+  rows: number,
+  revision: string,
+): Array<Record<string, unknown>> {
+  const repeated = ids[ids.length - 1];
+  const items = ids.map((id, index) => ({
+    id,
+    input: `${revision} input ${index}`,
+    expected_output: `${revision} output ${index}`,
+  }));
+  for (let repeat = 1; repeat <= rows - ids.length; repeat++) {
+    items.push({
+      id: repeated,
+      input: `${revision} input repeat ${repeat}`,
+      expected_output: `${revision} output repeat ${repeat}`,
+    });
+  }
+  return items;
+}
+
+test.describe('Dataset version counters — repeated item ids', { tag: ['@area:datasets'] }, () => {
+  /** Items toolbar collapses to icon-only (no accessible name) below ~850px container width. */
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  test(
+    'A first batch that repeats an item id sizes the version from distinct ids, and the Version history tab renders that size',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ project, sdkClient, backendClient, testNamespace, page }) => {
+      const datasetName = `${testNamespace}-first`;
+      const ids = Array.from({ length: FIRST_BATCH_DISTINCT }, () => uuid7());
+      const repeatedId = ids[ids.length - 1];
+
+      const datasetId = await test.step(
+        `Seed a fresh dataset with one ${FIRST_BATCH_ROWS}-row batch carrying ${FIRST_BATCH_DISTINCT} distinct ids`,
+        async () => {
+          const created = await sdkClient.python.createDataset({
+            project_name: project.name,
+            name: datasetName,
+            description: 'first version sized from a batch with a repeated id',
+            items: batchWithRepeatedId(ids, FIRST_BATCH_ROWS, 'v1'),
+          });
+          return created.id;
+        },
+      );
+
+      try {
+        await test.step('The dataset stores one row per distinct id', async () => {
+          const storedIds = await backendClient.listDatasetItemIds(datasetId);
+          // Asserted as a set AND a length: a stored duplicate would keep the
+          // set right while the length — and the counter below — go wrong.
+          expect(storedIds).toHaveLength(FIRST_BATCH_DISTINCT);
+          expect(new Set(storedIds)).toEqual(new Set(ids));
+          expect(storedIds.filter((id) => id === repeatedId)).toHaveLength(1);
+        });
+
+        await test.step('The first version counts the repeated id once', async () => {
+          const versions = await backendClient.getDatasetVersions(datasetId);
+          // One insert() call, so exactly one version — a second version here
+          // would mean the batch was split, and the totals below would be
+          // measuring something other than what the test set up.
+          expect(versions).toHaveLength(1);
+          expect(versions[0]).toMatchObject({
+            versionName: 'v1',
+            itemsTotal: FIRST_BATCH_DISTINCT,
+            itemsAdded: FIRST_BATCH_DISTINCT,
+            itemsModified: 0,
+            isLatest: true,
+          });
+        });
+
+        await test.step('The Version history tab renders that total as "Item count"', async () => {
+          const datasets = new DatasetsPage(page);
+          await datasets.goto(project.id);
+          await datasets.waitForReady();
+          const items = await datasets.openDatasetByName(datasetName);
+          await items.waitForReady();
+
+          // The rendered rows are the other half of the claim: the count the
+          // tab shows has to be the count the Records tab actually lists.
+          expect(await items.countItems()).toBe(FIRST_BATCH_DISTINCT);
+          await expect(items.itemRowById(repeatedId)).toHaveCount(1);
+
+          await items.openVersionHistory();
+          await expect(items.versionHistoryRow('v1')).toHaveCount(1);
+          await expect(items.versionItemCount('v1')).toHaveText(
+            FIRST_BATCH_DISTINCT.toLocaleString('en-US'),
+          );
+        });
+      } finally {
+        await backendClient.deleteDataset(datasetId);
+      }
+    },
+  );
+
+  test(
+    'A delta batch that repeats a new item id adds it once to the running version total',
+    { tag: ['@t2-cuj', '@cap:datasets.version-history-view'] },
+    async ({ project, sdkClient, backendClient, testNamespace }) => {
+      const datasetName = `${testNamespace}-delta`;
+      const baseIds = Array.from({ length: 2 }, () => uuid7());
+      const deltaIds = Array.from({ length: DELTA_BATCH_DISTINCT }, () => uuid7());
+      const expectedTotal = baseIds.length + DELTA_BATCH_DISTINCT;
+
+      const datasetId = await test.step('Seed a dataset that already has a version', async () => {
+        const created = await sdkClient.python.createDataset({
+          project_name: project.name,
+          name: datasetName,
+          description: 'delta version sized from a batch with a repeated id',
+          items: baseIds.map((id, index) => ({
+            id,
+            input: `base input ${index}`,
+            expected_output: `base output ${index}`,
+          })),
+        });
+        return created.id;
+      });
+
+      try {
+        await test.step('The base version is the plain, all-unique case', async () => {
+          // The delta assertions below are arithmetic on this number, so a
+          // wrong base would make them pass for the wrong reason.
+          const versions = await backendClient.getDatasetVersions(datasetId);
+          expect(versions).toHaveLength(1);
+          expect(versions[0]).toMatchObject({
+            versionName: 'v1',
+            itemsTotal: baseIds.length,
+            isLatest: true,
+          });
+        });
+
+        await test.step(
+          `Insert a ${DELTA_BATCH_ROWS}-row batch carrying ${DELTA_BATCH_DISTINCT} distinct new ids`,
+          async () => {
+            await sdkClient.python.insertDatasetItems({
+              project_name: project.name,
+              dataset_name: datasetName,
+              items: batchWithRepeatedId(deltaIds, DELTA_BATCH_ROWS, 'v2'),
+            });
+          },
+        );
+
+        await test.step('The delta version counts the repeated id once, in both total and added', async () => {
+          const versions = await backendClient.getDatasetVersions(datasetId);
+          expect(versions).toHaveLength(2);
+          const latest = versions.filter((v) => v.isLatest);
+          expect(latest).toHaveLength(1);
+          expect(latest[0]).toMatchObject({
+            versionName: 'v2',
+            itemsTotal: expectedTotal,
+            itemsAdded: DELTA_BATCH_DISTINCT,
+            // Every id in the delta batch is new, so nothing was modified —
+            // the repeated row must not be booked as an edit of itself.
+            itemsModified: 0,
+          });
+        });
+
+        await test.step('And that total is the number of items the dataset actually holds', async () => {
+          const storedIds = await backendClient.listDatasetItemIds(datasetId);
+          expect(storedIds).toHaveLength(expectedTotal);
+          expect(new Set(storedIds)).toEqual(new Set([...baseIds, ...deltaIds]));
+        });
+      } finally {
+        await backendClient.deleteDataset(datasetId);
+      }
+    },
+  );
+});


### PR DESCRIPTION
> **Generated by the release QA side flow.** A human verified the flow by hand on
> the PR's own environment first; the spec was then written, run and committed by
> an agent. It is a **draft** and needs review before merge — nothing here has been
> reviewed by a person.

## Where this came from

Exploratory testing of **#7966** — `[OPIK-7891] [BE] fix: count distinct item ids
when sizing a dataset version` — on that PR's own deployed environment,
`https://pr-7966.dev.comet.com` (`2.2.14-6218`, OSS install, workspace `default`).
A human walked the flow there and confirmed the corrected behaviour on both
version-creating paths before any spec was written.

## Why this targets #7966's branch, not `main`

**Base branch: `danield/OPIK-7891-items-total-inflation`** (the head branch of #7966).

The spec asserts `items_total == 4` for a 5-row batch carrying 4 distinct ids.
That is precisely what #7966 changes — on `main` the same batch still sizes the
version from `items.size()` and reports 5, so this spec would land red there. It
has to sit on top of the change it tests. It was written and run against
`10a4d68fb50a19ce77095c9d226591c2129e6959`, which was that branch's head at the
time.

## What the spec covers

`tests_end_to_end/e2e/tests/datasets/dataset-version-duplicate-ids.spec.ts` —
`@area:datasets`, `@cap:datasets.version-history-view`, both tests `@t2-cuj`.

One batch may legitimately carry the same `dataset_item_id` more than once (two
rows with different content collapse to one stored item), so a version must count
distinct ids rather than rows. When it does not, the rows on the page are right
and the number above them is wrong — `items_total` renders as the Version history
tab's **Item count** column and feeds `dataset_items_count` on the datasets list,
so a user has no way to tell.

| Test | Asserts | Result |
|---|---|---|
| A first batch that repeats an item id sizes the version from distinct ids, and the Version history tab renders that size | `createFirstVersion` path. A 5-row / 4-distinct-id batch into a fresh dataset stores exactly 4 items (asserted as both a set and a length, with the repeated id resolving to one row), cuts exactly one version with `items_total`/`items_added` = 4 and `items_modified` = 0, and the Version history tab's Item count cell reads `4` while the Records tab lists 4 rows | **passed** |
| A delta batch that repeats a new item id adds it once to the running version total | `applyDelta` path. Onto a 2-item v1, a 3-row / 2-distinct-new-id batch produces v2 with `items_total` = 4, `items_added` = 2, `items_modified` = 0, and the dataset then holds exactly those 4 ids | **passed** |

The existing counter coverage on `main`
(`datasets/dataset-version-counters.spec.ts`) seeds only unique ids across its
1200-item batches, so it cannot reach this — the gap is the seed shape, not the
capability.

The fixture is checked for its ability to discriminate: the repeated rows carry
*different* content on purpose, because the Python SDK dedupes items whose
payload hashes match before it ever sends them
(`Dataset.__internal_api__insert_items_as_dataclasses__`). Identical repeats would
never reach the backend and the test could not fail.

## Verification

Run against `https://pr-7966.dev.comet.com` (`OPIK_DEPLOYMENT=oss`,
`OPIK_WORKSPACE=default`), from `tests_end_to_end/e2e/`:

```
npx playwright test tests/datasets/dataset-version-duplicate-ids.spec.ts --reporter=list
  2 passed (18.8s)

# shared POM touched, so the whole feature directory too
npx playwright test tests/datasets/ --reporter=list
  7 passed (28.0s)

npx tsc --noEmit                                   # clean
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
  tag-lint: 27 specs checked, 1 exempt, 0 problem(s)
```

> One environment note for whoever re-runs this: the TS SDK rejects a non-`localhost`
> `apiUrl` without an API key, so a remote OSS install needs any non-empty
> `OPIK_API_KEY` (`oss-no-auth` was used). Nothing on the install checks it.

## Supporting changes — all lifted verbatim from `main`

This branch predates a chunk of the e2e estate, so five helpers the spec needs do
not exist here yet. **Every one of them is copied byte-for-byte from `main`** so
the eventual merge is a duplicate-add rather than a divergence — please resolve in
`main`'s favour, they are the same code:

- `core/backend/uuid7.ts`
- `backendClient.getDatasetVersions()` / `listDatasetItemIds()` + `DatasetVersionRef`
- `DatasetItemsPage.openVersionHistory()` / `versionHistoryRow()` / `versionItemCount()`
- the SDK bridge's `POST /datasets/insert-items` route and its two schemas
- the `timeoutMs` option on the bridge client's `request()` helper (only because
  `insertDatasetItems` on `main` passes it)

Taxonomy updated in the same change: the spec is added to the `datasets` area's
`specs:` list and `datasets.version-history-view` flips to `covered: true`,
`tier: t2-cuj`, with a note bounding what is and is not covered. On `main` that
capability is already `covered: true` for a different reason, which is another
merge point to resolve in `main`'s favour — keeping the note.

## What was deliberately not written

**One candidate dropped of two.**

The exploration also found the *same* inflation on the sibling un-versioned insert
path — `PUT /v1/private/datasets/items` with **no** `batch_group_id` routes to
`DatasetItemService.insertItemsIntoVersion`, which counts raw rows and discards
`insertItems`' return value, so `items_total` reads 5 for a 4-row dataset and
`items_modified` reads 2 for one edited item. That is **not** a regression from
this PR — the sibling path never used the value #7966 fixes, so it was equally
wrong before — but it is the same user-visible symptom on the same column.

No spec for it here, for two reasons: it fails today, so it would land red; and
whether that path is *supposed* to dedupe is a product decision nobody has made.
Both official SDKs always send a `batch_group_id`, so only a direct REST caller
reaches it. Worth its own ticket rather than a red test. The taxonomy note records
the boundary.

---

Please do not mark this ready for review without reading the assertions.


[OPIK-7891]: https://comet-ml.atlassian.net/browse/OPIK-7891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ