### PR TITLE
[OPIK-8021] [FE] perf: virtualize the trace logs view's columns and rows

### DIFF
--- a/apps/opik-frontend/src/contexts/usePageBodyScrollContainer.tsx
+++ b/apps/opik-frontend/src/contexts/usePageBodyScrollContainer.tsx
@@ -3,6 +3,8 @@ import noop from "lodash/noop";
 
 type PageBodyScrollContainerContextData = {
   scrollContainer: HTMLDivElement | null;
+  horizontalScrollContainer: HTMLElement | null;
+  registerHorizontalScrollContainer: (element: HTMLElement | null) => void;
   tableOffset: number;
   recalculateOffsets: () => void;
 };
@@ -10,6 +12,8 @@ type PageBodyScrollContainerContextData = {
 export const PageBodyScrollContainerContext =
   React.createContext<PageBodyScrollContainerContextData>({
     scrollContainer: null,
+    horizontalScrollContainer: null,
+    registerHorizontalScrollContainer: noop,
     tableOffset: 0,
     recalculateOffsets: noop,
   });

--- a/apps/opik-frontend/src/shared/DataTable/DataTableWrapper.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTableWrapper.tsx
@@ -2,9 +2,13 @@ import React, { useCallback, useRef } from "react";
 
 export type DataTableWrapperProps = {
   children: React.ReactNode;
+  scrollRef?: React.Ref<HTMLDivElement>;
 };
 
-const DataTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
+const DataTableWrapper: React.FC<DataTableWrapperProps> = ({
+  children,
+  scrollRef,
+}) => {
   const rafId = useRef(0);
   const wasScrolled = useRef(false);
 
@@ -22,6 +26,7 @@ const DataTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
 
   return (
     <div
+      ref={scrollRef}
       className="overflow-x-auto overflow-y-hidden rounded-md border"
       data-table-scroll-container
       onScroll={handleScroll}

--- a/apps/opik-frontend/src/shared/DataTable/ScrollTableWrapper.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/ScrollTableWrapper.tsx
@@ -1,11 +1,15 @@
 import React from "react";
 
 import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
-import DataTableWrapper, {
-  DataTableWrapperProps,
-} from "@/shared/DataTable/DataTableWrapper";
+import DataTableWrapper from "@/shared/DataTable/DataTableWrapper";
 
-const ScrollTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
+type ScrollTableWrapperProps = {
+  children: React.ReactNode;
+};
+
+const ScrollTableWrapper: React.FC<ScrollTableWrapperProps> = ({
+  children,
+}) => {
   const { registerHorizontalScrollContainer } = usePageBodyScrollContainer();
 
   return (

--- a/apps/opik-frontend/src/shared/DataTable/ScrollTableWrapper.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/ScrollTableWrapper.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+import usePageBodyScrollContainer from "@/contexts/usePageBodyScrollContainer";
+import DataTableWrapper, {
+  DataTableWrapperProps,
+} from "@/shared/DataTable/DataTableWrapper";
+
+const ScrollTableWrapper: React.FC<DataTableWrapperProps> = ({ children }) => {
+  const { registerHorizontalScrollContainer } = usePageBodyScrollContainer();
+
+  return (
+    <DataTableWrapper scrollRef={registerHorizontalScrollContainer}>
+      {children}
+    </DataTableWrapper>
+  );
+};
+
+export default ScrollTableWrapper;

--- a/apps/opik-frontend/src/shared/DataTable/TableScrollContainer.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/TableScrollContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 import noop from "lodash/noop";
 
 import { PageBodyScrollContainerContext } from "@/contexts/usePageBodyScrollContainer";
@@ -19,24 +19,22 @@ const TableScrollContainer: React.FC<TableScrollContainerProps> = ({
   const [horizontalScrollContainer, setHorizontalScrollContainer] =
     useState<HTMLElement | null>(null);
 
-  const registerHorizontalScrollContainer = useCallback(
-    (element: HTMLElement | null) => setHorizontalScrollContainer(element),
-    [],
-  );
-
   return (
     <PageBodyScrollContainerContext.Provider
       value={{
         scrollContainer,
         horizontalScrollContainer,
-        registerHorizontalScrollContainer,
+        registerHorizontalScrollContainer: setHorizontalScrollContainer,
         tableOffset: 0,
         recalculateOffsets: noop,
       }}
     >
       <div
         ref={setScrollContainer}
-        className={cn("min-h-0 flex-1 overflow-auto", className)}
+        className={cn(
+          "min-h-0 flex-1 overflow-x-hidden overflow-y-auto",
+          className,
+        )}
       >
         {children}
       </div>

--- a/apps/opik-frontend/src/shared/DataTable/TableScrollContainer.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/TableScrollContainer.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useState } from "react";
+import noop from "lodash/noop";
+
+import { PageBodyScrollContainerContext } from "@/contexts/usePageBodyScrollContainer";
+import { cn } from "@/lib/utils";
+
+type TableScrollContainerProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+const TableScrollContainer: React.FC<TableScrollContainerProps> = ({
+  children,
+  className,
+}) => {
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+  const [horizontalScrollContainer, setHorizontalScrollContainer] =
+    useState<HTMLElement | null>(null);
+
+  const registerHorizontalScrollContainer = useCallback(
+    (element: HTMLElement | null) => setHorizontalScrollContainer(element),
+    [],
+  );
+
+  return (
+    <PageBodyScrollContainerContext.Provider
+      value={{
+        scrollContainer,
+        horizontalScrollContainer,
+        registerHorizontalScrollContainer,
+        tableOffset: 0,
+        recalculateOffsets: noop,
+      }}
+    >
+      <div
+        ref={setScrollContainer}
+        className={cn("min-h-0 flex-1 overflow-auto", className)}
+      >
+        {children}
+      </div>
+    </PageBodyScrollContainerContext.Provider>
+  );
+};
+
+export default TableScrollContainer;

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
@@ -23,7 +23,6 @@ const EMPTY_LAYOUT = {
 export type ColumnVirtualizationConfig = {
   enabled?: boolean;
   overscan?: number;
-  getScrollElement?: () => HTMLElement | null;
 };
 
 const useColumnVirtualization = <TData>(
@@ -31,20 +30,15 @@ const useColumnVirtualization = <TData>(
   config?: ColumnVirtualizationConfig,
   { supported = true }: { supported?: boolean } = {},
 ): ColumnWindow => {
-  const { scrollContainer: pageBodyScrollContainer } =
+  const { scrollContainer, horizontalScrollContainer } =
     usePageBodyScrollContainer();
   const visibleColumns = table.getVisibleLeafColumns();
   const columnSizing = table.getState().columnSizing;
 
-  const {
-    enabled: optedIn = false,
-    overscan = DEFAULT_OVERSCAN_COLUMNS,
-    getScrollElement,
-  } = config ?? {};
+  const { enabled: optedIn = false, overscan = DEFAULT_OVERSCAN_COLUMNS } =
+    config ?? {};
 
-  const scrollElement = getScrollElement
-    ? getScrollElement()
-    : pageBodyScrollContainer;
+  const scrollElement = horizontalScrollContainer ?? scrollContainer;
 
   const windowable =
     supported &&

--- a/apps/opik-frontend/src/shared/DataTable/utils.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/utils.tsx
@@ -479,3 +479,10 @@ export const generateGroupedRowCellDef = <TData, TValue>(
     enableHiding: false,
   } as ColumnDef<TData, TValue>;
 };
+
+export const getVirtualizationConfig = (
+  columnCount: number,
+  rowCount: number,
+): { enabled: boolean } => ({
+  enabled: columnCount * rowCount > 3000,
+});

--- a/apps/opik-frontend/src/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
+++ b/apps/opik-frontend/src/v2/layout/PageBodyScrollContainer/PageBodyScrollContainer.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import noop from "lodash/noop";
 import { cn } from "@/lib/utils";
 import { useObserveResizeNode } from "@/hooks/useObserveResizeNode";
 import { STICKY_ATTRIBUTE_VERTICAL } from "@/shared/PageBodyStickyContainer/PageBodyStickyContainer";
@@ -93,6 +94,8 @@ const PageBodyScrollContainer: React.FC<PageBodyScrollContainerProps> = ({
     <PageBodyScrollContainerContext.Provider
       value={{
         scrollContainer: scrollContainer ?? null,
+        horizontalScrollContainer: null,
+        registerHorizontalScrollContainer: noop,
         tableOffset,
         recalculateOffsets,
       }}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
@@ -894,8 +894,8 @@ const TraceLogsView: React.FunctionComponent<TraceLogsViewProps> = ({
   ]);
 
   const virtualization = useMemo(
-    () => getVirtualizationConfig(columns.length, rows.length),
-    [columns.length, rows.length],
+    () => getVirtualizationConfig(columns.length, rows.length || (size ?? 0)),
+    [columns.length, rows.length, size],
   );
 
   const columnsToExport = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
@@ -52,7 +52,10 @@ import {
 } from "@/types/traces";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import { getJSONPaths, cn } from "@/lib/utils";
-import { generateSelectColumDef } from "@/shared/DataTable/utils";
+import {
+  generateSelectColumDef,
+  getVirtualizationConfig,
+} from "@/shared/DataTable/utils";
 import SearchInput from "@/shared/SearchInput/SearchInput";
 import useFilterChips from "@/shared/filter-chips/hooks/useFilterChips";
 import FilterChipBar from "@/shared/filter-chips/FilterChipBar/FilterChipBar";
@@ -75,7 +78,10 @@ import DataTableRowHeightSelector from "@/shared/DataTableRowHeightSelector/Data
 import ColumnsButton from "@/shared/ColumnsButton/ColumnsButton";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import DataTable from "@/shared/DataTable/DataTable";
+import DataTableVirtualBody from "@/shared/DataTable/DataTableVirtualBody";
 import { DataTableWrapperProps } from "@/shared/DataTable/DataTableWrapper";
+import TableScrollContainer from "@/shared/DataTable/TableScrollContainer";
+import ScrollTableWrapper from "@/shared/DataTable/ScrollTableWrapper";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
 import DataTableNoMatchingData from "@/shared/DataTableNoData/DataTableNoMatchingData";
 import emptyLogsLightUrl from "/images/empty-logs-light.svg";
@@ -887,6 +893,11 @@ const TraceLogsView: React.FunctionComponent<TraceLogsViewProps> = ({
     metadataColumnsOrder,
   ]);
 
+  const virtualization = useMemo(
+    () => getVirtualizationConfig(columns.length, rows.length),
+    [columns.length, rows.length],
+  );
+
   const columnsToExport = useMemo(() => {
     return columns
       .map((c) => get(c, "accessorKey", ""))
@@ -1132,6 +1143,9 @@ const TraceLogsView: React.FunctionComponent<TraceLogsViewProps> = ({
           />
         }
         showLoadingOverlay={isPlaceholderData && isFetching}
+        TableBody={DataTableVirtualBody}
+        columnVirtualization={virtualization}
+        rowVirtualization={virtualization}
         {...extraProps}
       />
     </DataTableStateHandler>
@@ -1196,9 +1210,9 @@ const TraceLogsView: React.FunctionComponent<TraceLogsViewProps> = ({
         {metricsSummary && <div className="px-6 pt-4">{metricsSummary}</div>}
         {/* Same single row as the page layout. */}
         <div className="flex items-start gap-2 px-6 py-4">{toolbarRow}</div>
-        <div className="min-h-0 flex-1 overflow-auto border-b px-6">
-          {renderTable()}
-        </div>
+        <TableScrollContainer className="border-b px-6">
+          {renderTable({ TableWrapper: ScrollTableWrapper })}
+        </TableScrollContainer>
         <div className="border-t px-6 py-3">{pagination}</div>
       </div>
       {panels}

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1346,8 +1346,8 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
   ]);
 
   const virtualization = useMemo(
-    () => getVirtualizationConfig(columns.length, rows.length),
-    [columns.length, rows.length],
+    () => getVirtualizationConfig(columns.length, rows.length || (size ?? 0)),
+    [columns.length, rows.length, size],
   );
 
   const columnsToExport = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -76,7 +76,10 @@ import { BaseTraceData, Span, Trace, LOGS_SOURCE } from "@/types/traces";
 import { convertColumnDataToColumn, migrateSelectedColumns } from "@/lib/table";
 import { getJSONPaths } from "@/lib/utils";
 import { buildDocsUrl } from "@/v2/lib/utils";
-import { generateSelectColumDef } from "@/shared/DataTable/utils";
+import {
+  generateSelectColumDef,
+  getVirtualizationConfig,
+} from "@/shared/DataTable/utils";
 import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyContent";
 import { useOpenQuickStartDialog } from "@/v2/pages-shared/onboarding/QuickstartDialog/QuickstartDialog";
 import emptyLogsLightUrl from "/images/empty-logs-light.svg";
@@ -1342,21 +1345,9 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
     metadataColumnsOrder,
   ]);
 
-  const cellCount = columns.length * rows.length;
-
-  // One decision drives both axes: the table is windowed or it isn't. Either
-  // axis crossing its own count, or the combined cell count crossing the
-  // shared budget, is enough — an AND here would block a lopsided table like
-  // 1000 columns × 10 rows from windowing at all. The budget sits above the
-  // default view (~15 columns × 100 rows = 1500) so normal tables stay fully
-  // rendered. Below 15 on both axes, there's nothing meaningful to skip.
   const virtualization = useMemo(
-    () => ({
-      enabled:
-        (columns.length >= 15 || rows.length >= 15) &&
-        (columns.length > 50 || rows.length > 25 || cellCount > 3000),
-    }),
-    [columns.length, rows.length, cellCount],
+    () => getVirtualizationConfig(columns.length, rows.length),
+    [columns.length, rows.length],
   );
 
   const columnsToExport = useMemo(() => {


### PR DESCRIPTION
## Details

Extends the traces-table virtualization from OPIK-8021 to `TraceLogsView`, the shared view behind both the experiment Logs tab and the "Go to logs" sidebar. Windowing there needed a new piece: the sidebar layout scrolls its two axes on *different* elements — rows on the view's own container, columns on the inner wrapper `DataTableWrapper` opens for horizontal overflow — whereas page-scrolled tables share one element via `PageBodyScrollContainer`.

- Adds `TableScrollContainer` + `ScrollTableWrapper` so a table scrolling outside the page body can publish both axes. `DataTable` renders `TableWrapper` with no props, so the wrapper reports its element through the scroll-container context rather than a callback prop; this keeps call sites free of `getScrollElement` plumbing.
- Extends the scroll-container context with `horizontalScrollContainer` + a register callback. `PageBodyScrollContainer` leaves it null, so page-scrolled tables resolve both axes to the page body exactly as before — no behaviour change for the 12 tables using `PageBodyStickyTableWrapper`.
- Replaces the per-axis floors and count triggers with a single cell-count gate (`columns * rows > 3000`), extracted as `getVirtualizationConfig` so `TracesSpansTab` and `TraceLogsView` decide identically. The old rule windowed trivial tables: 10 columns by 26 rows is 260 cells but virtualized because the row count crossed 25. At 100 rows a table now windows past 30 columns; at 10 rows, past 300.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8021

Related but not resolved here: OPIK_8056 (traces list returns one row per trace x experiment pair, so a trace in N experiments appears N times).

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 4.5, Claude Sonnet 4.5
- Scope: full implementation
- Human verification: code review + manual testing in a browser against dev data

## Testing

Commands:
- `scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) — clean
- `npm run typecheck` / `npm run lint` — clean
- `npx vitest run src/shared/DataTable/` — 9/9 pass (`columnWindow.test.ts`)

Verified in Chrome against dev data (321 feedback-score columns, 120-item experiments), measuring rendered cells rather than eyeballing:

**Sidebar layout ("Go to logs" from an annotation queue)** — the case this PR fixes:
- Column window follows horizontal scroll: headers move `Start time/Input/Output…` -> `leadership_*` -> `structure_*/User feedback` as `scrollLeft` goes 0 -> 15000 -> 29282, with table width pinned at 30710px throughout. Before this change the window was frozen on the first N columns, because the virtualizer watched an element whose `scrollLeft` never changed.
- 36 of 100 rows in the DOM, `scrollHeight` 3347 preserved via spacers.
- Header/body alignment exact: 19 headers, 19 body cells, all left edges within 1.5px at `scrollLeft=9000`.
- 201 selected columns x 100 rows: 19 columns x ~34 rows rendered.

**Page layout (Logs tab)** — regression check on the shared-context change:
- 30 of 100 rows, 10 header cells on a 52300px table, window follows scroll. Unchanged from before.

**Threshold**, both directions on the same table (73 columns):
- x100 rows = 7300 cells (over budget): windowed 10/73 columns, 32/100 rows.
- x25 rows = 1825 cells (under budget): all 74 columns and all 25 rows rendered.

Not run: no automated rendering test for the sidebar layout — the virtualizers resolve their scroll element from a live layout, so this was verified in a browser instead. Unit coverage is on `sliceColumnWindow`, the pure slicing function.

Note on console noise while testing: the annotation-queue page logs React duplicate-key warnings from `TraceQueueItemsTab`, its own table. That is OPIK_8056 (duplicate rows from the backend join), not this change — `TracesSpansTab` already carries a `uniqBy` workaround and `TraceQueueItemsTab` does not.

## Documentation

N/A — internal rendering change, no user-facing docs affected.
