### PR TITLE
[OPIK-6901] [BE] refactor: make trace-delete pruning cutover-agnostic, drop its flag

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -155,20 +155,6 @@ databaseAnalyticsDataModel:
   #   MODIFY TTL target `traces_local` only (the Distributed `traces` rejects them); ADD/DROP/MODIFY COLUMN must target
   #   both `traces_local` and `traces`, else reads can't see the column (code 47).
   tracesDistributedWrapEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
-  #  Default: false
-  #  Description: Enables partition-aware PRUNING of trace deletes - it does NOT create or activate any partitioning.
-  #   With it on, a trace DELETE bounds itself to the weekly partitions its own ids resolve to instead of being planned
-  #   against every part of the table. Turning it on therefore ASSERTS a schema fact rather than causing one: that the
-  #   live mutation target already IS the weekly partitioned successor, id_at as DateTime64(0,'UTC') under
-  #   PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1))). Installing that schema is the
-  #   EXCHANGE step of the cutover, never this flag. Purely an optimisation: false keeps the unbounded mutation, which
-  #   is always correct and merely slower. A third flag on purpose - the partitioning appears at the EXCHANGE, and
-  #   neither sibling marks it:
-  #   traceColumnsNonNullable must be rolled out BEFORE the EXCHANGE, tracesDistributedWrapEnabled flips at the wrap,
-  #   which may be deferred long after it. Leave false at deploy time; set true once the EXCHANGE is confirmed, and back
-  #   to false BEFORE a rollback promotes the original `traces` (legacy `traces` has no PARTITION BY and a 32-bit
-  #   DateTime id_at that overflows past 2106, so the predicate would silently match zero rows for a far-future id).
-  tracesWeeklyPartitionPruningEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED:-false}
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -423,29 +423,27 @@ the `traceColumnsNonNullable` flip").
 
 On rollback, after swapping the Nullable original back, revert the flag to `false` **and** run that repair.
 
-**The `tracesWeeklyPartitionPruningEnabled` flip (optional, and why it goes last).** `databaseAnalyticsDataModel.tracesWeeklyPartitionPruningEnabled`
-(env `ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED`, default `false`) lets a trace `DELETE` bind itself to
-the weekly partitions its own ids resolve to (OPIK-6901), instead of being planned against every part of the table — on
-prod-test, 12 ids rewrote 3,928 parts / 5.40 TiB without it. It asserts a **schema** fact: that `traces` (or
-`traces_local`) is the successor, with `id_at` as `DateTime64(0,'UTC')` under the weekly `PARTITION BY`.
+**Trace-delete partition pruning needs no flip at all (OPIK-6901).** A trace `DELETE` binds itself to the weekly
+partitions its own ids resolve to instead of being planned against every part of the table — on prod-test, 12 ids
+rewrote 3,928 parts / 5.40 TiB before this. There is **no flag, no ordering constraint, and nothing to revert on
+rollback**: the predicate is emitted unconditionally, and one rendered statement is correct against the original and
+against the successor alike.
 
-> **It enables the *pruning*, not the partitioning — the name is deliberate.** Setting it does not create, activate or
-> migrate anything; the partitioned schema arrives with the `EXCHANGE` above and nowhere else. So it is never a step that
-> *makes* the cutover progress, and setting it early does not bring the partitioning forward — it only starts emitting a
-> predicate against whatever table is live, which is the failure below.
+That works because the derivation (`WeeklyPartitions`) names, for each id, the week it partitions into under **each**
+`id_at` type a mutation can meet — the successor's `DateTime64(0,'UTC')` and the original's 32-bit `DateTime`, which
+holds `epochSecond % 2^32`. Below 2106 the two coincide and the set is one value per week, which is all real traffic;
+only a far-future id (the litellm ~2201 rows) contributes a second, and widening an `IN` set can only select an extra
+partition — the `(project_id, id)` predicate it is ANDed with still decides which rows go. Against a 220-partition
+table the pruning is identical either way (3/220 parts with or without the extra value).
 
-It is a third flag precisely because **neither of the two above marks the `EXCHANGE`**, which is when the partitioning
-appears: `traceColumnsNonNullable` must lead it (above), and `tracesDistributedWrapEnabled` flips at the wrap, which may
-be deferred long after it (`--skip-wrap` … `--wrap-only`). So gate on this one, not on either of those.
+This is what an earlier revision gated on a `tracesWeeklyPartitionPruningEnabled` flag, which asserted the `EXCHANGE`
+had already happened and had to be reverted **before** a stage B/C rollback promoted the original. That flag is gone,
+along with its footgun: a stale `true` used to make trace deletes on the original match **zero rows while reporting
+success**, because a set carrying only the honest week cannot match a row the 32-bit column filed under a wrapped
+timestamp. Both weeks are now in the set, so neither direction of the swap needs an operator step.
 
-Unlike its siblings it is **safe to lag and unsafe to lead**: `false` is the previous unbounded delete, always correct
-and merely slower, so turn it on at leisure **after** the `EXCHANGE` is confirmed. Turning it on early — while `traces` is
-still the original — is the failure mode worth avoiding: the original has **no `PARTITION BY` at all** (nothing to prune)
-and declares `id_at` as a 32-bit `DateTime` that overflows past 2106, so a far-future id (the litellm ~2201 rows) is
-stored under a wrapped recent timestamp that the derived partition cannot match, and the delete reports success having
-matched **zero rows**. For the same reason, a stage B/C **rollback must revert it to `false` — and roll-restart every
-instance — before promoting the original**, ahead of the swap rather than after it. Like its siblings it comes from a
-startup snapshot of `OpikConfiguration`, so the config change alone changes nothing until each instance restarts.
+Coverage sits in `TracesPartitionPruningMutationTest` (the successor) and `TracesLegacyTablePruningMutationTest` (the
+original), which delete the same far-future row shape with the same rendered predicate against each schema.
 
 ## Batching and throttling
 
@@ -957,11 +955,6 @@ statements, so a failure *between* them needs a restart path:
 **Rolling back the `traceColumnsNonNullable` flip.** After a stage B or C rollback, `traces` is the Nullable original
 again, so the flip has to be undone in two steps — `rollback.sh` prints both when the stage finishes. The rollback is not
 complete until they land.
-
-> **If `tracesWeeklyPartitionPruningEnabled` was turned on, revert it *before* the stage runs, not after.** It asserts the
-> live table is the partitioned successor, and the restored original is not one, so a stale `true` makes trace deletes
-> match zero rows while reporting success — see "The `tracesWeeklyPartitionPruningEnabled` flip". It is the one flag whose
-> revert has to lead the swap; the two steps below follow it.
 
 1. **Revert `traceColumnsNonNullable` to `false` AND roll-restart every backend instance.** The flag is read from a
    **startup snapshot** of `OpikConfiguration` (bound via `toInstance`), so a config change does **not** take effect until

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1924,13 +1924,16 @@ class TraceDAOImpl implements TraceDAO {
      * project_id}, so no delete is ever project-less - also required once {@code traces} is a Distributed table
      * (OPIK-7455).
      * <p>
-     * {@code <if(partitions)>} adds the table's own weekly partition expression, bound as the exact set of partitions
-     * the batch's ids resolve to. Both conditions must hold for it to be emitted: the live table must be the weekly
-     * partitioned successor ({@link #tracesWeeklyPartitionPruningEnabled()}), and every id in the batch must be one whose
-     * partition can be derived exactly ({@link WeeklyPartitions#of}). Otherwise the predicate is omitted and the
-     * statement is byte-identical to the previous unbounded form. That is what preserves the original guarantee — a
-     * row whose {@code id_at} cannot be trusted is still deleted, because no id in such a batch is used to derive a
-     * partition.
+     * {@code <if(partitions)>} adds the table's own weekly partition expression, bound as the set of partitions the
+     * batch's ids resolve to. It is emitted whenever every id in the batch is one whose partition can be derived
+     * exactly ({@link WeeklyPartitions#of}); otherwise the predicate is omitted and the statement is byte-identical to
+     * the previous unbounded form. That is what preserves the original guarantee — a row whose {@code id_at} cannot be
+     * trusted is still deleted, because no id in such a batch is used to derive a partition.
+     * <p>
+     * No schema flag gates it. {@link WeeklyPartitions} derives a value per {@code id_at} type the mutation may meet
+     * — the legacy 32-bit {@code DateTime} of {@code traces} as well as the {@code DateTime64(0)} of the partitioned
+     * successor — so one rendered statement is correct on both sides of the cutover EXCHANGE, in either direction, with
+     * nothing to flip and nothing to revert on rollback.
      * <p>
      * Why it matters: a mutation selects parts at the <b>partition</b> stage, where the (workspace_id, project_id, id)
      * predicate prunes nothing, so deleting a handful of rows rewrote every part of the table. Measured on prod-test
@@ -3372,49 +3375,6 @@ class TraceDAOImpl implements TraceDAO {
     }
 
     /**
-     * Whether a trace mutation may prune to the partitions its ids resolve to ({@link WeeklyPartitions}). The flag
-     * enables the <b>pruning</b>, never the partitioning: it asserts that the live mutation target already is the
-     * weekly partitioned successor — {@code id_at} as {@code DateTime64(0, 'UTC')} under
-     * {@code PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} — which the cutover's
-     * EXCHANGE installs, not this flag.
-     * <p>
-     * This has to be its own flag because <b>neither existing schema flag marks the EXCHANGE, which is the moment the
-     * partitioning appears</b>, and both are wrong in a different direction:
-     * <ul>
-     *     <li>{@link #tracesDistributedWrapEnabled()} is too late. The wrap is a separate, deferrable step after the
-     *     EXCHANGE (it may be skipped entirely with {@code --skip-wrap} and applied weeks later with
-     *     {@code --wrap-only}), so between the two {@code traces} is already the partitioned successor while the flag is
-     *     still {@code false} — the state prod-test sat in. Gating on it would simply forgo the pruning there.</li>
-     *     <li>{@link #traceColumnsNonNullable()} is too early, which is the dangerous direction. It is a runtime
-     *     concern, not a schema one, and the runbook requires it rolled out to {@code true} on every instance
-     *     <b>before</b> the EXCHANGE (a rolling restart cannot be atomic with a metadata swap). Gating on it would emit
-     *     the predicate against the legacy {@code traces} for the whole rollout window.</li>
-     * </ul>
-     * Emitting it against the legacy table is not merely unhelpful, it is wrong: legacy {@code traces} has no
-     * {@code PARTITION BY} at all (one {@code all} partition, so nothing to prune) and declares {@code id_at} as a
-     * 32-bit {@code DateTime} that overflows past 2106, so a far-future id — the litellm ~2201 ids, real
-     * customer-facing rows — is stored under a wrapped recent timestamp that the derived partition cannot match. The
-     * delete would then match zero rows and report success.
-     * <p>
-     * Only ever {@code true} while {@code traces} really is that successor, so unlike its siblings it is safe to lag:
-     * {@code false} is the always-correct unbounded behaviour, and only {@code true} asserts something about the
-     * schema. Turn it on once the EXCHANGE is confirmed, and back off <b>before</b> a rollback stage B/C promotes the
-     * original.
-     */
-    private boolean tracesWeeklyPartitionPruningEnabled() {
-        return configuration.getDatabaseAnalyticsDataModel().tracesWeeklyPartitionPruningEnabled();
-    }
-
-    /**
-     * The partitions a delete batch may bound itself to, or empty to leave the mutation unbounded. Empty whenever the
-     * live table is not the partitioned successor, ahead of asking {@link WeeklyPartitions} at all — the derivation is
-     * only meaningful against a table that partitions on it.
-     */
-    private Optional<Set<Long>> weeklyPartitionsFor(Collection<UUID> ids) {
-        return tracesWeeklyPartitionPruningEnabled() ? WeeklyPartitions.of(ids) : Optional.empty();
-    }
-
-    /**
      * Binds input, output, metadata, and their slim versions (input_slim, output_slim) to a statement.
      * Centralizes the JSON conversion and binding logic for consistency across single and batch inserts.
      *
@@ -3587,9 +3547,10 @@ class TraceDAOImpl implements TraceDAO {
                     var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
                     var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
 
-                    // Prune to the batch's own partitions when the schema and every id in the batch allow it;
-                    // otherwise emit the unbounded form.
-                    var partitions = weeklyPartitionsFor(batch.stream().map(Pair::getRight).toList());
+                    // Prune to the batch's own partitions when every id in the batch allows it; otherwise emit the
+                    // unbounded form. Needs no schema flag: WeeklyPartitions derives a value per id_at type the
+                    // mutation may meet, so the set is correct on the legacy traces and on the partitioned successor.
+                    var partitions = WeeklyPartitions.of(batch.stream().map(Pair::getRight).toList());
                     // Flag only, exactly like distributed_wrap: the values reach ClickHouse via the bind below,
                     // never through the template, so the rendered SQL is constant regardless of batch contents.
                     partitions.ifPresent(_ -> template.add("partitions", true));

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -50,26 +50,6 @@ import lombok.Builder;
  * {@code MODIFY COLUMN} must be applied to <b>both</b> {@code traces_local} and the {@code Distributed} {@code traces}
  * (the wrapper accepts them as metadata-only, and targeting only {@code traces_local} leaves the wrapper without the
  * column, so reads fail with code 47).</p>
- *
- * <p>{@code tracesWeeklyPartitionPruningEnabled}: enables partition-aware <b>pruning</b> of trace deletes — a trace
- * {@code DELETE} bounds itself to the weekly partitions its own ids resolve to instead of being planned against every
- * part of the table (OPIK-6901). It does <b>not</b> create or activate any partitioning; installing the partitioned
- * schema is the EXCHANGE step of the cutover. Turning it on therefore <b>asserts</b> a schema fact rather than causing
- * one: that the live mutation target already is the weekly partitioned successor — {@code id_at} as
- * {@code DateTime64(0, 'UTC')} under
- * {@code PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))}. Purely an optimisation:
- * {@code false} keeps the unbounded mutation, which is always correct and merely slower, and only {@code true} asserts
- * anything about the schema.</p>
- *
- * <p>It is deliberately a third flag rather than a reuse of the two above, because the partitioning appears at the
- * <b>EXCHANGE</b> and neither of them marks that moment. {@code traceColumnsNonNullable} must be rolled out
- * <b>before</b> the EXCHANGE (a rolling restart cannot be atomic with a metadata swap), and
- * {@code tracesDistributedWrapEnabled} flips at the wrap, a separate step that may be deferred long after it — so one
- * flag would be true too early and the other true too late. Emitting the predicate too early is the harmful direction:
- * legacy {@code traces} has no {@code PARTITION BY} at all and declares {@code id_at} as a 32-bit {@code DateTime} that
- * overflows past 2106, so a far-future id is stored under a wrapped timestamp the derived partition cannot match and
- * the delete would silently affect zero rows. Left {@code false} at deploy time; set {@code true} once the EXCHANGE is
- * confirmed on the target, and back to {@code false} <b>before</b> a rollback promotes the original {@code traces}.</p>
  */
 @Builder(toBuilder = true)
 public record DatabaseAnalyticsDataModelConfig(
@@ -78,6 +58,5 @@ public record DatabaseAnalyticsDataModelConfig(
         boolean traceDeletionEventsCaptureEnabled,
         boolean spanDeletionEventsCaptureEnabled,
         @Min(1) @Max(2_000) int deletionEventsInsertBatchSize,
-        boolean tracesDistributedWrapEnabled,
-        boolean tracesWeeklyPartitionPruningEnabled) {
+        boolean tracesDistributedWrapEnabled) {
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
@@ -20,38 +20,63 @@ import java.util.UUID;
  *
  * <p>Mirrors the partition expression of {@code traces_local_v2} / {@code spans_local_v2} exactly —
  * {@code PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))}, where {@code id_at} is
- * {@code DateTime64(0, 'UTC') MATERIALIZED UUIDv7ToDateTime(toUUID(id))} — i.e. the Monday of the id's UTC week as
- * {@code yyyyMMdd}. Both tables share the expression, so it is derived here once rather than per DAO.</p>
+ * {@code MATERIALIZED UUIDv7ToDateTime(toUUID(id))} — i.e. the Monday of the id's UTC week as {@code yyyyMMdd}. Both
+ * tables share the expression, so it is derived here once rather than per DAO.</p>
  *
- * <p><b>Why the caller must treat an empty result as "no predicate", never as "no partitions".</b> The whole value of
- * the derivation is that a partition the batch resolves to is the <em>only</em> place its rows can be; a value that is
- * merely close is a silently skipped delete, not a slower one. So this returns a set only when every id in the batch
- * is one it can derive exactly, and empty otherwise — leaving the caller to emit its unbounded form, which is always
- * correct and merely slower. The two rejections are:</p>
+ * <h2>Why an id contributes two values, and why that removes a cutover flag</h2>
+ *
+ * <p>The predicate has to be correct against <b>both</b> shapes of the table a mutation may run into during the
+ * {@code traces_local_v2} cutover, because nothing in the application marks the EXCHANGE that swaps them. They declare
+ * {@code id_at} with different widths:</p>
+ * <ul>
+ *     <li><b>legacy {@code traces}</b> (migration {@code 000091}): {@code DateTime('UTC')} — 32-bit, so a timestamp
+ *     past {@code 2106-02-07 06:28:15} is stored <b>wrapped</b> modulo 2<sup>32</sup> seconds;</li>
+ *     <li><b>{@code traces_local_v2}</b> (migration {@code 000114}): {@code DateTime64(0, 'UTC')} — the honest value.</li>
+ * </ul>
+ *
+ * <p>So a far-future id (a UUIDv7 minted with a bad clock — litellm
+ * <a href="https://github.com/BerriAI/litellm/issues/31294">BerriAI/litellm#31294</a> mints ~2201, and prod already
+ * holds such rows) partitions as {@code 22010803} on the successor and as the wrapped {@code 20650622} on the legacy
+ * table. A set carrying only one of the two is correct on one schema and, on the other, a predicate that matches
+ * nothing — a delete that reports success and removes no rows.</p>
+ *
+ * <p>Rather than being told which schema is live, each id therefore contributes the partition it resolves to under
+ * <b>each</b> {@code id_at} type the mutation may meet. For every id before 2106 the two coincide and the set is
+ * unchanged, which is all but a rounding error of real traffic; only a far-future id adds a second value. Widening an
+ * {@code IN} set can only ever select an extra partition — the {@code (project_id, id)} predicate it is ANDed with
+ * still decides which rows are deleted — so the union is safe in the direction that matters, while omitting a value is
+ * not. Measured against a 220-partition table, the pruning is identical either way: 3/220 parts with the honest set,
+ * 3/220 with the union.</p>
+ *
+ * <p>This is what lets the predicate be emitted unconditionally, with no flag asserting that the EXCHANGE has already
+ * happened — matching the rest of the project's partition-pruning predicates, which are likewise written to hold
+ * before and after the cutover.</p>
+ *
+ * <h2>Why the caller must treat an empty result as "no predicate", never as "no partitions"</h2>
+ *
+ * <p>The whole value of the derivation is that the partitions a batch resolves to are the <em>only</em> places its rows
+ * can be; a set that is merely close is a silently skipped delete, not a slower one. So this returns a set only when
+ * every id in the batch is one it can derive exactly, and empty otherwise — leaving the caller to emit its unbounded
+ * form, which is always correct and merely slower. The two rejections are:</p>
  * <ul>
  *     <li><b>Any id that is not a UUIDv7.</b> Its high 48 bits are not a timestamp, and {@code UUIDv7ToDateTime}
  *     returns {@code 1970-01-01} for it rather than throwing, so the row sits in the epoch partition while the bits
  *     read as an arbitrary week. All-or-nothing across the batch, not per id: a partially derived set is a set the
  *     rows of the underivable ids are not in.</li>
- *     <li><b>Any id whose embedded timestamp is outside {@code DateTime64}'s range</b> ({@link #ID_AT_CEILING}). Java
- *     has no such bound, so past it the two disagree: ClickHouse stores the saturated bound and the row lands in
- *     {@code 22991225}, while this would compute the real (out-of-range) week. Rejecting is deliberate in preference
- *     to clamping to {@code 22991225}: clamping would make correctness depend on reproducing ClickHouse's saturation
- *     semantics exactly — including where the saturation happens, which is already two steps before {@code toDate32}
- *     (see below) — to buy pruning for ids that should not exist. Falling back to the unbounded mutation costs
- *     performance on those batches and nothing else.</li>
+ *     <li><b>Any id whose embedded timestamp is at or past {@link #ID_AT_CEILING}</b>, the end of {@code DateTime64}'s
+ *     range. Past it the successor no longer stores a value this can reproduce: {@code DateTime64} saturates rather
+ *     than wrapping, so the row lands in {@code 22991225} whatever its real week. Rejecting is deliberate in
+ *     preference to adding {@code 22991225} to the union: that would make correctness depend on reproducing
+ *     ClickHouse's saturation semantics exactly — including where the saturation happens, which is already two steps
+ *     before {@code toDate32} — to buy pruning for ids no clock, however broken, produces. Falling back to the
+ *     unbounded mutation costs performance on those batches and nothing else.</li>
  * </ul>
- *
- * <p>Far-future ids <em>within</em> the range are supported on purpose and are the common case of the two: a UUIDv7
- * minted with a bad clock (litellm <a href="https://github.com/BerriAI/litellm/issues/31294">BerriAI/litellm#31294</a>
- * mints ~2201) has a bogus but self-consistent {@code id_at}, so it lives in the far-future partition this computes and
- * stays deletable and prunable. Verified on prod-test: 0 partition mismatches across 11.23 M far-future rows.</p>
  */
 @UtilityClass
 public class WeeklyPartitions {
 
     /**
-     * First instant {@code id_at} cannot represent. {@code DateTime64} spans
+     * First instant {@code id_at} cannot represent on the partitioned successor. {@code DateTime64} spans
      * {@code [1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999]} and saturates rather than wrapping or throwing, and
      * it saturates twice over before {@code toDate32} is reached: {@code UUIDv7ToDateTime} already returns
      * {@code DateTime64(3)}, and the column is {@code DateTime64(0)}. So an id at or past this instant is stored as
@@ -64,9 +89,21 @@ public class WeeklyPartitions {
             .toEpochMilli();
 
     /**
-     * The weekly partition values the ids resolve to, or empty if the batch contains an id whose partition cannot be
-     * derived exactly (see the class javadoc) — in which case the caller must omit its partition predicate entirely.
-     * An empty batch yields empty for the same reason: there is nothing to bound the mutation to.
+     * The wrap of legacy {@code traces.id_at}, a 32-bit {@code DateTime}: it holds
+     * {@code epochSecond % 2^32}, so anything past {@code 2106-02-07 06:28:15} reappears somewhere in
+     * {@code [1970-01-01, 2106-02-07]}. Modulo, not saturation — verified against ClickHouse 26.3 across a spread of
+     * ordinary and far-future ids, every row satisfying
+     * {@code toUnixTimestamp(id_at) = intDiv(unix_ts_ms, 1000) % 4294967296}, and pinned by
+     * {@code TracesLegacyTablePruningMutationTest}, which deletes a far-future row from the real legacy table — so a
+     * change in that conversion fails CI rather than production.
+     */
+    private static final long ID_AT_LEGACY_MODULUS = 1L << 32;
+
+    /**
+     * The weekly partition values the ids resolve to — under each {@code id_at} type the mutation may run against (see
+     * the class javadoc) — or empty if the batch contains an id whose partition cannot be derived exactly. In the empty
+     * case the caller must omit its partition predicate entirely. An empty batch yields empty for the same reason:
+     * there is nothing to bound the mutation to.
      * <p>
      * A {@code null} batch throws rather than reading as empty, which is the one place this class is deliberately
      * intolerant. Empty is a <em>documented answer</em> — "this batch cannot be pruned, emit the unbounded form" — and a
@@ -84,23 +121,35 @@ public class WeeklyPartitions {
                 return Optional.empty();
             }
             // UUIDv7: the high 48 bits are the unix epoch in milliseconds. `>>> 16` reads them unsigned, so the value
-            // is in [0, 2^48) — never negative, and never large enough for Instant.ofEpochMilli to overflow. That is
-            // also why only the ceiling is checked: the floor of the range is 1900-01-01, the smallest id_at any
-            // UUIDv7 can carry is the epoch, and even its Monday (1969-12-29) is comfortably inside Date32.
+            // is in [0, 2^48) — never negative, and never large enough for Instant.ofEpochSecond to overflow. That is
+            // also why neither derivation checks a floor: the smallest id_at any UUIDv7 can carry is the epoch, and
+            // even its Monday (1969-12-29) is comfortably inside Date32 on both schemas.
             long epochMilli = id.getMostSignificantBits() >>> 16;
             if (epochMilli >= ID_AT_CEILING) {
                 return Optional.empty();
             }
-            LocalDate monday = Instant.ofEpochMilli(epochMilli)
-                    .atZone(ZoneOffset.UTC)
-                    .toLocalDate()
-                    .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-            partitions.add(monday.getYear() * 10000L + monday.getMonthValue() * 100L + monday.getDayOfMonth());
+            // Truncating to whole seconds is the column's own conversion (DateTime64(0) / DateTime both store seconds)
+            // and cannot move a value into an earlier day, so it never changes the week.
+            long epochSecond = epochMilli / 1_000L;
+            partitions.add(weeklyPartitionOf(epochSecond)); // DateTime64(0, 'UTC') — the partitioned successor
+            partitions.add(weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS)); // DateTime('UTC') — legacy traces
         }
 
         // Set.copyOf, not the working HashSet: what escapes here decides which partitions a DELETE mutation touches, so
         // a caller holding a mutable reference could narrow the set after it was derived and turn a correct delete into
         // a silent no-op. Immutable by default per apps/opik-backend/AGENTS.md, and the accumulator stays local.
         return partitions.isEmpty() ? Optional.empty() : Optional.of(Set.copyOf(partitions));
+    }
+
+    /**
+     * {@code toYYYYMMDD(toDate32(t) - toIntervalDay(toDayOfWeek(t, 1)))} for a UTC epoch second — the Monday of its
+     * week as {@code yyyyMMdd}.
+     */
+    private static long weeklyPartitionOf(long epochSecond) {
+        LocalDate monday = Instant.ofEpochSecond(epochSecond)
+                .atZone(ZoneOffset.UTC)
+                .toLocalDate()
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return monday.getYear() * 10000L + monday.getMonthValue() * 100L + monday.getDayOfMonth();
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
@@ -91,7 +91,8 @@ public class WeeklyPartitions {
     /**
      * The wrap of legacy {@code traces.id_at}, a 32-bit {@code DateTime}: it holds
      * {@code epochSecond % 2^32}, so anything past {@code 2106-02-07 06:28:15} reappears somewhere in
-     * {@code [1970-01-01, 2106-02-07]}. Modulo, not saturation — verified against ClickHouse 26.3 across a spread of
+     * {@code [1970-01-01, 2106-02-07]}. Also the threshold itself — below it the modulo is the identity, which is why
+     * only an id past this point contributes a second value. Modulo, not saturation — verified against ClickHouse 26.3 across a spread of
      * ordinary and far-future ids, every row satisfying
      * {@code toUnixTimestamp(id_at) = intDiv(unix_ts_ms, 1000) % 4294967296}, and pinned by
      * {@code TracesLegacyTablePruningMutationTest}, which deletes a far-future row from the real legacy table — so a
@@ -132,7 +133,11 @@ public class WeeklyPartitions {
             // and cannot move a value into an earlier day, so it never changes the week.
             long epochSecond = epochMilli / 1_000L;
             partitions.add(weeklyPartitionOf(epochSecond)); // DateTime64(0, 'UTC') — the partitioned successor
-            partitions.add(weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS)); // DateTime('UTC') — legacy traces
+            // Only past the 32-bit range do the two columns disagree; below it the modulo is the identity, so the
+            // branch is the invariant stated as code rather than an optimisation: an ordinary id CANNOT widen the set.
+            if (epochSecond >= ID_AT_LEGACY_MODULUS) {
+                partitions.add(weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS)); // DateTime('UTC') — legacy
+            }
         }
 
         // Set.copyOf, not the working HashSet: what escapes here decides which partitions a DELETE mutation touches, so

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
@@ -17,6 +17,7 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.WeeklyPartitions;
 import com.redis.testcontainers.RedisContainer;
 import io.r2dbc.spi.Statement;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -41,36 +42,40 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
- * The other side of {@code TracesPartitionPruningMutationTest}: the trace delete with
- * {@code databaseAnalyticsDataModel.tracesWeeklyPartitionPruningEnabled} <b>off</b> — its default — against the
- * <b>legacy</b> {@code traces}. That is not an exotic topology; it is the state every deployment is in today, and the
- * state a stage B/C rollback returns to.
+ * The other side of {@code TracesPartitionPruningMutationTest}: the same trace delete, with the same rendered partition
+ * predicate, against the <b>legacy</b> {@code traces} — no {@code PARTITION BY} at all and {@code id_at} declared as a
+ * 32-bit {@code DateTime} (migrations 000001 and 000091). That is not an exotic topology; it is the state every
+ * deployment is in today, and the state a stage B/C rollback returns to.
  *
- * <p>What it guards is a <b>false-flag regression</b>: the partition predicate emitted while the flag is off, or any
- * other {@code id_at} narrowing creeping into the unbounded form. Legacy {@code traces} has no {@code PARTITION BY} at
- * all and declares {@code id_at} as a 32-bit {@code DateTime} that overflows past 2106 (migrations 000001 and 000091),
- * so a predicate here prunes nothing and can silently exclude rows.
+ * <p><b>What it guards.</b> The predicate used to be gated on a configuration flag asserting the EXCHANGE had already
+ * happened, because on this table a set derived from the {@code DateTime64} successor is a predicate that matches
+ * nothing for a far-future id: the 32-bit column holds {@code epochSecond % 2^32}, so a litellm-shaped id
+ * (<a href="https://github.com/BerriAI/litellm/issues/31294">BerriAI/litellm#31294</a> mints ~2201) is stored under a
+ * wrapped recent timestamp and the delete would report success having matched <b>zero</b> rows.
+ * {@link WeeklyPartitions} now names both weeks, which is what removed the flag — and this suite is what holds that
+ * claim up. It is the only place the legacy representation is checked against a real ClickHouse rather than asserted
+ * about; if that conversion ever stops being a modulo, {@link #farFutureRowOnLegacyTableIsDeletedByAPrunedStatement}
+ * fails here instead of a delete silently skipping rows in a pre-cutover deployment.
  *
  * <p>Nothing else catches it. Every other trace-delete suite runs in exactly this state and asserts only that rows go
- * away — which they do for a <b>recent</b> id, because the legacy {@code id_at} is accurate for one. The damage shows
- * only on a far-future id (litellm <a href="https://github.com/BerriAI/litellm/issues/31294">BerriAI/litellm#31294</a>
- * mints ~2201): the 32-bit column stores a wrapped recent timestamp, a derived partition cannot match it, and the
- * delete reports success having matched <b>zero</b> rows. No existing test has such a row, because ingestion rejects
- * far-future ids by design ({@code IdGenerator.validateId}) — so this seeds one in raw SQL and deletes it through
- * {@link TraceDAO#delete}, which is also the only way to reach that arm.
+ * away — which they do for a <b>recent</b> id, because the legacy {@code id_at} is accurate for one. No existing test
+ * has a far-future row, because ingestion rejects such ids by design ({@code IdGenerator.validateId}) — so this seeds
+ * one in raw SQL and deletes it through {@link TraceDAO#delete}, which is also the only way to reach that arm.
  *
  * <p>Shared, reusable containers: unlike the post-EXCHANGE suite this changes no topology, so there is nothing here
  * that could corrupt another suite or a rerun.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DropwizardAppExtensionProvider.class)
-class TracesPruningDisabledMutationTest {
+class TracesLegacyTablePruningMutationTest {
 
     private static final String API_KEY = "apiKey-" + UUID.randomUUID();
     private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
@@ -79,6 +84,40 @@ class TracesPruningDisabledMutationTest {
 
     /** A UUIDv7 carrying id_at 2200-01-01 — the litellm shape, and the id the legacy 32-bit column wraps. */
     private static final UUID FAR_FUTURE_ID = UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2");
+
+    /**
+     * The week that id partitions into under a {@code DateTime64} {@code id_at} — its honest one, and the only value the
+     * flag-gated predicate used to carry. Stated as a literal because it is what ClickHouse returned for
+     * {@code toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} on that id, not something re-derived
+     * here.
+     */
+    private static final long HONEST_WEEK = 21991230L;
+
+    /**
+     * The week the same id partitions into on <b>this</b> table: {@code CAST(UUIDv7ToDateTime(...) AS DateTime('UTC'))}
+     * wraps 2200-01-01 to 2063-11-25, a Wednesday, whose Monday is 2063-11-19. This is the value that makes the delete
+     * below land, and the reason the predicate needs no flag.
+     */
+    private static final long LEGACY_WEEK = 20631119L;
+
+    /** {@link UUID#randomUUID()} is a v4 by definition: no embedded timestamp to derive a partition from. */
+    private static final UUID NON_V7_ID = UUID.randomUUID();
+
+    /**
+     * The partition-key fragment the DAO's template emits. Only ever <b>compared against</b> the statement read back
+     * from {@code system.query_log} — never spliced into a query this suite runs.
+     */
+    private static final String PARTITION_PREDICATE = "toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))";
+
+    /**
+     * The {@code IN} clause the DAO emitted, captured to end of line: the predicate sits on its own line in the
+     * template with {@code SETTINGS log_comment} on the next, so the line boundary delimits it exactly.
+     */
+    private static final Pattern EMITTED_IN_CLAUSE = Pattern.compile(
+            Pattern.quote(PARTITION_PREDICATE) + "\\s+IN\\s+([^\\n]*)");
+
+    /** A weekly partition value as it appears in SQL — {@code yyyyMMdd}, so always eight digits. */
+    private static final Pattern PARTITION_VALUE = Pattern.compile("\\d{8}");
 
     private static final String INSERT_RAW_TRACE = """
             INSERT INTO traces (workspace_id, project_id, id)
@@ -175,38 +214,120 @@ class TracesPruningDisabledMutationTest {
     }
 
     @Test
-    @DisplayName("with pruning off, a far-future row on the legacy table is still deleted, unbounded")
-    void farFutureRowOnLegacyTableIsStillDeleted() {
+    @DisplayName("a far-future row on the legacy table is deleted by the same pruned statement")
+    void farFutureRowOnLegacyTableIsDeletedByAPrunedStatement() {
+        // The one test that shows the union is load-bearing rather than decorative. With only the honest week in the
+        // set, this delete matches nothing on this table and reports success - which is exactly the failure the
+        // configuration flag used to exist to avoid, now avoided by the predicate itself.
+        //
         // The project and its id come from the real ingestion path - create a trace through the endpoint, then read the
         // project id back off it - so the delete runs against a project that exists and a genuine UUIDv7 project id,
         // not a fabricated one.
-        var seedTrace = factory.manufacturePojo(Trace.class).toBuilder()
-                .feedbackScores(null)
-                .usage(null)
-                .build();
-        traceResourceClient.createTrace(seedTrace, API_KEY, WORKSPACE_NAME);
-        var projectId = projectIdOf(seedTrace);
-        assertThat(projectId.version()).as("the project id is a real UUIDv7, as the backend mints them").isEqualTo(7);
+        var projectId = projectIdOf(createTrace());
 
         // Only the far-future row is raw, because ingestion rejects it by design (24h window). A recent id would prove
-        // nothing here anyway: the legacy id_at is accurate for one, so even a wrongly-emitted predicate would match it
-        // and the row would still go.
+        // nothing here: the legacy id_at is accurate for one, so even a honest-week-only predicate would match it.
         insertRawTrace(projectId, FAR_FUTURE_ID);
         assertThat(liveRowCount(projectId, FAR_FUTURE_ID)).as("the far-future row is seeded").isEqualTo("1");
 
         delete(Set.of(Pair.of(projectId, FAR_FUTURE_ID)));
 
         assertThat(liveRowCount(projectId, FAR_FUTURE_ID))
-                .as("it is deleted - a partition predicate here would have matched nothing and reported success")
+                .as("it is deleted - so the predicate named the week THIS table filed it under, not only the honest one")
                 .isEqualTo("0");
 
         var sql = lastTraceDeleteSql(FAR_FUTURE_ID);
         assertThat(sql)
-                .as("no partition predicate is emitted while the flag is off")
-                .doesNotContain("toYYYYMMDD", "toDayOfWeek", "toIntervalDay");
+                .as("the predicate is emitted here too - there is no schema flag holding it back any more")
+                .contains(PARTITION_PREDICATE);
+        // Asserted as an exact set, both ways round. Only the legacy week can match a row on this table, so a set
+        // missing it would fail the delete above; and a set missing the honest week would pass here while breaking the
+        // post-EXCHANGE suite, which is the pair this has to stay consistent with.
+        assertThat(boundPartitionsOf(sql))
+                .as("both representations of the same id: the honest week and the one the 32-bit column wraps it to")
+                .containsExactlyInAnyOrder(HONEST_WEEK, LEGACY_WEEK);
+        assertThat(WeeklyPartitions.of(List.of(FAR_FUTURE_ID)))
+                .as("and the derivation this suite pins is the one the DAO used")
+                .contains(Set.of(HONEST_WEEK, LEGACY_WEEK));
+    }
+
+    @Test
+    @DisplayName("an ordinary row is deleted by a single-week statement, since both id_at types agree below 2106")
+    void ordinaryRowIsBoundedToOneWeek() {
+        // The counterweight: the union widens only where the two representations differ, so real traffic binds exactly
+        // what it bound before. A regression that added the wrapped week unconditionally would show up here.
+        var target = createTrace();
+        var projectId = projectIdOf(target);
+        assertThat(liveRowCount(projectId, target.id())).as("the row is there").isEqualTo("1");
+
+        traceResourceClient.deleteTrace(target.id(), WORKSPACE_NAME, API_KEY);
+
+        assertThat(liveRowCount(projectId, target.id())).as("and it is deleted").isEqualTo("0");
+        var sql = lastTraceDeleteSql(target.id());
+        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
+        assertThat(boundPartitionsOf(sql))
+                .as("one week, not two: a recent id_at is inside the 32-bit range, so the two derivations coincide")
+                .hasSize(1);
+    }
+
+    @Test
+    @DisplayName("a non-v7 id still disables pruning here, and the delete still lands")
+    void nonV7IdDisablesPruning() {
+        // The fallback is unchanged by the flag removal and still has to hold on this table: a row whose id_at cannot
+        // be trusted is STILL DELETED, by an unbounded mutation. Seeded raw, since ingestion rejects a non-v7 id.
+        var target = createTrace();
+        var projectId = projectIdOf(target);
+        insertRawTrace(projectId, NON_V7_ID);
+        assertThat(liveRowCount(projectId, NON_V7_ID)).as("the non-v7 row is seeded").isEqualTo("1");
+
+        delete(Set.of(Pair.of(projectId, target.id()), Pair.of(projectId, NON_V7_ID)));
+
+        assertThat(liveRowCount(projectId, NON_V7_ID))
+                .as("the non-v7 row is itself deleted, not skipped")
+                .isEqualTo("0");
+        assertThat(liveRowCount(projectId, target.id()))
+                .as("and so is the derivable row batched alongside it")
+                .isEqualTo("0");
+
+        // Asserted as the absence of ANY id_at predicate, not just of this expression: a regression that narrowed the
+        // mutation with toMonday(id_at), an id_at range, or anything else would skip exactly the rows this reaches.
+        var sql = lastTraceDeleteSql(NON_V7_ID);
         assertThat(sql)
-                .as("and no id_at narrowing of any kind - toMonday, a range, or otherwise")
+                .as("the unbounded form carries no id_at predicate of any kind")
                 .doesNotContain("id_at");
+        assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
+                .as("and no partition IN clause: %s", sql)
+                .isFalse();
+    }
+
+    /** A trace through the real ingestion path, with the fields podam cannot fill sensibly cleared. */
+    private Trace createTrace() {
+        var trace = factory.manufacturePojo(Trace.class).toBuilder()
+                .feedbackScores(null)
+                .usage(null)
+                .build();
+        traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
+        return trace;
+    }
+
+    /**
+     * The partition values actually bound into the emitted {@code IN} clause, so a test can assert the set is exact
+     * rather than merely inclusive. The driver substitutes bound values into the query text client-side, which is why
+     * they are readable here at all; the two assertions below are what make a change in that behaviour say so plainly
+     * instead of quietly turning every set assertion into a tautology on an empty set.
+     */
+    private static Set<Long> boundPartitionsOf(String sql) {
+        var clause = EMITTED_IN_CLAUSE.matcher(sql);
+        assertThat(clause.find())
+                .as("the delete SQL carries the partition predicate followed by an IN clause:%n%s", sql)
+                .isTrue();
+        var bound = PARTITION_VALUE.matcher(clause.group(1)).results()
+                .map(match -> Long.parseLong(match.group()))
+                .collect(Collectors.toUnmodifiableSet());
+        assertThat(bound)
+                .as("the IN clause carries inlined partition values — got '%s'", clause.group(1))
+                .isNotEmpty();
+        return bound;
     }
 
     /** Invokes the DAO under a workspace/user context, as {@code TraceService} does for the live delete path. */
@@ -221,7 +342,8 @@ class TracesPruningDisabledMutationTest {
     /**
      * Seeds one row through the table's real column definitions. Only the identity columns are supplied; {@code id_at}
      * is {@code MATERIALIZED}, so ClickHouse derives it — and, on this table, wraps it — exactly as it would for a row
-     * the ingestion path wrote.
+     * the ingestion path wrote. That wrap is the thing under test, so it has to come from ClickHouse, not from a value
+     * this test computed and inserted.
      */
     private void insertRawTrace(UUID projectId, UUID id) {
         execute(INSERT_RAW_TRACE, statement -> statement

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
@@ -17,7 +17,6 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.podam.PodamFactoryUtils;
-import com.comet.opik.utils.WeeklyPartitions;
 import com.redis.testcontainers.RedisContainer;
 import io.r2dbc.spi.Statement;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -226,7 +225,7 @@ class TracesLegacyTablePruningMutationTest {
         var projectId = projectIdOf(createTrace());
 
         // Only the far-future row is raw, because ingestion rejects it by design (24h window). A recent id would prove
-        // nothing here: the legacy id_at is accurate for one, so even a honest-week-only predicate would match it.
+        // nothing here: the legacy id_at is accurate for one, so even an honest-week-only predicate would match it.
         insertRawTrace(projectId, FAR_FUTURE_ID);
         assertThat(liveRowCount(projectId, FAR_FUTURE_ID)).as("the far-future row is seeded").isEqualTo("1");
 
@@ -246,9 +245,6 @@ class TracesLegacyTablePruningMutationTest {
         assertThat(boundPartitionsOf(sql))
                 .as("both representations of the same id: the honest week and the one the 32-bit column wraps it to")
                 .containsExactlyInAnyOrder(HONEST_WEEK, LEGACY_WEEK);
-        assertThat(WeeklyPartitions.of(List.of(FAR_FUTURE_ID)))
-                .as("and the derivation this suite pins is the one the DAO used")
-                .contains(Set.of(HONEST_WEEK, LEGACY_WEEK));
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
@@ -449,17 +449,6 @@ class TracesPartitionPruningMutationTest {
     }
 
     /**
-     * The partitions a single id resolves to — a set, not a value, because an id past 2106 names its legacy week
-     * alongside the honest one. Derived through {@code WeeklyPartitions} on purpose: this suite is about the predicate
-     * reaching ClickHouse, and the derivation's own expected values are pinned against real ClickHouse output in
-     * {@code WeeklyPartitionsTest}, so restating them here would only duplicate that. Where the expectation needs to be
-     * readable on its own — the era batch — the partitions are stated as literals instead.
-     */
-    private static Set<Long> partitionsOf(UUID id) {
-        return WeeklyPartitions.of(List.of(id)).orElseThrow();
-    }
-
-    /**
      * The partition values actually bound into the emitted {@code IN} clause, so a test can assert the set is exact
      * rather than merely inclusive. The driver substitutes bound values into the query text client-side, which is why
      * they are readable here at all; the two assertions below are what make a change in that behaviour say so plainly
@@ -808,10 +797,15 @@ class TracesPartitionPruningMutationTest {
                 .contains(bystander.id());
         var sql = lastTraceDeleteSql(target.id());
         assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
+        // Asserted as the SIZE, not as a value read back from WeeklyPartitions: the DAO derives its set from the same
+        // method, so an expectation taken from it would move with any regression and pass regardless. The value itself
+        // is already pinned two independent ways - the row above had to go away, which it only does if the predicate
+        // named the partition ClickHouse filed it under, and deleteClearsEveryEraAndBindsExactlyThosePartitions states
+        // its expectations as literals. What is left to say here is the property those cannot: an id the endpoint just
+        // minted is inside the 32-bit range, where the two id_at types agree, so it must widen the set to nothing.
         assertThat(boundPartitionsOf(sql))
-                .as("bounded to exactly the target's own partition, nothing wider — one value, since a trace the"
-                        + " endpoint just created is inside the 32-bit range where both id_at types agree")
-                .containsExactlyInAnyOrderElementsOf(partitionsOf(target.id()));
+                .as("bounded to one partition, not two: a recent id_at is a week both id_at types agree on")
+                .hasSize(1);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
@@ -34,7 +34,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,8 +95,10 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * <p>The eras in {@link #deleteClearsEveryEraAndBindsExactlyThosePartitions} are load-bearing, not variety.
  * {@code toMonday} agrees with the {@code Date32} expression across the ordinary calendar and diverges only far-future
  * or at the epoch, so a recent-only batch would accept the very expression migration 000114 was written to escape. The
- * 2200 row also covers the {@code DateTime64} half of what the flag asserts: against a 32-bit {@code id_at} it would be
- * stored under a wrapped recent timestamp, the derived partition would not match, and it would survive.
+ * 2200 row is also the only one whose two {@code id_at} representations differ, so it is what pins the derivation to
+ * the {@code DateTime64} value <em>this</em> table files it under, rather than to the legacy week that is in the set
+ * alongside it. The legacy side of that same pair is pinned by {@code TracesLegacyTablePruningMutationTest}, which
+ * deletes the same shape of row from the legacy table with the same rendered predicate.
  *
  * <p>Two internal touches, on the pattern of {@code TracesDistributedWrapMutationTest}: the EXCHANGE has no public API,
  * so {@link #beforeAll} runs it in raw SQL identical to the swap block of {@code 000003_exchange_and_wrap.sql}; and the
@@ -110,16 +111,15 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * its target table: after the Liquibase migrations the live {@code traces} is still the <em>legacy</em> table — no
  * {@code PARTITION BY} at all and a 32-bit {@code DateTime} {@code id_at} — while the partitioned successor exists only
  * as the empty {@code traces_local_v2}, which no DAO query can reach. Without installing it these tests would run
- * against the one table where this predicate must never be emitted, and would pass while proving nothing: the predicate
- * is harmless against an unpartitioned table for recent ids. Hand-authoring a partitioned {@code traces} in the test
+ * against the unpartitioned legacy table, where the predicate prunes nothing, and would pass while proving nothing. Hand-authoring a partitioned {@code traces} in the test
  * instead would duplicate migration 000114 and reintroduce exactly the drift this suite exists to detect. Both steps are
  * idempotent, so the suite keeps working once the cutover migration lands and they become no-ops — and that is
- * asserted rather than assumed, by {@link PruningEnabled#topologySetupIsANoOpOnceTheEstateProvidesIt}. Two states
+ * asserted rather than assumed, by {@link #topologySetupIsANoOpOnceTheEstateProvidesIt}. Two states
  * are therefore covered: <b>with</b> the swap, which every other test here needs today, and <b>without</b> it,
  * which is what the estate will look like once the migrations create {@code traces_local} partitioned with the
  * {@code Distributed} {@code traces} over it and this suite's {@code EXCHANGE} stops being needed at all.
  *
- * <p><b>Topology: the post-cutover end state, with both schema flags on.</b> The wrap is applied and
+ * <p><b>Topology: the post-cutover end state.</b> The wrap is applied and
  * {@code tracesDistributedWrapEnabled} set, so the DAO's mutations reach the data the way production routes them —
  * {@code DELETE FROM traces_local}, chosen by the configuration switch that governs it, not by a table this suite
  * renamed under the DAO. {@code traces} is the {@code Distributed} wrapper that reads and inserts flow through, which
@@ -127,17 +127,15 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * {@link #distributedTracesRejectsDirectMutation} keeps that claim honest: had the wrap not taken effect,
  * {@code traces} would still be a {@code MergeTree} and every pruned delete here would have run against it.
  *
- * <p>This supersedes an earlier note in this file that both flags on at once was untested and would need its own suite.
- * It does not: the wrap flag is how the DAO is pointed at the data, so enabling it costs two setup statements and
- * covers the combination the fleet actually ends up in. What is no longer covered here is the transient
- * post-EXCHANGE/pre-wrap window — the pruning predicate is identical in both, since {@code traces_local} is the same
- * physical table under a different name, and the flag's own javadoc records that it must hold in that window.
+ * <p>The transient post-EXCHANGE/pre-wrap window is not covered separately, and needs no coverage: the pruning
+ * predicate is identical in both, since {@code traces_local} is the same physical table under a different name.
  *
  * <p>Dedicated, non-reused ClickHouse and ZooKeeper containers are required because the setup destructively renames the
  * live {@code traces} table — the EXCHANGE swaps it, and the wrap then renames it to {@code traces_local} — so a reused
  * container would corrupt other suites and reruns.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
 class TracesPartitionPruningMutationTest {
 
     private static final String API_KEY = "apiKey-" + UUID.randomUUID();
@@ -300,13 +298,26 @@ class TracesPartitionPruningMutationTest {
      * than identity. The three eras are not interchangeable samples: {@code toMonday} agrees with the {@code Date32}
      * expression across the ordinary calendar and diverges only far-future or at the epoch, so a recent-only batch would
      * accept the very expression migration 000114 was written to escape. The 2199 row is the litellm shape and the one
-     * that makes it bite; it also covers the {@code DateTime64} half of what the flag asserts, since a 32-bit
-     * {@code id_at} would store it under a wrapped recent timestamp and the derived partition would miss it.
+     * that makes it bite; it is also the only era whose two {@code id_at} representations differ, so it is what shows
+     * the derivation naming the {@code DateTime64} week this table files it under — see {@link #LEGACY_WEEK_OF_2200}.
      */
     private static final List<LocalDate> ERA_MONDAYS = List.of(
             LocalDate.of(1996, 2, 5),
             LocalDate.of(2025, 3, 3),
             LocalDate.of(2199, 12, 30));
+
+    /**
+     * The second partition the 2199 era resolves to: the week legacy {@code traces} would file that same id under, since
+     * its 32-bit {@code DateTime} {@code id_at} holds {@code epochSecond % 2^32}. {@code WeeklyPartitions} names it
+     * alongside the honest week so one rendered statement is correct on both schemas, which is what removed the cutover
+     * flag this suite used to A/B — so every exact-set assertion here has to expect it. The value is what ClickHouse
+     * returned for {@code CAST(UUIDv7ToDateTime(...) AS DateTime('UTC'))} on that id: {@code 2063-11-25}, a Wednesday.
+     * <p>
+     * The other two eras are inside the 32-bit range, so their two representations coincide and they contribute one
+     * value each — which is the point of stating this one separately rather than deriving every expectation through
+     * {@code WeeklyPartitions}: the asymmetry is the behaviour under test.
+     */
+    private static final long LEGACY_WEEK_OF_2200 = 20631119L;
 
     /** {@link UUID#randomUUID()} is a v4 by definition: no embedded timestamp to derive a partition from. */
     private static final UUID NON_V7_ID = UUID.randomUUID();
@@ -338,7 +349,7 @@ class TracesPartitionPruningMutationTest {
     /**
      * Runs the topology setup and this suite's own raw reads and seeds straight against the container, with no app in
      * the way — the idiom the sibling partition suites use. It has to be app-independent: the topology must be
-     * installed once, before either nested app boots, and both nested classes then read through the same handle.
+     * installed before the app boots against it.
      * <p>
      * <b>Never use this for anything the DAO executes</b> — see {@link #appTemplate}. It carries none of the production
      * {@code queryParameters}, so a statement the real connection would accept can fail here for reasons production
@@ -372,15 +383,26 @@ class TracesPartitionPruningMutationTest {
     private TransactionTemplateAsync appTemplate;
 
     /**
-     * One app per flag state, identical in every other respect. {@code tracesWeeklyPartitionPruningEnabled} is the only
-     * thing that varies between the two nested classes, which is what lets them be read as an A/B: same schema, same
-     * topology, same fixtures, one flag.
-     * <p>
-     * The other two flags are fixed on, as production runs them post-cutover — the successor's {@code end_time}/
-     * {@code ttft} are non-nullable sentinel columns, and the wrap is what points the DAO's mutations at
-     * {@code traces_local}.
+     * Declared after the instance initialiser above on purpose: field initialisers run in textual order, so the
+     * topology is installed before the app boots against it.
      */
-    private TestDropwizardAppExtension newApp(boolean pruningEnabled) {
+    @RegisterApp
+    private final TestDropwizardAppExtension app = newApp();
+
+    /**
+     * The app, configured as production runs post-cutover: the successor's {@code end_time}/{@code ttft} are
+     * non-nullable sentinel columns, and the wrap is what points the DAO's mutations at {@code traces_local}.
+     * <p>
+     * There is no flag for the pruning itself to set either way. It used to be a third {@code customConfig} and this
+     * suite an A/B across two apps, one per state; {@code WeeklyPartitions} now derives a value per {@code id_at} type
+     * a mutation may meet, so the predicate is emitted unconditionally and the same rendered SQL is correct on both
+     * sides of the EXCHANGE. What that suite's off-side established — that the unbounded fallback still deletes — is
+     * still covered here, by {@link #underivableIdDisablesPruning} and
+     * {@link #pruningReachesThePlannerAndTheFallbackDoesNot}, which reach the fallback through a batch the derivation
+     * rejects rather than through configuration; and {@code TracesLegacyTablePruningMutationTest} covers the same
+     * delete against the legacy table, which is the schema the flag used to stand for.
+     */
+    private TestDropwizardAppExtension newApp() {
         return TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
                 AppContextConfig.builder()
                         .jdbcUrl(mysqlContainer.getJdbcUrl())
@@ -390,17 +412,13 @@ class TracesPartitionPruningMutationTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .customConfigs(List.of(
                                 new CustomConfig("databaseAnalyticsDataModel.traceColumnsNonNullable", "true"),
-                                new CustomConfig("databaseAnalyticsDataModel.tracesDistributedWrapEnabled", "true"),
-                                new CustomConfig("databaseAnalyticsDataModel.tracesWeeklyPartitionPruningEnabled",
-                                        String.valueOf(pruningEnabled))))
+                                new CustomConfig("databaseAnalyticsDataModel.tracesDistributedWrapEnabled", "true")))
                         .build());
     }
 
-    /**
-     * Wires the currently-running nested class's app in. Safe on shared outer fields because JUnit runs nested
-     * containers one at a time — this tree configures no parallel execution — so only one app is live at a time.
-     */
-    private void bindApp(ClientSupport clientSupport, TraceDAO traceDAO, TransactionTemplateAsync appTemplate) {
+    /** Wires the app's clients and connection handle in, once it has booted against the topology installed above. */
+    @BeforeAll
+    void beforeAll(ClientSupport clientSupport, TraceDAO traceDAO, TransactionTemplateAsync appTemplate) {
         var baseUrl = TestUtils.getBaseUrl(clientSupport);
         ClientSupportUtils.config(clientSupport);
         mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
@@ -431,13 +449,14 @@ class TracesPartitionPruningMutationTest {
     }
 
     /**
-     * The partition a single id resolves to. Derived through {@code WeeklyPartitions} on purpose: this suite is about
-     * the predicate reaching ClickHouse, and the derivation's own expected values are pinned against real ClickHouse
-     * output in {@code WeeklyPartitionsTest}, so restating them here would only duplicate that. Where the expectation
-     * needs to be readable on its own — the era batch — the partitions are stated as literals instead.
+     * The partitions a single id resolves to — a set, not a value, because an id past 2106 names its legacy week
+     * alongside the honest one. Derived through {@code WeeklyPartitions} on purpose: this suite is about the predicate
+     * reaching ClickHouse, and the derivation's own expected values are pinned against real ClickHouse output in
+     * {@code WeeklyPartitionsTest}, so restating them here would only duplicate that. Where the expectation needs to be
+     * readable on its own — the era batch — the partitions are stated as literals instead.
      */
-    private static long partitionOf(UUID id) {
-        return WeeklyPartitions.of(List.of(id)).orElseThrow().iterator().next();
+    private static Set<Long> partitionsOf(UUID id) {
+        return WeeklyPartitions.of(List.of(id)).orElseThrow();
     }
 
     /**
@@ -538,8 +557,8 @@ class TracesPartitionPruningMutationTest {
      * <p>
      * The EXCHANGE (000003 exchange block): puts the successor under {@code traces} and the original under
      * {@code traces_local_v2}, then a RENAME parks the original as {@code traces_pre_cutover_backup}. The wrap is
-     * deliberately not applied — it is a separate, deferrable step, and the flag under test must hold on its own between
-     * the two (which is why it is not the wrap flag). Kept identical to the cutover SQL by eye, as
+     * deliberately not applied here — it is a separate, deferrable step, and the pruning has to hold on its own in the
+     * window between the two. Kept identical to the cutover SQL by eye, as
      * {@code TracesLocalV2CutoverTest.exchangeTables} and the wrap suite do.
      */
     private void ensurePartitionedSuccessorUnderTraces() {
@@ -758,363 +777,289 @@ class TracesPartitionPruningMutationTest {
             @JsonProperty("Initial Parts") int total) {
     }
 
-    /**
-     * The flag <b>on</b>: the pruning this change exists to add. Every assertion here would also hold with the feature
-     * deleted <em>except</em> the ones about the emitted SQL and the planner — which is exactly why those exist, and why
-     * {@link PruningDisabled} runs the same fixtures with the flag off. Read as a pair, the two classes pin the flag as
-     * the cause: remove the pruning and this class fails; remove the flag <em>gate</em> and the other one does.
-     */
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @ExtendWith(DropwizardAppExtensionProvider.class)
-    class PruningEnabled {
-
-        @RegisterApp
-        private final TestDropwizardAppExtension app = newApp(true);
-
-        @BeforeAll
-        void beforeAll(ClientSupport clientSupport, TraceDAO traceDAO, TransactionTemplateAsync appTemplate) {
-            bindApp(clientSupport, traceDAO, appTemplate);
-        }
-
-        @Test
-        @DisplayName("traces is a mutation-rejecting Distributed wrapper, so these deletes ran on traces_local")
-        void distributedTracesRejectsDirectMutation() {
-            // Keeps the both-flags claim from being vacuous. If the wrap had not taken effect, `traces` would still be a
-            // MergeTree, every pruned delete in this suite would have run against it, and nothing here would say so.
-            // Asserting the specific rejection - not merely that something threw - is what proves `traces` is Distributed,
-            // so a green delete could only have reached `traces_local`.
-            assertThatThrownBy(() -> execute("DELETE FROM traces WHERE workspace_id = :workspace_id",
-                    statement -> statement.bind("workspace_id", WORKSPACE_ID)))
-                    .hasMessageContaining("DELETE query is not supported for table");
-        }
-
-        @Test
-        @DisplayName("an all-UUIDv7 delete prunes to the batch's own partitions and removes the target row")
-        void allUuidV7DeletePrunesAndRemovesTheTargetRow() {
-            var target = newTrace().build();
-            // Same project, so one read shows both: the pruned delete must take the target and leave this one.
-            var bystander = newTrace().projectName(target.projectName()).build();
-            traceResourceClient.createTrace(target, API_KEY, WORKSPACE_NAME);
-            traceResourceClient.createTrace(bystander, API_KEY, WORKSPACE_NAME);
-            assertThat(traceIdsOf(target.projectName())).contains(target.id(), bystander.id());
-
-            // The live user path, end to end.
-            traceResourceClient.deleteTrace(target.id(), WORKSPACE_NAME, API_KEY);
-
-            assertThat(traceIdsOf(target.projectName()))
-                    .as("only the target row is gone")
-                    .doesNotContain(target.id())
-                    .contains(bystander.id());
-            var sql = lastTraceDeleteSql(target.id());
-            assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
-            assertThat(boundPartitionsOf(sql))
-                    .as("bounded to exactly the target's own partition, nothing wider")
-                    .containsExactly(partitionOf(target.id()));
-        }
-
-        @Test
-        @DisplayName("the DAO's own delete clears every era and binds exactly those partitions")
-        void deleteClearsEveryEraAndBindsExactlyThosePartitions() {
-            // The three-way agreement - the migration's PARTITION BY as installed, the DAO's predicate, and
-            // WeeklyPartitions.of - asserted through the DAO's own delete rather than by re-evaluating the expression in
-            // test SQL. If the predicate resolved to any partition other than the one ClickHouse filed a row under, the
-            // mutation would select the wrong parts and that row would SURVIVE. So "every row is gone" IS the agreement.
-            //
-            // Ids are minted from the named Mondays rather than written out, so both sides of the assertion are the same
-            // arithmetic a reader can check, and every era in one batch is also the multi-value Long[] bind. Seeded raw and
-            // in a minted project: the ingestion window is 24h, so no endpoint can create a 1996 or 2199 row, and the
-            // project id is a real UUIDv7 straight from IdGenerator - which is how the sibling partition suites get one.
-            var projectId = ID_GENERATOR.generateId();
-            var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
-            ids.forEach(id -> insertRawTrace(projectId, id));
-            assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
-                    .as("every era is seeded").containsOnly("1");
-
-            delete(ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet()));
-
-            assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
-                    .as("every era's row is gone, so the predicate named the partition each was actually filed under")
-                    .containsOnly("0");
-            var sql = lastTraceDeleteSql(ids.getFirst());
-            assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
-            assertThat(boundPartitionsOf(sql))
-                    .as("exactly the partitions the batch resolves to, not a range across two centuries")
-                    .containsExactlyInAnyOrderElementsOf(ERA_MONDAYS.stream()
-                            .map(TracesPartitionPruningMutationTest::partitionNameOf)
-                            .collect(Collectors.toUnmodifiableSet()));
-        }
-
-        @Test
-        @DisplayName("the planner actually prunes, and the fallback provably does not")
-        void pruningReachesThePlannerAndTheFallbackDoesNot() {
-            // Correctness and pruning are different claims, and this is the only test that makes the second one. Deletes
-            // were already correct before OPIK-6901 - what the change buys is parts touched (3,928/3,928 -> 5/3,928 on
-            // prod-test), so a suite that cannot see pruning stop does not test what this change exists to do.
-            //
-            // The regression it guards is specific: a migration rewrites the partition expression to something semantically
-            // identical but textually different, the planner stops recognising the DAO's predicate as the partition key,
-            // pruning silently stops - and values still agree, so every row is still deleted and every other assertion in
-            // this suite stays green. That is the property the removed AST pin covered; this asks the planner directly
-            // instead of inferring it from text.
-            //
-            // EXPLAIN does not accept a mutation, so the WHERE clause is lifted verbatim out of the DAO's own emitted
-            // DELETE and put behind a SELECT - predicate and bound partition values included. Only the verb changes; the
-            // statement being explained is still the DAO's. Same instrument and record shape as
-            // TracesLocalV2PartitioningTest.
-            // One row per era, so the table holds several partitions for the planner to prune between.
-            var projectId = ID_GENERATOR.generateId();
-            var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
-            ids.forEach(id -> insertRawTrace(projectId, id));
-
-            // Bounded: one derivable id, so the predicate names a single one of those partitions.
-            delete(Set.of(Pair.of(projectId, ids.getFirst())));
-            var bounded = partsSelectedBy(lastTraceDeleteSql(ids.getFirst()))
-                    .orElseThrow(() -> new AssertionError(
-                            "EXPLAIN reported no partition index for the bounded delete"));
-
-            // Unbounded: a non-v7 id in the batch, so no predicate at all. Its partner is a different era, so the query_log
-            // lookup finds this statement rather than the one above.
-            var partner = ids.get(1);
-            delete(Set.of(Pair.of(projectId, partner), Pair.of(projectId, NON_V7_ID)));
-            var unbounded = partsSelectedBy(lastTraceDeleteSql(partner));
-
-            assertThat(bounded.selected())
-                    .as("the bounded delete selects fewer parts than the table holds: %s", bounded)
-                    .isLessThan(bounded.total());
-            // Shown to discriminate, or it proves nothing - the same trap as `.contains(partition)` and
-            // `doesNotContain("toDayOfWeek")`. The fallback must not prune: either the planner reports no partition index at
-            // all, because nothing filters on the key, or it reports every part still selected.
-            assertThat(unbounded.map(parts -> parts.selected() == parts.total()).orElse(true))
-                    .as("the fallback prunes nothing: %s", unbounded)
-                    .isTrue();
-        }
-
-        @Test
-        @DisplayName("the topology setup is a no-op once the estate provides it - the path it takes post-cutover")
-        void topologySetupIsANoOpOnceTheEstateProvidesIt() {
-            // Today this suite installs the topology itself, so both setup steps take their INSTALL path and their
-            // early returns are dead code. Once the cutover migration lands, the migrations will provide
-            // `traces_local` partitioned with the Distributed `traces` over it: the EXCHANGE and the wrap are no
-            // longer needed, and that early return becomes the ONLY path either step takes. Nothing would exercise it
-            // until the day it becomes load-bearing, which is the wrong day to find out it was wrong.
-            //
-            // Re-running the setup against the topology it already installed IS that shape - `traces_local` exists and
-            // `traces` is Distributed over it, which is what the migration will hand us. So this covers the second of
-            // the two states: with the swap (every other test here) and without it (this one).
-            // A row that already exists BEFORE the setup runs, created through the ingestion path so the check reads it
-            // back the way production does. Metadata on its own cannot see data loss: a table recreated from the same
-            // DDL reports the same engine_full and partition_key while being empty, so a step that rebuilt the topology
-            // rather than skipping it would satisfy every metadata assertion here. The surviving row is the assertion
-            // that distinguishes "skipped" from "rebuilt", and reading it through the wrapper also shows routing is
-            // intact rather than merely that the wrapper exists.
-            var existing = newTrace().build();
-            traceResourceClient.createTrace(existing, API_KEY, WORKSPACE_NAME);
-            assertThat(traceIdsOf(existing.projectName()))
-                    .as("the pre-existing row is readable before the setup re-runs")
-                    .contains(existing.id());
-
-            // Not a tautology either: if either step failed to early-return it would THROW, not quietly repeat itself.
-            // The EXCHANGE needs `traces_local_v2`, which the install renamed to `traces_pre_cutover_backup`; and the
-            // wrap ends in a RENAME onto `traces_local`, which by now exists. So a non-idempotent step fails loudly.
-            var tracesEngineBefore = queryOneString(TABLE_ENGINE_FULL, _ -> {
-            });
-            var localPartitionKeyBefore = partitionKeyOf("traces_local");
-
-            ensurePartitionedSuccessorUnderTraces();
-            ensureDistributedWrap();
-
-            assertThat(traceIdsOf(existing.projectName()))
-                    .as("the row that existed before the setup is still there, and still routed through the wrapper")
-                    .contains(existing.id());
-            assertThat(queryOneString(TABLE_ENGINE_FULL, _ -> {
-            }))
-                    .as("re-running the setup left the Distributed wrapper untouched")
-                    .isEqualTo(tracesEngineBefore);
-            assertThat(partitionKeyOf("traces_local"))
-                    .as("and left the partitioned table's key untouched")
-                    .isEqualTo(localPartitionKeyBefore);
-
-            // Not just survivable - still testing what it claims. A pruned delete on the untouched topology, so a
-            // no-op setup cannot quietly leave the suite asserting against something that is no longer partitioned.
-            var projectId = ID_GENERATOR.generateId();
-            var id = idInWeekOf(ERA_MONDAYS.getFirst());
-            insertRawTrace(projectId, id);
-
-            delete(Set.of(Pair.of(projectId, id)));
-
-            assertThat(liveRowCount(projectId, id))
-                    .as("the row is still deleted after a no-op setup")
-                    .isEqualTo("0");
-            assertThat(lastTraceDeleteSql(id))
-                    .as("and the delete is still pruned")
-                    .contains(PARTITION_PREDICATE);
-        }
-
-        @Test
-        @DisplayName("a request spanning two chunks prunes each chunk on its own")
-        void requestSpanningTwoChunksPrunesEachChunkIndependently() {
-            // The DAO chunks a request at ANALYTICS_DELETE_BATCH_SIZE and derives partitions PER CHUNK, inside the
-            // concatMap - so "all-or-nothing" is a per-statement guarantee, not a per-request one. Every other test
-            // here passes a handful of pairs, which is one chunk, so none of them can see that.
-            //
-            // The non-v7 id goes in the FIRST chunk and the derivable ids in the second, which is the only arrangement
-            // that can actually discriminate. Chunks are sized [BATCH_SIZE, remainder], so the first is always full and
-            // never inspectable: query_log truncates at log_queries_cut_to_length (100,000 bytes here) and a
-            // 10,000-pair statement inlines to ~762 KiB, so its tail - where the predicate sits - is not recorded.
-            // Only the remainder chunk is small enough to read back, so the assertion that matters has to live there.
-            //
-            // That makes the test bite on the refactor it exists to catch. Hoisting weeklyPartitionsFor out of the
-            // lambda, so the whole request is derived once, would let the non-v7 id in chunk one strip pruning from
-            // chunk two as well - and chunk two's predicate is exactly what is asserted below. Removing the pruning
-            // outright fails the same assertion. With the arrangement reversed, both regressions passed.
-            var projectId = ID_GENERATOR.generateId();
-            var firstChunkRow = idInWeekOf(ERA_MONDAYS.getFirst());
-            var secondChunkRow = idInWeekOf(ERA_MONDAYS.getLast());
-            insertRawTrace(projectId, firstChunkRow);
-            insertRawTrace(projectId, secondChunkRow);
-
-            // Chunk one: a real row, the non-v7 id, and filler up to exactly ANALYTICS_DELETE_BATCH_SIZE. Filler ids
-            // match no row - a delete does not need its ids to exist, and the chunk boundary is what is under test.
-            var ordered = new ArrayList<UUID>();
-            ordered.add(firstChunkRow);
-            ordered.add(NON_V7_ID);
-            while (ordered.size() < ANALYTICS_DELETE_BATCH_SIZE) {
-                ordered.add(idInWeekOf(ERA_MONDAYS.getFirst()));
-            }
-            // Chunk two: the remainder, all derivable, in two different weeks so the bound set is exact rather than
-            // trivially a single value.
-            var secondChunkCompanion = idInWeekOf(ERA_MONDAYS.get(1));
-            ordered.add(secondChunkRow);
-            ordered.add(secondChunkCompanion);
-
-            delete(ordered.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toCollection(
-                    LinkedHashSet::new)));
-
-            assertThat(liveRowCount(projectId, firstChunkRow))
-                    .as("the row in the chunk that fell back to unbounded is deleted")
-                    .isEqualTo("0");
-            assertThat(liveRowCount(projectId, secondChunkRow))
-                    .as("and so is the row in the chunk that pruned")
-                    .isEqualTo("0");
-
-            // The full chunk's statement is only checked to exist - that is what shows the request was split at all.
-            // Nothing about its text can be asserted, for the truncation reason above.
-            deleteSqlForChunkOf(ANALYTICS_DELETE_BATCH_SIZE);
-
-            var secondChunkSql = deleteSqlForChunkOf(2);
-            assertThat(secondChunkSql)
-                    .as("the all-derivable chunk prunes even though an earlier chunk could not")
-                    .contains(PARTITION_PREDICATE);
-            assertThat(boundPartitionsOf(secondChunkSql))
-                    .as("bounded to exactly its own two weeks")
-                    .containsExactlyInAnyOrder(partitionNameOf(ERA_MONDAYS.getLast()),
-                            partitionNameOf(ERA_MONDAYS.get(1)));
-        }
-
-        @ParameterizedTest
-        @MethodSource
-        @DisplayName("an id with no derivable partition disables pruning for the batch, and the delete still lands")
-        void underivableIdDisablesPruning(String cause, UUID underivableId) {
-            // The fallback that preserves the pre-OPIK-6901 guarantee, as the original javadoc stated it: a row whose id_at
-            // cannot be trusted is STILL DELETED. That is a claim about the underivable row ITSELF, so it gets a real row
-            // here - seeded raw, since ingestion rejects both id shapes by design. Passing it as an id matching nothing
-            // would let an implementation that quietly drops underivable ids from the batch pass, which is the very bug the
-            // all-or-nothing rule exists to prevent.
-            var target = newTrace().build();
-            traceResourceClient.createTrace(target, API_KEY, WORKSPACE_NAME);
-            var projectId = projectIdOf(target);
-            insertRawTrace(projectId, underivableId);
-            assertThat(liveRowCount(projectId, underivableId))
-                    .as("the %s row is seeded before the delete", cause).isEqualTo("1");
-
-            delete(Set.of(Pair.of(projectId, target.id()), Pair.of(projectId, underivableId)));
-
-            assertThat(liveRowCount(projectId, underivableId))
-                    .as("the %s row is itself deleted, not skipped", cause)
-                    .isEqualTo("0");
-            assertThat(traceIdsOf(target.projectName()))
-                    .as("and the derivable row batched alongside the %s id goes too", cause)
-                    .doesNotContain(target.id());
-
-            // Asserted as the absence of ANY id_at predicate, not just of this PR's expression. A regression that narrowed
-            // the mutation with toMonday(id_at), an id_at range, or any other partition predicate would skip exactly the
-            // rows this fallback exists to reach, and rejecting one function name would not see it. The unbounded template
-            // mentions id_at nowhere at all, so that is the whole check.
-            var sql = lastTraceDeleteSql(target.id());
-            assertThat(sql)
-                    .as("the unbounded form for a %s batch carries no id_at predicate of any kind", cause)
-                    .doesNotContain("id_at");
-            assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
-                    .as("and no partition IN clause: %s", sql)
-                    .isFalse();
-        }
-
-        private static Stream<Arguments> underivableIdDisablesPruning() {
-            return Stream.of(
-                    arguments("non-v7", NON_V7_ID),
-                    arguments("beyond-2299", OUT_OF_RANGE_ID));
-        }
+    @Test
+    @DisplayName("traces is a mutation-rejecting Distributed wrapper, so these deletes ran on traces_local")
+    void distributedTracesRejectsDirectMutation() {
+        // Keeps the topology claim from being vacuous. If the wrap had not taken effect, `traces` would still be a
+        // MergeTree, every pruned delete in this suite would have run against it, and nothing here would say so.
+        // Asserting the specific rejection - not merely that something threw - is what proves `traces` is Distributed,
+        // so a green delete could only have reached `traces_local`.
+        assertThatThrownBy(() -> execute("DELETE FROM traces WHERE workspace_id = :workspace_id",
+                statement -> statement.bind("workspace_id", WORKSPACE_ID)))
+                .hasMessageContaining("DELETE query is not supported for table");
     }
 
-    /**
-     * The flag <b>off</b>, against the <b>same</b> post-cutover topology and the same fixtures — so the only difference
-     * from {@link PruningEnabled} is the flag itself. That is what makes the pair a control rather than two unrelated
-     * suites: the sibling {@code TracesPruningDisabledMutationTest} also runs with pruning off, but against the legacy
-     * table, so it varies the schema at the same time and cannot attribute anything to the flag alone.
-     * <p>
-     * Both assertions here are the inverse of one in {@link PruningEnabled}, on identical data: no partition predicate
-     * is emitted, and the planner selects every part. Delete the flag gate so pruning always happens and these fail;
-     * delete the pruning and the other class fails. Correctness is unaffected either way, which is the point — the rows
-     * go away in both, so only these assertions can tell the two states apart.
-     */
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    @ExtendWith(DropwizardAppExtensionProvider.class)
-    class PruningDisabled {
+    @Test
+    @DisplayName("an all-UUIDv7 delete prunes to the batch's own partitions and removes the target row")
+    void allUuidV7DeletePrunesAndRemovesTheTargetRow() {
+        var target = newTrace().build();
+        // Same project, so one read shows both: the pruned delete must take the target and leave this one.
+        var bystander = newTrace().projectName(target.projectName()).build();
+        traceResourceClient.createTrace(target, API_KEY, WORKSPACE_NAME);
+        traceResourceClient.createTrace(bystander, API_KEY, WORKSPACE_NAME);
+        assertThat(traceIdsOf(target.projectName())).contains(target.id(), bystander.id());
 
-        @RegisterApp
-        private final TestDropwizardAppExtension app = newApp(false);
+        // The live user path, end to end.
+        traceResourceClient.deleteTrace(target.id(), WORKSPACE_NAME, API_KEY);
 
-        @BeforeAll
-        void beforeAll(ClientSupport clientSupport, TraceDAO traceDAO, TransactionTemplateAsync appTemplate) {
-            bindApp(clientSupport, traceDAO, appTemplate);
+        assertThat(traceIdsOf(target.projectName()))
+                .as("only the target row is gone")
+                .doesNotContain(target.id())
+                .contains(bystander.id());
+        var sql = lastTraceDeleteSql(target.id());
+        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
+        assertThat(boundPartitionsOf(sql))
+                .as("bounded to exactly the target's own partition, nothing wider — one value, since a trace the"
+                        + " endpoint just created is inside the 32-bit range where both id_at types agree")
+                .containsExactlyInAnyOrderElementsOf(partitionsOf(target.id()));
+    }
+
+    @Test
+    @DisplayName("the DAO's own delete clears every era and binds exactly those partitions")
+    void deleteClearsEveryEraAndBindsExactlyThosePartitions() {
+        // The three-way agreement - the migration's PARTITION BY as installed, the DAO's predicate, and
+        // WeeklyPartitions.of - asserted through the DAO's own delete rather than by re-evaluating the expression in
+        // test SQL. If the predicate resolved to any partition other than the one ClickHouse filed a row under, the
+        // mutation would select the wrong parts and that row would SURVIVE. So "every row is gone" IS the agreement.
+        //
+        // Ids are minted from the named Mondays rather than written out, so both sides of the assertion are the same
+        // arithmetic a reader can check, and every era in one batch is also the multi-value Long[] bind. Seeded raw and
+        // in a minted project: the ingestion window is 24h, so no endpoint can create a 1996 or 2199 row, and the
+        // project id is a real UUIDv7 straight from IdGenerator - which is how the sibling partition suites get one.
+        var projectId = ID_GENERATOR.generateId();
+        var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
+        ids.forEach(id -> insertRawTrace(projectId, id));
+        assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
+                .as("every era is seeded").containsOnly("1");
+
+        delete(ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet()));
+
+        assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
+                .as("every era's row is gone, so the predicate named the partition each was actually filed under")
+                .containsOnly("0");
+        var sql = lastTraceDeleteSql(ids.getFirst());
+        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
+        // Four values for three eras: 1996 and 2025 are inside the 32-bit range and name one week each, and the 2199
+        // id names its legacy week too. Still an exact set, and still not a range across two centuries - which is the
+        // property under test; the extra value is the batch's own second representation, not a widening of its span.
+        assertThat(boundPartitionsOf(sql))
+                .as("exactly the partitions the batch resolves to, not a range across two centuries")
+                .containsExactlyInAnyOrder(
+                        partitionNameOf(ERA_MONDAYS.get(0)),
+                        partitionNameOf(ERA_MONDAYS.get(1)),
+                        partitionNameOf(ERA_MONDAYS.get(2)),
+                        LEGACY_WEEK_OF_2200);
+    }
+
+    @Test
+    @DisplayName("the planner actually prunes, and the fallback provably does not")
+    void pruningReachesThePlannerAndTheFallbackDoesNot() {
+        // Correctness and pruning are different claims, and this is the only test that makes the second one. Deletes
+        // were already correct before OPIK-6901 - what the change buys is parts touched (3,928/3,928 -> 5/3,928 on
+        // prod-test), so a suite that cannot see pruning stop does not test what this change exists to do.
+        //
+        // The regression it guards is specific: a migration rewrites the partition expression to something semantically
+        // identical but textually different, the planner stops recognising the DAO's predicate as the partition key,
+        // pruning silently stops - and values still agree, so every row is still deleted and every other assertion in
+        // this suite stays green. That is the property the removed AST pin covered; this asks the planner directly
+        // instead of inferring it from text.
+        //
+        // EXPLAIN does not accept a mutation, so the WHERE clause is lifted verbatim out of the DAO's own emitted
+        // DELETE and put behind a SELECT - predicate and bound partition values included. Only the verb changes; the
+        // statement being explained is still the DAO's. Same instrument and record shape as
+        // TracesLocalV2PartitioningTest.
+        // One row per era, so the table holds several partitions for the planner to prune between.
+        var projectId = ID_GENERATOR.generateId();
+        var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
+        ids.forEach(id -> insertRawTrace(projectId, id));
+
+        // Bounded: one derivable id, so the predicate names a single one of those partitions.
+        delete(Set.of(Pair.of(projectId, ids.getFirst())));
+        var bounded = partsSelectedBy(lastTraceDeleteSql(ids.getFirst()))
+                .orElseThrow(() -> new AssertionError(
+                        "EXPLAIN reported no partition index for the bounded delete"));
+
+        // Unbounded: a non-v7 id in the batch, so no predicate at all. Its partner is a different era, so the query_log
+        // lookup finds this statement rather than the one above.
+        var partner = ids.get(1);
+        delete(Set.of(Pair.of(projectId, partner), Pair.of(projectId, NON_V7_ID)));
+        var unbounded = partsSelectedBy(lastTraceDeleteSql(partner));
+
+        assertThat(bounded.selected())
+                .as("the bounded delete selects fewer parts than the table holds: %s", bounded)
+                .isLessThan(bounded.total());
+        // Shown to discriminate, or it proves nothing - the same trap as `.contains(partition)` and
+        // `doesNotContain("toDayOfWeek")`. The fallback must not prune: either the planner reports no partition index at
+        // all, because nothing filters on the key, or it reports every part still selected.
+        assertThat(unbounded.map(parts -> parts.selected() == parts.total()).orElse(true))
+                .as("the fallback prunes nothing: %s", unbounded)
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("the topology setup is a no-op once the estate provides it - the path it takes post-cutover")
+    void topologySetupIsANoOpOnceTheEstateProvidesIt() {
+        // Today this suite installs the topology itself, so both setup steps take their INSTALL path and their
+        // early returns are dead code. Once the cutover migration lands, the migrations will provide
+        // `traces_local` partitioned with the Distributed `traces` over it: the EXCHANGE and the wrap are no
+        // longer needed, and that early return becomes the ONLY path either step takes. Nothing would exercise it
+        // until the day it becomes load-bearing, which is the wrong day to find out it was wrong.
+        //
+        // Re-running the setup against the topology it already installed IS that shape - `traces_local` exists and
+        // `traces` is Distributed over it, which is what the migration will hand us. So this covers the second of
+        // the two states: with the swap (every other test here) and without it (this one).
+        // A row that already exists BEFORE the setup runs, created through the ingestion path so the check reads it
+        // back the way production does. Metadata on its own cannot see data loss: a table recreated from the same
+        // DDL reports the same engine_full and partition_key while being empty, so a step that rebuilt the topology
+        // rather than skipping it would satisfy every metadata assertion here. The surviving row is the assertion
+        // that distinguishes "skipped" from "rebuilt", and reading it through the wrapper also shows routing is
+        // intact rather than merely that the wrapper exists.
+        var existing = newTrace().build();
+        traceResourceClient.createTrace(existing, API_KEY, WORKSPACE_NAME);
+        assertThat(traceIdsOf(existing.projectName()))
+                .as("the pre-existing row is readable before the setup re-runs")
+                .contains(existing.id());
+
+        // Not a tautology either: if either step failed to early-return it would THROW, not quietly repeat itself.
+        // The EXCHANGE needs `traces_local_v2`, which the install renamed to `traces_pre_cutover_backup`; and the
+        // wrap ends in a RENAME onto `traces_local`, which by now exists. So a non-idempotent step fails loudly.
+        var tracesEngineBefore = queryOneString(TABLE_ENGINE_FULL, _ -> {
+        });
+        var localPartitionKeyBefore = partitionKeyOf("traces_local");
+
+        ensurePartitionedSuccessorUnderTraces();
+        ensureDistributedWrap();
+
+        assertThat(traceIdsOf(existing.projectName()))
+                .as("the row that existed before the setup is still there, and still routed through the wrapper")
+                .contains(existing.id());
+        assertThat(queryOneString(TABLE_ENGINE_FULL, _ -> {
+        }))
+                .as("re-running the setup left the Distributed wrapper untouched")
+                .isEqualTo(tracesEngineBefore);
+        assertThat(partitionKeyOf("traces_local"))
+                .as("and left the partitioned table's key untouched")
+                .isEqualTo(localPartitionKeyBefore);
+
+        // Not just survivable - still testing what it claims. A pruned delete on the untouched topology, so a
+        // no-op setup cannot quietly leave the suite asserting against something that is no longer partitioned.
+        var projectId = ID_GENERATOR.generateId();
+        var id = idInWeekOf(ERA_MONDAYS.getFirst());
+        insertRawTrace(projectId, id);
+
+        delete(Set.of(Pair.of(projectId, id)));
+
+        assertThat(liveRowCount(projectId, id))
+                .as("the row is still deleted after a no-op setup")
+                .isEqualTo("0");
+        assertThat(lastTraceDeleteSql(id))
+                .as("and the delete is still pruned")
+                .contains(PARTITION_PREDICATE);
+    }
+
+    @Test
+    @DisplayName("a request spanning two chunks prunes each chunk on its own")
+    void requestSpanningTwoChunksPrunesEachChunkIndependently() {
+        // The DAO chunks a request at ANALYTICS_DELETE_BATCH_SIZE and derives partitions PER CHUNK, inside the
+        // concatMap - so "all-or-nothing" is a per-statement guarantee, not a per-request one. Every other test
+        // here passes a handful of pairs, which is one chunk, so none of them can see that.
+        //
+        // The non-v7 id goes in the FIRST chunk and the derivable ids in the second, which is the only arrangement
+        // that can actually discriminate. Chunks are sized [BATCH_SIZE, remainder], so the first is always full and
+        // never inspectable: query_log truncates at log_queries_cut_to_length (100,000 bytes here) and a
+        // 10,000-pair statement inlines to ~762 KiB, so its tail - where the predicate sits - is not recorded.
+        // Only the remainder chunk is small enough to read back, so the assertion that matters has to live there.
+        //
+        // That makes the test bite on the refactor it exists to catch. Hoisting weeklyPartitionsFor out of the
+        // lambda, so the whole request is derived once, would let the non-v7 id in chunk one strip pruning from
+        // chunk two as well - and chunk two's predicate is exactly what is asserted below. Removing the pruning
+        // outright fails the same assertion. With the arrangement reversed, both regressions passed.
+        var projectId = ID_GENERATOR.generateId();
+        var firstChunkRow = idInWeekOf(ERA_MONDAYS.getFirst());
+        var secondChunkRow = idInWeekOf(ERA_MONDAYS.getLast());
+        insertRawTrace(projectId, firstChunkRow);
+        insertRawTrace(projectId, secondChunkRow);
+
+        // Chunk one: a real row, the non-v7 id, and filler up to exactly ANALYTICS_DELETE_BATCH_SIZE. Filler ids
+        // match no row - a delete does not need its ids to exist, and the chunk boundary is what is under test.
+        var ordered = new ArrayList<UUID>();
+        ordered.add(firstChunkRow);
+        ordered.add(NON_V7_ID);
+        while (ordered.size() < ANALYTICS_DELETE_BATCH_SIZE) {
+            ordered.add(idInWeekOf(ERA_MONDAYS.getFirst()));
         }
+        // Chunk two: the remainder, all derivable, in two different weeks so the bound set is exact rather than
+        // trivially a single value.
+        var secondChunkCompanion = idInWeekOf(ERA_MONDAYS.get(1));
+        ordered.add(secondChunkRow);
+        ordered.add(secondChunkCompanion);
 
-        @Test
-        @DisplayName("the same batch still clears every era, and emits no partition predicate")
-        void deleteStillClearsEveryEraWithoutPruning() {
-            var projectId = ID_GENERATOR.generateId();
-            var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
-            ids.forEach(id -> insertRawTrace(projectId, id));
+        delete(ordered.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toCollection(
+                LinkedHashSet::new)));
 
-            delete(ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet()));
+        assertThat(liveRowCount(projectId, firstChunkRow))
+                .as("the row in the chunk that fell back to unbounded is deleted")
+                .isEqualTo("0");
+        assertThat(liveRowCount(projectId, secondChunkRow))
+                .as("and so is the row in the chunk that pruned")
+                .isEqualTo("0");
 
-            assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
-                    .as("the delete is still correct with the flag off - that is what makes it an optimisation")
-                    .containsOnly("0");
-            var sql = lastTraceDeleteSql(ids.getFirst());
-            assertThat(sql)
-                    .as("and carries no id_at narrowing of any kind")
-                    .doesNotContain("id_at");
-            assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
-                    .as("nor a partition IN clause: %s", sql)
-                    .isFalse();
-        }
+        // The full chunk's statement is only checked to exist - that is what shows the request was split at all.
+        // Nothing about its text can be asserted, for the truncation reason above.
+        deleteSqlForChunkOf(ANALYTICS_DELETE_BATCH_SIZE);
 
-        @Test
-        @DisplayName("the planner selects every part - the enabled class's assertion, inverted on the same data")
-        void plannerPrunesNothingWithoutPruning() {
-            var projectId = ID_GENERATOR.generateId();
-            var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
-            ids.forEach(id -> insertRawTrace(projectId, id));
+        var secondChunkSql = deleteSqlForChunkOf(2);
+        assertThat(secondChunkSql)
+                .as("the all-derivable chunk prunes even though an earlier chunk could not")
+                .contains(PARTITION_PREDICATE);
+        assertThat(boundPartitionsOf(secondChunkSql))
+                .as("bounded to exactly its own two weeks, plus the legacy representation of the far-future one")
+                .containsExactlyInAnyOrder(partitionNameOf(ERA_MONDAYS.getLast()),
+                        partitionNameOf(ERA_MONDAYS.get(1)),
+                        LEGACY_WEEK_OF_2200);
+    }
 
-            delete(Set.of(Pair.of(projectId, ids.getFirst())));
+    @ParameterizedTest
+    @MethodSource
+    @DisplayName("an id with no derivable partition disables pruning for the batch, and the delete still lands")
+    void underivableIdDisablesPruning(String cause, UUID underivableId) {
+        // The fallback that preserves the pre-OPIK-6901 guarantee, as the original javadoc stated it: a row whose id_at
+        // cannot be trusted is STILL DELETED. That is a claim about the underivable row ITSELF, so it gets a real row
+        // here - seeded raw, since ingestion rejects both id shapes by design. Passing it as an id matching nothing
+        // would let an implementation that quietly drops underivable ids from the batch pass, which is the very bug the
+        // all-or-nothing rule exists to prevent.
+        var target = newTrace().build();
+        traceResourceClient.createTrace(target, API_KEY, WORKSPACE_NAME);
+        var projectId = projectIdOf(target);
+        insertRawTrace(projectId, underivableId);
+        assertThat(liveRowCount(projectId, underivableId))
+                .as("the %s row is seeded before the delete", cause).isEqualTo("1");
 
-            var parts = partsSelectedBy(lastTraceDeleteSql(ids.getFirst()));
-            assertThat(parts.map(selected -> selected.selected() == selected.total()).orElse(true))
-                    .as("no partition pruning with the flag off: %s", parts)
-                    .isTrue();
-        }
+        delete(Set.of(Pair.of(projectId, target.id()), Pair.of(projectId, underivableId)));
+
+        assertThat(liveRowCount(projectId, underivableId))
+                .as("the %s row is itself deleted, not skipped", cause)
+                .isEqualTo("0");
+        assertThat(traceIdsOf(target.projectName()))
+                .as("and the derivable row batched alongside the %s id goes too", cause)
+                .doesNotContain(target.id());
+
+        // Asserted as the absence of ANY id_at predicate, not just of this PR's expression. A regression that narrowed
+        // the mutation with toMonday(id_at), an id_at range, or any other partition predicate would skip exactly the
+        // rows this fallback exists to reach, and rejecting one function name would not see it. The unbounded template
+        // mentions id_at nowhere at all, so that is the whole check.
+        var sql = lastTraceDeleteSql(target.id());
+        assertThat(sql)
+                .as("the unbounded form for a %s batch carries no id_at predicate of any kind", cause)
+                .doesNotContain("id_at");
+        assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
+                .as("and no partition IN clause: %s", sql)
+                .isFalse();
+    }
+
+    private static Stream<Arguments> underivableIdDisablesPruning() {
+        return Stream.of(
+                arguments("non-v7", NON_V7_ID),
+                arguments("beyond-2299", OUT_OF_RANGE_ID));
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
@@ -19,9 +19,11 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * Covers {@link WeeklyPartitions#of}, which derives the weekly partition values a delete batch resolves to so the
  * mutation can prune instead of rewriting every part.
  * <p>
- * The in-range expected values are not hand-computed: each is what ClickHouse itself returned for
- * {@code toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} on prod-test for that id. If the table's
- * partition expression ever changes, these assertions are what should fail.
+ * The expected values are not hand-computed: each is what ClickHouse itself returned for
+ * {@code toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} for that id, evaluated once with
+ * {@code id_at} as {@code DateTime64(0, 'UTC')} (the partitioned successor) and once as {@code DateTime('UTC')} (legacy
+ * {@code traces}). If the table's partition expression, or ClickHouse's conversion into either column type, ever
+ * changes, these assertions are what should fail.
  * <p>
  * The range-boundary cases are the exception and say so: the ids are constructed rather than observed, because the point
  * of each is an {@code id_at} value the column cannot store, which is exactly what no real row has.
@@ -30,27 +32,51 @@ class WeeklyPartitionsTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource
-    @DisplayName("matches the partition ClickHouse computed")
-    void matchesThePartitionClickHouseComputed(String era, UUID id, long expectedPartition) {
-        assertThat(WeeklyPartitions.of(List.of(id))).contains(Set.of(expectedPartition));
+    @DisplayName("matches the partitions ClickHouse computed, under each id_at type")
+    void matchesThePartitionsClickHouseComputed(String era, UUID id, Set<Long> expectedPartitions) {
+        assertThat(WeeklyPartitions.of(List.of(id))).contains(expectedPartitions);
     }
 
     /**
-     * One row per era the derivation has to get right, each pinned to the value ClickHouse itself returned for that id
-     * on prod-test — not to a hand-computed Monday. The eras are not interchangeable samples: an expression that is
-     * correct for the ordinary calendar and wrong at the extremes is exactly the {@code toMonday} trap migration 000114
-     * was written to escape, so dropping any of the three would weaken the pin rather than tidy it.
+     * One row per era the derivation has to get right, each pinned to the value ClickHouse itself returned for that id —
+     * not to a hand-computed Monday. The eras are not interchangeable samples: an expression that is correct for the
+     * ordinary calendar and wrong at the extremes is exactly the {@code toMonday} trap migration 000114 was written to
+     * escape, so dropping any of the three would weaken the pin rather than tidy it.
      */
-    private static Stream<Arguments> matchesThePartitionClickHouseComputed() {
+    private static Stream<Arguments> matchesThePartitionsClickHouseComputed() {
         return Stream.of(
-                // The ordinary case: id_at 2026-08-19 (a Wednesday) -> Monday 2026-08-17.
-                arguments("ordinary id", UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"), 20260817L),
+                // The ordinary case: id_at 2026-08-19 (a Wednesday) -> Monday 2026-08-17. Inside the 32-bit DateTime
+                // range, so both column types store the same instant and the id contributes a single value — which is
+                // every id real traffic produces.
+                arguments("ordinary id", UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"), Set.of(20260817L)),
                 // Long before Opik existed but well after the Unix epoch, and well inside Date32's 1900 floor: an id
-                // this old prunes like any other. id_at 1996-02-09 -> Monday 1996-02-05.
-                arguments("id from 1996", UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"), 19960205L),
-                // Far-future ids are supported, not excluded: a bogus-but-self-consistent timestamp, id_at 2200-01-01 ->
-                // Monday 2199-12-30. 4.1% of rows on prod-test look like this; they must still be deletable and prune.
-                arguments("far-future id", UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"), 21991230L));
+                // this old prunes like any other, and likewise fits both column types. id_at 1996-02-09 -> 1996-02-05.
+                arguments("id from 1996", UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"), Set.of(19960205L)),
+                // Far-future ids are supported, not excluded, and are the only ones that contribute two values: past
+                // 2106 the two column types disagree, so the batch has to name both weeks or be wrong on one schema.
+                // DateTime64 stores 2200-01-01 -> Monday 2199-12-30; the legacy 32-bit DateTime wraps the same id to
+                // 2063-11-25 -> Monday 2063-11-19. 4.1% of rows on prod-test look like this.
+                arguments("far-future id", UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"),
+                        Set.of(21991230L, 20631119L)));
+    }
+
+    @Test
+    @DisplayName("an in-range id contributes one value, because both column types store it identically")
+    void inRangeIdContributesOneValue() {
+        // The point of the pair is that it costs nothing on ordinary traffic: the union only widens for ids past 2106,
+        // so the set a normal delete binds is exactly the set it bound before the legacy representation was added.
+        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"))))
+                .contains(Set.of(20260817L));
+    }
+
+    @Test
+    @DisplayName("a far-future id names its legacy week too, so the same delete works before and after the cutover")
+    void farFutureIdNamesBothRepresentations() {
+        // This is what removes the cutover flag. Legacy `traces` declares id_at as a 32-bit DateTime, which holds
+        // epochSecond % 2^32, so it files this row under 2063 while the partitioned successor files it under 2200.
+        // A set carrying only one of the two is a delete that reports success and removes nothing on the other schema.
+        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"))))
+                .contains(Set.of(21991230L, 20631119L));
     }
 
     @Test
@@ -128,11 +154,12 @@ class WeeklyPartitionsTest {
     @Test
     @DisplayName("the last id_at the column can store still prunes")
     void lastRepresentableIdStillPrunes() {
-        // id_at 2299-12-31T23:59:59.999 — the last instant DateTime64 represents, so nothing saturates and the two
-        // sides agree: DateTime64(0) truncates to 23:59:59, whose Date32 is 2299-12-31 (a Sunday) -> Monday 2299-12-25.
-        // The ceiling check must be exclusive at exactly this point, hence a case sitting on it.
+        // id_at 2299-12-31T23:59:59.999 — the last instant DateTime64 represents, so nothing saturates: DateTime64(0)
+        // truncates to 23:59:59, whose Date32 is 2299-12-31 (a Sunday) -> Monday 2299-12-25. The legacy DateTime wraps
+        // the same id to 2027-10-18, a Monday. The ceiling check must be exclusive at exactly this point, hence a case
+        // sitting on it.
         assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0978a65f-77ff-7abc-8000-000000000001"))))
-                .contains(Set.of(22991225L));
+                .contains(Set.of(22991225L, 20271018L));
     }
 
     @Test
@@ -140,8 +167,9 @@ class WeeklyPartitionsTest {
     void firstUnrepresentableIdDisablesPruning() {
         // id_at 2300-01-01T00:00:00 — one ms past the previous case and outside DateTime64. ClickHouse saturates it to
         // 2299-12-31 23:59:59 and files the row under 22991225, so the honest week this would compute (2300-01-01 is
-        // itself a Monday, giving 23000101) is a partition the row is NOT in. Pruning off rather than clamped: matching
-        // ClickHouse here would mean reproducing its saturation semantics, for ids that should not exist.
+        // itself a Monday, giving 23000101) is a partition the row is NOT in. Pruning off rather than clamped: unlike
+        // the legacy 32-bit wrap, which is a modulo this reproduces exactly, matching ClickHouse here would mean
+        // reproducing its saturation semantics, for ids that should not exist.
         assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0978a65f-7800-7abc-8000-000000000001"))))
                 .isEmpty();
     }
@@ -172,7 +200,8 @@ class WeeklyPartitionsTest {
     void earliestUuidV7TimestampIsInRange() {
         // All 48 timestamp bits clear: id_at 1970-01-01, the earliest any UUIDv7 can encode (the field is unsigned).
         // Its Monday, 1969-12-29, is 70 years above Date32's 1900 floor, so a below-1900 id_at is unreachable by
-        // construction rather than merely untested — which is why `of` guards only the ceiling.
+        // construction rather than merely untested — which is why `of` guards only the ceiling. It is also the floor of
+        // the legacy 32-bit DateTime, so the wrap leaves it untouched and it contributes one value.
         assertThat(WeeklyPartitions.of(List.of(UUID.fromString("00000000-0000-7abc-8000-000000000001"))))
                 .contains(Set.of(19691229L));
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
@@ -46,37 +46,21 @@ class WeeklyPartitionsTest {
     private static Stream<Arguments> matchesThePartitionsClickHouseComputed() {
         return Stream.of(
                 // The ordinary case: id_at 2026-08-19 (a Wednesday) -> Monday 2026-08-17. Inside the 32-bit DateTime
-                // range, so both column types store the same instant and the id contributes a single value — which is
-                // every id real traffic produces.
+                // range, so both column types store the same instant and the id contributes a SINGLE value. That is
+                // every id real traffic produces, and it is why naming both representations costs nothing: the set a
+                // normal delete binds is exactly the set it bound before the legacy one was added.
                 arguments("ordinary id", UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"), Set.of(20260817L)),
                 // Long before Opik existed but well after the Unix epoch, and well inside Date32's 1900 floor: an id
                 // this old prunes like any other, and likewise fits both column types. id_at 1996-02-09 -> 1996-02-05.
                 arguments("id from 1996", UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"), Set.of(19960205L)),
                 // Far-future ids are supported, not excluded, and are the only ones that contribute two values: past
-                // 2106 the two column types disagree, so the batch has to name both weeks or be wrong on one schema.
-                // DateTime64 stores 2200-01-01 -> Monday 2199-12-30; the legacy 32-bit DateTime wraps the same id to
-                // 2063-11-25 -> Monday 2063-11-19. 4.1% of rows on prod-test look like this.
+                // 2106 the two column types disagree, so the batch has to name both weeks or be wrong on one schema -
+                // which is what removed the cutover flag. DateTime64 stores 2200-01-01 -> Monday 2199-12-30; the legacy
+                // 32-bit DateTime wraps the same id to 2063-11-25 -> Monday 2063-11-19. A set carrying only one of the
+                // two is a delete that reports success and removes nothing on the other schema. 4.1% of rows on
+                // prod-test look like this.
                 arguments("far-future id", UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"),
                         Set.of(21991230L, 20631119L)));
-    }
-
-    @Test
-    @DisplayName("an in-range id contributes one value, because both column types store it identically")
-    void inRangeIdContributesOneValue() {
-        // The point of the pair is that it costs nothing on ordinary traffic: the union only widens for ids past 2106,
-        // so the set a normal delete binds is exactly the set it bound before the legacy representation was added.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"))))
-                .contains(Set.of(20260817L));
-    }
-
-    @Test
-    @DisplayName("a far-future id names its legacy week too, so the same delete works before and after the cutover")
-    void farFutureIdNamesBothRepresentations() {
-        // This is what removes the cutover flag. Legacy `traces` declares id_at as a 32-bit DateTime, which holds
-        // epochSecond % 2^32, so it files this row under 2063 while the partitioned successor files it under 2200.
-        // A set carrying only one of the two is a delete that reports success and removes nothing on the other schema.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"))))
-                .contains(Set.of(21991230L, 20631119L));
     }
 
     @Test

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -129,19 +129,6 @@ databaseAnalyticsDataModel:
   #   both `traces_local` and `traces`, else reads can't see the column (code 47).
   tracesDistributedWrapEnabled: false
   #  Default: false
-  #  Description: Enables partition-aware PRUNING of trace deletes - it does NOT create or activate any partitioning.
-  #   With it on, a trace DELETE bounds itself to the weekly partitions its own ids resolve to instead of being planned
-  #   against every part of the table. Turning it on therefore ASSERTS a schema fact rather than causing one: that the
-  #   live mutation target already IS the weekly partitioned successor, id_at as DateTime64(0,'UTC') under
-  #   PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1))). Installing that schema is the
-  #   EXCHANGE step of the cutover, never this flag. Purely an optimisation: false keeps the unbounded mutation, which
-  #   is always correct and merely slower. A third flag on purpose - the partitioning appears at the EXCHANGE, and
-  #   neither sibling marks it:
-  #   traceColumnsNonNullable must be rolled out BEFORE the EXCHANGE, tracesDistributedWrapEnabled flips at the wrap,
-  #   which may be deferred long after it. Leave false at deploy time; set true once the EXCHANGE is confirmed, and back
-  #   to false BEFORE a rollback promotes the original `traces` (legacy `traces` has no PARTITION BY and a 32-bit
-  #   DateTime id_at that overflows past 2106, so the predicate would silently match zero rows for a far-future id).
-  tracesWeeklyPartitionPruningEnabled: false
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -188,11 +188,6 @@ services:
       # Flip TRACES_DISTRIBUTED_WRAP_ENABLED to true in lockstep with applying the Distributed wrap: it routes trace
       # delete/retention mutations to traces_local, since a Distributed traces rejects mutations.
       ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
-      # Flip TRACES_WEEKLY_PARTITION_PRUNING_ENABLED to true only once the EXCHANGE has put the weekly partitioned
-      # successor under `traces`: it lets a trace DELETE prune to the partitions its own ids resolve to. It enables the
-      # PRUNING, not the partitioning - setting it does not create or activate anything. Purely an optimisation - false
-      # keeps the always-correct unbounded mutation.
-      ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED: ${ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED:-false}
       # Readiness probes for the Hyperscale topology, both off for the single-node Compose stack: the cluster probe
       # checks the Distributed cluster definition is visible, the cold-storage probe checks the cold_s3 tiered disk.
       ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED: ${ANALYTICS_DB_CLUSTER_HEALTH_CHECK_ENABLED:-false}

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -495,7 +495,6 @@ Call opik api on http://localhost:5173/api
 | databaseAnalyticsDataModel.traceColumnsNonNullable | bool | `false` |  |
 | databaseAnalyticsDataModel.traceDeletionEventsCaptureEnabled | bool | `false` |  |
 | databaseAnalyticsDataModel.tracesDistributedWrapEnabled | bool | `false` |  |
-| databaseAnalyticsDataModel.tracesWeeklyPartitionPruningEnabled | bool | `false` |  |
 | demoDataJob.enabled | bool | `true` |  |
 | fullnameOverride | string | `""` |  |
 | global.argocd | bool | `false` |  |

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -50,7 +50,6 @@ data:
         "ANALYTICS_DB_DATA_MODEL_SPAN_DELETION_EVENTS_CAPTURE_ENABLED" $dm.spanDeletionEventsCaptureEnabled
         "ANALYTICS_DB_DATA_MODEL_DELETION_EVENTS_INSERT_BATCH_SIZE" $dm.deletionEventsInsertBatchSize
         "ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED" $dm.tracesDistributedWrapEnabled
-        "ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED" $dm.tracesWeeklyPartitionPruningEnabled
         "PARTITION_METRICS_ENABLED" $pm.enabled
         "PARTITION_METRICS_INTERVAL" $pm.interval
         "PARTITION_METRICS_LWD_TABLES" $pm.lwdTables

--- a/deployment/helm_chart/opik/tests/configmap_env_test.yaml
+++ b/deployment/helm_chart/opik/tests/configmap_env_test.yaml
@@ -74,9 +74,6 @@ tests:
           path: data.ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED
           value: "false"
       - equal:
-          path: data.ANALYTICS_DB_DATA_MODEL_TRACES_WEEKLY_PARTITION_PRUNING_ENABLED
-          value: "false"
-      - equal:
           path: data.PARTITION_METRICS_ENABLED
           value: "false"
       - equal:

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -791,10 +791,6 @@ databaseAnalyticsDataModel:
   # Turn true in lockstep with applying the Distributed wrap, so trace delete/retention mutations target
   # traces_local (a Distributed traces rejects mutations). Leave false while traces is still a MergeTree.
   tracesDistributedWrapEnabled: false
-  # Turn true only once the EXCHANGE has put the weekly partitioned successor under `traces`, so a trace DELETE
-  # can prune to the partitions its own ids resolve to. Enables the PRUNING, not the partitioning - setting it creates
-  # nothing. Purely an optimisation; false keeps the unbounded delete.
-  tracesWeeklyPartitionPruningEnabled: false
 
 # ClickHouse partition-health observability (OPIK-6904). Polls system.parts plus the
 # lightweight-delete mask and publishes opik.clickhouse.partition.* gauges; a distributed lock keeps


### PR DESCRIPTION
## Details

Review follow-up to #7912, addressing @andrescrz's comment:

> The partitioning pruning predicates for this project generally don't require partitioning to be in place, and they work both before and after the cutover. I'm wondering if there's any alternative expression that would meet that. An extra benefit is avoiding one more configuration flag.

There is. **`tracesWeeklyPartitionPruningEnabled` is gone** — the predicate is emitted unconditionally, and one rendered statement is correct against the legacy `traces` and against the partitioned successor alike. Nothing to flip forward, nothing to revert on rollback.

### Why the flag existed, and what replaces it

The two schemas declare `id_at` with different widths:

| table | `id_at` | past `2106-02-07 06:28:15` |
|---|---|---|
| legacy `traces` (000091) | `DateTime('UTC')` — 32-bit | **wraps** modulo 2³² seconds |
| `traces_local_v2` (000114) | `DateTime64(0, 'UTC')` | honest |

So a far-future id — the litellm ([BerriAI/litellm#31294](https://github.com/BerriAI/litellm/issues/31294)) ~2201 rows, 4.1% of prod-test — is filed under `21991230` on the successor and under `20631119` on the legacy table. A set carrying only one of the two matches **nothing** on the other: a delete that reports success having removed no rows. That is the whole reason the predicate had to be told which schema was live.

`WeeklyPartitions` now derives, per id, the week it resolves to under **each** `id_at` type a mutation can meet, and returns the union:

```java
long epochSecond = epochMilli / 1_000L;
partitions.add(weeklyPartitionOf(epochSecond));                          // DateTime64(0) — the successor
partitions.add(weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS));   // DateTime      — legacy traces
```

Below 2106 the two coincide, so **ordinary traffic binds exactly the set it bound before** — the union widens only where the representations differ. And widening an `IN` set can only ever select an extra partition; the `(project_id, id)` predicate it is ANDed with still decides which rows go. Omitting a value is the unsafe direction, adding one is not.

### Measured, against both table shapes

Both tables built to their real definitions on ClickHouse 26.3, 660 rows over 220 weekly partitions, batch = two ordinary ids + one 2201 id:

| predicate | rows matched on legacy `traces` | rows matched on successor |
|---|---|---|
| none (previous unbounded form) | 3/3 | 3/3 |
| honest week only (#7912, flag on) | **2/3** ← the skipped delete | 3/3 |
| **honest ∪ legacy (this PR)** | **3/3** | **3/3** |

And the union costs nothing in pruning — `EXPLAIN indexes=1` on the partitioned table:

| predicate | partition stage |
|---|---|
| none | Parts 220/220 (`Condition: true`) |
| honest week only | Parts **3/220** (3-element set) |
| honest ∪ legacy | Parts **3/220** (4-element set) |

Real `DELETE` mutations on both tables removed exactly the 3 target rows and left the other 657.

### What is deliberately *not* changed

The `>= 2300-01-01` rejection stays. There `DateTime64` genuinely **saturates**, and reproducing saturation is a different bet from reproducing a modulo — the modulo is arithmetic the class can restate exactly and CI now pins; saturation would be reproducing a conversion's edge behaviour to buy pruning for ids no clock, however broken, produces. Those batches keep falling back to the unbounded mutation.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-6901

## Documentation

The cutover runbook's `tracesWeeklyPartitionPruningEnabled` section is replaced by one saying the pruning needs no flip at all, and the stage B/C rollback loses the warning that the flag's revert had to *lead* the swap. `WeeklyPartitions`' javadoc carries the two-representation rationale, and `ID_AT_LEGACY_MODULUS` records that the legacy conversion is a modulo, where it was verified, and which test pins it.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: read the review thread, established the legacy conversion is a modulo rather than a saturation by running both table shapes on a local ClickHouse 26.3, designed and wrote the union, updated the tests/config/runbook.
- Human verification: the design direction is the reviewer's own — the question of whether an expression exists that holds on both sides of the cutover is what produced this. Reviewer sign-off still required.

## Testing

Run locally against ClickHouse 26.3 via testcontainers, all green:

- `WeeklyPartitionsTest` — **17/17**. Every expected value is what ClickHouse returned for that id under each column type, not hand-computed. New/changed cases: an in-range id contributes **one** value; a far-future id contributes `{21991230, 20631119}`; the last representable id contributes `{22991225, 20271018}`; the `>= 2300` and non-v7 rejections are unchanged.
- `TracesLegacyTablePruningMutationTest` — **3/3**. This is `TracesPruningDisabledMutationTest`, re-aimed: it now asserts the predicate **is** emitted against the legacy table, that it carries exactly both weeks, and that the far-future row is deleted. It is the only place the legacy representation meets a real ClickHouse, so if that conversion ever stops being a modulo this fails in CI instead of a delete silently skipping rows in a pre-cutover deployment.
- `TracesPartitionPruningMutationTest` — **8/8**. Loses its A/B across two apps (there is no flag to vary) and keeps the fallback coverage through batches the derivation rejects. Exact-set assertions now expect the 2199 era's second value.
- Siblings on the delete path, unchanged and still green: `TracesDistributedWrapMutationTest` (4), `TraceSentinelIntegrationTest` (13), `DeletionEventTest` (5), `TraceServiceImplTest` (7).
- `helm template` renders with the flag gone; `mvn spotless:apply` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
