### PR TITLE
[OPIK-7940] [CI] test: skip token-auth e2e specs when the backend can't reach the mock

### DIFF
--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -11,7 +11,7 @@
  *    MOCK_AUTH_URL_FOR_BACKEND=http://host.docker.internal:9878 (and make sure the backend
  *    runs with LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed, as the compose file ships).
  */
-import { checkProviderAuthConfig } from './provider-keys';
+import { AuthConfigCheckError, checkProviderAuthConfig } from './provider-keys';
 
 export const MOCK_AUTH_PORT = parseInt(process.env.MOCK_AUTH_PORT ?? '9878', 10);
 
@@ -48,6 +48,16 @@ export async function mockAuthRevokeAll(): Promise<void> {
   if (!response.ok) throw new Error(`mock-auth /revoke returned ${response.status}`);
 }
 
+const AUTH_CONFIG_TEST_PATH = '/auth-config/test';
+
+/**
+ * Backend wordings for "the destination was never successfully contacted"
+ * (AuthTokenProvider): an IOException on send, and a refusal by the SSRF destination guard.
+ * Deliberately narrow — "token fetch failed with status" (rejected credentials) and the
+ * non-JSON/missing-field replies share the 400 but indicate a broken mock, not a topology gap.
+ */
+const UNREACHABLE_PATTERNS = [/could not reach/i, /destination/i];
+
 /**
  * Whether the OPIK BACKEND can fetch a token from the mock service — not whether THIS process
  * can reach it. The two differ whenever the backend runs in docker-compose while the mock runs
@@ -56,7 +66,11 @@ export async function mockAuthRevokeAll(): Promise<void> {
  * backend's own test-connection endpoint (which performs the fetch server-side) turns that into
  * a skip that names the cause.
  *
- * Resolves to null when the backend CAN reach it, else the reason to skip with.
+ * Only two outcomes are a skip: the deployment lacks the endpoint, or the backend cannot reach
+ * the destination. Everything else — auth, permissions, rejected credentials, a malformed
+ * reply — is a real problem this suite must not hide behind a green run, so it propagates and
+ * fails the setup. Resolves to null when the backend CAN reach the mock.
+ *
  * Cached: the answer is a property of the deployment, and every spec in the area asks.
  */
 let mockAuthGate: Promise<string | null> | undefined;
@@ -77,17 +91,26 @@ export function mockAuthSkipReason(): Promise<string | null> {
       });
       return null;
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      // 404 = deployment predates the endpoint (OPIK-7940), so token auth isn't there to test.
-      if (detail.includes('404')) {
-        return `deployment has no /auth-config/test endpoint, so dynamic token auth is unavailable (${detail})`;
+      if (!(err instanceof AuthConfigCheckError)) throw err;
+
+      // No endpoint: the deployment predates dynamic token auth (OPIK-7940), so there is
+      // nothing here to test.
+      if (err.status === 404) {
+        return `deployment has no ${AUTH_CONFIG_TEST_PATH} endpoint, so dynamic token auth is unavailable`;
       }
-      return (
-        `the Opik backend cannot fetch a token from ${mockTokenUrlForBackend} (${detail}). ` +
-        'If the backend runs in docker-compose, set MOCK_AUTH_URL_FOR_BACKEND to a host-reachable ' +
-        'address (CI uses http://172.17.0.1:9878) and run the backend with ' +
-        'LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed.'
-      );
+
+      // 400 covers every fetch failure, so match the two the backend words distinctly: an
+      // unreachable destination, and one refused by the SSRF guard. Rejected credentials or a
+      // malformed reply share the status but mean the mock itself is broken — never skip those.
+      if (err.status === 400 && UNREACHABLE_PATTERNS.some((re) => re.test(err.body))) {
+        return (
+          `the Opik backend cannot fetch a token from ${mockTokenUrlForBackend}: ${err.body} ` +
+          '— if the backend runs in docker-compose, set MOCK_AUTH_URL_FOR_BACKEND to a ' +
+          'host-reachable address (CI uses http://172.17.0.1:9878).'
+        );
+      }
+
+      throw err;
     }
   })();
   return mockAuthGate;

--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -11,13 +11,17 @@
  *    MOCK_AUTH_URL_FOR_BACKEND=http://host.docker.internal:9878 (and make sure the backend
  *    runs with LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed, as the compose file ships).
  */
+import { checkProviderAuthConfig } from './provider-keys';
+
 export const MOCK_AUTH_PORT = parseInt(process.env.MOCK_AUTH_PORT ?? '9878', 10);
 
 export const mockAuthBaseUrl =
-  process.env.MOCK_AUTH_URL ?? `http://localhost:${MOCK_AUTH_PORT}`;
+  process.env.MOCK_AUTH_URL || `http://localhost:${MOCK_AUTH_PORT}`;
 
+// Treat an empty value as unset: CI passes this conditionally, and a `${{ ... || '' }}`
+// expression yields "" rather than omitting the variable.
 export const mockAuthBaseUrlForBackend =
-  process.env.MOCK_AUTH_URL_FOR_BACKEND ?? mockAuthBaseUrl;
+  process.env.MOCK_AUTH_URL_FOR_BACKEND || mockAuthBaseUrl;
 
 /** Fixed identities the mock accepts (see mock_token_auth_service.py). */
 export const MOCK_AUTH_CLIENT_ID = 'opik-test';
@@ -42,4 +46,49 @@ export async function mockAuthStats(): Promise<MockAuthStats> {
 export async function mockAuthRevokeAll(): Promise<void> {
   const response = await fetch(`${mockAuthBaseUrl}/revoke`, { method: 'POST' });
   if (!response.ok) throw new Error(`mock-auth /revoke returned ${response.status}`);
+}
+
+/**
+ * Whether the OPIK BACKEND can fetch a token from the mock service — not whether THIS process
+ * can reach it. The two differ whenever the backend runs in docker-compose while the mock runs
+ * on the host: the default `localhost:9878` then resolves to the container's own loopback, so
+ * every token fetch fails and these specs die on an opaque missing success toast. Probing the
+ * backend's own test-connection endpoint (which performs the fetch server-side) turns that into
+ * a skip that names the cause.
+ *
+ * Resolves to null when the backend CAN reach it, else the reason to skip with.
+ * Cached: the answer is a property of the deployment, and every spec in the area asks.
+ */
+let mockAuthGate: Promise<string | null> | undefined;
+
+export function mockAuthSkipReason(): Promise<string | null> {
+  mockAuthGate ??= (async () => {
+    try {
+      // A bare auth_config needs no stored provider: the backend runs the token fetch and
+      // answers 200 with the lifetime when the URL is reachable.
+      await checkProviderAuthConfig({
+        token_url: mockTokenUrlForBackend,
+        send_as: 'basic',
+        credentials: [
+          { key: 'grant_type', value: 'client_credentials', secret: false },
+          { key: 'client_id', value: MOCK_AUTH_CLIENT_ID, secret: false },
+          { key: 'client_secret', value: MOCK_AUTH_CLIENT_SECRET, secret: true },
+        ],
+      });
+      return null;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      // 404 = deployment predates the endpoint (OPIK-7940), so token auth isn't there to test.
+      if (detail.includes('404')) {
+        return `deployment has no /auth-config/test endpoint, so dynamic token auth is unavailable (${detail})`;
+      }
+      return (
+        `the Opik backend cannot fetch a token from ${mockTokenUrlForBackend} (${detail}). ` +
+        'If the backend runs in docker-compose, set MOCK_AUTH_URL_FOR_BACKEND to a host-reachable ' +
+        'address (CI uses http://172.17.0.1:9878) and run the backend with ' +
+        'LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed.'
+      );
+    }
+  })();
+  return mockAuthGate;
 }

--- a/tests_end_to_end/e2e/core/provider-keys.ts
+++ b/tests_end_to_end/e2e/core/provider-keys.ts
@@ -86,12 +86,24 @@ export async function deleteProviderKeyByName(providerName: string): Promise<voi
   }
 }
 
+/** Carries the HTTP status so callers can classify a failure instead of parsing prose. */
+export class AuthConfigCheckError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`auth-config check returned ${status}: ${body}`);
+    this.name = 'AuthConfigCheckError';
+  }
+}
+
 /**
  * Server-side connection check: the BACKEND performs the token fetch. Passing a provider id
  * tests the stored recipe (resolving __SECRET__ sentinels); passing an auth_config tests
  * submitted values without needing a stored provider at all.
- * Throws on a non-2xx — notably 400, which the endpoint returns when the token fetch itself
- * failed (unreachable URL, rejected credentials, malformed reply).
+ * Throws AuthConfigCheckError on a non-2xx. Note 400 is overloaded — the endpoint returns it
+ * for every way the fetch itself can fail (unreachable URL, refused destination, rejected
+ * credentials, malformed reply), so the status alone does not identify the cause.
  */
 export async function checkProviderAuthConfig(
   target: string | ProviderAuthConfig,
@@ -104,7 +116,7 @@ export async function checkProviderAuthConfig(
     body: JSON.stringify(body),
   });
   if (!response.ok) {
-    throw new Error(`auth-config check returned ${response.status}: ${await response.text()}`);
+    throw new AuthConfigCheckError(response.status, await response.text());
   }
   return (await response.json()) as { lifetime_seconds: number };
 }

--- a/tests_end_to_end/e2e/core/provider-keys.ts
+++ b/tests_end_to_end/e2e/core/provider-keys.ts
@@ -86,12 +86,22 @@ export async function deleteProviderKeyByName(providerName: string): Promise<voi
   }
 }
 
-/** Server-side connection check; resolves __SECRET__ sentinels via provider_id. */
-export async function checkProviderAuthConfig(providerId: string): Promise<{ lifetime_seconds: number }> {
+/**
+ * Server-side connection check: the BACKEND performs the token fetch. Passing a provider id
+ * tests the stored recipe (resolving __SECRET__ sentinels); passing an auth_config tests
+ * submitted values without needing a stored provider at all.
+ * Throws on a non-2xx — notably 400, which the endpoint returns when the token fetch itself
+ * failed (unreachable URL, rejected credentials, malformed reply).
+ */
+export async function checkProviderAuthConfig(
+  target: string | ProviderAuthConfig,
+): Promise<{ lifetime_seconds: number }> {
+  const body =
+    typeof target === 'string' ? { provider_id: target } : { auth_config: target };
   const response = await fetch(endpoint('/auth-config/test'), {
     method: 'POST',
     headers: restHeaders(),
-    body: JSON.stringify({ provider_id: providerId }),
+    body: JSON.stringify(body),
   });
   if (!response.ok) {
     throw new Error(`auth-config check returned ${response.status}: ${await response.text()}`);

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-dialog.spec.ts
@@ -3,6 +3,7 @@ import { ConfigurationPage } from '@e2e/pom/configuration.page';
 import {
   MOCK_AUTH_CLIENT_ID,
   MOCK_AUTH_CLIENT_SECRET,
+  mockAuthSkipReason,
   mockGatewayUrlForBackend,
   mockTokenUrlForBackend,
 } from '@e2e/core/mock-auth';
@@ -20,6 +21,13 @@ const SECRET_SENTINEL = '__SECRET__';
  * seeded and torn down by the providerKeys fixture.
  */
 test.describe('AI Providers — OAuth2 token auth', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
+  // Every test here needs the backend itself to reach the mock; without that they would all
+  // fail on a missing success toast, hiding a deployment misconfiguration behind a UI symptom.
+  test.beforeAll(async () => {
+    const reason = await mockAuthSkipReason();
+    test.skip(reason !== null, reason ?? '');
+  });
+
   test('configure with test connection, persist the recipe masked', { tag: ['@cap:configuration.ai-provider-add'] }, async ({
     page,
     testNamespace,

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@e2e/fixtures';
 import { PlaygroundPage } from '@e2e/pom/playground.page';
-import { mockAuthRevokeAll, mockAuthStats } from '@e2e/core/mock-auth';
+import { mockAuthRevokeAll, mockAuthSkipReason, mockAuthStats } from '@e2e/core/mock-auth';
 
 /**
  * Reactive token refetch (OPIK-7940): when the gateway rejects a cached bearer
@@ -14,6 +14,13 @@ import { mockAuthRevokeAll, mockAuthStats } from '@e2e/core/mock-auth';
  * exercises the same transparent retry and still passes.
  */
 test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smoke', '@area:configuration'] }, () => {
+  // The refetch is asserted through the mock's own counters, so a backend that cannot reach
+  // the mock would report zero refusals rather than a connectivity problem.
+  test.beforeAll(async () => {
+    const reason = await mockAuthSkipReason();
+    test.skip(reason !== null, reason ?? '');
+  });
+
   test('a revoked token is transparently refetched and the request retried', { tag: ['@cap:configuration.ai-provider-token-refetch'] }, async ({
     page,
     project,


### PR DESCRIPTION
## Details

The OAuth2 token-auth e2e specs need the **Opik backend** — not the test process — to reach the hermetic mock token service that Playwright spawns on the host. When the backend runs in docker-compose and `MOCK_AUTH_URL_FOR_BACKEND` is unset, the suite's default `localhost:9878` resolves to the container's own loopback, so every server-side token fetch fails and all four specs die on a missing "Connection successful" toast. That reads as a product regression when it is a deployment misconfiguration.

This adds a fail-fast precondition: probe the backend's own `/auth-config/test` endpoint (which performs the token fetch server-side, and accepts a bare `auth_config` so no provider key is needed) and skip with a reason that names the actual cause.

- Skips on exactly two outcomes: **404** (deployment predates the endpoint) and a **400** whose body reads as an unreachable or SSRF-guard-refused destination.
- Every other probe failure propagates and fails the setup — 401/403 (the `AI_PROVIDER_UPDATE` permission check), 422, 500, and also the *other* 400s. `400` is overloaded: per `AuthTokenProvider` it also covers rejected credentials and malformed replies, which mean the mock or the seeded credentials are broken. Skipping on those would hide the class of bug this suite exists to catch.
- `checkProviderAuthConfig` throws a typed `AuthConfigCheckError` carrying `status`/`body`, so classification keys on the status code rather than substring-matching prose, and accepts either a provider id or an `auth_config` (the endpoint's two documented modes).
- Treats an empty `MOCK_AUTH_URL*` as unset (`||` rather than `??`), since a CI `${{ … || '' }}` expression yields `""` rather than omitting the variable.

Observed in Allure launch 100777 (Critical User Journeys daily run). The launcher-side fix is comet-ml/comet-automation-tests#357; this PR makes the suite diagnose the condition instead of failing opaquely on it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7940

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Investigated the failing launch, wrote the reachability gate and the `checkProviderAuthConfig` signature change, ran the verification below.
- Human verification: Diagnosis confirmed against the launch's own DOM snapshot and workflow sources; diff and test outcomes reviewed by the author.

## Testing

Exact commands (from `tests_end_to_end/e2e/`):

```bash
npx tsc --noEmit -p tsconfig.json
```
```bash
npx playwright test tests/ai-providers/ --grep @t1-smoke --reporter=line --workers=2
```

Scenarios validated:

- **Typecheck** — clean (exit 0).
- **Collection** — `--list` still reports all 5 tests in 2 files, so the gate hides no tests.
- **Classification matrix** — 12 cases over the backend's real wordings: 404 → skip; the three unreachable/guard-refused 400s → skip; rejected-credentials, non-JSON, missing-field, and no-auth_config 400s → throw; 401, 403, 422, 500 → throw. All 12 as expected.
- **Skips correctly (real deployment)** — against a live dockerized Opik whose image predates `/auth-config/test`, the specs report `5 skipped` (exit 0) instead of 4 opaque failures, with reason `deployment has no /auth-config/test endpoint, so dynamic token auth is unavailable`.
- **Fails loudly (unreachable API)** — with `OPIK_BASE_URL` at a dead port the run exits **1** rather than skipping. This is the case an earlier revision got wrong, and it is what the review thread caught.
- **Empty-var fallback** — `MOCK_AUTH_URL_FOR_BACKEND=` resolves to `http://localhost:9878/oauth/token`, not a bare path.
- **Lint** — `pre-commit run --files <changed files>` exits 0.

Not run: the specs' own happy path (green token-auth assertions). The only Opik instance available locally predates the `/auth-config/test` endpoint, so the pass-through branch of the gate could not be exercised here; it is covered by the existing post-merge workflow, where these specs already pass.

Environment: macOS, Docker Compose Opik (backend + frontend on `localhost:5173`), Playwright chromium.

## Documentation

No user-facing behavior change; the reasoning is captured in `core/mock-auth.ts`.
