### PR TITLE
[OPIK-8021] [QA] Proposed e2e specs for the virtualized traces table (from #7947 exploration)

### DIFF
--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -28,6 +28,7 @@ import DataTableWrapper, {
 } from "@/shared/DataTable/DataTableWrapper";
 import DataTableBody, {
   DataTableBodyProps,
+  RowVirtualizationConfig,
 } from "@/shared/DataTable/DataTableBody";
 import DataTableSkeletonBody from "@/shared/DataTable/DataTableSkeletonBody";
 import {
@@ -54,6 +55,12 @@ import {
 } from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import useCustomRowClick from "@/shared/DataTable/useCustomRowClick";
+import useColumnVirtualization, {
+  ColumnVirtualizationConfig,
+  ColumnSpacerCell,
+  isColumnSpacer,
+  sliceColumnWindow,
+} from "@/shared/DataTable/columnVirtualization";
 
 declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -139,6 +146,8 @@ interface DataTableProps<TData, TValue> {
   stickyHeader?: boolean;
   TableWrapper?: React.FC<DataTableWrapperProps>;
   TableBody?: React.FC<DataTableBodyProps<TData>>;
+  columnVirtualization?: ColumnVirtualizationConfig;
+  rowVirtualization?: RowVirtualizationConfig;
   meta?: Omit<
     TableMeta<TData>,
     "columnsStatistic" | "rowHeight" | "rowHeightStyle"
@@ -171,6 +180,8 @@ const DataTable = <TData, TValue>({
   autoWidth = false,
   TableWrapper = DataTableWrapper,
   TableBody = DataTableBody,
+  columnVirtualization,
+  rowVirtualization,
   stickyHeader = false,
   meta,
   getSubRows,
@@ -254,6 +265,10 @@ const DataTable = <TData, TValue>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [headers, columnSizing]);
 
+  const columnWindow = useColumnVirtualization(table, columnVirtualization, {
+    supported: !isFunction(renderCustomRow),
+  });
+
   const [tableHeight, setTableHeight] = useState(0);
   const [hasHorizontalScroll, setHasHorizontalScroll] = useState(false);
   const { ref: tableRef } = useObserveResizeNode<HTMLTableElement>((node) => {
@@ -311,7 +326,13 @@ const DataTable = <TData, TValue>({
             }
           : {})}
       >
-        {cells.map((cell) => renderCell(row, cell))}
+        {sliceColumnWindow(cells, columnWindow).map((cell) =>
+          isColumnSpacer(cell) ? (
+            <ColumnSpacerCell key={cell.id} spacer={cell} />
+          ) : (
+            renderCell(row, cell)
+          ),
+        )}
       </TableRow>
     );
   };
@@ -420,7 +441,7 @@ const DataTable = <TData, TValue>({
             }}
           >
             <colgroup>
-              {cols.map((i) => (
+              {sliceColumnWindow(cols, columnWindow).map((i) => (
                 <col key={i.id} style={{ width: `${i.size}px` }} />
               ))}
             </colgroup>
@@ -441,51 +462,68 @@ const DataTable = <TData, TValue>({
                       !isLastRow && "!border-b-0",
                     )}
                   >
-                    {headerGroup.headers.map((header) => {
-                      return (
-                        <TableHead
-                          key={header.id}
-                          data-header-id={header.id}
-                          style={{
-                            zIndex: TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
-                            ...getCommonPinningStyles({
+                    {sliceColumnWindow(headerGroup.headers, columnWindow).map(
+                      (header) => {
+                        if (isColumnSpacer(header)) {
+                          return (
+                            <ColumnSpacerCell
+                              key={header.id}
+                              spacer={header}
+                              isHeader
+                            />
+                          );
+                        }
+
+                        return (
+                          <TableHead
+                            key={header.id}
+                            data-header-id={header.id}
+                            style={{
+                              zIndex:
+                                TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
+                              ...getCommonPinningStyles({
+                                column: header.column,
+                                isHeader: true,
+                                isLastHeaderRow: isLastRow,
+                                lastRightPinnedColumnId,
+                              }),
+                            }}
+                            className={getCommonPinningClasses({
                               column: header.column,
                               isHeader: true,
-                              isLastHeaderRow: isLastRow,
-                              lastRightPinnedColumnId,
-                            }),
-                          }}
-                          className={getCommonPinningClasses({
-                            column: header.column,
-                            isHeader: true,
-                            lastLeftPinnedColumnId,
-                          })}
-                          colSpan={header.colSpan}
-                        >
-                          {header.isPlaceholder
-                            ? ""
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                          {isResizable ? (
-                            <DataTableColumnResizer header={header} />
-                          ) : null}
-                        </TableHead>
-                      );
-                    })}
+                              lastLeftPinnedColumnId,
+                            })}
+                            colSpan={header.colSpan}
+                          >
+                            {header.isPlaceholder
+                              ? ""
+                              : flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext(),
+                                )}
+                            {isResizable ? (
+                              <DataTableColumnResizer header={header} />
+                            ) : null}
+                          </TableHead>
+                        );
+                      },
+                    )}
                   </TableRow>
                 );
               })}
             </TableHeader>
             {showSkeleton ? (
-              <DataTableSkeletonBody table={table} />
+              <DataTableSkeletonBody
+                table={table}
+                columnWindow={columnWindow}
+              />
             ) : (
               <TableBody
                 table={table}
                 renderRow={renderRow}
                 renderNoData={renderNoData}
                 showLoadingOverlay={showLoadingOverlay}
+                rowVirtualization={rowVirtualization}
               />
             )}
           </Table>

--- a/apps/opik-frontend/src/shared/DataTable/DataTableBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableBody.tsx
@@ -3,11 +3,16 @@ import { TableBody } from "@/ui/table";
 import { Row, Table } from "@tanstack/react-table";
 import { cn } from "@/lib/utils";
 
+export type RowVirtualizationConfig = {
+  enabled?: boolean;
+};
+
 export type DataTableBodyProps<TData> = {
   table: Table<TData>;
   renderRow: (row: Row<TData>) => React.ReactNode | null;
   renderNoData: () => React.ReactNode | null;
   showLoadingOverlay?: boolean;
+  rowVirtualization?: RowVirtualizationConfig;
 };
 
 export const DataTableBody = <TData,>({

--- a/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
@@ -28,9 +28,10 @@ const DataTableSkeletonBody = <TData,>({
   table,
   columnWindow,
 }: DataTableSkeletonBodyProps<TData>) => {
-  const columns = sliceColumnWindow(
-    table.getVisibleLeafColumns(),
-    columnWindow,
+  const visibleColumns = table.getVisibleLeafColumns();
+  const columns = useMemo(
+    () => sliceColumnWindow(visibleColumns, columnWindow),
+    [visibleColumns, columnWindow],
   );
   const rowHeightEnum = table.options.meta?.rowHeight ?? ROW_HEIGHT.small;
   const rowHeightStyle = table.options.meta?.rowHeightStyle;

--- a/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableSkeletonBody.tsx
@@ -4,6 +4,12 @@ import { TableBody, TableCell, TableRow } from "@/ui/table";
 import { Skeleton } from "@/ui/skeleton";
 import { ROW_HEIGHT } from "@/types/shared";
 import { ROW_HEIGHT_MAP } from "@/constants/shared";
+import {
+  ColumnSpacerCell,
+  ColumnWindow,
+  isColumnSpacer,
+  sliceColumnWindow,
+} from "@/shared/DataTable/columnVirtualization";
 
 const MAX_SKELETON_ROWS = 50;
 
@@ -15,12 +21,17 @@ const SCREEN_FRACTION: Record<ROW_HEIGHT, number> = {
 
 type DataTableSkeletonBodyProps<TData> = {
   table: Table<TData>;
+  columnWindow: ColumnWindow;
 };
 
 const DataTableSkeletonBody = <TData,>({
   table,
+  columnWindow,
 }: DataTableSkeletonBodyProps<TData>) => {
-  const columns = table.getAllLeafColumns();
+  const columns = sliceColumnWindow(
+    table.getVisibleLeafColumns(),
+    columnWindow,
+  );
   const rowHeightEnum = table.options.meta?.rowHeight ?? ROW_HEIGHT.small;
   const rowHeightStyle = table.options.meta?.rowHeightStyle;
   const defaultHeight = ROW_HEIGHT_MAP[rowHeightEnum].height as string;
@@ -39,13 +50,17 @@ const DataTableSkeletonBody = <TData,>({
     <TableBody>
       {Array.from({ length: count }, (_, rowIndex) => (
         <TableRow key={rowIndex}>
-          {columns.map((column) => (
-            <TableCell key={column.id}>
-              <div className="flex items-center p-2" style={rowHeightStyle}>
-                <Skeleton className="size-full" />
-              </div>
-            </TableCell>
-          ))}
+          {columns.map((column) =>
+            isColumnSpacer(column) ? (
+              <ColumnSpacerCell key={column.id} spacer={column} />
+            ) : (
+              <TableCell key={column.id}>
+                <div className="flex items-center p-2" style={rowHeightStyle}>
+                  <Skeleton className="size-full" />
+                </div>
+              </TableCell>
+            ),
+          )}
         </TableRow>
       ))}
     </TableBody>

--- a/apps/opik-frontend/src/shared/DataTable/DataTableVirtualBody.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableVirtualBody.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import first from "lodash/first";
 import last from "lodash/last";
@@ -6,6 +6,7 @@ import last from "lodash/last";
 import { TableBody } from "@/ui/table";
 import { DataTableBodyProps } from "@/shared/DataTable/DataTableBody";
 import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
+import { observeOwnAxisOffset } from "@/shared/DataTable/virtualizerOptions";
 import { cn } from "@/lib/utils";
 
 const ROW_BORDER_SIZE = 1;
@@ -18,11 +19,13 @@ export const DataTableVirtualBody = <TData,>({
   renderRow,
   renderNoData,
   showLoadingOverlay = false,
+  rowVirtualization,
 }: DataTableBodyProps<TData>) => {
   const { scrollContainer, tableOffset } = usePageBodyScrollContainer();
   const { height } = table.options.meta?.rowHeightStyle ?? { height: "44" };
 
-  const rows = table.getRowModel().rows ?? [];
+  const enabled = rowVirtualization?.enabled ?? true;
+  const rows = table.getRowModel().rows;
   const virtualRowHeight = parseInt(height as string, 10) + ROW_BORDER_SIZE;
   const overscan = Math.max(
     MIN_OVER_SCAN_ROWS,
@@ -32,13 +35,20 @@ export const DataTableVirtualBody = <TData,>({
     ),
   );
 
+  const getItemKey = useCallback(
+    (index: number) => rows[index]?.id ?? index,
+    [rows],
+  );
+
   const { getVirtualItems, measure } = useVirtualizer({
+    enabled,
     count: rows.length,
     getScrollElement: () => scrollContainer,
-    getItemKey: (index: number) => rows[index].id ?? index,
+    getItemKey,
     estimateSize: () => virtualRowHeight,
     paddingStart: tableOffset,
     overscan,
+    observeElementOffset: observeOwnAxisOffset,
   });
   const virtualRows = getVirtualItems();
   const firsRowHeight = (first(virtualRows)?.index ?? 0) * virtualRowHeight;
@@ -75,7 +85,11 @@ export const DataTableVirtualBody = <TData,>({
     <TableBody
       className={cn(showLoadingOverlay && "comet-table-body-loading-overlay")}
     >
-      {rows?.length ? renderVirtualRows() : renderNoData()}
+      {rows.length
+        ? enabled
+          ? renderVirtualRows()
+          : rows.map(renderRow)
+        : renderNoData()}
     </TableBody>
   );
 };

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/ColumnSpacerCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/ColumnSpacerCell.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+
+import { ColumnSpacer } from "@/shared/DataTable/columnVirtualization/columnWindow";
+
+type ColumnSpacerCellProps = {
+  spacer: ColumnSpacer;
+  isHeader?: boolean;
+};
+
+const ColumnSpacerCell: React.FC<ColumnSpacerCellProps> = ({
+  spacer,
+  isHeader,
+}) => {
+  const style = { padding: 0, border: 0, width: `${spacer.size}px` };
+
+  return isHeader ? (
+    <th aria-hidden style={style} />
+  ) : (
+    <td aria-hidden style={style} />
+  );
+};
+
+export default ColumnSpacerCell;

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -86,6 +86,42 @@ describe("sliceColumnWindow", () => {
     ]);
   });
 
+  it("returns only spacers for an empty items array", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 0,
+      centerCount: 0,
+      start: 0,
+      end: -1,
+      leadingWidth: 100,
+      trailingWidth: 50,
+    };
+
+    expect(sliceColumnWindow([], window)).toEqual([
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+    ]);
+  });
+
+  it("does not throw when start/end exceed the actual item count", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 100,
+      start: 90,
+      end: 120,
+      leadingWidth: 100,
+      trailingWidth: 0,
+    };
+
+    expect(() => sliceColumnWindow(items, window)).not.toThrow();
+    expect(sliceColumnWindow(items, window)).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+    ]);
+  });
+
   it("keeps all pinned left and right columns outside the windowed range", () => {
     const window: ColumnWindow = {
       active: true,

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  sliceColumnWindow,
+  isColumnSpacer,
+  INACTIVE_COLUMN_WINDOW,
+  ColumnWindow,
+} from "./columnWindow";
+
+const items = ["l0", "l1", "c0", "c1", "c2", "c3", "c4", "r0"];
+
+describe("sliceColumnWindow", () => {
+  it("returns items unchanged when window is inactive", () => {
+    expect(sliceColumnWindow(items, INACTIVE_COLUMN_WINDOW)).toBe(items);
+  });
+
+  it("inserts lead and trail spacers around the windowed center columns", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 1,
+      end: 3,
+      leadingWidth: 100,
+      trailingWidth: 50,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      "c1",
+      "c2",
+      "c3",
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+      "r0",
+    ]);
+  });
+
+  it("omits the lead spacer when the window starts at the first center column", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 0,
+      end: 2,
+      leadingWidth: 0,
+      trailingWidth: 50,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      "c0",
+      "c1",
+      "c2",
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+      "r0",
+    ]);
+  });
+
+  it("omits the trail spacer when the window ends at the last center column", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 3,
+      end: 4,
+      leadingWidth: 100,
+      trailingWidth: 0,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result).toEqual([
+      "l0",
+      "l1",
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      "c3",
+      "c4",
+      "r0",
+    ]);
+  });
+
+  it("keeps all pinned left and right columns outside the windowed range", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 2,
+      end: 2,
+      leadingWidth: 200,
+      trailingWidth: 100,
+    };
+
+    const result = sliceColumnWindow(items, window);
+
+    expect(result[0]).toBe("l0");
+    expect(result[1]).toBe("l1");
+    expect(result[result.length - 1]).toBe("r0");
+  });
+});
+
+describe("isColumnSpacer", () => {
+  it("identifies column spacer objects", () => {
+    expect(isColumnSpacer({ id: "s", size: 10, isColumnSpacer: true })).toBe(
+      true,
+    );
+  });
+
+  it("rejects non-spacer values", () => {
+    expect(isColumnSpacer("c0")).toBe(false);
+    expect(isColumnSpacer(null)).toBe(false);
+    expect(isColumnSpacer(undefined)).toBe(false);
+    expect(isColumnSpacer({ id: "s", size: 10 })).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
@@ -1,0 +1,56 @@
+export type ColumnWindow = {
+  active: boolean;
+  leftCount: number;
+  centerCount: number;
+  start: number;
+  end: number;
+  leadingWidth: number;
+  trailingWidth: number;
+};
+
+export const INACTIVE_COLUMN_WINDOW: ColumnWindow = {
+  active: false,
+  leftCount: 0,
+  centerCount: 0,
+  start: 0,
+  end: -1,
+  leadingWidth: 0,
+  trailingWidth: 0,
+};
+
+export type ColumnSpacer = {
+  id: string;
+  size: number;
+  isColumnSpacer: true;
+};
+
+export const isColumnSpacer = (item: unknown): item is ColumnSpacer =>
+  (item as ColumnSpacer | null)?.isColumnSpacer === true;
+
+const createSpacer = (id: string, size: number): ColumnSpacer => ({
+  id,
+  size,
+  isColumnSpacer: true,
+});
+
+export const sliceColumnWindow = <T>(
+  items: T[],
+  window: ColumnWindow,
+): (T | ColumnSpacer)[] => {
+  if (!window.active) return items;
+
+  const { leftCount, centerCount, start, end, leadingWidth, trailingWidth } =
+    window;
+
+  return [
+    ...items.slice(0, leftCount),
+    ...(leadingWidth
+      ? [createSpacer("__column_spacer_lead", leadingWidth)]
+      : []),
+    ...items.slice(leftCount + start, leftCount + end + 1),
+    ...(trailingWidth
+      ? [createSpacer("__column_spacer_trail", trailingWidth)]
+      : []),
+    ...items.slice(leftCount + centerCount),
+  ];
+};

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
@@ -1,0 +1,11 @@
+export { default as default } from "@/shared/DataTable/columnVirtualization/useColumnVirtualization";
+export type { ColumnVirtualizationConfig } from "@/shared/DataTable/columnVirtualization/useColumnVirtualization";
+export {
+  sliceColumnWindow,
+  isColumnSpacer,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+export type {
+  ColumnWindow,
+  ColumnSpacer,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+export { default as ColumnSpacerCell } from "@/shared/DataTable/columnVirtualization/ColumnSpacerCell";

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo } from "react";
+import { Column, Table } from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
+import { observeOwnAxisOffset } from "@/shared/DataTable/virtualizerOptions";
+import {
+  ColumnWindow,
+  INACTIVE_COLUMN_WINDOW,
+} from "@/shared/DataTable/columnVirtualization/columnWindow";
+
+const DEFAULT_OVERSCAN_COLUMNS = 3;
+
+const EMPTY_LAYOUT = {
+  centerColumns: [] as Column<never>[],
+  leftCount: 0,
+  centerCount: 0,
+  leftWidth: 0,
+  rightWidth: 0,
+  centerWidth: 0,
+};
+
+export type ColumnVirtualizationConfig = {
+  enabled?: boolean;
+  overscan?: number;
+  getScrollElement?: () => HTMLElement | null;
+};
+
+const useColumnVirtualization = <TData>(
+  table: Table<TData>,
+  config?: ColumnVirtualizationConfig,
+  { supported = true }: { supported?: boolean } = {},
+): ColumnWindow => {
+  const { scrollContainer: pageBodyScrollContainer } =
+    usePageBodyScrollContainer();
+  const visibleColumns = table.getVisibleLeafColumns();
+  const columnSizing = table.getState().columnSizing;
+
+  const {
+    enabled: optedIn = false,
+    overscan = DEFAULT_OVERSCAN_COLUMNS,
+    getScrollElement,
+  } = config ?? {};
+
+  const scrollElement = getScrollElement
+    ? getScrollElement()
+    : pageBodyScrollContainer;
+
+  const windowable =
+    supported &&
+    table.getHeaderGroups().length === 1 &&
+    table.getState().grouping.length === 0;
+
+  const enabled = windowable && optedIn && Boolean(scrollElement);
+
+  const layout = useMemo(() => {
+    if (!enabled) return EMPTY_LAYOUT;
+
+    const centerColumns = table.getCenterVisibleLeafColumns();
+
+    return {
+      centerColumns,
+      leftCount: table.getLeftVisibleLeafColumns().length,
+      centerCount: centerColumns.length,
+      leftWidth: table.getLeftTotalSize(),
+      rightWidth: table.getRightTotalSize(),
+      centerWidth: table.getCenterTotalSize(),
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, table, visibleColumns, columnSizing]);
+
+  const getItemKey = useCallback(
+    (index: number) => layout.centerColumns[index]?.id ?? index,
+    [layout],
+  );
+
+  const virtualizer = useVirtualizer({
+    enabled,
+    horizontal: true,
+    count: layout.centerCount,
+    getScrollElement: () => scrollElement,
+    initialOffset: () => scrollElement?.scrollLeft ?? 0,
+    initialRect: {
+      width: scrollElement?.clientWidth ?? 0,
+      height: scrollElement?.clientHeight ?? 0,
+    },
+    estimateSize: (index) => layout.centerColumns[index].getSize(),
+    getItemKey,
+    paddingStart: layout.leftWidth,
+    paddingEnd: layout.rightWidth,
+    overscan,
+    observeElementOffset: observeOwnAxisOffset,
+  });
+
+  const virtualColumns = virtualizer.getVirtualItems();
+  const { measure } = virtualizer;
+
+  useEffect(() => {
+    measure();
+  }, [measure, layout]);
+
+  return useMemo(() => {
+    if (!enabled || virtualColumns.length === 0) return INACTIVE_COLUMN_WINDOW;
+
+    const first = virtualColumns[0];
+    const last = virtualColumns[virtualColumns.length - 1];
+
+    return {
+      active: true,
+      leftCount: layout.leftCount,
+      centerCount: layout.centerCount,
+      start: first.index,
+      end: last.index,
+      leadingWidth: Math.max(first.start - layout.leftWidth, 0),
+      trailingWidth: Math.max(
+        layout.leftWidth + layout.centerWidth - (last.start + last.size),
+        0,
+      ),
+    };
+  }, [enabled, layout, virtualColumns]);
+};
+
+export default useColumnVirtualization;

--- a/apps/opik-frontend/src/shared/DataTable/virtualizerOptions.ts
+++ b/apps/opik-frontend/src/shared/DataTable/virtualizerOptions.ts
@@ -1,0 +1,17 @@
+import { observeElementOffset, Virtualizer } from "@tanstack/react-virtual";
+
+export const observeOwnAxisOffset = <
+  TScroll extends Element,
+  TItem extends Element,
+>(
+  instance: Virtualizer<TScroll, TItem>,
+  cb: (offset: number, isScrolling: boolean) => void,
+) => {
+  let lastOffset: number | undefined;
+
+  return observeElementOffset(instance, (offset, isScrolling) => {
+    if (offset === lastOffset && isScrolling) return;
+    lastOffset = offset;
+    cb(offset, isScrolling);
+  });
+};

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -284,9 +284,6 @@ const METADATA_MAIN_COLUMN_DATA: ColumnData<BaseTraceData>[] = [
   },
 ];
 
-const VIRTUALIZATION_MIN_COLUMNS = 50;
-const VIRTUALIZATION_MIN_ROWS = 25;
-
 const DEFAULT_TRACES_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID],
   right: [],
@@ -1345,13 +1342,26 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataColumnsOrder,
   ]);
 
-  const virtualization = useMemo(
+  const cellCount = columns.length * rows.length;
+
+  // Each axis decides on its own count or on total cells crossing the combined
+  // budget (50 columns × 25 rows), so a lopsided table like 1000 columns × 10
+  // rows still windows the axis that needs it instead of being blocked by the
+  // other axis's count. Below 15, an axis is never windowed: with this few
+  // columns/rows there's nothing meaningful on screen to skip.
+  const columnVirtualization = useMemo(
     () => ({
       enabled:
-        columns.length > VIRTUALIZATION_MIN_COLUMNS &&
-        rows.length >= VIRTUALIZATION_MIN_ROWS,
+        columns.length >= 15 && (columns.length > 50 || cellCount > 1250),
     }),
-    [columns.length, rows.length],
+    [columns.length, cellCount],
+  );
+
+  const rowVirtualization = useMemo(
+    () => ({
+      enabled: rows.length >= 15 && (rows.length > 25 || cellCount > 1250),
+    }),
+    [rows.length, cellCount],
   );
 
   const columnsToExport = useMemo(() => {
@@ -1624,8 +1634,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           }
           TableWrapper={PageBodyStickyTableWrapper}
           TableBody={DataTableVirtualBody}
-          columnVirtualization={virtualization}
-          rowVirtualization={virtualization}
+          columnVirtualization={columnVirtualization}
+          rowVirtualization={rowVirtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -17,6 +17,7 @@ import isObject from "lodash/isObject";
 import isNumber from "lodash/isNumber";
 import isArray from "lodash/isArray";
 import get from "lodash/get";
+import uniqBy from "lodash/uniqBy";
 import uniq from "lodash/uniq";
 import keyBy from "lodash/keyBy";
 import compact from "lodash/compact";
@@ -121,6 +122,7 @@ import ThreadDetailsPanel from "@/v2/pages-shared/traces/ThreadDetailsPanel/Thre
 import TraceDetailsPanel from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDetailsPanel";
 import PageBodyStickyContainer from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
 import PageBodyStickyTableWrapper from "@/v2/layout/PageBodyStickyTableWrapper/PageBodyStickyTableWrapper";
+import DataTableVirtualBody from "@/shared/DataTable/DataTableVirtualBody";
 import { formatDuration } from "@/lib/date";
 import { formatCost } from "@/lib/money";
 import TimeCell from "@/shared/DataTableCells/TimeCell";
@@ -281,6 +283,9 @@ const METADATA_MAIN_COLUMN_DATA: ColumnData<BaseTraceData>[] = [
     cell: CodeCell as never,
   },
 ];
+
+const VIRTUALIZATION_MIN_COLUMNS = 50;
+const VIRTUALIZATION_MIN_ROWS = 25;
 
 const DEFAULT_TRACES_COLUMN_PINNING: ColumnPinningState = {
   left: [COLUMN_SELECT_ID],
@@ -928,7 +933,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   }, [setSearch, clearAllChips, setEnvironment, setPage]);
 
   const rows: Array<Span | Trace> = useMemo(
-    () => data?.content ?? [],
+    () => uniqBy(data?.content ?? [], "id"),
     [data?.content],
   );
 
@@ -1340,6 +1345,15 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataColumnsOrder,
   ]);
 
+  const virtualization = useMemo(
+    () => ({
+      enabled:
+        columns.length > VIRTUALIZATION_MIN_COLUMNS &&
+        rows.length >= VIRTUALIZATION_MIN_ROWS,
+    }),
+    [columns.length, rows.length],
+  );
+
   const columnsToExport = useMemo(() => {
     return columns
       .map((c) => get(c, "accessorKey", ""))
@@ -1609,6 +1623,9 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
             />
           }
           TableWrapper={PageBodyStickyTableWrapper}
+          TableBody={DataTableVirtualBody}
+          columnVirtualization={virtualization}
+          rowVirtualization={virtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1344,24 +1344,19 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
 
   const cellCount = columns.length * rows.length;
 
-  // Each axis decides on its own count or on total cells crossing the combined
-  // budget (50 columns × 25 rows), so a lopsided table like 1000 columns × 10
-  // rows still windows the axis that needs it instead of being blocked by the
-  // other axis's count. Below 15, an axis is never windowed: with this few
-  // columns/rows there's nothing meaningful on screen to skip.
-  const columnVirtualization = useMemo(
+  // One decision drives both axes: the table is windowed or it isn't. Either
+  // axis crossing its own count, or the combined cell count crossing the
+  // shared budget, is enough — an AND here would block a lopsided table like
+  // 1000 columns × 10 rows from windowing at all. The budget sits above the
+  // default view (~15 columns × 100 rows = 1500) so normal tables stay fully
+  // rendered. Below 15 on both axes, there's nothing meaningful to skip.
+  const virtualization = useMemo(
     () => ({
       enabled:
-        columns.length >= 15 && (columns.length > 50 || cellCount > 1250),
+        (columns.length >= 15 || rows.length >= 15) &&
+        (columns.length > 50 || rows.length > 25 || cellCount > 3000),
     }),
-    [columns.length, cellCount],
-  );
-
-  const rowVirtualization = useMemo(
-    () => ({
-      enabled: rows.length >= 15 && (rows.length > 25 || cellCount > 1250),
-    }),
-    [rows.length, cellCount],
+    [columns.length, rows.length, cellCount],
   );
 
   const columnsToExport = useMemo(() => {
@@ -1634,8 +1629,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
           }
           TableWrapper={PageBodyStickyTableWrapper}
           TableBody={DataTableVirtualBody}
-          columnVirtualization={columnVirtualization}
-          rowVirtualization={rowVirtualization}
+          columnVirtualization={virtualization}
+          rowVirtualization={virtualization}
           stickyHeader
           meta={meta}
           showLoadingOverlay={isPlaceholderData && isFetching}

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -250,6 +250,7 @@ areas:
       - trace-explore/trace-spans-depth.spec.ts
       - trace-explore/trace-delete.spec.ts
       - trace-explore/trace-filters.spec.ts
+      - trace-explore/traces-table-virtualization.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -262,7 +263,7 @@ areas:
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
       filter-traces:          { covered: true,  tier: t2-cuj }
-      configure-columns:      { covered: false }
+      configure-columns:      { covered: true,  tier: t2-cuj, note: "select-all from the Columns picker; asserts header/cell/colgroup alignment across the column window" }
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
       agent-graph-tab:        { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -232,6 +232,21 @@ export interface OptimizationRef {
 /** Backend discriminator for Dataset vs Test Suite (shared DB table). */
 const TEST_SUITE_TYPE = 'evaluation_suite';
 
+/** Rows per `POST /v1/private/traces/batch` — the endpoint's own documented cap. */
+const TRACE_BATCH_SIZE = 1000;
+
+/** Scores per `PUT /v1/private/traces/feedback-scores` — same cap, same reason. */
+const FEEDBACK_SCORE_BATCH_SIZE = 1000;
+
+/** Split `items` into consecutive slices of at most `size`. */
+function chunked<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
 /** One clause of the `sorting` query param the grids serialise. */
 export interface BackendSort {
   field: string;
@@ -812,6 +827,71 @@ export function makeBackendClient(apiKey: string | null = null) {
 
     async deleteTraces(ids: string[]): Promise<void> {
       await opik.api.traces.deleteTraces({ ids });
+    },
+
+    /**
+     * Create many traces in one `POST /v1/private/traces/batch`.
+     *
+     * The bridge creates one trace per call and flushes the Python SDK each
+     * time, which is the right shape for the three-to-five-trace fixtures but
+     * not for the forty-plus a windowed table needs — forty sequential
+     * round-trips is most of a test's budget spent on setup. Same reasoning as
+     * `createTraceWithSource` above: ids are caller-supplied because the write
+     * answers 204 with no body, and these tests assert on exact ids.
+     *
+     * `startTime` is deliberately required rather than defaulted: the seeds
+     * this exists for are ordered, and a shared default would put every trace
+     * on the same instant.
+     */
+    async createTracesBatch(args: {
+      projectName: string;
+      traces: Array<{
+        id: string;
+        name: string;
+        startTime: Date;
+        input?: Record<string, unknown>;
+        output?: Record<string, unknown>;
+      }>;
+    }): Promise<void> {
+      for (const chunk of chunked(args.traces, TRACE_BATCH_SIZE)) {
+        await opik.api.traces.createTraces({
+          traces: chunk.map((t) => ({
+            id: t.id,
+            projectName: args.projectName,
+            name: t.name,
+            startTime: t.startTime,
+            ...(t.input ? { input: t.input } : {}),
+            ...(t.output ? { output: t.output } : {}),
+          })),
+        });
+      }
+    },
+
+    /**
+     * Attach feedback scores to traces in bulk, via
+     * `PUT /v1/private/traces/feedback-scores`.
+     *
+     * Every distinct score *name* in a project becomes a selectable column in
+     * the Logs table, so this is how a fixture widens a table past the point
+     * where column windowing engages. The write is chunked because the backend
+     * caps a single batch, and a fixture that needs sixty columns across forty
+     * rows is well past that cap.
+     */
+    async scoreTracesBatch(args: {
+      projectName: string;
+      scores: Array<{ traceId: string; name: string; value: number }>;
+    }): Promise<void> {
+      for (const chunk of chunked(args.scores, FEEDBACK_SCORE_BATCH_SIZE)) {
+        await opik.api.traces.scoreBatchOfTraces({
+          scores: chunk.map((s) => ({
+            id: s.traceId,
+            projectName: args.projectName,
+            name: s.name,
+            value: s.value,
+            source: 'sdk' as const,
+          })),
+        });
+      }
     },
 
     async pollTraceForFeedbackScore(

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './automation-rules.fixture';
+export { test, expect } from './windowed-traces.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -84,4 +84,9 @@ export type {
   TokenUsageSpansFixtures,
 } from './token-usage-spans.fixture';
 export type { AutomationRulesCleanupFixtures } from './automation-rules.fixture';
+export type {
+  WindowedTracesRef,
+  WideTracesTableRef,
+  WindowedTracesFixtures,
+} from './windowed-traces.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/windowed-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/windowed-traces.fixture.ts
@@ -1,0 +1,205 @@
+import { test as baseTest } from './automation-rules.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7, type BackendClient } from '../core/backend';
+
+/**
+ * Enough traces that the row window is unambiguously smaller than the data.
+ *
+ * The Logs table windows rows once there are more than 25 of them, and renders
+ * roughly a viewport's worth plus overscan — a little under 40 rows at the
+ * suite's 1280x720 viewport. Sixty leaves ~20 rows of headroom, so "fewer rows
+ * are in the DOM than were seeded" stays true rather than depending on how tall
+ * the runner's viewport happens to be.
+ */
+const TRACE_COUNT = 60;
+
+/**
+ * Distinct feedback-score names, each of which the Logs table offers as its own
+ * column. Forty-five puts the table past sixty columns in total, well beyond
+ * the fifty-column threshold at which the column window engages.
+ */
+const SCORE_NAME_COUNT = 45;
+
+/** One second between seeded traces, so their order is total and known. */
+const TRACE_SPACING_MS = 1_000;
+
+/** How long a seeded write may take to become readable before we give up. */
+const INGEST_TIMEOUT_MS = 60_000;
+const INGEST_POLL_MS = 500;
+
+export interface WindowedTracesRef {
+  /**
+   * Every seeded trace id, in the order `GET /v1/private/traces` answers for
+   * this project — the same query, and therefore the same order, the Logs table
+   * renders from. Read back from the API rather than assumed from the seed
+   * order, so the expectation is the app's own answer and not a guess about how
+   * it sorts.
+   */
+  orderedIds: string[];
+  /** Each seeded trace's rendered name, keyed by id. */
+  nameById: Record<string, string>;
+  /** How many traces were seeded — `orderedIds.length`, named for legibility. */
+  count: number;
+}
+
+export interface WideTracesTableRef {
+  /** The distinct feedback-score names every seeded trace carries. */
+  scoreNames: string[];
+}
+
+export interface WindowedTracesFixtures {
+  windowedTraces: WindowedTracesRef;
+  wideTracesTable: WideTracesTableRef;
+}
+
+/**
+ * Poll until the project lists exactly `expectedIds` and nothing else,
+ * returning them in the API's order.
+ *
+ * Both halves matter. Waiting only for a count would accept a partially-landed
+ * batch topped up by a stray trace, and the specs built on this fixture assert
+ * that the table's rows are a contiguous slice of *this* list — an extra id in
+ * it makes every one of those assertions meaningless.
+ */
+async function waitForTracesListed(
+  backendClient: BackendClient,
+  projectId: string,
+  expectedIds: string[],
+): Promise<string[]> {
+  const expected = new Set(expectedIds);
+  const deadline = Date.now() + INGEST_TIMEOUT_MS;
+  let listed: string[] = [];
+
+  while (Date.now() < deadline) {
+    listed = await backendClient.listTraceIds({ projectId, size: expectedIds.length + 50 });
+    if (listed.length === expected.size && listed.every((id) => expected.has(id))) {
+      return listed;
+    }
+    await new Promise((resolve) => setTimeout(resolve, INGEST_POLL_MS));
+  }
+
+  throw new Error(
+    `[windowedTraces fixture] project ${projectId} listed ${listed.length} traces after ` +
+      `${INGEST_TIMEOUT_MS}ms, expected exactly the ${expected.size} seeded ones`,
+  );
+}
+
+/** Poll until `traceId` carries all `expected` feedback-score names. */
+async function waitForScoresLanded(
+  backendClient: BackendClient,
+  traceId: string,
+  expected: string[],
+): Promise<void> {
+  const deadline = Date.now() + INGEST_TIMEOUT_MS;
+  let seen = 0;
+
+  while (Date.now() < deadline) {
+    const trace = await backendClient.getTrace(traceId);
+    const names = new Set((trace?.feedbackScores ?? []).map((score) => score.name));
+    seen = names.size;
+    if (expected.every((name) => names.has(name))) return;
+    await new Promise((resolve) => setTimeout(resolve, INGEST_POLL_MS));
+  }
+
+  throw new Error(
+    `[wideTracesTable fixture] trace ${traceId} carries ${seen} feedback-score names after ` +
+      `${INGEST_TIMEOUT_MS}ms, expected ${expected.length}`,
+  );
+}
+
+export const test = baseTest.extend<WindowedTracesFixtures>({
+  /**
+   * Sixty traces in the fixture project, seeded in one batch write with
+   * caller-minted UUIDv7 ids one second apart.
+   *
+   * Minting the ids is what makes the seed assertable: the batch write answers
+   * 204 with no body, and the backend reads a trace's creation instant out of
+   * its id, so spacing the ids is what gives the set a total, known order
+   * instead of sixty traces sharing one millisecond.
+   *
+   * Teardown deletes the traces explicitly. Deleting a project does not cascade
+   * to its traces, and `global-teardown`'s run-prefix sweep only knows about
+   * experiments, datasets and projects — so without this the run leaves sixty
+   * traces behind in the workspace.
+   */
+  windowedTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    const oldest = Date.now() - TRACE_COUNT * TRACE_SPACING_MS;
+    const seeds = Array.from({ length: TRACE_COUNT }, (_, index) => {
+      const moment = new Date(oldest + index * TRACE_SPACING_MS);
+      return {
+        id: uuid7(moment),
+        name: `${testNamespace}-row-${String(index + 1).padStart(2, '0')}`,
+        startTime: moment,
+        input: { question: `question ${index + 1}` },
+        output: { answer: `answer ${index + 1}` },
+      };
+    });
+
+    await backendClient.createTracesBatch({ projectName: project.name, traces: seeds });
+
+    const orderedIds = await waitForTracesListed(
+      backendClient,
+      project.id,
+      seeds.map((seed) => seed.id),
+    );
+
+    const ref: WindowedTracesRef = {
+      orderedIds,
+      nameById: Object.fromEntries(seeds.map((seed) => [seed.id, seed.name])),
+      count: orderedIds.length,
+    };
+
+    await testInfo.attach('opik.windowedTraces', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteTraces(orderedIds);
+      } catch (err) {
+        console.warn(`[windowedTraces fixture] delete warning for ${project.name}:`, err);
+      }
+    }
+  },
+
+  /**
+   * The same sixty traces, each carrying forty-five distinct feedback scores.
+   *
+   * Every distinct score name in a project becomes its own column in the Logs
+   * table, so this is how the table is widened past the point where the column
+   * window engages — the state the alignment assertions need in order to be
+   * testing anything at all.
+   *
+   * No teardown of its own: feedback scores live on the traces, which the
+   * `windowedTraces` fixture this chains from deletes.
+   */
+  wideTracesTable: async ({ backendClient, project, windowedTraces }, use) => {
+    const scoreNames = Array.from(
+      { length: SCORE_NAME_COUNT },
+      (_, index) => `qa-score-${String(index + 1).padStart(2, '0')}`,
+    );
+
+    await backendClient.scoreTracesBatch({
+      projectName: project.name,
+      scores: windowedTraces.orderedIds.flatMap((traceId) =>
+        scoreNames.map((name, index) => ({ traceId, name, value: (index % 10) / 10 })),
+      ),
+    });
+
+    // Both ends of the batch: the write is chunked, so checking only the first
+    // trace would accept a run where a later chunk never landed.
+    await waitForScoresLanded(backendClient, windowedTraces.orderedIds[0], scoreNames);
+    await waitForScoresLanded(
+      backendClient,
+      windowedTraces.orderedIds[windowedTraces.count - 1],
+      scoreNames,
+    );
+
+    await use({ scoreNames });
+  },
+});
+
+export { expect } from './automation-rules.fixture';

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Locator } from '@playwright/test';
+import { test, expect, type Page, type Locator, type JSHandle } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
 import { ThreadPanelPage } from './thread-panel.page';
@@ -414,6 +414,238 @@ export class LogsPage {
     return test.step('Clear all filters', async () => {
       await this.clearAllFiltersButton.click();
       await this.clearAllFiltersButton.waitFor({ state: 'hidden' });
+    });
+  }
+
+  // --- Virtualized table windows ---
+
+  /**
+   * What a windowing spacer contributes to a header or cell sequence.
+   *
+   * The table replaces the columns either side of the window with a single
+   * `aria-hidden` spacer cell carrying their combined width, and those spacers
+   * are positions in the row like any other — so a sequence that dropped them
+   * could not detect a spacer landing in the wrong place, which is exactly the
+   * failure that shifts every cell under the wrong header.
+   */
+  static readonly COLUMN_SPACER = '__spacer';
+
+  /**
+   * The scroll container the Logs table virtualizes against.
+   *
+   * Resolved as the nearest scrollable ancestor of the table wrapper rather
+   * than by class name: the element carries no `data-testid` (it should — see
+   * `PageBodyScrollContainer.tsx`), and its only other distinguishing mark is a
+   * Tailwind `overflow-auto` class that a restyle would take away. "The thing
+   * the table scrolls inside" is the durable property, and it is the same
+   * lookup the virtualizer itself makes through React context.
+   */
+  private scrollContainerHandle(): Promise<JSHandle<HTMLElement>> {
+    return this.page.evaluateHandle(() => {
+      const wrapper = document.querySelector('[data-table-wrapper]');
+      if (!wrapper) {
+        throw new Error('LogsPage: no [data-table-wrapper] on the page');
+      }
+      let element = wrapper.parentElement;
+      while (element) {
+        const { overflowY } = getComputedStyle(element);
+        if (overflowY === 'auto' || overflowY === 'scroll') return element;
+        element = element.parentElement;
+      }
+      throw new Error('LogsPage: the table wrapper has no scrollable ancestor');
+    });
+  }
+
+  /** How far the table can be scrolled down and right from the origin. */
+  async readTableScrollExtent(): Promise<{ maxTop: number; maxLeft: number }> {
+    return test.step('Read the table scroll extent', async () => {
+      const container = await this.scrollContainerHandle();
+      try {
+        return await container.evaluate((element) => ({
+          maxTop: element.scrollHeight - element.clientHeight,
+          maxLeft: element.scrollWidth - element.clientWidth,
+        }));
+      } finally {
+        await container.dispose();
+      }
+    });
+  }
+
+  /**
+   * Scroll the table and wait for the window it renders to settle.
+   *
+   * Settling is observed, not slept through: two consecutive samples of the
+   * header's column sequence and the rendered row ids have to agree before this
+   * returns. A virtualized re-render is driven by the scroll event, so there is
+   * always state to wait on.
+   */
+  async scrollTableTo(offset: { top?: number; left?: number }): Promise<void> {
+    return test.step(`Scroll the table to top=${offset.top ?? '-'} left=${offset.left ?? '-'}`, async () => {
+      const container = await this.scrollContainerHandle();
+      try {
+        await container.evaluate((element, target) => {
+          if (target.top !== undefined) element.scrollTop = target.top;
+          if (target.left !== undefined) element.scrollLeft = target.left;
+        }, offset);
+      } finally {
+        await container.dispose();
+      }
+
+      let previous: string | null = null;
+      await expect
+        .poll(
+          async () => {
+            const sample = JSON.stringify([
+              await this.readHeaderColumnSequence(),
+              await this.readTraceIdsInOrder(),
+            ]);
+            const settled = sample === previous;
+            previous = sample;
+            return settled;
+          },
+          { intervals: [150, 150, 250, 500, 1000] },
+        )
+        .toBe(true);
+    });
+  }
+
+  /**
+   * The column ids the header renders, left to right, with every spacer marked.
+   *
+   * Read in one round trip: a windowed 60-column table still renders a dozen or
+   * more header cells per sample and the specs sample at several scroll
+   * offsets, so per-cell `getAttribute` calls would dominate the test's runtime.
+   */
+  async readHeaderColumnSequence(): Promise<string[]> {
+    return this.page
+      .locator('thead tr th')
+      .evaluateAll(
+        (cells, spacer) => cells.map((cell) => cell.getAttribute('data-header-id') ?? spacer),
+        LogsPage.COLUMN_SPACER,
+      );
+  }
+
+  /**
+   * Every rendered row's column sequence, in the same encoding as
+   * `readHeaderColumnSequence` — so the two are directly comparable, which is
+   * the whole point: a row whose sequence differs from the header's is a row
+   * whose cells sit under the wrong columns.
+   */
+  async readRenderedRowColumnSequences(): Promise<Array<{ traceId: string; columns: string[] }>> {
+    return this.traceRows.evaluateAll(
+      (rows, spacer) =>
+        rows.map((row) => {
+          const traceId = row.getAttribute('data-row-id') ?? '';
+          return {
+            traceId,
+            columns: Array.from(row.querySelectorAll('td')).map((cell) => {
+              const cellId = cell.getAttribute('data-cell-id');
+              // Cell ids are `<rowId>_<columnId>`; a spacer carries none.
+              return cellId ? cellId.slice(traceId.length + 1) : spacer;
+            }),
+          };
+        }),
+      LogsPage.COLUMN_SPACER,
+    );
+  }
+
+  /**
+   * How many `<col>` entries the table's colgroup declares. The colgroup is
+   * what fixes each rendered column's width, so it has to be sliced by the same
+   * window as the headers and cells — a colgroup of a different length is the
+   * table laid out to a different set of columns than it is showing.
+   */
+  countColgroupColumns(): Promise<number> {
+    return this.page.locator('colgroup col').count();
+  }
+
+  /** The `aria-hidden` spacer cells in the header row — present only while the column window is active. */
+  get headerColumnSpacers(): Locator {
+    return this.page.locator('thead tr th[aria-hidden]');
+  }
+
+  /**
+   * Where the left-pinned `select` column sits, on the header and on every
+   * rendered row, alongside the scroll container's own left edge.
+   *
+   * Position and offset are read from the computed style rather than the
+   * inline one so a stylesheet that overrode either still fails the check, and
+   * the viewport x of each cell is returned so "sticky at 0" can be confirmed
+   * as actually flush with the container rather than merely declared.
+   */
+  async readPinnedSelectColumnGeometry(): Promise<{
+    containerLeft: number;
+    header: { position: string; left: string; viewportLeft: number } | null;
+    rows: Array<{ traceId: string; position: string; left: string; viewportLeft: number }>;
+  }> {
+    return test.step('Read the pinned select column geometry', async () => {
+      const container = await this.scrollContainerHandle();
+      try {
+        return await container.evaluate((element) => {
+          const round = (value: number) => Math.round(value);
+          const describe = (cell: Element) => {
+            const style = getComputedStyle(cell);
+            return {
+              position: style.position,
+              left: style.left,
+              viewportLeft: round(cell.getBoundingClientRect().left),
+            };
+          };
+
+          const headerCell = document.querySelector('thead tr th[data-header-id="select"]');
+
+          return {
+            containerLeft: round(element.getBoundingClientRect().left),
+            header: headerCell ? describe(headerCell) : null,
+            rows: Array.from(document.querySelectorAll('tr[data-row-id]')).flatMap((row) => {
+              const traceId = row.getAttribute('data-row-id') ?? '';
+              const cell = row.querySelector(`[data-cell-id="${traceId}_select"]`);
+              return cell ? [{ traceId, ...describe(cell) }] : [];
+            }),
+          };
+        });
+      } finally {
+        await container.dispose();
+      }
+    });
+  }
+
+  // --- Columns picker ---
+
+  /** The "Columns N/M" trigger for the column picker. */
+  get columnsButton(): Locator {
+    return this.page.getByTestId('columns-button');
+  }
+
+  /** The picker's selected/total counts, read off the trigger's badge. */
+  async readColumnsSelection(): Promise<{ selected: number; total: number }> {
+    return test.step('Read the columns selection counts', async () => {
+      const text = (await this.columnsButton.textContent()) ?? '';
+      const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+      if (!match) {
+        throw new Error(`LogsPage.readColumnsSelection: no "selected/total" badge in "${text}"`);
+      }
+      return { selected: Number(match[1]), total: Number(match[2]) };
+    });
+  }
+
+  /**
+   * Turn every available column on from the Columns picker, then close it.
+   *
+   * The picker's own select-all row is a single checkbox labelled
+   * "N of M selected"; matching it on that shape rather than on a fixed count
+   * keeps the locator valid as the label updates itself after the click.
+   */
+  async selectAllColumns(): Promise<void> {
+    return test.step('Select every column from the Columns picker', async () => {
+      await this.columnsButton.click();
+      const menu = this.page.getByRole('menu');
+      await menu.waitFor({ state: 'visible' });
+      await menu
+        .getByRole('menuitemcheckbox', { name: /^\d+ of \d+ selected$/ })
+        .click();
+      await this.page.keyboard.press('Escape');
+      await menu.waitFor({ state: 'hidden' });
     });
   }
 

--- a/tests_end_to_end/e2e/tests/trace-explore/traces-table-virtualization.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/traces-table-virtualization.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * The Logs table stops rendering every row and every column once it grows past
+ * a threshold, and instead renders a moving window of each. Both specs below
+ * exist because the failure mode of a window is *silence*: a row dropped or
+ * repeated at a seam, or a spacer of the wrong width shifting every cell one
+ * column left, renders as a perfectly plausible table. Nothing throws, nothing
+ * looks broken, and the numbers on screen belong to the wrong thing.
+ *
+ * So neither spec asserts "the table rendered". Each pins the rendered window
+ * against the answer the API gave for the same query: the rows must be a
+ * contiguous slice of the API's ordering with no repeats, and every row's cell
+ * sequence must match the header's position for position.
+ */
+
+/** Vertical scroll step, in pixels — several rows at a time, small enough that no window is skipped. */
+const SCROLL_STEP_PX = 250;
+
+/** Fractions of the horizontal scroll extent to sample the column window at. */
+const HORIZONTAL_SAMPLE_FRACTIONS = [0, 0.25, 0.5, 0.75, 1];
+
+test.describe('Traces table row virtualization', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test(
+    'Scrolling a windowed traces table renders every seeded trace exactly once, in the API order',
+    { tag: ['@cap:traces.list-traces'] },
+    async ({ windowedTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { orderedIds, count } = windowedTraces;
+
+      await test.step('Confirm the API lists exactly the seeded traces', () => {
+        // The whole spec compares the rendered window against this list, so a
+        // list that was short, padded or duplicated would make every assertion
+        // below pass while checking nothing.
+        expect(orderedIds).toHaveLength(count);
+        expect(new Set(orderedIds).size).toBe(count);
+      });
+
+      await test.step('Open Logs and confirm the table is windowed', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+
+        // The count card reports the full set even though only part of it is
+        // in the DOM — that gap is the precondition for everything below.
+        expect(await logs.countTraces()).toBe(count);
+        const rendered = await logs.traceRows.count();
+        expect(rendered).toBeGreaterThan(0);
+        expect(rendered).toBeLessThan(count);
+      });
+
+      const seen = new Map<string, number>();
+
+      await test.step('Sweep from top to bottom, checking each window', async () => {
+        const { maxTop } = await logs.readTableScrollExtent();
+        expect(maxTop).toBeGreaterThan(0);
+
+        const offsets: number[] = [];
+        for (let top = 0; top < maxTop; top += SCROLL_STEP_PX) offsets.push(top);
+        offsets.push(maxTop);
+
+        for (const top of offsets) {
+          await logs.scrollTableTo({ top });
+          const rendered = await logs.readTraceIdsInOrder();
+
+          expect(
+            new Set(rendered).size,
+            `scrollTop=${top}: the same trace is in the DOM twice`,
+          ).toBe(rendered.length);
+
+          // A window is only correct if it is a *contiguous* run of the
+          // ordering, starting where it claims to: anchoring on the first
+          // rendered id and comparing the whole run catches a row silently
+          // dropped mid-window, which a set comparison would not.
+          const start = orderedIds.indexOf(rendered[0]);
+          expect(start, `scrollTop=${top}: first rendered row is not a seeded trace`).toBeGreaterThanOrEqual(0);
+          expect(rendered, `scrollTop=${top}: rendered rows are not a contiguous slice of the API order`).toEqual(
+            orderedIds.slice(start, start + rendered.length),
+          );
+
+          for (const id of rendered) seen.set(id, (seen.get(id) ?? 0) + 1);
+        }
+      });
+
+      await test.step('Confirm the sweep reached every seeded trace', async () => {
+        expect([...seen.keys()].sort()).toEqual([...orderedIds].sort());
+        // The last window has to be the tail of the ordering, or the sweep
+        // stopped early and "saw everything" only by accident of overscan.
+        const finalWindow = await logs.readTraceIdsInOrder();
+        expect(finalWindow[finalWindow.length - 1]).toBe(orderedIds[count - 1]);
+      });
+    },
+  );
+});
+
+test.describe('Traces table column virtualization', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test(
+    'Turning on every column keeps headers, cells and colgroup aligned across the column window',
+    { tag: ['@cap:traces.configure-columns'] },
+    async ({ wideTracesTable, windowedTraces, project, backendClient, page }) => {
+      const logs = new LogsPage(page);
+      const { scoreNames } = wideTracesTable;
+
+      await test.step('Confirm the seeded traces really carry every score name', async () => {
+        // Each distinct score name is one more column, so this is what makes
+        // the table wide enough for the window to engage. If the seed only
+        // half-landed the table would fit on screen and the alignment
+        // assertions below would be checking an unwindowed table.
+        const trace = await backendClient.getTrace(windowedTraces.orderedIds[0]);
+        expect(trace, 'the seeded trace is not readable').not.toBeNull();
+        expect(new Set(trace!.feedbackScores.map((score) => score.name))).toEqual(
+          new Set(scoreNames),
+        );
+      });
+
+      await test.step('Open Logs and turn every column on', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+
+        const before = await logs.readColumnsSelection();
+        expect(before.total).toBeGreaterThanOrEqual(scoreNames.length);
+
+        await logs.selectAllColumns();
+
+        const after = await logs.readColumnsSelection();
+        expect(after.selected).toBe(after.total);
+        expect(after.total).toBe(before.total);
+        // Past fifty columns is where the column window engages at all.
+        expect(after.total).toBeGreaterThan(50);
+      });
+
+      await test.step('Confirm the column window is active', async () => {
+        await logs.scrollTableTo({ left: 0 });
+        // Without a spacer in the header row every column is in the DOM, and a
+        // sequence comparison across a fully-rendered table cannot fail.
+        await expect(logs.headerColumnSpacers.first()).toBeVisible();
+        const header = await logs.readHeaderColumnSequence();
+        expect(header.length).toBeLessThan((await logs.readColumnsSelection()).total);
+      });
+
+      await test.step('Check header, cell and colgroup alignment across the width', async () => {
+        const { maxLeft } = await logs.readTableScrollExtent();
+        expect(maxLeft, 'the table is not wider than its container').toBeGreaterThan(0);
+
+        const sampledHeaders: string[] = [];
+
+        for (const fraction of HORIZONTAL_SAMPLE_FRACTIONS) {
+          const left = Math.round(maxLeft * fraction);
+          await logs.scrollTableTo({ left });
+
+          const header = await logs.readHeaderColumnSequence();
+          const rows = await logs.readRenderedRowColumnSequences();
+          const colgroup = await logs.countColgroupColumns();
+
+          expect(rows.length, `scrollLeft=${left}: no rows rendered`).toBeGreaterThan(0);
+          expect(
+            colgroup,
+            `scrollLeft=${left}: the colgroup declares a different number of columns than the header renders`,
+          ).toBe(header.length);
+
+          for (const row of rows) {
+            expect(
+              row.columns,
+              `scrollLeft=${left}: row ${row.traceId} is misaligned with the header`,
+            ).toEqual(header);
+          }
+
+          sampledHeaders.push(header.join(','));
+        }
+
+        // Alignment holding at five offsets means nothing if the same columns
+        // were rendered at all five — that is a table that never windowed, and
+        // it agrees with itself trivially.
+        expect(
+          new Set(sampledHeaders).size,
+          'the column window did not move across the scroll extent',
+        ).toBeGreaterThan(1);
+      });
+
+      await test.step('Confirm the pinned select column stays at the container edge', async () => {
+        const { maxLeft } = await logs.readTableScrollExtent();
+        await logs.scrollTableTo({ left: maxLeft });
+
+        const geometry = await logs.readPinnedSelectColumnGeometry();
+        expect(geometry.header, 'the select column header is not rendered').not.toBeNull();
+        expect(geometry.header!.position).toBe('sticky');
+        expect(geometry.header!.left).toBe('0px');
+        expect(geometry.header!.viewportLeft).toBe(geometry.containerLeft);
+
+        expect(geometry.rows.length).toBeGreaterThan(0);
+        for (const row of geometry.rows) {
+          expect(row.position, `row ${row.traceId} select cell is not sticky`).toBe('sticky');
+          expect(row.left, `row ${row.traceId} select cell is not pinned to 0`).toBe('0px');
+          expect(
+            row.viewportLeft,
+            `row ${row.traceId} select cell drifted from the container edge`,
+          ).toBe(geometry.containerLeft);
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
> **Generated by the release QA side flow — draft, needs human review before merge.**
> Nothing here has been reviewed by a person. Two specs were written from an
> exploratory testing pass and run green against the source PR's own deployed
> environment; a third candidate was dropped (see below).

## Where these came from

Exploratory testing of **comet-ml/opik#7947** — "[OPIK-8021] [FE] perf: virtualize
the traces table's columns and rows" — against that PR's own deployed
environment (`https://pr-7947.dev.comet.com`, serving `2.2.37-7947-merge-3045`,
OSS install, workspace `default`). A human worked the flows by hand there first;
these specs automate the two that held up.

**This PR targets `andriid/OPIK-8021-traces-table-columns-perf`, not `main`.**
The behaviour asserted here — a traces table that renders a moving window of
rows and columns instead of all of them — only exists on that branch. On `main`
the table still renders every row, so the specs' own precondition checks
(*fewer rows in the DOM than were seeded*, *spacer cells present in the header
row*) would fail. Rebase this onto `main` once #7947 lands.

Written and verified against `4b66cdd4c1d0583a08ffd574fb983371c40bba8b`, which
was #7947's head at the time.

## The specs

Both live in `tests_end_to_end/e2e/tests/trace-explore/traces-table-virtualization.spec.ts`.

### 1. `@cap:traces.list-traces` — row window renders every trace exactly once

Seeds 60 traces, reads the API's ordering for the same project, then sweeps the
page body from top to bottom in 250px steps. At every offset it asserts the
rendered `data-row-id`s are a **contiguous slice of the API's ordering** starting
where they claim to, and that no id is in the DOM twice at once. Across the whole
sweep, every seeded trace must have been seen, and the final window must be the
tail of the ordering.

The failure this is for is a row silently dropped or repeated at a window seam —
which renders as a plausible-looking table, not as an error. `traces.list-traces`
is nominally covered by `trace-explore-smoke.spec.ts`, but that spec seeds three
traces and so never crosses the 25-row threshold; this is the only spec that
reaches the windowed code path at all.

**Verification: passed.** `npx playwright test tests/trace-explore/traces-table-virtualization.spec.ts`
against `https://pr-7947.dev.comet.com`, green on 4 consecutive runs (~24s each).

### 2. `@cap:traces.configure-columns` — column window keeps everything aligned

Gives the same 60 traces 45 distinct feedback-score names, which the Logs table
offers as 45 extra columns (67 in total), then turns every column on from the
Columns picker. At five horizontal scroll offsets it reads the header's column
sequence — including the `aria-hidden` spacer cells, which are positions in the
row like any other — and asserts **every rendered row's cell sequence and the
`<colgroup>` match it position for position**, and that the sampled sequences
are not all identical (i.e. the window actually moved). Finally, at maximum
scrollLeft, the pinned `select` column must be `position: sticky` at `left: 0`
and geometrically flush with the scroll container's left edge, on the header and
on every rendered row.

The failure this is for is a spacer of the wrong width shifting every cell one
column across: correct data under the wrong header, which looks like correct
data. `traces.configure-columns` had no spec at all before this.

**Verification: passed.** Same command and environment, green on 4 consecutive
runs (~16s each).

## What this change also touches

- **`fixtures/windowed-traces.fixture.ts`** (new) — `windowedTraces` seeds 60
  traces in one batch write with caller-minted UUIDv7 ids one second apart, then
  polls until the project lists *exactly* those ids and returns them in the API's
  order. `wideTracesTable` chains from it and adds the 45 score names. Sixty
  rather than the forty the exploration used, so "fewer rows in the DOM than were
  seeded" has ~20 rows of headroom rather than 2 and does not depend on the
  runner's viewport height. Teardown deletes the traces explicitly — deleting a
  project does not cascade to them, and `global-teardown`'s prefix sweep only
  knows about experiments, datasets and projects.
- **`pom/logs.page.ts`** — window-reading helpers (header/cell/colgroup
  sequences, scroll extent, a scroll-and-settle step, pinned-column geometry) and
  the Columns picker. No raw selectors leak into the spec.
- **`core/backend/client.ts`** — `createTracesBatch` and `scoreTracesBatch`. The
  Python bridge creates one trace per call and flushes each time, which is right
  for a three-trace fixture and not for sixty traces carrying 2,700 scores.
- **`coverage/taxonomy.yaml`** — spec added to the `traces` area's `specs:` list;
  `configure-columns` flipped to `covered: true, tier: t2-cuj`. `list-traces` was
  already `covered: true` at `t1-smoke` and is left as-is.

## Two things a reviewer should look at

1. **The scroll container has no `data-testid`.** `PageBodyScrollContainer.tsx`
   renders the element the table virtualizes against, and its only distinguishing
   marks are Tailwind classes. The POM resolves it as *the nearest scrollable
   ancestor of `[data-table-wrapper]`* — semantic rather than class-coupled, and
   the same lookup the virtualizer makes through React context. The house
   conventions say to add a `data-testid` in the same change; that is deliberately
   **not** done here, because the target environment serves a prebuilt frontend
   image, so a testid added in this PR could not have been exercised by the run
   above. A `data-testid="page-body-scroll-container"` would be a strict
   improvement and the POM helper should switch to it.
2. **The exploration flagged a possible gap in the gate, which these specs do not
   assert.** `TracesSpansTab.tsx` builds one `virtualization` object for both
   axes and the comment says one decision drives both, but the column axis was
   observed not to engage on a wide table with few columns. That is an
   optimisation gap, not a correctness bug — nothing renders wrongly — so no
   assertion here pins the current behaviour. Worth an author sanity check
   independently of this PR.

## What was deliberately not written

One candidate of three was dropped: **select-all and bulk delete covering rows
outside the rendered window** (`traces.delete-traces`). It verified by hand, but
`traces.delete-traces` is already covered by `trace-delete.spec.ts`, and the
right shape is probably to raise that spec's seed count past the windowing
threshold rather than add a second delete spec — a call for whoever owns that
file, not for a generated PR.

## Verification, in full

Run from `tests_end_to_end/e2e/`, against `OPIK_BASE_URL=https://pr-7947.dev.comet.com`
(`OPIK_DEPLOYMENT=oss`, workspace `default`):

```
npx tsc --noEmit                                                    # clean
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml \
  --estate tests_end_to_end                                         # 44 specs, 0 problems
npx playwright test tests/trace-explore/traces-table-virtualization.spec.ts
                                                                    # 2 passed
npx playwright test tests/trace-explore/traces-table-virtualization.spec.ts --repeat-each=3
                                                                    # 6 passed
npx playwright test tests/trace-explore/                            # 20 passed
```

The whole `trace-explore/` directory was run because this change touches a shared
POM, a shared fixture chain and the shared backend client.


[OPIK-8021]: https://comet-ml.atlassian.net/browse/OPIK-8021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ