### PR TITLE
[OPIK-7834] [BE] feat: redact trace content on read for callers without the original-data permission

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1846,6 +1846,11 @@ redaction:
   # Default: false
   # Description: Master switch. Also gates the workspace settings that expose this in the UI.
   enabled: ${OPIK_REDACTION_ENABLED:-false}
+  # Default: [] with enabled=false. An empty set with enabled=true fails startup rather than masking nothing
+  # while appearing to be on.
+  # NOTE ON SHAPE: this key names the mechanism (regex rules). If the enforcement mechanism is ever replaced,
+  # deployments configured on `rules` face a breaking migration. A `mode:` discriminator with the rules nested
+  # under it would make that additive instead; worth doing before this is enabled anywhere.
   # Default: [] (no rules, so nothing is redacted even when enabled)
   # Description: JSON array of {"regex", "replace"} applied in order to every string in a response, each rule
   # seeing the previous rule's output. "replace" is literal text: unlike the SDK anonymizer, backreferences are
@@ -1854,6 +1859,21 @@ redaction:
   # rather than silently disabling redaction.
   # Object keys are never rewritten, only values: a key is part of the document's shape, and rewriting it would
   # break lookups into that object. Sensitive data therefore has to be in values, not field names.
+  # THEREFORE a payload shaped {"john.doe@example.com": "..."} carries the identifier in a key and is returned as
+  # stored. Rewriting keys is not the fix: two keys collapsing to the same replacement produce a document with
+  # duplicate keys, and the parser that reads it keeps only one of them - valid JSON that has silently lost data.
+  # Keys are structure; the place to keep identifiers out of them is the instrumentation that writes them.
+  # The permission is read from the cached authentication result, so granting or revoking trace_original_data_view
+  # takes effect within authentication.apiKeyResolutionCacheTTLInSec (default 5s) rather than immediately.
+  # Revocation is the direction that matters: for those few seconds a caller who has just lost it still reads
+  # originals.
+  # NOT YET COVERED: the dataset CSV export (datasetExport.enabled, false by default) writes its file from a
+  # background job with no caller, and the download streams those bytes without applying the rules. Enable the
+  # export feature and an unpermitted caller can read stored content through it. Masking belongs on the download,
+  # which does have a caller, applied per cell through the CSV parser so the rules cannot reach the delimiters.
+  # A value whose rules cannot be evaluated within the internal match budget is masked whole rather than returned
+  # (see MatchBudget). Anchored rules never approach it; an unanchored one on a long token will, and the value is
+  # then withheld rather than shown.
   # Callers with no credentials reading a public project are redacted too: an anonymous reader cannot hold the
   # permission, so the public view shows the redacted content rather than what is stored. The MCP OAuth route resolves the
   # caller from a username header rather than an authenticated principal, so on a deployment that enables it the

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1861,6 +1861,9 @@ redaction:
   # An environment name auto-created from a trace is exempt as an entity name, so a value that survives the
   # ^[A-Za-z0-9_-]+$ filter can read redacted on the trace and verbatim on /v1/private/environments. Digits and
   # hyphens pass that filter, so a rule written for dates or national identifiers can differ across the two.
+  # A span's model and provider are exempt by decision: they name a vendor and a model rather than carry personal
+  # data, and the UI filters and groups by them, so redacting them would rewrite legitimate identifiers such as
+  # gpt-4o-2024-08-06 under a date rule. Content placed in those two fields is therefore returned as stored.
   # Structural properties (project_name, thread_id, dataset_name and similar lookup keys) are exempt:
   # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
   # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1848,9 +1848,10 @@ redaction:
   enabled: ${OPIK_REDACTION_ENABLED:-false}
   # Default: [] with enabled=false. An empty set with enabled=true fails startup rather than masking nothing
   # while appearing to be on.
-  # NOTE ON SHAPE: this key names the mechanism (regex rules). If the enforcement mechanism is ever replaced,
-  # deployments configured on `rules` face a breaking migration. A `mode:` discriminator with the rules nested
-  # under it would make that additive instead; worth doing before this is enabled anywhere.
+  # NOT A STABLE CONTRACT YET: this key names the mechanism (regex rules), so replacing the mechanism means
+  # replacing the key. Left as-is deliberately - the feature is in beta and off by default, so the shape can
+  # change in a later PR rather than being generalised now for a successor that does not exist yet. Do not build
+  # tooling or deployment templates against `rules` on the assumption that it is fixed.
   # Default: [] (no rules, so nothing is redacted even when enabled)
   # Description: JSON array of {"regex", "replace"} applied in order to every string in a response, each rule
   # seeing the previous rule's output. "replace" is literal text: unlike the SDK anonymizer, backreferences are

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1845,6 +1845,11 @@ agentConfig:
 redaction:
   # Default: false
   # Description: Master switch. Also gates the workspace settings that expose this in the UI.
+  # REQUIRES AUTHENTICATION. The exemption is the trace_original_data_view workspace permission, which arrives on
+  # the authentication call and from nowhere else, so with authentication.enabled=false no caller can hold it and
+  # every response is masked for everybody with no way to grant an exemption. The backend logs that at startup.
+  # This is why there is no self-hosted guide for the feature: on a deployment without the platform's
+  # authentication there is nothing to configure per caller.
   enabled: ${OPIK_REDACTION_ENABLED:-false}
   # Default: [] - which is valid only while enabled=false. An empty set with enabled=true fails startup
   # ("redaction.rules must not be empty when redaction.enabled=true") rather than masking nothing while

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1886,6 +1886,11 @@ redaction:
   # gpt-4o-2024-08-06 under a date rule. Content placed in those two fields is therefore returned as stored.
   # Structural properties (project_name, thread_id, dataset_name and similar lookup keys) are exempt:
   # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
-  # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as
-  # [\w.+-]+@... is quadratic on long base64 payloads and will stall reads.
+  # its keys are named.
+  # thread_id specifically is exempt by decision, not by oversight. It is chosen by the caller and used for
+  # navigation and grouping, so what goes in it is the instrumentation's responsibility - the same contract as
+  # object keys above. Do not put content there that the workspace's readers may not see.
+  # Anchor patterns so they cannot start mid-token — an unanchored local part such as [\w.+-]+@... is quadratic
+  # on long base64 payloads. The match budget now bounds that rather than leaving it to the pattern, but an
+  # anchored rule is still the difference between exact masking and a value withheld whole.
   rules: '${OPIK_REDACTION_RULES:-[]}'

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1848,9 +1848,10 @@ redaction:
   enabled: ${OPIK_REDACTION_ENABLED:-false}
   # Default: [] (no rules, so nothing is redacted even when enabled)
   # Description: JSON array of {"regex", "replace"} applied in order to every string in a response, each rule
-  # seeing the previous rule's output — the same semantics as the SDK anonymizer, so an existing rule set ports
-  # across unchanged. Callable rules have no equivalent here: the server only runs regexes. A malformed regex
-  # fails startup rather than silently disabling redaction.
+  # seeing the previous rule's output. "replace" is literal text: unlike the SDK anonymizer, backreferences are
+  # not expanded, so a partial-mask replacement such as "\1***@\2" is emitted verbatim rather than substituted.
+  # Callable rules have no equivalent here either: the server only runs regexes. A malformed regex fails startup
+  # rather than silently disabling redaction.
   # Structural properties (project_name, thread_id, model, sortable_by and similar lookup keys) are exempt:
   # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
   # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1838,3 +1838,21 @@ agentConfig:
   # Default: 5000ms
   # Description: Duration of the distributed lock held during blueprint create/update operations
   blueprintLockDuration: ${OPIK_AGENT_CONFIG_BLUEPRINT_LOCK_DURATION:-5000ms}
+
+# Read-time redaction: rewrites trace and span content on the way out for callers who may not see the
+# originals. Data is stored as sent; nothing is rewritten at ingestion. With enabled=false no serializer is
+# registered and every response is byte-identical to before this feature existed.
+redaction:
+  # Default: false
+  # Description: Master switch. Also gates the workspace settings that expose this in the UI.
+  enabled: ${OPIK_REDACTION_ENABLED:-false}
+  # Default: [] (no rules, so nothing is redacted even when enabled)
+  # Description: JSON array of {"regex", "replace"} applied in order to every string in a response, each rule
+  # seeing the previous rule's output — the same semantics as the SDK anonymizer, so an existing rule set ports
+  # across unchanged. Callable rules have no equivalent here: the server only runs regexes. A malformed regex
+  # fails startup rather than silently disabling redaction.
+  # Structural properties (project_name, thread_id, model, sortable_by and similar lookup keys) are exempt:
+  # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
+  # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as
+  # [\w.+-]+@... is quadratic on long base64 payloads and will stall reads.
+  rules: '${OPIK_REDACTION_RULES:-[]}'

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1852,7 +1852,11 @@ redaction:
   # not expanded, so a partial-mask replacement such as "\1***@\2" is emitted verbatim rather than substituted.
   # Callable rules have no equivalent here either: the server only runs regexes. A malformed regex fails startup
   # rather than silently disabling redaction.
-  # Structural properties (project_name, thread_id, model, sortable_by and similar lookup keys) are exempt:
+  # Object keys are never rewritten, only values: a key is part of the document's shape, and rewriting it would
+  # break lookups into that object. Sensitive data therefore has to be in values, not field names.
+  # Callers with no credentials reading a public project are redacted too: an anonymous reader cannot hold the
+  # permission, so the public view shows the redacted content rather than what is stored.
+  # Structural properties (project_name, thread_id, dataset_name and similar lookup keys) are exempt:
   # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
   # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as
   # [\w.+-]+@... is quadratic on long base64 payloads and will stall reads.

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1874,8 +1874,13 @@ redaction:
   # A value whose rules cannot be evaluated within the internal match budget is masked whole rather than returned
   # (see MatchBudget). Anchored rules never approach it; an unanchored one on a long token will, and the value is
   # then withheld rather than shown.
-  # Callers with no credentials reading a public project are redacted too: an anonymous reader cannot hold the
-  # permission, so the public view shows the redacted content rather than what is stored. The MCP OAuth route resolves the
+  # trace_original_data_view is a workspace-scoped grant, so only a member of the workspace can hold it. That
+  # settles what a public project shows: a viewer who is not a member is never a holder, so with this enabled the
+  # public view is redacted, always. A member who holds it reads originals on public and private projects alike.
+  # The mechanism follows from where permissions are set - the public fallback in RemoteAuthService.authenticate
+  # runs only after member authentication has failed, and it sets workspace, visibility and a "Public" user name
+  # but no permissions. An empty permission set is redacted, so no separate public-visibility branch is needed.
+  # The MCP OAuth route resolves the
   # caller from a username header rather than an authenticated principal, so on a deployment that enables it the
   # gate is only as strong as the network boundary in front of the platform's auth endpoint.
   # An environment name auto-created from a trace is exempt as an entity name, so a value that survives the

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1845,9 +1845,11 @@ agentConfig:
 redaction:
   # Default: false
   # Description: Master switch. Also gates the workspace settings that expose this in the UI.
-  # REQUIRES AUTHENTICATION. The exemption is the trace_original_data_view workspace permission, which arrives on
-  # the authentication call and from nowhere else, so with authentication.enabled=false no caller can hold it and
-  # every response is masked for everybody with no way to grant an exemption. The backend logs that at startup.
+  # REQUIRES AUTHENTICATION. The exemption is the original_data_view workspace permission, read from the
+  # platform's workspace permissions API and from nowhere else, so with authentication.enabled=false no caller can
+  # hold it and every response is masked for everybody with no way to grant an exemption. The backend logs that at
+  # startup. Redaction is opt-in per caller: the permission is granted to every default role that can read data,
+  # so enabling this masks nothing until an admin revokes it for someone.
   # This is why there is no self-hosted guide for the feature: on a deployment without the platform's
   # authentication there is nothing to configure per caller.
   enabled: ${OPIK_REDACTION_ENABLED:-false}
@@ -1870,7 +1872,7 @@ redaction:
   # stored. Rewriting keys is not the fix: two keys collapsing to the same replacement produce a document with
   # duplicate keys, and the parser that reads it keeps only one of them - valid JSON that has silently lost data.
   # Keys are structure; the place to keep identifiers out of them is the instrumentation that writes them.
-  # The permission is read from the cached authentication result, so granting or revoking trace_original_data_view
+  # The permission is resolved alongside the cached credentials, so granting or revoking original_data_view
   # takes effect within authentication.apiKeyResolutionCacheTTLInSec (default 5s) rather than immediately.
   # Revocation is the direction that matters: for those few seconds a caller who has just lost it still reads
   # originals.
@@ -1890,7 +1892,7 @@ redaction:
   # may come out - four times, or 64 KB, whichever is larger. The second only binds on a rule whose replacement
   # is longer than the text it matches, applied to a value full of such matches; that combination would otherwise
   # let a caller's payload and the replacement multiply into a response many times the size of either.
-  # trace_original_data_view is a workspace-scoped grant, so only a member of the workspace can hold it. That
+  # original_data_view is a workspace-scoped grant, so only a member of the workspace can hold it. That
   # settles what a public project shows: a viewer who is not a member is never a holder, so with this enabled the
   # public view is redacted, always. A member who holds it reads originals on public and private projects alike.
   # The mechanism follows from where permissions are set - the public fallback in RemoteAuthService.authenticate

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1878,9 +1878,12 @@ redaction:
   # background job with no caller, and the download streams those bytes without applying the rules. Enable the
   # export feature and an unpermitted caller can read stored content through it. Masking belongs on the download,
   # which does have a caller, applied per cell through the CSV parser so the rules cannot reach the delimiters.
-  # A value whose rules cannot be evaluated within the internal match budget is masked whole rather than returned
-  # (see MatchBudget). Anchored rules never approach it; an unanchored one on a long token will, and the value is
-  # then withheld rather than shown.
+  # A value whose rules cannot be evaluated within the internal bounds is masked whole rather than returned (see
+  # MatchBudget). Two bounds apply: the work one rule may do against one value, which an anchored rule never
+  # approaches and an unanchored one on a long token will, and how much longer than the stored value the rewrite
+  # may come out - four times, or 64 KB, whichever is larger. The second only binds on a rule whose replacement
+  # is longer than the text it matches, applied to a value full of such matches; that combination would otherwise
+  # let a caller's payload and the replacement multiply into a response many times the size of either.
   # trace_original_data_view is a workspace-scoped grant, so only a member of the workspace can hold it. That
   # settles what a public project shows: a viewer who is not a member is never a holder, so with this enabled the
   # public view is redacted, always. A member who holds it reads originals on public and private projects alike.

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1846,13 +1846,14 @@ redaction:
   # Default: false
   # Description: Master switch. Also gates the workspace settings that expose this in the UI.
   enabled: ${OPIK_REDACTION_ENABLED:-false}
-  # Default: [] with enabled=false. An empty set with enabled=true fails startup rather than masking nothing
-  # while appearing to be on.
+  # Default: [] - which is valid only while enabled=false. An empty set with enabled=true fails startup
+  # ("redaction.rules must not be empty when redaction.enabled=true") rather than masking nothing while
+  # appearing to be on, so switching the feature on means setting this at the same time, e.g.
+  # OPIK_REDACTION_RULES='[{"regex":"(?<![\w.+-])[\w.+-]+@[\w-]+\.[\w.]+","replace":"[EMAIL]"}]'
   # NOT A STABLE CONTRACT YET: this key names the mechanism (regex rules), so replacing the mechanism means
   # replacing the key. Left as-is deliberately - the feature is in beta and off by default, so the shape can
   # change in a later PR rather than being generalised now for a successor that does not exist yet. Do not build
   # tooling or deployment templates against `rules` on the assumption that it is fixed.
-  # Default: [] (no rules, so nothing is redacted even when enabled)
   # Description: JSON array of {"regex", "replace"} applied in order to every string in a response, each rule
   # seeing the previous rule's output. "replace" is literal text: unlike the SDK anonymizer, backreferences are
   # not expanded, so a partial-mask replacement such as "\1***@\2" is emitted verbatim rather than substituted.

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1855,7 +1855,12 @@ redaction:
   # Object keys are never rewritten, only values: a key is part of the document's shape, and rewriting it would
   # break lookups into that object. Sensitive data therefore has to be in values, not field names.
   # Callers with no credentials reading a public project are redacted too: an anonymous reader cannot hold the
-  # permission, so the public view shows the redacted content rather than what is stored.
+  # permission, so the public view shows the redacted content rather than what is stored. The MCP OAuth route resolves the
+  # caller from a username header rather than an authenticated principal, so on a deployment that enables it the
+  # gate is only as strong as the network boundary in front of the platform's auth endpoint.
+  # An environment name auto-created from a trace is exempt as an entity name, so a value that survives the
+  # ^[A-Za-z0-9_-]+$ filter can read redacted on the trace and verbatim on /v1/private/environments. Digits and
+  # hyphens pass that filter, so a rule written for dates or national identifiers can differ across the two.
   # Structural properties (project_name, thread_id, dataset_name and similar lookup keys) are exempt:
   # rewriting them conceals nothing and breaks navigation. Content carried as JSON is always redacted, whatever
   # its keys are named. Anchor patterns so they cannot start mid-token — an unanchored local part such as

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1868,6 +1868,12 @@ redaction:
   # takes effect within authentication.apiKeyResolutionCacheTTLInSec (default 5s) rather than immediately.
   # Revocation is the direction that matters: for those few seconds a caller who has just lost it still reads
   # originals.
+  # NOT GUARDED: a client that reads masked content and writes it back persists the replacement over the
+  # original. Nothing rejects that - the write path is untouched by this feature, by design, since content is
+  # stored exactly as sent. A caller without the permission editing and saving a prompt, dataset item or
+  # experiment they have only ever seen masked will therefore overwrite stored content with the replacement.
+  # Out of scope here; it needs the write path to recognise the token or refuse the write, which is a separate
+  # decision about how much editing such a caller should be able to do at all.
   # NOT YET COVERED: the dataset CSV export (datasetExport.enabled, false by default) writes its file from a
   # background job with no caller, and the download streams those bytes without applying the rules. Enable the
   # export feature and an unpermitted caller can read stored content through it. Masking belongs on the download,

--- a/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/OpikApplication.java
@@ -31,6 +31,7 @@ import com.comet.opik.infrastructure.llm.openai.OpenAIModule;
 import com.comet.opik.infrastructure.llm.openrouter.OpenRouterModule;
 import com.comet.opik.infrastructure.llm.vertexai.VertexAIModule;
 import com.comet.opik.infrastructure.ratelimit.RateLimitModule;
+import com.comet.opik.infrastructure.redaction.RedactionModule;
 import com.comet.opik.infrastructure.redis.RedisModule;
 import com.comet.opik.infrastructure.usagelimit.UsageLimitModule;
 import com.comet.opik.infrastructure.web.InstantParamConverter;
@@ -131,6 +132,12 @@ public class OpikApplication extends Application<OpikConfiguration> {
                         .addDeserializer(BigDecimal.class, JsonBigDecimalDeserializer.INSTANCE)
                         .addDeserializer(Message.class, OpenAiMessageJsonDeserializer.INSTANCE)
                         .addDeserializer(Duration.class, StrictDurationDeserializer.INSTANCE));
+
+        // Read-time redaction, registered only when switched on: with the flag off there is no serializer in
+        // the chain at all, so responses are written exactly as before.
+        if (configuration.getRedaction().isEnabled()) {
+            environment.getObjectMapper().registerModule(new RedactionModule());
+        }
 
         int maxStringLength = configuration.getJacksonConfig().getMaxStringLength();
         long maxDocumentLength = configuration.getJacksonConfig().getMaxDocumentLength();

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/internal/AnalyticsQueriesResource.java
@@ -8,6 +8,7 @@ import com.comet.opik.domain.FreeFormSqlQueryService;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
+import com.comet.opik.infrastructure.redaction.RedactionGuard;
 import com.google.common.base.Throwables;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -70,6 +71,10 @@ public class AnalyticsQueriesResource {
         if (!serviceToggles.isOllieEnabled()) {
             return Response.status(Response.Status.NOT_IMPLEMENTED).build();
         }
+
+        // The caller chooses the projection, so rewriting the result is not enforceable: a value returned
+        // through base64() or substring() matches no rule written against the plain text.
+        RedactionGuard.rejectUnmaskable(requestContext.get().isRedactResponse(), "Agent Insights free-form SQL");
 
         String workspaceId = requestContext.get().getWorkspaceId();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AttachmentResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/AttachmentResource.java
@@ -12,6 +12,7 @@ import com.comet.opik.api.attachment.StartMultipartUploadResponse;
 import com.comet.opik.api.error.ErrorMessage;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.redaction.RedactionGuard;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -189,6 +190,8 @@ public class AttachmentResource {
             @QueryParam("entity_id") @NotNull UUID entityId,
             @QueryParam("file_name") @NotBlank String fileName,
             @QueryParam("mime_type") @NotBlank String mimeType) {
+        // Streams bytes that never become a JsonNode, so no serializer can reach the content.
+        RedactionGuard.rejectUnmaskable(requestContext.get().isRedactResponse(), "Attachment download");
 
         String workspaceId = requestContext.get().getWorkspaceId();
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalWorkspacePermissionsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/LocalWorkspacePermissionsService.java
@@ -9,6 +9,22 @@ public class LocalWorkspacePermissionsService implements WorkspacePermissionsSer
 
     @Override
     public WorkspaceUserPermissions getPermissions(@NonNull String apiKey, @NonNull String workspaceName) {
+        return noPermissions(workspaceName);
+    }
+
+    @Override
+    public WorkspaceUserPermissions getPermissionsBySession(@NonNull String sessionToken,
+            @NonNull String workspaceName) {
+        return noPermissions(workspaceName);
+    }
+
+    @Override
+    public WorkspaceUserPermissions getPermissionsByUsername(@NonNull String userName,
+            @NonNull String workspaceName) {
+        return noPermissions(workspaceName);
+    }
+
+    private static WorkspaceUserPermissions noPermissions(String workspaceName) {
         return WorkspaceUserPermissions.builder()
                 .userName(ProjectService.DEFAULT_USER)
                 .workspaceName(workspaceName)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/RemoteWorkspacePermissionsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/RemoteWorkspacePermissionsService.java
@@ -33,7 +33,7 @@ public class RemoteWorkspacePermissionsService implements WorkspacePermissionsSe
 
     @Override
     public WorkspaceUserPermissions getPermissions(@NonNull String apiKey, @NonNull String workspaceName) {
-        log.info("Requesting workspace permissions for workspace '{}'", workspaceName);
+        log.debug("Requesting workspace permissions for workspace '{}'", workspaceName);
 
         try (var response = client.target(URI.create(reactServiceUrl.url()))
                 .path("opik")
@@ -50,7 +50,7 @@ public class RemoteWorkspacePermissionsService implements WorkspacePermissionsSe
     @Override
     public WorkspaceUserPermissions getPermissionsBySession(@NonNull String sessionToken,
             @NonNull String workspaceName) {
-        log.info("Requesting workspace permissions for workspace '{}' on the session path", workspaceName);
+        log.debug("Requesting workspace permissions for workspace '{}' on the session path", workspaceName);
 
         try (var response = permissionsRequest("workspace-permissions-session")
                 .cookie(RequestContext.SESSION_COOKIE, sessionToken)
@@ -63,7 +63,7 @@ public class RemoteWorkspacePermissionsService implements WorkspacePermissionsSe
     @Override
     public WorkspaceUserPermissions getPermissionsByUsername(@NonNull String userName,
             @NonNull String workspaceName) {
-        log.info("Requesting workspace permissions for workspace '{}' on the OAuth path", workspaceName);
+        log.debug("Requesting workspace permissions for workspace '{}' on the OAuth path", workspaceName);
 
         try (var response = permissionsRequest("workspace-permissions-by-username")
                 .header(OAUTH_USERNAME_HEADER, userName)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/RemoteWorkspacePermissionsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/RemoteWorkspacePermissionsService.java
@@ -3,10 +3,13 @@ package com.comet.opik.domain;
 import com.comet.opik.api.ReactServiceErrorResponse;
 import com.comet.opik.api.WorkspaceUserPermissions;
 import com.comet.opik.infrastructure.AuthenticationConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -15,6 +18,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.OAUTH_USERNAME_HEADER;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,6 +47,40 @@ public class RemoteWorkspacePermissionsService implements WorkspacePermissionsSe
         }
     }
 
+    @Override
+    public WorkspaceUserPermissions getPermissionsBySession(@NonNull String sessionToken,
+            @NonNull String workspaceName) {
+        log.info("Requesting workspace permissions for workspace '{}' on the session path", workspaceName);
+
+        try (var response = permissionsRequest("workspace-permissions-session")
+                .cookie(RequestContext.SESSION_COOKIE, sessionToken)
+                .post(Entity.json(new WorkspacePermissionsRequest(workspaceName)))) {
+
+            return parseResponse(response);
+        }
+    }
+
+    @Override
+    public WorkspaceUserPermissions getPermissionsByUsername(@NonNull String userName,
+            @NonNull String workspaceName) {
+        log.info("Requesting workspace permissions for workspace '{}' on the OAuth path", workspaceName);
+
+        try (var response = permissionsRequest("workspace-permissions-by-username")
+                .header(OAUTH_USERNAME_HEADER, userName)
+                .post(Entity.json(new WorkspacePermissionsRequest(workspaceName)))) {
+
+            return parseResponse(response);
+        }
+    }
+
+    private Invocation.Builder permissionsRequest(String path) {
+        return client.target(URI.create(reactServiceUrl.url()))
+                .path("opik")
+                .path(path)
+                .request()
+                .accept(MediaType.APPLICATION_JSON);
+    }
+
     private WorkspaceUserPermissions parseResponse(Response response) {
         if (response.getStatusInfo().getFamily() == Response.Status.Family.SUCCESSFUL) {
             return response.readEntity(WorkspaceUserPermissions.class);
@@ -51,6 +90,14 @@ public class RemoteWorkspacePermissionsService implements WorkspacePermissionsSe
         } else if (response.getStatus() == Response.Status.BAD_REQUEST.getStatusCode()) {
             var errorResponse = response.readEntity(ReactServiceErrorResponse.class);
             throw new ClientErrorException(errorResponse.msg(), Response.Status.BAD_REQUEST);
+        }
+
+        if (response.getStatus() == Response.Status.NOT_FOUND.getStatusCode()) {
+            // A platform that predates the session and OAuth variants of this endpoint. Named separately so
+            // the cause is legible: the caller is left unprivileged, which redacts, and reading "not found"
+            // rather than a generic failure is what tells an operator to deploy the platform side.
+            log.warn("The platform does not expose this workspace permissions endpoint");
+            throw new NotFoundException();
         }
 
         log.error("Unexpected error while fetching workspace permissions, status: {}", response.getStatus());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -66,8 +66,8 @@ public class Streamer {
                     ? redactionService.rules()
                     : RedactionRules.empty();
         } catch (RuntimeException outsideRequestScope) {
-            // No caller to decide against: redact, because this path cannot prove the reader is permitted.
-            return redactionService.rules();
+            // See RedactionService.redactWhenCallerUnknown - one definition, consulted by both write paths.
+            return redactionService.redactWhenCallerUnknown() ? redactionService.rules() : RedactionRules.empty();
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -74,17 +74,28 @@ public class Streamer {
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {
         try {
-            // deepCopy only when something will be rewritten: JsonUtils.readTree is convertValue, which returns
-            // the same instance when handed a JsonNode, and the redactor rewrites in place. Copying
-            // unconditionally would duplicate every tree on the streaming hot path of every deployment, since
-            // redaction is off by default.
             var tree = JsonUtils.readTree(item);
             outputStream.write(rules.isEmpty()
                     ? tree
-                    : JsonNodeRedactor.redact(tree.deepCopy(), rules, item.getClass()));
+                    : JsonNodeRedactor.redact(copyIfShared(tree, item), rules, item.getClass()));
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }
+    }
+
+    /**
+     * The redactor rewrites in place, so what it is handed must belong to nobody else.
+     * <p>
+     * JsonUtils.readTree is convertValue, which serializes the item into a TokenBuffer and reads it back - a
+     * tree built for this call, sharing no node with the item, whatever the item was. Copying it again duplicates
+     * every streamed tree for nothing.
+     * <p>
+     * The identity check is what makes that safe to rely on rather than a claim about Jackson: convertValue is
+     * documented as free to return its argument when the argument is already of the target type, and an item that
+     * is itself a JsonNode is the case where that would matter. If it ever does, this copies.
+     */
+    static <T> JsonNode copyIfShared(JsonNode tree, T item) {
+        return tree == item ? tree.deepCopy() : tree;
     }
 
     private <T> Flux<T> handleError(Throwable throwable, ChunkedOutput<JsonNode> outputStream) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -73,7 +73,11 @@ public class Streamer {
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {
         try {
-            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item), rules, item.getClass()));
+            // deepCopy: JsonUtils.readTree is convertValue, which returns the same instance when handed a
+            // JsonNode, and the redactor rewrites in place. Today every caller passes a POJO so the tree is
+            // already fresh, but a future Flux<JsonNode> would have its source mutated underneath it, silently.
+            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item).deepCopy(), rules,
+                    item.getClass()));
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.redaction.RedactionRules;
 import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.OutOfScopeException;
 import com.google.inject.ProvisionException;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.inject.Inject;
@@ -56,7 +57,7 @@ public class Streamer {
         return outputStream;
     }
 
-    private RedactionRules resolveRules() {
+    RedactionRules resolveRules() {
         if (!redactionService.isEnabled()) {
             return RedactionRules.empty();
         }
@@ -66,17 +67,32 @@ public class Streamer {
             return context != null && context.isRedactResponse()
                     ? redactionService.rules()
                     : RedactionRules.empty();
-        } catch (ProvisionException outsideRequestScope) {
-            // ProvisionException, not RuntimeException: catching everything turned a ProvisionException, a
-            // provider bug or a fault in isRedactResponse() into the unknown-caller policy, so a defect came back
-            // as a successful redacted stream instead of failing. And not OutOfScopeException either - Guice
-            // wraps that at the provider boundary, which is why AnalyticsService.resolveIdentity catches
-            // ProvisionException for this same "no request scope" case.
-            //
+        } catch (ProvisionException provisionException) {
+            // Only the missing request scope gets the fallback. Guice reports that as a ProvisionException
+            // wrapping an OutOfScopeException at the provider boundary - which is why this cannot catch
+            // OutOfScopeException directly, and why AnalyticsService.resolveIdentity catches ProvisionException
+            // for the same case. Every other ProvisionException is a provider bug or a fault in
+            // isRedactResponse(), and answering those with the unknown-caller policy would return a defect as a
+            // successful redacted stream, so they propagate.
+            if (!isOutsideRequestScope(provisionException)) {
+                throw provisionException;
+            }
+
+            log.debug("No request scope for this stream, applying the unknown-caller redaction policy");
+
             // See RedactionService.redactWhenCallerUnknown for why a stream can answer this and the writer
             // interceptor cannot.
             return redactionService.redactWhenCallerUnknown() ? redactionService.rules() : RedactionRules.empty();
         }
+    }
+
+    private static boolean isOutsideRequestScope(ProvisionException exception) {
+        for (Throwable cause = exception.getCause(); cause != null; cause = cause.getCause()) {
+            if (cause instanceof OutOfScopeException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -66,7 +66,8 @@ public class Streamer {
                     ? redactionService.rules()
                     : RedactionRules.empty();
         } catch (RuntimeException outsideRequestScope) {
-            // See RedactionService.redactWhenCallerUnknown - one definition, consulted by both write paths.
+            // See RedactionService.redactWhenCallerUnknown for why a stream can answer this and the writer
+            // interceptor cannot.
             return redactionService.redactWhenCallerUnknown() ? redactionService.rules() : RedactionRules.empty();
         }
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -1,8 +1,14 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.redaction.JsonNodeRedactor;
+import com.comet.opik.infrastructure.redaction.RedactionRules;
+import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.jersey.errors.ErrorMessage;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +24,16 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 public class Streamer {
 
+    private final RedactionService redactionService;
+    private final Provider<RequestContext> requestContext;
+
+    @Inject
+    public Streamer(@NonNull RedactionService redactionService,
+            @NonNull Provider<RequestContext> requestContext) {
+        this.redactionService = redactionService;
+        this.requestContext = requestContext;
+    }
+
     public <T> ChunkedOutput<JsonNode> getOutputStream(@NonNull Flux<T> flux) {
         return getOutputStream(flux, () -> {
         });
@@ -25,8 +41,11 @@ public class Streamer {
 
     public <T> ChunkedOutput<JsonNode> getOutputStream(@NonNull Flux<T> flux, Runnable onCompleted) {
         var outputStream = new ChunkedOutput<JsonNode>(JsonNode.class, "\r\n");
+        // Resolved here, while still on the request thread: the items below are built and written on a
+        // scheduler thread, where neither the request scope nor the writer interceptor's thread-local exists.
+        var rules = resolveRules();
         Schedulers.boundedElastic()
-                .schedule(() -> flux.doOnNext(item -> sendItem(item, outputStream))
+                .schedule(() -> flux.doOnNext(item -> sendItem(item, outputStream, rules))
                         .onErrorResume(throwable -> handleError(throwable, outputStream))
                         .doFinally(signalType -> {
                             close(outputStream);
@@ -36,9 +55,25 @@ public class Streamer {
         return outputStream;
     }
 
-    private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream) {
+    private RedactionRules resolveRules() {
+        if (!redactionService.isEnabled()) {
+            return RedactionRules.empty();
+        }
+
         try {
-            outputStream.write(JsonUtils.readTree(item));
+            var context = requestContext.get();
+            return context != null && context.isRedactResponse()
+                    ? redactionService.rules()
+                    : RedactionRules.empty();
+        } catch (RuntimeException outsideRequestScope) {
+            // No caller to decide against: redact, because this path cannot prove the reader is permitted.
+            return redactionService.rules();
+        }
+    }
+
+    private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {
+        try {
+            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item), rules));
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.redaction.RedactionRules;
 import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Throwables;
 import com.google.inject.OutOfScopeException;
 import com.google.inject.ProvisionException;
 import io.dropwizard.jersey.errors.ErrorMessage;
@@ -86,13 +87,13 @@ public class Streamer {
         }
     }
 
+    /**
+     * Guava rather than a hand-rolled walk: {@code getCausalChain} detects a cycle and throws instead of
+     * spinning, and a cause chain that references itself is reachable through wrapping.
+     */
     private static boolean isOutsideRequestScope(ProvisionException exception) {
-        for (Throwable cause = exception.getCause(); cause != null; cause = cause.getCause()) {
-            if (cause instanceof OutOfScopeException) {
-                return true;
-            }
-        }
-        return false;
+        return Throwables.getCausalChain(exception).stream()
+                .anyMatch(OutOfScopeException.class::isInstance);
     }
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -73,7 +73,7 @@ public class Streamer {
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {
         try {
-            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item), rules));
+            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item), rules, item.getClass()));
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.redaction.RedactionRules;
 import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.ProvisionException;
 import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.inject.Inject;
 import jakarta.inject.Provider;
@@ -65,7 +66,13 @@ public class Streamer {
             return context != null && context.isRedactResponse()
                     ? redactionService.rules()
                     : RedactionRules.empty();
-        } catch (RuntimeException outsideRequestScope) {
+        } catch (ProvisionException outsideRequestScope) {
+            // ProvisionException, not RuntimeException: catching everything turned a ProvisionException, a
+            // provider bug or a fault in isRedactResponse() into the unknown-caller policy, so a defect came back
+            // as a successful redacted stream instead of failing. And not OutOfScopeException either - Guice
+            // wraps that at the provider boundary, which is why AnalyticsService.resolveIdentity catches
+            // ProvisionException for this same "no request scope" case.
+            //
             // See RedactionService.redactWhenCallerUnknown for why a stream can answer this and the writer
             // interceptor cannot.
             return redactionService.redactWhenCallerUnknown() ? redactionService.rules() : RedactionRules.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/Streamer.java
@@ -73,11 +73,14 @@ public class Streamer {
 
     private <T> void sendItem(T item, ChunkedOutput<JsonNode> outputStream, RedactionRules rules) {
         try {
-            // deepCopy: JsonUtils.readTree is convertValue, which returns the same instance when handed a
-            // JsonNode, and the redactor rewrites in place. Today every caller passes a POJO so the tree is
-            // already fresh, but a future Flux<JsonNode> would have its source mutated underneath it, silently.
-            outputStream.write(JsonNodeRedactor.redact(JsonUtils.readTree(item).deepCopy(), rules,
-                    item.getClass()));
+            // deepCopy only when something will be rewritten: JsonUtils.readTree is convertValue, which returns
+            // the same instance when handed a JsonNode, and the redactor rewrites in place. Copying
+            // unconditionally would duplicate every tree on the streaming hot path of every deployment, since
+            // redaction is off by default.
+            var tree = JsonUtils.readTree(item);
+            outputStream.write(rules.isEmpty()
+                    ? tree
+                    : JsonNodeRedactor.redact(tree.deepCopy(), rules, item.getClass()));
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspacePermissionsService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspacePermissionsService.java
@@ -6,4 +6,16 @@ import lombok.NonNull;
 public interface WorkspacePermissionsService {
 
     WorkspaceUserPermissions getPermissions(@NonNull String apiKey, @NonNull String workspaceName);
+
+    /**
+     * The same lookup for a caller identified by session cookie rather than by api key.
+     * <p>
+     * Read-time redaction has to decide for browser and OAuth callers too, and this service answered only for
+     * api keys. Keeping both on the permissions API means the answer arrives as data, rather than being
+     * inferred from an authentication failure or bolted onto the authentication response.
+     */
+    WorkspaceUserPermissions getPermissionsBySession(@NonNull String sessionToken, @NonNull String workspaceName);
+
+    /** The same lookup for an OAuth caller, identified by the username the token resolved to. */
+    WorkspaceUserPermissions getPermissionsByUsername(@NonNull String userName, @NonNull String workspaceName);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -187,4 +187,7 @@ public class OpikConfiguration extends JobConfiguration {
 
     @Valid @NotNull @JsonProperty
     private ReportGenerationConfig reportGeneration = new ReportGenerationConfig();
+
+    @Valid @NotNull @JsonProperty
+    private RedactionConfig redaction = new RedactionConfig();
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.validation.constraints.AssertTrue;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -39,8 +38,11 @@ public class RedactionConfig {
 
     @Data
     public static class Rule {
+        // No bean-validation annotation here: these are produced by JsonUtils.readValue inside compile(), never
+        // by Dropwizard's config binding, so any constraint on this class would silently never run. Validated in
+        // compile() instead.
         @JsonProperty
-        @NotBlank private String regex;
+        private String regex;
 
         /** Empty is meaningful: it removes the match instead of replacing it. */
         @JsonProperty
@@ -67,7 +69,19 @@ public class RedactionConfig {
             return RedactionRules.empty();
         }
 
-        return new RedactionRules(JsonUtils.readValue(rules, RULES_TYPE).stream()
+        var parsed = JsonUtils.readValue(rules, RULES_TYPE);
+
+        for (int index = 0; index < parsed.size(); index++) {
+            // A blank pattern is the dangerous case, not merely an invalid one: it matches at every position, so
+            // every string in every response would be replaced. A missing one would otherwise surface as a bare
+            // Lombok NPE from RedactionRule.of, naming neither the field nor which entry was wrong.
+            if (StringUtils.isBlank(parsed.get(index).getRegex())) {
+                throw new IllegalArgumentException(
+                        "redaction.rules[%d].regex must not be blank".formatted(index));
+            }
+        }
+
+        return new RedactionRules(parsed.stream()
                 .map(rule -> RedactionRule.of(rule.getRegex(), rule.getReplace()))
                 .toList());
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
@@ -3,8 +3,11 @@ package com.comet.opik.infrastructure;
 import com.comet.opik.infrastructure.redaction.RedactionRule;
 import com.comet.opik.infrastructure.redaction.RedactionRules;
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -37,7 +40,7 @@ public class RedactionConfig {
     @Data
     public static class Rule {
         @JsonProperty
-        private String regex;
+        @NotBlank private String regex;
 
         /** Empty is meaningful: it removes the match instead of replacing it. */
         @JsonProperty
@@ -48,6 +51,17 @@ public class RedactionConfig {
      * Parses and compiles the rule set. Called once at startup so a malformed regex or malformed JSON stops
      * the deployment rather than silently disabling redaction at request time.
      */
+    /**
+     * Enabled with nothing to apply would leave every response exactly as stored while the deployment believes
+     * its content is protected. Nothing about that is visible from outside: no error, no failed request. It is
+     * the same reasoning that makes a malformed regex fail startup rather than silently disabling redaction, and
+     * an empty rule set is the case that reasoning missed.
+     */
+    @JsonIgnore
+    @AssertTrue(message = "redaction.rules must not be empty when redaction.enabled=true") public boolean isConfiguredWhenEnabled() {
+        return !enabled || (StringUtils.isNotBlank(rules) && !compile().isEmpty());
+    }
+
     public RedactionRules compile() {
         if (StringUtils.isBlank(rules)) {
             return RedactionRules.empty();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
@@ -1,0 +1,60 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.infrastructure.redaction.RedactionRule;
+import com.comet.opik.infrastructure.redaction.RedactionRules;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+
+/**
+ * Read-time redaction of trace and span content.
+ * <p>
+ * Rules are deployment-level rather than per workspace: the installations that need this run dedicated and
+ * single-tenant, and keeping them here means they compile once at startup instead of being read and cached per
+ * request. Per-workspace rules can be layered on later without changing the mechanism.
+ * <p>
+ * They are carried as a JSON array in a single scalar so the whole set can come from one environment variable,
+ * which a YAML list cannot: {@code [{"regex":"...","replace":"[EMAIL]"}]}. With {@code enabled} false nothing
+ * is registered and every response is written exactly as it is stored.
+ */
+@Data
+public class RedactionConfig {
+
+    private static final TypeReference<List<Rule>> RULES_TYPE = new TypeReference<>() {
+    };
+
+    @JsonProperty
+    private boolean enabled;
+
+    @JsonProperty
+    @NotNull private String rules = "[]";
+
+    @Data
+    public static class Rule {
+        @JsonProperty
+        private String regex;
+
+        /** Empty is meaningful: it removes the match instead of replacing it. */
+        @JsonProperty
+        private String replace = "";
+    }
+
+    /**
+     * Parses and compiles the rule set. Called once at startup so a malformed regex or malformed JSON stops
+     * the deployment rather than silently disabling redaction at request time.
+     */
+    public RedactionRules compile() {
+        if (StringUtils.isBlank(rules)) {
+            return RedactionRules.empty();
+        }
+
+        return new RedactionRules(JsonUtils.readValue(rules, RULES_TYPE).stream()
+                .map(rule -> RedactionRule.of(rule.getRegex(), rule.getReplace()))
+                .toList());
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/RedactionConfig.java
@@ -61,7 +61,24 @@ public class RedactionConfig {
      */
     @JsonIgnore
     @AssertTrue(message = "redaction.rules must not be empty when redaction.enabled=true") public boolean isConfiguredWhenEnabled() {
-        return !enabled || (StringUtils.isNotBlank(rules) && !compile().isEmpty());
+        if (!enabled) {
+            return true;
+        }
+
+        if (StringUtils.isBlank(rules)) {
+            return false;
+        }
+
+        try {
+            return !compile().isEmpty();
+        } catch (RuntimeException malformed) {
+            // Not this constraint's business, and reporting it here makes it worse: a validator that throws
+            // surfaces as "HV000090: Unable to access isConfiguredWhenEnabled" with the cause discarded.
+            // Malformed JSON, a blank regex and an uncompilable pattern each surface at startup from
+            // RedactionService's constructor with their own message - JsonMappingException with the position,
+            // "redaction.rules[0].regex must not be blank", PatternSyntaxException with the index.
+            return true;
+        }
     }
 
     public RedactionRules compile() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheService.java
@@ -34,12 +34,14 @@ class AuthCredentialsCacheService implements CacheService {
     private static final String WORKSPACE_ID_KEY = "workspaceId";
     private static final String WORKSPACE_NAME_KEY = "workspaceName";
     private static final String QUOTAS_KEY = "quotas";
+    private static final String PERMISSIONS_KEY = "permissions";
 
     private static final Set<String> V2_MAP_FIELDS = Set.of(
             USER_NAME_KEY,
             WORKSPACE_ID_KEY,
             WORKSPACE_NAME_KEY,
-            QUOTAS_KEY);
+            QUOTAS_KEY,
+            PERMISSIONS_KEY);
 
     private final @NonNull RedissonReactiveClient redissonClient;
     private final int ttlInSeconds;
@@ -65,6 +67,7 @@ class AuthCredentialsCacheService implements CacheService {
                         .workspaceId(m.get(WORKSPACE_ID_KEY))
                         .workspaceName(m.get(WORKSPACE_NAME_KEY))
                         .quotas(getQuotas(m))
+                        .permissions(getPermissions(m))
                         .build());
     }
 
@@ -98,7 +101,9 @@ class AuthCredentialsCacheService implements CacheService {
                 USER_NAME_KEY, credentials.userName(),
                 WORKSPACE_ID_KEY, credentials.workspaceId(),
                 WORKSPACE_NAME_KEY, Optional.ofNullable(credentials.workspaceName()).orElse(requestWorkspaceName),
-                QUOTAS_KEY, JsonUtils.writeValueAsString(Optional.ofNullable(credentials.quotas()).orElse(List.of())));
+                QUOTAS_KEY, JsonUtils.writeValueAsString(Optional.ofNullable(credentials.quotas()).orElse(List.of())),
+                PERMISSIONS_KEY,
+                JsonUtils.writeValueAsString(Optional.ofNullable(credentials.permissions()).orElse(List.of())));
 
         RBatchReactive batch = redissonClient.createBatch();
         RMapReactive<String, String> v2Map = batch.getMap(v2Key);
@@ -126,5 +131,14 @@ class AuthCredentialsCacheService implements CacheService {
     private List<Quota> getQuotas(Map<String, String> redisMap) {
         var rawQuotas = Optional.ofNullable(redisMap.get(QUOTAS_KEY)).orElse("[]");
         return JsonUtils.readCollectionValue(rawQuotas, List.class, Quota.class);
+    }
+
+    /**
+     * Absent for entries written before permissions were cached, which read back as no permissions until the
+     * entry expires — the same answer an unpermitted caller gets, so a stale entry withholds rather than grants.
+     */
+    private List<String> getPermissions(Map<String, String> redisMap) {
+        var rawPermissions = Optional.ofNullable(redisMap.get(PERMISSIONS_KEY)).orElse("[]");
+        return JsonUtils.readCollectionValue(rawPermissions, List.class, String.class);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -5,6 +5,7 @@ import com.comet.opik.domain.RemoteWorkspacePermissionsService;
 import com.comet.opik.domain.WorkspacePermissionsService;
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.RedactionConfig;
 import com.google.common.base.Preconditions;
 import com.google.inject.Provides;
 import jakarta.inject.Provider;
@@ -26,7 +27,8 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
             @Config("authentication") AuthenticationConfig config,
             @NonNull Provider<RequestContext> requestContext,
             @NonNull RedissonReactiveClient redissonClient,
-            @NonNull Client client) {
+            @NonNull Client client,
+            @Config("redaction") RedactionConfig redactionConfig) {
 
         if (!config.isEnabled()) {
             return new AuthServiceImpl(requestContext);
@@ -42,7 +44,8 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
                 ? new AuthCredentialsCacheService(redissonClient, config.getApiKeyResolutionCacheTTLInSec())
                 : new NoopCacheService();
 
-        return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService);
+        return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService,
+                redactionConfig.isEnabled());
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -5,7 +5,7 @@ import com.comet.opik.domain.RemoteWorkspacePermissionsService;
 import com.comet.opik.domain.WorkspacePermissionsService;
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
-import com.comet.opik.infrastructure.RedactionConfig;
+import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.google.common.base.Preconditions;
 import com.google.inject.Provides;
 import jakarta.inject.Provider;
@@ -28,7 +28,7 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
             @NonNull Provider<RequestContext> requestContext,
             @NonNull RedissonReactiveClient redissonClient,
             @NonNull Client client,
-            @Config("redaction") RedactionConfig redactionConfig) {
+            @NonNull RedactionService redactionService) {
 
         if (!config.isEnabled()) {
             return new AuthServiceImpl(requestContext);
@@ -44,8 +44,11 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
                 ? new AuthCredentialsCacheService(redissonClient, config.getApiKeyResolutionCacheTTLInSec())
                 : new NoopCacheService();
 
+        // Asking RedactionService rather than the raw config so the request and the thing that acts on the
+        // answer cannot disagree: a deployment with the flag on but no rules redacts nothing, and must not pay
+        // for permissions it will not use.
         return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService,
-                redactionConfig.isEnabled());
+                redactionService.isEnabled());
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -34,10 +34,10 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
 
         if (!config.isEnabled()) {
             if (redactionService.isEnabled()) {
-                // trace_original_data_view is resolved by the authentication call and nothing else sets it, so
-                // with authentication off no caller can hold it and every response is masked for everybody, with
-                // no way to grant an exemption. Said out loud because the configuration reads as if it were a
-                // per-caller control here, and it is not.
+                // trace_original_data_view is resolved from the workspace permissions API and nothing else
+                // sets it, so with authentication off no caller can hold it and every response is masked for
+                // everybody, with no way to grant an exemption. Said out loud because the configuration reads
+                // as if it were a per-caller control here, and it is not.
                 log.warn("Read-time redaction is enabled while authentication is disabled: no caller can hold "
                         + "'{}', so every response will be redacted for every caller",
                         WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
@@ -60,6 +60,7 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
         // answer cannot disagree: a deployment with the flag on but no rules redacts nothing, and must not pay
         // for permissions it will not use.
         return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService,
+                new RemoteWorkspacePermissionsService(client, config.getReactService()),
                 redactionService.isEnabled());
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -12,6 +12,7 @@ import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.client.Client;
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.redisson.api.RedissonReactiveClient;
 import ru.vyarus.dropwizard.guice.module.support.DropwizardAwareModule;
@@ -19,6 +20,7 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 
 import java.util.Objects;
 
+@Slf4j
 public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
 
     @Provides
@@ -31,6 +33,16 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
             @NonNull RedactionService redactionService) {
 
         if (!config.isEnabled()) {
+            if (redactionService.isEnabled()) {
+                // trace_original_data_view is resolved by the authentication call and nothing else sets it, so
+                // with authentication off no caller can hold it and every response is masked for everybody, with
+                // no way to grant an exemption. Said out loud because the configuration reads as if it were a
+                // per-caller control here, and it is not.
+                log.warn("Read-time redaction is enabled while authentication is disabled: no caller can hold "
+                        + "'{}', so every response will be redacted for every caller",
+                        WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+            }
+
             return new AuthServiceImpl(requestContext);
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -30,7 +30,8 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
             @NonNull Provider<RequestContext> requestContext,
             @NonNull RedissonReactiveClient redissonClient,
             @NonNull Client client,
-            @NonNull RedactionService redactionService) {
+            @NonNull RedactionService redactionService,
+            @NonNull WorkspacePermissionsService workspacePermissionsService) {
 
         if (!config.isEnabled()) {
             if (redactionService.isEnabled()) {
@@ -60,8 +61,7 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
         // answer cannot disagree: a deployment with the flag on but no rules redacts nothing, and must not pay
         // for permissions it will not use.
         return new RemoteAuthService(client, config.getReactService(), requestContext, cacheService,
-                new RemoteWorkspacePermissionsService(client, config.getReactService()),
-                redactionService.isEnabled());
+                workspacePermissionsService, redactionService.isEnabled());
     }
 
     @Provides

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthModule.java
@@ -34,13 +34,13 @@ public class AuthModule extends DropwizardAwareModule<OpikConfiguration> {
 
         if (!config.isEnabled()) {
             if (redactionService.isEnabled()) {
-                // trace_original_data_view is resolved from the workspace permissions API and nothing else
+                // original_data_view is resolved from the workspace permissions API and nothing else
                 // sets it, so with authentication off no caller can hold it and every response is masked for
                 // everybody, with no way to grant an exemption. Said out loud because the configuration reads
                 // as if it were a per-caller control here, and it is not.
                 log.warn("Read-time redaction is enabled while authentication is disabled: no caller can hold "
                         + "'{}', so every response will be redacted for every caller",
-                        WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+                        WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue());
             }
 
             return new AuthServiceImpl(requestContext);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/CacheService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/CacheService.java
@@ -13,7 +13,8 @@ interface CacheService {
             String userName,
             String workspaceId,
             String workspaceName,
-            List<Quota> quotas) {
+            List<Quota> quotas,
+            List<String> permissions) {
     }
 
     void cache(

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -2,7 +2,9 @@ package com.comet.opik.infrastructure.auth;
 
 import com.comet.opik.api.ReactServiceErrorResponse;
 import com.comet.opik.api.Visibility;
+import com.comet.opik.api.WorkspaceUserPermissions;
 import com.comet.opik.domain.ProjectService;
+import com.comet.opik.domain.WorkspacePermissionsService;
 import com.comet.opik.domain.mcpoauth.ValidatedToken;
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.usagelimit.Quota;
@@ -32,6 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_API_KEY;
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_WORKSPACE;
@@ -92,38 +95,25 @@ class RemoteAuthService implements AuthService {
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull CacheService cacheService;
 
+    private final @NonNull WorkspacePermissionsService workspacePermissionsService;
+
     /**
-     * Whether to ask the platform for the caller's workspace permissions.
+     * Whether the caller's workspace permissions are resolved at all.
      * <p>
-     * Only read-time redaction needs them, and resolving them costs the platform an extra read on the path
-     * every Opik request takes. So it is requested only where something will act on the answer; with the
-     * feature off the auth call is exactly what it was before.
+     * Only read-time redaction needs them, and resolving them costs a call on the path every Opik request
+     * takes. So it happens only where something acts on the answer; with the feature off no permission lookup
+     * is made and the authentication call is exactly what it was before.
      */
-    private final boolean includePermissions;
+    private final boolean resolvePermissions;
 
     @Builder(toBuilder = true)
     record AuthRequest(String workspaceName, String path,
-            @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> requiredPermissions,
-            @JsonInclude(JsonInclude.Include.NON_DEFAULT) boolean includePermissions) {
+            @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> requiredPermissions) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     @Builder(toBuilder = true)
-    record AuthResponse(
-            String user, String workspaceId, String workspaceName, List<Quota> quotas,
-            List<WorkspacePermission> permissions) {
-    }
-
-    /**
-     * One resolved permission as the platform reports it. The value is carried as text because that is the
-     * platform's representation; only {@code "true"} grants.
-     */
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    record WorkspacePermission(String permissionName, String permissionValue) {
-
-        boolean granted() {
-            return Boolean.parseBoolean(permissionValue);
-        }
+    record AuthResponse(String user, String workspaceId, String workspaceName, List<Quota> quotas) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -139,25 +129,15 @@ class RemoteAuthService implements AuthService {
             List<Quota> quotas,
             List<String> permissions) {
 
-        static ValidatedAuthCredentials from(AuthResponse authResponse) {
+        static ValidatedAuthCredentials from(AuthResponse authResponse, List<String> permissions) {
             return ValidatedAuthCredentials.builder()
                     .shouldCache(true)
                     .userName(authResponse.user())
                     .workspaceId(authResponse.workspaceId())
                     .workspaceName(authResponse.workspaceName())
                     .quotas(authResponse.quotas())
-                    .permissions(grantedNames(authResponse.permissions()))
+                    .permissions(permissions)
                     .build();
-        }
-
-        /** Only the granted names are kept; a permission reported as false is the same as absent. */
-        private static List<String> grantedNames(List<WorkspacePermission> permissions) {
-            return permissions == null
-                    ? List.of()
-                    : permissions.stream()
-                            .filter(WorkspacePermission::granted)
-                            .map(WorkspacePermission::permissionName)
-                            .toList();
         }
 
         static ValidatedAuthCredentials from(CacheService.AuthCredentials authCredentials) {
@@ -264,10 +244,11 @@ class RemoteAuthService implements AuthService {
                         .workspaceName(token.workspaceName())
                         .path(path)
                         .requiredPermissions(contextInfo.requiredPermissions())
-                        .includePermissions(includePermissions)
                         .build()))) {
             var authResponse = verifyResponse(response);
-            var credentials = ValidatedAuthCredentials.from(authResponse);
+            var credentials = ValidatedAuthCredentials.from(authResponse, grantedPermissions(
+                    () -> workspacePermissionsService.getPermissionsByUsername(token.userName(),
+                            token.workspaceName())));
             setCredentialIntoContext(credentials, token.workspaceName(), null);
         }
     }
@@ -438,10 +419,11 @@ class RemoteAuthService implements AuthService {
                         .workspaceName(workspaceName)
                         .path(path)
                         .requiredPermissions(requiredPermissions)
-                        .includePermissions(includePermissions)
                         .build()))) {
             var authResponse = verifyResponse(response);
-            var credentials = ValidatedAuthCredentials.from(authResponse);
+            var credentials = ValidatedAuthCredentials.from(authResponse, grantedPermissions(
+                    () -> workspacePermissionsService.getPermissionsBySession(sessionToken.getValue(),
+                            workspaceName)));
             setCredentialIntoContext(credentials, workspaceName, sessionToken.getValue());
         }
     }
@@ -480,13 +462,44 @@ class RemoteAuthService implements AuthService {
                             .workspaceName(workspaceName)
                             .path(path)
                             .requiredPermissions(requiredPermissions)
-                            .includePermissions(includePermissions)
                             .build()))) {
                 var authResponse = verifyResponse(response);
-                return ValidatedAuthCredentials.from(authResponse);
+                return ValidatedAuthCredentials.from(authResponse, grantedPermissions(
+                        () -> workspacePermissionsService.getPermissions(apiKey, workspaceName)));
             }
         } else {
             return ValidatedAuthCredentials.from(credentials.get());
+        }
+    }
+
+    /**
+     * The caller's granted permission names, or none.
+     * <p>
+     * Read from the permissions API rather than the authentication response, so the answer is data about what
+     * the caller may see and not a by-product of whether it could be authenticated. Skipped entirely when
+     * nothing acts on it.
+     * <p>
+     * A lookup that fails leaves the caller with no permissions, which redacts. That is the safe direction for
+     * a feature whose purpose is withholding, but it does mean a permissions outage reads as masked content
+     * rather than as an error, so it is logged at warn to stay diagnosable.
+     */
+    private List<String> grantedPermissions(Supplier<WorkspaceUserPermissions> lookup) {
+        if (!resolvePermissions) {
+            return List.of();
+        }
+
+        try {
+            var permissions = lookup.get().permissions();
+            return permissions == null
+                    ? List.of()
+                    : permissions.stream()
+                            .filter(permission -> Boolean.parseBoolean(permission.permissionValue()))
+                            .map(WorkspaceUserPermissions.Permission::permissionName)
+                            .toList();
+        } catch (RuntimeException lookupFailed) {
+            log.warn("Could not resolve workspace permissions, treating the caller as unprivileged",
+                    lookupFailed);
+            return List.of();
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -92,9 +92,19 @@ class RemoteAuthService implements AuthService {
     private final @NonNull Provider<RequestContext> requestContext;
     private final @NonNull CacheService cacheService;
 
+    /**
+     * Whether to ask the platform for the caller's workspace permissions.
+     * <p>
+     * Only read-time redaction needs them, and resolving them costs the platform an extra read on the path
+     * every Opik request takes. So it is requested only where something will act on the answer; with the
+     * feature off the auth call is exactly what it was before.
+     */
+    private final boolean includePermissions;
+
     @Builder(toBuilder = true)
     record AuthRequest(String workspaceName, String path,
-            @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> requiredPermissions) {
+            @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> requiredPermissions,
+            @JsonInclude(JsonInclude.Include.NON_DEFAULT) boolean includePermissions) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -254,6 +264,7 @@ class RemoteAuthService implements AuthService {
                         .workspaceName(token.workspaceName())
                         .path(path)
                         .requiredPermissions(contextInfo.requiredPermissions())
+                        .includePermissions(includePermissions)
                         .build()))) {
             var authResponse = verifyResponse(response);
             var credentials = ValidatedAuthCredentials.from(authResponse);
@@ -427,6 +438,7 @@ class RemoteAuthService implements AuthService {
                         .workspaceName(workspaceName)
                         .path(path)
                         .requiredPermissions(requiredPermissions)
+                        .includePermissions(includePermissions)
                         .build()))) {
             var authResponse = verifyResponse(response);
             var credentials = ValidatedAuthCredentials.from(authResponse);
@@ -468,6 +480,7 @@ class RemoteAuthService implements AuthService {
                             .workspaceName(workspaceName)
                             .path(path)
                             .requiredPermissions(requiredPermissions)
+                            .includePermissions(includePermissions)
                             .build()))) {
                 var authResponse = verifyResponse(response);
                 return ValidatedAuthCredentials.from(authResponse);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -100,7 +100,20 @@ class RemoteAuthService implements AuthService {
     @JsonIgnoreProperties(ignoreUnknown = true)
     @Builder(toBuilder = true)
     record AuthResponse(
-            String user, String workspaceId, String workspaceName, List<Quota> quotas) {
+            String user, String workspaceId, String workspaceName, List<Quota> quotas,
+            List<WorkspacePermission> permissions) {
+    }
+
+    /**
+     * One resolved permission as the platform reports it. The value is carried as text because that is the
+     * platform's representation; only {@code "true"} grants.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record WorkspacePermission(String permissionName, String permissionValue) {
+
+        boolean granted() {
+            return Boolean.parseBoolean(permissionValue);
+        }
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -113,7 +126,8 @@ class RemoteAuthService implements AuthService {
             String userName,
             String workspaceId,
             String workspaceName,
-            List<Quota> quotas) {
+            List<Quota> quotas,
+            List<String> permissions) {
 
         static ValidatedAuthCredentials from(AuthResponse authResponse) {
             return ValidatedAuthCredentials.builder()
@@ -122,7 +136,18 @@ class RemoteAuthService implements AuthService {
                     .workspaceId(authResponse.workspaceId())
                     .workspaceName(authResponse.workspaceName())
                     .quotas(authResponse.quotas())
+                    .permissions(grantedNames(authResponse.permissions()))
                     .build();
+        }
+
+        /** Only the granted names are kept; a permission reported as false is the same as absent. */
+        private static List<String> grantedNames(List<WorkspacePermission> permissions) {
+            return permissions == null
+                    ? List.of()
+                    : permissions.stream()
+                            .filter(WorkspacePermission::granted)
+                            .map(WorkspacePermission::permissionName)
+                            .toList();
         }
 
         static ValidatedAuthCredentials from(CacheService.AuthCredentials authCredentials) {
@@ -132,6 +157,7 @@ class RemoteAuthService implements AuthService {
                     .workspaceId(authCredentials.workspaceId())
                     .workspaceName(authCredentials.workspaceName())
                     .quotas(authCredentials.quotas())
+                    .permissions(authCredentials.permissions())
                     .build();
         }
 
@@ -141,6 +167,7 @@ class RemoteAuthService implements AuthService {
                     .workspaceId(workspaceId)
                     .workspaceName(workspaceName)
                     .quotas(quotas)
+                    .permissions(permissions)
                     .build();
         }
     }
@@ -483,6 +510,9 @@ class RemoteAuthService implements AuthService {
         requestContext.get().setWorkspaceName(workspaceName);
         requestContext.get().setQuotas(credentials.quotas());
         requestContext.get().setApiKey(apiKey);
+        requestContext.get().setPermissions(credentials.permissions() == null
+                ? Set.of()
+                : Set.copyOf(credentials.permissions()));
     }
 
     private boolean isEndpointPublic(ContextInfoHolder contextInfo) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RequestContext.java
@@ -10,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 
 @RequestScoped
 @Data
@@ -47,6 +48,19 @@ public class RequestContext {
     private List<Quota> quotas;
     private Visibility visibility;
     private String workspaceFallbackMessage;
+
+    /**
+     * Whether this caller's response content must be redacted. Resolved once, after authentication, because
+     * serialization happens long after the resource method has returned.
+     */
+    private boolean redactResponse;
+
+    /**
+     * The workspace permissions the platform resolved for this caller, as returned by the authentication
+     * call. Empty when authentication is disabled, since there is no identity to attach a role to.
+     */
+    @Builder.Default
+    private Set<String> permissions = Set.of();
 
     public void setWorkspaceFallbackFor(String entityType, String entityName) {
         this.workspaceFallbackMessage = WORKSPACE_FALLBACK_MESSAGE_TEMPLATE.formatted(entityType, entityName);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
@@ -18,6 +18,7 @@ public enum WorkspaceUserPermission {
     TRACE_SPAN_THREAD_LOG("trace_span_thread_log"),
     TRACE_SPAN_THREAD_ANNOTATE("trace_span_thread_annotate"),
     TRACE_DELETE("trace_delete"),
+    TRACE_ORIGINAL_DATA_VIEW("trace_original_data_view"),
 
     ONLINE_EVALUATION_RULE_UPDATE("online_evaluation_rule_update"),
     ALERT_UPDATE("alert_update"),

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceUserPermission.java
@@ -18,10 +18,16 @@ public enum WorkspaceUserPermission {
     TRACE_SPAN_THREAD_LOG("trace_span_thread_log"),
     TRACE_SPAN_THREAD_ANNOTATE("trace_span_thread_annotate"),
     TRACE_DELETE("trace_delete"),
-    TRACE_ORIGINAL_DATA_VIEW("trace_original_data_view"),
 
     ONLINE_EVALUATION_RULE_UPDATE("online_evaluation_rule_update"),
     ALERT_UPDATE("alert_update"),
+
+    /**
+     * Reading stored content rather than a redacted view of it. Not named for traces: it gates every stored
+     * value read-time redaction can reach - traces, spans, threads, experiments, datasets, runner jobs and
+     * analytics results - so a trace-shaped name would understate it.
+     */
+    ORIGINAL_DATA_VIEW("original_data_view"),
 
     DASHBOARD_VIEW("dashboard_view"),
     DASHBOARD_CREATE("dashboard_create"),

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
@@ -30,19 +30,19 @@ public class JsonNodeRedactor {
     }
 
     /**
-     * @param itemType the streamed DTO, or {@code null} once below its own properties.
-     *                 <p>
-     *                 Exemptions apply at the item's own level only, which does <em>not</em> match the
-     *                 serializer: {@code BeanSerializerModifier.changeProperties} runs for every bean in the
-     *                 graph, so a nested exempt property is exempt when paged and rewritten when streamed -
-     *                 {@code Experiment.promptVersions[].commit} is the concrete case.
-     *                 <p>
-     *                 Applying the names at every depth would close that but open a worse hole: this walk cannot
-     *                 tell a declared property from a caller-chosen map key, so a metadata entry named
-     *                 {@code id} or {@code model} would become exempt and leak. That is the hazard
-     *                 {@link RedactionModule}'s own comment cites for using the modifier in the first place.
-     *                 Neither approximation is exact without per-level type information; under-exempting is the
-     *                 one that cannot leak, so it is the one taken.
+     * Rewrites one streamed item, exempting the structural properties at the item's own level.
+     * <p>
+     * That does <em>not</em> match the serializer. {@code BeanSerializerModifier.changeProperties} runs for every
+     * bean in the graph, so a nested exempt property is exempt when paged and rewritten when streamed —
+     * {@code Experiment.promptVersions[].commit} is the concrete case.
+     * <p>
+     * Applying the names at every depth would close that but open a worse hole: this walk cannot tell a declared
+     * property from a caller-chosen map key, so a metadata entry named {@code id} or {@code model} would become
+     * exempt and leak. That is the hazard {@link RedactionModule}'s own comment cites for using the modifier in
+     * the first place. Neither approximation is exact without per-level type information; under-exempting is the
+     * one that cannot leak, so it is the one taken.
+     *
+     * @param itemType the streamed DTO, or {@code null} once below its own properties
      */
     private JsonNode rewrite(JsonNode node, RedactionRules rules, Class<?> itemType) {
         if (node.isObject()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
@@ -1,0 +1,56 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+import java.util.Map;
+
+/**
+ * Applies a rule set directly to a parsed tree, for the paths that cannot go through the serializer.
+ * <p>
+ * Streamed responses are built and written on a scheduler thread, so the thread-local the writer interceptor
+ * sets is not in force there. The stream therefore redacts its items explicitly instead, using the decision
+ * captured on the request thread.
+ * <p>
+ * Nodes are rewritten in place: each item is freshly parsed for the stream, so nothing else holds a reference.
+ */
+@UtilityClass
+public class JsonNodeRedactor {
+
+    public JsonNode redact(JsonNode node, @NonNull RedactionRules rules) {
+        if (node == null || rules.isEmpty()) {
+            return node;
+        }
+
+        return rewrite(node, rules);
+    }
+
+    private JsonNode rewrite(JsonNode node, RedactionRules rules) {
+        if (node.isObject()) {
+            ObjectNode object = (ObjectNode) node;
+            // Field names are collected first: replacing a value while iterating the live view would fail.
+            for (String name : object.propertyStream().map(Map.Entry::getKey).toList()) {
+                object.set(name, rewrite(object.get(name), rules));
+            }
+            return object;
+        }
+
+        if (node.isArray()) {
+            ArrayNode array = (ArrayNode) node;
+            for (int i = 0; i < array.size(); i++) {
+                array.set(i, rewrite(array.get(i), rules));
+            }
+            return array;
+        }
+
+        if (node.isTextual()) {
+            return TextNode.valueOf(rules.apply(node.textValue()));
+        }
+
+        return node;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
@@ -30,9 +30,19 @@ public class JsonNodeRedactor {
     }
 
     /**
-     * @param itemType the streamed DTO, or {@code null} once below its own properties. Exemptions apply only at
-     *                 the top level, mirroring the {@code BeanSerializerModifier}, which reaches declared
-     *                 properties and nothing else - a caller-chosen map key nested in a payload is not structure.
+     * @param itemType the streamed DTO, or {@code null} once below its own properties.
+     *                 <p>
+     *                 Exemptions apply at the item's own level only, which does <em>not</em> match the
+     *                 serializer: {@code BeanSerializerModifier.changeProperties} runs for every bean in the
+     *                 graph, so a nested exempt property is exempt when paged and rewritten when streamed -
+     *                 {@code Experiment.promptVersions[].commit} is the concrete case.
+     *                 <p>
+     *                 Applying the names at every depth would close that but open a worse hole: this walk cannot
+     *                 tell a declared property from a caller-chosen map key, so a metadata entry named
+     *                 {@code id} or {@code model} would become exempt and leak. That is the hazard
+     *                 {@link RedactionModule}'s own comment cites for using the modifier in the first place.
+     *                 Neither approximation is exact without per-level type information; under-exempting is the
+     *                 one that cannot leak, so it is the one taken.
      */
     private JsonNode rewrite(JsonNode node, RedactionRules rules, Class<?> itemType) {
         if (node.isObject()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactor.java
@@ -21,20 +21,28 @@ import java.util.Map;
 @UtilityClass
 public class JsonNodeRedactor {
 
-    public JsonNode redact(JsonNode node, @NonNull RedactionRules rules) {
+    public JsonNode redact(JsonNode node, @NonNull RedactionRules rules, @NonNull Class<?> itemType) {
         if (node == null || rules.isEmpty()) {
             return node;
         }
 
-        return rewrite(node, rules);
+        return rewrite(node, rules, itemType);
     }
 
-    private JsonNode rewrite(JsonNode node, RedactionRules rules) {
+    /**
+     * @param itemType the streamed DTO, or {@code null} once below its own properties. Exemptions apply only at
+     *                 the top level, mirroring the {@code BeanSerializerModifier}, which reaches declared
+     *                 properties and nothing else - a caller-chosen map key nested in a payload is not structure.
+     */
+    private JsonNode rewrite(JsonNode node, RedactionRules rules, Class<?> itemType) {
         if (node.isObject()) {
             ObjectNode object = (ObjectNode) node;
             // Field names are collected first: replacing a value while iterating the live view would fail.
             for (String name : object.propertyStream().map(Map.Entry::getKey).toList()) {
-                object.set(name, rewrite(object.get(name), rules));
+                if (itemType != null && RedactionModule.isExemptProperty(itemType, name)) {
+                    continue;
+                }
+                object.set(name, rewrite(object.get(name), rules, null));
             }
             return object;
         }
@@ -42,7 +50,7 @@ public class JsonNodeRedactor {
         if (node.isArray()) {
             ArrayNode array = (ArrayNode) node;
             for (int i = 0; i < array.size(); i++) {
-                array.set(i, rewrite(array.get(i), rules));
+                array.set(i, rewrite(array.get(i), rules, itemType));
             }
             return array;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
@@ -1,0 +1,85 @@
+package com.comet.opik.infrastructure.redaction;
+
+import lombok.NonNull;
+
+/**
+ * Bounds the work one regex may do against one value, so a rule cannot be made to run without limit.
+ * <p>
+ * {@code java.util.regex} backtracks, so the time a pattern takes is a property of the pattern <em>and</em> the
+ * input. A rule whose leading quantifier is unanchored — {@code [\w.+-]+@...} is the shape that invites it — is
+ * quadratic in the length of an unbroken run of characters it can consume. The rules are written by whoever
+ * operates the deployment; the input is whatever a caller last logged, and {@code jacksonConfig.maxStringLength}
+ * allows a single value of 100 MB. Measured, that combination reaches seconds of CPU at 32 KB and minutes well
+ * before the configured ceiling, on a request thread, for one read.
+ * <p>
+ * Anchoring the pattern removes it, which is why the configuration says to. Advice is not a control, though, so
+ * this makes the bound real: the matcher reads the value through a {@link CharSequence} that counts accesses and
+ * aborts past a budget. On real payloads the counting costs about 4%, because the values are short; the runaway
+ * case stops in single-digit milliseconds regardless of how long the input is.
+ * <p>
+ * Aborting {@link #EXCEEDED} means the value is masked whole rather than returned: a rule that could not be
+ * evaluated is not evidence that the value is safe to show.
+ */
+record MatchBudget(long limit) {
+
+    /** Sentinel returned instead of a rewritten value when the budget runs out. */
+    static final String EXCEEDED = null;
+
+    /**
+     * Generous enough that no realistic value approaches it — a 100 KB value matched linearly costs a few
+     * hundred thousand accesses — and small enough that the quadratic case aborts in milliseconds.
+     */
+    static final MatchBudget DEFAULT = new MatchBudget(2_000_000L);
+
+    /** Thrown and caught inside a single {@code apply}; carries no stack trace, since nothing inspects it. */
+    static final class Exceeded extends RuntimeException {
+        private static final Exceeded INSTANCE = new Exceeded();
+
+        private Exceeded() {
+            super(null, null, false, false);
+        }
+    }
+
+    CharSequence wrap(@NonNull String value) {
+        return new Counted(value, limit);
+    }
+
+    /**
+     * Deliberately not a {@code String}: the matcher's fast paths are String-specific, and going through
+     * {@code charAt} is what makes the accounting possible at all.
+     */
+    private static final class Counted implements CharSequence {
+
+        private final String delegate;
+        private final long limit;
+        private long used;
+
+        private Counted(String delegate, long limit) {
+            this.delegate = delegate;
+            this.limit = limit;
+        }
+
+        @Override
+        public int length() {
+            return delegate.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (++used > limit) {
+                throw Exceeded.INSTANCE;
+            }
+            return delegate.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return delegate.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return delegate;
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
@@ -82,6 +82,11 @@ record MatchBudget(long limit) {
     /**
      * Deliberately not a {@code String}: the matcher's fast paths are String-specific, and going through
      * {@code charAt} is what makes the accounting possible at all.
+     * <p>
+     * Mutable and <em>not</em> thread-safe. It does not need to be: {@code RedactionRules.apply} builds a
+     * budget per rule per value and {@link #wrap} a counter per {@code RedactionRule.apply}, so an instance
+     * never leaves the single call that created it. Made safe by confinement rather than by an atomic
+     * deliberately - {@code charAt} is the hot path here, once per character per rule.
      */
     private static final class Counted implements CharSequence {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
@@ -26,10 +26,23 @@ record MatchBudget(long limit) {
     static final String EXCEEDED = null;
 
     /**
-     * Generous enough that no realistic value approaches it — a 100 KB value matched linearly costs a few
-     * hundred thousand accesses — and small enough that the quadratic case aborts in milliseconds.
+     * Per-character allowance. A linear scan costs about one access per character per rule, so this leaves two
+     * orders of magnitude of headroom for backtracking that stays proportional, while a quadratic pattern
+     * exceeds it almost immediately - at 32 KB the quadratic case wants ~500M accesses against an allowance of
+     * ~3M.
+     * <p>
+     * Scaled rather than absolute because an absolute ceiling fails closed on size alone:
+     * {@code jacksonConfig.maxStringLength} permits 100 MB, so a fixed 2M budget would destroy a perfectly
+     * anchored 5 MB value that contains no match at all, purely from the forward scan.
      */
-    static final MatchBudget DEFAULT = new MatchBudget(2_000_000L);
+    private static final long ALLOWANCE_PER_CHARACTER = 100L;
+
+    /** Floor, so a short value still gets room for legitimate backtracking. */
+    private static final long MINIMUM = 100_000L;
+
+    static MatchBudget forValue(@NonNull String value) {
+        return new MatchBudget(Math.max(MINIMUM, ALLOWANCE_PER_CHARACTER * value.length()));
+    }
 
     /** Thrown and caught inside a single {@code apply}; carries no stack trace, since nothing inspects it. */
     static final class Exceeded extends RuntimeException {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/MatchBudget.java
@@ -15,7 +15,9 @@ import lombok.NonNull;
  * Anchoring the pattern removes it, which is why the configuration says to. Advice is not a control, though, so
  * this makes the bound real: the matcher reads the value through a {@link CharSequence} that counts accesses and
  * aborts past a budget. On real payloads the counting costs about 4%, because the values are short; the runaway
- * case stops in single-digit milliseconds regardless of how long the input is.
+ * case stops after the budget's worth of accesses however long the input is, which is why the budget has a
+ * ceiling as well as a floor - measured, an access costs about 2 ns, so what the ceiling buys is the difference
+ * between about a second and about twenty.
  * <p>
  * Aborting {@link #EXCEEDED} means the value is masked whole rather than returned: a rule that could not be
  * evaluated is not evidence that the value is safe to show.
@@ -31,7 +33,7 @@ record MatchBudget(long limit) {
      * exceeds it almost immediately - at 32 KB the quadratic case wants ~500M accesses against an allowance of
      * ~3M.
      * <p>
-     * Scaled rather than absolute because an absolute ceiling fails closed on size alone:
+     * Scaled rather than absolute because a purely absolute ceiling fails closed on size alone:
      * {@code jacksonConfig.maxStringLength} permits 100 MB, so a fixed 2M budget would destroy a perfectly
      * anchored 5 MB value that contains no match at all, purely from the forward scan.
      */
@@ -40,8 +42,28 @@ record MatchBudget(long limit) {
     /** Floor, so a short value still gets room for legitimate backtracking. */
     private static final long MINIMUM = 100_000L;
 
+    /**
+     * Ceiling, so the largest permitted value cannot buy a correspondingly large amount of CPU.
+     * <p>
+     * The scaled allowance alone is unbounded in the only variable a caller controls: {@code maxStringLength}
+     * permits a 100 MB value, which at 100 accesses per character is 10.5 billion accesses - measured at ~2 ns
+     * each, some 20 seconds on a request thread, per rule, for one read. Capping the count caps the time.
+     * <p>
+     * Set where it cannot reach a legitimate rule. Measured over 10 MB values, the anchored patterns the
+     * configuration recommends - e-mail, telephone, card, JWT - consume between 1.0 and 3.2 accesses per
+     * character, matching or not. A billion leaves ~9.5 per character at the largest value {@code
+     * maxStringLength} allows and does not bind at all below 10 MB, where the scaled allowance is the smaller of
+     * the two; the worst case it admits is about two seconds rather than twenty.
+     */
+    private static final long CEILING = 1_000_000_000L;
+
     static MatchBudget forValue(@NonNull String value) {
-        return new MatchBudget(Math.max(MINIMUM, ALLOWANCE_PER_CHARACTER * value.length()));
+        return new MatchBudget(limitFor(value.length()));
+    }
+
+    /** Split out so the bounds can be asserted without allocating a 100 MB string to assert them against. */
+    static long limitFor(int length) {
+        return Math.min(CEILING, Math.max(MINIMUM, ALLOWANCE_PER_CHARACTER * length));
     }
 
     /** Thrown and caught inside a single {@code apply}; carries no stack trace, since nothing inspects it. */

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionContext.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionContext.java
@@ -1,0 +1,30 @@
+package com.comet.opik.infrastructure.redaction;
+
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+/**
+ * The rule set in force while the current response is being written.
+ * <p>
+ * Held per thread because redaction happens during serialization, after the resource method has returned:
+ * there is no argument left to pass it through. Empty means "write the values as stored", which is what
+ * every request gets when the feature is off or the caller may see originals.
+ */
+@UtilityClass
+public class RedactionContext {
+
+    private static final ThreadLocal<RedactionRules> CURRENT = new ThreadLocal<>();
+
+    public void set(@NonNull RedactionRules rules) {
+        CURRENT.set(rules);
+    }
+
+    public void clear() {
+        CURRENT.remove();
+    }
+
+    public RedactionRules current() {
+        RedactionRules rules = CURRENT.get();
+        return rules == null ? RedactionRules.empty() : rules;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionGuard.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionGuard.java
@@ -19,7 +19,7 @@ import lombok.extern.slf4j.Slf4j;
  * written against the plain text.</li>
  * </ul>
  * These are all authenticated and workspace-scoped already; that is a different question. The permission this
- * gates on is {@code trace_original_data_view}, which an authenticated member in good standing may lack, and who
+ * gates on is {@code original_data_view}, which an authenticated member in good standing may lack, and who
  * would receive masked content from the JSON API for the same data.
  * <p>
  * So refusing is the honest answer rather than an omission: withholding is the point of the feature, and a
@@ -48,10 +48,10 @@ public class RedactionGuard {
         }
 
         log.info("Refusing '{}': the response cannot be masked and the caller lacks '{}'", what,
-                WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+                WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue());
 
         throw new ForbiddenException(
                 "%s returns stored content that cannot be masked. The '%s' permission is required to read it."
-                        .formatted(what, WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+                        .formatted(what, WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionGuard.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionGuard.java
@@ -1,0 +1,57 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import jakarta.ws.rs.ForbiddenException;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Refuses a response the serializer cannot reach.
+ * <p>
+ * {@code COVERED_PATHS} declares the whole private API in scope, and the request filter duly resolves a decision
+ * for every request under it. Three responses under that scope are not written by Jackson, so the decision is
+ * resolved and then has nothing to act on:
+ * <ul>
+ * <li>attachment download, which streams bytes that never become a {@code JsonNode};</li>
+ * <li>Agent Insights free-form SQL, where rewriting the result is not enforceable in principle - the caller
+ * chooses the projection, so a value returned through {@code base64()} or {@code substring()} matches no rule
+ * written against the plain text.</li>
+ * </ul>
+ * These are all authenticated and workspace-scoped already; that is a different question. The permission this
+ * gates on is {@code trace_original_data_view}, which an authenticated member in good standing may lack, and who
+ * would receive masked content from the JSON API for the same data.
+ * <p>
+ * So refusing is the honest answer rather than an omission: withholding is the point of the feature, and a
+ * response that cannot be masked cannot be withheld any other way. It applies only while the feature is enabled
+ * and the caller lacks the permission, so an install with the flag off is unaffected.
+ * <p>
+ * TODO: the dataset CSV export is a third such response and is deliberately <em>not</em> handled. Its file is
+ * produced by a background consumer with no caller, so the decision belongs to the download, which does have one:
+ * a permitted caller should receive the stored bytes and an unpermitted one the same rows with the rules applied
+ * per cell, through the CSV parser so the rules cannot reach the delimiters. Left out because
+ * {@code datasetExport.enabled} defaults to false, so the path is unreachable on a default deployment - it needs
+ * doing before the export feature is switched on anywhere, not before this merges.
+ */
+@Slf4j
+@UtilityClass
+public class RedactionGuard {
+
+    /**
+     * @param redactResponse the decision already resolved for this caller by {@code RedactionRequestFilter}
+     * @param what           named in the refusal, so the caller learns which response was withheld
+     * @throws ForbiddenException when this caller's responses are masked
+     */
+    public static void rejectUnmaskable(boolean redactResponse, @NonNull String what) {
+        if (!redactResponse) {
+            return;
+        }
+
+        log.info("Refusing '{}': the response cannot be masked and the caller lacks '{}'", what,
+                WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+
+        throw new ForbiddenException(
+                "%s returns stored content that cannot be masked. The '%s' permission is required to read it."
+                        .formatted(what, WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -51,17 +51,25 @@ public class RedactionModule extends SimpleModule {
      * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
      * covered by the same set.
      */
+    /**
+     * Properties the API addresses by, where rewriting the value breaks a round trip: a caller who reads a
+     * project name back redacted can no longer query with it.
+     * <p>
+     * Deliberately not here: {@code model}, {@code provider}, {@code providers} and {@code environment}. Those
+     * are caller-supplied on spans and threads, so exempting them by name would let anything placed in them
+     * through unredacted. They are filter facets rather than addresses, and their legitimate values — "gpt-4o",
+     * "openai", "production" — cannot match a redaction rule, so leaving them redactable costs nothing real.
+     */
     private static final Set<String> EXEMPT_PROPERTIES = Set.of(
             // Resolved by name elsewhere in the API; redacting them breaks lookup.
             "project_name", "projectName",
             "dataset_name", "datasetName",
             "prompt_name", "promptName",
             "thread_id", "threadId",
-            "environment",
             // Identifiers that happen to be typed as String rather than UUID.
             "id", "workspace_id", "workspaceId",
             // Version and cost lookup keys.
-            "commit", "version_number", "versionNumber", "model", "provider", "providers",
+            "commit", "version_number", "versionNumber",
             "total_estimated_cost_version", "totalEstimatedCostVersion",
             // Pure API metadata, never caller content.
             "sortable_by", "sortableBy");

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -1,0 +1,192 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.node.POJONode;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Applies the active rule set to every string a response writes.
+ * <p>
+ * Registered on the mapper that serializes responses, so a new endpoint is covered the moment it exists —
+ * unlike an allowlist of fields, which protects only what somebody remembered to list.
+ * <p>
+ * Two serializers are needed. {@code String} covers ordinary properties. {@code JsonNode} covers trace and
+ * span payloads, and it has to walk the tree by hand: a node writes its own children through
+ * {@code JsonSerializable}, so nothing registered for the scalar types is ever consulted, and the strings
+ * inside an input or output would sail straight through untouched.
+ * <p>
+ * Only values are rewritten — field names are written back verbatim.
+ * <p>
+ * A small set of structural properties is exempt. These are lookup keys and API metadata rather than content:
+ * rewriting a {@code projectName} or a {@code threadId} does not conceal anything a caller could not obtain
+ * anyway, and it breaks navigation and filtering with no error to show for it.
+ * <p>
+ * The exemption is applied through a {@link BeanSerializerModifier}, which reaches declared bean properties and
+ * nothing else. That distinction is load-bearing: several DTOs carry {@code Map<String, String>} metadata whose
+ * keys the caller chooses, and a name-based check against the generator's current field would exempt the value
+ * of any entry a caller happened to call {@code id} or {@code model}. Matching on properties instead means map
+ * entries and {@code JsonNode} content are redacted whatever they are named.
+ */
+public class RedactionModule extends SimpleModule {
+
+    /**
+     * Held in the serialized form, since that is what the generator reports — these DTOs are snake_case on the
+     * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
+     * covered by the same set.
+     */
+    private static final Set<String> EXEMPT_PROPERTIES = Set.of(
+            // Resolved by name elsewhere in the API; redacting them breaks lookup.
+            "project_name", "projectName",
+            "dataset_name", "datasetName",
+            "prompt_name", "promptName",
+            "thread_id", "threadId",
+            "environment",
+            // Identifiers that happen to be typed as String rather than UUID.
+            "id", "workspace_id", "workspaceId",
+            // Version and cost lookup keys.
+            "commit", "version_number", "versionNumber", "model", "provider", "providers",
+            "total_estimated_cost_version", "totalEstimatedCostVersion",
+            // Pure API metadata, never caller content.
+            "sortable_by", "sortableBy");
+
+    public RedactionModule() {
+        addSerializer(String.class, new RedactingStringSerializer());
+        addSerializer(JsonNode.class, new RedactingJsonNodeSerializer());
+        setSerializerModifier(new ExemptStructuralProperties());
+    }
+
+    /**
+     * Swaps in a pass-through serializer for the exempt properties, covering both a bare {@code String} and a
+     * collection of them ({@code sortableBy}, {@code providers}).
+     */
+    private static class ExemptStructuralProperties extends BeanSerializerModifier {
+
+        @Override
+        public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDesc,
+                List<BeanPropertyWriter> beanProperties) {
+
+            for (BeanPropertyWriter property : beanProperties) {
+                if (!EXEMPT_PROPERTIES.contains(property.getName())) {
+                    continue;
+                }
+
+                var type = property.getType();
+                boolean text = type.hasRawClass(String.class);
+                boolean textCollection = type.isCollectionLikeType()
+                        && type.getContentType() != null
+                        && type.getContentType().hasRawClass(String.class);
+
+                if (text || textCollection) {
+                    property.assignSerializer(VerbatimSerializer.INSTANCE);
+                }
+            }
+
+            return beanProperties;
+        }
+    }
+
+    /**
+     * Writes text straight to the generator. Values written that way never reach a registered serializer,
+     * which is the same reason a {@code UUID} or an {@code Instant} is already immune to redaction.
+     */
+    private static class VerbatimSerializer extends JsonSerializer<Object> {
+
+        private static final VerbatimSerializer INSTANCE = new VerbatimSerializer();
+
+        @Override
+        public void serialize(Object value, JsonGenerator generator, SerializerProvider provider)
+                throws IOException {
+
+            if (value instanceof String text) {
+                generator.writeString(text);
+                return;
+            }
+
+            generator.writeStartArray();
+            for (Object element : (Collection<?>) value) {
+                if (element == null) {
+                    generator.writeNull();
+                } else {
+                    generator.writeString(element.toString());
+                }
+            }
+            generator.writeEndArray();
+        }
+    }
+
+    private static class RedactingStringSerializer extends JsonSerializer<String> {
+        @Override
+        public void serialize(String value, JsonGenerator generator, SerializerProvider provider)
+                throws IOException {
+            generator.writeString(RedactionContext.current().apply(value));
+        }
+    }
+
+    private static class RedactingJsonNodeSerializer extends JsonSerializer<JsonNode> {
+
+        @Override
+        public void serialize(JsonNode node, JsonGenerator generator, SerializerProvider provider)
+                throws IOException {
+            write(node, generator, provider);
+        }
+
+        private void write(JsonNode node, JsonGenerator generator, SerializerProvider provider)
+                throws IOException {
+
+            switch (node.getNodeType()) {
+                case OBJECT -> {
+                    generator.writeStartObject();
+                    var fields = node.fields();
+                    while (fields.hasNext()) {
+                        var field = fields.next();
+                        generator.writeFieldName(field.getKey());
+                        write(field.getValue(), generator, provider);
+                    }
+                    generator.writeEndObject();
+                }
+                case ARRAY -> {
+                    generator.writeStartArray();
+                    for (JsonNode child : node) {
+                        write(child, generator, provider);
+                    }
+                    generator.writeEndArray();
+                }
+                case STRING -> generator.writeString(RedactionContext.current().apply(node.textValue()));
+                case NUMBER -> writeNumber(node, generator);
+                case BOOLEAN -> generator.writeBoolean(node.booleanValue());
+                case BINARY -> generator.writeBinary(node.binaryValue());
+                // Deliberately not generator.writeTree(node): that would route back through this serializer.
+                case POJO -> provider.defaultSerializeValue(((POJONode) node).getPojo(), generator);
+                default -> generator.writeNull();
+            }
+        }
+
+        private void writeNumber(JsonNode node, JsonGenerator generator) throws IOException {
+            if (node.isInt()) {
+                generator.writeNumber(node.intValue());
+            } else if (node.isLong()) {
+                generator.writeNumber(node.longValue());
+            } else if (node.isBigInteger()) {
+                generator.writeNumber(node.bigIntegerValue());
+            } else if (node.isBigDecimal()) {
+                generator.writeNumber(node.decimalValue());
+            } else if (node.isFloat()) {
+                generator.writeNumber(node.floatValue());
+            } else {
+                generator.writeNumber(node.doubleValue());
+            }
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -108,7 +108,12 @@ public class RedactionModule extends SimpleModule {
                         && type.getContentType() != null
                         && type.getContentType().hasRawClass(String.class);
 
-                if (text || textCollection) {
+                // hasSerializer guard: assignSerializer throws IllegalStateException when one is already set,
+                // and the exempt names (id, name, model, provider, commit) recur across many DTOs. Adding
+                // @JsonSerialize to any field with one of those names would otherwise 500 that endpoint, with
+                // nothing connecting the failure to redaction. An explicit per-field serializer should win here
+                // anyway - Webhook.secretToken's masking serializer is the example that must not be overridden.
+                if ((text || textCollection) && !property.hasSerializer()) {
                     property.assignSerializer(VerbatimSerializer.INSTANCE);
                 }
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -54,12 +54,16 @@ public class RedactionModule extends SimpleModule {
      * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
      * covered by the same set.
      * <p>
-     * Deliberately not here: {@code model}, {@code provider}, {@code providers} and {@code environment}. Those
-     * are caller-supplied on spans and threads, so exempting them by name would let anything placed in them
-     * through unredacted. They are filter facets rather than addresses, and their legitimate values are unlikely
-     * to match a well-scoped rule — though not guaranteed to escape a loose one, since a dated model id such as
-     * {@code gpt-4o-2024-08-06} will match a rule written for dates. Losing a facet value to redaction is a
-     * cosmetic cost; letting caller content through is not.
+     * {@code model}, {@code provider} and {@code providers} are here by decision rather than by mechanism. They
+     * are caller-supplied on spans, so nothing stops someone putting content in them — but they name a vendor
+     * and a model from what is in practice a closed vocabulary, not a field anyone carries personal data in, and
+     * they are what the UI filters and groups by. Redacting them also rewrites legitimate identifiers: a dated
+     * model id such as {@code gpt-4o-2024-08-06} matches a rule written for dates, leaving a facet value that no
+     * longer selects its own spans. The trade is accepted knowingly: content placed in these two fields is
+     * returned as stored.
+     * <p>
+     * {@code environment} is not here, unlike those two: it is free text the caller invents rather than a name
+     * drawn from a vendor's catalogue, so it stays redactable.
      */
     private static final Set<String> EXEMPT_PROPERTIES = Set.of(
             // Resolved by name elsewhere in the API; redacting them breaks lookup.
@@ -69,6 +73,8 @@ public class RedactionModule extends SimpleModule {
             "thread_id", "threadId",
             // Identifiers that happen to be typed as String rather than UUID.
             "id", "workspace_id", "workspaceId",
+            // Vendor identifiers the UI filters and groups by; see the note above on the trade-off.
+            "model", "provider", "providers",
             // Version and cost lookup keys.
             "commit", "version_number", "versionNumber",
             "total_estimated_cost_version", "totalEstimatedCostVersion",

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -22,75 +22,44 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Applies the active rule set to every string a response writes.
+ * Applies the active rule set to every string a response writes, on the mapper that serializes responses, so a
+ * new endpoint is covered the moment it exists.
  * <p>
- * Registered on the mapper that serializes responses, so a new endpoint is covered the moment it exists —
- * unlike an allowlist of fields, which protects only what somebody remembered to list.
+ * Two serializers, because a {@code JsonNode} writes its own children through {@code JsonSerializable}: the one
+ * registered for {@code String} is never consulted for trace and span payloads, so the tree is walked by hand.
+ * Only values are rewritten; field names are written verbatim.
  * <p>
- * Two serializers are needed. {@code String} covers ordinary properties. {@code JsonNode} covers trace and
- * span payloads, and it has to walk the tree by hand: a node writes its own children through
- * {@code JsonSerializable}, so nothing registered for the scalar types is ever consulted, and the strings
- * inside an input or output would sail straight through untouched.
- * <p>
- * Only values are rewritten — field names are written back verbatim.
- * <p>
- * A small set of structural properties is exempt. These are lookup keys and API metadata rather than content:
- * rewriting a {@code projectName} or a {@code threadId} does not conceal anything a caller could not obtain
- * anyway, and it breaks navigation and filtering with no error to show for it.
- * <p>
- * The exemption is applied through a {@link BeanSerializerModifier}, which reaches declared bean properties and
- * nothing else. That distinction is load-bearing: several DTOs carry {@code Map<String, String>} metadata whose
- * keys the caller chooses, and a name-based check against the generator's current field would exempt the value
- * of any entry a caller happened to call {@code id} or {@code model}. Matching on properties instead means map
- * entries and {@code JsonNode} content are redacted whatever they are named.
+ * Exemptions go through a {@link BeanSerializerModifier} so they reach declared properties and nothing else.
+ * Several DTOs carry {@code Map<String, String>} metadata whose keys the caller chooses, and a name-based check
+ * would exempt the value of any entry a caller happened to call {@code id} or {@code model}.
  */
 public class RedactionModule extends SimpleModule {
 
     /**
-     * Properties the API addresses by, where rewriting the value breaks a round trip: a caller who reads a
-     * project name back redacted can no longer query with it.
-     * <p>
-     * Held in the serialized form, since that is what the generator reports — these DTOs are snake_case on the
-     * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
-     * covered by the same set.
-     * <p>
-     * {@code model}, {@code provider} and {@code providers} are here by decision rather than by mechanism. They
-     * are caller-supplied on spans, so nothing stops someone putting content in them — but they name a vendor
-     * and a model from what is in practice a closed vocabulary, not a field anyone carries personal data in, and
-     * they are what the UI filters and groups by. Redacting them also rewrites legitimate identifiers: a dated
-     * model id such as {@code gpt-4o-2024-08-06} matches a rule written for dates, leaving a facet value that no
-     * longer selects its own spans. The trade is accepted knowingly: content placed in these two fields is
-     * returned as stored.
-     * <p>
-     * {@code environment} is not here, unlike those two: it is free text the caller invents rather than a name
-     * drawn from a vendor's catalogue, so it stays redactable.
+     * Values that must survive redaction because something resolves by them. Listed in both spellings, since
+     * a DTO that does not apply the naming strategy reports camelCase.
      */
     private static final Set<String> EXEMPT_PROPERTIES = Set.of(
-            // Resolved by name elsewhere in the API; redacting them breaks lookup.
+            // Addressed by name; redacting them breaks lookup.
             "project_name", "projectName",
             "dataset_name", "datasetName",
             "prompt_name", "promptName",
             "thread_id", "threadId",
-            // Identifiers that happen to be typed as String rather than UUID.
+            // Identifiers typed as String rather than UUID.
             "id", "workspace_id", "workspaceId",
-            // Vendor identifiers the UI filters and groups by; see the note above on the trade-off.
+            // Vendor names the UI filters by. Exempt by decision: anything put here is returned as stored.
             "model", "provider", "providers",
             // Version and cost lookup keys.
             "commit", "version_number", "versionNumber",
             "total_estimated_cost_version", "totalEstimatedCostVersion",
-            // Pure API metadata, never caller content.
+            // API metadata, never caller content.
             "sortable_by", "sortableBy");
 
     /**
-     * Entities whose {@code name} addresses them in the API, so it has to survive.
-     * <p>
-     * Their create endpoints are get-or-create and the SDK replays the name it was handed, so a rewritten one
-     * does not fail — it quietly creates a second entity under the replacement text and writes there. Kept as
-     * an explicit list rather than "everything except traces and spans" so a new entity stays redacted until
-     * someone decides otherwise; the cost is that a new name-addressed entity has to be added here.
-     * <p>
-     * {@code Trace.name} and {@code Span.name} are deliberately absent: those are free text the caller writes
-     * per call, and can carry content.
+     * Entities whose {@code name} addresses them, so it has to survive. Their create endpoints are get-or-create and
+     * the SDK replays the name it was handed, so a rewritten one does not fail — it quietly creates a second entity
+     * under the replacement text. Listed explicitly so a new entity stays redacted until someone decides otherwise.
+     * {@code Trace.name} and {@code Span.name} are absent: free text the caller writes per call.
      */
     private static final Set<Class<?>> NAME_ADDRESSED_ENTITIES = Set.of(
             Dataset.class, Project.class, Prompt.class, Experiment.class, Environment.class);
@@ -104,8 +73,7 @@ public class RedactionModule extends SimpleModule {
     }
 
     /**
-     * Swaps in a pass-through serializer for the exempt properties, covering both a bare {@code String} and a
-     * collection of them ({@code sortableBy}, {@code providers}).
+     * Covers both a bare {@code String} and a collection of them ({@code sortableBy}, {@code providers}).
      */
     private static class ExemptStructuralProperties extends BeanSerializerModifier {
 
@@ -140,8 +108,7 @@ public class RedactionModule extends SimpleModule {
     }
 
     /**
-     * Writes text straight to the generator. Values written that way never reach a registered serializer,
-     * which is the same reason a {@code UUID} or an {@code Instant} is already immune to redaction.
+     * Writes straight to the generator, which is why a {@code UUID} or an {@code Instant} is already immune.
      */
     private static class VerbatimSerializer extends JsonSerializer<Object> {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -66,6 +66,22 @@ public class RedactionModule extends SimpleModule {
 
     private static final String NAME_PROPERTY = "name";
 
+    /**
+     * The single definition of what survives redaction, shared with {@link JsonNodeRedactor}.
+     * <p>
+     * A streamed response is rewritten by hand rather than through the serializer, so without this the two paths
+     * hold two copies of one policy and drift: the streamed items skipped these exemptions entirely, returning
+     * rewritten {@code thread_id}, {@code id} and {@code model} values from the search endpoints the SDK uses
+     * while the paged endpoints returned them intact.
+     *
+     * @param beanClass    the DTO being written, which decides whether {@code name} addresses the entity
+     * @param propertyName as serialized
+     */
+    static boolean isExemptProperty(Class<?> beanClass, String propertyName) {
+        return EXEMPT_PROPERTIES.contains(propertyName)
+                || (NAME_PROPERTY.equals(propertyName) && NAME_ADDRESSED_ENTITIES.contains(beanClass));
+    }
+
     public RedactionModule() {
         addSerializer(String.class, new RedactingStringSerializer());
         addSerializer(JsonNode.class, new RedactingJsonNodeSerializer());
@@ -101,9 +117,7 @@ public class RedactionModule extends SimpleModule {
         }
 
         private boolean isExempt(BeanDescription beanDesc, String propertyName) {
-            return EXEMPT_PROPERTIES.contains(propertyName)
-                    || (NAME_PROPERTY.equals(propertyName)
-                            && NAME_ADDRESSED_ENTITIES.contains(beanDesc.getBeanClass()));
+            return isExemptProperty(beanDesc.getBeanClass(), propertyName);
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -1,5 +1,10 @@
 package com.comet.opik.infrastructure.redaction;
 
+import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Environment;
+import com.comet.opik.api.Experiment;
+import com.comet.opik.api.Project;
+import com.comet.opik.api.Prompt;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.BeanDescription;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -61,6 +66,22 @@ public class RedactionModule extends SimpleModule {
             // Pure API metadata, never caller content.
             "sortable_by", "sortableBy");
 
+    /**
+     * Entities whose {@code name} addresses them in the API, so it has to survive.
+     * <p>
+     * Their create endpoints are get-or-create and the SDK replays the name it was handed, so a rewritten one
+     * does not fail — it quietly creates a second entity under the replacement text and writes there. Kept as
+     * an explicit list rather than "everything except traces and spans" so a new entity stays redacted until
+     * someone decides otherwise; the cost is that a new name-addressed entity has to be added here.
+     * <p>
+     * {@code Trace.name} and {@code Span.name} are deliberately absent: those are free text the caller writes
+     * per call, and can carry content.
+     */
+    private static final Set<Class<?>> NAME_ADDRESSED_ENTITIES = Set.of(
+            Dataset.class, Project.class, Prompt.class, Experiment.class, Environment.class);
+
+    private static final String NAME_PROPERTY = "name";
+
     public RedactionModule() {
         addSerializer(String.class, new RedactingStringSerializer());
         addSerializer(JsonNode.class, new RedactingJsonNodeSerializer());
@@ -78,7 +99,7 @@ public class RedactionModule extends SimpleModule {
                 List<BeanPropertyWriter> beanProperties) {
 
             for (BeanPropertyWriter property : beanProperties) {
-                if (!EXEMPT_PROPERTIES.contains(property.getName())) {
+                if (!isExempt(beanDesc, property.getName())) {
                     continue;
                 }
 
@@ -94,6 +115,12 @@ public class RedactionModule extends SimpleModule {
             }
 
             return beanProperties;
+        }
+
+        private boolean isExempt(BeanDescription beanDesc, String propertyName) {
+            return EXEMPT_PROPERTIES.contains(propertyName)
+                    || (NAME_PROPERTY.equals(propertyName)
+                            && NAME_ADDRESSED_ENTITIES.contains(beanDesc.getBeanClass()));
         }
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -47,18 +47,19 @@ import java.util.Set;
 public class RedactionModule extends SimpleModule {
 
     /**
-     * Held in the serialized form, since that is what the generator reports — these DTOs are snake_case on the
-     * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
-     * covered by the same set.
-     */
-    /**
      * Properties the API addresses by, where rewriting the value breaks a round trip: a caller who reads a
      * project name back redacted can no longer query with it.
      * <p>
+     * Held in the serialized form, since that is what the generator reports — these DTOs are snake_case on the
+     * wire. The camel-case spellings are kept alongside so a DTO that does not apply the naming strategy is
+     * covered by the same set.
+     * <p>
      * Deliberately not here: {@code model}, {@code provider}, {@code providers} and {@code environment}. Those
      * are caller-supplied on spans and threads, so exempting them by name would let anything placed in them
-     * through unredacted. They are filter facets rather than addresses, and their legitimate values — "gpt-4o",
-     * "openai", "production" — cannot match a redaction rule, so leaving them redactable costs nothing real.
+     * through unredacted. They are filter facets rather than addresses, and their legitimate values are unlikely
+     * to match a well-scoped rule — though not guaranteed to escape a loose one, since a dated model id such as
+     * {@code gpt-4o-2024-08-06} will match a rule written for dates. Losing a facet value to redaction is a
+     * cosmetic cost; letting caller content through is not.
      */
     private static final Set<String> EXEMPT_PROPERTIES = Set.of(
             // Resolved by name elsewhere in the API; redacting them breaks lookup.

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionModule.java
@@ -197,6 +197,9 @@ public class RedactionModule extends SimpleModule {
                 case BINARY -> generator.writeBinary(node.binaryValue());
                 // Deliberately not generator.writeTree(node): that would route back through this serializer.
                 case POJO -> provider.defaultSerializeValue(((POJONode) node).getPojo(), generator);
+                // MISSING is deliberately folded in here: MissingNode.serialize writes null, and the field
+                // name has already been emitted above, so handling it separately and writing nothing would
+                // produce {"field":} - invalid JSON.
                 default -> generator.writeNull();
             }
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
@@ -1,0 +1,71 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Resolves once per request whether this caller's response must be redacted, and records it on the request
+ * context for the writer interceptor to act on.
+ * <p>
+ * The priority places it after authentication so the permissions the platform resolved are already on the
+ * context. Request filters run lowest-priority-first and the auth filter carries the default
+ * {@code Priorities.USER}, so this has to sit above it; sharing that default leaves the order undefined, and
+ * running first makes every caller — admins included — look unpermitted. The decision is recorded here rather
+ * than at write time because a response can be serialized in more than one pass when it is streamed.
+ */
+@jakarta.ws.rs.ext.Provider
+@Singleton
+@Priority(Priorities.USER + 100)
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class RedactionRequestFilter implements ContainerRequestFilter {
+
+    private static final String VERSIONED_API = "/v1/";
+
+    /**
+     * Paths under the versioned API that must be written as stored. Kept to what genuinely cannot carry
+     * caller content: a redirect has no body worth rewriting, and resolving a decision for it would add a
+     * permission lookup to a hot path for nothing.
+     */
+    private static final Set<String> EXEMPT_PATHS = Set.of("/v1/session/redirect");
+
+    private final @NonNull RedactionService redactionService;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @Override
+    public void filter(ContainerRequestContext context) throws IOException {
+        if (!redactionService.isEnabled()) {
+            return;
+        }
+        if (!coversPath(context.getUriInfo().getRequestUri().getPath())) {
+            return;
+        }
+
+        RequestContext current = requestContext.get();
+        current.setRedactResponse(redactionService.shouldRedactFor(current.getPermissions()));
+    }
+
+    /**
+     * Whether redaction covers this path.
+     * <p>
+     * Phrased as "the whole versioned API, less a named exemption list" rather than "only {@code /v1/private}".
+     * The narrower form silently missed {@code /v1/internal/analytics-queries}, which returns stored trace
+     * content from caller-supplied SQL, and would have missed every future route outside the private prefix the
+     * same way — a route is only as protected as somebody's memory of adding it. Anything outside the versioned
+     * API is left alone deliberately: the OAuth endpoints return tokens, and a rule written to catch a bearer
+     * token or a JWT would happily destroy one.
+     */
+    static boolean coversPath(@NonNull String path) {
+        return path.contains(VERSIONED_API) && EXEMPT_PATHS.stream().noneMatch(path::contains);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
@@ -30,14 +30,22 @@ import java.util.Set;
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class RedactionRequestFilter implements ContainerRequestFilter {
 
-    private static final String VERSIONED_API = "/v1/";
-
     /**
-     * Paths under the versioned API that must be written as stored. Kept to what genuinely cannot carry
-     * caller content: a redirect has no body worth rewriting, and resolving a decision for it would add a
-     * permission lookup to a hot path for nothing.
+     * The paths that carry stored content to an authenticated caller.
+     * <p>
+     * Redaction only means something where there is a caller to decide about, so this tracks what
+     * {@code AuthFilter} authenticates rather than the whole versioned API. Covering more than that redacts
+     * responses with no identity behind them: {@code /v1/internal/usage/*} is unauthenticated, and its
+     * per-user rows would come back masked, collapsing the platform's usage attribution into one bucket.
+     * <p>
+     * {@code /v1/internal/analytics-queries} is named explicitly because it is authenticated and returns
+     * stored trace content from caller-supplied SQL — a private-prefix test alone would miss it. A new
+     * authenticated content path has to be added here, which is the same deliberate act as adding it to
+     * {@code AuthFilter}.
      */
-    private static final Set<String> EXEMPT_PATHS = Set.of("/v1/session/redirect");
+    private static final Set<String> COVERED_PATHS = Set.of(
+            "/v1/private/",
+            "/v1/internal/analytics-queries");
 
     private final @NonNull RedactionService redactionService;
     private final @NonNull Provider<RequestContext> requestContext;
@@ -56,16 +64,10 @@ public class RedactionRequestFilter implements ContainerRequestFilter {
     }
 
     /**
-     * Whether redaction covers this path.
-     * <p>
-     * Phrased as "the whole versioned API, less a named exemption list" rather than "only {@code /v1/private}".
-     * The narrower form silently missed {@code /v1/internal/analytics-queries}, which returns stored trace
-     * content from caller-supplied SQL, and would have missed every future route outside the private prefix the
-     * same way — a route is only as protected as somebody's memory of adding it. Anything outside the versioned
-     * API is left alone deliberately: the OAuth endpoints return tokens, and a rule written to catch a bearer
-     * token or a JWT would happily destroy one.
+     * Whether redaction covers this path. See {@link #COVERED_PATHS} for why this is not simply the whole
+     * versioned API.
      */
     static boolean coversPath(@NonNull String path) {
-        return path.contains(VERSIONED_API) && EXEMPT_PATHS.stream().noneMatch(path::contains);
+        return COVERED_PATHS.stream().anyMatch(path::contains);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
@@ -68,6 +68,6 @@ public class RedactionRequestFilter implements ContainerRequestFilter {
      * versioned API.
      */
     static boolean coversPath(@NonNull String path) {
-        return COVERED_PATHS.stream().anyMatch(path::contains);
+        return COVERED_PATHS.stream().anyMatch(path::startsWith);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilter.java
@@ -15,14 +15,19 @@ import java.io.IOException;
 import java.util.Set;
 
 /**
- * Resolves once per request whether this caller's response must be redacted, and records it on the request
- * context for the writer interceptor to act on.
+ * Resolves once per request whether this caller's response must be redacted, and records it where the write can
+ * find it again.
  * <p>
  * The priority places it after authentication so the permissions the platform resolved are already on the
  * context. Request filters run lowest-priority-first and the auth filter carries the default
  * {@code Priorities.USER}, so this has to sit above it; sharing that default leaves the order undefined, and
  * running first makes every caller — admins included — look unpermitted. The decision is recorded here rather
  * than at write time because a response can be serialized in more than one pass when it is streamed.
+ * <p>
+ * It is recorded twice, on purpose. {@code RequestContext} is what the resources read, and it is
+ * {@code @RequestScoped} and therefore thread-bound; the Jersey request property is not, so the writer
+ * interceptor can read the same answer on whichever thread the response is written from — including the reactor
+ * thread that resumes a {@code @Suspended AsyncResponse}.
  */
 @jakarta.ws.rs.ext.Provider
 @Singleton
@@ -47,6 +52,17 @@ public class RedactionRequestFilter implements ContainerRequestFilter {
             "/v1/private/",
             "/v1/internal/analytics-queries");
 
+    /**
+     * Where the decision is left for {@link RedactionWriterInterceptor}.
+     * <p>
+     * A Jersey request property rather than the request context, because the write does not always happen on the
+     * request thread: {@code LocalRunnersResource.nextJob} and the other long-polling endpoints resume a
+     * {@code @Suspended AsyncResponse} from a reactor thread, where the {@code @RequestScoped} context cannot be
+     * resolved at all. The property lives on the {@code ContainerRequest}, which Jersey hands to the writer
+     * interceptor chain as its properties delegate, so it is visible from any thread that writes this response.
+     */
+    static final String REDACT_RESPONSE_PROPERTY = "com.comet.opik.redaction.redact-response";
+
     private final @NonNull RedactionService redactionService;
     private final @NonNull Provider<RequestContext> requestContext;
 
@@ -60,7 +76,10 @@ public class RedactionRequestFilter implements ContainerRequestFilter {
         }
 
         RequestContext current = requestContext.get();
-        current.setRedactResponse(redactionService.shouldRedactFor(current.getPermissions()));
+        boolean redact = redactionService.shouldRedactFor(current.getPermissions());
+
+        current.setRedactResponse(redact);
+        context.setProperty(REDACT_RESPONSE_PROPERTY, redact);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
@@ -25,10 +25,18 @@ public record RedactionRule(@NonNull Pattern pattern, @NonNull String replacemen
     }
 
     /**
+     * @param outputLimit the longest output this rewrite may produce, past which the value is masked whole
+     *                    rather than materialized. A replacement longer than the text it replaces multiplies the
+     *                    value's length by however many matches it contains - a rule replacing single characters
+     *                    with a ten-character token turns a 2 MB value into a 20 MB one, and two such rules
+     *                    chained turn 100 KB into 10 MB - so the size of the response is otherwise a product of
+     *                    the caller's payload and the operator's replacement, with nothing bounding it.
+     *                    {@code StreamReadConstraints} do not: they bound what is parsed in, not what is built
+     *                    on the way out.
      * @return the rewritten text, or {@link MatchBudget#EXCEEDED} when evaluating this rule against this value
-     *         exhausted the budget - see {@link MatchBudget} for why that is not treated as "no match".
+     *         exhausted either bound - see {@link MatchBudget} for why that is not treated as "no match".
      */
-    public String apply(@NonNull String text, @NonNull MatchBudget budget) {
+    public String apply(@NonNull String text, @NonNull MatchBudget budget, long outputLimit) {
         try {
             var matcher = pattern.matcher(budget.wrap(text));
             StringBuilder rewritten = null;
@@ -40,6 +48,13 @@ public record RedactionRule(@NonNull Pattern pattern, @NonNull String replacemen
                 }
                 rewritten.append(text, last, matcher.start()).append(replacement);
                 last = matcher.end();
+
+                // Checked as it grows rather than predicted: the builder is the allocation being bounded, so
+                // stopping once it is over the limit costs one comparison per match and never holds more than
+                // the limit plus one replacement.
+                if (rewritten.length() > outputLimit) {
+                    return MatchBudget.EXCEEDED;
+                }
             }
 
             if (rewritten == null) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
@@ -6,8 +6,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * One find-and-replace rule, mirroring the SDK's RegexRule so a workspace can move the rules it already
- * runs client-side onto the server unchanged.
+ * One find-and-replace rule: a pattern, and the literal text that replaces each match.
+ * <p>
+ * The replacement is literal, unlike the SDK's RegexRule, where Python's {@code re.sub} expands
+ * backreferences — so a partial-mask rule that produced {@code j***@example.com} client-side emits the text
+ * {@code \1***@\2} here. A rule set moves across unchanged only if its replacements are plain text.
  * <p>
  * Both halves are prepared once, when the rule set is loaded: the pattern is compiled, and the replacement is
  * quoted so a payload containing {@code $1} or a backslash is treated as literal text rather than a group

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
@@ -22,7 +22,31 @@ public record RedactionRule(@NonNull Pattern pattern, @NonNull String quotedRepl
         return new RedactionRule(Pattern.compile(regex), Matcher.quoteReplacement(replacement));
     }
 
-    public String apply(@NonNull String text) {
-        return pattern.matcher(text).replaceAll(quotedReplacement);
+    /**
+     * @return the rewritten text, or {@link MatchBudget#EXCEEDED} when evaluating this rule against this value
+     *         exhausted the budget - see {@link MatchBudget} for why that is not treated as "no match".
+     */
+    public String apply(@NonNull String text, @NonNull MatchBudget budget) {
+        try {
+            var matcher = pattern.matcher(budget.wrap(text));
+            StringBuilder rewritten = null;
+            int last = 0;
+
+            while (matcher.find()) {
+                if (rewritten == null) {
+                    rewritten = new StringBuilder(text.length());
+                }
+                rewritten.append(text, last, matcher.start()).append(quotedReplacement);
+                last = matcher.end();
+            }
+
+            if (rewritten == null) {
+                return text;
+            }
+
+            return rewritten.append(text, last, text.length()).toString();
+        } catch (MatchBudget.Exceeded exceeded) {
+            return MatchBudget.EXCEEDED;
+        }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
@@ -1,0 +1,25 @@
+package com.comet.opik.infrastructure.redaction;
+
+import lombok.NonNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * One find-and-replace rule, mirroring the SDK's RegexRule so a workspace can move the rules it already
+ * runs client-side onto the server unchanged.
+ * <p>
+ * Both halves are prepared once, when the rule set is loaded: the pattern is compiled, and the replacement is
+ * quoted so a payload containing {@code $1} or a backslash is treated as literal text rather than a group
+ * reference.
+ */
+public record RedactionRule(@NonNull Pattern pattern, @NonNull String quotedReplacement) {
+
+    public static RedactionRule of(@NonNull String regex, @NonNull String replacement) {
+        return new RedactionRule(Pattern.compile(regex), Matcher.quoteReplacement(replacement));
+    }
+
+    public String apply(@NonNull String text) {
+        return pattern.matcher(text).replaceAll(quotedReplacement);
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRule.java
@@ -2,7 +2,6 @@ package com.comet.opik.infrastructure.redaction;
 
 import lombok.NonNull;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -16,10 +15,13 @@ import java.util.regex.Pattern;
  * quoted so a payload containing {@code $1} or a backslash is treated as literal text rather than a group
  * reference.
  */
-public record RedactionRule(@NonNull Pattern pattern, @NonNull String quotedReplacement) {
+public record RedactionRule(@NonNull Pattern pattern, @NonNull String replacement) {
 
     public static RedactionRule of(@NonNull String regex, @NonNull String replacement) {
-        return new RedactionRule(Pattern.compile(regex), Matcher.quoteReplacement(replacement));
+        // Stored raw, not quoted: the replacement is appended verbatim below rather than going through
+        // appendReplacement, which is what would have un-escaped it. Quoting here as well would emit the
+        // escapes themselves - a replacement of \1***@\2 would come out as \\1***@\\2.
+        return new RedactionRule(Pattern.compile(regex), replacement);
     }
 
     /**
@@ -36,7 +38,7 @@ public record RedactionRule(@NonNull Pattern pattern, @NonNull String quotedRepl
                 if (rewritten == null) {
                     rewritten = new StringBuilder(text.length());
                 }
-                rewritten.append(text, last, matcher.start()).append(quotedReplacement);
+                rewritten.append(text, last, matcher.start()).append(replacement);
                 last = matcher.end();
             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.redaction;
 
 import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
 
@@ -8,7 +9,14 @@ import java.util.List;
  * An ordered rule set. Rules are applied in sequence and each sees the previous rule's output, which is how
  * the SDK behaves — a broad pattern placed first will consume the matches a narrower one was written for.
  */
+@Slf4j
 public record RedactionRules(@NonNull List<RedactionRule> rules) {
+
+    /**
+     * Written in place of a value whose rules could not be evaluated within budget. Not configurable: it is a
+     * failure signal, and an operator tuning it would be tuning how a failure looks rather than fixing it.
+     */
+    private static final String UNEVALUATED = "[REDACTED]";
 
     private static final RedactionRules EMPTY = new RedactionRules(List.of());
 
@@ -24,7 +32,17 @@ public record RedactionRules(@NonNull List<RedactionRule> rules) {
         String result = text;
 
         for (RedactionRule rule : rules) {
-            result = rule.apply(result);
+            String rewritten = rule.apply(result, MatchBudget.DEFAULT);
+
+            if (rewritten == MatchBudget.EXCEEDED) {
+                // Fail closed. A rule that could not be evaluated is not evidence the value is safe to show, and
+                // the value is the caller's own content, so an attacker choosing it must not choose the outcome.
+                log.warn("Redaction budget exhausted on a value of '{}' characters; masking it whole",
+                        text.length());
+                return UNEVALUATED;
+            }
+
+            result = rewritten;
         }
 
         return result;

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
@@ -1,0 +1,32 @@
+package com.comet.opik.infrastructure.redaction;
+
+import lombok.NonNull;
+
+import java.util.List;
+
+/**
+ * An ordered rule set. Rules are applied in sequence and each sees the previous rule's output, which is how
+ * the SDK behaves — a broad pattern placed first will consume the matches a narrower one was written for.
+ */
+public record RedactionRules(@NonNull List<RedactionRule> rules) {
+
+    private static final RedactionRules EMPTY = new RedactionRules(List.of());
+
+    public static RedactionRules empty() {
+        return EMPTY;
+    }
+
+    public boolean isEmpty() {
+        return rules.isEmpty();
+    }
+
+    public String apply(@NonNull String text) {
+        String result = text;
+
+        for (RedactionRule rule : rules) {
+            result = rule.apply(result);
+        }
+
+        return result;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
@@ -32,13 +32,14 @@ public record RedactionRules(@NonNull List<RedactionRule> rules) {
         String result = text;
 
         for (RedactionRule rule : rules) {
-            String rewritten = rule.apply(result, MatchBudget.DEFAULT);
+            String rewritten = rule.apply(result, MatchBudget.forValue(result));
 
             if (rewritten == MatchBudget.EXCEEDED) {
                 // Fail closed. A rule that could not be evaluated is not evidence the value is safe to show, and
                 // the value is the caller's own content, so an attacker choosing it must not choose the outcome.
-                log.warn("Redaction budget exhausted on a value of '{}' characters; masking it whole",
-                        text.length());
+                // debug, not warn: this is per value, so a wide page would flood the log at warn.
+                log.debug("Redaction budget exhausted on a value of '{}' characters; masking it whole",
+                        result.length());
                 return UNEVALUATED;
             }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
@@ -20,6 +20,17 @@ public record RedactionRules(@NonNull List<RedactionRule> rules) {
 
     private static final RedactionRules EMPTY = new RedactionRules(List.of());
 
+    /**
+     * How much longer than the value it was given a rewrite may come out. Four, because a replacement is
+     * ordinarily shorter than the text it replaces - a rule masking a match to a token is what the
+     * configuration describes - and the cases where it is longer replace short matches with a longer token,
+     * which is nowhere near quadrupling the whole value.
+     */
+    private static final long MAXIMUM_GROWTH_FACTOR = 4L;
+
+    /** Floor, so a short value can be replaced by a much longer token without hitting the bound. */
+    private static final long MINIMUM_OUTPUT = 64 * 1024L;
+
     public static RedactionRules empty() {
         return EMPTY;
     }
@@ -30,15 +41,18 @@ public record RedactionRules(@NonNull List<RedactionRule> rules) {
 
     public String apply(@NonNull String text) {
         String result = text;
+        // Measured against the value as stored, not against each rule's input, so a chain cannot compound: two
+        // rules that each quadruple would otherwise be allowed sixteen times the original between them.
+        long outputLimit = Math.max(MINIMUM_OUTPUT, MAXIMUM_GROWTH_FACTOR * text.length());
 
         for (RedactionRule rule : rules) {
-            String rewritten = rule.apply(result, MatchBudget.forValue(result));
+            String rewritten = rule.apply(result, MatchBudget.forValue(result), outputLimit);
 
             if (rewritten == MatchBudget.EXCEEDED) {
                 // Fail closed. A rule that could not be evaluated is not evidence the value is safe to show, and
                 // the value is the caller's own content, so an attacker choosing it must not choose the outcome.
                 // debug, not warn: this is per value, so a wide page would flood the log at warn.
-                log.debug("Redaction budget exhausted on a value of '{}' characters; masking it whole",
+                log.debug("Redaction bounds exhausted on a value of '{}' characters; masking it whole",
                         result.length());
                 return UNEVALUATED;
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionRules.java
@@ -12,6 +12,13 @@ import java.util.List;
 @Slf4j
 public record RedactionRules(@NonNull List<RedactionRule> rules) {
 
+    public RedactionRules(@NonNull List<RedactionRule> rules) {
+        // Copied, not held. This is the policy in force for the life of the process - RedactionService compiles
+        // it once at startup and every response reads it - so it must not be something a caller can still
+        // change afterwards.
+        this.rules = List.copyOf(rules);
+    }
+
     /**
      * Written in place of a value whose rules could not be evaluated within budget. Not configurable: it is a
      * failure signal, and an operator tuning it would be tuning how a failure looks rather than fixing it.

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
@@ -55,11 +55,16 @@ public class RedactionService {
      * everyone else is redacted, so an empty or unresolved permission set means redacted.
      */
     /**
-     * What to do when there is no caller to decide against - a response written outside a request scope.
+     * What a stream does when there is no caller to decide against.
      * <p>
-     * Defined once because the two places that faced it answered it differently: the writer interceptor wrote
-     * values as stored, the streamer redacted them. Redacting is the answer, since a path that cannot establish
-     * who is reading cannot establish that the reader is permitted.
+     * Only {@code Streamer} asks, and only it can: it resolves the decision on the request thread and carries it,
+     * so reaching this means the stream genuinely has no caller, and redacting is right - a path that cannot
+     * establish who is reading cannot establish that the reader is permitted.
+     * <p>
+     * {@code RedactionWriterInterceptor} deliberately does not share this. It cannot tell "no caller" from
+     * "running on a thread where the request scope is not visible", and the second is ordinary: a
+     * {@code @Suspended AsyncResponse} resumed from a reactor thread lands there, so redacting would rewrite
+     * those payloads for permitted callers too.
      */
     public boolean redactWhenCallerUnknown() {
         return isEnabled();

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
@@ -1,0 +1,62 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.infrastructure.RedactionConfig;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
+
+import java.util.Set;
+
+/**
+ * Decides whether a caller sees stored content or redacted content, and holds the compiled rule set.
+ * <p>
+ * The decision reads the permissions the platform resolved during authentication and put on the request
+ * context. That keeps the authority where it belongs — Opik does not evaluate roles, it consumes the answer —
+ * and it costs nothing per request: the permissions arrive on the auth call that already happens, cached with
+ * the rest of the credentials. Asking a separate permissions endpoint instead would only work for callers
+ * presenting an api key, which silently excludes every browser and OAuth session.
+ * <p>
+ * Rules are compiled once here; the per-caller part is a set lookup.
+ */
+@Slf4j
+@Singleton
+public class RedactionService {
+
+    private final boolean enabled;
+    private final RedactionRules rules;
+
+    @Inject
+    public RedactionService(@Config RedactionConfig config) {
+        this.enabled = config.isEnabled();
+        this.rules = config.isEnabled() ? config.compile() : RedactionRules.empty();
+
+        if (enabled) {
+            log.info("Read-time redaction enabled with '{}' rule(s)", rules.rules().size());
+        }
+    }
+
+    /** For contexts that never redact — a test wiring a component directly, for instance. */
+    public static RedactionService disabled() {
+        return new RedactionService(new RedactionConfig());
+    }
+
+    public boolean isEnabled() {
+        return enabled && !rules.isEmpty();
+    }
+
+    public RedactionRules rules() {
+        return rules;
+    }
+
+    /**
+     * Whether this caller's responses must be redacted. Holding the original-data permission exempts them;
+     * everyone else is redacted, so an empty or unresolved permission set means redacted.
+     */
+    public boolean shouldRedactFor(Set<String> permissions) {
+        return isEnabled()
+                && (permissions == null
+                        || !permissions.contains(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
@@ -51,25 +51,23 @@ public class RedactionService {
     }
 
     /**
-     * Whether this caller's responses must be redacted. Holding the original-data permission exempts them;
-     * everyone else is redacted, so an empty or unresolved permission set means redacted.
-     */
-    /**
      * What a stream does when there is no caller to decide against.
      * <p>
      * Only {@code Streamer} asks, and only it can: it resolves the decision on the request thread and carries it,
      * so reaching this means the stream genuinely has no caller, and redacting is right - a path that cannot
      * establish who is reading cannot establish that the reader is permitted.
      * <p>
-     * {@code RedactionWriterInterceptor} deliberately does not share this. It cannot tell "no caller" from
-     * "running on a thread where the request scope is not visible", and the second is ordinary: a
-     * {@code @Suspended AsyncResponse} resumed from a reactor thread lands there, so redacting would rewrite
-     * those payloads for permitted callers too.
+     * {@code RedactionWriterInterceptor} has no equivalent, because it never has to guess: the decision is
+     * recorded on the request itself, so it is readable from whichever thread writes the response.
      */
     public boolean redactWhenCallerUnknown() {
         return isEnabled();
     }
 
+    /**
+     * Whether this caller's responses must be redacted. Holding the original-data permission exempts them;
+     * everyone else is redacted, so an empty or unresolved permission set means redacted.
+     */
     public boolean shouldRedactFor(Set<String> permissions) {
         return isEnabled()
                 && (permissions == null

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
@@ -54,6 +54,17 @@ public class RedactionService {
      * Whether this caller's responses must be redacted. Holding the original-data permission exempts them;
      * everyone else is redacted, so an empty or unresolved permission set means redacted.
      */
+    /**
+     * What to do when there is no caller to decide against - a response written outside a request scope.
+     * <p>
+     * Defined once because the two places that faced it answered it differently: the writer interceptor wrote
+     * values as stored, the streamer redacted them. Redacting is the answer, since a path that cannot establish
+     * who is reading cannot establish that the reader is permitted.
+     */
+    public boolean redactWhenCallerUnknown() {
+        return isEnabled();
+    }
+
     public boolean shouldRedactFor(Set<String> permissions) {
         return isEnabled()
                 && (permissions == null

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionService.java
@@ -71,6 +71,6 @@ public class RedactionService {
     public boolean shouldRedactFor(Set<String> permissions) {
         return isEnabled()
                 && (permissions == null
-                        || !permissions.contains(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+                        || !permissions.contains(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
@@ -1,0 +1,53 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.infrastructure.auth.RequestContext;
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+
+/**
+ * Puts the rule set in force while one response body is written, and takes it out again afterwards.
+ * <p>
+ * This is the narrowest point that still catches everything: it wraps the serialization itself, so an
+ * endpoint that does not exist yet is covered without anyone touching it. The rules are cleared in a finally
+ * block because these threads are pooled — a set left behind would redact somebody else's response.
+ */
+@jakarta.ws.rs.ext.Provider
+@Singleton
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class RedactionWriterInterceptor implements WriterInterceptor {
+
+    private final @NonNull RedactionService redactionService;
+    private final @NonNull Provider<RequestContext> requestContext;
+
+    @Override
+    public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
+        if (!redactionService.isEnabled() || !shouldRedact()) {
+            context.proceed();
+            return;
+        }
+
+        RedactionContext.set(redactionService.rules());
+        try {
+            context.proceed();
+        } finally {
+            RedactionContext.clear();
+        }
+    }
+
+    private boolean shouldRedact() {
+        try {
+            return requestContext.get().isRedactResponse();
+        } catch (RuntimeException outsideRequestScope) {
+            // Written outside a request (an error page, say): nothing to decide against, so write as stored.
+            return false;
+        }
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
@@ -46,8 +46,9 @@ public class RedactionWriterInterceptor implements WriterInterceptor {
         try {
             return requestContext.get().isRedactResponse();
         } catch (RuntimeException outsideRequestScope) {
-            // Written outside a request (an error page, say): nothing to decide against, so write as stored.
-            return false;
+            // No caller to decide against. See RedactionService.redactWhenCallerUnknown for why this redacts
+            // rather than writing as stored, and why both paths now consult one definition of it.
+            return redactionService.redactWhenCallerUnknown();
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
@@ -46,9 +46,17 @@ public class RedactionWriterInterceptor implements WriterInterceptor {
         try {
             return requestContext.get().isRedactResponse();
         } catch (RuntimeException outsideRequestScope) {
-            // No caller to decide against. See RedactionService.redactWhenCallerUnknown for why this redacts
-            // rather than writing as stored, and why both paths now consult one definition of it.
-            return redactionService.redactWhenCallerUnknown();
+            // Deliberately not redacting, and deliberately not symmetric with Streamer.
+            //
+            // RequestContext is @RequestScoped and thread-bound, so this throws on any thread that is not the
+            // request thread - including the reactor thread that resumes a @Suspended AsyncResponse, as
+            // LocalRunnersResource.nextJob does. Redacting here would rewrite those payloads for every caller,
+            // permitted ones included, because the permission is never consulted on that path.
+            //
+            // Streamer can fail closed because it resolves the decision on the request thread and carries it.
+            // An interceptor cannot: by the time it runs the decision is either on the context or unavailable.
+            // Fixing this properly means carrying the resolved decision to the write, not guessing at it here.
+            return false;
         }
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redaction/RedactionWriterInterceptor.java
@@ -1,8 +1,6 @@
 package com.comet.opik.infrastructure.redaction;
 
-import com.comet.opik.infrastructure.auth.RequestContext;
 import jakarta.inject.Inject;
-import jakarta.inject.Provider;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.ext.WriterInterceptor;
@@ -25,11 +23,10 @@ import java.io.IOException;
 public class RedactionWriterInterceptor implements WriterInterceptor {
 
     private final @NonNull RedactionService redactionService;
-    private final @NonNull Provider<RequestContext> requestContext;
 
     @Override
     public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
-        if (!redactionService.isEnabled() || !shouldRedact()) {
+        if (!redactionService.isEnabled() || !shouldRedact(context)) {
             context.proceed();
             return;
         }
@@ -42,21 +39,19 @@ public class RedactionWriterInterceptor implements WriterInterceptor {
         }
     }
 
-    private boolean shouldRedact() {
-        try {
-            return requestContext.get().isRedactResponse();
-        } catch (RuntimeException outsideRequestScope) {
-            // Deliberately not redacting, and deliberately not symmetric with Streamer.
-            //
-            // RequestContext is @RequestScoped and thread-bound, so this throws on any thread that is not the
-            // request thread - including the reactor thread that resumes a @Suspended AsyncResponse, as
-            // LocalRunnersResource.nextJob does. Redacting here would rewrite those payloads for every caller,
-            // permitted ones included, because the permission is never consulted on that path.
-            //
-            // Streamer can fail closed because it resolves the decision on the request thread and carries it.
-            // An interceptor cannot: by the time it runs the decision is either on the context or unavailable.
-            // Fixing this properly means carrying the resolved decision to the write, not guessing at it here.
-            return false;
-        }
+    /**
+     * Reads the decision {@link RedactionRequestFilter} resolved for this request, rather than resolving one
+     * here.
+     * <p>
+     * The property is on the request, not on a thread, which is the whole point: a {@code @Suspended
+     * AsyncResponse} is written from the thread that resumes it — a reactor thread, for the local-runner
+     * long-polls — and the {@code @RequestScoped} context is not resolvable there. Reading the context instead
+     * threw on exactly those responses, so they were written as stored however the permission had come out.
+     * <p>
+     * Absent means no decision was resolved for this response: the feature is off, or the path is outside
+     * {@code COVERED_PATHS}, and neither is a response to redact.
+     */
+    private boolean shouldRedact(WriterInterceptorContext context) {
+        return Boolean.TRUE.equals(context.getProperty(RedactionRequestFilter.REDACT_RESPONSE_PROPERTY));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
@@ -99,6 +99,29 @@ public class AuthTestUtils {
                         .willReturn(forbidden()));
     }
 
+    /**
+     * The session-cookie counterpart of {@link #mockTargetWorkspaceWithPermissions}. Browser and OAuth callers
+     * authenticate through {@code /opik/auth-session}, which returns the same permission set, so anything that
+     * reads permissions has to be exercised on this path too and not only with an api key.
+     */
+    public static void mockSessionCookieTargetWorkspaceWithPermissions(WireMockServer server, String sessionToken,
+            String workspaceName, String workspaceId, String user, List<String> grantedPermissions) {
+        var response = new LinkedHashMap<String, Object>();
+        response.put("user", user);
+        response.put("workspaceId", workspaceId);
+        response.put("workspaceName", workspaceName);
+        response.put("quotas", null);
+        response.put("permissions", grantedPermissions.stream()
+                .map(name -> Map.of("permissionName", name, "permissionValue", "true"))
+                .toList());
+
+        server.stubFor(
+                post(urlPathEqualTo("/opik/auth-session"))
+                        .withCookie(SESSION_COOKIE, equalTo(sessionToken))
+                        .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(workspaceName)))
+                        .willReturn(okJson(JsonUtils.writeValueAsString(response))));
+    }
+
     public static void mockSessionCookieTargetWorkspace(WireMockServer server, String sessionToken,
             String workspaceName, String workspaceId, String user) {
         mockSessionCookieTargetWorkspace(server, sessionToken, workspaceName, workspaceId, user, null);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
@@ -8,6 +8,7 @@ import lombok.experimental.UtilityClass;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.comet.opik.infrastructure.auth.RequestContext.SESSION_COOKIE;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -40,6 +41,29 @@ public class AuthTestUtils {
     public static void mockTargetWorkspace(WireMockServer server, String apiKey, String workspaceName,
             String workspaceId, String user) {
         mockTargetWorkspace(server, apiKey, workspaceName, workspaceId, user, null);
+    }
+
+    /**
+     * Stubs the auth call so it returns the caller's workspace permissions, the way the platform does. Pass
+     * the granted permission names; anything omitted is simply absent, which is how a withheld permission
+     * reaches the backend.
+     */
+    public static void mockTargetWorkspaceWithPermissions(WireMockServer server, String apiKey,
+            String workspaceName, String workspaceId, String user, List<String> grantedPermissions) {
+        var response = new LinkedHashMap<String, Object>();
+        response.put("user", user);
+        response.put("workspaceId", workspaceId);
+        response.put("workspaceName", workspaceName);
+        response.put("quotas", null);
+        response.put("permissions", grantedPermissions.stream()
+                .map(name -> Map.of("permissionName", name, "permissionValue", "true"))
+                .toList());
+
+        server.stubFor(
+                post(urlPathEqualTo("/opik/auth"))
+                        .withHeader(HttpHeaders.AUTHORIZATION, equalTo(apiKey))
+                        .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(workspaceName)))
+                        .willReturn(okJson(JsonUtils.writeValueAsString(response))));
     }
 
     public static void mockTargetWorkspace(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/AuthTestUtils.java
@@ -50,20 +50,29 @@ public class AuthTestUtils {
      */
     public static void mockTargetWorkspaceWithPermissions(WireMockServer server, String apiKey,
             String workspaceName, String workspaceId, String user, List<String> grantedPermissions) {
+        mockTargetWorkspace(server, apiKey, workspaceName, workspaceId, user);
+
+        server.stubFor(
+                post(urlPathEqualTo("/opik/workspace-permissions"))
+                        .withHeader(HttpHeaders.AUTHORIZATION, equalTo(apiKey))
+                        .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(workspaceName)))
+                        .willReturn(okJson(newPermissionsResponse(user, workspaceName, grantedPermissions))));
+    }
+
+    /**
+     * The workspace permissions API answers what a caller may see, on its own endpoint per credential type.
+     * The authentication response carries no permissions, so these stubs are what a test with the redaction
+     * feature enabled needs in addition to the authentication stub.
+     */
+    private static String newPermissionsResponse(String user, String workspaceName,
+            List<String> grantedPermissions) {
         var response = new LinkedHashMap<String, Object>();
-        response.put("user", user);
-        response.put("workspaceId", workspaceId);
+        response.put("userName", user);
         response.put("workspaceName", workspaceName);
-        response.put("quotas", null);
         response.put("permissions", grantedPermissions.stream()
                 .map(name -> Map.of("permissionName", name, "permissionValue", "true"))
                 .toList());
-
-        server.stubFor(
-                post(urlPathEqualTo("/opik/auth"))
-                        .withHeader(HttpHeaders.AUTHORIZATION, equalTo(apiKey))
-                        .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(workspaceName)))
-                        .willReturn(okJson(JsonUtils.writeValueAsString(response))));
+        return JsonUtils.writeValueAsString(response);
     }
 
     public static void mockTargetWorkspace(
@@ -106,20 +115,13 @@ public class AuthTestUtils {
      */
     public static void mockSessionCookieTargetWorkspaceWithPermissions(WireMockServer server, String sessionToken,
             String workspaceName, String workspaceId, String user, List<String> grantedPermissions) {
-        var response = new LinkedHashMap<String, Object>();
-        response.put("user", user);
-        response.put("workspaceId", workspaceId);
-        response.put("workspaceName", workspaceName);
-        response.put("quotas", null);
-        response.put("permissions", grantedPermissions.stream()
-                .map(name -> Map.of("permissionName", name, "permissionValue", "true"))
-                .toList());
+        mockSessionCookieTargetWorkspace(server, sessionToken, workspaceName, workspaceId, user);
 
         server.stubFor(
-                post(urlPathEqualTo("/opik/auth-session"))
+                post(urlPathEqualTo("/opik/workspace-permissions-session"))
                         .withCookie(SESSION_COOKIE, equalTo(sessionToken))
                         .withRequestBody(matchingJsonPath("$.workspaceName", equalTo(workspaceName)))
-                        .willReturn(okJson(JsonUtils.writeValueAsString(response))));
+                        .willReturn(okJson(newPermissionsResponse(user, workspaceName, grantedPermissions))));
     }
 
     public static void mockSessionCookieTargetWorkspace(WireMockServer server, String sessionToken,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetsResourceIntegrationTest.java
@@ -23,6 +23,7 @@ import com.comet.opik.infrastructure.FeatureFlags;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.infrastructure.json.JsonNodeMessageBodyWriter;
+import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -76,7 +77,8 @@ class DatasetsResourceIntegrationTest {
                 .addResource(new DatasetsResource(
                         service, itemService, expansionService, versionService, () -> requestContext,
                         new FiltersFactory(new FilterQueryBuilder()),
-                        TestIdGeneratorFactory.create(), new Streamer(), sortingFactory, csvProcessor, jsonProcessor,
+                        TestIdGeneratorFactory.create(), new Streamer(RedactionService.disabled(), () -> null),
+                        sortingFactory, csvProcessor, jsonProcessor,
                         featureFlags, csvExportService, analyticsService))
                 .addProvider(JsonNodeMessageBodyWriter.class)
                 .addProvider(MultiPartFeature.class)

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionDisabledResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionDisabledResourceTest.java
@@ -1,0 +1,172 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceSearchStreamRequest;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Read Time Redaction Disabled Resource Test")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class ReadTimeRedactionDisabledResourceTest {
+
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String WORKSPACE_NAME = RandomStringUtils.randomAlphabetic(10);
+
+    private static final String ADMIN_API_KEY = UUID.randomUUID().toString();
+    private static final String MEMBER_API_KEY = UUID.randomUUID().toString();
+
+    private static final String EMAIL = "john.doe@example.com";
+    private static final String PHONE = "555-123-4567";
+    private static final String RULES_JSON = """
+            [{"regex":"(?<![\\\\w.+-])[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+","replace":"[EMAIL]"},\
+            {"regex":"\\\\b\\\\d{3}-\\\\d{3}-\\\\d{4}\\\\b","replace":"[PHONE]"}]""";
+
+    private static final String STORED_INPUT = """
+            {"prompt":"Refund for %s, callback %s"}""".formatted(EMAIL, PHONE);
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+
+    /**
+     * Own network, and reuse switched off. The shared defaults hand back the same ZooKeeper as the sibling
+     * redaction test, and the replicated-table migration is not idempotent against ZooKeeper state another
+     * ClickHouse instance already wrote — which made the two classes fail intermittently when run together.
+     */
+    private final Network NETWORK = Network.newNetwork();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils
+            .newZookeeperContainer(false, NETWORK);
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(false, NETWORK, ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        DatabaseAnalyticsFactory databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        APP = newTestDropwizardAppExtension(
+                TestDropwizardAppExtensionUtils.AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .customConfigs(List.of(
+                                new CustomConfig("redaction.enabled", "false"),
+                                new CustomConfig("redaction.rules", RULES_JSON)))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private String baseURI;
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        this.baseURI = TestUtils.getBaseUrl(client);
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
+
+        ClientSupportUtils.config(client);
+
+        // The platform returns the caller's permissions on the auth call itself, so that is what decides.
+        AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_API_KEY, WORKSPACE_NAME,
+                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+        AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_API_KEY, WORKSPACE_NAME,
+                WORKSPACE_ID, USER, List.of());
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    private UUID createTraceWithPii(String projectName) {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .projectName(projectName)
+                .input(JsonUtils.getJsonNodeFromString(STORED_INPUT))
+                .output(null)
+                .metadata(null)
+                .feedbackScores(null)
+                .comments(null)
+                .guardrailsValidations(null)
+                .usage(null)
+                .build();
+
+        return traceResourceClient.createTrace(trace, ADMIN_API_KEY, WORKSPACE_NAME);
+    }
+
+    @Test
+    @DisplayName("with the flag off, content reaches even an unpermitted caller exactly as stored")
+    void withFlagOffContentReachesUnpermittedCallerAsStored() {
+        var traceId = createTraceWithPii("redaction-off-" + UUID.randomUUID());
+
+        // MEMBER_API_KEY is mocked as not holding the permission, and rules are configured. Only the flag is
+        // off — which must be enough to leave every response byte-identical to an install without the feature.
+        var trace = traceResourceClient.getById(traceId, WORKSPACE_NAME, MEMBER_API_KEY);
+
+        assertThat(trace.input().toString()).contains(EMAIL).contains(PHONE);
+        assertThat(trace.input().toString()).doesNotContain("[EMAIL]").doesNotContain("[PHONE]");
+    }
+
+    @Test
+    @DisplayName("streamed results are untouched with the flag off as well")
+    void streamedResultsAreUntouchedWithFlagOff() {
+        var projectName = "redaction-off-stream-" + UUID.randomUUID();
+        createTraceWithPii(projectName);
+
+        var streamed = traceResourceClient.getStreamAndAssertContent(MEMBER_API_KEY, WORKSPACE_NAME,
+                TraceSearchStreamRequest.builder().projectName(projectName).build());
+
+        assertThat(streamed).isNotEmpty();
+        assertThat(streamed.toString()).contains(EMAIL).doesNotContain("[EMAIL]");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionDisabledResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionDisabledResourceTest.java
@@ -119,7 +119,7 @@ class ReadTimeRedactionDisabledResourceTest {
 
         // The platform returns the caller's permissions on the auth call itself, so that is what decides.
         AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_API_KEY, WORKSPACE_NAME,
-                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()));
         AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_API_KEY, WORKSPACE_NAME,
                 WORKSPACE_ID, USER, List.of());
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -28,6 +28,7 @@ import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -58,6 +59,8 @@ import java.util.UUID;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
 import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static com.comet.opik.infrastructure.auth.RequestContext.SESSION_COOKIE;
+import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -71,6 +74,9 @@ class ReadTimeRedactionResourceTest {
 
     private static final String ADMIN_API_KEY = UUID.randomUUID().toString();
     private static final String MEMBER_API_KEY = UUID.randomUUID().toString();
+
+    private static final String ADMIN_SESSION_TOKEN = UUID.randomUUID().toString();
+    private static final String MEMBER_SESSION_TOKEN = UUID.randomUUID().toString();
 
     private static final String EMAIL = "john.doe@example.com";
     private static final String PHONE = "555-123-4567";
@@ -124,6 +130,7 @@ class ReadTimeRedactionResourceTest {
 
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
 
+    private ClientSupport client;
     private String baseURI;
     private TraceResourceClient traceResourceClient;
     private LocalRunnersResourceClient runnersClient;
@@ -132,6 +139,7 @@ class ReadTimeRedactionResourceTest {
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
+        this.client = client;
         this.baseURI = TestUtils.getBaseUrl(client);
         this.traceResourceClient = new TraceResourceClient(client, baseURI);
         this.runnersClient = new LocalRunnersResourceClient(client, baseURI);
@@ -145,6 +153,13 @@ class ReadTimeRedactionResourceTest {
                 WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
         AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_API_KEY, WORKSPACE_NAME,
                 WORKSPACE_ID, USER, List.of());
+
+        // The same two callers over a session cookie, which authenticates through a different endpoint.
+        AuthTestUtils.mockSessionCookieTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_SESSION_TOKEN,
+                WORKSPACE_NAME, WORKSPACE_ID, USER,
+                List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+        AuthTestUtils.mockSessionCookieTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_SESSION_TOKEN,
+                WORKSPACE_NAME, WORKSPACE_ID, USER, List.of());
     }
 
     @AfterAll
@@ -377,5 +392,51 @@ class ReadTimeRedactionResourceTest {
         assertThat(streamed).hasSize(1);
         assertThat(streamed.getFirst().threadId()).isEqualTo(paged.threadId());
         assertThat(streamed.getFirst().input()).isEqualTo(paged.input());
+    }
+
+    /**
+     * The same two decisions over a session cookie rather than an api key.
+     * <p>
+     * Browser and OAuth callers authenticate through {@code /opik/auth-session}, a different branch of
+     * {@code RemoteAuthService} that resolves its own credentials before the context is populated. It reaches the
+     * same {@code ValidatedAuthCredentials.from(authResponse)}, so nothing here is expected to differ — which is
+     * exactly why it was untested: a branch that drops permissions on this path only, or inverts the decision,
+     * would have left every api-key test green.
+     */
+    private Trace getTraceWithSessionCookie(UUID traceId, String sessionToken) {
+        try (var response = client.target("%s/v1/private/traces/%s".formatted(baseURI, traceId))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .cookie(SESSION_COOKIE, sessionToken)
+                .header(WORKSPACE_HEADER, WORKSPACE_NAME)
+                .get()) {
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            return response.readEntity(Trace.class);
+        }
+    }
+
+    @Test
+    @DisplayName("a session caller without the permission is redacted, as an api key caller is")
+    void aSessionCallerWithoutThePermissionIsRedacted() {
+        var traceId = createTraceWithPii("redaction-session-member-" + UUID.randomUUID());
+
+        var trace = getTraceWithSessionCookie(traceId, MEMBER_SESSION_TOKEN);
+
+        assertThat(trace.input().toString())
+                .doesNotContain(EMAIL)
+                .doesNotContain(PHONE)
+                .contains("[EMAIL]")
+                .contains("[PHONE]");
+    }
+
+    @Test
+    @DisplayName("a session caller holding the permission reads stored content, as an api key caller does")
+    void aSessionCallerHoldingThePermissionReadsStoredContent() {
+        var traceId = createTraceWithPii("redaction-session-admin-" + UUID.randomUUID());
+
+        var trace = getTraceWithSessionCookie(traceId, ADMIN_SESSION_TOKEN);
+
+        assertThat(trace.input().toString()).contains(EMAIL).contains(PHONE);
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -63,6 +63,12 @@ class ReadTimeRedactionResourceTest {
     private static final String STORED_INPUT = """
             {"prompt":"Refund for %s, callback %s"}""".formatted(EMAIL, PHONE);
 
+    /**
+     * Deliberately a value the PHONE rule matches. Nothing but the structural exemption keeps it intact, so if
+     * the exemption is missing on a path the assertion fails rather than passing by luck.
+     */
+    private static final String RULE_MATCHING_THREAD_ID = PHONE;
+
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
     private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
@@ -182,5 +188,49 @@ class ReadTimeRedactionResourceTest {
 
         assertThat(streamed).isNotEmpty();
         assertThat(streamed.toString()).doesNotContain(EMAIL).doesNotContain(PHONE).contains("[EMAIL]");
+    }
+
+    @Test
+    @DisplayName("streamed items keep the structural exemptions the paged path applies")
+    void streamedItemsKeepTheStructuralExemptions() {
+        // The streamed path is rewritten by hand rather than through the serializer, so it needs the same
+        // exemptions or the two representations of one trace disagree. thread_id here matches a configured rule:
+        // without the exemption it comes back rewritten from search while the UI shows it intact, and
+        // get_trace_by_id on a rewritten id returns nothing.
+        var projectName = "redaction-exempt-" + UUID.randomUUID();
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .projectName(projectName)
+                .threadId(RULE_MATCHING_THREAD_ID)
+                .input(JsonUtils.getJsonNodeFromString(STORED_INPUT))
+                .output(null)
+                .metadata(null)
+                .feedbackScores(null)
+                .comments(null)
+                .guardrailsValidations(null)
+                .usage(null)
+                .build();
+        traceResourceClient.createTrace(trace, ADMIN_API_KEY, WORKSPACE_NAME);
+
+        var streamed = traceResourceClient.getStreamAndAssertContent(MEMBER_API_KEY, WORKSPACE_NAME,
+                TraceSearchStreamRequest.builder().projectName(projectName).build());
+
+        assertThat(streamed).hasSize(1);
+        assertThat(streamed.getFirst().threadId()).isEqualTo(RULE_MATCHING_THREAD_ID);
+        assertThat(streamed.getFirst().input().toString()).doesNotContain(EMAIL).contains("[EMAIL]");
+    }
+
+    @Test
+    @DisplayName("streamed and paged reads of one trace agree")
+    void streamedAndPagedReadsAgree() {
+        var projectName = "redaction-parity-" + UUID.randomUUID();
+        var traceId = createTraceWithPii(projectName);
+
+        var paged = traceResourceClient.getById(traceId, WORKSPACE_NAME, MEMBER_API_KEY);
+        var streamed = traceResourceClient.getStreamAndAssertContent(MEMBER_API_KEY, WORKSPACE_NAME,
+                TraceSearchStreamRequest.builder().projectName(projectName).build());
+
+        assertThat(streamed).hasSize(1);
+        assertThat(streamed.getFirst().threadId()).isEqualTo(paged.threadId());
+        assertThat(streamed.getFirst().input()).isEqualTo(paged.input());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -1,0 +1,186 @@
+package com.comet.opik.api.resources.v1.priv;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceSearchStreamRequest;
+import com.comet.opik.api.resources.utils.AuthTestUtils;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Read Time Redaction Resource Test")
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class ReadTimeRedactionResourceTest {
+
+    private static final String USER = UUID.randomUUID().toString();
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String WORKSPACE_NAME = RandomStringUtils.randomAlphabetic(10);
+
+    private static final String ADMIN_API_KEY = UUID.randomUUID().toString();
+    private static final String MEMBER_API_KEY = UUID.randomUUID().toString();
+
+    private static final String EMAIL = "john.doe@example.com";
+    private static final String PHONE = "555-123-4567";
+    private static final String RULES_JSON = """
+            [{"regex":"(?<![\\\\w.+-])[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+","replace":"[EMAIL]"},\
+            {"regex":"\\\\b\\\\d{3}-\\\\d{3}-\\\\d{4}\\\\b","replace":"[PHONE]"}]""";
+
+    private static final String STORED_INPUT = """
+            {"prompt":"Refund for %s, callback %s"}""".formatted(EMAIL, PHONE);
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
+            .newClickHouseContainer(ZOOKEEPER_CONTAINER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    @RegisterApp
+    private final TestDropwizardAppExtension APP;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE_CONTAINER, MYSQL, ZOOKEEPER_CONTAINER).join();
+
+        wireMock = WireMockUtils.startWireMock();
+
+        DatabaseAnalyticsFactory databaseAnalyticsFactory = ClickHouseContainerUtils
+                .newDatabaseAnalyticsFactory(CLICKHOUSE_CONTAINER, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE_CONTAINER);
+
+        APP = newTestDropwizardAppExtension(
+                TestDropwizardAppExtensionUtils.AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .customConfigs(List.of(
+                                new CustomConfig("redaction.enabled", "true"),
+                                new CustomConfig("redaction.rules", RULES_JSON)))
+                        .build());
+    }
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private String baseURI;
+    private TraceResourceClient traceResourceClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport client) {
+        this.baseURI = TestUtils.getBaseUrl(client);
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
+
+        ClientSupportUtils.config(client);
+
+        // The platform returns the caller's permissions on the auth call itself, so that is what decides.
+        AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_API_KEY, WORKSPACE_NAME,
+                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+        AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_API_KEY, WORKSPACE_NAME,
+                WORKSPACE_ID, USER, List.of());
+    }
+
+    @AfterAll
+    void tearDownAll() {
+        wireMock.server().stop();
+    }
+
+    private UUID createTraceWithPii(String projectName) {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .projectName(projectName)
+                .input(JsonUtils.getJsonNodeFromString(STORED_INPUT))
+                .output(null)
+                .metadata(null)
+                .feedbackScores(null)
+                .comments(null)
+                .guardrailsValidations(null)
+                .usage(null)
+                .build();
+
+        return traceResourceClient.createTrace(trace, ADMIN_API_KEY, WORKSPACE_NAME);
+    }
+
+    @Test
+    @DisplayName("stored content reaches a caller who may see originals")
+    void storedContentReachesCallerWhoMaySeeOriginals() {
+        var traceId = createTraceWithPii("redaction-admin-" + UUID.randomUUID());
+
+        var trace = traceResourceClient.getById(traceId, WORKSPACE_NAME, ADMIN_API_KEY);
+
+        assertThat(trace.input().toString()).contains(EMAIL).contains(PHONE);
+    }
+
+    @Test
+    @DisplayName("content is redacted for a caller who may not")
+    void contentIsRedactedForCallerWhoMayNot() {
+        var traceId = createTraceWithPii("redaction-member-" + UUID.randomUUID());
+
+        var trace = traceResourceClient.getById(traceId, WORKSPACE_NAME, MEMBER_API_KEY);
+
+        assertThat(trace.input().toString())
+                .doesNotContain(EMAIL)
+                .doesNotContain(PHONE)
+                .contains("[EMAIL]")
+                .contains("[PHONE]");
+    }
+
+    @Test
+    @DisplayName("the list endpoint is redacted too, without being touched")
+    void listEndpointIsRedactedToo() {
+        var projectName = "redaction-list-" + UUID.randomUUID();
+        createTraceWithPii(projectName);
+
+        var traces = traceResourceClient.getByProjectName(projectName, MEMBER_API_KEY, WORKSPACE_NAME);
+
+        assertThat(traces).isNotEmpty();
+        assertThat(traces.toString()).doesNotContain(EMAIL).contains("[EMAIL]");
+    }
+
+    @Test
+    @DisplayName("streamed search results are redacted, which a response filter would have missed")
+    void streamedSearchResultsAreRedacted() {
+        var projectName = "redaction-stream-" + UUID.randomUUID();
+        createTraceWithPii(projectName);
+
+        var streamed = traceResourceClient.getStreamAndAssertContent(MEMBER_API_KEY, WORKSPACE_NAME,
+                TraceSearchStreamRequest.builder().projectName(projectName).build());
+
+        assertThat(streamed).isNotEmpty();
+        assertThat(streamed.toString()).doesNotContain(EMAIL).doesNotContain(PHONE).contains("[EMAIL]");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -2,6 +2,8 @@ package com.comet.opik.api.resources.v1.priv;
 
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceSearchStreamRequest;
+import com.comet.opik.api.connect.ActivateRequest;
+import com.comet.opik.api.connect.CreateSessionRequest;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
@@ -11,7 +13,14 @@ import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.LocalRunnersResourceClient;
+import com.comet.opik.api.resources.utils.resources.PairingResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.runner.CreateLocalRunnerJobRequest;
+import com.comet.opik.api.runner.LocalRunner;
+import com.comet.opik.api.runner.LocalRunnerJob;
+import com.comet.opik.api.runner.RunnerType;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
@@ -34,7 +43,16 @@ import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
@@ -68,6 +86,8 @@ class ReadTimeRedactionResourceTest {
      * the exemption is missing on a path the assertion fails rather than passing by luck.
      */
     private static final String RULE_MATCHING_THREAD_ID = PHONE;
+
+    private static final String RUNNER_AGENT = "redaction-agent";
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -106,11 +126,17 @@ class ReadTimeRedactionResourceTest {
 
     private String baseURI;
     private TraceResourceClient traceResourceClient;
+    private LocalRunnersResourceClient runnersClient;
+    private PairingResourceClient pairingClient;
+    private ProjectResourceClient projectClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client) {
         this.baseURI = TestUtils.getBaseUrl(client);
         this.traceResourceClient = new TraceResourceClient(client, baseURI);
+        this.runnersClient = new LocalRunnersResourceClient(client, baseURI);
+        this.pairingClient = new PairingResourceClient(client, baseURI);
+        this.projectClient = new ProjectResourceClient(client, baseURI, factory);
 
         ClientSupportUtils.config(client);
 
@@ -217,6 +243,113 @@ class ReadTimeRedactionResourceTest {
         assertThat(streamed).hasSize(1);
         assertThat(streamed.getFirst().threadId()).isEqualTo(RULE_MATCHING_THREAD_ID);
         assertThat(streamed.getFirst().input().toString()).doesNotContain(EMAIL).contains("[EMAIL]");
+    }
+
+    /**
+     * A local runner job is the async case: {@code nextJob} suspends and its response is written from the
+     * reactor thread that resumes it, where the request-scoped context does not exist. The decision therefore
+     * has to travel on the request rather than on the thread, and these two tests are what says it does — the
+     * unpermitted caller is masked, and the permitted one is not, which is the half that a fail-closed
+     * interceptor got wrong.
+     */
+    private UUID connectRunner(String apiKey) {
+        UUID projectId = projectClient.createProject("redaction-runner-" + UUID.randomUUID(), apiKey,
+                WORKSPACE_NAME);
+
+        byte[] activationKey = new byte[32];
+        new SecureRandom().nextBytes(activationKey);
+
+        var session = pairingClient.createSession(CreateSessionRequest.builder()
+                .projectId(projectId)
+                .activationKey(Base64.getEncoder().encodeToString(activationKey))
+                .ttlSeconds(300)
+                .type(RunnerType.ENDPOINT)
+                .build(), apiKey, WORKSPACE_NAME);
+
+        String runnerName = "redaction-runner";
+        UUID runnerId = pairingClient.activate(session.sessionId(), ActivateRequest.builder()
+                .runnerName(runnerName)
+                .hmac(hmac(session.sessionId(), activationKey, runnerName))
+                .build(), apiKey, WORKSPACE_NAME);
+
+        runnersClient.registerAgents(runnerId, Map.of(RUNNER_AGENT, LocalRunner.Agent.builder()
+                .name(RUNNER_AGENT).build()), apiKey, WORKSPACE_NAME);
+        runnersClient.heartbeat(runnerId, apiKey, WORKSPACE_NAME);
+
+        return runnerId;
+    }
+
+    private static String hmac(UUID sessionId, byte[] activationKey, String runnerName) {
+        try {
+            var sessionIdBytes = ByteBuffer.allocate(16)
+                    .putLong(sessionId.getMostSignificantBits())
+                    .putLong(sessionId.getLeastSignificantBits())
+                    .array();
+            byte[] runnerNameHash = MessageDigest.getInstance("SHA-256")
+                    .digest(runnerName.getBytes(StandardCharsets.UTF_8));
+            byte[] message = new byte[sessionIdBytes.length + runnerNameHash.length];
+            System.arraycopy(sessionIdBytes, 0, message, 0, sessionIdBytes.length);
+            System.arraycopy(runnerNameHash, 0, message, sessionIdBytes.length, runnerNameHash.length);
+
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(activationKey, "HmacSHA256"));
+            return Base64.getEncoder().encodeToString(mac.doFinal(message));
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    private UUID createJobWithPii(UUID runnerId, String apiKey) {
+        LocalRunner runner = runnersClient.getRunner(runnerId, apiKey, WORKSPACE_NAME);
+
+        return runnersClient.createJob(CreateLocalRunnerJobRequest.builder()
+                .agentName(RUNNER_AGENT)
+                .projectId(runner.projectId())
+                .inputs(JsonUtils.getJsonNodeFromString(STORED_INPUT))
+                .build(), apiKey, WORKSPACE_NAME);
+    }
+
+    @Test
+    @DisplayName("a long-polled job is redacted, though its response is written off the request thread")
+    void aLongPolledJobIsRedacted() {
+        UUID runnerId = connectRunner(ADMIN_API_KEY);
+        UUID jobId = createJobWithPii(runnerId, ADMIN_API_KEY);
+
+        LocalRunnerJob polled;
+        try (var response = runnersClient.callNextJob(runnerId, MEMBER_API_KEY, WORKSPACE_NAME)) {
+            assertThat(response.getStatus()).isEqualTo(200);
+            polled = response.readEntity(LocalRunnerJob.class);
+        }
+
+        assertThat(polled.id()).isEqualTo(jobId);
+        assertThat(polled.inputs().toString())
+                .doesNotContain(EMAIL)
+                .doesNotContain(PHONE)
+                .contains("[EMAIL]")
+                .contains("[PHONE]");
+
+        // The same job read through the synchronous endpoint, which the interceptor has always covered: the two
+        // representations of one job have to agree, and before the decision travelled with the request they did
+        // not.
+        var fetched = runnersClient.getJob(jobId, MEMBER_API_KEY, WORKSPACE_NAME);
+
+        assertThat(fetched.inputs()).isEqualTo(polled.inputs());
+    }
+
+    @Test
+    @DisplayName("a long-polled job reaches a permitted caller as stored")
+    void aLongPolledJobReachesAPermittedCallerAsStored() {
+        // Failing closed on the async path instead of carrying the decision rewrote this response too, for a
+        // caller who is allowed to see it and whose permission was never consulted.
+        UUID runnerId = connectRunner(ADMIN_API_KEY);
+        createJobWithPii(runnerId, ADMIN_API_KEY);
+
+        try (var response = runnersClient.callNextJob(runnerId, ADMIN_API_KEY, WORKSPACE_NAME)) {
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.readEntity(LocalRunnerJob.class).inputs().toString())
+                    .contains(EMAIL)
+                    .contains(PHONE);
+        }
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -150,14 +150,14 @@ class ReadTimeRedactionResourceTest {
 
         // The platform returns the caller's permissions on the auth call itself, so that is what decides.
         AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_API_KEY, WORKSPACE_NAME,
-                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+                WORKSPACE_ID, USER, List.of(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()));
         AuthTestUtils.mockTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_API_KEY, WORKSPACE_NAME,
                 WORKSPACE_ID, USER, List.of());
 
         // The same two callers over a session cookie, which authenticates through a different endpoint.
         AuthTestUtils.mockSessionCookieTargetWorkspaceWithPermissions(wireMock.server(), ADMIN_SESSION_TOKEN,
                 WORKSPACE_NAME, WORKSPACE_ID, USER,
-                List.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()));
+                List.of(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()));
         AuthTestUtils.mockSessionCookieTargetWorkspaceWithPermissions(wireMock.server(), MEMBER_SESSION_TOKEN,
                 WORKSPACE_NAME, WORKSPACE_ID, USER, List.of());
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ReadTimeRedactionResourceTest.java
@@ -328,12 +328,19 @@ class ReadTimeRedactionResourceTest {
                 .contains("[EMAIL]")
                 .contains("[PHONE]");
 
-        // The same job read through the synchronous endpoint, which the interceptor has always covered: the two
-        // representations of one job have to agree, and before the decision travelled with the request they did
-        // not.
-        var fetched = runnersClient.getJob(jobId, MEMBER_API_KEY, WORKSPACE_NAME);
+        // The same job as a permitted caller sees it, which bounds what redaction was allowed to touch: every
+        // other field has to survive intact. Asserting only on inputs() would pass just as well if the rules
+        // had also rewritten agent_name, blueprint_name or the metadata on their way out.
+        var stored = runnersClient.getJob(jobId, ADMIN_API_KEY, WORKSPACE_NAME);
 
-        assertThat(fetched.inputs()).isEqualTo(polled.inputs());
+        assertThat(stored.inputs().toString()).contains(EMAIL).contains(PHONE);
+        assertThat(polled).isEqualTo(stored.toBuilder().inputs(polled.inputs()).build());
+
+        // And the two representations of one job have to agree with each other, which is the part that a
+        // thread-bound decision got wrong: before it travelled with the request, only the synchronous read
+        // was masked.
+        assertThat(runnersClient.getJob(jobId, MEMBER_API_KEY, WORKSPACE_NAME).inputs())
+                .isEqualTo(polled.inputs());
     }
 
     @Test
@@ -342,14 +349,19 @@ class ReadTimeRedactionResourceTest {
         // Failing closed on the async path instead of carrying the decision rewrote this response too, for a
         // caller who is allowed to see it and whose permission was never consulted.
         UUID runnerId = connectRunner(ADMIN_API_KEY);
-        createJobWithPii(runnerId, ADMIN_API_KEY);
+        UUID jobId = createJobWithPii(runnerId, ADMIN_API_KEY);
 
+        LocalRunnerJob polled;
         try (var response = runnersClient.callNextJob(runnerId, ADMIN_API_KEY, WORKSPACE_NAME)) {
             assertThat(response.getStatus()).isEqualTo(200);
-            assertThat(response.readEntity(LocalRunnerJob.class).inputs().toString())
-                    .contains(EMAIL)
-                    .contains(PHONE);
+            polled = response.readEntity(LocalRunnerJob.class);
         }
+
+        assertThat(polled.inputs().toString()).contains(EMAIL).contains(PHONE);
+
+        // Whole job, not just inputs: "reaches a permitted caller as stored" is a claim about the entire
+        // response, and the interceptor either leaves it alone or it does not.
+        assertThat(polled).isEqualTo(runnersClient.getJob(jobId, ADMIN_API_KEY, WORKSPACE_NAME));
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/StreamerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/StreamerTest.java
@@ -1,17 +1,25 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Trace;
+import com.comet.opik.infrastructure.RedactionConfig;
+import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.redaction.JsonNodeRedactor;
 import com.comet.opik.infrastructure.redaction.RedactionRule;
 import com.comet.opik.infrastructure.redaction.RedactionRules;
+import com.comet.opik.infrastructure.redaction.RedactionService;
 import com.comet.opik.utils.JsonUtils;
+import com.google.inject.OutOfScopeException;
+import com.google.inject.ProvisionException;
+import jakarta.inject.Provider;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Streamer")
 class StreamerTest {
@@ -66,5 +74,60 @@ class StreamerTest {
 
         assertThat(tree.get("input").toString()).contains("[EMAIL]");
         assertThat(trace.input().toString()).isEqualTo(stored.toString()).contains("john.doe@example.com");
+    }
+
+    @Nested
+    @DisplayName("resolving the rules for a stream")
+    class ResolveRules {
+
+        private static final String RULES_JSON = "[{\"regex\":\"[\\\\w.]+@[\\\\w.]+\",\"replace\":\"[EMAIL]\"}]";
+
+        private static RedactionService enabledService() {
+            var config = new RedactionConfig();
+            config.setEnabled(true);
+            config.setRules(RULES_JSON);
+            return new RedactionService(config);
+        }
+
+        private static Streamer streamerWhoseContextThrows(RedactionService service, RuntimeException failure) {
+            Provider<RequestContext> provider = () -> {
+                throw failure;
+            };
+            return new Streamer(service, provider);
+        }
+
+        /** What Guice actually raises for a request-scoped binding read off the request thread. */
+        private static ProvisionException outsideRequestScope() {
+            return new ProvisionException("Unable to provision", new OutOfScopeException("Cannot access scoped"));
+        }
+
+        @Test
+        @DisplayName("a missing request scope falls back to the unknown-caller policy")
+        void aMissingRequestScopeFallsBackToTheUnknownCallerPolicy() {
+            var rules = streamerWhoseContextThrows(enabledService(), outsideRequestScope()).resolveRules();
+
+            assertThat(rules.isEmpty()).isFalse();
+            assertThat(rules.apply("mail john.doe@example.com")).isEqualTo("mail [EMAIL]");
+        }
+
+        @Test
+        @DisplayName("with the feature off the fallback is never reached, so a stream costs nothing")
+        void withTheFeatureOffTheFallbackIsNeverReached() {
+            // The provider would throw if it were consulted at all; that it is not is the guarantee.
+            var streamer = streamerWhoseContextThrows(RedactionService.disabled(), outsideRequestScope());
+
+            assertThat(streamer.resolveRules().isEmpty()).isTrue();
+        }
+
+        @Test
+        @DisplayName("a ProvisionException that is not a missing scope propagates instead of masking a defect")
+        void aProvisionExceptionThatIsNotAMissingScopePropagates() {
+            // The reason the catch inspects the cause: a provider bug or a fault in isRedactResponse() answered
+            // with the unknown-caller policy would come back as a successful redacted stream, hiding it.
+            var failure = new ProvisionException("Unable to provision", new IllegalStateException("provider bug"));
+
+            assertThatThrownBy(() -> streamerWhoseContextThrows(enabledService(), failure).resolveRules())
+                    .isSameAs(failure);
+        }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/StreamerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/StreamerTest.java
@@ -1,0 +1,70 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.infrastructure.redaction.JsonNodeRedactor;
+import com.comet.opik.infrastructure.redaction.RedactionRule;
+import com.comet.opik.infrastructure.redaction.RedactionRules;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Streamer")
+class StreamerTest {
+
+    private static final String STORED = "{\"prompt\":\"refund for john.doe@example.com\"}";
+
+    private static final RedactionRules RULES = new RedactionRules(List.of(
+            RedactionRule.of("(?<![\\w.+-])[\\w.+-]+@[\\w-]+\\.[\\w.]+", "[EMAIL]")));
+
+    private static Trace traceWith(com.fasterxml.jackson.databind.JsonNode input) {
+        return Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("project")
+                .name("trace")
+                .input(input)
+                .build();
+    }
+
+    @Test
+    @DisplayName("a streamed DTO is not copied, because conversion already built a tree of its own")
+    void aStreamedDtoIsNotCopied() {
+        var trace = traceWith(JsonUtils.getJsonNodeFromString(STORED));
+
+        var tree = JsonUtils.readTree(trace);
+
+        assertThat(Streamer.copyIfShared(tree, trace)).isSameAs(tree);
+    }
+
+    @Test
+    @DisplayName("an item that is itself a tree is copied, since rewriting it in place would rewrite the item")
+    void anItemThatIsItselfATreeIsCopied() {
+        var node = JsonUtils.getJsonNodeFromString(STORED);
+
+        var copy = Streamer.copyIfShared(node, node);
+
+        assertThat(copy).isNotSameAs(node).isEqualTo(node);
+    }
+
+    @Test
+    @DisplayName("rewriting the streamed tree in place leaves the item it was built from untouched")
+    void rewritingTheStreamedTreeLeavesTheItemUntouched() {
+        // What the dropped deepCopy was guarding against. convertValue serializes the item into a TokenBuffer
+        // and reads it back, so no node is shared - including the JsonNode the DTO carries, which is the one
+        // that would have been rewritten under the item's feet.
+        var stored = JsonUtils.getJsonNodeFromString(STORED);
+        var trace = traceWith(stored);
+
+        var tree = JsonUtils.readTree(trace);
+        assertThat(tree.get("input")).isNotSameAs(stored);
+
+        JsonNodeRedactor.redact(Streamer.copyIfShared(tree, trace), RULES, Trace.class);
+
+        assertThat(tree.get("input").toString()).contains("[EMAIL]");
+        assertThat(trace.input().toString()).isEqualTo(stored.toString()).contains("john.doe@example.com");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/RedactionConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/RedactionConfigTest.java
@@ -1,15 +1,26 @@
 package com.comet.opik.infrastructure;
 
+import com.comet.opik.infrastructure.redaction.RedactionService;
 import io.dropwizard.jersey.validation.Validators;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.UncheckedIOException;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Redaction Config Validation Test")
 class RedactionConfigTest {
+
+    private static final String EMPTY_WHEN_ENABLED = "redaction.rules must not be empty when redaction.enabled=true";
 
     private static final String ONE_RULE = """
             [{"regex":"(?<![\\\\w.+-])[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+","replace":"[EMAIL]"}]""";
@@ -29,16 +40,20 @@ class RedactionConfigTest {
         assertThat(validator.validate(config(false, "[]"))).isEmpty();
     }
 
-    @Test
+    @ParameterizedTest(name = "rules={0}")
+    @MethodSource
     @DisplayName("enabled with no rules fails startup rather than masking nothing while appearing to be on")
-    void enabledWithNoRulesFailsStartup() {
+    void enabledWithNoRulesFailsStartup(String rules) {
         // The contract config.yml documents. Asserted here because the two have disagreed: the key's own
-        // comment also claimed [] was a no-op when enabled, which this rejects.
-        assertThat(validator.validate(config(true, "[]")))
+        // comment also claimed [] was a no-op when enabled, which this rejects. Pinned to the message rather
+        // than isNotEmpty(), which would also pass on an unrelated constraint and prove nothing about this one.
+        assertThat(validator.validate(config(true, rules)))
                 .extracting(ConstraintViolation::getMessage)
-                .containsExactly("redaction.rules must not be empty when redaction.enabled=true");
+                .containsExactly(EMPTY_WHEN_ENABLED);
+    }
 
-        assertThat(validator.validate(config(true, "  "))).isNotEmpty();
+    static Stream<String> enabledWithNoRulesFailsStartup() {
+        return Stream.of("[]", "  ", "");
     }
 
     @Test
@@ -51,12 +66,37 @@ class RedactionConfigTest {
         assertThat(config.compile().apply("mail john.doe@example.com now")).isEqualTo("mail [EMAIL] now");
     }
 
-    @Test
-    @DisplayName("a malformed rule set is left for startup to report, not turned into a validation message")
-    void aMalformedRuleSetIsLeftForStartup() {
+    @ParameterizedTest(name = "{0}")
+    @MethodSource
+    @DisplayName("a malformed rule set validates clean and is reported by startup instead")
+    void aMalformedRuleSetIsLeftForStartupToReport(String label, String rules,
+            Class<? extends Throwable> expected, String messageFragment) {
+
+        var config = config(true, rules);
+
         // The validator must not throw: Hibernate Validator reports that as "HV000090: Unable to access
-        // isConfiguredWhenEnabled" with the cause discarded, hiding the real error.
-        assertThat(validator.validate(config(true, "not json"))).isEmpty();
-        assertThat(validator.validate(config(true, "[{\"replace\":\"[X]\"}]"))).isEmpty();
+        // isConfiguredWhenEnabled" with the cause discarded, which is less use than the message below.
+        assertThat(validator.validate(config)).isEmpty();
+
+        // And startup must actually report it, asserted through the constructor that runs at startup - that
+        // half was previously only claimed in a comment.
+        assertThatThrownBy(() -> new RedactionService(config))
+                .isInstanceOf(expected)
+                .hasMessageContaining(messageFragment);
+    }
+
+    static Stream<Arguments> aMalformedRuleSetIsLeftForStartupToReport() {
+        return Stream.of(
+                Arguments.of("not json at all", "not json",
+                        UncheckedIOException.class, "Unrecognized token"),
+                Arguments.of("a rule with no regex", "[{\"replace\":\"[X]\"}]",
+                        IllegalArgumentException.class, "redaction.rules[0].regex must not be blank"),
+                Arguments.of("a rule whose regex is blank", "[{\"regex\":\"\",\"replace\":\"[X]\"}]",
+                        IllegalArgumentException.class, "redaction.rules[0].regex must not be blank"),
+                Arguments.of("a second rule whose regex is blank, named by its index",
+                        "[{\"regex\":\"a\"},{\"regex\":\" \"}]",
+                        IllegalArgumentException.class, "redaction.rules[1].regex must not be blank"),
+                Arguments.of("a pattern that will not compile", "[{\"regex\":\"[unclosed\",\"replace\":\"[X]\"}]",
+                        PatternSyntaxException.class, "Unclosed character class"));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/RedactionConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/RedactionConfigTest.java
@@ -1,0 +1,62 @@
+package com.comet.opik.infrastructure;
+
+import io.dropwizard.jersey.validation.Validators;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Redaction Config Validation Test")
+class RedactionConfigTest {
+
+    private static final String ONE_RULE = """
+            [{"regex":"(?<![\\\\w.+-])[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+","replace":"[EMAIL]"}]""";
+
+    private final Validator validator = Validators.newValidator();
+
+    private static RedactionConfig config(boolean enabled, String rules) {
+        var config = new RedactionConfig();
+        config.setEnabled(enabled);
+        config.setRules(rules);
+        return config;
+    }
+
+    @Test
+    @DisplayName("the shipped defaults pass, since an empty set is only meaningful while the feature is off")
+    void theShippedDefaultsPass() {
+        assertThat(validator.validate(config(false, "[]"))).isEmpty();
+    }
+
+    @Test
+    @DisplayName("enabled with no rules fails startup rather than masking nothing while appearing to be on")
+    void enabledWithNoRulesFailsStartup() {
+        // The contract config.yml documents. Asserted here because the two have disagreed: the key's own
+        // comment also claimed [] was a no-op when enabled, which this rejects.
+        assertThat(validator.validate(config(true, "[]")))
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("redaction.rules must not be empty when redaction.enabled=true");
+
+        assertThat(validator.validate(config(true, "  "))).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("enabled with a rule passes and compiles to that rule")
+    void enabledWithARulePasses() {
+        var config = config(true, ONE_RULE);
+
+        assertThat(validator.validate(config)).isEmpty();
+        assertThat(config.compile().rules()).hasSize(1);
+        assertThat(config.compile().apply("mail john.doe@example.com now")).isEqualTo("mail [EMAIL] now");
+    }
+
+    @Test
+    @DisplayName("a malformed rule set is left for startup to report, not turned into a validation message")
+    void aMalformedRuleSetIsLeftForStartup() {
+        // The validator must not throw: Hibernate Validator reports that as "HV000090: Unable to access
+        // isConfiguredWhenEnabled" with the cause discarded, hiding the real error.
+        assertThat(validator.validate(config(true, "not json"))).isEmpty();
+        assertThat(validator.validate(config(true, "[{\"replace\":\"[X]\"}]"))).isEmpty();
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
@@ -276,7 +276,7 @@ public class AuthCredentialsCacheServiceTest {
         String workspaceName = getRandomId();
 
         // Without this round-trip the permissions are lost on every cache hit, so a caller holding
-        // trace_original_data_view would be treated as unpermitted for the length of the cache TTL.
+        // original_data_view would be treated as unpermitted for the length of the cache TTL.
         cacheService.cache(apiKey, workspaceName, List.of(),
                 CacheService.AuthCredentials.builder()
                         .userName(getRandomId()).workspaceId(getRandomId())
@@ -293,8 +293,8 @@ public class AuthCredentialsCacheServiceTest {
         return Stream.of(
                 arguments(named("null permissions", null)),
                 arguments(named("no permissions", List.of())),
-                arguments(named("the original-data permission", List.of("trace_original_data_view"))),
+                arguments(named("the original-data permission", List.of("original_data_view"))),
                 arguments(named("several permissions",
-                        List.of("trace_original_data_view", "project_data_view", "dataset_view"))));
+                        List.of("original_data_view", "project_data_view", "dataset_view"))));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthCredentialsCacheServiceTest.java
@@ -249,6 +249,9 @@ public class AuthCredentialsCacheServiceTest {
                 .workspaceId(workspaceId)
                 .workspaceName(workspaceName)
                 .quotas(List.of())
+                // A record written before permissions were cached has no such field, and reads back as none
+                // held — the same answer an unpermitted caller gets, so a stale entry withholds, never grants.
+                .permissions(List.of())
                 .build();
         assertThat(resolved).contains(expected);
     }
@@ -264,5 +267,34 @@ public class AuthCredentialsCacheServiceTest {
 
     private String getRandomId() {
         return RandomStringUtils.secure().nextAlphanumeric(32);
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void cacheAndRetrievePermissions(List<String> permissions) {
+        String apiKey = getRandomId();
+        String workspaceName = getRandomId();
+
+        // Without this round-trip the permissions are lost on every cache hit, so a caller holding
+        // trace_original_data_view would be treated as unpermitted for the length of the cache TTL.
+        cacheService.cache(apiKey, workspaceName, List.of(),
+                CacheService.AuthCredentials.builder()
+                        .userName(getRandomId()).workspaceId(getRandomId())
+                        .workspaceName(getRandomId()).permissions(permissions).build());
+
+        Optional<CacheService.AuthCredentials> credentials = cacheService
+                .resolveApiKeyUserAndWorkspaceIdFromCache(apiKey, workspaceName, List.of());
+
+        assertThat(credentials).isPresent();
+        assertThat(credentials.get().permissions()).isEqualTo(ListUtils.emptyIfNull(permissions));
+    }
+
+    Stream<Arguments> cacheAndRetrievePermissions() {
+        return Stream.of(
+                arguments(named("null permissions", null)),
+                arguments(named("no permissions", List.of())),
+                arguments(named("the original-data permission", List.of("trace_original_data_view"))),
+                arguments(named("several permissions",
+                        List.of("trace_original_data_view", "project_data_view", "dataset_view"))));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.co.jemos.podam.api.PodamFactory;
 
@@ -58,6 +59,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -732,15 +734,79 @@ class RemoteAuthServiceTest {
         return paramMap;
     }
 
-    @Test
-    void authRequestAsksForPermissionsOnlyWhenRedactionIsEnabled() {
-        // Resolving permissions costs the platform an extra read on the path every Opik request takes, so a
-        // deployment with redaction off must send exactly the payload it sent before the feature existed.
-        var off = RemoteAuthService.AuthRequest.builder()
-                .workspaceName("ws").path("/v1/private/traces").includePermissions(false).build();
-        var on = off.toBuilder().includePermissions(true).build();
+    /**
+     * Every path that produces credentials must ask for permissions when redaction is on. Dropping the flag
+     * from one of them would redact administrators on that path alone — the failure the session-cookie route
+     * already produced once — while the other paths kept working and the suite stayed green.
+     * <p>
+     * Asserted against the bytes WireMock actually received, not against a mapper chosen here: the outbound
+     * client is built with its own camelCase mapper, so serializing by hand in the test would prove nothing
+     * about the field name the platform binds.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/opik/auth", "/opik/auth-session", "/opik/auth-by-username"})
+    void authRequestAsksForPermissionsOnEveryPath_whenRedactionIsEnabled(String emPath)
+            throws JsonProcessingException {
+        authenticateVia(emPath, serviceRequestingPermissions(true));
 
-        assertThat(JsonUtils.writeValueAsString(off)).doesNotContain("permissions");
-        assertThat(JsonUtils.writeValueAsString(on)).contains("include_permissions");
+        // The field name is asserted as the platform sees it: LlmAuthRequest binds includePermissions,
+        // so a rename here silently stops permissions resolving and everyone reads redacted content.
+        var body = OBJECT_MAPPER.readTree(requestBodySentTo(emPath));
+        assertThat(body.has("includePermissions")).isTrue();
+        assertThat(body.get("includePermissions").asBoolean()).isTrue();
+    }
+
+    /**
+     * With redaction off the payload must be exactly what it was before this feature existed, so the platform
+     * skips the permission lookup and older platforms see nothing new.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"/opik/auth", "/opik/auth-session", "/opik/auth-by-username"})
+    void authRequestOmitsThePermissionsFlagEntirely_whenRedactionIsDisabled(String emPath)
+            throws JsonProcessingException {
+        authenticateVia(emPath, serviceRequestingPermissions(false));
+
+        // Asserted on the parsed field, not the raw text: absent is the requirement, and a substring
+        // check would pass just as happily for a payload carrying the flag explicitly as false.
+        assertThat(OBJECT_MAPPER.readTree(requestBodySentTo(emPath)).has("includePermissions")).isFalse();
+    }
+
+    private RemoteAuthService serviceRequestingPermissions(boolean includePermissions) {
+        return new RemoteAuthService(TestHttpClientUtils.client(),
+                new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
+                () -> requestContext,
+                new NoopCacheService(), includePermissions);
+    }
+
+    /** Drives the entry point that reaches {@code emPath}, so the flag is observed on a real request. */
+    private void authenticateVia(String emPath, RemoteAuthService service) throws JsonProcessingException {
+        var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class);
+        WIRE_MOCK.server().stubFor(post(emPath)
+                .willReturn(okJson(OBJECT_MAPPER.writeValueAsString(authResponse))));
+
+        var contextInfo = ContextInfoHolder.builder()
+                .uriInfo(createMockUriInfo("/priv/something"))
+                .method("GET")
+                .build();
+        var workspaceName = "workspace-" + UUID.randomUUID();
+
+        switch (emPath) {
+            case "/opik/auth" -> service.authenticate(
+                    getHeadersMock(workspaceName, "apiKey-" + UUID.randomUUID()), null, contextInfo);
+            case "/opik/auth-session" -> service.authenticate(
+                    getHeadersMock(workspaceName, ""), sessionCookie("session-" + UUID.randomUUID()),
+                    contextInfo);
+            case "/opik/auth-by-username" -> service.authorizeOAuth(ValidatedToken.builder()
+                    .userName("oauth-user-" + UUID.randomUUID())
+                    .workspaceName(workspaceName)
+                    .build(), contextInfo);
+            default -> throw new IllegalArgumentException("Unhandled auth path: " + emPath);
+        }
+    }
+
+    private String requestBodySentTo(String emPath) {
+        var requests = WIRE_MOCK.server().findAll(postRequestedFor(urlPathEqualTo(emPath)));
+        assertThat(requests).as("a request should have reached %s", emPath).hasSize(1);
+        return requests.getFirst().getBodyAsString();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -766,7 +766,7 @@ class RemoteAuthServiceTest {
         // And the granted permission reaches the context, so the assertion covers the decision and not just
         // the call: an endpoint answered but parsed wrong would still leave the caller unprivileged.
         assertThat(requestContext.getPermissions())
-                .containsExactly(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+                .containsExactly(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue());
     }
 
     static Stream<Arguments> permissionsAreResolvedOnEveryPath_whenRedactionIsEnabled() {
@@ -836,7 +836,7 @@ class RemoteAuthServiceTest {
                 .userName("user")
                 .workspaceName("workspace")
                 .permissions(List.of(new WorkspaceUserPermissions.Permission(
-                        WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue(), "true")))
+                        WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue(), "true")))
                 .build();
         Stream.of("/opik/workspace-permissions", "/opik/workspace-permissions-session",
                 "/opik/workspace-permissions-by-username")

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -89,7 +89,7 @@ class RemoteAuthServiceTest {
         remoteAuthService = new RemoteAuthService(client,
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                new NoopCacheService());
+                new NoopCacheService(), false);
     }
 
     @AfterAll
@@ -185,7 +185,7 @@ class RemoteAuthServiceTest {
         var cachingService = new RemoteAuthService(TestHttpClientUtils.client(),
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                mockCache);
+                mockCache, false);
         var contextInfo = ContextInfoHolder.builder()
                 .uriInfo(createMockUriInfo("/priv/something"))
                 .method("GET")
@@ -271,7 +271,7 @@ class RemoteAuthServiceTest {
         var gzipEnabledAuthService = new RemoteAuthService(newGzipEnabledClient(),
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                new NoopCacheService());
+                new NoopCacheService(), false);
 
         gzipEnabledAuthService.authenticate(
                 getHeadersMock(workspaceName, apiKey), null,
@@ -730,5 +730,17 @@ class RemoteAuthServiceTest {
         }
 
         return paramMap;
+    }
+
+    @Test
+    void authRequestAsksForPermissionsOnlyWhenRedactionIsEnabled() {
+        // Resolving permissions costs the platform an extra read on the path every Opik request takes, so a
+        // deployment with redaction off must send exactly the payload it sent before the feature existed.
+        var off = RemoteAuthService.AuthRequest.builder()
+                .workspaceName("ws").path("/v1/private/traces").includePermissions(false).build();
+        var on = off.toBuilder().includePermissions(true).build();
+
+        assertThat(JsonUtils.writeValueAsString(off)).doesNotContain("permissions");
+        assertThat(JsonUtils.writeValueAsString(on)).contains("include_permissions");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -3,8 +3,10 @@ package com.comet.opik.infrastructure.auth;
 import com.codahale.metrics.MetricRegistry;
 import com.comet.opik.TestConfigUtils;
 import com.comet.opik.api.ReactServiceErrorResponse;
+import com.comet.opik.api.WorkspaceUserPermissions;
 import com.comet.opik.api.resources.utils.TestHttpClientUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.domain.RemoteWorkspacePermissionsService;
 import com.comet.opik.domain.mcpoauth.ValidatedToken;
 import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.http.HttpModule;
@@ -31,12 +33,12 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.net.URI;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -91,7 +93,10 @@ class RemoteAuthServiceTest {
         remoteAuthService = new RemoteAuthService(client,
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                new NoopCacheService(), false);
+                new NoopCacheService(),
+                new RemoteWorkspacePermissionsService(client,
+                        new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url(""))),
+                false);
     }
 
     @AfterAll
@@ -187,7 +192,10 @@ class RemoteAuthServiceTest {
         var cachingService = new RemoteAuthService(TestHttpClientUtils.client(),
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                mockCache, false);
+                mockCache,
+                new RemoteWorkspacePermissionsService(TestHttpClientUtils.client(),
+                        new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url(""))),
+                false);
         var contextInfo = ContextInfoHolder.builder()
                 .uriInfo(createMockUriInfo("/priv/something"))
                 .method("GET")
@@ -273,7 +281,10 @@ class RemoteAuthServiceTest {
         var gzipEnabledAuthService = new RemoteAuthService(newGzipEnabledClient(),
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                new NoopCacheService(), false);
+                new NoopCacheService(),
+                new RemoteWorkspacePermissionsService(TestHttpClientUtils.client(),
+                        new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url(""))),
+                false);
 
         gzipEnabledAuthService.authenticate(
                 getHeadersMock(workspaceName, apiKey), null,
@@ -735,54 +746,102 @@ class RemoteAuthServiceTest {
     }
 
     /**
-     * Every path that produces credentials must ask for permissions when redaction is on. Dropping the flag
-     * from one of them would redact administrators on that path alone — the failure the session-cookie route
-     * already produced once — while the other paths kept working and the suite stayed green.
+     * Every path that produces credentials must resolve permissions when redaction is on. Dropping it from one
+     * of them would redact administrators on that path alone - the failure the session-cookie route already
+     * produced once - while the other paths kept working and the suite stayed green.
      * <p>
-     * Asserted against the bytes WireMock actually received, not against a mapper chosen here: the outbound
-     * client is built with its own camelCase mapper, so serializing by hand in the test would prove nothing
-     * about the field name the platform binds.
+     * The answer is read from the workspace permissions API, one endpoint per credential type, rather than off
+     * the authentication response: what a caller may see is data about the caller, not a by-product of whether
+     * it could be authenticated.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"/opik/auth", "/opik/auth-session", "/opik/auth-by-username"})
-    void authRequestAsksForPermissionsOnEveryPath_whenRedactionIsEnabled(String emPath)
-            throws JsonProcessingException {
-        authenticateVia(emPath, serviceRequestingPermissions(true));
+    @MethodSource
+    void permissionsAreResolvedOnEveryPath_whenRedactionIsEnabled(String emPath, String permissionsPath) {
+        authenticateVia(emPath, serviceResolvingPermissions(true));
 
-        // The field name is asserted as the platform sees it: LlmAuthRequest binds includePermissions,
-        // so a rename here silently stops permissions resolving and everyone reads redacted content.
-        var body = OBJECT_MAPPER.readTree(requestBodySentTo(emPath));
-        assertThat(body.has("includePermissions")).isTrue();
-        assertThat(body.get("includePermissions").asBoolean()).isTrue();
+        assertThat(WIRE_MOCK.server().findAll(postRequestedFor(urlPathEqualTo(permissionsPath))))
+                .as("%s should resolve permissions through %s", emPath, permissionsPath)
+                .hasSize(1);
+
+        // And the granted permission reaches the context, so the assertion covers the decision and not just
+        // the call: an endpoint answered but parsed wrong would still leave the caller unprivileged.
+        assertThat(requestContext.getPermissions())
+                .containsExactly(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue());
+    }
+
+    static Stream<Arguments> permissionsAreResolvedOnEveryPath_whenRedactionIsEnabled() {
+        return Stream.of(
+                Arguments.of("/opik/auth", "/opik/workspace-permissions"),
+                Arguments.of("/opik/auth-session", "/opik/workspace-permissions-session"),
+                Arguments.of("/opik/auth-by-username", "/opik/workspace-permissions-by-username"));
     }
 
     /**
-     * With redaction off the payload must be exactly what it was before this feature existed, so the platform
-     * skips the permission lookup and older platforms see nothing new.
+     * With redaction off the platform must see exactly the traffic it saw before this feature existed: the
+     * same authentication payload, and no permission lookup at all. That is what makes the toggle safe to
+     * ship, and what lets an older platform run against this build unchanged.
      */
     @ParameterizedTest
-    @ValueSource(strings = {"/opik/auth", "/opik/auth-session", "/opik/auth-by-username"})
-    void authRequestOmitsThePermissionsFlagEntirely_whenRedactionIsDisabled(String emPath)
+    @MethodSource("permissionsAreResolvedOnEveryPath_whenRedactionIsEnabled")
+    void noPermissionTrafficAtAll_whenRedactionIsDisabled(String emPath, String permissionsPath)
             throws JsonProcessingException {
-        authenticateVia(emPath, serviceRequestingPermissions(false));
+        authenticateVia(emPath, serviceResolvingPermissions(false));
 
-        // Asserted on the parsed field, not the raw text: absent is the requirement, and a substring
-        // check would pass just as happily for a payload carrying the flag explicitly as false.
-        assertThat(OBJECT_MAPPER.readTree(requestBodySentTo(emPath)).has("includePermissions")).isFalse();
+        assertThat(WIRE_MOCK.server().findAll(postRequestedFor(urlPathEqualTo(permissionsPath))))
+                .as("%s must not resolve permissions while the feature is off", emPath)
+                .isEmpty();
+
+        // Asserted on the parsed fields, not the raw text: the requirement is that nothing was added to the
+        // authentication request, and a substring check would pass for a payload carrying a new field as false.
+        assertThat(OBJECT_MAPPER.readTree(requestBodySentTo(emPath)).fieldNames())
+                .toIterable()
+                .containsOnly("workspaceName", "path");
     }
 
-    private RemoteAuthService serviceRequestingPermissions(boolean includePermissions) {
+    /**
+     * A platform that predates the session and OAuth permission endpoints. The caller is left unprivileged,
+     * which redacts, rather than the request failing: rolling the platform back must not take the API down.
+     */
+    @Test
+    void anOlderPlatformLeavesTheCallerUnprivileged() {
+        // Higher priority than the granted stub authenticateVia registers, which would otherwise win by
+        // being registered later.
+        WIRE_MOCK.server().stubFor(post(urlPathEqualTo("/opik/workspace-permissions-session"))
+                .atPriority(1)
+                .willReturn(aResponse().withStatus(404)));
+
+        authenticateVia("/opik/auth-session", serviceResolvingPermissions(true));
+
+        assertThat(requestContext.getPermissions()).isEmpty();
+    }
+
+    private RemoteAuthService serviceResolvingPermissions(boolean resolvePermissions) {
         return new RemoteAuthService(TestHttpClientUtils.client(),
                 new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url("")),
                 () -> requestContext,
-                new NoopCacheService(), includePermissions);
+                new NoopCacheService(),
+                new RemoteWorkspacePermissionsService(TestHttpClientUtils.client(),
+                        new AuthenticationConfig.UrlConfig(WIRE_MOCK.server().url(""))),
+                resolvePermissions);
     }
 
-    /** Drives the entry point that reaches {@code emPath}, so the flag is observed on a real request. */
-    private void authenticateVia(String emPath, RemoteAuthService service) throws JsonProcessingException {
+    private void authenticateVia(String emPath, RemoteAuthService service) {
         var authResponse = podamFactory.manufacturePojo(RemoteAuthService.AuthResponse.class);
         WIRE_MOCK.server().stubFor(post(emPath)
-                .willReturn(okJson(OBJECT_MAPPER.writeValueAsString(authResponse))));
+                .willReturn(okJson(writeJson(authResponse))));
+
+        // Granted, so a path that resolves permissions correctly ends up privileged and one that skips the
+        // lookup ends up masked - the two outcomes the tests above tell apart.
+        var granted = WorkspaceUserPermissions.builder()
+                .userName("user")
+                .workspaceName("workspace")
+                .permissions(List.of(new WorkspaceUserPermissions.Permission(
+                        WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue(), "true")))
+                .build();
+        Stream.of("/opik/workspace-permissions", "/opik/workspace-permissions-session",
+                "/opik/workspace-permissions-by-username")
+                .forEach(path -> WIRE_MOCK.server().stubFor(post(urlPathEqualTo(path))
+                        .willReturn(okJson(writeJson(granted)))));
 
         var contextInfo = ContextInfoHolder.builder()
                 .uriInfo(createMockUriInfo("/priv/something"))
@@ -801,6 +860,14 @@ class RemoteAuthServiceTest {
                     .workspaceName(workspaceName)
                     .build(), contextInfo);
             default -> throw new IllegalArgumentException("Unhandled auth path: " + emPath);
+        }
+    }
+
+    private static String writeJson(Object value) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException(exception);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/JsonNodeRedactorTest.java
@@ -1,0 +1,64 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.api.Experiment;
+import com.comet.opik.api.Trace;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Json Node Redactor Test")
+class JsonNodeRedactorTest {
+
+    /** Matches the shape of a prompt commit, so the tree below is rewritten wherever it is not exempt. */
+    private static final RedactionRules RULES = new RedactionRules(List.of(
+            RedactionRule.of("\\b[0-9a-f]{8}\\b", "[HEX]")));
+
+    private static String redact(String json, Class<?> itemType) {
+        return JsonNodeRedactor.redact(JsonUtils.getJsonNodeFromString(json), RULES, itemType).toString();
+    }
+
+    @Test
+    @DisplayName("an exempt property at the item's own level survives")
+    void anExemptPropertyAtTheItemsOwnLevelSurvives() {
+        var redacted = redact("{\"thread_id\":\"a1b2c3d4\",\"name\":\"a1b2c3d4\"}", Trace.class);
+
+        assertThat(redacted).contains("\"thread_id\":\"a1b2c3d4\"");
+        // Trace.name is free text the caller writes per call, so it is not exempt - asserted so this test says
+        // the exemption is per property and not "the top level is skipped".
+        assertThat(redacted).contains("\"name\":\"[HEX]\"");
+    }
+
+    @Test
+    @DisplayName("a caller-chosen map key that happens to match an exempt name is still redacted")
+    void aCallerChosenMapKeyMatchingAnExemptNameIsStillRedacted() {
+        // The property this walk cannot distinguish from a declared one, and the reason exemptions stop at the
+        // item's own level: metadata is caller content, so an entry named thread_id or id must not buy itself an
+        // exemption. Under-exempting is recoverable; this would be a leak.
+        var redacted = redact("{\"metadata\":{\"thread_id\":\"a1b2c3d4\",\"id\":\"a1b2c3d4\"}}", Trace.class);
+
+        assertThat(redacted).doesNotContain("a1b2c3d4");
+        assertThat(redacted).contains("[HEX]");
+    }
+
+    @Test
+    @DisplayName("a nested DTO's exempt property is rewritten, which the paged path does not do")
+    void aNestedDtosExemptPropertyIsRewritten() {
+        // A known divergence between the two representations of one experiment, pinned rather than left
+        // undescribed: BeanSerializerModifier.changeProperties runs for every bean in the graph, so the paged
+        // read exempts PromptVersionLink.commit while the stream rewrites it.
+        //
+        // Closing it needs per-level type information the walk does not have, and approximating it by applying
+        // the names at every depth is the leak asserted above. The follow-up that masks by field name instead
+        // of exempting by it removes the exemption list altogether, and this assertion is what will flip when
+        // it does.
+        var redacted = redact("{\"id\":\"a1b2c3d4\",\"prompt_versions\":[{\"commit\":\"a1b2c3d4\"}]}",
+                Experiment.class);
+
+        assertThat(redacted).contains("\"id\":\"a1b2c3d4\"");
+        assertThat(redacted).contains("\"commit\":\"[HEX]\"");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
@@ -168,6 +168,18 @@ class MatchBudgetTest {
     }
 
     @Test
+    @DisplayName("a rule set does not change when the list it was built from does")
+    void aRuleSetDoesNotChangeWhenTheListItWasBuiltFromDoes() {
+        var mutable = new java.util.ArrayList<>(List.of(RedactionRule.of("secret", "[GONE]")));
+        var compiled = new RedactionRules(mutable);
+
+        mutable.clear();
+
+        assertThat(compiled.isEmpty()).isFalse();
+        assertThat(compiled.apply("a secret value")).isEqualTo("a [GONE] value");
+    }
+
+    @Test
     @DisplayName("a replacement is emitted literally, not with its own escaping visible")
     void aReplacementIsEmittedLiterally() {
         // Matcher.quoteReplacement escapes $ and \ for appendReplacement to undo. Appending the quoted form

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
@@ -118,6 +118,56 @@ class MatchBudgetTest {
     }
 
     @Test
+    @DisplayName("a replacement longer than what it replaces cannot multiply the response")
+    void aLongReplacementCannotMultiplyTheResponse() {
+        // Unbounded this returns a string ten times the length of its input, and the input is a caller's own
+        // content up to jacksonConfig.maxStringLength - 100 MB in, a gigabyte out.
+        var amplifying = new RedactionRules(List.of(RedactionRule.of("[0-9]", "[REDACTED]")));
+        var digits = "0123456789".repeat(20_000);
+
+        var masked = amplifying.apply(digits);
+
+        assertThat(masked).isEqualTo("[REDACTED]");
+        assertThat(masked.length()).isLessThan(digits.length());
+    }
+
+    @Test
+    @DisplayName("chained rules cannot compound the growth between them")
+    void chainedRulesCannotCompoundTheGrowth() {
+        // Ten times, then ten times again: bounding each rule against its own input would allow the product.
+        var chained = new RedactionRules(List.of(
+                RedactionRule.of("[0-9]", "0000000000"),
+                RedactionRule.of("0", "1111111111")));
+        var digits = "0123456789".repeat(20_000);
+
+        assertThat(chained.apply(digits)).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    @DisplayName("a token longer than the value it masks is still emitted")
+    void aTokenLongerThanTheValueItMasksIsStillEmitted() {
+        // The ordinary shape of an expanding rule, and the reason for the floor: growth measured as a factor
+        // alone would refuse to replace a short match with a long token.
+        var expanding = new RedactionRules(List.of(
+                RedactionRule.of("\\b\\d{3}-\\d{3}-\\d{4}\\b", "[PHONE_NUMBER_REDACTED_FOR_THIS_READER]")));
+
+        assertThat(expanding.apply("555-123-4567"))
+                .isEqualTo("[PHONE_NUMBER_REDACTED_FOR_THIS_READER]");
+    }
+
+    @Test
+    @DisplayName("a large value whose rewrite stays within the bound is rewritten, not masked")
+    void aLargeValueWithinTheBoundIsRewritten() {
+        var expanding = new RedactionRules(List.of(RedactionRule.of("secret", "[REDACTED]")));
+        var stored = "the secret is in here somewhere among other words ".repeat(20_000);
+
+        var rewritten = expanding.apply(stored);
+
+        assertThat(rewritten).doesNotContain("secret").contains("[REDACTED]");
+        assertThat(rewritten.length()).isGreaterThan(stored.length());
+    }
+
+    @Test
     @DisplayName("a replacement is emitted literally, not with its own escaping visible")
     void aReplacementIsEmittedLiterally() {
         // Matcher.quoteReplacement escapes $ and \ for appendReplacement to undo. Appending the quoted form

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
@@ -97,6 +97,27 @@ class MatchBudgetTest {
     }
 
     @Test
+    @DisplayName("the budget is bounded above as well as below, so the largest value cannot buy 20s of CPU")
+    void theBudgetIsBoundedAboveAsWellAsBelow() {
+        // 100 accesses per character is unbounded in the one variable a caller controls: at the 100 MB
+        // jacksonConfig.maxStringLength permits, it is 10.5 billion accesses, ~20s on a request thread.
+        int maxStringLength = 104_857_600;
+
+        assertThat(MatchBudget.limitFor(maxStringLength)).isEqualTo(1_000_000_000L);
+        // Still generous where it binds: ~9.5 accesses per character at that size, against the 1.0-3.2 a
+        // legitimate anchored rule was measured to use.
+        assertThat((double) MatchBudget.limitFor(maxStringLength) / maxStringLength).isGreaterThan(9.0);
+    }
+
+    @Test
+    @DisplayName("the ceiling does not bind on the values the scaled allowance was written for")
+    void theCeilingDoesNotBindOnOrdinaryValues() {
+        assertThat(MatchBudget.limitFor(0)).isEqualTo(100_000L);
+        assertThat(MatchBudget.limitFor(1_000)).isEqualTo(100_000L);
+        assertThat(MatchBudget.limitFor(5_000_000)).isEqualTo(500_000_000L);
+    }
+
+    @Test
     @DisplayName("a replacement is emitted literally, not with its own escaping visible")
     void aReplacementIsEmittedLiterally() {
         // Matcher.quoteReplacement escapes $ and \ for appendReplacement to undo. Appending the quoted form

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
@@ -84,4 +84,33 @@ class MatchBudgetTest {
 
         assertThat(chained.apply("a secret value")).isEqualTo("a [GONE] value");
     }
+
+    @Test
+    @DisplayName("a large value with no match survives, because the budget scales with its length")
+    void aLargeValueWithNoMatchSurvives() {
+        // An absolute ceiling failed closed on size alone: a linear scan of a 5 MB value costs more accesses
+        // than a fixed 2M budget allows, so legitimate content containing no match at all was destroyed.
+        var stored = "the assistant answered the question without any identifiers present. ".repeat(75_000);
+
+        assertThat(stored.length()).isGreaterThan(5_000_000);
+        assertThat(rules(ANCHORED_EMAIL).apply(stored)).isSameAs(stored);
+    }
+
+    @Test
+    @DisplayName("a replacement is emitted literally, not with its own escaping visible")
+    void aReplacementIsEmittedLiterally() {
+        // Matcher.quoteReplacement escapes $ and \ for appendReplacement to undo. Appending the quoted form
+        // directly - as the budgeted loop does - would emit the escapes themselves.
+        var backreferenceShaped = new RedactionRules(List.of(RedactionRule.of("secret", "\\1***@\\2")));
+
+        assertThat(backreferenceShaped.apply("a secret value")).isEqualTo("a \\1***@\\2 value");
+    }
+
+    @Test
+    @DisplayName("a replacement containing a dollar sign is emitted as written")
+    void aReplacementContainingADollarSignIsEmittedAsWritten() {
+        var dollars = new RedactionRules(List.of(RedactionRule.of("amount", "$$$")));
+
+        assertThat(dollars.apply("the amount here")).isEqualTo("the $$$ here");
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/MatchBudgetTest.java
@@ -1,0 +1,87 @@
+package com.comet.opik.infrastructure.redaction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Match Budget")
+class MatchBudgetTest {
+
+    /**
+     * The shape the configuration warns about: an unanchored leading quantifier over a class that can consume a
+     * whole token, so the matcher backtracks across every split of a run it can never complete a match on.
+     */
+    private static final String UNANCHORED_EMAIL = "[\\w.+-]+@[\\w.-]+\\.[a-z]{2,}";
+
+    /** Same intent, anchored - what an operator should write, and what the runaway case must not require. */
+    private static final String ANCHORED_EMAIL = "(?<![\\w.+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}";
+
+    private static RedactionRules rules(String regex) {
+        return new RedactionRules(List.of(RedactionRule.of(regex, "[EMAIL]")));
+    }
+
+    /** A run of characters the pattern can consume but never complete a match on, and with no '/' to break it. */
+    private static String unbrokenRun(int length) {
+        return "aB3_x-Yz9Q".repeat(length / 10);
+    }
+
+    @Test
+    @Timeout(value = 20, unit = TimeUnit.SECONDS)
+    @DisplayName("a runaway rule is stopped instead of running for minutes on one read")
+    void aRunawayRuleIsStopped() {
+        // Unbudgeted this is quadratic: ~1.8s at 32 KB, and jacksonConfig.maxStringLength permits 100 MB. The
+        // timeout is the assertion that matters - without the budget this method does not return.
+        var masked = rules(UNANCHORED_EMAIL).apply(unbrokenRun(1_000_000));
+
+        assertThat(masked).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    @DisplayName("aborting masks the value whole rather than returning it as stored")
+    void abortingMasksTheValueWhole() {
+        var stored = unbrokenRun(200_000);
+
+        // Fail closed: the value is the caller's own content, so whoever chooses it must not choose the outcome.
+        assertThat(rules(UNANCHORED_EMAIL).apply(stored)).doesNotContain(stored);
+    }
+
+    @Test
+    @DisplayName("an anchored rule handles the same input without coming near the budget")
+    void anAnchoredRuleHandlesTheSameInput() {
+        var stored = unbrokenRun(200_000);
+
+        // Not merely faster: it does not abort, so the operator who anchors keeps exact masking on large values.
+        assertThat(rules(ANCHORED_EMAIL).apply(stored)).isEqualTo(stored);
+    }
+
+    @Test
+    @DisplayName("ordinary values are rewritten exactly as before the budget existed")
+    void ordinaryValuesAreRewrittenExactly() {
+        var stored = "Refund for john.doe@example.com, cc jane@corp.co.uk";
+
+        assertThat(rules(ANCHORED_EMAIL).apply(stored)).isEqualTo("Refund for [EMAIL], cc [EMAIL]");
+    }
+
+    @Test
+    @DisplayName("a value with no match is returned unchanged and identical")
+    void aValueWithNoMatchIsReturnedUnchanged() {
+        var stored = "nothing sensitive in this sentence at all";
+
+        assertThat(rules(ANCHORED_EMAIL).apply(stored)).isSameAs(stored);
+    }
+
+    @Test
+    @DisplayName("rules still see the previous rule's output, so ordering behaves as documented")
+    void rulesStillSeeThePreviousRulesOutput() {
+        var chained = new RedactionRules(List.of(
+                RedactionRule.of("secret", "hidden"),
+                RedactionRule.of("hidden", "[GONE]")));
+
+        assertThat(chained.apply("a secret value")).isEqualTo("a [GONE] value");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionCoverageArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionCoverageArchTest.java
@@ -1,0 +1,46 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.domain.Streamer;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.glassfish.jersey.server.ChunkedOutput;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Architectural guard for read-time redaction coverage.
+ * <p>
+ * Redaction is applied by serializers registered on the environment's {@code ObjectMapper}, so any response
+ * Jackson writes through it is covered — including endpoints that do not exist yet. A chunked response is the
+ * one shape that escapes: its items are serialized on a scheduler thread where the writer interceptor's
+ * thread-local is not in force, which is why {@link Streamer} redacts each item explicitly. A new
+ * {@code ChunkedOutput} built anywhere else would stream stored content with no rules applied, and nothing at
+ * runtime would say so — the streamed-search leak this feature already shipped once.
+ * <p>
+ * The exclusion list is therefore the registry of known-uncovered streaming responses, and it is deliberately
+ * awkward to extend: adding a class here is a decision to leave that response unredacted.
+ */
+@AnalyzeClasses(packages = "com.comet.opik", importOptions = ImportOption.DoNotIncludeTests.class)
+class RedactionCoverageArchTest {
+
+    /**
+     * allowEmptyShould: a negative rule, so in the healthy state the should-clause matches nothing, which
+     * ArchUnit otherwise rejects. It still fails the build when a new constructor call appears.
+     */
+    @ArchTest
+    static final ArchRule chunked_responses_must_be_built_by_the_redaction_aware_streamer = noClasses()
+            .that().doNotBelongToAnyOf(Streamer.class,
+                    com.comet.opik.api.resources.v1.priv.ChatCompletionsResource.class)
+            .should().callConstructorWhere(DescribedPredicate.describe("a ChunkedOutput constructor",
+                    target -> target.getTargetOwner().isAssignableTo(ChunkedOutput.class)))
+            .because("""
+                    a chunked response is serialized off the request thread, so the writer interceptor cannot \
+                    reach it; only Streamer applies the rules explicitly. ChatCompletionsResource streams \
+                    provider text through ChunkedOutput<String> and is a known, documented gap — every other \
+                    chunked response must go through Streamer
+                    """)
+            .allowEmptyShould(true);
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionGuardTest.java
@@ -23,7 +23,7 @@ class RedactionGuardTest {
     void theRefusalNamesTheResponseAndThePermission() {
         assertThatThrownBy(() -> RedactionGuard.rejectUnmaskable(true, "Attachment download"))
                 .hasMessageContaining("Attachment download")
-                .hasMessageContaining("trace_original_data_view");
+                .hasMessageContaining("original_data_view");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionGuardTest.java
@@ -1,0 +1,47 @@
+package com.comet.opik.infrastructure.redaction;
+
+import jakarta.ws.rs.ForbiddenException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Redaction Guard")
+class RedactionGuardTest {
+
+    @Test
+    @DisplayName("a caller whose responses are masked is refused")
+    void aCallerWhoseResponsesAreMaskedIsRefused() {
+        assertThatThrownBy(() -> RedactionGuard.rejectUnmaskable(true, "Attachment download"))
+                .isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("the refusal names the response and the permission, so the caller can act on it")
+    void theRefusalNamesTheResponseAndThePermission() {
+        assertThatThrownBy(() -> RedactionGuard.rejectUnmaskable(true, "Attachment download"))
+                .hasMessageContaining("Attachment download")
+                .hasMessageContaining("trace_original_data_view");
+    }
+
+    @Test
+    @DisplayName("a caller who may see originals passes through")
+    void aCallerWhoMaySeeOriginalsPassesThrough() {
+        // Also the flag-off case: RedactionRequestFilter leaves redactResponse false when the feature is
+        // disabled, so an install with the flag off never reaches the refusal.
+        assertThatCode(() -> RedactionGuard.rejectUnmaskable(false, "Attachment download"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("the refusal is 403, not 401 or 500")
+    void theRefusalIsForbidden() {
+        var thrown = org.junit.jupiter.api.Assertions.assertThrows(ForbiddenException.class,
+                () -> RedactionGuard.rejectUnmaskable(true, "Agent Insights free-form SQL"));
+
+        // 403 rather than 401: the caller is authenticated, they simply may not read this content.
+        assertThat(thrown.getResponse().getStatus()).isEqualTo(403);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
@@ -1,0 +1,211 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class RedactionModuleTest {
+
+    private static final String EMAIL = "john.doe@example.com";
+    private static final String PHONE = "555-123-4567";
+
+    // Built from the configured mapper so the test exercises the same serialization the app uses.
+    private final ObjectMapper mapper = JsonUtils.getMapper().copy().registerModule(new RedactionModule());
+
+    private static RedactionRules rules() {
+        return new RedactionRules(List.of(
+                RedactionRule.of("(?<![\\w.+-])[\\w.+-]+@[\\w-]+\\.[\\w.]+", "[EMAIL]"),
+                RedactionRule.of("\\b\\d{3}-\\d{3}-\\d{4}\\b", "[PHONE]")));
+    }
+
+    @AfterEach
+    void tearDown() {
+        RedactionContext.clear();
+    }
+
+    @Test
+    @DisplayName("redacts strings inside a JsonNode payload, which is where trace input actually lives")
+    void redactsStringsInsideJsonNodePayload() throws Exception {
+        var trace = Trace.builder()
+                .id(UUID.randomUUID())
+                .name("refund")
+                .startTime(Instant.now())
+                .input(JsonUtils.getJsonNodeFromString(
+                        """
+                                {"prompt":"Refund for %s, call %s","attempts":3,"nested":{"cc":"%s"}}"""
+                                .formatted(EMAIL, PHONE, EMAIL)))
+                .build();
+
+        RedactionContext.set(rules());
+        String json = mapper.writeValueAsString(trace);
+
+        assertThat(json).doesNotContain(EMAIL).doesNotContain(PHONE);
+        assertThat(json).contains("[EMAIL]").contains("[PHONE]");
+        // A number is not a string, so it is never visited — the same blind spot the SDK has.
+        assertThat(json).contains("\"attempts\":3");
+    }
+
+    @Test
+    @DisplayName("redacts an ordinary String property too")
+    void redactsOrdinaryStringProperty() throws Exception {
+        var trace = Trace.builder()
+                .id(UUID.randomUUID())
+                .name("contact %s".formatted(EMAIL))
+                .startTime(Instant.now())
+                .build();
+
+        RedactionContext.set(rules());
+
+        assertThat(mapper.writeValueAsString(trace)).doesNotContain(EMAIL).contains("[EMAIL]");
+    }
+
+    @Test
+    @DisplayName("leaves property names alone")
+    void leavesPropertyNamesAlone() throws Exception {
+        RedactionContext.set(new RedactionRules(List.of(RedactionRule.of("name", "[REDACTED]"))));
+
+        var json = mapper.writeValueAsString(Trace.builder()
+                .id(UUID.randomUUID())
+                .name("kept")
+                .startTime(Instant.now())
+                .build());
+
+        assertThat(json).contains("\"name\"");
+    }
+
+    @Test
+    @DisplayName("writes values as stored when no rules are in force")
+    void writesValuesAsStoredWhenNoRules() throws Exception {
+        var trace = Trace.builder()
+                .id(UUID.randomUUID())
+                .name("contact %s".formatted(EMAIL))
+                .startTime(Instant.now())
+                .input(JsonUtils.getJsonNodeFromString("""
+                        {"prompt":"%s"}""".formatted(PHONE)))
+                .build();
+
+        // No RedactionContext.set(...) — this is what every request looks like with the feature off.
+        var json = mapper.writeValueAsString(trace);
+
+        assertThat(json).contains(EMAIL).contains(PHONE).doesNotContain("[EMAIL]");
+    }
+
+    @Test
+    @DisplayName("a payload containing $1 or a backslash is replaced literally, not as a group reference")
+    void payloadContainingReplacementSyntaxIsTreatedLiterally() throws Exception {
+        RedactionContext.set(rules());
+
+        var payload = JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(
+                java.util.Map.of("template", "$1 ${name} \\1 \\\\ literal, mail " + EMAIL)));
+
+        var written = mapper.writeValueAsString(payload);
+
+        // The surrounding syntax has to survive verbatim; only the address is rewritten.
+        assertThat(written).contains("$1").contains("${name}").contains("[EMAIL]").doesNotContain(EMAIL);
+    }
+
+    @Test
+    @DisplayName("a long unbroken token stays linear, so an unanchored rule cannot stall a response")
+    void longUnbrokenTokenStaysLinear() {
+        // A base64-style run is the realistic trigger: an unanchored local part can start at every offset,
+        // which turns a 250 KB attachment into a quadratic scan and a multi-second response.
+        var token = "QWxpY2VIb3BwZXJCYXJjbGF5c1JlY29uY2lsaWF0aW9u".repeat(6000);
+        // rules() carries the anchored local part. The unanchored form takes over 100 seconds on this input,
+        // because the match can start at every offset in the token; the anchor is what keeps it linear.
+        RedactionContext.set(rules());
+
+        assertThatCode(() -> {
+            var start = Instant.now();
+            var written = mapper.writeValueAsString(
+                    JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(
+                            java.util.Map.of("attachment", token))));
+            var elapsed = Duration.between(start, Instant.now());
+
+            assertThat(written).contains(token);
+            assertThat(elapsed).describedAs("redacting a %d char token took %s", token.length(), elapsed)
+                    .isLessThan(Duration.ofSeconds(5));
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("identifiers are written by their own serializers, so no rule can rewrite them")
+    void identifiersAreNotRewritten() throws Exception {
+        var id = UUID.randomUUID();
+        // A rule broad enough to match the hex and hyphens of a UUID, to prove ids never reach the
+        // String serializer at all rather than merely happening not to match.
+        RedactionContext.set(new RedactionRules(List.of(RedactionRule.of("[0-9a-f-]{8,}", "[REDACTED]"))));
+
+        var written = mapper.writeValueAsString(Trace.builder()
+                .id(id)
+                .projectId(UUID.randomUUID())
+                .name("refund")
+                .startTime(Instant.now())
+                .build());
+
+        assertThat(written).contains(id.toString()).doesNotContain("[REDACTED]");
+    }
+
+    @Test
+    @DisplayName("structural properties are exempt, but the same name inside content is not")
+    void structuralPropertiesAreExemptButContentIsNot() throws Exception {
+        // A rule broad enough to hit any word, so an exemption is the only thing that can spare a value.
+        RedactionContext.set(new RedactionRules(List.of(RedactionRule.of("[a-z-]{4,}", "[X]"))));
+
+        var written = mapper.writeValueAsString(Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("refund-project")
+                .threadId("thread-alpha")
+                .name("refund-trace")
+                .startTime(Instant.now())
+                .input(JsonUtils.getJsonNodeFromString("{\"projectName\":\"secret-content\"}"))
+                .build());
+
+        // Lookup keys survive so navigation keeps working...
+        assertThat(written).contains("refund-project").contains("thread-alpha");
+        // ...while an identically named key inside caller content gets no such protection.
+        assertThat(written).doesNotContain("secret-content");
+        // A non-exempt property is still redacted.
+        assertThat(written).doesNotContain("refund-trace");
+    }
+
+    @Test
+    @DisplayName("a map entry is redacted even when the caller names its key after an exempt property")
+    void mapEntryIsRedactedEvenWhenKeyMatchesAnExemptProperty() throws Exception {
+        RedactionContext.set(rules());
+
+        // Several DTOs expose Map<String, String> metadata whose keys the caller chooses. Exempting by field
+        // name alone would hand those callers an opt-out simply by naming a key "id" or "model".
+        var written = mapper.writeValueAsString(java.util.Map.of("id", EMAIL, "model", PHONE));
+
+        assertThat(written).doesNotContain(EMAIL).doesNotContain(PHONE)
+                .contains("[EMAIL]").contains("[PHONE]");
+    }
+
+    @Test
+    @DisplayName("a collection-typed structural property is exempt as a whole")
+    void collectionTypedStructuralPropertyIsExempt() throws Exception {
+        RedactionContext.set(new RedactionRules(List.of(RedactionRule.of("[a-z_]{4,}", "[X]"))));
+
+        var written = mapper.writeValueAsString(Trace.TracePage.builder()
+                .page(1)
+                .size(1)
+                .total(1)
+                .content(List.of())
+                .sortableBy(List.of("start_time", "last_updated_at"))
+                .build());
+
+        // Sort keys are what the UI sends straight back as query parameters; rewriting them breaks sorting.
+        assertThat(written).contains("start_time").contains("last_updated_at").doesNotContain("[X]");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
@@ -1,7 +1,9 @@
 package com.comet.opik.infrastructure.redaction;
 
 import com.comet.opik.api.Dataset;
+import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
+import com.comet.opik.domain.SpanType;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
@@ -178,6 +180,32 @@ class RedactionModuleTest {
         assertThat(written).doesNotContain("secret-content");
         // A non-exempt property is still redacted.
         assertThat(written).doesNotContain("refund-trace");
+    }
+
+    @Test
+    @DisplayName("caller-supplied span fields are redacted, so a name-based exemption cannot be used as a bypass")
+    void callerSuppliedSpanFieldsAreRedacted() throws Exception {
+        // model, provider and environment are set by whoever logs the span, so a caller could put anything
+        // there. Exempting them by property name would hand that value straight back to a reader who is not
+        // permitted to see stored content.
+        RedactionContext.set(new RedactionRules(
+                List.of(RedactionRule.of("(?<![\\w.+-])[\\w.+-]+@[\\w-]+\\.[\\w.]+", "[EMAIL]"))));
+
+        var written = mapper.writeValueAsString(Span.builder()
+                .id(UUID.randomUUID())
+                .traceId(UUID.randomUUID())
+                .projectName("refund-project")
+                .name("llm-call")
+                .type(SpanType.llm)
+                .startTime(Instant.now())
+                .model("alice.brown@example.com")
+                .provider("bob.jones@example.com")
+                .build());
+
+        assertThat(written).doesNotContain("alice.brown@example.com").doesNotContain("bob.jones@example.com");
+        assertThat(written).contains("[EMAIL]");
+        // The genuine lookup key is still spared.
+        assertThat(written).contains("refund-project");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.infrastructure.redaction;
 
+import com.comet.opik.api.Dataset;
 import com.comet.opik.api.Trace;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -207,5 +208,24 @@ class RedactionModuleTest {
 
         // Sort keys are what the UI sends straight back as query parameters; rewriting them breaks sorting.
         assertThat(written).contains("start_time").contains("last_updated_at").doesNotContain("[X]");
+    }
+
+    @Test
+    @DisplayName("a name that addresses an entity is exempt, while a trace name is not")
+    void nameIsExemptOnlyWhereItAddressesAnEntity() throws Exception {
+        RedactionContext.set(new RedactionRules(List.of(RedactionRule.of("[a-z-]{4,}", "[X]"))));
+
+        // Dataset names are replayed by the SDK against a get-or-create endpoint, so a rewritten one silently
+        // creates a second dataset instead of failing.
+        var dataset = mapper.writeValueAsString(Dataset.builder().name("customer-records").build());
+        assertThat(dataset).contains("customer-records").doesNotContain("[X]");
+
+        // A trace name is free text the caller writes per call, so it stays redacted.
+        var trace = mapper.writeValueAsString(Trace.builder()
+                .id(UUID.randomUUID())
+                .name("refund-for-someone")
+                .startTime(Instant.now())
+                .build());
+        assertThat(trace).doesNotContain("refund-for-someone").contains("[X]");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
@@ -183,11 +183,12 @@ class RedactionModuleTest {
     }
 
     @Test
-    @DisplayName("caller-supplied span fields are redacted, so a name-based exemption cannot be used as a bypass")
-    void callerSuppliedSpanFieldsAreRedacted() throws Exception {
-        // model, provider and environment are set by whoever logs the span, so a caller could put anything
-        // there. Exempting them by property name would hand that value straight back to a reader who is not
-        // permitted to see stored content.
+    @DisplayName("a span's model and provider are returned as stored, even when a rule would match them")
+    void vendorIdentifiersAreExemptEvenWhenARuleMatches() throws Exception {
+        // Exempting these is a decision, not an oversight: they name a vendor and a model, the UI filters and
+        // groups by them, and redacting them would rewrite legitimate identifiers such as gpt-4o-2024-08-06
+        // under a date rule. The cost is that content placed in them is returned as stored — asserted here so
+        // that nobody later reads it as a leak and 'fixes' it.
         RedactionContext.set(new RedactionRules(
                 List.of(RedactionRule.of("(?<![\\w.+-])[\\w.+-]+@[\\w-]+\\.[\\w.]+", "[EMAIL]"))));
 
@@ -195,17 +196,18 @@ class RedactionModuleTest {
                 .id(UUID.randomUUID())
                 .traceId(UUID.randomUUID())
                 .projectName("refund-project")
-                .name("llm-call")
+                .name("call for alice.brown@example.com")
                 .type(SpanType.llm)
                 .startTime(Instant.now())
                 .model("alice.brown@example.com")
                 .provider("bob.jones@example.com")
                 .build());
 
-        assertThat(written).doesNotContain("alice.brown@example.com").doesNotContain("bob.jones@example.com");
-        assertThat(written).contains("[EMAIL]");
-        // The genuine lookup key is still spared.
-        assertThat(written).contains("refund-project");
+        assertThat(written).contains("\"model\":\"alice.brown@example.com\"");
+        assertThat(written).contains("\"provider\":\"bob.jones@example.com\"");
+        // A caller-supplied field that is not exempt is still redacted, so the exemption is scoped and not
+        // a hole that swallowed the whole span.
+        assertThat(written).contains("\"name\":\"call for [EMAIL]\"");
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionModuleTest.java
@@ -205,6 +205,17 @@ class RedactionModuleTest {
 
         assertThat(written).contains("\"model\":\"alice.brown@example.com\"");
         assertThat(written).contains("\"provider\":\"bob.jones@example.com\"");
+
+        // providers is a collection, which the modifier reaches through a separate condition to the scalar one.
+        var trace = mapper.writeValueAsString(Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("refund-project")
+                .name("trace for dave.green@example.com")
+                .startTime(Instant.now())
+                .providers(List.of("carol.white@example.com", "openai"))
+                .build());
+        assertThat(trace).contains("\"providers\":[\"carol.white@example.com\",\"openai\"]");
+        assertThat(trace).contains("\"name\":\"trace for [EMAIL]\"");
         // A caller-supplied field that is not exempt is still redacted, so the exemption is scoped and not
         // a hole that swallowed the whole span.
         assertThat(written).contains("\"name\":\"call for [EMAIL]\"");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilterTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilterTest.java
@@ -13,7 +13,7 @@ class RedactionRequestFilterTest {
 
     @ParameterizedTest(name = "{0} -> covered={1}")
     @MethodSource
-    @DisplayName("redaction covers the versioned API, minus the named exemptions")
+    @DisplayName("redaction covers the authenticated paths that carry stored content, and nothing else")
     void coversPath(String path, boolean expected) {
         assertThat(RedactionRequestFilter.coversPath(path)).isEqualTo(expected);
     }
@@ -27,7 +27,10 @@ class RedactionRequestFilterTest {
                 // The route that made the previous private-only predicate a bypass: caller-supplied SQL
                 // returning stored trace content.
                 Arguments.of("/v1/internal/analytics-queries/projects/01a0", true),
-                Arguments.of("/v1/internal/usage/workspace-trace-counts", true),
+                // Unauthenticated, so there is no caller to decide about — and its rows carry a per-user
+                // identifier the platform's usage attribution depends on.
+                Arguments.of("/v1/internal/usage/workspace-trace-counts", false),
+                Arguments.of("/v1/internal/usage/bi-traces", false),
                 // A redirect carries nothing worth rewriting.
                 Arguments.of("/v1/session/redirect", false),
                 // Outside the versioned API: these return tokens and metadata, and the rule set includes

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilterTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionRequestFilterTest.java
@@ -1,0 +1,40 @@
+package com.comet.opik.infrastructure.redaction;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RedactionRequestFilterTest {
+
+    @ParameterizedTest(name = "{0} -> covered={1}")
+    @MethodSource
+    @DisplayName("redaction covers the versioned API, minus the named exemptions")
+    void coversPath(String path, boolean expected) {
+        assertThat(RedactionRequestFilter.coversPath(path)).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> coversPath() {
+        return Stream.of(
+                Arguments.of("/v1/private/traces", true),
+                Arguments.of("/v1/private/traces/search", true),
+                Arguments.of("/v1/private/spans", true),
+                Arguments.of("/v1/private/datasets/items/stream", true),
+                // The route that made the previous private-only predicate a bypass: caller-supplied SQL
+                // returning stored trace content.
+                Arguments.of("/v1/internal/analytics-queries/projects/01a0", true),
+                Arguments.of("/v1/internal/usage/workspace-trace-counts", true),
+                // A redirect carries nothing worth rewriting.
+                Arguments.of("/v1/session/redirect", false),
+                // Outside the versioned API: these return tokens and metadata, and the rule set includes
+                // patterns for bearer tokens and JWTs that would destroy them.
+                Arguments.of("/oauth/register", false),
+                Arguments.of("/.well-known/oauth-authorization-server", false),
+                Arguments.of("/is-alive/ping", false),
+                Arguments.of("/openapi.json", false));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionServiceTest.java
@@ -36,7 +36,7 @@ class RedactionServiceTest {
         var enabled = service(true, ONE_RULE);
 
         assertThat(enabled.shouldRedactFor(
-                Set.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()))).isFalse();
+                Set.of(WorkspaceUserPermission.ORIGINAL_DATA_VIEW.getValue()))).isFalse();
         assertThat(enabled.shouldRedactFor(Set.of("some_other_permission"))).isTrue();
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/redaction/RedactionServiceTest.java
@@ -1,0 +1,61 @@
+package com.comet.opik.infrastructure.redaction;
+
+import com.comet.opik.infrastructure.RedactionConfig;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Redaction Service")
+class RedactionServiceTest {
+
+    private static final String ONE_RULE = """
+            [{"regex":"(?<![\\\\w.+-])[\\\\w.+-]+@[\\\\w-]+\\\\.[\\\\w.]+","replace":"[EMAIL]"}]""";
+
+    private static RedactionService service(boolean enabled, String rules) {
+        var config = new RedactionConfig();
+        config.setEnabled(enabled);
+        config.setRules(rules);
+        return new RedactionService(config);
+    }
+
+    @Test
+    @DisplayName("the feature is off unless it is both switched on and given something to apply")
+    void theFeatureIsOffUnlessSwitchedOnAndGivenRules() {
+        assertThat(service(false, ONE_RULE).isEnabled()).isFalse();
+        assertThat(service(true, "[]").isEnabled()).isFalse();
+        assertThat(service(true, ONE_RULE).isEnabled()).isTrue();
+    }
+
+    @Test
+    @DisplayName("holding the original-data permission is the only thing that exempts a caller")
+    void holdingThePermissionIsTheOnlyExemption() {
+        var enabled = service(true, ONE_RULE);
+
+        assertThat(enabled.shouldRedactFor(
+                Set.of(WorkspaceUserPermission.TRACE_ORIGINAL_DATA_VIEW.getValue()))).isFalse();
+        assertThat(enabled.shouldRedactFor(Set.of("some_other_permission"))).isTrue();
+    }
+
+    @Test
+    @DisplayName("an unresolved permission set is redacted, which is also every caller when auth is disabled")
+    void anUnresolvedPermissionSetIsRedacted() {
+        // RequestContext.permissions defaults to an empty set and only the authentication call fills it, so
+        // with authentication.enabled=false this is what every caller looks like: masked, with no way to be
+        // granted an exemption. AuthModule logs that at startup, and config.yml says so.
+        var enabled = service(true, ONE_RULE);
+
+        assertThat(enabled.shouldRedactFor(Set.of())).isTrue();
+        assertThat(enabled.shouldRedactFor(null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("nothing is redacted while the feature is off, whatever the caller holds")
+    void nothingIsRedactedWhileTheFeatureIsOff() {
+        assertThat(service(false, ONE_RULE).shouldRedactFor(Set.of())).isFalse();
+        assertThat(service(false, ONE_RULE).redactWhenCallerUnknown()).isFalse();
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -400,6 +400,17 @@ cors:
   # Description: Whether or not to allow cross site scripting
   enabled: false
 
+# Read-time redaction configuration
+redaction:
+  # Default: false
+  # Description: Master switch. Off here so the suite exercises the shipped default; the tests that need it on
+  # override redaction.enabled and redaction.rules per application, which is what keeps this file honest about
+  # the keys existing.
+  enabled: false
+  # Default: [] - valid only while enabled=false, since an empty set with enabled=true fails startup.
+  # Description: JSON array of {"regex", "replace"} applied to every string in a response.
+  rules: '[]'
+
 # Encryption related configuration
 encryption:
   # Default: GiTHubiLoVeYouAA


### PR DESCRIPTION
## Details

Trace content can now be redacted at read time, so what is stored and what a given caller
is allowed to read are decided separately. Content is persisted exactly as the SDK sends it;
responses are rewritten during serialization for callers that do not hold the
`trace_original_data_view` workspace permission. Everything is behind a feature flag that is
off by default — with it off, no serializer is registered, no permission is requested from the
platform, and responses are byte-identical to before.

- Rules are a deployment-level JSON array of `{regex, replace}`, compiled once at startup so a
  malformed pattern stops the deployment rather than silently disabling redaction.
- The decision is resolved once after authentication and carried on the request, because
  serialization happens long after the resource method has returned.
- Streamed responses redact explicitly: they are written on a scheduler thread where the
  writer interceptor's thread-local does not apply. An ArchUnit test fails the build if a new
  `ChunkedOutput` producer appears outside that path.
- Structural properties (`project_name`, `thread_id`, `model`, `sortable_by`, and the `name` of
  entities the API addresses by name) are exempt, so navigation and filtering keep working.

Requires the companion platform change that returns the caller's workspace permissions on the
authentication response, requested only when this feature is enabled:
comet-ml/comet-backend#5650.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7834

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: implementation, tests, and configuration in this PR, authored iteratively with review
  and direction at each step.
- Human verification: reviewed diff by diff; findings from two code-review passes were applied
  or explicitly deferred with reasons; verified end to end against a local stack with real
  authentication (see Testing).

## Testing

Automated — `cd apps/opik-backend && mvn test -Dtest="..."`:
- `RemoteAuthServiceTest` (57), `AuthCredentialsCacheServiceTest` (14) — auth plumbing,
  credentials cache round-trip, and the request flag on every credential-producing path
  (api key, session cookie, OAuth).
- `RedactionModuleTest` (11), `RedactionRequestFilterTest` (12), `RedactionCoverageArchTest` (1)
  — serializer behaviour including map keys and structural exemptions, path scoping, and
  stream coverage.
- `ReadTimeRedactionResourceTest` (4), `ReadTimeRedactionDisabledResourceTest` (2) —
  integration, flag on and flag off.
- `mvn spotless:check` clean.

Mutation-verified the new wire assertions rather than trusting a green run: dropping the flag
from one auth path fails that path alone, renaming the serialized field fails all three enabled
cases, and removing the inclusion rule fails all three disabled cases.

End to end on a local stack with the platform running and two real users in one workspace
(organization admin with `workspace-manage`; member with `workspace-write`):
- 12 specimen values (email, UK phone, national insurance number, postcode, card, sort code,
  IBAN, SSN, date of birth, AWS key, API key, IP) returned as stored for the administrator and
  redacted for the member, on both the api-key and browser-session paths.
- A payload with no sensitive content passes through unchanged.

Not run: the full backend suite. Scope was the auth and redaction packages plus their
integration tests.

## Documentation

`config.yml` documents the flag, the rule format, the literal-replacement behaviour, and the
structural exemptions. Configuration reference and user-facing docs to follow before this is
enabled anywhere.
