### PR TITLE
[OPIK-8065] [BE] fix: map slash_command and identity_context spend blocks to real lanes

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -256,7 +256,9 @@ public class CipxSpendBlockDAO {
             return switch (category) {
                 case "tool_io" -> toolServer.isEmpty() ? "built_in_tools" : "mcp_servers";
                 case "system_tools", "system_tools_deferred" -> "built_in_tools";
-                case "user_prompts" -> "user_prompts";
+                // slash_command is a user-invoked expansion — user-driven content, so it
+                // rides the user_prompts lane rather than the harness's static_overhead.
+                case "user_prompts", "slash_command" -> "user_prompts";
                 case "prior_assistant" -> "prior_assistant";
                 case "mcp_tools_active", "mcp_tools_deferred", "mcp_server_instructions" -> "mcp_servers";
                 case "skills_menu", "skills_loaded" -> "skills";
@@ -264,7 +266,10 @@ public class CipxSpendBlockDAO {
                 case "memory" -> "memory";
                 case "file_attachments" -> "file_attachments";
                 case "system_prompt", "env_info" -> "static_overhead";
-                case "auto_classifier", "agent_overhead" -> "static_overhead";
+                // identity_context here is the surviving framing (identity reminders +
+                // other <system-reminder> riders carved out of another parent); the pure
+                // identity_context/identity_context rows are dropped at ingestion.
+                case "auto_classifier", "agent_overhead", "identity_context" -> "static_overhead";
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
                 case "built_in_tool_calls" -> "built_in_tool_calls";
@@ -294,13 +299,13 @@ public class CipxSpendBlockDAO {
                 case "user_prompts" ->
                     chars < 1_000 ? "small" : chars < 10_000 ? "medium" : chars < 100_000 ? "large" : "xlarge";
                 case "file_attachments", "skills_menu", "skills_loaded", "custom_agents", "memory",
-                        "skill_invocations" ->
+                        "skill_invocations", "slash_command" ->
                     resource;
                 case "tool_io" -> toolServer.isEmpty() ? toolName : toolServer;
                 case "system_tools", "system_tools_deferred" -> toolName.isEmpty() ? "(unattributed)" : toolName;
                 case "prior_assistant" -> kind;
                 case "mcp_tools_active", "mcp_tool_calls" -> toolServer;
-                case "system_prompt", "env_info", "auto_classifier", "agent_overhead" -> category;
+                case "system_prompt", "env_info", "auto_classifier", "agent_overhead", "identity_context" -> category;
                 case "thinking" -> "thinking";
                 case "assistant_text" -> "assistant_text";
                 case "built_in_tool_calls" -> toolName;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -348,6 +348,42 @@ class CostIntelligenceIngestionTest {
             });
         }
 
+        @Test
+        @DisplayName("slash_command lands in user_prompts keyed by command name; identity_context framing lands in static_overhead")
+        void slashCommandAndIdentityContextLanes() {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(slashCommandCipxMetadata("claude-sonnet-4-6", 200))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                // raw idx 1 (identity_context/identity_context) is dropped at ingestion;
+                // the two remaining blocks must not fall to 'unattributed' (OPIK-8065).
+                var rows = getCipxBlocks(span.id(), ws.workspaceId());
+                assertThat(rows).hasSize(2);
+
+                var slashCommand = rows.getFirst();
+                assertThat(slashCommand.category()).isEqualTo("slash_command");
+                assertThat(slashCommand.lane()).isEqualTo("user_prompts");
+                assertThat(slashCommand.bdLane()).isEqualTo("user_prompts");
+                assertThat(slashCommand.label()).isEqualTo("commit-helper");
+                assertThat(slashCommand.isDefinition()).isEqualTo(0);
+
+                // identity_context whose parent is another category: framing carved out of
+                // that parent — kept, and folded under static_overhead like the other riders.
+                var identityContext = rows.getLast();
+                assertThat(identityContext.category()).isEqualTo("identity_context");
+                assertThat(identityContext.lane()).isEqualTo("static_overhead");
+                assertThat(identityContext.bdLane()).isEqualTo("static_overhead");
+                assertThat(identityContext.label()).isEqualTo("identity_context");
+                assertThat(identityContext.isDefinition()).isEqualTo(0);
+            });
+        }
+
         @DisplayName("write blocks inherit the span's cache TTL (1h vs 5m)")
         @ParameterizedTest
         @CsvSource({
@@ -614,6 +650,31 @@ class CostIntelligenceIngestionTest {
                               {"category":"system_tools_deferred","side":"input","cache_status":"read","parent_category":"context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
                               {"category":"system_prompt","side":"input","cache_status":"read","parent_category":"context","chars":40,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
                               {"category":"env_info","side":"input","cache_status":"read","parent_category":"context","chars":30,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
+                            ]
+                          }
+                        }
+                        """
+                        .formatted(model, cacheRead));
+    }
+
+    private static JsonNode slashCommandCipxMetadata(String model, long cacheRead) {
+        return JsonUtils.getJsonNodeFromString(
+                """
+                        {
+                          "cipx": {
+                            "call": {
+                              "model": "%s",
+                              "usage": {
+                                "input_tokens": 0,
+                                "cache_read_input_tokens": %d,
+                                "cache_creation_input_tokens": 0,
+                                "output_tokens": 0
+                              }
+                            },
+                            "blocks": [
+                              {"category":"slash_command","side":"input","cache_status":"read","parent_category":"user_prompts","chars":150,"tool_name":"","tool_server":"","tool_use_id":"","resource":"commit-helper","kind":"text"},
+                              {"category":"identity_context","side":"input","cache_status":"read","parent_category":"identity_context","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
+                              {"category":"identity_context","side":"input","cache_status":"read","parent_category":"user_prompts","chars":40,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
                             ]
                           }
                         }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -367,6 +367,7 @@ class CostIntelligenceIngestionTest {
                 assertThat(rows).hasSize(2);
 
                 var slashCommand = rows.getFirst();
+                assertThat(slashCommand.blockIdx()).isEqualTo(0);
                 assertThat(slashCommand.category()).isEqualTo("slash_command");
                 assertThat(slashCommand.lane()).isEqualTo("user_prompts");
                 assertThat(slashCommand.bdLane()).isEqualTo("user_prompts");
@@ -375,7 +376,9 @@ class CostIntelligenceIngestionTest {
 
                 // identity_context whose parent is another category: framing carved out of
                 // that parent — kept, and folded under static_overhead like the other riders.
+                // blockIdx 2, not 1: the dropped row still consumes its raw index.
                 var identityContext = rows.getLast();
+                assertThat(identityContext.blockIdx()).isEqualTo(2);
                 assertThat(identityContext.category()).isEqualTo("identity_context");
                 assertThat(identityContext.lane()).isEqualTo("static_overhead");
                 assertThat(identityContext.bdLane()).isEqualTo("static_overhead");


### PR DESCRIPTION
## Details

`lane()` in `CipxSpendBlockDAO` had no case for `slash_command` or `identity_context`, so those spend-block rows fell to `unattributed` (prod sample: 114 + 595 rows; affects claude_code as well as codex).

- `slash_command` → `user_prompts` lane, breakdown label = resource (the command name) — user-invoked expansion, so it rides the user lane rather than static overhead.
- `identity_context` → `static_overhead` lane, label = category, same convention as system_prompt/env_info/agent_overhead. (Pure identity_context/identity_context rows stay dropped at ingestion, unchanged.)

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-8065

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Fable 5
- Scope: lane/label mapping in CipxSpendBlockDAO + ingestion test
- Human verification: reviewed diff; test run locally

## Testing

- `mvn test -Dtest=CostIntelligenceIngestionTest` — 10/10 pass, including the new `slashCommandAndIdentityContextLanes` case (slash_command → user_prompts keyed by command name; carved identity_context → static_overhead; identity_context/identity_context still dropped).

## Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
