### PR TITLE
[NA] [BE] Fix CostServiceTest Mistral Small case broken by model-price updates

### DIFF
--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -521,7 +521,11 @@ class CostServiceTest {
     private static Stream<Arguments> provideMistralModels() {
         return Stream.of(
                 // Upstream LiteLLM row: $6e-08 in / $1.8e-07 out → 0.06 + 0.18 = 0.24
-                Arguments.of("mistral-small-latest", "0.24"),
+                // Pinned to the dated id rather than the `mistral-small-latest` alias: aliases are
+                // re-priced upstream whenever Mistral ships a new generation (Small 4 moved
+                // `mistral-small-latest` to 1.5e-07 / 6e-07), which breaks an exact-cost assertion
+                // on every automated model-prices update.
+                Arguments.of("mistral-small-3-2-2506", "0.24"),
                 // Upstream LiteLLM row: $5e-07 in / $1.5e-06 out → 0.5 + 1.5 = 2.00
                 Arguments.of("mistral-large-3", "2.00"),
                 // Upstream LiteLLM row: $3e-07 in / $9e-07 out → 0.3 + 0.9 = 1.20


### PR DESCRIPTION
## Details

`CostServiceTest.calculateCostForMistralModels[1]` fails on #7962 (the automated `[NA] [BE] Update model prices file` PR).

That case asserts an exact cost for the **`mistral-small-latest` alias**. #7962 re-points the alias at Mistral Small 4:

```diff
     "mistral/mistral-small-latest": {
-        "input_cost_per_token": 6e-08,
+        "input_cost_per_token": 1.5e-07,
-        "output_cost_per_token": 1.8e-07,
+        "output_cost_per_token": 6e-07,
+        "source": "https://docs.mistral.ai/models/model-cards/mistral-small-4-0-26-03",
```

With 1M in + 1M out the cost is now `0.15 + 0.60 = 0.75`, so the expected `0.24` no longer holds.

### Why this one and not the other ~25 exact-cost assertions

They follow the same pattern — it wasn't a different style that saved them. Diffing the price file field-by-field across #7962, **32 models had cost fields change** and only one is referenced anywhere in `CostServiceTest`. The near-misses:

| #7962 re-priced | `CostServiceTest` pins instead |
|---|---|
| `deepseek-v4-flash`, `deepseek-v4-pro` | `deepseek/deepseek-coder`, `deepseek/deepseek-chat` |
| `moonshot/kimi-k3` (new) | `moonshot/kimi-k2-0711-preview` |
| `gpt-5.6`, `gpt-5.6-sol` | `gpt-5.4` tier cases |
| `mistral/codestral-latest` (1e-06 → 3e-07) | `codestral-2508` (only `max_tokens` moved) |

The cases that held all pin **dated / generation-locked ids**, which upstream never re-prices — a new model gets a new key. `mistral-small-latest` is an **alias**, so it re-prices by design on every new Small generation. It was the only `-latest` alias asserted with an exact cost in the whole file.

### Fix

Pin the dated `mistral-small-3-2-2506` row. It carries the same `6e-08` / `1.8e-07` rates both before and after #7962, so the expected `0.24` and its explanatory comment stay correct — and it can't be moved by a future generation bump.

The intent the test guards (that `mistral` is in `PROVIDERS_MAPPING`, so `litellm_provider: "mistral"` rows aren't dropped at startup) is unaffected; alias resolution itself is covered separately by `calculateCost_overrideAliasResolvesToTargetPricing`.

## Change checklist

- [ ] User facing change
- [ ] Documentation update

## Issues

N/A — CI failure on #7962.

## Testing

`mvn -Dtest=CostServiceTest test` run twice, both green (`tests=107 errors=0 skipped=0 failures=0`):

1. On this branch against **`main`**'s price file — so it merges cleanly on its own.
2. On top of **#7962**'s head commit `285aadce1e` — so that PR goes green once this lands and its CI re-runs.

## Documentation

N/A