### PR TITLE
[OPIK-8021] [FE] perf: virtualize the experiment results table

### DIFF
--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -60,6 +60,7 @@ import useColumnVirtualization, {
   ColumnSpacerCell,
   isColumnSpacer,
   sliceColumnWindow,
+  sliceColumnWindowHeaders,
 } from "@/shared/DataTable/columnVirtualization";
 
 declare module "@tanstack/react-table" {
@@ -462,52 +463,54 @@ const DataTable = <TData, TValue>({
                       !isLastRow && "!border-b-0",
                     )}
                   >
-                    {sliceColumnWindow(headerGroup.headers, columnWindow).map(
-                      (header) => {
-                        if (isColumnSpacer(header)) {
-                          return (
-                            <ColumnSpacerCell
-                              key={header.id}
-                              spacer={header}
-                              isHeader
-                            />
-                          );
-                        }
-
+                    {sliceColumnWindowHeaders(
+                      headerGroup.headers,
+                      columnWindow,
+                    ).map((entry) => {
+                      if (isColumnSpacer(entry)) {
                         return (
-                          <TableHead
-                            key={header.id}
-                            data-header-id={header.id}
-                            style={{
-                              zIndex:
-                                TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
-                              ...getCommonPinningStyles({
-                                column: header.column,
-                                isHeader: true,
-                                isLastHeaderRow: isLastRow,
-                                lastRightPinnedColumnId,
-                              }),
-                            }}
-                            className={getCommonPinningClasses({
+                          <ColumnSpacerCell
+                            key={entry.id}
+                            spacer={entry}
+                            isHeader
+                          />
+                        );
+                      }
+
+                      const { header, colSpan } = entry;
+
+                      return (
+                        <TableHead
+                          key={header.id}
+                          data-header-id={header.id}
+                          style={{
+                            zIndex: TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),
+                            ...getCommonPinningStyles({
                               column: header.column,
                               isHeader: true,
-                              lastLeftPinnedColumnId,
-                            })}
-                            colSpan={header.colSpan}
-                          >
-                            {header.isPlaceholder
-                              ? ""
-                              : flexRender(
-                                  header.column.columnDef.header,
-                                  header.getContext(),
-                                )}
-                            {isResizable ? (
-                              <DataTableColumnResizer header={header} />
-                            ) : null}
-                          </TableHead>
-                        );
-                      },
-                    )}
+                              isLastHeaderRow: isLastRow,
+                              lastRightPinnedColumnId,
+                            }),
+                          }}
+                          className={getCommonPinningClasses({
+                            column: header.column,
+                            isHeader: true,
+                            lastLeftPinnedColumnId,
+                          })}
+                          colSpan={colSpan}
+                        >
+                          {header.isPlaceholder
+                            ? ""
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                          {isResizable ? (
+                            <DataTableColumnResizer header={header} />
+                          ) : null}
+                        </TableHead>
+                      );
+                    })}
                   </TableRow>
                 );
               })}

--- a/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
+++ b/apps/opik-frontend/src/shared/DataTable/DataTable.tsx
@@ -477,11 +477,11 @@ const DataTable = <TData, TValue>({
                         );
                       }
 
-                      const { header, colSpan } = entry;
+                      const { header, colSpan, key } = entry;
 
                       return (
                         <TableHead
-                          key={header.id}
+                          key={key ?? header.id}
                           data-header-id={header.id}
                           style={{
                             zIndex: TABLE_HEADER_Z_INDEX + (isLastRow ? 0 : 1),

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 
 import {
   sliceColumnWindow,
+  sliceColumnWindowHeaders,
   isColumnSpacer,
   INACTIVE_COLUMN_WINDOW,
   ColumnWindow,
@@ -153,5 +154,89 @@ describe("isColumnSpacer", () => {
     expect(isColumnSpacer(null)).toBe(false);
     expect(isColumnSpacer(undefined)).toBe(false);
     expect(isColumnSpacer({ id: "s", size: 10 })).toBe(false);
+  });
+});
+
+describe("sliceColumnWindowHeaders", () => {
+  const groupRow = [
+    { id: "select", colSpan: 1 },
+    { id: "dataset", colSpan: 2 },
+    { id: "evaluation", colSpan: 4 },
+    { id: "scores", colSpan: 320 },
+  ];
+
+  it("passes headers through untouched when the window is inactive", () => {
+    expect(sliceColumnWindowHeaders(groupRow, INACTIVE_COLUMN_WINDOW)).toEqual(
+      groupRow.map((header) => ({ header, colSpan: header.colSpan })),
+    );
+  });
+
+  it("shrinks a group to the leaves inside the window and drops the rest", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 1,
+      centerCount: 326,
+      start: 100,
+      end: 114,
+      leadingWidth: 5000,
+      trailingWidth: 9000,
+    };
+
+    const result = sliceColumnWindowHeaders(groupRow, window);
+
+    expect(result).toEqual([
+      { header: groupRow[0], colSpan: 1 },
+      { id: "__column_spacer_lead", size: 5000, isColumnSpacer: true },
+      { header: groupRow[3], colSpan: 15 },
+      { id: "__column_spacer_trail", size: 9000, isColumnSpacer: true },
+    ]);
+  });
+
+  it("keeps every group whose leaves straddle the window edges", () => {
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 1,
+      centerCount: 326,
+      start: 0,
+      end: 8,
+      leadingWidth: 0,
+      trailingWidth: 9000,
+    };
+
+    const result = sliceColumnWindowHeaders(groupRow, window);
+
+    expect(result).toEqual([
+      { header: groupRow[0], colSpan: 1 },
+      { header: groupRow[1], colSpan: 2 },
+      { header: groupRow[2], colSpan: 4 },
+      { header: groupRow[3], colSpan: 3 },
+      { id: "__column_spacer_trail", size: 9000, isColumnSpacer: true },
+    ]);
+  });
+
+  it("slices a leaf header row the same way sliceColumnWindow does", () => {
+    const leaves = items.map((id) => ({ id, colSpan: 1 }));
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 2,
+      centerCount: 5,
+      start: 1,
+      end: 3,
+      leadingWidth: 100,
+      trailingWidth: 50,
+    };
+
+    const result = sliceColumnWindowHeaders(leaves, window);
+
+    expect(result).toEqual([
+      { header: leaves[0], colSpan: 1 },
+      { header: leaves[1], colSpan: 1 },
+      { id: "__column_spacer_lead", size: 100, isColumnSpacer: true },
+      { header: leaves[3], colSpan: 1 },
+      { header: leaves[4], colSpan: 1 },
+      { header: leaves[5], colSpan: 1 },
+      { id: "__column_spacer_trail", size: 50, isColumnSpacer: true },
+      { header: leaves[7], colSpan: 1 },
+    ]);
   });
 });

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.test.ts
@@ -214,6 +214,31 @@ describe("sliceColumnWindowHeaders", () => {
     ]);
   });
 
+  it("gives each segment of a group split by a pinned boundary its own key", () => {
+    const straddling = [
+      { id: "select", colSpan: 1 },
+      { id: "scores", colSpan: 4 },
+    ];
+    const window: ColumnWindow = {
+      active: true,
+      leftCount: 1,
+      centerCount: 3,
+      start: 0,
+      end: 1,
+      leadingWidth: 0,
+      trailingWidth: 700,
+    };
+
+    const result = sliceColumnWindowHeaders(straddling, window);
+
+    expect(result).toEqual([
+      { header: straddling[0], colSpan: 1 },
+      { header: straddling[1], colSpan: 2 },
+      { id: "__column_spacer_trail", size: 700, isColumnSpacer: true },
+      { header: straddling[1], colSpan: 1, key: "scores__2" },
+    ]);
+  });
+
   it("slices a leaf header row the same way sliceColumnWindow does", () => {
     const leaves = items.map((id) => ({ id, colSpan: 1 }));
     const window: ColumnWindow = {

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
@@ -36,6 +36,7 @@ const createSpacer = (id: string, size: number): ColumnSpacer => ({
 export type WindowedHeader<THeader> = {
   header: THeader;
   colSpan: number;
+  key?: string;
 };
 
 export const sliceColumnWindow = <T>(
@@ -60,7 +61,9 @@ export const sliceColumnWindow = <T>(
   ];
 };
 
-export const sliceColumnWindowHeaders = <THeader extends { colSpan: number }>(
+export const sliceColumnWindowHeaders = <
+  THeader extends { id: string; colSpan: number },
+>(
   headers: THeader[],
   window: ColumnWindow,
 ): (WindowedHeader<THeader> | ColumnSpacer)[] => {
@@ -71,6 +74,8 @@ export const sliceColumnWindowHeaders = <THeader extends { colSpan: number }>(
   const leafSlots = headers.flatMap((header) =>
     new Array<THeader>(Math.max(header.colSpan, 1)).fill(header),
   );
+
+  const segments = new Map<THeader, number>();
 
   return sliceColumnWindow(leafSlots, window).reduce<
     (WindowedHeader<THeader> | ColumnSpacer)[]
@@ -84,9 +89,17 @@ export const sliceColumnWindowHeaders = <THeader extends { colSpan: number }>(
 
     if (!isColumnSpacer(previous) && previous?.header === entry) {
       previous.colSpan += 1;
-    } else {
-      acc.push({ header: entry, colSpan: 1 });
+      return acc;
     }
+
+    const segment = (segments.get(entry) ?? 0) + 1;
+    segments.set(entry, segment);
+
+    acc.push({
+      header: entry,
+      colSpan: 1,
+      ...(segment > 1 && { key: `${entry.id}__${segment}` }),
+    });
 
     return acc;
   }, []);

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/columnWindow.ts
@@ -33,6 +33,11 @@ const createSpacer = (id: string, size: number): ColumnSpacer => ({
   isColumnSpacer: true,
 });
 
+export type WindowedHeader<THeader> = {
+  header: THeader;
+  colSpan: number;
+};
+
 export const sliceColumnWindow = <T>(
   items: T[],
   window: ColumnWindow,
@@ -53,4 +58,36 @@ export const sliceColumnWindow = <T>(
       : []),
     ...items.slice(leftCount + centerCount),
   ];
+};
+
+export const sliceColumnWindowHeaders = <THeader extends { colSpan: number }>(
+  headers: THeader[],
+  window: ColumnWindow,
+): (WindowedHeader<THeader> | ColumnSpacer)[] => {
+  if (!window.active) {
+    return headers.map((header) => ({ header, colSpan: header.colSpan }));
+  }
+
+  const leafSlots = headers.flatMap((header) =>
+    new Array<THeader>(Math.max(header.colSpan, 1)).fill(header),
+  );
+
+  return sliceColumnWindow(leafSlots, window).reduce<
+    (WindowedHeader<THeader> | ColumnSpacer)[]
+  >((acc, entry) => {
+    if (isColumnSpacer(entry)) {
+      acc.push(entry);
+      return acc;
+    }
+
+    const previous = acc[acc.length - 1];
+
+    if (!isColumnSpacer(previous) && previous?.header === entry) {
+      previous.colSpan += 1;
+    } else {
+      acc.push({ header: entry, colSpan: 1 });
+    }
+
+    return acc;
+  }, []);
 };

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/index.ts
@@ -2,10 +2,12 @@ export { default as default } from "@/shared/DataTable/columnVirtualization/useC
 export type { ColumnVirtualizationConfig } from "@/shared/DataTable/columnVirtualization/useColumnVirtualization";
 export {
   sliceColumnWindow,
+  sliceColumnWindowHeaders,
   isColumnSpacer,
 } from "@/shared/DataTable/columnVirtualization/columnWindow";
 export type {
   ColumnWindow,
   ColumnSpacer,
+  WindowedHeader,
 } from "@/shared/DataTable/columnVirtualization/columnWindow";
 export { default as ColumnSpacerCell } from "@/shared/DataTable/columnVirtualization/ColumnSpacerCell";

--- a/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
+++ b/apps/opik-frontend/src/shared/DataTable/columnVirtualization/useColumnVirtualization.ts
@@ -40,10 +40,7 @@ const useColumnVirtualization = <TData>(
 
   const scrollElement = horizontalScrollContainer ?? scrollContainer;
 
-  const windowable =
-    supported &&
-    table.getHeaderGroups().length === 1 &&
-    table.getState().grouping.length === 0;
+  const windowable = supported && table.getState().grouping.length === 0;
 
   const enabled = windowable && optedIn && Boolean(scrollElement);
 

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/ExperimentItemsTab/ExperimentItemsTab.tsx
@@ -723,6 +723,7 @@ const ExperimentItemsTab: React.FunctionComponent<ExperimentItemsTabProps> = ({
         noData={<DataTableNoData title={noDataText} />}
         TableWrapper={PageBodyStickyTableWrapper}
         TableBody={DataTableVirtualBody}
+        columnVirtualization={{ enabled: true }}
         stickyHeader
         meta={meta}
         showSkeleton={isTableLoading}


### PR DESCRIPTION
## Details

The experiment Results tab renders one column per feedback-score name, so a project with 300+ score names produced a ~326-column table that blocked the main thread for seconds on every scroll. Column windowing already existed but was skipped for any table with more than one header row, because section-header cells span many leaves and cannot be sliced by leaf index the way the leaf row is.

- Header rows are now sliced by `colSpan`: each header is expanded into one slot per leaf it spans, the existing column slicer runs over those slots, and consecutive slots of the same header collapse back into a `colSpan`. A group survives while any of its leaves are inside the window. Window geometry (spacer placement, pinned sections, edge cases) stays in a single place.
- The windowing guard now keys off row grouping state instead of header-row count, so grouped-header tables are no longer excluded.
- Column virtualization is always enabled on this table, matching row virtualization, which was already unconditional there. This is deliberate rather than the cell-count gate the Logs tables use: `DataTableVirtualBody` was already unconditional here, so the trade-offs of windowing (find-in-page and full-table copy skipping off-screen cells) already applied along the vertical axis.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8021

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Opus 5
  - Scope: full implementation
  - Human verification: code review + manual browser testing with 326-column fixtures

## Testing

Commands run:

- `bash scripts/dev-runner.sh --lint-fe` (lint:fix + typecheck + deps:validate) — clean
- `npx vitest run src/shared/DataTable/` — 13/13 pass, including 4 new cases covering grouped header rows (group shrinking, straddling the window edges, leaf-row equivalence with the existing slicer)

Scenarios validated in the browser (local dev, Chrome) against seeded fixtures of 320 feedback-score names / 100 dataset items:

Grouped header (experiment Results tab, 326 columns, 2 header rows) — at scrollLeft 0, mid-scroll and max-scroll, both header rows always sum to the same colSpan total as the body cell count (13/13, 18/18, 14/14), header and body cell offsets match exactly at every position, table width stable at 48950px, no duplicate `data-header-id` in any row, and the window returns to its original state on scroll back.

Single header regression check (Logs page, 345 columns, 1 header row) — windows to 10 header cells, window follows scroll, every leaf `colSpan` is 1, header/body aligned, width stable at 52300px, 30 rows in DOM.

Also switched away to another tab and back to confirm no transient collapsed window on remount (13/13 immediately).

Not run: backend and SDK suites (frontend-only change).

## Documentation

N/A
