### PR TITLE
[OPIK-8045] [QA] Proposed e2e spec from the #7949 exploration — online scoring on odd-shaped trace sections

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorLlmAsJudge.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorLlmAsJudge.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.evaluators;
 
 import com.comet.opik.api.filter.TraceFilter;
+import com.comet.opik.api.validation.SupportedVariablePaths;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -38,7 +39,9 @@ public final class AutomationRuleEvaluatorLlmAsJudge extends AutomationRuleEvalu
             @JsonView({
                     View.Public.class, View.Write.class}) @NotNull LlmAsJudgeModelParameters model,
             @JsonView({View.Public.class, View.Write.class}) @NotNull List<LlmAsJudgeMessage> messages,
-            @JsonView({View.Public.class, View.Write.class}) @NotNull Map<String, String> variables,
+            @JsonView({
+                    View.Public.class,
+                    View.Write.class}) @NotNull @SupportedVariablePaths Map<String, String> variables,
             @JsonView({View.Public.class, View.Write.class}) @NotNull List<LlmAsJudgeOutputSchema> schema,
             @JsonView({View.Public.class, View.Write.class}) @Positive BigDecimal maxCostUsd) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorSpanLlmAsJudge.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/evaluators/AutomationRuleEvaluatorSpanLlmAsJudge.java
@@ -1,6 +1,7 @@
 package com.comet.opik.api.evaluators;
 
 import com.comet.opik.api.filter.SpanFilter;
+import com.comet.opik.api.validation.SupportedVariablePaths;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
@@ -38,7 +39,9 @@ public final class AutomationRuleEvaluatorSpanLlmAsJudge
             @JsonView({
                     View.Public.class, View.Write.class}) @NotNull LlmAsJudgeModelParameters model,
             @JsonView({View.Public.class, View.Write.class}) @NotNull List<LlmAsJudgeMessage> messages,
-            @JsonView({View.Public.class, View.Write.class}) @NotNull Map<String, String> variables,
+            @JsonView({
+                    View.Public.class,
+                    View.Write.class}) @NotNull @SupportedVariablePaths Map<String, String> variables,
             @JsonView({View.Public.class, View.Write.class}) @NotNull List<LlmAsJudgeOutputSchema> schema) {
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
@@ -157,6 +157,18 @@ public interface AgenticScoringService {
     boolean supportsToolCalling(LlmProvider provider);
 
     /**
+     * Tool choice for the FIRST call of the agentic loop. {@link ToolChoice#REQUIRED} is what stops an
+     * OpenAI judge from answering straight from visible context (see {@link SupportedJudgeProvider} for
+     * the empirical asymmetry), but langchain4j's {@code VertexAiGeminiChatModel} rejects any explicit
+     * tool choice with {@code UnsupportedFeatureException} — and since that is terminal, forcing it there
+     * failed the evaluation outright instead of scoring it. Vertex therefore gets
+     * {@link ToolChoice#AUTO}: the model may skip the tool loop, which the loop already handles (a first
+     * response with no tool-execution requests finishes it), so a possibly-tool-less evaluation replaces
+     * a guaranteed failure.
+     */
+    ToolChoice firstRoundToolChoice(LlmProvider provider);
+
+    /**
      * Attach the tool specs from the registered {@link ToolRegistry} and the given {@code toolChoice} to
      * {@code request}'s parameters. Tool specs live inside {@link ChatRequestParameters}, so we copy the
      * existing parameters via {@code overrideWith} and layer tool specs on top — setting
@@ -436,6 +448,18 @@ class AgenticScoringServiceImpl implements AgenticScoringService {
         return switch (provider) {
             case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, VERTEX_AI, BEDROCK -> true;
             case OLLAMA, CUSTOM_LLM, OPIK_FREE -> false;
+        };
+    }
+
+    @Override
+    public ToolChoice firstRoundToolChoice(@NonNull LlmProvider provider) {
+        return switch (provider) {
+            // VertexAiGeminiChatModel.validate() throws UnsupportedFeatureException on any toolChoice.
+            case VERTEX_AI -> ToolChoice.AUTO;
+            case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, BEDROCK -> ToolChoice.REQUIRED;
+            // Unreachable while callers gate on supportsToolCalling first; AUTO keeps a caller that
+            // forgets the gate on the harmless side.
+            case OLLAMA, CUSTOM_LLM, OPIK_FREE -> ToolChoice.AUTO;
         };
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgenticScoringService.java
@@ -454,12 +454,12 @@ class AgenticScoringServiceImpl implements AgenticScoringService {
     @Override
     public ToolChoice firstRoundToolChoice(@NonNull LlmProvider provider) {
         return switch (provider) {
-            // VertexAiGeminiChatModel.validate() throws UnsupportedFeatureException on any toolChoice.
-            case VERTEX_AI -> ToolChoice.AUTO;
             case OPEN_AI, ANTHROPIC, GEMINI, OPEN_ROUTER, BEDROCK -> ToolChoice.REQUIRED;
-            // Unreachable while callers gate on supportsToolCalling first; AUTO keeps a caller that
-            // forgets the gate on the harmless side.
-            case OLLAMA, CUSTOM_LLM, OPIK_FREE -> ToolChoice.AUTO;
+            // VERTEX_AI: VertexAiGeminiChatModel.validate() throws UnsupportedFeatureException on any
+            // toolChoice other than AUTO, even though the provider does support tools. The rest have no
+            // tool support at all, so callers gate them out before reaching here; AUTO keeps a caller
+            // that forgets the gate on the harmless side.
+            case VERTEX_AI, OLLAMA, CUSTOM_LLM, OPIK_FREE -> ToolChoice.AUTO;
         };
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 import dev.langchain4j.data.message.AudioContent;
 import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.ImageContent;
@@ -903,27 +904,45 @@ public class OnlineScoringEngine {
             // nested path to walk), which lands on the fallback below rather than propagating.
             var value = JsonPath.parse(forcedObject).read(path);
             return value != null ? serializeToJsonString(value) : null;
-        } catch (Exception e) {
+        } catch (PathNotFoundException e) {
             // DEBUG, and without the throwable: a scalar/array section reaches this line by design (it
             // has no nested path), so at production volumes this fires for every unresolved variable of
             // every scored trace — and when the flat fallback below succeeds there is nothing to report
             // at all. The PathNotFoundException message says nothing the log line does not.
             log.debug("couldn't find path inside json, trying flat structure, path={}, nodeType={}",
                     path, json.getNodeType());
-            return Optional.ofNullable(forcedObject)
-                    .filter(Map.class::isInstance)
-                    .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
-                    .map(OnlineScoringEngine::serializeToJsonString)
-                    .orElseGet(() -> {
-                        // The node's type, not its content: this is a trace's input/output/metadata, so
-                        // it carries customer prompts and completions that have no business in the
-                        // application log. The rule's own user-facing log already tells the customer
-                        // which variable failed to resolve.
-                        log.info("couldn't find flat or nested path in json, path={}, nodeType={}",
-                                path, json.getNodeType());
-                        return null;
-                    });
+            return flatFallback(forcedObject, path, json);
+        } catch (Exception e) {
+            // Anything else means the path itself didn't parse — JsonPath raises InvalidPathException for
+            // a malformed expression, and the path is user-supplied ({@code toVariableMapping} builds it
+            // from the rule's variable mapping), so a typo lands here. That is a config error rather than
+            // an expected shape, and only the parser's message says where the expression broke, so keep
+            // it. Message without the stack trace: a bad mapping fires on every trace the rule scores.
+            log.warn("invalid json path, trying flat structure, path={}, nodeType={}, error={}",
+                    path, json.getNodeType(), e.getMessage());
+            return flatFallback(forcedObject, path, json);
         }
+    }
+
+    /**
+     * Last resort when the JsonPath lookup didn't resolve: treat the path's tail as a literal property
+     * name, which is how a mapping like {@code output.flat.key} finds a property actually called
+     * "flat.key". Only meaningful for an object section — a scalar or a list has no properties.
+     */
+    private static String flatFallback(Object forcedObject, String path, JsonNode json) {
+        return Optional.ofNullable(forcedObject)
+                .filter(Map.class::isInstance)
+                .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
+                .map(OnlineScoringEngine::serializeToJsonString)
+                .orElseGet(() -> {
+                    // The node's type, not its content: this is a trace's input/output/metadata, so it
+                    // carries customer prompts and completions that have no business in the application
+                    // log. The rule's own user-facing log already tells the customer which variable
+                    // failed to resolve.
+                    log.info("couldn't find flat or nested path in json, path={}, nodeType={}",
+                            path, json.getNodeType());
+                    return null;
+                });
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -904,17 +904,23 @@ public class OnlineScoringEngine {
             var value = JsonPath.parse(forcedObject).read(path);
             return value != null ? serializeToJsonString(value) : null;
         } catch (Exception e) {
-            // INFO without the throwable: since a scalar/array section reaches this line by design
-            // (it has no nested path), a WARN with a PathNotFoundException stack trace would fire on
-            // every unresolved variable of every scored trace, and the exception message says nothing
-            // the log line does not. Matches the terminal "couldn't find flat or nested path" line below.
-            log.info("couldn't find path inside json, trying flat structure, path={}, json={}", path, json);
+            // DEBUG, and without the throwable: a scalar/array section reaches this line by design (it
+            // has no nested path), so at production volumes this fires for every unresolved variable of
+            // every scored trace — and when the flat fallback below succeeds there is nothing to report
+            // at all. The PathNotFoundException message says nothing the log line does not.
+            log.debug("couldn't find path inside json, trying flat structure, path={}, nodeType={}",
+                    path, json.getNodeType());
             return Optional.ofNullable(forcedObject)
                     .filter(Map.class::isInstance)
                     .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
                     .map(OnlineScoringEngine::serializeToJsonString)
                     .orElseGet(() -> {
-                        log.info("couldn't find flat or nested path in json, path={}, json={}", path, json);
+                        // The node's type, not its content: this is a trace's input/output/metadata, so
+                        // it carries customer prompts and completions that have no business in the
+                        // application log. The rule's own user-facing log already tells the customer
+                        // which variable failed to resolve.
+                        log.info("couldn't find flat or nested path in json, path={}, nodeType={}",
+                                path, json.getNodeType());
                         return null;
                     });
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -899,12 +899,16 @@ public class OnlineScoringEngine {
         }
 
         try {
-            // JsonPath.parse rejects a non-container (a scalar section has no nested path to walk), which
-            // lands on the fallback below rather than propagating.
+            // JsonPath.read throws PathNotFoundException on a non-container (a scalar section has no
+            // nested path to walk), which lands on the fallback below rather than propagating.
             var value = JsonPath.parse(forcedObject).read(path);
             return value != null ? serializeToJsonString(value) : null;
         } catch (Exception e) {
-            log.warn("couldn't find path inside json, trying flat structure, path={}, json={}", path, json, e);
+            // INFO without the throwable: since a scalar/array section reaches this line by design
+            // (it has no nested path), a WARN with a PathNotFoundException stack trace would fire on
+            // every unresolved variable of every scored trace, and the exception message says nothing
+            // the log line does not. Matches the terminal "couldn't find flat or nested path" line below.
+            log.info("couldn't find path inside json, trying flat structure, path={}, json={}", path, json);
             return Optional.ofNullable(forcedObject)
                     .filter(Map.class::isInstance)
                     .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -17,12 +17,10 @@ import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateParseUtils;
 import com.comet.opik.utils.ValidationUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.google.api.gax.rpc.InvalidArgumentException;
 import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.JsonPath;
 import dev.langchain4j.data.message.AudioContent;
@@ -885,23 +883,31 @@ public class OnlineScoringEngine {
             }
         }
 
-        Map<String, Object> forcedObject;
+        Object forcedObject;
         try {
             // JsonPath didn't work with JsonNode, even explicitly using
-            // JacksonJsonProvider, so we convert to a Map
-            forcedObject = OBJECT_MAPPER.convertValue(json, new TypeReference<>() {
-            });
-        } catch (InvalidArgumentException e) {
+            // JacksonJsonProvider, so we convert to a plain Object: a Map for an object node, a List for
+            // an array node, and the scalar itself for anything else. Converting straight to
+            // Map<String, Object> instead threw MismatchedInputException (wrapped in
+            // IllegalArgumentException) whenever the section was NOT an object — e.g. a trace whose
+            // output is the bare string "how can I help?" — and that escaped prepareLlmRequest and failed
+            // the whole evaluation before the LLM was ever called.
+            forcedObject = OBJECT_MAPPER.convertValue(json, Object.class);
+        } catch (IllegalArgumentException e) {
             log.warn("failed to parse json, json={}", json, e);
             return null;
         }
 
         try {
+            // JsonPath.parse rejects a non-container (a scalar section has no nested path to walk), which
+            // lands on the fallback below rather than propagating.
             var value = JsonPath.parse(forcedObject).read(path);
             return value != null ? serializeToJsonString(value) : null;
         } catch (Exception e) {
             log.warn("couldn't find path inside json, trying flat structure, path={}, json={}", path, json, e);
-            return Optional.ofNullable(forcedObject.get(path.replace("$.", "")))
+            return Optional.ofNullable(forcedObject)
+                    .filter(Map.class::isInstance)
+                    .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
                     .map(OnlineScoringEngine::serializeToJsonString)
                     .orElseGet(() -> {
                         log.info("couldn't find flat or nested path in json, path={}, json={}", path, json);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -16,6 +16,7 @@ import com.comet.opik.infrastructure.log.LogContextAware;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.TemplateParseUtils;
 import com.comet.opik.utils.ValidationUtils;
+import com.comet.opik.utils.VariablePathUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -882,6 +883,17 @@ public class OnlineScoringEngine {
                 log.warn("failed to serialize entire json object, json={}", json, e);
                 return null;
             }
+        }
+
+        // Rules are validated on write (@SupportedVariablePaths), but ones stored before that existed
+        // still arrive here, so the grammar is enforced at the point of use too. Recursive descent and
+        // filter predicates walk the whole section, and scoring shares a scheduler across workspaces, so
+        // the cost of one rule's expression is not confined to that rule.
+        var unsupported = VariablePathUtils.findUnsupportedConstructInJsonPath(path);
+        if (unsupported.isPresent()) {
+            log.warn("unsupported construct '{}' in json path, dropping variable, path={}, nodeType={}",
+                    unsupported.get(), path, json.getNodeType());
+            return null;
         }
 
         Object jsonValue;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -884,7 +884,7 @@ public class OnlineScoringEngine {
             }
         }
 
-        Object forcedObject;
+        Object jsonValue;
         try {
             // JsonPath didn't work with JsonNode, even explicitly using
             // JacksonJsonProvider, so we convert to a plain Object: a Map for an object node, a List for
@@ -893,7 +893,7 @@ public class OnlineScoringEngine {
             // IllegalArgumentException) whenever the section was NOT an object — e.g. a trace whose
             // output is the bare string "how can I help?" — and that escaped prepareLlmRequest and failed
             // the whole evaluation before the LLM was ever called.
-            forcedObject = OBJECT_MAPPER.convertValue(json, Object.class);
+            jsonValue = OBJECT_MAPPER.convertValue(json, Object.class);
         } catch (IllegalArgumentException e) {
             log.warn("failed to parse json, json={}", json, e);
             return null;
@@ -902,7 +902,7 @@ public class OnlineScoringEngine {
         try {
             // JsonPath.read throws PathNotFoundException on a non-container (a scalar section has no
             // nested path to walk), which lands on the fallback below rather than propagating.
-            var value = JsonPath.parse(forcedObject).read(path);
+            var value = JsonPath.parse(jsonValue).read(path);
             return value != null ? serializeToJsonString(value) : null;
         } catch (PathNotFoundException e) {
             // DEBUG, and without the throwable: a scalar/array section reaches this line by design (it
@@ -911,7 +911,7 @@ public class OnlineScoringEngine {
             // at all. The PathNotFoundException message says nothing the log line does not.
             log.debug("couldn't find path inside json, trying flat structure, path={}, nodeType={}",
                     path, json.getNodeType());
-            return flatFallback(forcedObject, path, json);
+            return flatFallback(jsonValue, path, json);
         } catch (Exception e) {
             // Anything else means the path itself didn't parse — JsonPath raises InvalidPathException for
             // a malformed expression, and the path is user-supplied ({@code toVariableMapping} builds it
@@ -920,7 +920,7 @@ public class OnlineScoringEngine {
             // it. Message without the stack trace: a bad mapping fires on every trace the rule scores.
             log.warn("invalid json path, trying flat structure, path={}, nodeType={}, error={}",
                     path, json.getNodeType(), e.getMessage());
-            return flatFallback(forcedObject, path, json);
+            return flatFallback(jsonValue, path, json);
         }
     }
 
@@ -929,10 +929,12 @@ public class OnlineScoringEngine {
      * name, which is how a mapping like {@code output.flat.key} finds a property actually called
      * "flat.key". Only meaningful for an object section — a scalar or a list has no properties.
      */
-    private static String flatFallback(Object forcedObject, String path, JsonNode json) {
-        return Optional.ofNullable(forcedObject)
+    private static String flatFallback(Object jsonValue, String path, JsonNode json) {
+        return Optional.ofNullable(jsonValue)
                 .filter(Map.class::isInstance)
-                .map(object -> ((Map<?, ?>) object).get(path.replace("$.", "")))
+                // Strip only the leading "$." — replace() would rewrite a key that itself
+                // contains "$." (a mapping of "output.a$.b" looked up "ab") and miss it.
+                .map(object -> ((Map<?, ?>) object).get(StringUtils.removeStart(path, "$.")))
                 .map(OnlineScoringEngine::serializeToJsonString)
                 .orElseGet(() -> {
                     // The node's type, not its content: this is a trace's input/output/metadata, so it

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -33,7 +33,6 @@ import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -483,8 +482,10 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 // for the empirical asymmetry. Follow-up rounds in handleToolCalls switch to
                 // AUTO so the model can decide when it has enough info to stop investigating;
                 // a uniform REQUIRED would loop forever because the wrap-up turn would also
-                // be forced to call a tool.
-                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                // be forced to call a tool. Providers that reject a forced choice outright get
+                // AUTO here too — see firstRoundToolChoice.
+                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                        agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
             }
 
             // summarizeRequest is cheap (no per-message toString streaming since the chars-count

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -24,7 +24,6 @@ import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import lombok.Builder;
@@ -311,8 +310,10 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                 llmProviderFactory.getStructuredOutputStrategy(modelName),
                 onlineScoringConfig.getMaxPromptFieldChars(), drillDownHint, spanStructureJson);
         // REQUIRED on the first call only forces ≥1 tool call; follow-ups switch to AUTO in
-        // handleToolCalls so the model can decide when to stop investigating.
-        scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+        // handleToolCalls so the model can decide when to stop investigating. Providers that reject
+        // a forced choice outright get AUTO here too — see firstRoundToolChoice.
+        scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
         return LlmRequests.builder().score(scoreRequest).structured(structuredRequest).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -28,7 +28,6 @@ import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.log.UserFacingLoggingFactory;
 import dev.langchain4j.model.chat.request.ChatRequest;
-import dev.langchain4j.model.chat.request.ToolChoice;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.NotFoundException;
@@ -439,7 +438,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                 // REQUIRED on the first call only — same reasoning as the trace scorer: forces
                 // ≥1 tool call before the model can answer from skeleton alone. Follow-up rounds
                 // switch to AUTO so the wrap-up turn can emit JSON without invoking a tool.
-                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest, ToolChoice.REQUIRED);
+                // Providers that reject a forced choice outright get AUTO here too — see
+                // firstRoundToolChoice.
+                scoreRequest = agenticScoringService.addToolSpecs(scoreRequest,
+                        agenticScoringService.firstRoundToolChoice(llmProviderFactory.getLlmProvider(modelName)));
             }
 
             // summarizeRequest is cheap (no per-message toString streaming). At INFO to mirror

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/SupportedVariablePaths.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/SupportedVariablePaths.java
@@ -1,0 +1,29 @@
+package com.comet.opik.api.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates an automation rule's variable mappings against the supported path grammar — see
+ * {@link com.comet.opik.utils.VariablePathUtils}. Rejects recursive descent ({@code ..}) and filter
+ * predicates ({@code [?(}), whose evaluation cost grows with the size of the scored trace on a
+ * scheduler shared by every workspace on the pod. Indexed access and single-level wildcards stay
+ * supported.
+ */
+@Documented
+@Constraint(validatedBy = SupportedVariablePathsValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SupportedVariablePaths {
+    String message() default "contains an unsupported path construct";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/validation/SupportedVariablePathsValidator.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/validation/SupportedVariablePathsValidator.java
@@ -1,0 +1,26 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.utils.VariablePathUtils;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Map;
+
+public class SupportedVariablePathsValidator
+        implements
+            ConstraintValidator<SupportedVariablePaths, Map<String, String>> {
+
+    @Override
+    public boolean isValid(Map<String, String> variables, ConstraintValidatorContext context) {
+        var violation = VariablePathUtils.validate(variables);
+        if (violation.isEmpty()) {
+            return true;
+        }
+        // Replace the default message so the response names the offending variable and construct: the
+        // mapping is the user's own input and "contains an unsupported path construct" alone would leave
+        // them guessing which one.
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(violation.get()).addConstraintViolation();
+        return false;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/VariablePathUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/VariablePathUtils.java
@@ -1,0 +1,98 @@
+package com.comet.opik.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Supported grammar for an automation rule's variable mappings — the {@code output.choices[0].message}
+ * strings that {@code OnlineScoringEngine} turns into a JsonPath and reads out of a trace's
+ * input/output/metadata.
+ * <p>
+ * Everything JsonPath accepts is allowed except the two constructs whose cost is unbounded in the
+ * section's size:
+ * <ul>
+ *   <li><b>recursive descent</b> ({@code ..}) — walks the whole subtree, and chained descents multiply:
+ *       measured at ~40x the cost of a single descent, ~2.4s on a 54 MB section.</li>
+ *   <li><b>filter predicates</b> ({@code [?(...)]}) — evaluated against every node the descent reaches.</li>
+ * </ul>
+ * Indexed access ({@code [0]}) and single-level wildcards ({@code [*]}) stay supported: both are bounded
+ * by one level's child count, and rules in the field use them.
+ * <p>
+ * Scoring runs on a scheduler shared by every workspace on the pod, so an expression whose cost scales
+ * with the trace is not merely the rule author's own problem.
+ */
+@UtilityClass
+public class VariablePathUtils {
+
+    private static final String RECURSIVE_DESCENT = "..";
+    private static final String FILTER_PREDICATE = "[?(";
+
+    /**
+     * Prefixes that make a mapping value a path into the entity rather than a literal replacement.
+     * Mirrors {@code OnlineScoringEngine.TraceSection}; a value that matches none of these is a literal
+     * and is never handed to JsonPath, so it is not constrained.
+     */
+    private static final List<String> SECTION_PREFIXES = List.of("input.", "output.", "metadata.");
+
+    public static boolean isEntityPath(String mappingValue) {
+        return mappingValue != null && SECTION_PREFIXES.stream().anyMatch(mappingValue::startsWith);
+    }
+
+    /**
+     * @return the unsupported construct found in the mapping value, or empty when it is supported
+     *         (including when it is a literal rather than a path).
+     */
+    public static Optional<String> findUnsupportedConstruct(String mappingValue) {
+        if (!isEntityPath(mappingValue)) {
+            return Optional.empty();
+        }
+        if (mappingValue.contains(RECURSIVE_DESCENT)) {
+            return Optional.of(RECURSIVE_DESCENT);
+        }
+        if (mappingValue.contains(FILTER_PREDICATE)) {
+            return Optional.of(FILTER_PREDICATE);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Same check against an already-built JsonPath (the {@code $.…} form), for the extraction path. Rules
+     * stored before this validation existed still reach the engine, so the guard has to hold there too.
+     */
+    public static Optional<String> findUnsupportedConstructInJsonPath(String jsonPath) {
+        if (jsonPath == null) {
+            return Optional.empty();
+        }
+        if (jsonPath.contains(RECURSIVE_DESCENT)) {
+            return Optional.of(RECURSIVE_DESCENT);
+        }
+        if (jsonPath.contains(FILTER_PREDICATE)) {
+            return Optional.of(FILTER_PREDICATE);
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return a message naming every offending variable, or empty when all mappings are supported.
+     */
+    public static Optional<String> validate(Map<String, String> variables) {
+        if (variables == null) {
+            return Optional.empty();
+        }
+        var offenders = variables.entrySet().stream()
+                .flatMap(entry -> findUnsupportedConstruct(entry.getValue())
+                        .map(construct -> "'%s' (%s uses '%s')"
+                                .formatted(entry.getKey(), entry.getValue(), construct))
+                        .stream())
+                .toList();
+        return offenders.isEmpty()
+                ? Optional.empty()
+                : Optional.of(("unsupported path construct in variable mapping: %s. Recursive descent ('..') and "
+                        + "filter predicates ('[?(') are not supported because their cost grows with the size of "
+                        + "the trace; use an explicit path or an index instead")
+                        .formatted(String.join(", ", offenders)));
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
@@ -14,6 +14,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
@@ -22,9 +25,11 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -112,28 +117,45 @@ class AgenticScoringServiceTest {
         assertThat(emitted.get()).isLessThan(5);
     }
 
-    @Test
-    @DisplayName("firstRoundToolChoice forces a tool call except on providers that reject a forced choice")
-    void firstRoundToolChoicePerProvider() {
-        // Vertex AI's langchain4j model throws UnsupportedFeatureException on any explicit tool choice,
-        // which is terminal — it failed the evaluation instead of scoring it.
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.VERTEX_AI)).isEqualTo(ToolChoice.AUTO);
+    /**
+     * One row per {@link LlmProvider} — deliberately explicit rather than derived from
+     * {@code supportsToolCalling}, so adding a provider fails
+     * {@link #firstRoundToolChoiceCoversEveryProvider()} until its tool choice is decided here
+     * instead of silently inheriting a default.
+     */
+    static Stream<Arguments> firstRoundToolChoices() {
+        return Stream.of(
+                // langchain4j's ChatRequestValidationUtils.validate throws
+                // UnsupportedFeatureException for any tool choice other than AUTO, and Vertex's
+                // model calls it — a forced choice failed the evaluation instead of scoring it.
+                arguments(LlmProvider.VERTEX_AI, ToolChoice.AUTO),
+                arguments(LlmProvider.OPEN_AI, ToolChoice.REQUIRED),
+                arguments(LlmProvider.ANTHROPIC, ToolChoice.REQUIRED),
+                arguments(LlmProvider.GEMINI, ToolChoice.REQUIRED),
+                arguments(LlmProvider.OPEN_ROUTER, ToolChoice.REQUIRED),
+                arguments(LlmProvider.BEDROCK, ToolChoice.REQUIRED),
+                // No tool support at all: callers gate these out, and AUTO keeps a caller that
+                // forgets the gate on the harmless side.
+                arguments(LlmProvider.OLLAMA, ToolChoice.AUTO),
+                arguments(LlmProvider.CUSTOM_LLM, ToolChoice.AUTO),
+                arguments(LlmProvider.OPIK_FREE, ToolChoice.AUTO));
+    }
 
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_AI)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.ANTHROPIC)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.GEMINI)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_ROUTER)).isEqualTo(ToolChoice.REQUIRED);
-        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.BEDROCK)).isEqualTo(ToolChoice.REQUIRED);
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("firstRoundToolChoices")
+    @DisplayName("firstRoundToolChoice forces a tool call except where the provider rejects one")
+    void firstRoundToolChoicePerProvider(LlmProvider provider, ToolChoice expected) {
+        assertThat(agenticScoringService.firstRoundToolChoice(provider)).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("firstRoundToolChoice never forces a choice on a provider that has no tool support")
-    void firstRoundToolChoiceOnNonToolCallingProviders() {
-        Stream.of(LlmProvider.values())
-                .filter(provider -> !agenticScoringService.supportsToolCalling(provider))
-                .forEach(provider -> assertThat(agenticScoringService.firstRoundToolChoice(provider))
-                        .as("provider %s", provider)
-                        .isEqualTo(ToolChoice.AUTO));
+    @DisplayName("firstRoundToolChoice has a case for every LlmProvider")
+    void firstRoundToolChoiceCoversEveryProvider() {
+        var covered = firstRoundToolChoices()
+                .map(arguments -> (LlmProvider) arguments.get()[0])
+                .collect(Collectors.toSet());
+
+        assertThat(covered).containsExactlyInAnyOrder(LlmProvider.values());
     }
 
     private static Span spanWithInput(String payload) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgenticScoringServiceTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.LlmProvider;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
@@ -8,6 +9,7 @@ import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.TestIdGeneratorFactory;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.utils.JsonUtils;
+import dev.langchain4j.model.chat.request.ToolChoice;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -107,6 +110,30 @@ class AgenticScoringServiceTest {
         assertThat(result.spans()).isEmpty();
         // Cancelled almost immediately — a handful of elements at most, not the unbounded stream.
         assertThat(emitted.get()).isLessThan(5);
+    }
+
+    @Test
+    @DisplayName("firstRoundToolChoice forces a tool call except on providers that reject a forced choice")
+    void firstRoundToolChoicePerProvider() {
+        // Vertex AI's langchain4j model throws UnsupportedFeatureException on any explicit tool choice,
+        // which is terminal — it failed the evaluation instead of scoring it.
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.VERTEX_AI)).isEqualTo(ToolChoice.AUTO);
+
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_AI)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.ANTHROPIC)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.GEMINI)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.OPEN_ROUTER)).isEqualTo(ToolChoice.REQUIRED);
+        assertThat(agenticScoringService.firstRoundToolChoice(LlmProvider.BEDROCK)).isEqualTo(ToolChoice.REQUIRED);
+    }
+
+    @Test
+    @DisplayName("firstRoundToolChoice never forces a choice on a provider that has no tool support")
+    void firstRoundToolChoiceOnNonToolCallingProviders() {
+        Stream.of(LlmProvider.values())
+                .filter(provider -> !agenticScoringService.supportsToolCalling(provider))
+                .forEach(provider -> assertThat(agenticScoringService.firstRoundToolChoice(provider))
+                        .as("provider %s", provider)
+                        .isEqualTo(ToolChoice.AUTO));
     }
 
     private static Span spanWithInput(String payload) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
@@ -1,0 +1,109 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.Trace;
+import com.comet.opik.utils.JsonUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Variable extraction out of a trace's input/output/metadata section. Pure static functions, so no
+ * containers here — see {@link OnlineScoringEngineTest} for the end-to-end scoring flow.
+ * <p>
+ * The scalar-section cases are the regression: a trace whose section is a bare JSON string (or array)
+ * used to blow up {@code toReplacements} with a {@code MismatchedInputException}, which propagated out
+ * of {@code prepareLlmRequest} and failed the whole evaluation before the LLM was ever called.
+ */
+@DisplayName("OnlineScoringEngine variable extraction")
+class OnlineScoringEngineExtractFromJsonTest {
+
+    private static Trace traceWithOutput(String outputJson) {
+        return Trace.builder()
+                .id(UUID.randomUUID())
+                .projectName("project")
+                .projectId(UUID.randomUUID())
+                .createdBy("user")
+                .output(JsonUtils.getJsonNodeFromString(outputJson))
+                .build();
+    }
+
+    @Test
+    @DisplayName("nested path against a bare-string section drops the variable instead of throwing")
+    void nestedPathOnStringSection() {
+        var trace = traceWithOutput("\"Motor, elektrik, vites veya gövde?\"");
+        var variables = Map.of("answer", "output.answer");
+
+        assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, trace)).doesNotThrowAnyException();
+        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("answer");
+    }
+
+    @Test
+    @DisplayName("whole-section mapping of a bare-string section still resolves")
+    void wholeSectionOnStringSection() {
+        var trace = traceWithOutput("\"just a string\"");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("output", "output"), trace);
+
+        assertThat(replacements).containsEntry("output", "\"just a string\"");
+    }
+
+    @Test
+    @DisplayName("nested path against a numeric section drops the variable instead of throwing")
+    void nestedPathOnNumericSection() {
+        var trace = traceWithOutput("42");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("score", "output.score"), trace);
+
+        assertThat(replacements).doesNotContainKey("score");
+    }
+
+    @Test
+    @DisplayName("indexed path against an array section resolves the element")
+    void indexedPathOnArraySection() {
+        var trace = traceWithOutput("[{\"name\": \"first\"}, {\"name\": \"second\"}]");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.[0].name"), trace);
+
+        assertThat(replacements).containsEntry("name", "first");
+    }
+
+    @Test
+    @DisplayName("field path against an array section drops the variable instead of throwing")
+    void fieldPathOnArraySection() {
+        var trace = traceWithOutput("[\"a\", \"b\"]");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.name"), trace);
+
+        assertThat(replacements).doesNotContainKey("name");
+    }
+
+    @Test
+    @DisplayName("nested and flat paths against an object section keep working")
+    void objectSectionStillResolves() {
+        var trace = traceWithOutput("""
+                {
+                    "answer": "42",
+                    "details": {"unit": "meters"},
+                    "flat.key": "flat value"
+                }
+                """);
+
+        var replacements = OnlineScoringEngine.toReplacements(
+                Map.of(
+                        "answer", "output.answer",
+                        "unit", "output.details.unit",
+                        "flat", "output.flat.key"),
+                trace);
+
+        assertThat(replacements).containsEntry("answer", "42");
+        assertThat(replacements).containsEntry("unit", "meters");
+        // JsonPath reads "$.flat.key" as a nested miss, then the flat-structure fallback finds the
+        // literal "flat.key" property.
+        assertThat(replacements).containsEntry("flat", "flat value");
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
@@ -1,23 +1,31 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
+import com.comet.opik.domain.SpanType;
 import com.comet.opik.utils.JsonUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
- * Variable extraction out of a trace's input/output/metadata section. Pure static functions, so no
- * containers here — see {@link OnlineScoringEngineTest} for the end-to-end scoring flow.
+ * Variable extraction out of a trace's or span's input/output/metadata section. Pure static functions,
+ * so no containers here — see {@link OnlineScoringEngineTest} for the end-to-end scoring flow.
  * <p>
- * The scalar-section cases are the regression: a trace whose section is a bare JSON string (or array)
- * used to blow up {@code toReplacements} with a {@code MismatchedInputException}, which propagated out
- * of {@code prepareLlmRequest} and failed the whole evaluation before the LLM was ever called.
+ * The non-object-section cases are the regression: a section that is a bare JSON string (or array) used
+ * to blow up {@code toReplacements} with a {@code MismatchedInputException}, which propagated out of
+ * {@code prepareLlmRequest} and failed the whole evaluation before the LLM was ever called.
  */
 @DisplayName("OnlineScoringEngine variable extraction")
 class OnlineScoringEngineExtractFromJsonTest {
@@ -32,14 +40,51 @@ class OnlineScoringEngineExtractFromJsonTest {
                 .build();
     }
 
-    @Test
-    @DisplayName("nested path against a bare-string section drops the variable instead of throwing")
-    void nestedPathOnStringSection() {
-        var trace = traceWithOutput("\"Motor, elektrik, vites veya gövde?\"");
-        var variables = Map.of("answer", "output.answer");
+    private static Span spanWithOutput(String outputJson) {
+        return Span.builder()
+                .id(UUID.randomUUID())
+                .name("span")
+                .type(SpanType.llm)
+                .startTime(Instant.now())
+                .traceId(UUID.randomUUID())
+                .projectId(UUID.randomUUID())
+                .output(JsonUtils.getJsonNodeFromString(outputJson))
+                .build();
+    }
+
+    /**
+     * Section shapes that carry no nested path: the mapping cannot resolve, and the contract is that the
+     * variable is dropped rather than the evaluation failing.
+     */
+    static Stream<Arguments> unresolvableSections() {
+        return Stream.of(
+                arguments("bare string", "\"Motor, elektrik, vites veya gövde?\"", "output.answer"),
+                arguments("number", "42", "output.score"),
+                arguments("boolean", "true", "output.flag"),
+                arguments("null", "null", "output.answer"),
+                arguments("array, field path", "[\"a\", \"b\"]", "output.name"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unresolvableSections")
+    @DisplayName("an unresolvable path drops the variable instead of throwing")
+    void unresolvablePathDropsTheVariable(String shape, String outputJson, String mapping) {
+        var trace = traceWithOutput(outputJson);
+        var variables = Map.of("variable", mapping);
 
         assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, trace)).doesNotThrowAnyException();
-        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("answer");
+        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("variable");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unresolvableSections")
+    @DisplayName("the span overload behaves the same for an unresolvable path")
+    void unresolvablePathOnSpanDropsTheVariable(String shape, String outputJson, String mapping) {
+        var span = spanWithOutput(outputJson);
+        var variables = Map.of("variable", mapping);
+
+        assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, span)).doesNotThrowAnyException();
+        assertThat(OnlineScoringEngine.toReplacements(variables, span)).doesNotContainKey("variable");
     }
 
     @Test
@@ -53,16 +98,6 @@ class OnlineScoringEngineExtractFromJsonTest {
     }
 
     @Test
-    @DisplayName("nested path against a numeric section drops the variable instead of throwing")
-    void nestedPathOnNumericSection() {
-        var trace = traceWithOutput("42");
-
-        var replacements = OnlineScoringEngine.toReplacements(Map.of("score", "output.score"), trace);
-
-        assertThat(replacements).doesNotContainKey("score");
-    }
-
-    @Test
     @DisplayName("indexed path against an array section resolves the element")
     void indexedPathOnArraySection() {
         var trace = traceWithOutput("[{\"name\": \"first\"}, {\"name\": \"second\"}]");
@@ -70,16 +105,6 @@ class OnlineScoringEngineExtractFromJsonTest {
         var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.[0].name"), trace);
 
         assertThat(replacements).containsEntry("name", "first");
-    }
-
-    @Test
-    @DisplayName("field path against an array section drops the variable instead of throwing")
-    void fieldPathOnArraySection() {
-        var trace = traceWithOutput("[\"a\", \"b\"]");
-
-        var replacements = OnlineScoringEngine.toReplacements(Map.of("name", "output.name"), trace);
-
-        assertThat(replacements).doesNotContainKey("name");
     }
 
     @Test
@@ -117,5 +142,17 @@ class OnlineScoringEngineExtractFromJsonTest {
         // JsonPath reads "$.flat.key" as a nested miss, then the flat-structure fallback finds the
         // literal "flat.key" property.
         assertThat(replacements).containsEntry("flat", "flat value");
+    }
+
+    @Test
+    @DisplayName("a flat key containing \"$.\" resolves — only the leading prefix is stripped")
+    void flatKeyContainingTheRootPrefix() {
+        // Stripping every "$." rather than the leading one rewrote the lookup key ("$.a$.b" -> "ab")
+        // and missed a property that is present.
+        var trace = traceWithOutput("{\"a$.b\": \"present\"}");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("weird", "output.a$.b"), trace);
+
+        assertThat(replacements).containsEntry("weird", "present");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
@@ -83,6 +83,18 @@ class OnlineScoringEngineExtractFromJsonTest {
     }
 
     @Test
+    @DisplayName("a malformed path drops the variable instead of throwing")
+    void malformedPath() {
+        // The path comes from the rule's variable mapping, so a user typo reaches JsonPath as an
+        // unparseable expression (InvalidPathException) rather than a simple miss.
+        var trace = traceWithOutput("{\"k\": [{\"x\": 1}]}");
+        var variables = Map.of("broken", "output.k[?(@.x");
+
+        assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, trace)).doesNotThrowAnyException();
+        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("broken");
+    }
+
+    @Test
     @DisplayName("nested and flat paths against an object section keep working")
     void objectSectionStillResolves() {
         var trace = traceWithOutput("""

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineExtractFromJsonTest.java
@@ -145,6 +145,30 @@ class OnlineScoringEngineExtractFromJsonTest {
     }
 
     @Test
+    @DisplayName("a recursive-descent path is dropped at extraction, not evaluated")
+    void recursiveDescentIsRejected() {
+        // Rules are validated on write, but ones stored before that validation existed still reach the
+        // engine, so the grammar is enforced here too: the variable is dropped and scoring continues.
+        var trace = traceWithOutput("{\"a\": {\"b\": {\"content\": \"deep\"}}}");
+        var variables = Map.of("content", "output..content");
+
+        assertThatCode(() -> OnlineScoringEngine.toReplacements(variables, trace)).doesNotThrowAnyException();
+        assertThat(OnlineScoringEngine.toReplacements(variables, trace)).doesNotContainKey("content");
+    }
+
+    @Test
+    @DisplayName("a single-level wildcard still resolves — only unbounded traversal is rejected")
+    void singleLevelWildcardStillResolves() {
+        // Shape taken from a rule in the field: results[*].content. Bounded by one level's child count,
+        // so it stays supported.
+        var trace = traceWithOutput("{\"results\": [{\"content\": \"first\"}, {\"content\": \"second\"}]}");
+
+        var replacements = OnlineScoringEngine.toReplacements(Map.of("all", "output.results[*].content"), trace);
+
+        assertThat(replacements.get("all")).contains("first").contains("second");
+    }
+
+    @Test
     @DisplayName("a flat key containing \"$.\" resolves — only the leading prefix is stripped")
     void flatKeyContainingTheRootPrefix() {
         // Stripping every "$." rather than the leading one rewrote the lookup key ("$.a$.b" -> "ab")

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/validation/SupportedVariablePathsValidatorTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/validation/SupportedVariablePathsValidatorTest.java
@@ -1,0 +1,98 @@
+package com.comet.opik.api.validation;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorLlmAsJudge.LlmAsJudgeCode;
+import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+/**
+ * Save-time enforcement of the supported variable-path grammar. Recursive descent and filter predicates
+ * are rejected because their evaluation cost grows with the size of the scored trace, on a scheduler
+ * shared across workspaces; everything else JsonPath accepts stays allowed.
+ * <p>
+ * The supported cases are drawn from mappings actually in use, so the accepted grammar is pinned against
+ * real rules rather than guesswork.
+ */
+class SupportedVariablePathsValidatorTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    private static LlmAsJudgeCode codeWith(Map<String, String> variables) {
+        return new LlmAsJudgeCode(
+                LlmAsJudgeModelParameters.builder().name("gpt-4o-mini").temperature(0.0).build(),
+                List.of(),
+                variables,
+                List.of());
+    }
+
+    static Stream<Arguments> supportedMappings() {
+        return Stream.of(
+                arguments("plain nested", "output.response"),
+                arguments("deep nested", "output.output.choices[0].message.content"),
+                arguments("indexed", "input.messages[0].content"),
+                arguments("indexed root", "input[1].text"),
+                arguments("single-level wildcard", "output.output.results[*].content"),
+                arguments("whole section", "output"),
+                arguments("literal value, not a path", "some literal string"),
+                // A literal is never handed to JsonPath, so the grammar does not constrain it.
+                arguments("literal containing dots", "see ../docs for details"));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("supportedMappings")
+    @DisplayName("supported mappings pass validation")
+    void supported(String shape, String mapping) {
+        var violations = validator.validate(codeWith(Map.of("variable", mapping)));
+
+        assertThat(violations).isEmpty();
+    }
+
+    static Stream<Arguments> unsupportedMappings() {
+        return Stream.of(
+                arguments("recursive descent", "output..content", ".."),
+                arguments("recursive wildcard", "output..*", ".."),
+                arguments("chained descent", "output..a..b", ".."),
+                arguments("filter predicate", "output.items[?(@.role == 'user')].content", "[?("),
+                arguments("descent plus filter", "output..[?(@.leaf)]", ".."));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedMappings")
+    @DisplayName("unsupported mappings are rejected, naming the variable and the construct")
+    void unsupported(String shape, String mapping, String construct) {
+        var violations = validator.validate(codeWith(Map.of("answer", mapping)));
+
+        assertThat(violations).hasSize(1);
+        var message = violations.iterator().next().getMessage();
+        assertThat(message).contains("'answer'").contains(mapping).contains(construct);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("unsupportedMappings")
+    @DisplayName("a supported mapping alongside an unsupported one still fails")
+    void unsupportedAmongSupported(String shape, String mapping, String construct) {
+        var violations = validator.validate(codeWith(Map.of(
+                "fine", "output.response",
+                "answer", mapping)));
+
+        assertThat(violations).hasSize(1);
+        assertThat(violations.iterator().next().getMessage()).contains("'answer'").doesNotContain("'fine'");
+    }
+}

--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -92,12 +92,21 @@ class CodeExecutorBase(ABC):
                 logger.warning("Execution returned exit code 0 with no output")
                 return {"code": 400, "error": "Execution failed: the metric produced no output"}
             try:
-                return json.loads(lines[-1])
+                parsed = json.loads(lines[-1])
             except json.JSONDecodeError as e:
                 # Same reasoning: exit code 0 whose last line is not the result JSON means the
                 # client's metric printed something else last, not that the server misbehaved.
                 logger.warning(f"Failed to parse execution result as JSON: {e}")
                 return {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
+            if not isinstance(parsed, dict):
+                # Valid JSON that is not an object (`null`, `42`, `"done"`, `[1, 2]`) would reach
+                # the HTTP layer and blow up there instead — `"error" in response` raises TypeError
+                # for the non-iterables and `response.get` raises AttributeError for the rest, both
+                # surfacing as a 500. Reject it here, where the contract of this function (-> dict)
+                # is stated.
+                logger.warning(f"Execution result is not a JSON object: {type(parsed).__name__}")
+                return {"code": 400, "error": "Execution failed: the metric did not return a JSON object"}
+            return parsed
         else:
             logger.warning(f"Execution failed (Code: {result.exit_code}):\n{result.output.decode('utf-8')}")
             try:

--- a/apps/opik-python-backend/src/opik_backend/executor.py
+++ b/apps/opik-python-backend/src/opik_backend/executor.py
@@ -82,8 +82,22 @@ class CodeExecutorBase(ABC):
     def parse_execution_result(self, result: ExecutionResult) -> dict:
         """Parse execution result into API response format."""
         if result.exit_code == 0:
-            last_line = result.output.decode("utf-8").strip().splitlines()[-1]
-            return json.loads(last_line)
+            lines = result.output.decode("utf-8").strip().splitlines()
+            if not lines:
+                # Exit code 0 with no output at all: the client's metric ran to completion without
+                # printing its result line. Indexing [-1] here raised IndexError, which
+                # run_scoring's catch-all reported as an opaque "An unexpected error occurred" 500 —
+                # retried by the caller and counted against us. The executed code is the client's,
+                # so this is a 400 like every other way their metric can be wrong.
+                logger.warning("Execution returned exit code 0 with no output")
+                return {"code": 400, "error": "Execution failed: the metric produced no output"}
+            try:
+                return json.loads(lines[-1])
+            except json.JSONDecodeError as e:
+                # Same reasoning: exit code 0 whose last line is not the result JSON means the
+                # client's metric printed something else last, not that the server misbehaved.
+                logger.warning(f"Failed to parse execution result as JSON: {e}")
+                return {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
         else:
             logger.warning(f"Execution failed (Code: {result.exit_code}):\n{result.output.decode('utf-8')}")
             try:

--- a/apps/opik-python-backend/src/opik_backend/executor_docker.py
+++ b/apps/opik-python-backend/src/opik_backend/executor_docker.py
@@ -474,14 +474,21 @@ class DockerExecutor(CodeExecutorBase):
                 # Parse result and track outcome
                 parsed_result = self.parse_execution_result(exec_result)
 
-                # Determine outcome status based on result
-                if exec_result.exit_code == 0:
+                # Determine outcome status from the parsed result, not from the exit code alone: a
+                # metric can exit 0 and still fail to produce a usable result line, which
+                # parse_execution_result reports as a 4xx. Keying telemetry on the exit code
+                # counted those as successes while the caller was handed an error.
+                result_code = parsed_result.get("code") if isinstance(parsed_result, dict) else None
+                if exec_result.exit_code == 0 and result_code is None:
                     outcome_status = "success"
                 else:
                     outcome_status = "invalid_code"
-                    span.set_status(Status(StatusCode.ERROR, f"Execution failed with exit_code={exec_result.exit_code}"))
+                    span.set_status(Status(StatusCode.ERROR,
+                            f"Execution failed with exit_code={exec_result.exit_code}, result_code={result_code}"))
                     span.set_attribute("error.type", "invalid_code")
                     span.set_attribute("error.exit_code", exec_result.exit_code)
+                    if result_code is not None:
+                        span.set_attribute("error.result_code", result_code)
 
                 self._record_execution_outcome(outcome_status, payload_type)
                 return parsed_result

--- a/apps/opik-python-backend/tests/unit/test_executor_docker_outcome.py
+++ b/apps/opik-python-backend/tests/unit/test_executor_docker_outcome.py
@@ -1,0 +1,76 @@
+"""Execution-outcome telemetry of DockerExecutor.run_scoring.
+
+The outcome recorded on the ``execution_outcome_counter`` metric must match what
+the caller is actually handed. A metric can exit 0 and still fail to produce a
+usable result line — parse_execution_result reports that as a 4xx and the HTTP
+layer aborts with it — so keying the outcome on the exit code alone counted those
+runs as successes.
+
+The Docker daemon is not required: ``docker.from_env`` is mocked, pool pre-warming
+and the pool monitor are stubbed, and a container whose ``exec_run`` returns a
+canned result is injected into the pool.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opik_backend.executor_docker import DockerExecutor
+
+DATA = {"output": "x", "reference": "x"}
+
+
+@pytest.fixture
+def executor():
+    with (
+        patch("opik_backend.executor_docker.docker.from_env", return_value=MagicMock()),
+        patch("opik_backend.executor_docker.DockerExecutor._pre_warm_container_pool"),
+        patch("opik_backend.executor_docker.DockerExecutor._start_pool_monitor"),
+    ):
+        instance = DockerExecutor()
+        yield instance
+        instance.stop_event.set()
+
+
+def run_with_result(executor, exit_code, output: bytes):
+    """Run scoring against a container returning a canned exec result."""
+    container = MagicMock()
+    container.exec_run.return_value = MagicMock(exit_code=exit_code, output=output)
+    with patch.object(executor, "get_container", return_value=container):
+        with patch.object(executor, "_record_execution_outcome") as record:
+            response = executor.run_scoring(code="<unused>", data=DATA)
+    return response, [call.args[0] for call in record.call_args_list]
+
+
+def test_scores_payload_records_success(executor):
+    payload = {"scores": [{"name": "m", "value": 1.0}]}
+
+    response, outcomes = run_with_result(executor, 0, json.dumps(payload).encode("utf-8"))
+
+    assert response == payload
+    assert outcomes == ["success"]
+
+
+def test_exit_zero_without_output_is_not_recorded_as_success(executor):
+    response, outcomes = run_with_result(executor, 0, b"")
+
+    assert response["code"] == 400
+    assert outcomes == ["invalid_code"]
+
+
+def test_exit_zero_with_error_payload_is_not_recorded_as_success(executor):
+    # The sandbox runner catches a failing metric and prints its own 400 payload
+    # while still exiting 0; the HTTP layer aborts with that code.
+    body = {"code": 400, "error": "boom"}
+
+    response, outcomes = run_with_result(executor, 0, json.dumps(body).encode("utf-8"))
+
+    assert response == body
+    assert outcomes == ["invalid_code"]
+
+
+def test_nonzero_exit_records_invalid_code(executor):
+    response, outcomes = run_with_result(executor, 1, json.dumps({"error": "bad metric"}).encode("utf-8"))
+
+    assert response == {"code": 400, "error": "bad metric"}
+    assert outcomes == ["invalid_code"]

--- a/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
+++ b/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
@@ -1,0 +1,54 @@
+"""Tests for CodeExecutorBase.parse_execution_result"""
+import json
+
+from opik_backend.executor import CodeExecutorBase, ExecutionResult
+
+
+class _Executor(CodeExecutorBase):
+    """parse_execution_result lives on the base class; run_scoring is abstract but unused here."""
+
+    def run_scoring(self, code, data, payload_type=None):  # pragma: no cover - not exercised
+        raise NotImplementedError
+
+
+def parse(exit_code: int, output: bytes) -> dict:
+    return _Executor().parse_execution_result(ExecutionResult(exit_code=exit_code, output=output))
+
+
+def test_success_returns_last_line_payload():
+    payload = {"scores": [{"name": "m", "value": 1.0}]}
+    result = parse(0, b"some stdout noise\n" + json.dumps(payload).encode("utf-8"))
+
+    assert result == payload
+
+
+def test_success_with_no_output_reports_a_client_error():
+    # Used to raise IndexError from splitlines()[-1], which run_scoring's catch-all reported as
+    # "An unexpected error occurred" with HTTP 500 — retried by the caller and blamed on us.
+    result = parse(0, b"")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric produced no output"}
+
+
+def test_success_with_whitespace_only_output_reports_a_client_error():
+    result = parse(0, b"   \n\n  ")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric produced no output"}
+
+
+def test_success_with_non_json_last_line_reports_a_client_error():
+    result = parse(0, b"not json at all")
+
+    assert result == {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
+
+
+def test_failure_surfaces_the_user_error_as_400():
+    result = parse(1, json.dumps({"error": "bad metric"}).encode("utf-8"))
+
+    assert result == {"code": 400, "error": "bad metric"}
+
+
+def test_failure_with_no_output_falls_back_to_the_invalid_metric_message():
+    result = parse(1, b"")
+
+    assert result == {"code": 400, "error": "Execution failed: Python code contains an invalid metric"}

--- a/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
+++ b/apps/opik-python-backend/tests/unit/test_executor_parse_result.py
@@ -1,6 +1,8 @@
 """Tests for CodeExecutorBase.parse_execution_result"""
 import json
 
+import pytest
+
 from opik_backend.executor import CodeExecutorBase, ExecutionResult
 
 
@@ -40,6 +42,19 @@ def test_success_with_non_json_last_line_reports_a_client_error():
     result = parse(0, b"not json at all")
 
     assert result == {"code": 400, "error": "Execution failed: the metric returned an unparseable result"}
+
+
+@pytest.mark.parametrize(
+    "last_line",
+    ["null", "123", "true", '"done"', "[1, 2]"],
+    ids=["null", "int", "bool", "str", "list"],
+)
+def test_success_with_non_object_json_reports_a_client_error(last_line):
+    # Valid JSON that is not an object used to be handed straight to the HTTP layer, which then
+    # raised TypeError ("error" in None) or AttributeError (str/list have no .get) and returned 500.
+    result = parse(0, last_line.encode("utf-8"))
+
+    assert result == {"code": 400, "error": "Execution failed: the metric did not return a JSON object"}
 
 
 def test_failure_surfaces_the_user_error_as_400():

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -459,7 +459,7 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.networkPolicy.enabled | bool | `false` |  |
 | component.python-backend.podDisruptionBudget.enabled | bool | `false` |  |
 | component.python-backend.readinessProbe.failureThreshold | int | `3` |  |
-| component.python-backend.readinessProbe.httpGet.path | string | `"/health/readiness"` |  |
+| component.python-backend.readinessProbe.httpGet.path | string | `"/health/liveness"` |  |
 | component.python-backend.readinessProbe.httpGet.port | int | `8000` |  |
 | component.python-backend.readinessProbe.periodSeconds | int | `10` |  |
 | component.python-backend.readinessProbe.timeoutSeconds | int | `3` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -473,6 +473,11 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.service.type | string | `"ClusterIP"` |  |
 | component.python-backend.serviceAccount.create | bool | `true` |  |
 | component.python-backend.serviceAccount.name | string | `"opik-python-backend"` |  |
+| component.python-backend.startupProbe.failureThreshold | int | `60` |  |
+| component.python-backend.startupProbe.httpGet.path | string | `"/health/liveness"` |  |
+| component.python-backend.startupProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.startupProbe.periodSeconds | int | `5` |  |
+| component.python-backend.startupProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.waitForRedis.enabled | bool | `true` |  |
 | component.python-backend.waitForRedis.image.registry | string | `"docker.io"` |  |
 | component.python-backend.waitForRedis.image.repository | string | `"busybox"` |  |

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -445,11 +445,24 @@ Call opik api on http://localhost:5173/api
 | component.python-backend.ingress.tls.enabled | bool | `false` |  |
 | component.python-backend.ingress.tls.hosts | list | `[]` |  |
 | component.python-backend.ingress.tls.secretName | string | `""` |  |
+| component.python-backend.lifecycle.preStop.exec.command[0] | string | `"/bin/sh"` |  |
+| component.python-backend.lifecycle.preStop.exec.command[1] | string | `"-c"` |  |
+| component.python-backend.lifecycle.preStop.exec.command[2] | string | `"sleep 5"` |  |
+| component.python-backend.livenessProbe.failureThreshold | int | `3` |  |
+| component.python-backend.livenessProbe.httpGet.path | string | `"/health/liveness"` |  |
+| component.python-backend.livenessProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.livenessProbe.periodSeconds | int | `15` |  |
+| component.python-backend.livenessProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.metrics.enabled | bool | `false` |  |
 | component.python-backend.networkPolicy.additionalRules | list | `[]` |  |
 | component.python-backend.networkPolicy.annotations | object | `{}` |  |
 | component.python-backend.networkPolicy.enabled | bool | `false` |  |
 | component.python-backend.podDisruptionBudget.enabled | bool | `false` |  |
+| component.python-backend.readinessProbe.failureThreshold | int | `3` |  |
+| component.python-backend.readinessProbe.httpGet.path | string | `"/health/readiness"` |  |
+| component.python-backend.readinessProbe.httpGet.port | int | `8000` |  |
+| component.python-backend.readinessProbe.periodSeconds | int | `10` |  |
+| component.python-backend.readinessProbe.timeoutSeconds | int | `3` |  |
 | component.python-backend.replicaCount | int | `1` |  |
 | component.python-backend.secretRefs | list | `[]` |  |
 | component.python-backend.securityContext.privileged | bool | `true` |  |

--- a/deployment/helm_chart/opik/tests/component_probes_test.yaml
+++ b/deployment/helm_chart/opik/tests/component_probes_test.yaml
@@ -60,6 +60,25 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
           value: 3
 
+  - it: python-backend gates liveness behind a startup probe with room to boot
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      # 5s x 60 = five minutes, enough for entrypoint.sh to wait on dockerd and
+      # load the sandbox executor image before gunicorn binds. Kubernetes holds
+      # liveness and readiness until this passes, so the tighter liveness timings
+      # below can never restart a pod that is merely still starting.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 60
+
   - it: python-backend liveness uses the app's liveness endpoint
     documentSelector:
       path: metadata.name

--- a/deployment/helm_chart/opik/tests/component_probes_test.yaml
+++ b/deployment/helm_chart/opik/tests/component_probes_test.yaml
@@ -42,9 +42,12 @@ tests:
       path: metadata.name
       value: opik-python-backend
     asserts:
+      # /health/liveness, not /health/readiness: the latter pings Redis when the RQ worker is
+      # enabled (the default), which would let one Redis blip evict every replica from the
+      # Service at once. Endpoint membership must depend only on this pod serving HTTP.
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /health/readiness
+          value: /health/liveness
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.port
           value: 8000

--- a/deployment/helm_chart/opik/tests/component_probes_test.yaml
+++ b/deployment/helm_chart/opik/tests/component_probes_test.yaml
@@ -1,0 +1,107 @@
+suite: probes shipped per component
+
+# What each component's probes actually resolve to with default values — the
+# deployed contract, as opposed to tests/probe_test.yaml, which exercises the
+# `opik.probe` helper's own modes and defaults.
+#
+# Worth pinning per component because the consequences differ: backend's probes
+# gate the API's rollout, python-backend's keep a starting pod out of the
+# Service's endpoints (without them a rolling update made the backend's
+# evaluator calls fail with "connection refused"), and frontend deliberately has
+# none — asserting that keeps the helper suite's clean-slate vehicle honest.
+templates:
+  - templates/deployment.yaml
+
+tests:
+  # ---- backend --------------------------------------------------------------
+  - it: backend probes point at the dropwizard health-check endpoints
+    documentSelector:
+      path: metadata.name
+      value: opik-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health-check?name=all&type=alive
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8080
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health-check?name=all&type=ready
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8080
+      # Readiness waits for the app to boot; liveness has no delay of its own.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 20
+
+  # ---- python-backend -------------------------------------------------------
+  - it: python-backend readiness gates the endpoint on the app answering
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
+      # taken out of the endpoint list.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+
+  - it: python-backend liveness uses the app's liveness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 3
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 3
+
+  - it: python-backend drains before exiting so terminating pods leave the endpoints
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 5
+
+  # ---- frontend -------------------------------------------------------------
+  - it: frontend ships no probes
+    documentSelector:
+      path: metadata.name
+      value: opik-frontend
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -198,7 +198,10 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *pyb
+    # frontend, not python-backend: the latter ships a startupProbe of its own.
+    documentSelector:
+      path: metadata.name
+      value: opik-frontend
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
@@ -206,6 +209,9 @@ tests:
   - it: startupProbe renders in simplified mode
     set:
       component.python-backend.startupProbe:
+        # Cleared so the assertion below sees the helper's default, not the
+        # periodSeconds python-backend ships.
+        periodSeconds: null
         path: /healthcheck
         port: 8000
         failureThreshold: 30

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,26 +7,28 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Tests target the `python-backend` component: it has NO probe defined in
-# values.yaml, so each test's `set` is a clean probe spec rather than a deep
-# merge over a pre-existing httpGet default (which would leak into full-mode
-# assertions). The deployment renders one document per enabled component, so we
-# select the python-backend deployment by name and read its single container.
+# Tests target the `frontend` component: it is the only one with NO probe
+# defined in values.yaml, so each test's `set` is a clean probe spec rather than
+# a deep merge over a pre-existing httpGet default (which would leak into
+# full-mode assertions). The deployment renders one document per enabled
+# component, so we select the frontend deployment by name and read its first
+# container. The probes that `backend` and `python-backend` ship by default are
+# asserted at the bottom of this suite instead.
 templates:
   - templates/deployment.yaml
 
-documentSelector: &pyb
+documentSelector: &frontend
   path: metadata.name
-  value: opik-python-backend
+  value: opik-frontend
 
 tests:
   # ---- Simplified mode: only path/port set ----------------------------------
   - it: simplified mode renders httpGet with the Accept header
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -42,10 +44,10 @@ tests:
 
   - it: simplified mode fills in the hard-coded timing defaults
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
@@ -62,10 +64,10 @@ tests:
 
   - it: simplified mode defaults initialDelaySeconds to 0 when unset
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -73,11 +75,11 @@ tests:
 
   - it: simplified mode honors initialDelaySeconds when set
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         path: /healthcheck
         port: 8000
         initialDelaySeconds: 20
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -85,14 +87,14 @@ tests:
 
   - it: simplified mode honors overridden timing fields
     set:
-      component.python-backend.readinessProbe:
+      component.frontend.readinessProbe:
         path: /healthcheck
         port: 8000
         timeoutSeconds: 5
         periodSeconds: 30
         successThreshold: 3
         failureThreshold: 6
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
@@ -110,7 +112,7 @@ tests:
   # ---- Full-definition mode: spec emitted verbatim --------------------------
   - it: full httpGet definition is emitted verbatim and not overwritten
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         httpGet:
           path: /custom/health
           port: 9999
@@ -120,7 +122,7 @@ tests:
         timeoutSeconds: 7
         periodSeconds: 11
         failureThreshold: 4
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -143,14 +145,14 @@ tests:
 
   - it: full exec definition is emitted verbatim
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
             - curl -f http://localhost:8000/healthcheck
         initialDelaySeconds: 15
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
@@ -166,11 +168,11 @@ tests:
 
   - it: full tcpSocket definition is emitted verbatim
     set:
-      component.python-backend.livenessProbe:
+      component.frontend.livenessProbe:
         tcpSocket:
           port: 8000
         periodSeconds: 20
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
@@ -183,18 +185,18 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
   - it: startupProbe renders in simplified mode
     set:
-      component.python-backend.startupProbe:
+      component.frontend.startupProbe:
         path: /healthcheck
         port: 8000
         failureThreshold: 30
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -217,13 +219,13 @@ tests:
 
   - it: startupProbe renders in full-definition mode
     set:
-      component.python-backend.startupProbe:
+      component.frontend.startupProbe:
         httpGet:
           path: /startup
           port: 8000
         periodSeconds: 5
         failureThreshold: 60
-    documentSelector: *pyb
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -234,3 +236,57 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
+
+  # ---- Shipped defaults: probes the chart configures out of the box ---------
+  # python-backend previously had none, so a rolling update put pods into the
+  # Service's endpoints before gunicorn was listening and the backend's
+  # evaluator calls got "connection refused".
+  - it: python-backend ships a readiness probe on the app's readiness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 3
+      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
+      # taken out of the endpoint list.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 3
+
+  - it: python-backend ships a liveness probe on the app's liveness endpoint
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /health/liveness
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 15
+
+  - it: python-backend ships a preStop sleep so terminating pods drain
+    documentSelector:
+      path: metadata.name
+      value: opik-python-backend
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          value:
+            - /bin/sh
+            - -c
+            - sleep 5

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,13 +7,17 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Tests target the `frontend` component: it is the only one with NO probe
-# defined in values.yaml, so each test's `set` is a clean probe spec rather than
-# a deep merge over a pre-existing httpGet default (which would leak into
-# full-mode assertions). The deployment renders one document per enabled
-# component, so we select the frontend deployment by name and read its first
-# container. The probes that `backend` and `python-backend` ship by default are
-# asserted at the bottom of this suite instead.
+# Two groups, because the helper behaves differently depending on what the
+# component already has in values.yaml:
+#   * `frontend` has NO probe, so each `set` is a clean spec — the right vehicle
+#     for asserting the helper's own modes and defaults in isolation.
+#   * `python-backend` DOES ship probes, so a `set` deep-merges over them. That
+#     is the operator-facing path (overriding a shipped probe) and it has its own
+#     group below, including the explicit nulls an override needs.
+# The deployment renders one document per enabled component, so each test selects
+# its component's deployment by name and reads the first container. What each
+# component ships by default is a separate concern, asserted in
+# tests/component_probes_test.yaml.
 templates:
   - templates/deployment.yaml
 
@@ -237,56 +241,86 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
 
-  # ---- Shipped defaults: probes the chart configures out of the box ---------
-  # python-backend previously had none, so a rolling update put pods into the
-  # Service's endpoints before gunicorn was listening and the backend's
-  # evaluator calls got "connection refused".
-  - it: python-backend ships a readiness probe on the app's readiness endpoint
+  # ---- Overriding a component that already ships probes ---------------------
+  # values.yaml merges, so an override inherits whatever the component ships
+  # unless the inherited keys are explicitly nulled. These cover that path for
+  # python-backend, which ships httpGet + timings.
+  - it: partial override merges over the shipped probe rather than replacing it
+    set:
+      component.python-backend.readinessProbe:
+        periodSeconds: 30
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
+      # The shipped endpoint survives — only the named field changes.
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /health/readiness
       - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
-          value: 8000
-      - equal:
           path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 10
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
-          value: 3
-      # Above the 1s Kubernetes default, so a slow-but-alive gunicorn is not
-      # taken out of the endpoint list.
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
-          value: 3
+          value: 30
 
-  - it: python-backend ships a liveness probe on the app's liveness endpoint
+  - it: nulling the shipped keys returns the probe to simplified mode
+    set:
+      component.python-backend.livenessProbe:
+        httpGet: null
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
+        path: /healthcheck
+        port: 8000
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /health/liveness
-      - equal:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
-          value: 8000
+          value: /healthcheck
+      - contains:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders
+          content:
+            name: Accept
+            value: application/json
+      # Helper defaults apply again, not the shipped periodSeconds 15 / timeout 3.
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.periodSeconds
-          value: 15
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 2
 
-  - it: python-backend ships a preStop sleep so terminating pods drain
+  - it: a full-definition override drops the shipped httpGet when it is nulled
+    set:
+      component.python-backend.livenessProbe:
+        httpGet: null
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - curl -f http://localhost:8000/healthcheck
+        initialDelaySeconds: 15
     documentSelector:
       path: metadata.name
       value: opik-python-backend
     asserts:
       - equal:
-          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command
+          path: spec.template.spec.containers[0].livenessProbe.exec.command
           value:
             - /bin/sh
             - -c
-            - sleep 5
+            - curl -f http://localhost:8000/healthcheck
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 15
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+      # Full mode emits the spec verbatim — no simplified-mode defaults injected.
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe.successThreshold

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -319,7 +319,7 @@ tests:
       # Only the named field changes; the shipped endpoint survives.
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /health/readiness
+          value: /health/liveness
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.periodSeconds
           value: 30

--- a/deployment/helm_chart/opik/tests/probe_test.yaml
+++ b/deployment/helm_chart/opik/tests/probe_test.yaml
@@ -7,32 +7,32 @@ suite: opik.probe helper
 #      successThreshold 1 / failureThreshold 2).
 #   2. Full definition       — any other spec is emitted verbatim via toYaml.
 #
-# Two groups, because the helper behaves differently depending on what the
-# component already has in values.yaml:
-#   * `frontend` has NO probe, so each `set` is a clean spec — the right vehicle
-#     for asserting the helper's own modes and defaults in isolation.
-#   * `python-backend` DOES ship probes, so a `set` deep-merges over them. That
-#     is the operator-facing path (overriding a shipped probe) and it has its own
-#     group below, including the explicit nulls an override needs.
+# Tests target the `python-backend` component. It ships probes of its own, so a
+# `set` deep-merges over them: the three tests whose assertions would otherwise
+# see an inherited value null the specific keys they need cleared (simplified
+# mode ignores an inherited httpGet, since it builds its own from path/port, but
+# full mode emits the whole map verbatim). A small `frontend` group at the bottom
+# pins the same helper behaviour on a component with nothing to inherit, and one
+# python-backend test covers the merge itself. What each component ships by
+# default is a separate concern, asserted in tests/component_probes_test.yaml.
+#
 # The deployment renders one document per enabled component, so each test selects
-# its component's deployment by name and reads the first container. What each
-# component ships by default is a separate concern, asserted in
-# tests/component_probes_test.yaml.
+# its component's deployment by name and reads the first container.
 templates:
   - templates/deployment.yaml
 
-documentSelector: &frontend
+documentSelector: &pyb
   path: metadata.name
-  value: opik-frontend
+  value: opik-python-backend
 
 tests:
   # ---- Simplified mode: only path/port set ----------------------------------
   - it: simplified mode renders httpGet with the Accept header
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -48,10 +48,15 @@ tests:
 
   - it: simplified mode fills in the hard-coded timing defaults
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Cleared so the assertions below see the helper's defaults rather than
+        # the timings python-backend ships.
+        periodSeconds: null
+        timeoutSeconds: null
+        failureThreshold: null
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
@@ -68,10 +73,10 @@ tests:
 
   - it: simplified mode defaults initialDelaySeconds to 0 when unset
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -79,11 +84,11 @@ tests:
 
   - it: simplified mode honors initialDelaySeconds when set
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         path: /healthcheck
         port: 8000
         initialDelaySeconds: 20
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
@@ -91,14 +96,14 @@ tests:
 
   - it: simplified mode honors overridden timing fields
     set:
-      component.frontend.readinessProbe:
+      component.python-backend.readinessProbe:
         path: /healthcheck
         port: 8000
         timeoutSeconds: 5
         periodSeconds: 30
         successThreshold: 3
         failureThreshold: 6
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
@@ -116,7 +121,7 @@ tests:
   # ---- Full-definition mode: spec emitted verbatim --------------------------
   - it: full httpGet definition is emitted verbatim and not overwritten
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
         httpGet:
           path: /custom/health
           port: 9999
@@ -126,7 +131,7 @@ tests:
         timeoutSeconds: 7
         periodSeconds: 11
         failureThreshold: 4
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
@@ -149,14 +154,16 @@ tests:
 
   - it: full exec definition is emitted verbatim
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Full mode emits the map verbatim, so the shipped httpGet has to go.
+        httpGet: null
         exec:
           command:
             - /bin/sh
             - -c
             - curl -f http://localhost:8000/healthcheck
         initialDelaySeconds: 15
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
@@ -172,11 +179,13 @@ tests:
 
   - it: full tcpSocket definition is emitted verbatim
     set:
-      component.frontend.livenessProbe:
+      component.python-backend.livenessProbe:
+        # Full mode emits the map verbatim, so the shipped httpGet has to go.
+        httpGet: null
         tcpSocket:
           port: 8000
         periodSeconds: 20
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
@@ -189,18 +198,18 @@ tests:
 
   # ---- startupProbe: renders only when defined ------------------------------
   - it: startupProbe is absent when not defined
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - notExists:
           path: spec.template.spec.containers[0].startupProbe
 
   - it: startupProbe renders in simplified mode
     set:
-      component.frontend.startupProbe:
+      component.python-backend.startupProbe:
         path: /healthcheck
         port: 8000
         failureThreshold: 30
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -223,13 +232,13 @@ tests:
 
   - it: startupProbe renders in full-definition mode
     set:
-      component.frontend.startupProbe:
+      component.python-backend.startupProbe:
         httpGet:
           path: /startup
           port: 8000
         periodSeconds: 5
         failureThreshold: 60
-    documentSelector: *frontend
+    documentSelector: *pyb
     asserts:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.path
@@ -241,86 +250,70 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 60
 
-  # ---- Overriding a component that already ships probes ---------------------
-  # values.yaml merges, so an override inherits whatever the component ships
-  # unless the inherited keys are explicitly nulled. These cover that path for
-  # python-backend, which ships httpGet + timings.
-  - it: partial override merges over the shipped probe rather than replacing it
+  # ---- The same helper on a component with nothing to inherit ---------------
+  # frontend defines no probe in values.yaml, so these need none of the nulls
+  # above — which is what separates helper behaviour from merge behaviour.
+  - it: simplified mode on a probe-less component needs no clearing
     set:
-      component.python-backend.readinessProbe:
-        periodSeconds: 30
-    documentSelector:
-      path: metadata.name
-      value: opik-python-backend
-    asserts:
-      # The shipped endpoint survives — only the named field changes.
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /health/readiness
-      - equal:
-          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
-          value: 30
-
-  - it: nulling the shipped keys returns the probe to simplified mode
-    set:
-      component.python-backend.livenessProbe:
-        httpGet: null
-        periodSeconds: null
-        timeoutSeconds: null
-        failureThreshold: null
+      component.frontend.livenessProbe:
         path: /healthcheck
-        port: 8000
-    documentSelector:
+        port: 5173
+    documentSelector: &frontend
       path: metadata.name
-      value: opik-python-backend
+      value: opik-frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /healthcheck
-      - contains:
-          path: spec.template.spec.containers[0].livenessProbe.httpGet.httpHeaders
-          content:
-            name: Accept
-            value: application/json
-      # Helper defaults apply again, not the shipped periodSeconds 15 / timeout 3.
       - equal:
-          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
-          value: 10
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 5173
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
           value: 2
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 10
+      - equal:
           path: spec.template.spec.containers[0].livenessProbe.failureThreshold
           value: 2
 
-  - it: a full-definition override drops the shipped httpGet when it is nulled
+  - it: full definition on a probe-less component carries no inherited httpGet
     set:
-      component.python-backend.livenessProbe:
-        httpGet: null
-        periodSeconds: null
-        timeoutSeconds: null
-        failureThreshold: null
+      component.frontend.livenessProbe:
         exec:
           command:
             - /bin/sh
             - -c
-            - curl -f http://localhost:8000/healthcheck
+            - curl -f http://localhost:5173/
         initialDelaySeconds: 15
-    documentSelector:
-      path: metadata.name
-      value: opik-python-backend
+    documentSelector: *frontend
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.exec.command
           value:
             - /bin/sh
             - -c
-            - curl -f http://localhost:8000/healthcheck
+            - curl -f http://localhost:5173/
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
           value: 15
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe.httpGet
-      # Full mode emits the spec verbatim — no simplified-mode defaults injected.
       - notExists:
           path: spec.template.spec.containers[0].livenessProbe.successThreshold
+
+  # ---- The merge itself, for a component that ships probes ------------------
+  - it: a partial override merges over the shipped probe rather than replacing it
+    set:
+      component.python-backend.readinessProbe:
+        periodSeconds: 30
+    documentSelector: *pyb
+    asserts:
+      # Only the named field changes; the shipped endpoint survives.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health/readiness
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 30

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -270,12 +270,16 @@ component:
         path: /health/liveness
         port: 8000
       periodSeconds: 15
+      # Above the 1s Kubernetes default: gunicorn under load can take longer than
+      # a second to answer, and a probe timeout counts as a failure.
+      timeoutSeconds: 3
       failureThreshold: 3
     readinessProbe:
       httpGet:
         path: /health/readiness
         port: 8000
       periodSeconds: 10
+      timeoutSeconds: 3
       failureThreshold: 3
     lifecycle:
       preStop:

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -259,6 +259,28 @@ component:
           selectPolicy: Max
     backendConfigMap:
       enabled: true
+    # Without a readiness probe a pod joins the Service's endpoints as soon as its container
+    # starts, so during a rollout the backend's evaluator calls reach a gunicorn that is not
+    # listening yet and get "connection refused" (HttpHostConnectException) — the backend's four
+    # retries span only ~3.5s, less than a pod takes to boot. Readiness gates the endpoint on the
+    # app actually answering; the preStop sleep covers the other side of the race, giving
+    # kube-proxy time to drop a terminating pod from the endpoint list before the process exits.
+    livenessProbe:
+      httpGet:
+        path: /health/liveness
+        port: 8000
+      periodSeconds: 15
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /health/readiness
+        port: 8000
+      periodSeconds: 10
+      failureThreshold: 3
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 5"]
     podDisruptionBudget:
       enabled: false
     # Init container that blocks startup until Redis is reachable. Rendered only

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -265,6 +265,23 @@ component:
     # retries span only ~3.5s, less than a pod takes to boot. Readiness gates the endpoint on the
     # app actually answering; the preStop sleep covers the other side of the race, giving
     # kube-proxy time to drop a terminating pod from the endpoint list before the process exits.
+    #
+    # Overriding any of these replaces only the keys you set — Helm merges the rest of the map in
+    # from here. Set every field you care about, or null the ones you want gone
+    # (`httpGet: null`, `periodSeconds: null`, ...).
+    #
+    # The startup probe is what makes the liveness probe safe: with
+    # PYTHON_CODE_EXECUTOR_STRATEGY=docker, entrypoint.sh waits up to 30s for dockerd and then
+    # loads the sandbox executor image before gunicorn binds, so liveness alone (15s x 3) could
+    # restart the pod before it ever finished starting. Kubernetes suppresses both liveness and
+    # readiness until the startup probe passes, and 5s x 60 gives startup five minutes.
+    startupProbe:
+      httpGet:
+        path: /health/liveness
+        port: 8000
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 60
     livenessProbe:
       httpGet:
         path: /health/liveness

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -291,9 +291,17 @@ component:
       # a second to answer, and a probe timeout counts as a failure.
       timeoutSeconds: 3
       failureThreshold: 3
+    # Deliberately /health/liveness, not /health/readiness: the latter pings Redis whenever the RQ
+    # worker is enabled, which it is by default (RQ_WORKER_ENABLED defaults to "true" and this chart
+    # never sets it). That would put a shared dependency in the endpoint-membership decision, so a
+    # Redis blip would fail readiness on every replica at once and leave the backend's evaluator
+    # calls with no endpoints — the same outage this probe exists to prevent. Code execution needs
+    # no Redis; only the Optimization Studio worker does, and that is not what Service endpoints
+    # gate. (REDIS_TIMEOUT_SECONDS also defaults to 5s, above the timeout below, so a slow Redis
+    # would trip the probe before the handler could answer.)
     readinessProbe:
       httpGet:
-        path: /health/readiness
+        path: /health/liveness
         port: 8000
       periodSeconds: 10
       timeoutSeconds: 3

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -629,12 +629,13 @@ areas:
       - online-evaluation/online-evaluation-smoke.spec.ts
       - online-evaluation/online-evaluation-delete-rule.spec.ts
       - online-evaluation/online-evaluation-enable-disable-rule.spec.ts
+      - online-evaluation/online-evaluation-odd-shaped-sections.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
       llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
       create-python-rule:      { covered: true,  tier: t1-smoke }
-      python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0" }
-      scores-in-trace-panel:   { covered: true,  tier: t1-smoke }
+      python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0; plus a t2-cuj 4x4 mapping/section-shape matrix (scalar + array output sections still score)" }
+      scores-in-trace-panel:   { covered: true,  tier: t1-smoke, note: "plus the odd-shaped-sections spec asserting an unresolved-mapping score renders on a scalar-output trace" }
       list-rules:              { covered: false }
       rule-scope-thread-span:  { covered: false, note: "span/thread scope flags" }
       rule-filters:            { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -102,6 +102,13 @@ export interface AutomationRuleRef {
   name: string;
   projectIds: string[];
   enabled: boolean;
+  /**
+   * The stored variable mapping of a `user_defined_metric_python` rule — each
+   * of the metric's `score(...)` parameters against the trace path that feeds
+   * it. Null for every other rule type, so a spec asserting on a mapping has to
+   * assert the mapping is there rather than defaulting it away.
+   */
+  pythonMetricArguments: Record<string, string> | null;
 }
 
 export interface AnnotationQueueReviewerRef {
@@ -559,7 +566,112 @@ export function makeBackendClient(apiKey: string | null = null) {
         name: r.name,
         projectIds: (r.projects ?? []).map((p) => String(p.projectId)),
         enabled: r.enabled ?? true,
+        pythonMetricArguments:
+          r.type === 'user_defined_metric_python' ? (r.code?.arguments ?? null) : null,
       }));
+    },
+
+    /**
+     * A trace's `input` and `output` sections exactly as stored — no shaping.
+     *
+     * `TraceDetail.input` is typed `Record<string, unknown>`, which is the right
+     * answer for almost every caller but cannot represent a section that is a
+     * bare scalar or an array. A spec that seeds those shapes has to be able to
+     * prove the write kept them, so this returns them untyped.
+     */
+    async getTraceSections(
+      traceId: string,
+    ): Promise<{ input: unknown; output: unknown } | null> {
+      try {
+        const t = await opik.api.traces.getTraceById(traceId);
+        return { input: t.input ?? null, output: t.output ?? null };
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    /**
+     * Create a trace-scope `user_defined_metric_python` rule with an explicit
+     * variable mapping.
+     *
+     * The create-rule dialog can only express the shapes its form offers, and a
+     * spec that needs one specific mapping per rule (a JsonPath under test)
+     * would spend most of its runtime driving that dialog. Rule *creation*
+     * through the UI is already covered by
+     * `@cap:online-evaluation.create-python-rule` in the smoke spec, so seeding
+     * these through the API is setup, not a coverage gap.
+     *
+     * `arguments` maps each of the metric's `score(...)` keyword parameters to a
+     * trace path (`output`, `output.a.b`, `input.q`, …). A path that does not
+     * resolve is dropped from the payload the metric is called with, so the
+     * parameter falls back to its Python default — that drop is the observable
+     * this rule shape exists to expose.
+     */
+    async createPythonMetricRule(args: {
+      projectId: string;
+      name: string;
+      metric: string;
+      arguments: Record<string, string>;
+    }): Promise<void> {
+      await opik.api.automationRuleEvaluators.createAutomationRuleEvaluator({
+        type: 'user_defined_metric_python',
+        action: 'evaluator',
+        name: args.name,
+        projectId: args.projectId,
+        projectIds: [args.projectId],
+        samplingRate: 1.0,
+        enabled: true,
+        code: { metric: args.metric, arguments: args.arguments },
+      });
+    },
+
+    /**
+     * Create a trace whose `output` section is an arbitrary JSON value —
+     * including a bare scalar or an array, not just an object.
+     *
+     * Written as a raw REST call rather than through `opik.api.traces.createTrace`
+     * on purpose: the generated client types `output` as
+     * `Record<string, unknown> | Record<string, unknown>[] | string`, so a
+     * section like `"the answer"` or `["first", "second"]` cannot be expressed
+     * without lying to the type. Those are exactly the sections this seeds, so
+     * the write goes over the wire verbatim (same reasoning as
+     * `getProjectStats` above, which also drops to `fetch`).
+     *
+     * The id is caller-supplied because the write answers 201 with no body.
+     */
+    async createTraceWithRawOutput(args: {
+      id: string;
+      projectName: string;
+      name: string;
+      input: unknown;
+      output: unknown;
+    }): Promise<string> {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'Comet-Workspace': env.workspace,
+      };
+      const key = apiKey ?? env.apiKey;
+      if (key) headers['Authorization'] = key;
+
+      const res = await fetch(`${env.apiBaseUrl}/v1/private/traces`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          id: args.id,
+          project_name: args.projectName,
+          name: args.name,
+          start_time: new Date().toISOString(),
+          input: args.input,
+          output: args.output,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `POST /v1/private/traces -> ${res.status}: ${(await res.text()).slice(0, 300)}`,
+        );
+      }
+      return args.id;
     },
 
     async deleteAutomationRule(projectId: string, ruleId: string): Promise<void> {

--- a/tests_end_to_end/e2e/fixtures/automation-rules.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/automation-rules.fixture.ts
@@ -1,0 +1,91 @@
+import { test as baseTest } from './evaluated-thread.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface AutomationRulesCleanupFixtures {
+  /**
+   * Deletes the automation rules a test created under its fixture project.
+   *
+   * Requesting this fixture is the whole API — there is nothing to call. Rules
+   * are discovered from the project at teardown rather than registered by the
+   * test, so a rule created moments before a failure is still cleaned up; an
+   * id-registration API would leak exactly those.
+   */
+  automationRulesCleanup: void;
+}
+
+/**
+ * Teardown for automation rules created against the `project` fixture.
+ *
+ * Needed because rules do NOT cascade with their project: `ProjectService`'s
+ * delete path does not touch `automation_rule_projects`, so a project fixture
+ * teardown leaves every rule behind. Any spec that creates online-evaluation
+ * rules therefore has to delete them, and doing it in-test is fragile — a
+ * failing assertion skips a trailing cleanup step, and moving that step into a
+ * `finally` block invites two subtler bugs (see below).
+ *
+ * A fixture is the right home for three reasons:
+ *
+ *   1. Playwright runs fixture teardown regardless of test outcome, so cleanup
+ *      cannot be skipped by a failure the way a trailing `test.step` is.
+ *   2. It gets a settled `testInfo`, so `shouldLeaveArtifacts` actually works.
+ *      Inside a test's own `finally` the status is not final yet — it still
+ *      reads 'passed' on a failing test — so a retention check there silently
+ *      never fires.
+ *   3. It cannot swallow the test's failure. A `return` inside a test's
+ *      `finally` discards the in-flight exception and resolves the test, which
+ *      reports a genuinely failing test as PASSED. There is no such hazard in
+ *      fixture teardown.
+ *
+ * Deletion is workspace-global, not project-scoped: the delete path constrains
+ * only `workspace_id` and the rule id, so removing a rule that also targets
+ * another project destroys it there too. Rules are therefore skipped unless the
+ * fixture project is their sole target.
+ *
+ * Best-effort throughout: a cleanup failure warns rather than throws, so it
+ * cannot mask the assertion or scoring error that explains the run. Leaked
+ * rules are a tidiness problem; a masked failure costs a debugging session.
+ */
+export const test = baseTest.extend<AutomationRulesCleanupFixtures>({
+  automationRulesCleanup: [
+    async ({ project, backendClient }, use, testInfo) => {
+      await use();
+
+      if (shouldLeaveArtifacts(testInfo)) {
+        console.warn(
+          `[automationRulesCleanup] leaving rules under ${project.name} for debugging`,
+        );
+        return;
+      }
+
+      let rules;
+      try {
+        rules = await backendClient.listAutomationRulesForProject(project.id);
+      } catch (err) {
+        console.warn('[automationRulesCleanup] could not list rules:', err);
+        return;
+      }
+
+      for (const rule of rules) {
+        const sharedWith = rule.projectIds.filter((id) => id !== project.id);
+        if (sharedWith.length > 0) {
+          console.warn(
+            `[automationRulesCleanup] skipping ${rule.name}: also targets ` +
+              `${sharedWith.join(', ')}, and deletion is workspace-global`,
+          );
+          continue;
+        }
+        try {
+          await backendClient.deleteAutomationRule(project.id, rule.id);
+        } catch (err) {
+          // Keep going: one undeletable rule must not orphan the rest.
+          console.warn(`[automationRulesCleanup] could not delete ${rule.name}:`, err);
+        }
+      }
+    },
+    // `auto: false` — a spec opts in by naming the fixture, which keeps the
+    // teardown's cost off every other test in the suite.
+    { auto: false },
+  ],
+});
+
+export { expect } from './evaluated-thread.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './evaluated-thread.fixture';
+export { test, expect } from './automation-rules.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -65,4 +65,5 @@ export type {
   ThreadEvaluationRunRef,
   EvaluatedThreadFixtures,
 } from './evaluated-thread.fixture';
+export type { AutomationRulesCleanupFixtures } from './automation-rules.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-odd-shaped-sections.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-odd-shaped-sections.spec.ts
@@ -1,0 +1,371 @@
+import { test, expect } from '@e2e/fixtures';
+import { uuid7 } from '@e2e/core/backend';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * The sentinel a mapped argument falls back to when its path does not resolve.
+ *
+ * `OnlineScoringEngine.toReplacements` drops an unresolved variable from the map
+ * it hands the Python runner, and `process_worker` calls `metric.score(**data)`,
+ * so a dropped variable shows up as the parameter's Python default. Making that
+ * default an explicit sentinel is what lets the spec tell "the variable did not
+ * resolve" (fine) apart from "the rule produced no score at all" (the bug).
+ */
+const MISSING = '<<MISSING>>';
+
+/**
+ * The metric every rule in this spec runs.
+ *
+ * Two mapped arguments, and both are load-bearing:
+ *   - `echoed` carries the path under test and may legitimately fail to resolve;
+ *   - `anchor` is mapped to `input.q`, which resolves on every seeded trace.
+ *
+ * Without the anchor, a rule whose only mapping fails to resolve hands the
+ * runner an empty argument map and produces no score — for a benign reason that
+ * is indistinguishable on the wire from the crash this spec exists to catch.
+ * The anchor guarantees at least one resolved argument, so "no score" can only
+ * mean the evaluation itself failed.
+ *
+ * The reason is emitted as JSON so the spec can assert on the resolved value
+ * exactly, rather than pattern-matching a Python `repr`.
+ *
+ * `json` is a module import, not a `BaseMetric` subclass — the python_evaluator
+ * backend's `get_metric_class` picks the first `BaseMetric` subclass in the
+ * module alphabetically, so importing another metric class here would shadow
+ * this one. Importing a plain module is safe.
+ */
+function buildEchoMetric(scoreName: string): string {
+  return `import json
+from typing import Any
+from opik.evaluation.metrics import base_metric, score_result
+
+MISSING = ${JSON.stringify(MISSING)}
+SCORE_NAME = ${JSON.stringify(scoreName)}
+
+class EchoMapping(base_metric.BaseMetric):
+    def __init__(self, name: str = SCORE_NAME):
+        self.name = name
+
+    def score(self, echoed: Any = MISSING, anchor: Any = MISSING, **ignored_kwargs: Any) -> score_result.ScoreResult:
+        return score_result.ScoreResult(
+            value=0.0 if echoed == MISSING else 1.0,
+            name=self.name,
+            reason=json.dumps({"echoed": echoed, "anchor": anchor}),
+        )`;
+}
+
+/** The value `input.q` carries on every seeded trace, echoed back as `anchor`. */
+const ANCHOR_VALUE = 'question';
+
+/** A trace whose `output` section has a particular JSON shape. */
+interface SectionShape {
+  key: string;
+  /** The raw `output` section, passed to the REST write verbatim. */
+  output: unknown;
+  /** Why this shape is in the matrix. */
+  note: string;
+}
+
+const SHAPES: SectionShape[] = [
+  {
+    key: 'scalar',
+    output: 'the answer',
+    note: 'bare string — the production shape that used to fail the evaluation',
+  },
+  {
+    key: 'array',
+    output: ['first', 'second'],
+    note: 'array root — the other non-object section shape',
+  },
+  {
+    key: 'flatkey',
+    output: { 'flat.key': 'flatvalue' },
+    note: 'object with a literal dotted property name (reached via the flat fallback)',
+  },
+  {
+    key: 'nested',
+    output: { a: { b: 'nestedvalue' } },
+    note: 'ordinary nested object — the shape the existing smoke spec already covers',
+  },
+];
+
+/** A rule, identified by the variable mapping its `echoed` argument carries. */
+interface MappingUnderTest {
+  key: string;
+  path: string;
+  note: string;
+}
+
+const MAPPINGS: MappingUnderTest[] = [
+  {
+    key: 'root',
+    path: 'output',
+    note: 'section root — resolves to the whole section, whatever its shape',
+  },
+  {
+    key: 'descend',
+    path: 'output.output',
+    note: 'nested path that resolves on none of the seeded shapes',
+  },
+  { key: 'flatkey', path: 'output.flat.key', note: 'flat-fallback lookup of "flat.key"' },
+  { key: 'nested', path: 'output.a.b', note: 'ordinary nested JsonPath descent' },
+];
+
+/**
+ * The value each (mapping, shape) pair must echo back, keyed `<mapping>/<shape>`.
+ * `MISSING` means the mapping legitimately did not resolve against that section
+ * — which must still produce a score, just a 0.0 one.
+ *
+ * Every cell is stated, including the boring ones: the regression this spec
+ * guards is a missing score, so an expectation table with holes in it would let
+ * exactly the interesting cells go unasserted.
+ *
+ * The root mapping's values are the section serialized back to JSON, which is
+ * why the scalar cell carries its own quotes — `extractFromJson` special-cases
+ * the `$` path to `writeValueAsString(section)`. Everything else resolves to a
+ * bare string, so it arrives unquoted.
+ */
+const EXPECTED_ECHO: Record<string, string> = {
+  'root/scalar': '"the answer"',
+  'root/array': '["first","second"]',
+  'root/flatkey': '{"flat.key":"flatvalue"}',
+  'root/nested': '{"a":{"b":"nestedvalue"}}',
+
+  'descend/scalar': MISSING,
+  'descend/array': MISSING,
+  'descend/flatkey': MISSING,
+  'descend/nested': MISSING,
+
+  'flatkey/scalar': MISSING,
+  'flatkey/array': MISSING,
+  'flatkey/flatkey': 'flatvalue',
+  'flatkey/nested': MISSING,
+
+  'nested/scalar': MISSING,
+  'nested/array': MISSING,
+  'nested/flatkey': MISSING,
+  'nested/nested': 'nestedvalue',
+};
+
+test.describe(
+  'Online Evaluation — odd-shaped trace sections',
+  { tag: ['@t2-cuj', '@area:online-evaluation'] },
+  () => {
+    test(
+      'A rule whose mapping cannot resolve still scores a scalar or array output section',
+      { tag: ['@cap:online-evaluation.python-rule-scores', '@cap:online-evaluation.scores-in-trace-panel'] },
+      async ({ project, backendClient, testNamespace, page, automationRulesCleanup }) => {
+        // The inner waits run concurrently across the 4 traces, so the worst
+        // case is one trace's chain — a 120s anchor poll plus a 90s settle —
+        // not the sum over the matrix. 300s covers that plus rule creation,
+        // the seed and the UI leg. Kept just above the inner waits on purpose:
+        // each of those throws a diagnostic naming the trace and the scores it
+        // actually saw, which beats an opaque "test timeout exceeded".
+        test.setTimeout(300_000);
+
+        // One rule per mapping under test, all four scoring the same four
+        // traces. Score names are the rule names, so the matrix reads directly
+        // off each trace's feedback_scores. No rule name is a prefix of
+        // another, which the trace panel's substring row filter relies on.
+        const ruleName = (m: MappingUnderTest) => `${testNamespace}-r-${m.key}`;
+        const traceName = (s: SectionShape) => `${testNamespace}-t-${s.key}`;
+
+        await test.step('Create one code-metric rule per variable mapping', async () => {
+          // Sequential: rule creation is a cheap write and a serial loop keeps
+          // the failure message pointing at one mapping.
+          for (const mapping of MAPPINGS) {
+            await backendClient.createPythonMetricRule({
+              projectId: project.id,
+              name: ruleName(mapping),
+              metric: buildEchoMetric(ruleName(mapping)),
+              arguments: { echoed: mapping.path, anchor: 'input.q' },
+            });
+          }
+        });
+
+        // Guard, before a single trace is seeded, and it is the reason the rest
+        // of the test means anything. Every claim below is about which path a
+        // rule was mapped to; a rule that silently stored a different mapping
+        // would still score every trace, and the matrix would then pass while
+        // asserting nothing about the paths it names. Reading the persisted
+        // mapping back up front turns that silent no-op into a loud, early
+        // failure.
+        await test.step('All four rules persisted the mapping they were created with', async () => {
+          const rules = await backendClient.listAutomationRulesForProject(project.id);
+          expect(
+            rules.map((r) => r.name).sort(),
+            'exactly the four rules this spec created exist on the project',
+          ).toEqual(MAPPINGS.map(ruleName).sort());
+
+          const byName = new Map(rules.map((r) => [r.name, r]));
+          for (const mapping of MAPPINGS) {
+            const rule = byName.get(ruleName(mapping))!;
+            expect(rule.enabled, `${rule.name} is enabled`).toBe(true);
+            expect(rule.projectIds, `${rule.name} targets only this project`).toEqual([
+              project.id,
+            ]);
+            expect(
+              rule.pythonMetricArguments,
+              `${rule.name} stored its variable mapping verbatim`,
+            ).toEqual({ echoed: mapping.path, anchor: 'input.q' });
+          }
+        });
+
+        const traceIds = await test.step(
+          'Seed one trace per output-section shape, each with the same resolvable input',
+          async () => {
+            const entries = await Promise.all(
+              SHAPES.map(async (shape) => {
+                const id = await backendClient.createTraceWithRawOutput({
+                  id: uuid7(),
+                  projectName: project.name,
+                  name: traceName(shape),
+                  input: { q: ANCHOR_VALUE },
+                  output: shape.output,
+                });
+                return [shape.key, id] as const;
+              }),
+            );
+            return new Map(entries);
+          },
+        );
+
+        // The fixture has to prove it produced the shapes the matrix assumes.
+        // A trace whose output arrived as an object because the write coerced
+        // it would make every "odd-shaped section" assertion below vacuous, and
+        // it would read as coverage forever.
+        await test.step('Each seeded trace really carries the section shape it stands for', async () => {
+          for (const shape of SHAPES) {
+            const sections = await backendClient.getTraceSections(traceIds.get(shape.key)!);
+            expect(sections, `trace ${shape.key} is readable`).not.toBeNull();
+            expect(
+              sections!.output,
+              `trace ${shape.key} kept its ${shape.note} output section verbatim`,
+            ).toEqual(shape.output);
+            expect(sections!.input, `trace ${shape.key} carries the anchor input`).toEqual({
+              q: ANCHOR_VALUE,
+            });
+          }
+        });
+
+        const scoresByShape = await test.step(
+          'Wait for scoring to settle on every trace, then collect the score matrix',
+          async () => {
+            // Two-phase wait per trace, and the order matters.
+            // `waitForTraceScoresSettled` decides "settled" from a stable
+            // score-set fingerprint, so it must not start while the trace is
+            // still unscored. The root mapping resolves against every section
+            // shape — it is the `$` path, which `extractFromJson` special-cases
+            // before any conversion — so its score is guaranteed to arrive on
+            // all four traces and is safe to anchor on. Only then wait for the
+            // set to go quiet, which is what catches the other three rules'
+            // scores if they are coming.
+            const rootRule = ruleName(MAPPINGS.find((m) => m.key === 'root')!);
+            const collected = await Promise.all(
+              SHAPES.map(async (shape) => {
+                const id = traceIds.get(shape.key)!;
+                await backendClient.pollTraceForFeedbackScore(id, rootRule, {
+                  timeoutMs: 120_000,
+                });
+                const trace = await backendClient.waitForTraceScoresSettled(id, {
+                  quietPeriodMs: 10_000,
+                  timeoutMs: 90_000,
+                  minScores: 1,
+                });
+                return [shape.key, trace.feedbackScores] as const;
+              }),
+            );
+            return new Map(collected);
+          },
+        );
+
+        // THE regression. Before the fix, `extractFromJson` converted the
+        // section straight to a Map, which threw on anything that was not a
+        // JSON object; the throw escaped `toReplacements` and failed the whole
+        // evaluation, so a scalar or array output section produced NO score at
+        // all from any nested-path rule. After the fix the evaluation completes
+        // and only the unresolved variable drops.
+        await test.step('Every rule scored every trace — including the scalar and array sections', async () => {
+          const expectedNames = MAPPINGS.map(ruleName).sort();
+          for (const shape of SHAPES) {
+            const names = scoresByShape.get(shape.key)!.map((fs) => fs.name).sort();
+            expect(
+              names,
+              `every rule must score the ${shape.key} trace (${shape.note}) — ` +
+                `a missing score means the evaluation failed before the metric ran, ` +
+                `which is the regression this spec guards`,
+            ).toEqual(expectedNames);
+          }
+        });
+
+        await test.step('Each rule echoed back exactly the value its mapping resolves to', async () => {
+          for (const shape of SHAPES) {
+            const byName = new Map(
+              scoresByShape.get(shape.key)!.map((fs) => [fs.name, fs]),
+            );
+            for (const mapping of MAPPINGS) {
+              const cell = `${mapping.key}/${shape.key}`;
+              const score = byName.get(ruleName(mapping));
+              // Asserted rather than optional-chained: the step above proved
+              // the score is there, and coding around its absence here would
+              // turn a missing score into a silent pass.
+              expect(score, `score for ${cell} is present`).toBeDefined();
+              expect(
+                score!.reason,
+                `${cell} must carry the metric's JSON reason`,
+              ).not.toBeNull();
+
+              const reason = JSON.parse(score!.reason!) as {
+                echoed: string;
+                anchor: string;
+              };
+              expect(
+                reason.anchor,
+                `${cell}: the anchor resolves on every trace, so its absence means the ` +
+                  `evaluation ran on the wrong data rather than that a mapping failed`,
+              ).toBe(ANCHOR_VALUE);
+              expect(
+                reason.echoed,
+                `${cell}: mapping "${mapping.path}" (${mapping.note}) against a ` +
+                  `${shape.note} section`,
+              ).toBe(EXPECTED_ECHO[cell]);
+              expect(score!.value, `${cell}: value tracks whether "echoed" resolved`).toBe(
+                EXPECTED_ECHO[cell] === MISSING ? 0.0 : 1.0,
+              );
+            }
+          }
+        });
+
+        // The backend fix is only useful if the page a user reads shows the
+        // result. The scalar trace is the one that used to come back unscored,
+        // so it is the one worth opening.
+        await test.step('The scalar trace renders both scores in the Logs trace panel', async () => {
+          const logs = new LogsPage(page);
+          await logs.goto(project.id);
+          await logs.waitForReady();
+
+          const panel = await logs.openTraceById(traceIds.get('scalar')!);
+          await panel.waitForFullyLoaded();
+          await panel.openFeedbackScoresTab();
+
+          const rootRule = ruleName(MAPPINGS.find((m) => m.key === 'root')!);
+          const descendRule = ruleName(MAPPINGS.find((m) => m.key === 'descend')!);
+
+          // Resolve to exactly one row each, so an ambiguous name match fails
+          // loudly instead of silently reading a different rule's score.
+          await expect(
+            panel.feedbackScoreRow(rootRule),
+            'the resolving rule renders exactly one row',
+          ).toHaveCount(1);
+          await expect(
+            panel.feedbackScoreRow(descendRule),
+            'the unresolved-mapping rule renders a row too — it scored, it did not fail',
+          ).toHaveCount(1);
+
+          expect(await panel.readFeedbackScoreValue(rootRule)).toBe(1.0);
+          expect(await panel.readFeedbackScoreValue(descendRule)).toBe(0.0);
+        });
+      },
+    );
+  },
+);


### PR DESCRIPTION
> **Generated by the release QA side flow (`release-test-proposal`), not by a human.**
> It is a **draft** on purpose and needs review before it goes anywhere. Nothing here
> has been verified by a person.

## Where this came from

Exploratory testing of #7949 ("[OPIK-8045] [BE] fix: four online-scoring failures seen
in production") on that PR's own deployed environment produced one verified candidate
flow. This turns that flow into a permanent spec.

**Base branch.** This targets `thiagoh/online-scoring-failure-fixes`, not `main`, because
the behaviour it asserts only exists on that branch: on `main`,
`OnlineScoringEngine.extractFromJson` converts a trace section straight to
`Map<String, Object>`, which throws for any section that is not a JSON object. The throw
escapes `toReplacements` and fails the whole evaluation, so the spec's central assertion —
that a scalar or array `output` section still produces a score — fails on `main` by design.
The spec was written against #7949's head, `41c9fa9`.

## The spec

`tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-odd-shaped-sections.spec.ts`

`@t2-cuj` `@area:online-evaluation`
`@cap:online-evaluation.python-rule-scores` `@cap:online-evaluation.scores-in-trace-panel`

**What it asserts.** Four `user_defined_metric_python` rules — one per variable mapping
(`output`, `output.output`, `output.flat.key`, `output.a.b`) — against four traces, one per
`output`-section shape (bare scalar, array, object with a literal dotted key, ordinary
nested object). It then asserts the full 4×4 matrix:

1. **Every rule scored every trace**, including the scalar and array sections. This is the
   regression. Before the fix those two shapes produced *no score at all* from any
   nested-path rule, because the section-to-`Map` conversion threw before the metric ran.
   After it, the evaluation completes and only the unresolved variable drops.
2. **Each score carries the value the mapping actually resolves to** — `"the answer"` for
   the section root against a scalar, `flatvalue` through the flat fallback, `nestedvalue`
   through ordinary descent, and the metric's `<<MISSING>>` sentinel where the mapping
   legitimately does not resolve.
3. **The scores render in the Logs trace panel** for the scalar trace — both the resolving
   rule and the unresolved-mapping one. A backend fix nobody can see on the page is not a
   fix.

**Why a code metric and not an LLM judge.** `OnlineScoringUserDefinedMetricPythonScorer`
drives the same `OnlineScoringEngine.toReplacements` → `extractFromJson` path as the LLM
judge, so this covers the changed code with no provider key and no LLM non-determinism.

**Why every rule maps a second `anchor` argument** to `input.q`, which always resolves:
without it, a rule whose only mapping fails to resolve hands the Python runner an empty
argument map and produces no score — for a benign reason that is indistinguishable on the
wire from the crash the spec exists to catch. The anchor guarantees at least one resolved
argument, so "no score" can only mean the evaluation failed.

**Existing coverage this does not duplicate.** `online-evaluation-smoke.spec.ts` already
covers `python-rule-scores`, but it maps `output.output` against an ordinary object section
— the one branch that never had the bug. The taxonomy read `covered: true` for a capability
whose regression path was untested; both capability notes are updated to say what is
covered by which spec.

## Supporting changes

- `fixtures/automation-rules.fixture.ts` — **new.** Automation rules do not cascade with
  their project (`ProjectService`'s delete path never touches `automation_rule_projects`),
  so every online-evaluation spec today deletes its rules in a trailing `test.step` — which
  is skipped precisely when an assertion has failed and left the workspace dirtiest. This
  is the fixture form: teardown runs regardless of outcome, honours
  `OPIK_LEAVE_FAILURES`, and skips any rule that also targets another project because
  deletion is workspace-global. It is opt-in (`auto: false`), so it costs the rest of the
  suite nothing. **The three existing specs are left as they are** — converting them is a
  separate change and this PR should stay reviewable.
- `core/backend/client.ts` — three additions:
  - `createPythonMetricRule(...)` — creates a code-metric rule with an explicit variable
    mapping. Rule creation *through the dialog* is already covered by
    `@cap:online-evaluation.create-python-rule`, so seeding four differently-mapped rules
    through the API here is setup, not a coverage gap.
  - `createTraceWithRawOutput(...)` — the generated client types `output` as
    `Record<string, unknown> | Record<string, unknown>[] | string`, which cannot express a
    bare scalar or an array section. Those shapes are the entire point, so this writes them
    over the wire verbatim (same reasoning as the existing `getProjectStats`, which also
    drops to `fetch`).
  - `getTraceSections(...)` and `AutomationRuleRef.pythonMetricArguments` — so the spec can
    prove its own fixture before asserting on it: that each trace really kept the section
    shape it stands for, and that each rule really persisted the mapping it names. Without
    those, a coerced section or a dropped mapping would make the matrix pass while
    verifying nothing.
- `coverage/taxonomy.yaml` — spec added to the area's `specs:` list; the two capability
  notes updated.

**Every path this spec uses behaves identically on the deployed build and at `41c9fa9`.**
None of `output`, `output.output`, `output.flat.key`, `output.a.b` or `input.q` contains
`..` or `[?(`, so `VariablePathUtils.findUnsupportedConstruct` passes them at save time and
`findUnsupportedConstructInJsonPath` passes them at scoring time; none contains `$.` inside
a key, so the `StringUtils.removeStart` change does not reach them either. The only branch
of #7949 the spec depends on is the `convertValue(json, Object.class)` rewrite.

## Verification

> **⚠️ Read this before trusting the spec. The scoring assertions are UNPROVEN.** The spec
> ran three times against `https://pr-7949.dev.comet.com` (build `2.2.37-7949-merge-3051`,
> OSS, workspace `default`) and never reached them, because online scoring on that
> environment stopped and then the environment itself went down. **Someone needs to re-run
> this on a healthy environment before it is promoted.**

Command (from `tests_end_to_end/e2e/`):

```
OPIK_DEPLOYMENT=oss OPIK_BASE_URL=https://pr-7949.dev.comet.com OPIK_WORKSPACE=default \
  npx playwright test tests/online-evaluation/online-evaluation-odd-shaped-sections.spec.ts --reporter=list
```

**What did run, green, against the live app:**

| Step | Result |
|---|---|
| `npx tsc --noEmit` | clean |
| `tag_lint.py --taxonomy … --estate tests_end_to_end` | `40 specs checked, 1 exempt, 0 problem(s)` |
| Create one code-metric rule per variable mapping | ✅ |
| All four rules persisted the mapping they were created with | ✅ |
| Seed one trace per output-section shape | ✅ |
| Each seeded trace really carries the section shape it stands for | ✅ (scalar, array, dotted-key and nested sections all stored verbatim) |
| Wait for scoring to settle, collect the matrix | ❌ **timed out — no score ever arrived** |
| the three assertion steps after it | not reached |
| Fixture teardown (project + `automationRulesCleanup`) | ✅ nothing leaked |

**Why the failure is the environment, not the spec — the control.** Seeding a trace into the
*exploration's own* project (`cuj-20260824-124205-824b-engine`), whose pre-existing rules —
none of them created by this spec — had scored ten traces at 12:52, also produced no score.
A watcher repeated that probe every two minutes for 45 minutes: `scored=False` every time,
with `GET /automations/evaluators/{id}/logs` empty, meaning the engine never consumed the
message at all. Shortly after, the environment stopped serving entirely:

```
GET /api/v1/private/traces?project_id=… -> 504 Gateway Time-out, then 502 Bad Gateway (nginx)
GET /api/is-alive/ver                   -> 502 Bad Gateway (nginx)
```

So the last thing this spec observed was a preview environment on its way down. There is no
evidence here of a defect in this PR, and equally no evidence the spec is right — only that
it is not wrong for any reason this run could reach.

**What the expected values rest on instead.** Every cell of the 4×4 matrix is corroborated
by the exploration's own captured scores on this exact build, read back from the API before
the environment failed — including the two cells that matter most, a nested-path rule
returning `<<MISSING>>` with a resolved anchor on a scalar section and on an array section,
which is the post-fix behaviour this spec asserts. The `"the answer"` cell keeping its JSON
quotes (the `$`-path special case) is likewise observed, not inferred. The metric,
the anchor argument and the mapping set are the same ones the exploration drove.

That is a good reason to think the spec is right and **not a substitute for a green run.**

## What was deliberately not written

The exploration produced **one** candidate and this PR implements it. The report's own
"the test to write once the environment is rebuilt" — an API-surface spec asserting that
`POST`/`PATCH` **reject** `output..text` and `output.choices[?(…)]` and accept
`output.choices[0].message` — is **not** here, and should not be until someone drives it.
The PR's deployed environment ran an intermediate build (`2.2.37-7949-merge-3051`) that has
the `extractFromJson` fix but **not** `@SupportedVariablePaths`, the engine-side path guard,
or the `StringUtils.removeStart` flat-fallback fix, so nobody has ever seen that validation
work. A spec for a flow nobody reached is a guess, and this spec deliberately avoids every
path (`..`, `[?(`, `$.`-in-key) whose behaviour differs between that build and this branch.

The exploration also flagged, at medium confidence, that the new guard rejects a flat key
whose *literal name* contains `..` or `[?(` — `flatFallback` exists precisely so
`output.flat.key` can find a property called `flat.key`, and the guard at
`OnlineScoringEngine.java:892` runs before `convertValue`, so the flat tail is never
reached. That is a question for a reviewer, not something to encode as a test.

---

Draft. Do not merge without review. Closes nothing; links #7949.


[OPIK-8045]: https://comet-ml.atlassian.net/browse/OPIK-8045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ