### PR TITLE
[OPIK-8021] [QA] Proposed e2e specs from the #7971 (logs view virtualization) exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -250,6 +250,7 @@ areas:
       - trace-explore/trace-spans-depth.spec.ts
       - trace-explore/trace-delete.spec.ts
       - trace-explore/trace-filters.spec.ts
+      - trace-explore/trace-column-virtualization.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -262,7 +263,7 @@ areas:
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
       filter-traces:          { covered: true,  tier: t2-cuj }
-      configure-columns:      { covered: false }
+      configure-columns:      { covered: true,  tier: t2-cuj, note: "select-all columns over 100 traces; asserts the windowed table still reaches every row and column" }
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
       agent-graph-tab:        { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1003,6 +1003,58 @@ export function makeBackendClient(apiKey: string | null = null) {
     },
 
     /**
+     * Create many traces in one write.
+     *
+     * The per-trace `createTraceWithSource` above is a round trip each; a table
+     * big enough to exercise virtualization needs three figures of them, and
+     * seeding those one at a time costs more than the test that follows. Ids are
+     * caller-supplied for the same reason as there — the write answers 204 with
+     * no body, and these tests assert on exact ids.
+     */
+    async createTracesBatch(
+      traces: Array<{
+        id: string;
+        projectName: string;
+        name: string;
+        startTime: Date;
+        endTime?: Date;
+        input?: Record<string, unknown>;
+        output?: Record<string, unknown>;
+      }>,
+    ): Promise<void> {
+      await opik.api.traces.createTraces({
+        traces: traces.map((t) => ({
+          id: t.id,
+          projectName: t.projectName,
+          name: t.name,
+          startTime: t.startTime,
+          ...(t.endTime ? { endTime: t.endTime } : {}),
+          ...(t.input ? { input: t.input } : {}),
+          ...(t.output ? { output: t.output } : {}),
+        })),
+      });
+    },
+
+    /**
+     * Attach feedback scores to traces in one write. A distinct score *name* is
+     * what makes the Logs table grow a dynamic column, so this is how a fixture
+     * widens the table without touching the UI.
+     */
+    async scoreTracesBatch(
+      scores: Array<{ traceId: string; projectName: string; name: string; value: number }>,
+    ): Promise<void> {
+      await opik.api.traces.scoreBatchOfTraces({
+        scores: scores.map((s) => ({
+          id: s.traceId,
+          projectName: s.projectName,
+          name: s.name,
+          value: s.value,
+          source: 'sdk',
+        })),
+      });
+    },
+
+    /**
      * Create an optimization run row directly. Seeding the row rather than
      * launching a real run keeps the trial-scoping tests deterministic and
      * LLM-free — the thing under test is which traces a trial's Logs overlay

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './automation-rules.fixture';
+export { test, expect } from './wide-traces.fixture';
 export type { ProjectFixtures } from './project.fixture';
 export type { ScratchDir, ScratchDirFixtures } from './scratch-dir.fixture';
 export type {
@@ -84,4 +84,5 @@ export type {
   TokenUsageSpansFixtures,
 } from './token-usage-spans.fixture';
 export type { AutomationRulesCleanupFixtures } from './automation-rules.fixture';
+export type { WideTracesRef, WideTracesFixtures } from './wide-traces.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/wide-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/wide-traces.fixture.ts
@@ -1,0 +1,151 @@
+import { test as baseTest } from './automation-rules.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7 } from '../core/backend';
+
+export interface WideTracesRef {
+  /** Every seeded trace id, newest first — the order the Logs table renders. */
+  traceIds: string[];
+  /** How many traces were seeded. */
+  traceCount: number;
+  /** Distinct feedback score names, one dynamic column each. */
+  scoreNames: string[];
+  /** A term that matches exactly `searchMatchIds` by trace name. */
+  searchTerm: string;
+  /** The trace ids the search term matches, newest first. */
+  searchMatchIds: string[];
+}
+
+export interface WideTracesFixtures {
+  wideTraces: WideTracesRef;
+}
+
+/**
+ * Sized against the Logs table's virtualization budget (`columns × rows > 3000`,
+ * see `getVirtualizationConfig` in `shared/DataTable/utils.tsx`), so one project
+ * sits on both sides of it:
+ *
+ *   default column selection (10 static + one per score name, + the pinned
+ *   select column) x 100 rows  -> under the budget, nothing is windowed
+ *   every column selected                x 100 rows  -> over it, rows and columns window
+ *
+ * `SCORE_NAME_COUNT` is what holds that gap open, so the specs assert both sides
+ * from the counts the Columns control actually reports rather than trusting the
+ * arithmetic here — if the table's static column set drifts far enough to close
+ * the gap, they fail saying so instead of quietly stopping exercising windowing.
+ */
+const TRACE_COUNT = 100;
+const SCORE_NAME_COUNT = 14;
+const WRITE_CHUNK = 50;
+
+/** Traces are named `<ns>-b<bucket>-<index>`; buckets hold ten traces each. */
+const SEARCH_BUCKET = 1;
+const BUCKET_SIZE = 10;
+
+/**
+ * `TRACE_COUNT` traces in one project, wide enough to window the Logs table once
+ * every column is turned on.
+ *
+ * Ids are minted with an explicit, strictly increasing timestamp rather than
+ * left to the server: the table orders on the id's embedded UUIDv7 instant, and
+ * a batch write stamps every trace in the same millisecond, which would leave
+ * the row order down to the ids' random tails. These specs sweep the table and
+ * assert the window advances without skipping a row, so they need to know the
+ * order up front.
+ */
+export const test = baseTest.extend<WideTracesFixtures>({
+  wideTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    // Backdated so the seed sits inside the Logs page's default date window with
+    // room to spare, and far from anything else the run creates.
+    const firstStamp = Date.now() - 60 * 60 * 1000;
+
+    const seeds = Array.from({ length: TRACE_COUNT }, (_, i) => {
+      const index = String(i).padStart(3, '0');
+      const startTime = new Date(firstStamp + i * 1000);
+      return {
+        id: uuid7(startTime),
+        projectName: project.name,
+        name: `${testNamespace}-b${Math.floor(i / BUCKET_SIZE)}-${index}`,
+        startTime,
+        endTime: new Date(startTime.getTime() + 500),
+        input: { question: `question number ${index}` },
+        output: { answer: `answer number ${index}` },
+      };
+    });
+
+    for (let i = 0; i < seeds.length; i += WRITE_CHUNK) {
+      await backendClient.createTracesBatch(seeds.slice(i, i + WRITE_CHUNK));
+    }
+
+    const scoreNames = Array.from(
+      { length: SCORE_NAME_COUNT },
+      (_, i) => `score_${String(i).padStart(2, '0')}`,
+    );
+    // One trace carries all of them: a score *name* existing in the project is
+    // what grows the column, and which rows hold a value for it is irrelevant to
+    // how wide the table gets.
+    await backendClient.scoreTracesBatch(
+      scoreNames.map((name) => ({
+        traceId: seeds[0].id,
+        projectName: project.name,
+        name,
+        value: 0.5,
+      })),
+    );
+
+    // The batch write answers 204 before ClickHouse can serve the rows back, and
+    // a UI assertion over a project that is still half-seeded is a test that
+    // cannot fail. Block until the API agrees all of them are readable.
+    const expectedIds = new Set(seeds.map((s) => s.id));
+    const deadline = Date.now() + 60_000;
+    for (;;) {
+      const listed = await backendClient.listTraceIds({
+        projectId: project.id,
+        size: TRACE_COUNT + 10,
+      });
+      if (listed.length === TRACE_COUNT && listed.every((id) => expectedIds.has(id))) break;
+      if (Date.now() > deadline) {
+        throw new Error(
+          `[wideTraces fixture] seeded ${TRACE_COUNT} traces but the API lists ${listed.length} ` +
+            `for project ${project.name} after 60s`,
+        );
+      }
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+
+    const searchTerm = `-b${SEARCH_BUCKET}-`;
+    const matches = seeds.filter((s) => s.name.includes(searchTerm));
+    if (matches.length !== BUCKET_SIZE) {
+      throw new Error(
+        `[wideTraces fixture] search term "${searchTerm}" matches ${matches.length} of the ` +
+          `seeded names, expected ${BUCKET_SIZE} — the namespace or the naming scheme changed`,
+      );
+    }
+
+    const ref: WideTracesRef = {
+      // Newest first, which is how the table sorts by default.
+      traceIds: seeds.map((s) => s.id).reverse(),
+      traceCount: TRACE_COUNT,
+      scoreNames,
+      searchTerm,
+      searchMatchIds: matches.map((s) => s.id).reverse(),
+    };
+    await testInfo.attach('opik.wideTraces', {
+      body: JSON.stringify({ ...ref, projectId: project.id }, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      // Traces do not go with the project, and the run-prefix sweep in
+      // global-teardown only knows about experiments, datasets and projects.
+      try {
+        await backendClient.deleteTraces(seeds.map((s) => s.id));
+      } catch (err) {
+        console.warn(`[wideTraces fixture] trace delete warning for ${project.name}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './automation-rules.fixture';

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page, type Locator } from '@playwright/test';
+import { test, expect, type Page, type Locator, type ElementHandle } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
 import { ThreadPanelPage } from './thread-panel.page';
@@ -23,11 +23,18 @@ export class LogsPage {
 
   constructor(private readonly page: Page) {}
 
-  async goto(projectId: string): Promise<void> {
+  /**
+   * Open Logs for a project. `pageSize` pins the pagination size in the URL —
+   * the control otherwise remembers the last value in local storage, so a spec
+   * whose assertions depend on how many rows the table holds should say what it
+   * wants rather than inherit it.
+   */
+  async goto(projectId: string, opts: { pageSize?: number } = {}): Promise<void> {
     return test.step(`Open Logs for project ${projectId}`, async () => {
       this.projectId = projectId;
       const env = loadEnvConfig();
-      await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/logs`);
+      const query = opts.pageSize ? `?size=${opts.pageSize}` : '';
+      await this.page.goto(`${env.baseUrl}/${env.workspace}/projects/${projectId}/logs${query}`);
     });
   }
 
@@ -495,6 +502,350 @@ export class LogsPage {
       const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/logs?logsType=threads&thread=${threadId}`;
       await this.page.goto(url);
       return new ThreadPanelPage(this.page, threadId);
+    });
+  }
+
+  // --- Column configuration ---
+
+  /** The "Columns N/M" control that opens the column picker. */
+  get columnsButton(): Locator {
+    return this.page.getByTestId('columns-button');
+  }
+
+  /**
+   * The selected/total column counts the Columns control reports. Both move with
+   * the project's data — a feedback score name or a metadata key each add a
+   * dynamic column — so specs that care about the table's width read them here
+   * instead of hard-coding a number that the next FE column would invalidate.
+   */
+  async readColumnCounts(): Promise<{ selected: number; total: number }> {
+    return test.step('Read the Columns selected/total counts', async () => {
+      const text = (await this.columnsButton.textContent()) ?? '';
+      const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+      if (!match) {
+        throw new Error(`LogsPage.readColumnCounts: no "N/M" badge in "${text}"`);
+      }
+      return { selected: Number(match[1]), total: Number(match[2]) };
+    });
+  }
+
+  /**
+   * Turn on every column via the picker's select-all row.
+   *
+   * The row is the menu's own checkbox item, matched on the "N of M selected"
+   * label it renders; it is the only item in the menu whose label has that
+   * shape, and unlike the per-column items its text does not depend on which
+   * columns the project happens to have.
+   */
+  async selectAllColumns(): Promise<void> {
+    return test.step('Select every column', async () => {
+      await this.columnsButton.click();
+      const selectAll = this.page
+        .getByRole('menuitemcheckbox')
+        .filter({ hasText: /^\d+ of \d+ selected$/ });
+      await expect(selectAll).toHaveCount(1);
+      await selectAll.click();
+      await this.page.keyboard.press('Escape');
+      await expect(selectAll).toBeHidden();
+      await expect
+        .poll(async () => {
+          const { selected, total } = await this.readColumnCounts();
+          return selected === total;
+        })
+        .toBe(true);
+    });
+  }
+
+  // --- Row selection ---
+
+  /** The header checkbox that selects every row in the current page. */
+  get selectAllRowsCheckbox(): Locator {
+    return this.page.getByRole('checkbox', { name: 'Select all' });
+  }
+
+  /**
+   * The "Selected: N" summary in the bulk-actions bar. Text-matched: the bar has
+   * no testid, and the count is exactly what these specs are asserting on.
+   */
+  get selectionSummary(): Locator {
+    return this.page.getByText(/^Selected: \d+$/);
+  }
+
+  // --- Free-text search ---
+
+  /**
+   * The "Search by anything" box above the table. Every SearchInput in the app
+   * carries this testid, including the one inside the column picker — so call
+   * this only with that menu closed, which `selectAllColumns()` guarantees.
+   */
+  get searchInput(): Locator {
+    return this.page.getByTestId('search-input');
+  }
+
+  async searchTraces(term: string): Promise<void> {
+    return test.step(`Search traces for "${term}"`, async () => {
+      await this.searchInput.fill(term);
+    });
+  }
+
+  async clearTraceSearch(): Promise<void> {
+    return test.step('Clear the trace search', async () => {
+      await this.searchInput.fill('');
+    });
+  }
+
+  // --- Table virtualization ---
+  //
+  // Past a fixed budget (`columns × rows`, see `getVirtualizationConfig` in
+  // shared/DataTable/utils.tsx) the table renders only a window of its rows and
+  // columns. The helpers below are what let a spec assert on the WHOLE table
+  // anyway: sweep the scroll container and collect what each window rendered.
+
+  /** Header cells currently in the DOM. Spacer cells carry no `data-header-id`. */
+  get renderedHeaders(): Locator {
+    return this.page.locator('thead th[data-header-id]');
+  }
+
+  async renderedHeaderIds(): Promise<string[]> {
+    return test.step('Read rendered column ids', async () =>
+      this.renderedHeaders.evaluateAll((cells) =>
+        cells.map((c) => c.getAttribute('data-header-id') ?? ''),
+      ));
+  }
+
+  /**
+   * The dynamic feedback-score columns currently in the DOM, one per score name
+   * the project has seen. They arrive on their own query and are selected as
+   * they land, so a spec whose sizing depends on them has a real state to wait
+   * on rather than a guess about when the page has finished widening.
+   */
+  async renderedFeedbackScoreColumnIds(): Promise<string[]> {
+    return test.step('Read rendered feedback-score column ids', async () => {
+      const ids = await this.renderedHeaderIds();
+      return ids.filter((id) => id.startsWith('feedback_scores_'));
+    });
+  }
+
+  /**
+   * The zero-height filler rows the row virtualizer mounts in place of the rows
+   * outside its window. Their presence is the tell that windowing is on; real
+   * rows always carry a `data-row-id`.
+   */
+  get spacerRows(): Locator {
+    return this.page.locator('tbody tr:not([data-row-id])');
+  }
+
+  /**
+   * The element that scrolls the Logs table, on both axes.
+   *
+   * It is the page-body scroll container, which carries no testid — and this
+   * suite runs against pre-built deployments, so one cannot be added here and
+   * observed there. Rather than pin a structural CSS path (the container is
+   * identified only by the Tailwind height/overflow classes the layout owns),
+   * resolve it the way the FE's own virtualizer does: the nearest scrollable
+   * ancestor of the table. A `data-testid` on PageBodyScrollContainer would let
+   * this be a plain locator and is worth adding next time the FE is touched.
+   */
+  private async scrollContainer(): Promise<ElementHandle<HTMLElement>> {
+    const handle = await this.page.evaluateHandle(() => {
+      let el: HTMLElement | null = document.querySelector('table')?.parentElement ?? null;
+      while (el && el !== document.documentElement) {
+        const style = getComputedStyle(el);
+        if (/auto|scroll/.test(style.overflowY) && el.scrollHeight > el.clientHeight + 1) {
+          return el;
+        }
+        el = el.parentElement;
+      }
+      return null;
+    });
+    const element = handle.asElement() as ElementHandle<HTMLElement> | null;
+    if (!element) {
+      throw new Error('LogsPage.scrollContainer: the Logs table has no scrollable ancestor');
+    }
+    return element;
+  }
+
+  /**
+   * Scroll the table from top to bottom in half-viewport steps, collecting every
+   * row that renders on the way.
+   *
+   * `orderedIds` is the order the table is expected to list, and it does more
+   * than name the rows: after each step this waits until the rendered window is
+   * a contiguous run of that order which starts no later than one row past where
+   * the previous step ended. That is a real state to wait on rather than a
+   * sleep, and it is also the assertion — a window that jumped a row cannot
+   * satisfy it, so the sweep hangs and fails instead of quietly returning a set
+   * that is missing one.
+   */
+  async sweepRowsVertically(
+    orderedIds: string[],
+  ): Promise<{ seenIds: Set<string>; blankRows: number }> {
+    return test.step('Scroll the table top to bottom, collecting every row', async () => {
+      const container = await this.scrollContainer();
+      const seenIds = new Set<string>();
+      let blankRows = 0;
+      let previousLastIndex = -1;
+      let target = 0;
+
+      for (let step = 0; ; step++) {
+        if (step > orderedIds.length) {
+          throw new Error('LogsPage.sweepRowsVertically: scrolled more steps than there are rows');
+        }
+        const geometry = await container.evaluate((el, top) => {
+          el.scrollTop = top;
+          return {
+            top: el.scrollTop,
+            max: el.scrollHeight - el.clientHeight,
+            step: Math.floor(el.clientHeight / 2),
+          };
+        }, target);
+
+        await expect
+          .poll(
+            async () =>
+              container.evaluate(
+                (el, [ids, lastIndex]: [string[], number]) => {
+                  const rows = Array.from(
+                    document.querySelectorAll<HTMLElement>('tbody tr[data-row-id]'),
+                  );
+                  if (rows.length === 0) return false;
+                  const indices = rows.map((r) => ids.indexOf(r.getAttribute('data-row-id') ?? ''));
+                  if (indices.some((i) => i < 0)) return false;
+                  if (indices.some((v, k) => k > 0 && v !== indices[k - 1] + 1)) return false;
+                  if (indices[0] > lastIndex + 1) return false;
+                  // The window has settled once it reaches the bottom of the
+                  // viewport — or once it has rendered the last row there is.
+                  const bottom = rows[rows.length - 1].getBoundingClientRect().bottom;
+                  return (
+                    bottom >= el.getBoundingClientRect().bottom - 1 ||
+                    indices[indices.length - 1] === ids.length - 1
+                  );
+                },
+                [orderedIds, previousLastIndex] as [string[], number],
+              ),
+            {
+              timeout: 30_000,
+              message:
+                `the row window never settled into a gapless run continuing from index ` +
+                `${previousLastIndex} and covering the viewport`,
+            },
+          )
+          .toBe(true);
+
+        const rendered = await this.page.evaluate((ids: string[]) => {
+          const rows = Array.from(document.querySelectorAll<HTMLElement>('tbody tr[data-row-id]'));
+          return {
+            ids: rows.map((r) => r.getAttribute('data-row-id') ?? ''),
+            blanks: rows.filter((r) => (r.textContent ?? '').trim() === '').length,
+            lastIndex: ids.indexOf(rows[rows.length - 1].getAttribute('data-row-id') ?? ''),
+          };
+        }, orderedIds);
+        rendered.ids.forEach((id) => seenIds.add(id));
+        blankRows += rendered.blanks;
+        previousLastIndex = rendered.lastIndex;
+
+        if (previousLastIndex === orderedIds.length - 1 || geometry.top >= geometry.max - 1) break;
+        target = geometry.top + geometry.step;
+      }
+
+      return { seenIds, blankRows };
+    });
+  }
+
+  /**
+   * Scroll the table left to right in half-viewport steps, collecting every
+   * column that renders on the way, and report where the right-most header ends
+   * up once the scroll is exhausted.
+   *
+   * `lastHeaderRight` vs `containerRight` is what catches a mis-sized trailing
+   * spacer: the window can render every column and still leave the last one
+   * stranded past the edge of what the container can scroll to.
+   */
+  async sweepColumnsHorizontally(): Promise<{
+    headerIds: Set<string>;
+    lastHeaderRight: number;
+    containerRight: number;
+  }> {
+    return test.step('Scroll the table left to right, collecting every column', async () => {
+      const container = await this.scrollContainer();
+      const headerIds = new Set<string>();
+      let target = 0;
+      let edges = { lastHeaderRight: 0, containerRight: 0 };
+
+      for (let step = 0; ; step++) {
+        if (step > 200) {
+          throw new Error('LogsPage.sweepColumnsHorizontally: scroll never reached the right edge');
+        }
+        const geometry = await container.evaluate((el, left) => {
+          el.scrollLeft = left;
+          return {
+            left: el.scrollLeft,
+            max: el.scrollWidth - el.clientWidth,
+            step: Math.floor(el.clientWidth / 2),
+          };
+        }, target);
+
+        await expect
+          .poll(
+            async () =>
+              container.evaluate((el) => {
+                const headers = Array.from(
+                  document.querySelectorAll<HTMLElement>('thead th[data-header-id]'),
+                );
+                if (headers.length === 0) return false;
+                const right = headers[headers.length - 1].getBoundingClientRect().right;
+                return (
+                  right >= el.getBoundingClientRect().right - 1 ||
+                  el.scrollLeft >= el.scrollWidth - el.clientWidth - 1
+                );
+              }),
+            {
+              timeout: 30_000,
+              message: 'the column window never settled with its last header at the right edge',
+            },
+          )
+          .toBe(true);
+
+        const rendered = await container.evaluate((el) => {
+          const headers = Array.from(
+            document.querySelectorAll<HTMLElement>('thead th[data-header-id]'),
+          );
+          return {
+            ids: headers.map((h) => h.getAttribute('data-header-id') ?? ''),
+            lastHeaderRight: headers[headers.length - 1].getBoundingClientRect().right,
+            containerRight: el.getBoundingClientRect().right,
+          };
+        });
+        rendered.ids.forEach((id) => headerIds.add(id));
+        edges = {
+          lastHeaderRight: rendered.lastHeaderRight,
+          containerRight: rendered.containerRight,
+        };
+
+        if (geometry.left >= geometry.max - 1) break;
+        target = geometry.left + geometry.step;
+      }
+
+      return { headerIds, ...edges };
+    });
+  }
+
+  /** Scroll the table back to its top-left corner. */
+  async resetTableScroll(): Promise<void> {
+    return test.step('Scroll the table back to the top left', async () => {
+      const container = await this.scrollContainer();
+      await container.evaluate((el) => {
+        el.scrollTop = 0;
+        el.scrollLeft = 0;
+      });
+    });
+  }
+
+  /** How far down the table is scrolled, in pixels. */
+  async tableScrollTop(): Promise<number> {
+    return test.step('Read the table scroll offset', async () => {
+      const container = await this.scrollContainer();
+      return container.evaluate((el) => el.scrollTop);
     });
   }
 }

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-column-virtualization.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-column-virtualization.spec.ts
@@ -1,0 +1,209 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * Configuring columns on a project big enough to window the Logs table.
+ *
+ * Past a fixed budget (`columns × rows > 3000`, `getVirtualizationConfig` in
+ * shared/DataTable/utils.tsx) the table renders only a window of its rows and
+ * its columns. The failure that introduces is silent rather than loud: a row or
+ * a column that exists but is never in the DOM, or a selection count that only
+ * reports what is rendered. A spec that counted rendered rows would agree with
+ * every one of those. So each test here asserts on the WHOLE set — all 100
+ * seeded ids, all N column ids — by sweeping the scroll container and collecting
+ * what each window rendered.
+ *
+ * The seed sits on both sides of the budget on purpose: the default column
+ * selection stays under it and turning every column on crosses it. Both are
+ * asserted from the counts the Columns control itself reports, so if the table's
+ * column set ever drifts far enough to close that gap these fail saying so,
+ * rather than going quietly green having stopped exercising windowing at all.
+ */
+const VIRTUALIZATION_CELL_BUDGET = 3000;
+
+test.describe(
+  'Trace logs — column configuration under table virtualization',
+  { tag: ['@t2-cuj', '@area:traces'] },
+  () => {
+    test(
+      'Turning on every column windows the table while keeping every row and every column reachable',
+      { tag: ['@cap:traces.configure-columns'] },
+      async ({ wideTraces, project, page }) => {
+        const logs = new LogsPage(page);
+        let pinnedColumns = 0;
+        let totalColumns = 0;
+
+        await test.step('Open Logs with every seeded trace on one page', async () => {
+          await logs.goto(project.id, { pageSize: wideTraces.traceCount });
+          await logs.waitForReady();
+
+          // Under the budget: every row is in the DOM and there is no filler row.
+          await expect(logs.traceRows).toHaveCount(wideTraces.traceCount);
+          await expect(logs.spacerRows).toHaveCount(0);
+        });
+
+        await test.step('Confirm the default selection is under the virtualization budget', async () => {
+          // Every seeded score name becomes a column of its own, on a query of
+          // its own — so wait for them before reading the widths that decide
+          // which side of the budget this table is on.
+          await expect
+            .poll(async () => (await logs.renderedFeedbackScoreColumnIds()).length)
+            .toBe(wideTraces.scoreNames.length);
+
+          const { selected, total } = await logs.readColumnCounts();
+          const renderedNow = (await logs.renderedHeaderIds()).length;
+          // Nothing is windowed yet, so what is rendered IS the whole header row.
+          // The difference is the pinned select column, which the picker does not
+          // list — carry it forward so the "all columns" arithmetic below counts
+          // the same things the FE does.
+          pinnedColumns = renderedNow - selected;
+          totalColumns = total + pinnedColumns;
+          expect(pinnedColumns).toBeGreaterThan(0);
+
+          expect(renderedNow * wideTraces.traceCount).toBeLessThanOrEqual(
+            VIRTUALIZATION_CELL_BUDGET,
+          );
+          expect(totalColumns * wideTraces.traceCount).toBeGreaterThan(VIRTUALIZATION_CELL_BUDGET);
+        });
+
+        await test.step('Turn on every column and confirm the table is now windowed', async () => {
+          await logs.selectAllColumns();
+
+          await expect
+            .poll(async () => (await logs.renderedHeaderIds()).length)
+            .toBeLessThan(totalColumns);
+          expect(await logs.traceRows.count()).toBeLessThan(wideTraces.traceCount);
+          expect(await logs.spacerRows.count()).toBeGreaterThan(0);
+        });
+
+        await test.step('Scroll top to bottom and account for every seeded trace', async () => {
+          const { seenIds, blankRows } = await logs.sweepRowsVertically(wideTraces.traceIds);
+
+          expect(blankRows).toBe(0);
+          expect([...seenIds].sort()).toEqual([...wideTraces.traceIds].sort());
+        });
+
+        await test.step('Scroll left to right and account for every column', async () => {
+          await logs.resetTableScroll();
+          const { headerIds, lastHeaderRight, containerRight } =
+            await logs.sweepColumnsHorizontally();
+
+          expect(headerIds.size).toBe(totalColumns);
+          // Scrolled as far right as it goes, the right-most column ends flush
+          // with the container's edge: no column is stranded past what the
+          // scroll can reach, and the trailing spacer is sized correctly.
+          expect(Math.abs(lastHeaderRight - containerRight)).toBeLessThanOrEqual(1);
+        });
+      },
+    );
+
+    test(
+      'Select all reports every row while only a window of them is rendered, and rows scrolled into view arrive selected',
+      { tag: ['@cap:traces.configure-columns'] },
+      async ({ wideTraces, project, page }) => {
+        const logs = new LogsPage(page);
+
+        await test.step('Open Logs and turn on every column to window the table', async () => {
+          await logs.goto(project.id, { pageSize: wideTraces.traceCount });
+          await logs.waitForReady();
+          // Every seeded score name becomes a column of its own, on a query of
+          // its own — so wait for them before reading the widths that decide
+          // which side of the budget this table is on.
+          await expect
+            .poll(async () => (await logs.renderedFeedbackScoreColumnIds()).length)
+            .toBe(wideTraces.scoreNames.length);
+
+          await logs.selectAllColumns();
+          await expect.poll(async () => logs.spacerRows.count()).toBeGreaterThan(0);
+        });
+
+        await test.step('Select all rows and confirm the count covers the whole page', async () => {
+          await logs.selectAllRowsCheckbox.click();
+
+          // The count the bar reports is the whole page, not the rendered window —
+          // and the second assertion is what makes the first one mean something.
+          await expect(logs.selectionSummary).toHaveText(`Selected: ${wideTraces.traceCount}`);
+          expect(await logs.traceRows.count()).toBeLessThan(wideTraces.traceCount);
+        });
+
+        await test.step('Scroll to the bottom and confirm the rows rendered there are selected too', async () => {
+          const { seenIds } = await logs.sweepRowsVertically(wideTraces.traceIds);
+          expect([...seenIds].sort()).toEqual([...wideTraces.traceIds].sort());
+
+          const rows = await logs.traceRows.all();
+          expect(rows.length).toBeGreaterThan(0);
+          for (const row of rows) {
+            await expect(row).toHaveAttribute('data-state', 'selected');
+          }
+          await expect(logs.selectionSummary).toHaveText(`Selected: ${wideTraces.traceCount}`);
+        });
+      },
+    );
+
+    test(
+      'Searching below the virtualization budget renders the whole table again, and clearing the search restores every row',
+      { tag: ['@cap:traces.configure-columns'] },
+      async ({ wideTraces, project, page }) => {
+        const logs = new LogsPage(page);
+        let totalColumns = 0;
+        let scrollTopWhileWindowed = 0;
+
+        await test.step('Open Logs and turn on every column to window the table', async () => {
+          await logs.goto(project.id, { pageSize: wideTraces.traceCount });
+          await logs.waitForReady();
+          // Every seeded score name becomes a column of its own, on a query of
+          // its own — so wait for them before reading the widths that decide
+          // which side of the budget this table is on.
+          await expect
+            .poll(async () => (await logs.renderedFeedbackScoreColumnIds()).length)
+            .toBe(wideTraces.scoreNames.length);
+
+          const before = await logs.readColumnCounts();
+          const renderedBefore = (await logs.renderedHeaderIds()).length;
+          totalColumns = before.total + (renderedBefore - before.selected);
+
+          await logs.selectAllColumns();
+          await expect.poll(async () => logs.spacerRows.count()).toBeGreaterThan(0);
+        });
+
+        await test.step('Scroll away from the top so the reset below is observable', async () => {
+          await logs.sweepRowsVertically(wideTraces.traceIds);
+          scrollTopWhileWindowed = await logs.tableScrollTop();
+          expect(scrollTopWhileWindowed).toBeGreaterThan(0);
+        });
+
+        await test.step(`Search "${wideTraces.searchTerm}" and confirm windowing turns off`, async () => {
+          await logs.searchTraces(wideTraces.searchTerm);
+
+          await expect(logs.traceRows).toHaveCount(wideTraces.searchMatchIds.length);
+          for (const id of wideTraces.searchMatchIds) {
+            await expect(logs.traceRow(id)).toBeVisible();
+          }
+
+          // Few enough cells to fall under the budget: every column is in the
+          // DOM at once and there are no filler rows left.
+          await expect.poll(async () => (await logs.renderedHeaderIds()).length).toBe(totalColumns);
+          await expect(logs.spacerRows).toHaveCount(0);
+
+          // The table just got 90 rows shorter under a view that was scrolled to
+          // the bottom of the long one, so the result has to be on screen rather
+          // than stranded below it. Asserted as "the first match is in the
+          // viewport" and not as `scrollTop === 0`: the browser clamps to the
+          // new maximum, and whether ten rows still overflow at all is a fact
+          // about the window size, not about the flip.
+          expect(await logs.tableScrollTop()).toBeLessThan(scrollTopWhileWindowed);
+          await expect(logs.traceRow(wideTraces.searchMatchIds[0])).toBeInViewport();
+        });
+
+        await test.step('Clear the search and confirm every row is reachable again', async () => {
+          await logs.clearTraceSearch();
+
+          await expect.poll(async () => logs.spacerRows.count()).toBeGreaterThan(0);
+          const { seenIds, blankRows } = await logs.sweepRowsVertically(wideTraces.traceIds);
+          expect(blankRows).toBe(0);
+          expect([...seenIds].sort()).toEqual([...wideTraces.traceIds].sort());
+        });
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Where these came from

Generated by the **release QA side flow** from an exploratory pass over
comet-ml/opik#7971 — *"[OPIK-8021] [FE] perf: virtualize the trace logs view's columns and rows"*.
A human drove the flows by hand on that PR's own deployed environment
(`pr-7971.dev.comet.com`, `2.2.39-7971-merge-3056`) first; these specs are the two
strongest candidates from that pass, turned into permanent coverage.

**This is a generated PR and it needs review before merge.** It is a draft on purpose.

### Base branch

**#7971 is merged** (as `f03bcdc`, 2026-08-24 14:27Z) and its head branch
`andriid/OPIK-8021-logs-view-virtualization` has been deleted, so this targets **`main`**.
The specs were written against that PR's head commit
`cdda040c838a6126b0aa6eb168825fe0b1d2b067`, then rebased onto `main` and re-run there
(see *Verification*) — `main` already carries the change they exercise.

## What the specs cover

`tests_end_to_end/e2e/tests/trace-explore/trace-column-virtualization.spec.ts` —
`@t2-cuj`, `@area:traces`, `@cap:traces.configure-columns` (previously `covered: false`,
and the only uncovered capability the Logs table's windowing runs through).

The windowing this PR added fails *silently* when it fails: a row or a column that exists
but is never in the DOM, or a selection count that only reports the rendered window. A spec
that counted rendered rows would agree with every one of those. So all three tests assert
on the **whole** table — sweeping the scroll container and collecting every row and column
the successive windows mount.

The seed sits on **both sides** of the budget (`columns × rows > 3000`,
`getVirtualizationConfig` in `shared/DataTable/utils.tsx`) on purpose: 100 traces × the
default column selection stays under it, and turning every column on crosses it. Both sides
are asserted from the counts the Columns control itself reports — so if the table's column
set ever drifts far enough to close that gap, these fail saying so rather than going quietly
green having stopped exercising windowing at all.

| Test | Asserts |
|---|---|
| Turning on every column windows the table while keeping every row and every column reachable | Default selection is under the budget and all 100 rows are in the DOM with no filler row; select-all crosses it and the table windows; a top-to-bottom sweep accounts for **all 100 seeded trace ids** with no blank row; a left-to-right sweep accounts for **every column id**, and at full `scrollLeft` the right-most header ends flush with the container's edge (a mis-sized trailing spacer would strand it). |
| Select all reports every row while only a window of them is rendered, and rows scrolled into view arrive selected | The action bar reads `Selected: 100` while **strictly fewer than 100 rows are in the DOM** — the second half is what makes the first mean anything — and every row rendered after scrolling to the bottom carries `data-state="selected"`. |
| Searching below the virtualization budget renders the whole table again, and clearing the search restores every row | Searching down to 10 rows flips windowing **off**: every column mounts at once, no filler rows, and the view is clamped back into the now-shorter table (the first match is in the viewport). Clearing the search windows again and every one of the 100 rows is still reachable. |

Supporting changes, all in `tests_end_to_end/`:

- **`fixtures/wide-traces.fixture.ts`** (new) — seeds 100 traces and 14 feedback score names
  into one project. Ids are minted with strictly increasing timestamps rather than left to
  the server: the table orders on the id's embedded UUIDv7 instant and a batch write stamps
  every trace in the same millisecond, which would leave row order down to the ids' random
  tails. The fixture blocks until the API serves all 100 rows back (the batch write answers
  204 before ClickHouse can), so a UI assertion can't run over a half-seeded project, and it
  deletes the traces on teardown — they don't go with the project, and the run-prefix sweep
  in `global-teardown` doesn't know about them.
- **`core/backend/client.ts`** — `createTracesBatch` / `scoreTracesBatch`. Seeding three
  figures of traces one round trip at a time costs more than the test that follows.
- **`pom/logs.page.ts`** — the Columns control, the selection bar, the search box, and the
  sweep helpers. `goto()` gains an optional `pageSize`.
- **`coverage/taxonomy.yaml`** — spec added to the area's `specs:`, `configure-columns`
  flipped to `covered: true, tier: t2-cuj`.

## Verification

| | |
|---|---|
| `npx tsc --noEmit` | clean |
| `python3 tests_end_to_end/coverage/tag_lint.py --taxonomy … --estate tests_end_to_end` | `44 specs checked, 1 exempt, 0 problem(s)` |
| `npx playwright test tests/trace-explore/trace-column-virtualization.spec.ts` | **3 passed**, repeated 3× (~23s a run) |
| `npx playwright test tests/trace-explore/` | **21 passed** — the whole directory, since this touches the shared `LogsPage` POM |

**Please read this part before trusting the runs.** The environment the exploration used
(`$OPIK_BASE_URL` = `pr-7971.dev.comet.com`) started returning `502 Bad Gateway` on every
request part-way through this run and never recovered — plausibly torn down when #7971
merged. The runs above were therefore made against a **local OSS install of `main`**
(`docker compose --profile opik up`, `ghcr.io/comet-ml/opik/opik-frontend:latest` resolving
to `2.2.39` built 14:34Z — after the merge, and its bundle contains this PR's
`__column_spacer_lead`). That is the "re-run against main" step, not a substitute for it.

Before that environment went down, every assertion these specs make was also observed by
hand against the **deployed PR build** during selector discovery: 100/100 rows reachable,
37/37 columns, last header flush at `1280 == 1280`, `Selected: 100` with 32 rows in the DOM,
and the search flip in both directions. The numbers match the exploration's.

One assertion was **corrected after its first run**, and it is worth a reviewer's eye:
the exploration observed `scrollTop` returning to `0` when the search flips windowing off,
and the first draft asserted exactly that. It failed on `main` with `scrollTop == 72` — which
turned out to be `scrollHeight - clientHeight`, i.e. the browser correctly clamping to the
shortened table's new maximum. `0` was an artifact of the exploration's taller viewport, not
a property of the flip. The assertion now checks what actually matters to a user — the view
is clamped back into the results and the first match is on screen. **Not an app fault.**

## What I deliberately did not write

The exploration produced two candidates. **One was dropped.**

- ~~*The trace-logs sidebar's split scroll containers reach every row and every column*~~ —
  marked `weak` by the exploration itself. It reuses the **same** capability key as the spec
  above (the taxonomy has no key for the shared logs sidebar), so it would have added no
  coverage the map can see, and it needs the whole 100-trace + annotation-queue fixture for
  what is largely a layout assertion. The exploration's own note says "if only one spec is
  wanted, take candidate 1". It is the riskier half of the diff, so it is worth covering —
  but it wants a capability key of its own first.

One deliberate deviation from the candidate, flagged for review: the exploration drove this
flow on the **experiment-compare Logs tab**, and these specs drive the **project Logs page**.
The heuristic under test is the shared `getVirtualizationConfig` and the exploration
confirmed it governs both hosts. Placing it on the project Logs page keeps the spec's
directory (`trace-explore/`), its `@area:`, and its `@cap:` in agreement — a spec tagged
`@cap:traces.configure-columns` sitting in `tests/experiments/` would not — and drops a
dataset + 100-item experiment from the fixture. Each test runs in 7–9s as a result.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-8021]: https://comet-ml.atlassian.net/browse/OPIK-8021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ