### PR TITLE
[OPIK-8064] [BE] fix: bound an automation rule's sampling rate at the API boundary

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluator.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -26,6 +28,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.UUID;
+
+import static com.comet.opik.utils.ValidationUtils.MAX_SAMPLING_RATE;
+import static com.comet.opik.utils.ValidationUtils.MIN_SAMPLING_RATE;
 
 @Data
 @SuperBuilder(toBuilder = true)
@@ -80,7 +85,12 @@ public abstract sealed class AutomationRuleEvaluator<T, E extends Filter> implem
     @NotBlank @Size(max = 150, message = "cannot exceed 150 characters") private final String name;
 
     @JsonView({View.Public.class, View.Write.class})
-    private final float samplingRate;
+    // Bounded to match the automation_rules.sampling_rate CHECK constraint, so an out-of-range rate is rejected at
+    // the API boundary instead of failing the insert. A float also lets a caller overflow to Infinity (e.g. 1e40) or
+    // send a NaN literal, which the MySQL driver renders as a bare `Infinity`/`NaN` token — a SQLSyntaxErrorException
+    // ("Unknown column 'Infinity' in 'field list'") rather than a 4xx. @DecimalMin/@DecimalMax reject both: Hibernate
+    // Validator treats NaN as out of bounds and +/-Infinity as greater/less than any bound.
+    @DecimalMin(MIN_SAMPLING_RATE) @DecimalMax(MAX_SAMPLING_RATE) private final float samplingRate;
 
     @JsonView({View.Public.class, View.Write.class})
     @Builder.Default

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorUpdate.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorUpdate.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -21,6 +23,9 @@ import lombok.experimental.SuperBuilder;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+
+import static com.comet.opik.utils.ValidationUtils.MAX_SAMPLING_RATE;
+import static com.comet.opik.utils.ValidationUtils.MIN_SAMPLING_RATE;
 
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
@@ -54,7 +59,9 @@ public abstract sealed class AutomationRuleEvaluatorUpdate<T, E extends Filter> 
     // the API boundary instead of failing the update (OPIK-7371).
     @NotBlank @Size(max = 150, message = "cannot exceed 150 characters") private final String name;
 
-    private final float samplingRate;
+    // Bounded to match the automation_rules.sampling_rate CHECK constraint, so an out-of-range rate — or a NaN /
+    // overflowed-to-Infinity float — is rejected on update instead of failing the update, matching the create path.
+    @DecimalMin(MIN_SAMPLING_RATE) @DecimalMax(MAX_SAMPLING_RATE) private final float samplingRate;
 
     @Builder.Default
     private final boolean enabled = true;

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/ValidationUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/ValidationUtils.java
@@ -42,6 +42,13 @@ public class ValidationUtils {
     public static final int SCALE = 9;
 
     /**
+     * Bounds of an automation rule's sampling rate, matching the
+     * {@code automation_rules.sampling_rate FLOAT NOT NULL CHECK (sampling_rate >= 0 AND sampling_rate <= 1)} column.
+     */
+    public static final String MIN_SAMPLING_RATE = "0.0";
+    public static final String MAX_SAMPLING_RATE = "1.0";
+
+    /**
      * We're using FixedString(36) to store UUIDs in Clickhouse. This isn't a nullable field, but it can be null under
      * certain circumstances, mostly during LEFT JOIN statements when there are no matching records from the table on
      * the right.

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/AutomationRuleEvaluatorResourceClient.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.BatchDelete;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorUpdate;
 import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.utils.JsonUtils;
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -58,6 +59,33 @@ public class AutomationRuleEvaluatorResourceClient {
                 .header(HttpHeaders.AUTHORIZATION, apiKey)
                 .header(WORKSPACE_HEADER, workspaceName)
                 .post(Entity.json(evaluator));
+    }
+
+    /**
+     * Posts a body written as JSON text, for payloads a typed DTO cannot express — e.g. a sampling rate sent
+     * as {@code 1e40} or {@code "NaN"}, which only exist on the wire. The text is parsed to a tree so it is
+     * sent as a JSON object (a String entity would be written as a JSON string literal instead); number and
+     * string forms survive that round trip.
+     */
+    public Response callCreateEvaluatorWithJsonBody(String body, String workspaceName, String apiKey) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .post(Entity.json(JsonUtils.getJsonNodeFromString(body)));
+    }
+
+    /** The update counterpart of {@link #callCreateEvaluatorWithJsonBody}. */
+    public Response callUpdateEvaluatorWithJsonBody(UUID evaluatorId, String body, String workspaceName,
+            String apiKey) {
+        return client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(evaluatorId.toString())
+                .request()
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .header(HttpHeaders.AUTHORIZATION, apiKey)
+                .header(WORKSPACE_HEADER, workspaceName)
+                .method(HttpMethod.PATCH, Entity.json(JsonUtils.getJsonNodeFromString(body)));
     }
 
     public Response callUpdateEvaluator(UUID evaluatorId, String workspaceName,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -1051,6 +1051,92 @@ class AutomationRuleEvaluatorsResourceTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    @DisplayName("Sampling rate validation")
+    class SamplingRateValidation {
+
+        /**
+         * The rate is injected verbatim so a test can send what a client actually sends, including values no
+         * float field can hold: {@code 1e40} overflows to Infinity on parse, and Jackson maps the strings
+         * {@code "NaN"} / {@code "Infinity"} onto the matching float constants.
+         */
+        private static final String RULE_WITH_SAMPLING_RATE = """
+                {
+                  "name": "%s",
+                  "project_ids": ["%s"],
+                  "type": "llm_as_judge",
+                  "sampling_rate": %s,
+                  "enabled": true,
+                  "code": %s
+                }
+                """;
+
+        /**
+         * Every one of these reached MySQL before the bounds were enforced. The non-finite ones are the
+         * interesting half: the driver renders them as the bare tokens {@code Infinity} / {@code NaN}, so the
+         * insert came back as "Unknown column 'Infinity' in 'field list'" — a SQLSyntaxErrorException surfaced
+         * as a 500 instead of a rejected request.
+         */
+        private static Stream<String> hostileSamplingRates() {
+            return Stream.of("1.5", "-0.5", "1e40", "-1e40", "\"NaN\"", "\"Infinity\"", "\"-Infinity\"");
+        }
+
+        private String ruleBody(UUID projectId, String samplingRate) {
+            return RULE_WITH_SAMPLING_RATE.formatted(
+                    "Sampling probe " + UUID.randomUUID(), projectId, samplingRate, LLM_AS_A_JUDGE_EVALUATOR);
+        }
+
+        private UUID createProject() {
+            return projectResourceClient.createProject(UUID.randomUUID().toString(), API_KEY, WORKSPACE_NAME);
+        }
+
+        @ParameterizedTest
+        @MethodSource("hostileSamplingRates")
+        @DisplayName("create evaluator: when the sampling rate is out of range, then reject at the API boundary")
+        void createEvaluator__whenSamplingRateIsOutOfRange__thenReturnUnprocessableEntity(String samplingRate) {
+            var projectId = createProject();
+
+            try (var response = evaluatorsResourceClient.callCreateEvaluatorWithJsonBody(
+                    ruleBody(projectId, samplingRate), WORKSPACE_NAME, API_KEY)) {
+                assertThat(response.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+                assertThat(response.readEntity(com.comet.opik.api.error.ErrorMessage.class).errors())
+                        .isNotEmpty();
+            }
+        }
+
+        @ParameterizedTest
+        @MethodSource("hostileSamplingRates")
+        @DisplayName("update evaluator: when the sampling rate is out of range, then reject at the API boundary")
+        void updateEvaluator__whenSamplingRateIsOutOfRange__thenReturnUnprocessableEntity(String samplingRate) {
+            var projectId = createProject();
+            var evaluator = factory.manufacturePojo(AutomationRuleEvaluatorLlmAsJudge.class).toBuilder()
+                    .name("Sampling probe " + UUID.randomUUID())
+                    .projectIds(Set.of(projectId))
+                    .build();
+            var id = evaluatorsResourceClient.createEvaluator(evaluator, WORKSPACE_NAME, API_KEY);
+
+            try (var response = evaluatorsResourceClient.callUpdateEvaluatorWithJsonBody(
+                    id, ruleBody(projectId, samplingRate), WORKSPACE_NAME, API_KEY)) {
+                assertThat(response.getStatusInfo().getStatusCode())
+                        .isEqualTo(HttpStatus.SC_UNPROCESSABLE_ENTITY);
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"0", "0.5", "1", "1.0"})
+        @DisplayName("create evaluator: a rate on or inside the bounds is still accepted")
+        void createEvaluator__whenSamplingRateIsInRange__thenCreated(String samplingRate) {
+            var projectId = createProject();
+
+            try (var response = evaluatorsResourceClient.callCreateEvaluatorWithJsonBody(
+                    ruleBody(projectId, samplingRate), WORKSPACE_NAME, API_KEY)) {
+                assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(HttpStatus.SC_CREATED);
+            }
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class FindEvaluator {
 
         Stream<Class<? extends AutomationRuleEvaluator<?, ?>>> find() {


### PR DESCRIPTION
## Details

`sampling_rate` was a bare `float` with no bean-validation constraint, so anything the wire could express reached the INSERT and came back as a 500 instead of a 4xx. Production hit this today from `AutomationRuleEvaluatorDAO.saveBaseRule`:

```
java.sql.SQLSyntaxErrorException: Unknown column 'Infinity' in 'field list'
```

- `1e40` overflows to `Infinity` on parse, and Jackson maps the strings `"NaN"` / `"Infinity"` onto the matching float constants. The MySQL driver renders those as the bare tokens `Infinity` / `NaN`, which MySQL reads as *identifiers* — hence "Unknown column".
- Finite but out-of-range rates (`1.5`, `-0.5`) hit the `automation_rules_chk_1` CHECK constraint and also surfaced as a 500.
- Fix: bound the field to the column's CHECK range on both the create and update DTOs, the way OPIK_7371 bounded `name` to its VARCHAR length. Hibernate Validator's `DecimalMin`/`MaxValidatorForFloat` treat NaN as out of bounds and ±Infinity as greater/less than any bound, so one annotation pair covers all three shapes of bad input.
- The generated OpenAPI spec picks up `minimum: 0.0` / `maximum: 1.0` on `sampling_rate` as a side effect; the checked-in spec is refreshed by the existing generate-and-commit workflow.

No data was corrupted — the inserts failed, and prod `opik_prod.automation_rules` holds 4013 rows with none outside `[0, 1]`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8064

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: Diagnosed the production error from Loki logs, wrote the validation change and the `SamplingRateValidation` test class, ran the verification below.
- Human verification: Author reviewed the diff and the test results before pushing.

## Testing

```
mvn test -Dtest='AutomationRuleEvaluatorsResourceTest$SamplingRateValidation'
mvn spotless:check
```

New `AutomationRuleEvaluatorsResourceTest$SamplingRateValidation` — 18 cases, create and update paths over `1.5`, `-0.5`, `1e40`, `-1e40`, `"NaN"`, `"Infinity"`, `"-Infinity"`, plus in-range `0` / `0.5` / `1` / `1.0` still accepted.

- **With the annotations reverted:** 14 failures — every hostile value returned **500**, and the production `Unknown column 'Infinity'` / `'NaN'` error reproduced in the test log. This is what proves the tests catch the regression rather than merely passing.
- **With the fix:** 18/18 pass — 422 for hostile input, 201 for in-range.
- Spotless: BUILD SUCCESS.

Environment: local Maven + testcontainers (MySQL / ClickHouse / Redis), macOS. Full suite for this class not run beyond the new nested class; the change is a field-level constraint on two DTOs.

## Documentation

None — the bound is self-documenting via the OpenAPI spec's `minimum` / `maximum` on `sampling_rate`.