### PR TITLE
[NA] [BE][FE] feat: enable agentic tools everywhere by removing its feature toggle

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -1507,10 +1507,6 @@ serviceToggles:
   # Default: false
   # Description: Whether the project homepage is enabled. When false, the Ollie page is the default project page.
   projectHomepageEnabled: ${TOGGLE_PROJECT_HOMEPAGE_ENABLED:-"false"}
-  # Default: false
-  # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring. When false, the
-  #   inline path is used regardless of context size. Threshold lives under onlineScoring.agenticToolsThresholdTokens.
-  agenticToolsEnabled: ${TOGGLE_AGENTIC_TOOLS_ENABLED:-"false"}
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces/spans.
   #   When on, each evaluation produces one trace (source=evaluator) with one llm span per LLM round, so cost and

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -65,12 +65,14 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
     protected final OnlineScoringConfig onlineScoringConfig;
     protected final FeedbackScoreService feedbackScoreService;
     protected final TraceService traceService;
+    protected final SpanService spanService;
     protected final AutomationRuleEvaluatorType type;
 
     protected OnlineScoringBaseScorer(@NonNull @Config OnlineScoringConfig config,
             @NonNull RedissonReactiveClient redisson,
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull TraceService traceService,
+            @NonNull SpanService spanService,
             @NonNull AutomationRuleEvaluatorType type,
             @NonNull String metricsBaseName) {
         super(OnlineScoringStreamConfigurationAdapter.create(config, type),
@@ -81,6 +83,7 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
         this.onlineScoringConfig = config;
         this.feedbackScoreService = feedbackScoreService;
         this.traceService = traceService;
+        this.spanService = spanService;
         this.type = type;
     }
 
@@ -103,8 +106,8 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
      * <p>Shared by both trace-thread scorers so the sentinel semantics and the recovery boundary cannot
      * drift apart between them.
      */
-    protected Mono<Long> spansSizeOrUnavailable(@NonNull SpanService spanService, @NonNull Set<UUID> traceIds,
-            String workspaceId, String userName, String threadId) {
+    protected Mono<Long> spansSizeOrUnavailable(Set<UUID> traceIds, String workspaceId, String userName,
+            String threadId) {
         return spanService.getSpansSizeByTraceIds(traceIds)
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.WORKSPACE_ID, workspaceId)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.filter.Operator;
 import com.comet.opik.api.filter.TraceField;
 import com.comet.opik.api.filter.TraceFilter;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceSearchCriteria;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
@@ -27,6 +28,7 @@ import ru.vyarus.dropwizard.guice.module.yaml.bind.Config;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -80,6 +82,38 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
         this.feedbackScoreService = feedbackScoreService;
         this.traceService = traceService;
         this.type = type;
+    }
+
+    /**
+     * Sentinel emitted by {@link #spansSizeOrUnavailable} when the span-size aggregate could not be
+     * computed. Deliberately distinct from a genuine {@code 0} bytes so callers can skip the bounded
+     * preload on this path: without a size there is no way to tell a small thread from one that would
+     * blow the heap, and an aggregate that just failed is itself a reason not to follow it with a bulk
+     * fetch. See OPIK-7454.
+     */
+    protected static final long SPAN_SIZE_UNAVAILABLE = -1L;
+
+    /**
+     * The thread's span size from the cheap ClickHouse aggregate, with sizing treated as <em>advisory</em>
+     * rather than a prerequisite. Letting a failure propagate would abort the caller's chain, and
+     * {@link BaseRedisSubscriber} would retry {@code maxRetries} times and then acknowledge the message —
+     * permanently dropping the evaluation. On failure this emits {@link #SPAN_SIZE_UNAVAILABLE} instead, so
+     * the caller can route conservatively and still score.
+     *
+     * <p>Shared by both trace-thread scorers so the sentinel semantics and the recovery boundary cannot
+     * drift apart between them.
+     */
+    protected Mono<Long> spansSizeOrUnavailable(@NonNull SpanService spanService, @NonNull Set<UUID> traceIds,
+            String workspaceId, String userName, String threadId) {
+        return spanService.getSpansSizeByTraceIds(traceIds)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.USER_NAME, userName))
+                .onErrorResume(error -> {
+                    log.warn("Span-size aggregate failed for thread '{}'; scoring without span enrichment",
+                            threadId, error);
+                    return Mono.just(SPAN_SIZE_UNAVAILABLE);
+                });
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -110,8 +110,8 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
                         .put(RequestContext.WORKSPACE_ID, workspaceId)
                         .put(RequestContext.USER_NAME, userName))
                 .onErrorResume(error -> {
-                    log.warn("Span-size aggregate failed for thread '{}'; scoring without span enrichment",
-                            threadId, error);
+                    log.warn("Span-size aggregate failed for workspace '{}' and thread '{}'; scoring without"
+                            + " span enrichment", workspaceId, threadId, error);
                     return Mono.just(SPAN_SIZE_UNAVAILABLE);
                 });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -279,12 +279,10 @@ public class OnlineScoringEngine {
      * See {@link #injectSpecialVariable} for the shared substitution mechanics; the tree is serialized
      * lazily, only when the sentinel is actually referenced.
      *
-     * <p>An empty spans list still triggers the rewrite (rendering as {@code "[]"}).
-     * <strong>Intentionally not gated by {@code isAgenticToolsEnabled}</strong>: when the toggle is off,
-     * the scorer skips the spans fetch and threads an empty list here, which still rewrites
-     * sentinel-mapped variables to {@code "[]"}. Gating this would resurrect the bare-word leak for rules
-     * whose variables map still carries the sentinel from before the toggle flipped. See
-     * {@code OnlineScoringLlmAsJudgeScorer.shouldFetchSpans} for the full toggle-semantics rationale.
+     * <p>An empty spans list still triggers the rewrite (rendering as {@code "[]"}). The rewrite is
+     * deliberately unconditional: skipping it would let the sentinel value {@code "spans"} leak through
+     * {@code toReplacements}' literal-value fallback and render the bare word in the prompt. See
+     * {@code OnlineScoringLlmAsJudgeScorer.shouldFetchSpans} for when the fetch itself is skipped.
      */
     private static void injectSpansIntoReplacements(
             Map<String, String> replacements, Map<String, String> variables,
@@ -405,25 +403,6 @@ public class OnlineScoringEngine {
             @NonNull Span span,
             @NonNull StructuredOutputStrategy structuredOutputStrategy) {
         var renderedMessages = renderMessages(evaluatorCode.messages(), evaluatorCode.variables(), span);
-        return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
-    }
-
-    /**
-     * Inline variant that injects the pre-built {@code {{span}}} structure (span id + the span's own
-     * attachment {@code file_name}s) without capping — used by the span scorer when a rule references
-     * {@code {{span}}} but the provider can't call tools, so the variable still renders the structure
-     * instead of the bare word "span". Span templates always render with {@link PromptType#MUSTACHE}.
-     */
-    public static ChatRequest prepareSpanLlmRequest(
-            @NonNull AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode evaluatorCode,
-            @NonNull Span span,
-            @NonNull StructuredOutputStrategy structuredOutputStrategy,
-            String spanStructureJson) {
-        Map<String, String> replacements = toReplacements(evaluatorCode.variables(), span);
-        injectSpanIntoReplacements(replacements, evaluatorCode.variables(),
-                evaluatorCode.messages(), PromptType.MUSTACHE, spanStructureJson);
-        var renderedMessages = renderMessagesWithReplacements(evaluatorCode.messages(), replacements,
-                PromptType.MUSTACHE);
         return buildChatRequest(renderedMessages, evaluatorCode.schema(), structuredOutputStrategy);
     }
 
@@ -590,9 +569,10 @@ public class OnlineScoringEngine {
         Map<String, String> replacements = variablesMap.keySet().stream()
                 .map(variableName -> switch (variableName) {
                     case TraceThreadLlmAsJudgeCode.CONTEXT_VARIABLE_NAME -> {
-                        // Always use the enriched shape — when `spans` is empty (toggle off),
-                        // the `spans` field is omitted via @JsonInclude(NON_NULL) and the
-                        // JSON is wire-identical to today's [{role, content}, ...] shape.
+                        // Always use the enriched shape — when `spans` is empty (the tools path
+                        // renders no inline spans), the `spans` field is omitted via
+                        // @JsonInclude(NON_NULL) and the JSON is wire-identical to the legacy
+                        // [{role, content}, ...] shape.
                         try {
                             yield MessageVariableMapping.builder()
                                     .variableName(variableName)

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -78,7 +78,6 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
     private final TestSuiteAssertionCounterService testSuiteAssertionCounterService;
-    private final SpanService spanService;
     private final AgenticScoringService agenticScoringService;
     private final TraceCompressor traceCompressor;
     private final WorkspaceNameService workspaceNameService;
@@ -104,13 +103,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             @NonNull OpikConfiguration opikConfiguration,
             @NonNull OnlineEvaluationRecorder onlineEvaluationRecorder,
             @NonNull AttachmentService attachmentService) {
-        super(config, redisson, feedbackScoreService, traceService,
+        super(config, redisson, feedbackScoreService, traceService, spanService,
                 LLM_AS_JUDGE, Constants.LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringLlmAsJudgeScorer.class);
         this.llmProviderFactory = llmProviderFactory;
         this.testSuiteAssertionCounterService = testSuiteAssertionCounterService;
-        this.spanService = spanService;
         this.agenticScoringService = agenticScoringService;
         this.traceCompressor = traceCompressor;
         this.workspaceNameService = workspaceNameService;
@@ -526,6 +524,13 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      *       {@link OnlineScoringEngine#templateReferencesSpans} for both opt-in shapes
      *       (sentinel-valued variable AND implicit template reference).
      * </ul>
+     *
+     * <p><strong>Deliberately broader than {@link #shouldUseAgenticTools}</strong>, which also weighs
+     * the experimentId branch ({@link LlmAsJudgeToolsMode#shouldUseTools}), the size threshold and
+     * {@code {{trace}}}. Those cannot be consulted here: the size estimate is computed <em>from</em> the
+     * fetched spans, so the pre-fetch necessarily precedes the routing decision it feeds. Narrowing this
+     * gate to the experimentId branch would starve the two triggers that depend on the estimate — a trace
+     * over the token threshold would take the tools path with an unseeded read-tool cache.
      *
      * <p>This gates the {@code spanService.getByTraceIds} I/O only, not the substitution:
      * {@link OnlineScoringEngine#injectSpansIntoReplacements} runs unconditionally inside

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -607,8 +607,8 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                             + " (OpenAI / Anthropic / Gemini / OpenRouter / Vertex / Bedrock).",
                     message.trace().id(), modelName);
         } else if (!experimentIdPath && !overSizeThreshold && referencesTrace && useTools) {
-            log.debug("Trace '{}' rule references {{trace}}; switching to agentic-tools mode",
-                    message.trace().id());
+            log.debug("Agentic tools routing: rule references {{trace}}; switching to agentic-tools mode."
+                    + " traceId='{}'", message.trace().id());
         }
 
         recordRoutingDecision(message, useTools, experimentIdPath, overSizeThreshold, referencesTrace);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorer.java
@@ -181,10 +181,9 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                 UserLog.RULE_ID, message.ruleId().toString());
 
         // Spans are fetched here, in the reactive chain, only when they'll actually be consumed
-        // downstream — either to pre-seed the agentic-tools cache (provider supports tools AND
-        // experimentId branch OR size-based toggle is on) OR to substitute into a {{spans}}
-        // template variable on the inline path (sentinel: any variable mapped to the bare
-        // string "spans"). Skip the I/O otherwise. Keeping the fetch reactive and out of
+        // downstream — either to pre-seed the agentic-tools cache (provider supports tools) OR to
+        // substitute into a {{spans}} template variable on the inline path (sentinel: any variable
+        // mapped to the bare string "spans"). Skip the I/O otherwise. Keeping the fetch reactive and out of
         // evaluate() avoids the .block() pattern that pinned a workersScheduler thread for the
         // upstream wait (OPIK-6308).
         Mono<List<Span>> spansMono = shouldFetchSpans(message)
@@ -197,13 +196,11 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
 
         // Presence of the {{trace}} variable is the declarative agentic trigger: it injects the
         // trace structure (trace id, span ids, attachment file_names) into the prompt so the judge
-        // can call get_attachment with real ids instead of guessing. Gated by the agentic-tools
-        // toggle, same as the size-based path.
-        boolean referencesTrace = serviceTogglesConfig.isAgenticToolsEnabled()
-                && OnlineScoringEngine.templateReferencesTraceStructure(
-                        message.llmAsJudgeCode().messages(),
-                        message.llmAsJudgeCode().variables(),
-                        message.promptType());
+        // can call get_attachment with real ids instead of guessing.
+        boolean referencesTrace = OnlineScoringEngine.templateReferencesTraceStructure(
+                message.llmAsJudgeCode().messages(),
+                message.llmAsJudgeCode().variables(),
+                message.promptType());
 
         // Monitoring recorder for the evaluation loop (OPIK-6994): one hidden source=evaluator trace per
         // evaluation, one llm span per LLM round. NOOP when the toggle is off — the evaluation then runs
@@ -522,57 +519,41 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
      * Routing decision for whether to fetch the trace's spans before running the LLM call.
      * Spans are needed in two cases:
      * <ul>
-     *   <li>The agentic-tools path is possible (provider supports tools AND the experimentId
-     *       branch is on OR the size-based toggle is enabled) — spans pre-seed the read-tool
-     *       cache so the in-loop {@code get_trace_spans} call doesn't redo the fetch.
-     *   <li>The inline prompt template references {@code {{spans}}} — see
+     *   <li>The provider supports tool-calling, so the agentic-tools path is possible — spans
+     *       pre-seed the read-tool cache so the in-loop {@code get_trace_spans} call doesn't
+     *       redo the fetch.
+     *   <li>The inline prompt template references {@code {{spans}}} or {@code {{trace}}} — see
      *       {@link OnlineScoringEngine#templateReferencesSpans} for both opt-in shapes
-     *       (sentinel-valued variable AND implicit template reference). <strong>Gated by
-     *       {@code isAgenticToolsEnabled}</strong>: both pathways ship under the same flag.
+     *       (sentinel-valued variable AND implicit template reference).
      * </ul>
      *
-     * <p><strong>Toggle semantics — important and not symmetric:</strong> this method gates
-     * the {@code spanService.getByTraceIds} I/O. It does <em>not</em> gate the substitution
-     * itself — {@link OnlineScoringEngine#injectSpansIntoReplacements} runs unconditionally
-     * inside {@code prepareLlmRequest}. When the toggle is off and a rule still carries a
-     * sentinel-mapped {@code spans} variable (e.g. saved by an older FE before the toggle
-     * flipped), {@code {{spans}}} renders as the empty JSON array {@code []} via the empty
-     * spans list threaded through. We do <em>not</em> gate the substitution because doing so
-     * would let the sentinel value {@code "spans"} leak through {@code toReplacements}'
-     * literal-value fallback and render the bare word {@code spans} in the prompt — worse
-     * UX than {@code []}. Net behavior with toggle off:
-     * <ul>
-     *   <li>Existing rules with sentinel mapping → {@code Spans: []}
-     *   <li>New rules created via the FE → FE skips the auto-fill, user maps {@code spans}
-     *       like any other variable, BE renders whatever path they pick.
-     *   <li>Experiment-id (test-suite assertion) path → agentic-tools fires regardless, so
-     *       spans are still fetched and {@code {{spans}}} substitutes the actual JSON.
-     * </ul>
+     * <p>This gates the {@code spanService.getByTraceIds} I/O only, not the substitution:
+     * {@link OnlineScoringEngine#injectSpansIntoReplacements} runs unconditionally inside
+     * {@code prepareLlmRequest}, so a trace whose spans were not fetched renders {@code {{spans}}}
+     * as the empty JSON array {@code []} rather than leaking the bare sentinel word {@code spans}
+     * through {@code toReplacements}' literal-value fallback.
      */
     // Package-private for unit tests.
     boolean shouldFetchSpans(TraceToScoreLlmAsJudge message) {
         String modelName = message.llmAsJudgeCode().model().name();
         boolean agenticToolsPathPossible = agenticScoringService.supportsToolCalling(
-                llmProviderFactory.getLlmProvider(modelName))
-                && (LlmAsJudgeToolsMode.shouldUseTools(message)
-                        || serviceTogglesConfig.isAgenticToolsEnabled());
-        boolean templateNeedsSpans = serviceTogglesConfig.isAgenticToolsEnabled()
-                && (OnlineScoringEngine.templateReferencesSpans(
+                llmProviderFactory.getLlmProvider(modelName));
+        boolean templateNeedsSpans = OnlineScoringEngine.templateReferencesSpans(
+                message.llmAsJudgeCode().messages(),
+                message.llmAsJudgeCode().variables(),
+                message.promptType())
+                || OnlineScoringEngine.templateReferencesTraceStructure(
                         message.llmAsJudgeCode().messages(),
                         message.llmAsJudgeCode().variables(),
-                        message.promptType())
-                        || OnlineScoringEngine.templateReferencesTraceStructure(
-                                message.llmAsJudgeCode().messages(),
-                                message.llmAsJudgeCode().variables(),
-                                message.promptType()));
+                        message.promptType());
         return agenticToolsPathPossible || templateNeedsSpans;
     }
 
     /**
      * Routing decision for whether to attach tool specs + run the tool-call loop. Tools fire
      * when ANY of (a) the experimentId-driven branch applies (test-suite assertion), (b) the
-     * size-based branch applies (toggle on, context above threshold), or (c) the prompt references
-     * the {@code {{trace}}} skeleton variable (toggle on) — AND the provider supports tool-calling.
+     * context is above the size threshold, or (c) the prompt references the {@code {{trace}}}
+     * skeleton variable — AND the provider supports tool-calling.
      * Without the provider check, a non-tool-calling model (Ollama / Custom / OpikFree) selected
      * via {@code test_suite_model} metadata would crash inside the LangChain4j chat call when the
      * request carries {@code toolSpecifications}.
@@ -590,13 +571,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
         boolean experimentIdPath = LlmAsJudgeToolsMode.shouldUseTools(message);
         boolean providerSupportsTools = agenticScoringService.supportsToolCalling(
                 llmProviderFactory.getLlmProvider(modelName));
-        boolean overSizeThreshold = serviceTogglesConfig.isAgenticToolsEnabled()
-                && estimatedContextTokens >= onlineScoringConfig.getAgenticToolsThresholdTokens();
+        boolean overSizeThreshold = estimatedContextTokens >= onlineScoringConfig
+                .getAgenticToolsThresholdTokens();
         // The {{trace}} variable forces the agentic-tools path regardless of context size: the prompt
         // carries the trace skeleton (ids + attachment file_names) and the judge uses get_attachment /
-        // read to drill in. Gated by the same toggle as the size path.
-        boolean traceVariablePath = serviceTogglesConfig.isAgenticToolsEnabled() && referencesTrace;
-        boolean wantsTools = experimentIdPath || overSizeThreshold || traceVariablePath;
+        // read to drill in.
+        boolean wantsTools = experimentIdPath || overSizeThreshold || referencesTrace;
         boolean useTools = wantsTools && providerSupportsTools;
 
         if (experimentIdPath && !providerSupportsTools) {
@@ -615,7 +595,7 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
             userFacingLogger.info(
                     "Trace context exceeds '{}' tokens; switching to agentic-tools mode for traceId '{}'",
                     onlineScoringConfig.getAgenticToolsThresholdTokens(), message.trace().id());
-        } else if (!experimentIdPath && !overSizeThreshold && traceVariablePath && !providerSupportsTools) {
+        } else if (!experimentIdPath && !overSizeThreshold && referencesTrace && !providerSupportsTools) {
             // Surface to the user: their prompt references {{trace}} (so they expect tool-driven
             // inspection of the trace skeleton / attachments) but the chosen model's provider can't
             // call tools — an actionable misconfiguration, unlike the purely-internal routing
@@ -626,12 +606,12 @@ public class OnlineScoringLlmAsJudgeScorer extends OnlineScoringBaseScorer<Trace
                             + " skeleton or load attachments. Pick a tool-calling provider"
                             + " (OpenAI / Anthropic / Gemini / OpenRouter / Vertex / Bedrock).",
                     message.trace().id(), modelName);
-        } else if (!experimentIdPath && !overSizeThreshold && traceVariablePath && useTools) {
+        } else if (!experimentIdPath && !overSizeThreshold && referencesTrace && useTools) {
             log.debug("Trace '{}' rule references {{trace}}; switching to agentic-tools mode",
                     message.trace().id());
         }
 
-        recordRoutingDecision(message, useTools, experimentIdPath, overSizeThreshold, traceVariablePath);
+        recordRoutingDecision(message, useTools, experimentIdPath, overSizeThreshold, referencesTrace);
         return useTools;
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -51,9 +51,9 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
  * evaluator's message templates with values from the Span and prepares the structured-output schema.
  *
  * <p>By default scoring is inline (template variables substituted, one LLM call). When a rule's prompt
- * references the {@code {{span}}} structure variable (and the {@code agentic_tools} toggle is on and the
- * provider supports tool-calling), the scorer instead injects a compact span structure (span id + the
- * span's own attachment {@code file_name}s) and runs the agentic tool loop, so the judge can call
+ * references the {@code {{span}}} structure variable (and the provider supports tool-calling), the
+ * scorer instead injects a compact span structure (span id + the span's own attachment
+ * {@code file_name}s) and runs the agentic tool loop, so the judge can call
  * {@code get_attachment(type=span, ...)} / {@code read} / {@code jq} to load and inspect the span's
  * attachments. Span-level analogue of the {@code {{trace}}} path in {@link OnlineScoringLlmAsJudgeScorer}.
  */
@@ -117,18 +117,13 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                 UserLog.SPAN_ID, span.id().toString(),
                 UserLog.RULE_ID, message.ruleId().toString());
 
-        // The {{span}} variable is the declarative agentic trigger. Detection is independent of the
-        // agentic-tools toggle so the variable is always substituted (never leaking the bare "span"
-        // sentinel as a literal):
-        //   - toggle ON  → build the real span structure (span id + attachment file_names); if the
-        //                  provider supports tools, run the agentic loop so the judge can get_attachment.
-        //   - toggle OFF → skip the attachment fetch and inject a null structure, so {{span}} renders as
-        //                  "{}" inline (handled by the inline branch in prepareEvaluation).
+        // The {{span}} variable is the declarative agentic trigger: it builds the real span structure
+        // (span id + attachment file_names) and, when the provider supports tools, runs the agentic loop
+        // so the judge can call get_attachment.
         boolean referencesSpan = OnlineScoringEngine.templateReferencesSpanStructure(
                 message.llmAsJudgeCode().messages(),
                 message.llmAsJudgeCode().variables(),
                 PromptType.MUSTACHE);
-        boolean agenticToolsEnabled = serviceTogglesConfig.isAgenticToolsEnabled();
 
         // Monitoring recorder (OPIK-6994): one hidden source=evaluator trace per span evaluation with an
         // llm span for the scoring call. NOOP when the toggle is off — no extra writes.
@@ -137,10 +132,10 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                         message.llmAsJudgeCode().model().name(), message.workspaceId(), message.userName())
                 : EvaluationRecorder.NOOP;
 
-        Mono<List<FeedbackScoreBatchItem>> scoresMono = (referencesSpan && agenticToolsEnabled)
+        Mono<List<FeedbackScoreBatchItem>> scoresMono = referencesSpan
                 ? buildSpanStructure(span, message)
                         .flatMap(structure -> evaluate(message, structure, true, mdc, recorder))
-                : evaluate(message, null, referencesSpan, mdc, recorder);
+                : evaluate(message, null, false, mdc, recorder);
 
         return recorder.monitor(scoresMono)
                 .flatMap(scores -> storeSpanScores(scores, span, message.userName(), message.workspaceId()))
@@ -238,14 +233,13 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             userFacingLogger.info("Evaluating spanId '{}' sampled by rule '{}'", span.id(), message.ruleName());
 
             String modelName = message.llmAsJudgeCode().model().name();
-            boolean agenticToolsEnabled = serviceTogglesConfig.isAgenticToolsEnabled();
             boolean providerSupportsTools = agenticScoringService.supportsToolCalling(
                     llmProviderFactory.getLlmProvider(modelName));
-            // Tools require the {{span}} trigger AND the agentic-tools toggle AND a tool-calling provider.
-            // The {{span}} substitution itself is independent of tools — see the inline branch below.
-            boolean useTools = referencesSpan && agenticToolsEnabled && providerSupportsTools;
+            // Tools require the {{span}} trigger AND a tool-calling provider. The {{span}} substitution
+            // itself is independent of tools — see the inline branch below.
+            boolean useTools = referencesSpan && providerSupportsTools;
 
-            if (referencesSpan && agenticToolsEnabled && !providerSupportsTools) {
+            if (referencesSpan && !providerSupportsTools) {
                 // Actionable misconfiguration: the prompt references {{span}} (so the user expects
                 // tool-driven inspection / attachment loading) but the chosen model's provider can't
                 // call tools. We still inject the structure inline so the judge at least sees the ids.
@@ -261,10 +255,8 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             try {
                 if (useTools) {
                     requests = buildToolCallingRequests(message, span, modelName, spanStructureJson);
-                } else if (referencesSpan && spanStructureJson != null) {
-                    requests = buildInlineStructureRequests(message, span, modelName, spanStructureJson);
                 } else if (referencesSpan) {
-                    requests = buildSentinelStructureRequests(message, span, modelName, spanStructureJson);
+                    requests = buildInlineStructureRequests(message, span, modelName, spanStructureJson);
                 } else {
                     requests = buildPlainRequests(message, span, modelName);
                 }
@@ -291,7 +283,7 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     }
 
     /**
-     * {@code useTools}: {{span}} + agentic tools + tool-calling provider. The tool-loop request uses the
+     * {@code useTools}: {{span}} + a tool-calling provider. The tool-loop request uses the
      * soft InstructionStrategy; the wrap-up uses the provider-native structured-output strategy (same
      * asymmetry as the trace scorer — Anthropic in particular returns prose at the wrap-up turn under
      * InstructionStrategy).
@@ -318,8 +310,9 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
     }
 
     /**
-     * Inline fallback: {{span}} on a non-tool-calling provider (toggle ON, real structure). No read/jq
-     * tools to drill in, so cap the substitutions to bound the context window — otherwise a large span
+     * Inline fallback: {{span}} on a non-tool-calling provider, so the real structure is injected
+     * inline. No read/jq tools to drill in, so cap the substitutions to bound the context window —
+     * otherwise a large span
      * would inject uncapped and could overflow the model's context. No drill-down hint: the model can't
      * act on one, so over-cap values are just truncated.
      */
@@ -329,19 +322,6 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
                 message.llmAsJudgeCode(), span,
                 llmProviderFactory.getStructuredOutputStrategy(modelName),
                 onlineScoringConfig.getMaxPromptFieldChars(), INLINE_TRUNCATION_HINT, spanStructureJson);
-        return LlmRequests.builder().score(scoreRequest).structured(scoreRequest).build();
-    }
-
-    /**
-     * Inline path that still injects the {{span}} structure so the variable renders rather than leaking
-     * the bare sentinel. Toggle OFF: spanStructureJson is null → renders "{}" (tiny, no cap needed; user
-     * variables stay uncapped as on the normal inline path).
-     */
-    private LlmRequests buildSentinelStructureRequests(SpanToScoreLlmAsJudge message, Span span,
-            String modelName, String spanStructureJson) {
-        ChatRequest scoreRequest = OnlineScoringEngine.prepareSpanLlmRequest(
-                message.llmAsJudgeCode(), span,
-                llmProviderFactory.getStructuredOutputStrategy(modelName), spanStructureJson);
         return LlmRequests.builder().score(scoreRequest).structured(scoreRequest).build();
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorer.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.resources.v1.events.tools.EntityRef;
 import com.comet.opik.api.resources.v1.events.tools.EntityType;
 import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.domain.evaluation.EvaluationRecorder;
@@ -76,11 +77,13 @@ public class OnlineScoringSpanLlmAsJudgeScorer extends OnlineScoringBaseScorer<S
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull ChatCompletionService aiProxyService,
             @NonNull TraceService traceService,
+            @NonNull SpanService spanService,
             @NonNull LlmProviderFactory llmProviderFactory,
             @NonNull AgenticScoringService agenticScoringService,
             @NonNull AttachmentService attachmentService,
             @NonNull OnlineEvaluationRecorder onlineEvaluationRecorder) {
-        super(config, redisson, feedbackScoreService, traceService, SPAN_LLM_AS_JUDGE, Constants.SPAN_LLM_AS_JUDGE);
+        super(config, redisson, feedbackScoreService, traceService, spanService, SPAN_LLM_AS_JUDGE,
+                Constants.SPAN_LLM_AS_JUDGE);
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.aiProxyService = aiProxyService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringSpanLlmAsJudgeScorer.class);

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.events.SpanToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
@@ -50,8 +51,9 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
             @NonNull RedissonReactiveClient redisson,
             @NonNull FeedbackScoreService feedbackScoreService,
             @NonNull TraceService traceService,
+            @NonNull SpanService spanService,
             @NonNull PythonEvaluatorService pythonEvaluatorService) {
-        super(config, redisson, feedbackScoreService, traceService, SPAN_USER_DEFINED_METRIC_PYTHON,
+        super(config, redisson, feedbackScoreService, traceService, spanService, SPAN_USER_DEFINED_METRIC_PYTHON,
                 Constants.SPAN_USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -68,7 +68,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
     private final AgenticScoringService agenticScoringService;
     private final ServiceTogglesConfig serviceTogglesConfig;
-    private final SpanService spanService;
     private final OnlineEvaluationRecorder onlineEvaluationRecorder;
     private final AttachmentService attachmentService;
 
@@ -87,7 +86,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull SpanService spanService,
             @NonNull OnlineEvaluationRecorder onlineEvaluationRecorder,
             @NonNull AttachmentService attachmentService) {
-        super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_LLM_AS_JUDGE,
+        super(config, redisson, feedbackScoreService, traceService, spanService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
         this.llmProviderFactory = llmProviderFactory;
@@ -96,7 +95,6 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
         this.agenticScoringService = agenticScoringService;
         this.serviceTogglesConfig = serviceTogglesConfig;
-        this.spanService = spanService;
         this.onlineEvaluationRecorder = onlineEvaluationRecorder;
         this.attachmentService = attachmentService;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
@@ -228,8 +226,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         // Sizing is advisory, not a prerequisite — see spansSizeOrUnavailable. Degrading keeps the
         // evaluation alive on the unenriched inline route, matching the best-effort treatment the
         // attachment probe below already gets.
-        var spansSizeMono = spansSizeOrUnavailable(spanService, traceIds, message.workspaceId(),
-                message.userName(), threadId);
+        var spansSizeMono = spansSizeOrUnavailable(traceIds, message.workspaceId(), message.userName(),
+                threadId);
         // Monitoring recorder (OPIK-6994): one hidden evaluator trace per thread evaluation, with an
         // llm span per LLM round and tool spans for the agentic loop. NOOP when the toggle is off.
         // Resolved reactively because the project-name lookup is blocking.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -282,12 +282,16 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     var hasAttachments = tuple.getT3();
 
                     // Estimate the inline prompt size (trace bodies + span content) to route. spanBytes
-                    // comes from the cheap aggregate; the service adds the in-heap trace bodies. An
-                    // unavailable aggregate estimates 0, so routing falls to the attachment trigger alone.
+                    // comes from the cheap aggregate; the service adds the in-heap trace bodies.
+                    //
+                    // When the aggregate is unavailable, still estimate from the trace bodies with
+                    // spanBytes 0 rather than assuming 0 tokens: the bodies are already in heap, so they
+                    // cost nothing to measure, and a thread whose bodies alone clear the threshold must
+                    // still route to tools. Assuming 0 would send exactly those full inline and overflow
+                    // the context window. The estimate is a lower bound in this case, never an over-count.
                     var sizingUnavailable = spanBytes == SPAN_SIZE_UNAVAILABLE;
-                    var estimatedTokens = sizingUnavailable
-                            ? 0
-                            : agenticScoringService.estimateThreadContextTokens(traces, spanBytes);
+                    var estimatedTokens = agenticScoringService.estimateThreadContextTokens(
+                            traces, sizingUnavailable ? 0L : spanBytes);
                     // Fetch spans only for the inline/enriched path: under the routing threshold and no
                     // attachments (attachments force the tools path). Such a thread is small by
                     // construction, so the fetch is bounded; the streaming byte-cap stays a backstop. The

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -60,9 +60,6 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @Slf4j
 public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceThreadToScoreLlmAsJudge> {
 
-    /** Sentinel for a span-size aggregate that could not be computed, distinct from a genuine 0 bytes. */
-    private static final long SPAN_SIZE_UNAVAILABLE = -1L;
-
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
@@ -228,19 +225,11 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         // alone and takes the tools path (skeleton + per-trace ReadTool drill-down) without any bulk
         // fetch. Spans are fetched further down only on the inline path, where the thread is under the
         // threshold by construction.
-        // Sizing is advisory, not a prerequisite: letting an aggregate failure propagate would abort the
-        // zip below, and BaseRedisSubscriber would retry maxRetries times and then acknowledge the
-        // message — permanently dropping the evaluation. Degrade to the unenriched inline route instead,
-        // matching the best-effort treatment the attachment probe below already gets.
-        var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName()))
-                .onErrorResume(error -> {
-                    log.warn("Span-size aggregate failed for thread '{}'; scoring inline without span"
-                            + " enrichment", threadId, error);
-                    return Mono.just(SPAN_SIZE_UNAVAILABLE);
-                });
+        // Sizing is advisory, not a prerequisite — see spansSizeOrUnavailable. Degrading keeps the
+        // evaluation alive on the unenriched inline route, matching the best-effort treatment the
+        // attachment probe below already gets.
+        var spansSizeMono = spansSizeOrUnavailable(spanService, traceIds, message.workspaceId(),
+                message.userName(), threadId);
         // Monitoring recorder (OPIK-6994): one hidden evaluator trace per thread evaluation, with an
         // llm span per LLM round and tool spans for the agentic loop. NOOP when the toggle is off.
         // Resolved reactively because the project-name lookup is blocking.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -60,6 +60,9 @@ import static com.comet.opik.infrastructure.log.LogContextAware.wrapWithMdc;
 @Slf4j
 public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseScorer<TraceThreadToScoreLlmAsJudge> {
 
+    /** Sentinel for a span-size aggregate that could not be computed, distinct from a genuine 0 bytes. */
+    private static final long SPAN_SIZE_UNAVAILABLE = -1L;
+
     private final ChatCompletionService aiProxyService;
     private final Logger userFacingLogger;
     private final LlmProviderFactory llmProviderFactory;
@@ -225,10 +228,19 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         // alone and takes the tools path (skeleton + per-trace ReadTool drill-down) without any bulk
         // fetch. Spans are fetched further down only on the inline path, where the thread is under the
         // threshold by construction.
+        // Sizing is advisory, not a prerequisite: letting an aggregate failure propagate would abort the
+        // zip below, and BaseRedisSubscriber would retry maxRetries times and then acknowledge the
+        // message — permanently dropping the evaluation. Degrade to the unenriched inline route instead,
+        // matching the best-effort treatment the attachment probe below already gets.
         var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName()));
+                        .put(RequestContext.USER_NAME, message.userName()))
+                .onErrorResume(error -> {
+                    log.warn("Span-size aggregate failed for thread '{}'; scoring inline without span"
+                            + " enrichment", threadId, error);
+                    return Mono.just(SPAN_SIZE_UNAVAILABLE);
+                });
         // Monitoring recorder (OPIK-6994): one hidden evaluator trace per thread evaluation, with an
         // llm span per LLM round and tool spans for the agentic loop. NOOP when the toggle is off.
         // Resolved reactively because the project-name lookup is blocking.
@@ -270,15 +282,22 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     var hasAttachments = tuple.getT3();
 
                     // Estimate the inline prompt size (trace bodies + span content) to route. spanBytes
-                    // comes from the cheap aggregate; the service adds the in-heap trace bodies.
-                    var estimatedTokens = agenticScoringService.estimateThreadContextTokens(traces, spanBytes);
+                    // comes from the cheap aggregate; the service adds the in-heap trace bodies. An
+                    // unavailable aggregate estimates 0, so routing falls to the attachment trigger alone.
+                    var sizingUnavailable = spanBytes == SPAN_SIZE_UNAVAILABLE;
+                    var estimatedTokens = sizingUnavailable
+                            ? 0
+                            : agenticScoringService.estimateThreadContextTokens(traces, spanBytes);
                     // Fetch spans only for the inline/enriched path: under the routing threshold and no
                     // attachments (attachments force the tools path). Such a thread is small by
                     // construction, so the fetch is bounded; the streaming byte-cap stays a backstop. The
                     // tools path fetches nothing here — it drills per-trace via ReadTool on demand.
                     var maxPreloadBytes = agenticToolsMaxPreloadBytes();
-                    var fetchSpansForInline = estimatedTokens < onlineScoringConfig
-                            .getAgenticToolsThresholdTokens()
+                    // Skip the preload when sizing is unavailable: without a size we can't tell a small
+                    // thread from one that would blow the heap, and the aggregate failing is itself a
+                    // signal not to follow it with a bulk fetch.
+                    var fetchSpansForInline = !sizingUnavailable
+                            && estimatedTokens < onlineScoringConfig.getAgenticToolsThresholdTokens()
                             && !hasAttachments;
                     var spansMono = fetchSpansForInline
                             ? agenticScoringService.preloadThreadSpansBounded(

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -220,20 +220,15 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private Mono<Void> scoreThread(TraceThreadToScoreLlmAsJudge message, List<Trace> traces, UUID threadModelId,
             String threadId, AutomationRuleEvaluator<?, ?> rule, Map<String, String> mdc) {
         var traceIds = traces.stream().map(Trace::id).collect(Collectors.toSet());
-        // OPIK-7454 — route before fetch. When the flag is on, size the whole thread with a cheap
-        // ClickHouse aggregate (sum of span field lengths) that materializes no spans: a large thread is
-        // detected from this number alone and takes the tools path (skeleton + per-trace ReadTool
-        // drill-down) without any bulk fetch. Spans are fetched further down only on the inline path,
-        // where the thread is under the threshold by construction.
-        //
-        // When the flag is off, size is 0 (no query) and the inline serializer omits the `spans` field
-        // via @JsonInclude(NON_NULL), so the rendered JSON is unchanged.
-        var spansSizeMono = serviceTogglesConfig.isAgenticToolsEnabled()
-                ? spanService.getSpansSizeByTraceIds(traceIds)
-                        .contextWrite(ctx -> ctx
-                                .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                                .put(RequestContext.USER_NAME, message.userName()))
-                : Mono.just(0L);
+        // OPIK-7454 — route before fetch. Size the whole thread with a cheap ClickHouse aggregate (sum
+        // of span field lengths) that materializes no spans: a large thread is detected from this number
+        // alone and takes the tools path (skeleton + per-trace ReadTool drill-down) without any bulk
+        // fetch. Spans are fetched further down only on the inline path, where the thread is under the
+        // threshold by construction.
+        var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                        .put(RequestContext.USER_NAME, message.userName()));
         // Monitoring recorder (OPIK-6994): one hidden evaluator trace per thread evaluation, with an
         // llm span per LLM round and tool spans for the agentic loop. NOOP when the toggle is off.
         // Resolved reactively because the project-name lookup is blocking.
@@ -261,13 +256,12 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         // Check whether any trace in the thread has attachments — if so, force the agentic-tools
         // path regardless of context size (the judge needs get_attachment to fetch them). Best-effort:
         // a transient listing error returns false and falls back to the normal size-based routing.
-        Mono<Boolean> hasAttachmentsMono = serviceTogglesConfig.isAgenticToolsEnabled()
-                ? attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, traceIds)
-                        .onErrorReturn(false)
-                        .contextWrite(ctx -> ctx
-                                .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                                .put(RequestContext.USER_NAME, message.userName()))
-                : Mono.just(false);
+        Mono<Boolean> hasAttachmentsMono = attachmentService
+                .hasAnyAttachmentByEntityIds(EntityType.TRACE, traceIds)
+                .onErrorReturn(false)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                        .put(RequestContext.USER_NAME, message.userName()));
 
         return Mono.zip(recorderMono, spansSizeMono, hasAttachmentsMono)
                 .flatMap(tuple -> {
@@ -275,19 +269,16 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     var spanBytes = tuple.getT2();
                     var hasAttachments = tuple.getT3();
 
-                    // Estimate the inline prompt size (trace bodies + span content) to route; 0 when the
-                    // toggle is off. spanBytes comes from the cheap aggregate; the service adds the in-heap
-                    // trace bodies.
-                    var estimatedTokens = serviceTogglesConfig.isAgenticToolsEnabled()
-                            ? agenticScoringService.estimateThreadContextTokens(traces, spanBytes)
-                            : 0;
-                    // Fetch spans only for the inline/enriched path: toggle on, under the routing threshold,
-                    // and no attachments (attachments force the tools path). Such a thread is small by
+                    // Estimate the inline prompt size (trace bodies + span content) to route. spanBytes
+                    // comes from the cheap aggregate; the service adds the in-heap trace bodies.
+                    var estimatedTokens = agenticScoringService.estimateThreadContextTokens(traces, spanBytes);
+                    // Fetch spans only for the inline/enriched path: under the routing threshold and no
+                    // attachments (attachments force the tools path). Such a thread is small by
                     // construction, so the fetch is bounded; the streaming byte-cap stays a backstop. The
                     // tools path fetches nothing here — it drills per-trace via ReadTool on demand.
                     var maxPreloadBytes = agenticToolsMaxPreloadBytes();
-                    var fetchSpansForInline = serviceTogglesConfig.isAgenticToolsEnabled()
-                            && estimatedTokens < onlineScoringConfig.getAgenticToolsThresholdTokens()
+                    var fetchSpansForInline = estimatedTokens < onlineScoringConfig
+                            .getAgenticToolsThresholdTokens()
                             && !hasAttachments;
                     var spansMono = fetchSpansForInline
                             ? agenticScoringService.preloadThreadSpansBounded(
@@ -317,10 +308,10 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
 
     /**
      * Builds and runs the LLM scoring chain for the thread. Routes through the agentic-tools
-     * branch (skeleton + ReadTool/JqTool/SearchTool drill-down) when the toggle is on AND either
-     * the inline-rendered thread would exceed the configured size threshold OR the thread has
-     * attachments (so the judge can call get_attachment). Provider must support tool-calling and
-     * the template must be text-only. Otherwise the inline path runs unchanged — same shape as today.
+     * branch (skeleton + ReadTool/JqTool/SearchTool drill-down) when either the inline-rendered
+     * thread would exceed the configured size threshold OR the thread has attachments (so the judge
+     * can call get_attachment). Provider must support tool-calling and the template must be
+     * text-only. Otherwise the inline path runs, rendering the enriched {{context}} shape.
      */
     private Mono<List<FeedbackScoreBatchItemThread>> evaluate(TraceThreadToScoreLlmAsJudge message,
             List<Trace> traces, List<Span> spans, int estimatedTokens, boolean hasAttachments,
@@ -399,9 +390,9 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             userFacingLogger.info("Evaluating threadId '{}' sampled by rule '{}'", threadId, rule.getName());
 
             String modelName = message.code().model().name();
-            // estimatedContextTokens was derived up front from the cheap ClickHouse size aggregate (0 when
-            // the toggle is off). shouldUseAgenticTools re-checks the toggle, provider tool-support and
-            // template modality; `spans` is used only to render the inline path (empty on the tools path).
+            // estimatedContextTokens was derived up front from the cheap ClickHouse size aggregate.
+            // shouldUseAgenticTools re-checks the size threshold, provider tool-support and template
+            // modality; `spans` is used only to render the inline path (empty on the tools path).
             boolean useTools = shouldUseAgenticTools(estimatedContextTokens, hasAttachments, modelName,
                     threadId, message.code().messages());
 
@@ -422,8 +413,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
                     structuredRequest = scoreRequest;
                 } else {
                     // Inline path: render {{context}} with the enriched per-assistant `spans`
-                    // shape. When the toggle is off, `spans` is an empty list and the JSON is
-                    // wire-identical to today's [{role, content}, ...].
+                    // shape. When `spans` is empty the JSON is wire-identical to the legacy
+                    // [{role, content}, ...] shape.
                     scoreRequest = OnlineScoringEngine.prepareThreadLlmRequest(message.code(), traces, strategy,
                             spans);
                     structuredRequest = scoreRequest;
@@ -454,7 +445,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
 
     /**
      * Routing decision for whether to attach tool specs + run the tool-call loop for a thread.
-     * Requires the toggle on AND at least one of:
+     * Requires at least one of:
      * <ul>
      *   <li>estimated thread context exceeds the configured token threshold, OR</li>
      *   <li>the thread has attachments (the judge needs get_attachment to fetch them)</li>
@@ -464,12 +455,9 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
      */
     boolean shouldUseAgenticTools(int estimatedContextTokens, boolean hasAttachments, String modelName,
             String threadId, List<LlmAsJudgeMessage> templateMessages) {
-        if (!serviceTogglesConfig.isAgenticToolsEnabled()) {
-            return false;
-        }
         boolean overSizeThreshold = estimatedContextTokens >= onlineScoringConfig.getAgenticToolsThresholdTokens();
-        // Skip the provider lookup when neither trigger is met — most evaluations are toggle-off
-        // or have neither large contexts nor attachments.
+        // Skip the provider lookup when neither trigger is met — most evaluations have neither large
+        // contexts nor attachments.
         if (!overSizeThreshold && !hasAttachments) {
             return false;
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -55,9 +55,6 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         extends
             OnlineScoringBaseScorer<TraceThreadToScoreUserDefinedMetricPython> {
 
-    /** Sentinel for a span-size aggregate that could not be computed, distinct from a genuine 0 bytes. */
-    private static final long SPAN_SIZE_UNAVAILABLE = -1L;
-
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final PythonEvaluatorService pythonEvaluatorService;
     private final TraceThreadService traceThreadService;
@@ -222,18 +219,10 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         // score(...) sees the full call tree.
         var traceIds = traces.stream().map(Trace::id).collect(Collectors.toSet());
         var maxPreloadBytes = agenticToolsMaxPreloadBytes();
-        // Sizing is advisory, not a prerequisite: letting an aggregate failure propagate would abort the
-        // chain, and BaseRedisSubscriber would retry maxRetries times and then acknowledge the message —
-        // permanently dropping the evaluation. Degrade to the unenriched context instead.
-        var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
-                .contextWrite(ctx -> ctx
-                        .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName()))
-                .onErrorResume(error -> {
-                    log.warn("Span-size aggregate failed for thread '{}'; scoring with the unenriched"
-                            + " context", threadId, error);
-                    return Mono.just(SPAN_SIZE_UNAVAILABLE);
-                });
+        // Sizing is advisory, not a prerequisite — see spansSizeOrUnavailable. Degrading keeps the
+        // evaluation alive with the unenriched context.
+        var spansSizeMono = spansSizeOrUnavailable(spanService, traceIds, message.workspaceId(),
+                message.userName(), threadId);
         return spansSizeMono
                 .flatMap(sizeBytes -> {
                     // Without a size we can't tell a small thread from one that would blow the heap, so

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -55,6 +55,9 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         extends
             OnlineScoringBaseScorer<TraceThreadToScoreUserDefinedMetricPython> {
 
+    /** Sentinel for a span-size aggregate that could not be computed, distinct from a genuine 0 bytes. */
+    private static final long SPAN_SIZE_UNAVAILABLE = -1L;
+
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final PythonEvaluatorService pythonEvaluatorService;
     private final TraceThreadService traceThreadService;
@@ -219,14 +222,24 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         // score(...) sees the full call tree.
         var traceIds = traces.stream().map(Trace::id).collect(Collectors.toSet());
         var maxPreloadBytes = agenticToolsMaxPreloadBytes();
+        // Sizing is advisory, not a prerequisite: letting an aggregate failure propagate would abort the
+        // chain, and BaseRedisSubscriber would retry maxRetries times and then acknowledge the message —
+        // permanently dropping the evaluation. Degrade to the unenriched context instead.
         var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
                 .contextWrite(ctx -> ctx
                         .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName()));
+                        .put(RequestContext.USER_NAME, message.userName()))
+                .onErrorResume(error -> {
+                    log.warn("Span-size aggregate failed for thread '{}'; scoring with the unenriched"
+                            + " context", threadId, error);
+                    return Mono.just(SPAN_SIZE_UNAVAILABLE);
+                });
         return spansSizeMono
                 .flatMap(sizeBytes -> {
-                    var enrich = sizeBytes <= maxPreloadBytes;
-                    if (!enrich) {
+                    // Without a size we can't tell a small thread from one that would blow the heap, so
+                    // an unavailable aggregate skips enrichment rather than risking the bulk fetch.
+                    var enrich = sizeBytes != SPAN_SIZE_UNAVAILABLE && sizeBytes <= maxPreloadBytes;
+                    if (sizeBytes > maxPreloadBytes) {
                         try (var logContext = wrapWithMdc(mdc)) {
                             userFacingLogger.warn("""
                                     Thread span size estimate exceeds the enrichment cap; scoring with the \

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -61,7 +61,6 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
     private final Logger userFacingLogger;
     private final ProjectService projectService;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
-    private final SpanService spanService;
     private final AgenticScoringService agenticScoringService;
 
     @Inject
@@ -77,14 +76,14 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
             @NonNull SpanService spanService,
             @NonNull AgenticScoringService agenticScoringService) {
-        super(config, redisson, feedbackScoreService, traceService, TRACE_THREAD_USER_DEFINED_METRIC_PYTHON,
+        super(config, redisson, feedbackScoreService, traceService, spanService,
+                TRACE_THREAD_USER_DEFINED_METRIC_PYTHON,
                 Constants.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.traceThreadService = traceThreadService;
         this.projectService = projectService;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
-        this.spanService = spanService;
         this.agenticScoringService = agenticScoringService;
         this.userFacingLogger = UserFacingLoggingFactory
                 .getLogger(OnlineScoringTraceThreadUserDefinedMetricPythonScorer.class);
@@ -221,8 +220,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         var maxPreloadBytes = agenticToolsMaxPreloadBytes();
         // Sizing is advisory, not a prerequisite — see spansSizeOrUnavailable. Degrading keeps the
         // evaluation alive with the unenriched context.
-        var spansSizeMono = spansSizeOrUnavailable(spanService, traceIds, message.workspaceId(),
-                message.userName(), threadId);
+        var spansSizeMono = spansSizeOrUnavailable(traceIds, message.workspaceId(), message.userName(),
+                threadId);
         return spansSizeMono
                 .flatMap(sizeBytes -> {
                     // Without a size we can't tell a small thread from one that would blow the heap, so

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -216,19 +216,17 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         // cap. This Python path has no inline-vs-tools routing, so a thread over the cap degrades to the
         // unenriched {role, content} context instead of being buffered in full. When enriched, spans nest
         // under each trace's assistant ChatMessage via fromTraceToThreadEnriched so the user's Python
-        // score(...) sees the full call tree. Toggle off → size 0 (no query) → unenriched, unchanged.
+        // score(...) sees the full call tree.
         var traceIds = traces.stream().map(Trace::id).collect(Collectors.toSet());
         var maxPreloadBytes = agenticToolsMaxPreloadBytes();
-        var spansSizeMono = serviceTogglesConfig.isAgenticToolsEnabled()
-                ? spanService.getSpansSizeByTraceIds(traceIds)
-                        .contextWrite(ctx -> ctx
-                                .put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                                .put(RequestContext.USER_NAME, message.userName()))
-                : Mono.just(0L);
+        var spansSizeMono = spanService.getSpansSizeByTraceIds(traceIds)
+                .contextWrite(ctx -> ctx
+                        .put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                        .put(RequestContext.USER_NAME, message.userName()));
         return spansSizeMono
                 .flatMap(sizeBytes -> {
-                    var enrich = serviceTogglesConfig.isAgenticToolsEnabled() && sizeBytes <= maxPreloadBytes;
-                    if (serviceTogglesConfig.isAgenticToolsEnabled() && !enrich) {
+                    var enrich = sizeBytes <= maxPreloadBytes;
+                    if (!enrich) {
                         try (var logContext = wrapWithMdc(mdc)) {
                             userFacingLogger.warn("""
                                     Thread span size estimate exceeds the enrichment cap; scoring with the \
@@ -273,8 +271,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
 
             Project project = projectService.get(message.projectId(), message.workspaceId());
 
-            // Always use the enriched helper — when `spans` is empty (toggle off, see
-            // scoreThread), it emits the legacy [{role, content}, ...] shape via
+            // Always use the enriched helper — when `spans` is empty (thread over the enrichment
+            // cap, see scoreThread), it emits the legacy [{role, content}, ...] shape via
             // @JsonInclude(NON_NULL) on ChatMessage.spans. When non-empty, the assistant
             // entry for each trace carries the nested span tree.
             List<ChatMessage> context;

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -43,7 +43,6 @@ public class OnlineScoringUserDefinedMetricPythonScorer
 
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final PythonEvaluatorService pythonEvaluatorService;
-    private final SpanService spanService;
     private final Logger userFacingLogger;
 
     @Inject
@@ -54,10 +53,9 @@ public class OnlineScoringUserDefinedMetricPythonScorer
             @NonNull TraceService traceService,
             @NonNull SpanService spanService,
             @NonNull PythonEvaluatorService pythonEvaluatorService) {
-        super(config, redisson, feedbackScoreService, traceService, USER_DEFINED_METRIC_PYTHON,
+        super(config, redisson, feedbackScoreService, traceService, spanService, USER_DEFINED_METRIC_PYTHON,
                 Constants.USER_DEFINED_METRIC_PYTHON);
         this.pythonEvaluatorService = pythonEvaluatorService;
-        this.spanService = spanService;
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringUserDefinedMetricPythonScorer.class);
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/ServiceTogglesConfig.java
@@ -58,8 +58,6 @@ public class ServiceTogglesConfig {
     @JsonProperty
     @NotNull boolean projectHomepageEnabled;
     @JsonProperty
-    @NotNull boolean agenticToolsEnabled;
-    @JsonProperty
     @NotNull boolean onlineScoringTracingEnabled;
 
     @JsonProperty

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineTest.java
@@ -463,7 +463,6 @@ class OnlineScoringEngineTest {
 
         var aiResponse = ChatResponse.builder().aiMessage(AiMessage.aiMessage(aiMessage)).build();
 
-        ArgumentCaptor<List<FeedbackScoreBatchItem>> captor = ArgumentCaptor.forClass(List.class);
         Mockito.doReturn(Mono.empty()).when(feedbackScoreService).scoreBatchOfTraces(Mockito.any());
         Mockito.doReturn(aiResponse).when(aiProxyService).scoreTrace(Mockito.any(), Mockito.any(), Mockito.any());
 
@@ -471,6 +470,10 @@ class OnlineScoringEngineTest {
 
         // Wait longer for async processing to complete (both evaluators need to process)
         Awaitility.await().untilAsserted(() -> {
+            // Fresh captor per poll: a captor hoisted out of this lambda re-captures every prior
+            // invocation on each retry, so getAllValues() grows monotonically (6 → 12 → 18 …) and the
+            // size assertion below can never recover once a single poll lands before scoring finishes.
+            ArgumentCaptor<List<FeedbackScoreBatchItem>> captor = ArgumentCaptor.forClass(List.class);
             // Verify that evaluators were processed
             // We should have at least 1 call to scoreBatchOfTraces
             Mockito.verify(feedbackScoreService, Mockito.atLeastOnce()).scoreBatchOfTraces(captor.capture());
@@ -2377,56 +2380,6 @@ class OnlineScoringEngineTest {
         var allText = request.messages().stream().map(Object::toString).collect(Collectors.joining("\n"));
         assertThat(allText).contains(spanRef);
         // Sentinel literal must not leak into the rendered prompt.
-        assertThat(allText).doesNotContain("{{span}}");
-    }
-
-    @Test
-    @DisplayName("prepareSpanLlmRequest (inline) injects the {{span}} structure without capping")
-    void prepareSpanLlmRequestInlineInjectsSpanStructure() {
-        var evaluatorCode = AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.builder()
-                .model(LlmAsJudgeModelParameters.builder()
-                        .name("gpt-4o").temperature(0.3).build())
-                .messages(List.of(
-                        LlmAsJudgeMessage.builder()
-                                .role(ChatMessageType.USER)
-                                .content("Inspect: {{span}}")
-                                .build()))
-                .variables(new LinkedHashMap<>(Map.of("span", "span")))
-                .schema(List.of())
-                .build();
-        var span = createSpan(generator.generate(), generator.generate());
-        var spanRef = "span-" + RandomStringUtils.secure().nextAlphanumeric(12);
-        var structure = "{\"span_id\":\"%s\",\"attachments\":[]}".formatted(spanRef);
-
-        var request = OnlineScoringEngine.prepareSpanLlmRequest(evaluatorCode, span,
-                new InstructionStrategy(), structure);
-
-        var allText = request.messages().stream().map(Object::toString).collect(Collectors.joining("\n"));
-        assertThat(allText).contains(spanRef);
-        assertThat(allText).doesNotContain("{{span}}");
-    }
-
-    @Test
-    @DisplayName("prepareSpanLlmRequest renders {{span}} as {} when no structure is supplied, not the literal sentinel")
-    void prepareSpanLlmRequestRendersEmptyStructureWhenNull() {
-        var evaluatorCode = AutomationRuleEvaluatorSpanLlmAsJudge.SpanLlmAsJudgeCode.builder()
-                .model(LlmAsJudgeModelParameters.builder()
-                        .name("gpt-4o").temperature(0.3).build())
-                .messages(List.of(
-                        LlmAsJudgeMessage.builder()
-                                .role(ChatMessageType.USER)
-                                .content("Inspect: {{span}}")
-                                .build()))
-                .variables(new LinkedHashMap<>(Map.of("span", "span")))
-                .schema(List.of())
-                .build();
-        var span = createSpan(generator.generate(), generator.generate());
-
-        var request = OnlineScoringEngine.prepareSpanLlmRequest(evaluatorCode, span,
-                new InstructionStrategy(), null);
-
-        var allText = request.messages().stream().map(Object::toString).collect(Collectors.joining("\n"));
-        assertThat(allText).contains("Inspect: {}");
         assertThat(allText).doesNotContain("{{span}}");
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringLlmAsJudgeScorerTest.java
@@ -177,50 +177,34 @@ class OnlineScoringLlmAsJudgeScorerTest {
     class ShouldFetchSpansTests {
 
         // Truth table for the spans-fetch gate. Spans are fetched when EITHER:
-        //   (a) the agentic-tools path is possible (provider supports tools AND (experimentId
-        //       OR isAgenticToolsEnabled)), OR
-        //   (b) the inline {{spans}} template path applies — AND ALSO gated by
-        //       isAgenticToolsEnabled, so both pathways ship as one feature behind one toggle.
-        // Goal of the gate: skip the SpanService.getByTraceIds I/O on rules that don't need
-        // spans, and let ops kill the spans-in-prompts feature org-wide via a single flip.
-        @ParameterizedTest(name = "expId={0}, toggle={1}, provider={2}, sentinelInVars={3}, templateHasSpans={4} → expected={5}")
+        //   (a) the provider supports tool-calling, so the agentic-tools path is possible, OR
+        //   (b) the inline {{spans}} / {{trace}} template path applies.
+        // Goal of the gate: skip the SpanService.getByTraceIds I/O on rules that don't need spans.
+        // experimentId is inert for THIS gate — it no longer widens the agentic-tools branch (it
+        // still drives shouldUseAgenticTools); both values are exercised to lock that in.
+        @ParameterizedTest(name = "expId={0}, provider={1}, sentinelInVars={2}, templateHasSpans={3} → expected={4}")
         @CsvSource({
-                // Agentic-tools branch: provider supports tools AND (experimentId OR toggle).
-                "true,  false, OPEN_AI, false, false, true",
-                "false, true,  OPEN_AI, false, false, true",
-                // Provider doesn't support tools → agentic-tools branch off; with the new
-                // gating the template path also requires the toggle, so toggle=false means no
-                // fetch regardless of variables/template content.
-                "true,  true,  OLLAMA,  false, false, false",
-                "false, true,  OLLAMA,  false, false, false",
-                // Toggle off + no experimentId + no template → no fetch.
-                "false, false, OPEN_AI, false, false, false",
-                // Toggle off + template-only — feature gated, no fetch (regression test for the
-                // new isAgenticToolsEnabled gate on the template path).
-                "false, false, OPEN_AI, false, true,  false",
-                "false, false, OLLAMA,  false, true,  false",
-                // Toggle off + sentinel-in-variables — same gating applies: no fetch.
-                "false, false, OPEN_AI, true,  false, false",
-                // Toggle on + template-only on a non-tool-calling provider → fetch via template path.
-                "false, true,  OLLAMA,  false, true,  true",
-                // Toggle on + sentinel-in-variables on a non-tool-calling provider → fetch.
-                "false, true,  OLLAMA,  true,  false, true",
-                // Toggle off + experimentId path → spans fetched for the agentic-tools cache
-                // seed; the template substitution piggy-backs on the already-fetched data.
-                "true,  false, OPEN_AI, false, true,  true",
+                // Tool-calling provider → agentic-tools path possible → fetch to seed the read-tool
+                // cache, whatever the template says.
+                "true,  OPEN_AI, false, false, true",
+                "false, OPEN_AI, false, false, true",
+                "false, OPEN_AI, true,  true,  true",
+                // Non-tool-calling provider → only the template path can trigger a fetch.
+                "true,  OLLAMA,  false, false, false",
+                "false, OLLAMA,  false, false, false",
+                // Template references {{spans}} implicitly → fetch via the template path.
+                "false, OLLAMA,  false, true,  true",
+                // Sentinel-mapped variable → fetch via the template path.
+                "false, OLLAMA,  true,  false, true",
                 // Both branches on → still just one fetch (idempotent OR).
-                "true,  true,  OPEN_AI, true,  true,  true",
+                "true,  OPEN_AI, true,  true,  true",
         })
         void gateMatchesTruthTable(
-                boolean hasExperimentId, boolean toggleEnabled, LlmProvider provider,
+                boolean hasExperimentId, LlmProvider provider,
                 boolean sentinelInVariables, boolean templateHasSpans, boolean expected) {
             String modelName = "gpt-test";
             TraceToScoreLlmAsJudge message = buildSpansFetchMessage(
                     hasExperimentId, sentinelInVariables, templateHasSpans);
-            // Both lenient: the agenticToolsPathPossible expression short-circuits, so
-            // !supportsToolCalling AND experimentIdPath both skip the toggle check; the
-            // provider lookup is also skipped when the agentic-tools branch isn't probed.
-            lenient().when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(toggleEnabled);
             lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
 
             assertThat(scorer.shouldFetchSpans(message)).isEqualTo(expected);
@@ -265,47 +249,42 @@ class OnlineScoringLlmAsJudgeScorerTest {
     @Nested
     class RoutingGateTests {
 
-        // Truth table: experimentId × toggle × tokens >= threshold × provider supports tools → useTools.
-        // Tools fire when EITHER (a) the experimentId branch is on OR (b) the size branch is on,
-        // AND the provider supports tool-calling. Without the provider check, a non-tool-calling
-        // model selected via test_suite_model metadata would crash inside the chat call when the
-        // request carries tool specs (Logical bug surfaced by review of the experimentId path).
-        @ParameterizedTest(name = "expId={0}, toggle={1}, tokens={2}, threshold={3}, provider={4}, attachments={5} → expected useTools={6}")
+        // Truth table: experimentId × tokens >= threshold × {{trace}} × provider supports tools → useTools.
+        // Tools fire when ANY of (a) the experimentId branch, (b) the size branch, or (c) the {{trace}}
+        // branch is on, AND the provider supports tool-calling. Without the provider check, a
+        // non-tool-calling model selected via test_suite_model metadata would crash inside the chat call
+        // when the request carries tool specs (Logical bug surfaced by review of the experimentId path).
+        @ParameterizedTest(name = "expId={0}, tokens={1}, threshold={2}, provider={3}, attachments={4} → expected useTools={5}")
         @CsvSource({
                 // experimentId path → tools when provider supports them
-                "true,  false, 0,     50000, OPEN_AI, false, true",
-                "true,  true,  60000, 50000, OPEN_AI, false, true",
+                "true,  0,     50000, OPEN_AI, false, true",
+                "true,  60000, 50000, OPEN_AI, false, true",
                 // experimentId set BUT provider doesn't support tools → fall back to inline with a warn
                 // (assertions that depend on tool-driven span inspection won't be reliable for this model;
                 // we surface the misconfig loudly rather than crash inside the chat call).
-                "true,  true,  60000, 50000, OLLAMA,  false, false",
-                // size-based path — all three preconditions must hold
-                "false, true,  60000, 50000, OPEN_AI, false, true",
-                "false, true,  50000, 50000, OPEN_AI, false, true",
+                "true,  60000, 50000, OLLAMA,  false, false",
+                // size-based path — both preconditions must hold
+                "false, 60000, 50000, OPEN_AI, false, true",
+                "false, 50000, 50000, OPEN_AI, false, true",
                 // below threshold → inline
-                "false, true,  49999, 50000, OPEN_AI, false, false",
-                // toggle off → inline even on huge contexts
-                "false, false, 60000, 50000, OPEN_AI, false, false",
+                "false, 49999, 50000, OPEN_AI, false, false",
                 // provider doesn't support tool calling → inline (operator must pick a different model)
-                "false, true,  60000, 50000, OLLAMA,  false, false",
+                "false, 60000, 50000, OLLAMA,  false, false",
                 // no preconditions met
-                "false, false, 0,     50000, OPEN_AI, false, false",
-                // {{trace}}-driven path: toggle on + provider supports tools + below size
-                // threshold → tools fire so the judge can call get_attachment
-                "false, true,  0,     50000, OPEN_AI, true,  true",
-                // references {{trace}} but toggle off → inline (whole agentic feature is gated by the toggle)
-                "false, false, 0,     50000, OPEN_AI, true,  false",
+                "false, 0,     50000, OPEN_AI, false, false",
+                // {{trace}}-driven path: provider supports tools + below size threshold → tools fire so
+                // the judge can call get_attachment
+                "false, 0,     50000, OPEN_AI, true,  true",
                 // references {{trace}} but provider can't do tools → inline (internal warn)
-                "false, true,  0,     50000, OLLAMA,  true,  false",
+                "false, 0,     50000, OLLAMA,  true,  false",
         })
         void gateMatchesTruthTable(
-                boolean hasExperimentId, boolean toggleEnabled, int estimatedTokens,
+                boolean hasExperimentId, int estimatedTokens,
                 int thresholdTokens, LlmProvider provider, boolean referencesTrace, boolean expectedUseTools) {
             String modelName = "gpt-test";
             TraceToScoreLlmAsJudge message = hasExperimentId
                     ? newMessage(UUID.randomUUID())
                     : newMessageWithoutExperimentId(UUID.randomUUID());
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(toggleEnabled);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(thresholdTokens);
             lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
 
@@ -633,24 +612,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                 """;
 
         @Test
-        void skipsAttachmentFetchWhenToggleIsOff() {
-            var code = JsonUtils.readValue(EVALUATOR_JSON, LlmAsJudgeCode.class);
-            var message = buildScoringMessage(code);
-
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
-            lenient().when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
-            when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))
-                    .thenReturn(new ToolCallingStrategy());
-            when(aiProxyService.scoreTrace(any(), any(), any()))
-                    .thenReturn(ChatResponse.builder().aiMessage(AiMessage.aiMessage(LLM_RESPONSE)).build());
-            when(feedbackScoreService.scoreBatchOfTraces(any())).thenReturn(Mono.empty());
-
-            scorer.score(message).block();
-
-            verifyNoInteractions(attachmentService);
-        }
-
-        @Test
         void traceVariableInjectsStructureWithTraceAndSpanAttachments() {
             var code = JsonUtils.readValue(EVALUATOR_JSON_WITH_TRACE, LlmAsJudgeCode.class);
             var message = buildScoringMessage(code);
@@ -680,7 +641,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                     .fileName(spanFileName)
                     .build();
 
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(1_000_000);
             when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
             when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))
@@ -740,7 +700,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                     .fileName("diagram.png")
                     .build();
 
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(1_000_000);
             when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
             when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))
@@ -781,7 +740,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                     .input(JsonUtils.getJsonNodeFromString("{\"messages\":\"hi\"}"))
                     .build();
 
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(1_000_000);
             when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
             when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))
@@ -832,7 +790,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                     .fileName(fileName)
                     .build();
 
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(1_000_000);
             when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
             when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))
@@ -881,7 +838,6 @@ class OnlineScoringLlmAsJudgeScorerTest {
                     .fileName(spanFileName)
                     .build();
 
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens()).thenReturn(1_000_000);
             when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
             when(llmProviderFactory.getStructuredOutputStrategy("gpt-test"))

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
@@ -190,7 +190,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
                 .fileName(fileName)
                 .build();
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
         when(attachmentService.getAttachmentInfoByEntity(
@@ -228,7 +227,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
         var persistentAttachment = AttachmentInfo.builder()
                 .entityId(span.id()).entityType(EntityType.SPAN).fileName("diagram.png").build();
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
         when(attachmentService.getAttachmentInfoByEntity(
@@ -254,7 +252,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
         var span = createSpan();
         var message = buildMessage(span, code);
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
         // Attachment listing fails — onErrorReturn(List.of()) degrades to a structure without attachment
@@ -289,7 +286,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
                 .fileName(fileName)
                 .build();
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
         // Cold lookup: first subscription sees the not-yet-uploaded state (empty), the retry sees it land.
@@ -368,33 +364,8 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
     }
 
     @Test
-    void spanVariableWithToggleOffRendersEmptyStructureWithoutToolsOrFetch() {
-        var code = JsonUtils.readValue(EVALUATOR_JSON_WITH_SPAN, SpanLlmAsJudgeCode.class);
-        var span = createSpan();
-        var message = buildMessage(span, code);
-
-        // Agentic tools OFF, but the prompt references {{span}}. We must NOT fetch attachments or attach
-        // tools — yet {{span}} must still render (as "{}"), never the literal sentinel word "span".
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
-        when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
-        when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
-        ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);
-        when(aiProxyService.scoreTrace(requestCaptor.capture(), any(), any()))
-                .thenReturn(ChatResponse.builder().aiMessage(AiMessage.aiMessage(LLM_RESPONSE)).build());
-        when(feedbackScoreService.scoreBatchOfSpans(any())).thenReturn(Mono.empty());
-
-        scorer.score(message).block();
-
-        assertThat(requestCaptor.getValue().toolSpecifications()).isNullOrEmpty();
-        verifyNoInteractions(attachmentService);
-        String prompt = ((UserMessage) requestCaptor.getValue().messages().get(0)).singleText();
-        assertThat(prompt).contains("Score this span: {}");
-        assertThat(prompt).doesNotContain("{{span}}");
-    }
-
-    @Test
     void spanVariableOnNonToolProviderCapsInjectedStructure() {
-        // {{span}} + agentic tools ON, but the provider can't call tools → inline fallback. The injected
+        // {{span}} + a provider that can't call tools → inline fallback. The injected
         // span structure (built from the full span) must be CAPPED so a large span can't overflow the
         // model's context window; without the cap the whole span input/output would be inlined verbatim.
         var code = JsonUtils.readValue(EVALUATOR_JSON_WITH_SPAN, SpanLlmAsJudgeCode.class);
@@ -411,7 +382,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
                 .build();
         var message = buildMessage(span, code);
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         // OLLAMA does not support tool-calling → the {{span}} rule falls back to the inline path.
         when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OLLAMA);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
@@ -441,7 +411,6 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
         var span = createSpan();
         var message = buildMessage(span, code);
 
-        when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
         lenient().when(llmProviderFactory.getLlmProvider("gpt-test")).thenReturn(LlmProvider.OPEN_AI);
         when(llmProviderFactory.getStructuredOutputStrategy("gpt-test")).thenReturn(new ToolCallingStrategy());
         ArgumentCaptor<ChatRequest> requestCaptor = ArgumentCaptor.forClass(ChatRequest.class);

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanLlmAsJudgeScorerTest.java
@@ -12,6 +12,7 @@ import com.comet.opik.api.resources.v1.events.tools.ToolExecutor;
 import com.comet.opik.api.resources.v1.events.tools.ToolRegistry;
 import com.comet.opik.api.resources.v1.events.tools.TraceToolContext;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.domain.evaluation.OnlineEvaluationRecorder;
@@ -74,6 +75,9 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
     private ChatCompletionService aiProxyService;
     @Mock
     private TraceService traceService;
+    // Only reaches the base scorer's shared span-size helper, which this scorer never calls.
+    @Mock
+    private SpanService spanService;
     @Mock
     private LlmProviderFactory llmProviderFactory;
     @Mock
@@ -161,6 +165,7 @@ class OnlineScoringSpanLlmAsJudgeScorerTest {
                 feedbackScoreService,
                 aiProxyService,
                 traceService,
+                spanService,
                 llmProviderFactory,
                 agenticScoringService,
                 attachmentService,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorerTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.events.SpanToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
+import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
 import com.comet.opik.domain.evaluators.python.PythonScoreResult;
@@ -63,6 +64,9 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
 
     @Mock
     private TraceService traceService;
+    // Only reaches the base scorer's shared span-size helper, which this scorer never calls.
+    @Mock
+    private SpanService spanService;
 
     @Mock
     private PythonEvaluatorService pythonEvaluatorService;
@@ -105,6 +109,7 @@ class OnlineScoringSpanUserDefinedMetricPythonScorerTest {
                 redissonClient,
                 feedbackScoreService,
                 traceService,
+                spanService,
                 pythonEvaluatorService);
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -75,7 +75,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -191,33 +190,28 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     class RoutingGateTests {
 
         // Threads don't have an experimentId-driven branch (no test-suite-assertion equivalent),
-        // so the truth table is toggle × tokens-vs-threshold × provider-supports-tools × hasAttachments.
+        // so the truth table is tokens-vs-threshold × provider-supports-tools × hasAttachments.
         // Rows mirror the trace-side gate's design for symmetry.
-        @org.junit.jupiter.params.ParameterizedTest(name = "toggle={0}, tokens={1}, threshold={2}, provider={3}, hasAttachments={4} → expected useTools={5}")
+        @org.junit.jupiter.params.ParameterizedTest(name = "tokens={0}, threshold={1}, provider={2}, hasAttachments={3} → expected useTools={4}")
         @org.junit.jupiter.params.provider.CsvSource({
-                // size-based path — all three preconditions must hold
-                "true,  60000, 50000, OPEN_AI, false, true",
-                "true,  50000, 50000, OPEN_AI, false, true",
+                // size-based path — both preconditions must hold
+                "60000, 50000, OPEN_AI, false, true",
+                "50000, 50000, OPEN_AI, false, true",
                 // below threshold → inline
-                "true,  49999, 50000, OPEN_AI, false, false",
-                // toggle off → inline even on huge contexts
-                "false, 60000, 50000, OPEN_AI, false, false",
+                "49999, 50000, OPEN_AI, false, false",
                 // provider doesn't support tool calling → inline + warn
-                "true,  60000, 50000, OLLAMA,  false, false",
+                "60000, 50000, OLLAMA,  false, false",
                 // no preconditions met
-                "false, 0,     50000, OPEN_AI, false, false",
-                // attachment-driven path (OPIK-6555): toggle on + attachments + below size threshold → tools
-                "true,  0,     50000, OPEN_AI, true,  true",
-                // attachments but toggle off → inline (whole agentic feature is gated by the toggle)
-                "false, 0,     50000, OPEN_AI, true,  false",
+                "0,     50000, OPEN_AI, false, false",
+                // attachment-driven path (OPIK-6555): attachments + below size threshold → tools
+                "0,     50000, OPEN_AI, true,  true",
                 // attachments but provider can't do tools → inline + warn
-                "true,  0,     50000, OLLAMA,  true,  false",
+                "0,     50000, OLLAMA,  true,  false",
         })
         void gateMatchesTruthTable(
-                boolean toggleEnabled, int estimatedTokens, int thresholdTokens,
+                int estimatedTokens, int thresholdTokens,
                 com.comet.opik.api.LlmProvider provider, boolean hasAttachments, boolean expectedUseTools) {
             String modelName = "gpt-test";
-            Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(toggleEnabled);
             Mockito.lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens())
                     .thenReturn(thresholdTokens);
             Mockito.lenient().when(llmProviderFactory.getLlmProvider(modelName)).thenReturn(provider);
@@ -230,12 +224,11 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
 
         @org.junit.jupiter.api.Test
         void multimodalTemplateForcesInlineFallbackEvenWhenAllOtherPreconditionsHold() {
-            // Every other gate is satisfied (toggle on, over threshold, provider supports tools)
-            // but the template carries a non-string-content message. The agentic-tools render
-            // path can't substitute into multimodal templates, so we must downgrade to inline
-            // rather than letting renderThreadMessagesWithReplacement throw downstream.
+            // Every other gate is satisfied (over threshold, provider supports tools) but the template
+            // carries a non-string-content message. The agentic-tools render path can't substitute into
+            // multimodal templates, so we must downgrade to inline rather than letting
+            // renderThreadMessagesWithReplacement throw downstream.
             String modelName = "gpt-test";
-            Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             Mockito.lenient().when(onlineScoringConfig.getAgenticToolsThresholdTokens())
                     .thenReturn(50_000);
             Mockito.lenient().when(llmProviderFactory.getLlmProvider(modelName))
@@ -546,6 +539,15 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             when(aiProxyService.scoreTrace(any(ChatRequest.class), eq(code.model()), eq(workspaceId)))
                     .thenReturn(ChatResponse.builder().aiMessage(AiMessage.aiMessage(LLM_RESPONSE)).build());
             when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            // The scorer always probes span size and attachments before routing, so every scoring test
+            // reaches both services. These lenient defaults describe a small, attachment-free thread —
+            // i.e. the inline path; the routing tests below re-stub them with real sizes/attachments.
+            Mockito.lenient().when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
+                    .thenReturn(Mono.just(0L));
+            Mockito.lenient().when(spanService.getByTraceIds(Set.of(trace.id()))).thenReturn(Flux.empty());
+            Mockito.lenient()
+                    .when(attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, Set.of(trace.id())))
+                    .thenReturn(Mono.just(false));
         }
 
         @Test
@@ -577,7 +579,6 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             var project = Project.builder().id(projectId).name("test-project").build();
             var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
             stubThreadScoringHappyPath(trace, project, rule, code);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(10_000_000L));
             when(attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, Set.of(trace.id())))
                     .thenReturn(Mono.just(false));
@@ -604,7 +605,6 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                     .startTime(Instant.now()).traceId(trace.id()).projectId(projectId)
                     .build();
             stubThreadScoringHappyPath(trace, project, rule, code);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(10L));
             when(attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, Set.of(trace.id())))
                     .thenReturn(Mono.just(false));
@@ -629,7 +629,6 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             var project = Project.builder().id(projectId).name("test-project").build();
             var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
             stubThreadScoringHappyPath(trace, project, rule, code);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(10L));
             when(attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, Set.of(trace.id())))
                     .thenReturn(Mono.just(true));
@@ -640,27 +639,6 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             verify(spanService).getSpansSizeByTraceIds(Set.of(trace.id()));
             verify(spanService, never()).getByTraceIds(any());
             verify(feedbackScoreService).scoreBatchOfThreads(any());
-        }
-
-        @Test
-        void skipsSpanFetchWhenAgenticToolsDisabled() {
-            // Locks in the toggle gate: when isAgenticToolsEnabled=false, the scorer must NOT
-            // call spanService.getByTraceIds — that's how thread-scope evaluations preserve
-            // today's wire shape exactly (the enriched serializer omits the `spans` field on
-            // an empty list, falling back to [{role, content}, ...]).
-            var code = JsonUtils.readValue(EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
-            var message = sampleMessage().toBuilder().code(code).build();
-            var trace = sampleTrace();
-            var project = Project.builder().id(projectId).name("test-project").build();
-            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
-            stubThreadScoringHappyPath(trace, project, rule, code);
-            // Toggle off — the scorer should not even ask the SpanService (no size probe, no fetch).
-            Mockito.when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
-
-            scorer.score(message).block();
-
-            verifyNoInteractions(spanService);
-            verifyNoInteractions(attachmentService);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -642,7 +642,7 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
         }
 
         @Test
-        void stillScoresWhenSpanSizeAggregateFails() {
+        void stillScoresInlineWhenSpanSizeAggregateFails() {
             // Sizing is advisory: a failed aggregate must not abort the evaluation, because
             // BaseRedisSubscriber would retry maxRetries times and then acknowledge the message,
             // permanently dropping the thread. Degrade to the unenriched inline route and still persist.
@@ -660,6 +660,50 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
             // No bulk fetch follows a failed aggregate — without a size we can't bound the heap cost.
             verify(spanService, never()).getByTraceIds(any());
             verify(feedbackScoreService).scoreBatchOfThreads(any());
+            // Assert the ROUTE, not just that something scored: both routes return the stubbed response
+            // and persist, so without this the test passes even if the fallback took the tools path.
+            // No tool was ever executed => the inline branch ran.
+            Mockito.verifyNoInteractions(toolRegistry);
+            // And the rendered context carries no spans (unenriched).
+            var requests = ArgumentCaptor.forClass(ChatRequest.class);
+            verify(aiProxyService).scoreTrace(requests.capture(), any(), any());
+            var prompt = requests.getValue().messages().stream().map(Object::toString)
+                    .collect(java.util.stream.Collectors.joining("\n"));
+            org.assertj.core.api.Assertions.assertThat(prompt).doesNotContain("\"spans\"");
+        }
+
+        @Test
+        void traceBodiesAloneStillRouteToToolsWhenAggregateUnavailable() {
+            // Regression lock for the sizing fallback: estimating a flat 0 tokens when the aggregate fails
+            // would send a thread whose trace bodies alone clear the threshold full inline and overflow
+            // the context window. The bodies are already in heap, so they stay measurable with
+            // spanBytes 0 — which is what the fallback passes.
+            //
+            // Asserted end-to-end on the outgoing prompt rather than on the gate: the two routes differ
+            // observably in what they send (tools get a skeleton, inline gets the full bodies), so a
+            // regression back to a flat 0 fails here. A gate-only assertion would not catch it.
+            var body = "x".repeat(400_000);
+            var code = JsonUtils.readValue(EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+            var message = sampleMessage().toBuilder().code(code).build();
+            var trace = sampleTrace().toBuilder()
+                    .input(JsonUtils.getJsonNodeFromString("{\"q\":\"" + body + "\"}"))
+                    .build();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
+            stubThreadScoringHappyPath(trace, project, rule, code);
+            Mockito.when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
+                    .thenReturn(Mono.error(new IllegalStateException("clickhouse unavailable")));
+            Mockito.when(llmProviderFactory.getLlmProvider("gpt-4o"))
+                    .thenReturn(com.comet.opik.api.LlmProvider.OPEN_AI);
+
+            scorer.score(message).block();
+
+            var requests = ArgumentCaptor.forClass(ChatRequest.class);
+            verify(aiProxyService, Mockito.atLeastOnce()).scoreTrace(requests.capture(), any(), any());
+            var prompt = requests.getAllValues().get(0).messages().stream().map(Object::toString)
+                    .collect(java.util.stream.Collectors.joining("\n"));
+            // The tools route sends a skeleton; inlining the oversized body is the bug being locked out.
+            org.assertj.core.api.Assertions.assertThat(prompt).doesNotContain(body);
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -642,6 +642,27 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
         }
 
         @Test
+        void stillScoresWhenSpanSizeAggregateFails() {
+            // Sizing is advisory: a failed aggregate must not abort the evaluation, because
+            // BaseRedisSubscriber would retry maxRetries times and then acknowledge the message,
+            // permanently dropping the thread. Degrade to the unenriched inline route and still persist.
+            var code = JsonUtils.readValue(EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+            var message = sampleMessage().toBuilder().code(code).build();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
+            stubThreadScoringHappyPath(trace, project, rule, code);
+            Mockito.when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
+                    .thenReturn(Mono.error(new IllegalStateException("clickhouse unavailable")));
+
+            scorer.score(message).block();
+
+            // No bulk fetch follows a failed aggregate — without a size we can't bound the heap cost.
+            verify(spanService, never()).getByTraceIds(any());
+            verify(feedbackScoreService).scoreBatchOfThreads(any());
+        }
+
+        @Test
         void skipsScoringWhenThreadHasNoTraces() {
             var message = sampleMessage();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -231,6 +231,32 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
         }
 
         @Test
+        void stillScoresWhenSpanSizeAggregateFails() {
+            // Sizing is advisory: a failed aggregate must not abort the evaluation, because
+            // BaseRedisSubscriber would retry maxRetries times and then acknowledge the message,
+            // permanently dropping the thread. Degrade to the unenriched context and still persist.
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("test_score")
+                    .value(BigDecimal.valueOf(0.95))
+                    .reason("ok")
+                    .build();
+            stubPythonScoringHappyPath(trace, project);
+            when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
+                    .thenReturn(Mono.error(new IllegalStateException("clickhouse unavailable")));
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+
+            scorer.score(message).block();
+
+            // No bulk fetch follows a failed aggregate — without a size we can't bound the heap cost.
+            verify(spanService, never()).getByTraceIds(any());
+            verify(feedbackScoreService).scoreBatchOfThreads(any());
+        }
+
+        @Test
         void fetchesSpansAndEnrichesConversation() {
             // The scorer fetches every span across the thread and the captured ChatMessage list sent to
             // the Python evaluator carries the spans nested under the assistant entry. Locks in the

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -62,11 +62,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -199,6 +199,13 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .thenReturn(ruleFor(ruleName));
             when(projectService.get(projectId, workspaceId)).thenReturn(project);
             when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            // The scorer always probes the thread's span size before deciding whether to enrich, so every
+            // scoring test reaches the SpanService and needs a preload cap. Lenient defaults keep tests
+            // that don't care about the enrichment routing terse; the routing tests below re-stub these
+            // with real sizes/caps/spans.
+            lenient().when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(64);
+            lenient().when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(0L));
+            lenient().when(spanService.getByTraceIds(Set.of(trace.id()))).thenReturn(Flux.empty());
         }
 
         @Test
@@ -224,36 +231,11 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
         }
 
         @Test
-        void skipsSpanFetchWhenAgenticToolsDisabled() {
-            // Locks the toggle gate for the Python thread path: when isAgenticToolsEnabled
-            // is false, the scorer must NOT call spanService.getByTraceIds — preserves
-            // today's [{role, content}, ...] wire shape to the Python runner exactly.
-            var message = sampleMessage();
-            var trace = sampleTrace();
-            var project = Project.builder().id(projectId).name("test-project").build();
-            var pythonScore = PythonScoreResult.builder()
-                    .name("test_score")
-                    .value(BigDecimal.valueOf(0.95))
-                    .reason("ok")
-                    .build();
-            stubPythonScoringHappyPath(trace, project);
-            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
-                    .thenReturn(Mono.just(List.of(pythonScore)));
-            // Toggle off — the scorer should not even ask the SpanService.
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(false);
-
-            scorer.score(message).block();
-
-            verifyNoInteractions(spanService);
-        }
-
-        @Test
-        void fetchesSpansAndEnrichesConversationWhenAgenticToolsEnabled() {
-            // Toggle on: scorer fetches every span across the thread and the captured
-            // ChatMessage list sent to the Python evaluator carries the spans nested under
-            // the assistant entry. Locks in the end-to-end enrichment contract — a future
-            // refactor that quietly drops the SpanService fetch or routes through
-            // fromTraceToThread (legacy) would break this test loudly.
+        void fetchesSpansAndEnrichesConversation() {
+            // The scorer fetches every span across the thread and the captured ChatMessage list sent to
+            // the Python evaluator carries the spans nested under the assistant entry. Locks in the
+            // end-to-end enrichment contract — a future refactor that quietly drops the SpanService
+            // fetch or routes through fromTraceToThread (legacy) would break this test loudly.
             var message = sampleMessage();
             var trace = sampleTrace();
             var project = Project.builder().id(projectId).name("test-project").build();
@@ -272,7 +254,6 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .build();
 
             stubPythonScoringHappyPath(trace, project);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(64);
             // Cheap size probe (route-before-fetch): under the cap → enrich → fetch spans.
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(1_000L));
@@ -310,7 +291,6 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .build();
 
             stubPythonScoringHappyPath(trace, project);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(64); // cap = 64 MiB
             // Size probe reports 200 MiB — over the cap → no bulk fetch, unenriched context.
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
@@ -354,7 +334,6 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .build();
 
             stubPythonScoringHappyPath(trace, project);
-            when(serviceTogglesConfig.isAgenticToolsEnabled()).thenReturn(true);
             when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(1); // cap = 1 MiB
             // Aggregate under-counts (500 B, under the cap) → enrich is chosen...
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(500L));
@@ -466,6 +445,11 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .thenReturn(ruleFor(ruleName));
             when(projectService.get(projectId, workspaceId))
                     .thenReturn(Project.builder().id(projectId).name("test-project").build());
+            // The span-size probe runs before the evaluator call, so it has to resolve for the
+            // evaluator's failure to be the one that surfaces.
+            when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(64);
+            when(spanService.getSpansSizeByTraceIds(any())).thenReturn(Mono.just(0L));
+            when(spanService.getByTraceIds(any())).thenReturn(Flux.empty());
             when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
                     .thenReturn(Mono.error(error));
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -246,7 +246,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
             stubPythonScoringHappyPath(trace, project);
             when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
                     .thenReturn(Mono.error(new IllegalStateException("clickhouse unavailable")));
-            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+            ArgumentCaptor<List<ChatMessage>> contextCaptor = ArgumentCaptor.forClass(List.class);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), contextCaptor.capture()))
                     .thenReturn(Mono.just(List.of(pythonScore)));
 
             scorer.score(message).block();
@@ -254,6 +255,12 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
             // No bulk fetch follows a failed aggregate — without a size we can't bound the heap cost.
             verify(spanService, never()).getByTraceIds(any());
             verify(feedbackScoreService).scoreBatchOfThreads(any());
+            // Assert the PAYLOAD, not just that something scored: the runner must receive the legacy
+            // {role, content} shape, so a regression that supplies spans here would otherwise pass.
+            var captured = contextCaptor.getValue();
+            assertThat(captured).hasSize(2);
+            assertThat(captured.get(0).spans()).isNull();
+            assertThat(captured.get(1).spans()).isNull();
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -56,6 +56,8 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
+import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ROLE_ASSISTANT;
+import static com.comet.opik.domain.evaluators.python.TraceThreadPythonEvaluatorRequest.ROLE_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -255,12 +257,10 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
             // No bulk fetch follows a failed aggregate — without a size we can't bound the heap cost.
             verify(spanService, never()).getByTraceIds(any());
             verify(feedbackScoreService).scoreBatchOfThreads(any());
-            // Assert the PAYLOAD, not just that something scored: the runner must receive the legacy
-            // {role, content} shape, so a regression that supplies spans here would otherwise pass.
-            var captured = contextCaptor.getValue();
-            assertThat(captured).hasSize(2);
-            assertThat(captured.get(0).spans()).isNull();
-            assertThat(captured.get(1).spans()).isNull();
+            // Assert the WHOLE ordered payload, not a few fields of it: ChatMessage is a record, so
+            // isEqualTo covers role, content and spans together — and keeps covering any component
+            // added later. Spot-checking only `spans` let a swapped or emptied content through.
+            assertThat(contextCaptor.getValue()).isEqualTo(unenrichedContext(trace));
         }
 
         @Test
@@ -277,6 +277,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .value(BigDecimal.valueOf(0.9))
                     .reason("ok")
                     .build();
+            // input/output are populated so the assertion below covers the SpanForLlm projection
+            // carrying the span's payload through, not merely its name.
             var toolSpan = Span.builder()
                     .id(UUID.randomUUID())
                     .name("fetch_weather")
@@ -284,6 +286,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     .startTime(Instant.now())
                     .traceId(trace.id())
                     .projectId(projectId)
+                    .input(JsonUtils.readTree("{\"city\":\"Lisbon\"}"))
+                    .output(JsonUtils.readTree("{\"tempC\":21}"))
                     .build();
 
             stubPythonScoringHappyPath(trace, project);
@@ -298,15 +302,21 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
             scorer.score(message).block();
 
             verify(spanService).getByTraceIds(Set.of(trace.id()));
-            var captured = contextCaptor.getValue();
-            // Conversation contains user + assistant per trace (one trace here).
-            assertThat(captured).hasSize(2);
-            assertThat(captured.get(0).role()).isEqualTo("user");
-            assertThat(captured.get(0).spans()).isNull(); // user entry never carries spans
-            assertThat(captured.get(1).role()).isEqualTo("assistant");
-            assertThat(captured.get(1).spans()).isNotNull();
-            assertThat(captured.get(1).spans()).extracting(SpanForLlm::name)
-                    .containsExactly("fetch_weather");
+            // The whole ordered conversation: user turn carries the trace input and never any spans,
+            // assistant turn carries the trace output plus the span tree with the span's own payload.
+            // Built from the fixture's fields rather than through the production mapper, so the
+            // projection itself is under test.
+            assertThat(contextCaptor.getValue()).isEqualTo(List.of(
+                    ChatMessage.builder().role(ROLE_USER).content(trace.input()).build(),
+                    ChatMessage.builder().role(ROLE_ASSISTANT).content(trace.output())
+                            .spans(List.of(SpanForLlm.builder()
+                                    .name(toolSpan.name())
+                                    .type(toolSpan.type())
+                                    .startTime(toolSpan.startTime())
+                                    .input(toolSpan.input())
+                                    .output(toolSpan.output())
+                                    .build()))
+                            .build()));
         }
 
         @Test
@@ -336,10 +346,7 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
 
             // The OOM path is the bulk span fetch — it must not run when over the cap.
             verify(spanService, never()).getByTraceIds(any());
-            var captured = contextCaptor.getValue();
-            assertThat(captured).hasSize(2);
-            assertThat(captured.get(1).role()).isEqualTo("assistant");
-            assertThat(captured.get(1).spans()).isNull(); // unenriched — no per-turn span tree
+            assertThat(contextCaptor.getValue()).isEqualTo(unenrichedContext(trace));
         }
 
         @Test
@@ -382,10 +389,7 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
             // overflow, and the mismatch is surfaced rather than silent.
             verify(spanService).getByTraceIds(Set.of(trace.id()));
             verify(userFacingLogger).warn(contains("exceeded the enrichment cap"), eq(threadId), any(), any());
-            var captured = contextCaptor.getValue();
-            assertThat(captured).hasSize(2);
-            assertThat(captured.get(1).role()).isEqualTo("assistant");
-            assertThat(captured.get(1).spans()).isNull(); // unenriched — buffer dropped on overflow
+            assertThat(contextCaptor.getValue()).isEqualTo(unenrichedContext(trace));
         }
 
         @Test
@@ -506,6 +510,17 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                 .workspaceId(workspaceId)
                 .userName(userName)
                 .build();
+    }
+
+    /**
+     * The legacy {@code [{role, content}, ...]} conversation the Python runner must receive whenever
+     * enrichment is skipped: the trace's input as the user turn, its output as the assistant turn, and
+     * no {@code spans} on either — the shape rules written before enrichment existed depend on.
+     */
+    private static List<ChatMessage> unenrichedContext(Trace trace) {
+        return List.of(
+                ChatMessage.builder().role(ROLE_USER).content(trace.input()).build(),
+                ChatMessage.builder().role(ROLE_ASSISTANT).content(trace.output()).build());
     }
 
     private Trace sampleTrace() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TraceThreadOnlineScoringAgenticToolsE2ETest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/TraceThreadOnlineScoringAgenticToolsE2ETest.java
@@ -12,7 +12,6 @@ import com.comet.opik.api.resources.utils.MySQLContainerUtils;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
-import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.AutomationRuleEvaluatorResourceClient;
@@ -60,13 +59,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 /**
- * Black-box coverage for the trace-thread LLM-as-judge online scorer with {@code agenticTools} enabled —
- * the route-before-fetch path added in OPIK-7454. Drives the public flow (create rule + create a thread
- * with traces/spans) end-to-end so the async scorer runs with the toggle on, exercising the real
- * {@code getSpansSizeByTraceIds} aggregate + the bounded span preload before scoring. The scorer's
- * user-facing "Evaluating threadId ..." log (emitted after the size aggregate resolves) is asserted via
- * the rule logs, proving the whole path executed. Complements the existing toggle-off scorer coverage and
- * leaves a reference test for the agentic-tools path.
+ * Black-box coverage for the trace-thread LLM-as-judge online scorer's agentic-tools path — the
+ * route-before-fetch flow added in OPIK-7454. Drives the public flow (create rule + create a thread with
+ * traces/spans) end-to-end so the async scorer exercises the real {@code getSpansSizeByTraceIds}
+ * aggregate + the bounded span preload before scoring. The scorer's user-facing "Evaluating threadId ..."
+ * log (emitted after the size aggregate resolves) is asserted via the rule logs, proving the whole path
+ * executed.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ExtendWith(DropwizardAppExtensionProvider.class)
@@ -134,8 +132,6 @@ class TraceThreadOnlineScoringAgenticToolsE2ETest {
                                         Mockito.mock(LlmProviderFactory.class, Mockito.RETURNS_DEEP_STUBS));
                             }
                         }))
-                        // The subject under test: run the trace-thread scorers with agentic tools on.
-                        .customConfigs(List.of(new CustomConfig("serviceToggles.agenticToolsEnabled", "true")))
                         .build());
     }
 
@@ -158,7 +154,7 @@ class TraceThreadOnlineScoringAgenticToolsE2ETest {
     }
 
     @Test
-    void runsSizeAggregateAndScoresThreadWhenAgenticToolsEnabled(LlmProviderFactory llmProviderFactory)
+    void runsSizeAggregateAndScoresThread(LlmProviderFactory llmProviderFactory)
             throws Exception {
         when(llmProviderFactory.getLanguageModel(anyString(), any()).chat(any(ChatRequest.class)))
                 .thenAnswer(invocation -> ChatResponse.builder().aiMessage(AiMessage.from(LLM_RESPONSE)).build());
@@ -246,6 +242,10 @@ class TraceThreadOnlineScoringAgenticToolsE2ETest {
             var threads = traceResourceClient.getTraceThreads(projectId, projectName, API_KEY, WORKSPACE_NAME,
                     null, null, Map.of());
             assertThat(threads.content()).isNotEmpty();
+            // Assert before dereferencing: the "Evaluating threadId" log above is emitted before scoring
+            // finishes, so feedbackScores() is briefly null. An AssertionError is retried by
+            // untilAsserted; a raw NPE from .stream() would fail the test outright.
+            assertThat(threads.content().getFirst().feedbackScores()).isNotNull();
             var scoresByName = threads.content().getFirst().feedbackScores().stream()
                     .collect(toMap(FeedbackScore::name, FeedbackScore::value));
             assertThat(scoresByName).containsOnlyKeys("Relevance", "Conciseness");

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -840,9 +840,6 @@ serviceToggles:
   #   freeform SQL path and the clickhouse-readonly-freeform-sql health check. Tests flip this on when exercising
   #   the read-only ClickHouse client.
   ollieEnabled: "false"
-  # Default: false
-  # Description: Master switch for the agentic-tools path on LLM-as-judge online scoring.
-  agenticToolsEnabled: "false"
   # Default: true
   # Description: Whether the online-scoring (LLM-as-judge) evaluation loop is persisted as monitoring traces.
   onlineScoringTracingEnabled: "true"

--- a/apps/opik-frontend/src/constants/llm.ts
+++ b/apps/opik-frontend/src/constants/llm.ts
@@ -60,6 +60,19 @@ export const RESERVED_TRACE_EVALUATOR_VARIABLES: Readonly<
 });
 
 /**
+ * Python-metric span-scope reserved variables: there are none. `spans` is
+ * trace-scope only (a span has no sub-spans to inject), and
+ * `PythonCodeDetailsSpanFormSchema` accepts only `input`/`output`/`metadata`
+ * paths. Auto-filling `spans → spans` here would produce a mapping the user
+ * cannot see — `LLMPromptMessagesVariables` hides a variable whose value equals
+ * its sentinel — and cannot submit, because the schema rejects it. An explicit
+ * empty set keeps that pairing visible at the call site.
+ */
+export const RESERVED_SPAN_EVALUATOR_VARIABLES: Readonly<
+  Record<string, string>
+> = Object.freeze({});
+
+/**
  * LLM-as-judge trace-scope reserved variables. Superset of
  * {@link RESERVED_TRACE_EVALUATOR_VARIABLES}: adds `{{trace}}`, which injects the
  * trace skeleton (trace id, span ids, attachment file_names) into the prompt and

--- a/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
+++ b/apps/opik-frontend/src/contexts/feature-toggles-provider.tsx
@@ -33,7 +33,6 @@ const DEFAULT_STATE: FeatureToggles = {
   [FeatureToggleKeys.COST_INTELLIGENCE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_LLM_AS_JUDGE_ENABLED]: false,
   [FeatureToggleKeys.SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED]: false,
-  [FeatureToggleKeys.AGENTIC_TOOLS_ENABLED]: false,
   // LLM Provider feature flags - default false
   [FeatureToggleKeys.OPENAI_PROVIDER_ENABLED]: false,
   [FeatureToggleKeys.ANTHROPIC_PROVIDER_ENABLED]: false,

--- a/apps/opik-frontend/src/lib/llm.test.ts
+++ b/apps/opik-frontend/src/lib/llm.test.ts
@@ -98,6 +98,12 @@ describe("resolveTraceEvaluatorVariableDefault", () => {
   it("preserves a deliberate empty-string mapping rather than re-applying the sentinel", () => {
     // Treating "" as "not set" would silently clobber an API caller's explicit
     // `spans: ""` on every prompt re-parse.
+    //
+    // Note this state is reachable only via the API: the rule dialog's own schema
+    // rejects an empty mapping value (`.min(1)` plus the JSONPath/sentinel regex in
+    // AddEditRuleDialog/schema.ts), so the editor will not produce or re-submit one.
+    // The resolver still must not rewrite it — preserving a value it cannot author is
+    // what keeps an API-created rule's prompt re-parse non-destructive.
     expect(
       resolveTraceEvaluatorVariableDefault(
         "spans",

--- a/apps/opik-frontend/src/lib/llm.test.ts
+++ b/apps/opik-frontend/src/lib/llm.test.ts
@@ -1,16 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  reservedPythonMetricVariablesForScope,
-  resolveTraceEvaluatorVariableDefault,
-} from "./llm";
+import { resolveTraceEvaluatorVariableDefault } from "./llm";
 import {
   RESERVED_SPAN_EVALUATOR_VARIABLES,
   RESERVED_SPAN_LLM_JUDGE_VARIABLES,
   RESERVED_TRACE_EVALUATOR_VARIABLES,
   RESERVED_TRACE_LLM_JUDGE_VARIABLES,
 } from "@/constants/llm";
-import { PythonCodeDetailsSpanFormSchema } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 
 /**
@@ -102,7 +98,8 @@ describe("resolveTraceEvaluatorVariableDefault", () => {
 
   it("does not auto-fill spans on span scope, where the form schema rejects the sentinel", () => {
     // A span-scoped `def score(input, spans)` must leave `spans` unmapped. Auto-filling the
-    // trace sentinel would fail PythonCodeDetailsSpanFormSchema (asserted below) while
+    // trace sentinel would fail PythonCodeDetailsSpanFormSchema (asserted in
+    // AddEditRuleDialog/helpers.test.ts) while
     // LLMPromptMessagesVariables hid the offending row, leaving the dialog unsubmittable
     // with nothing to correct.
     expect(
@@ -132,48 +129,5 @@ describe("resolveTraceEvaluatorVariableDefault", () => {
         RESERVED_TRACE_LLM_JUDGE_VARIABLES,
       ),
     ).toBe("");
-  });
-});
-
-describe("reservedPythonMetricVariablesForScope", () => {
-  it("reserves spans on trace scope, where the scorer injects it", () => {
-    expect(
-      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.trace),
-    ).toEqual(RESERVED_TRACE_EVALUATOR_VARIABLES);
-  });
-
-  it("reserves nothing on span scope, so no sentinel is auto-filled or hidden", () => {
-    expect(
-      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.span),
-    ).toEqual(RESERVED_SPAN_EVALUATOR_VARIABLES);
-  });
-});
-
-/**
- * The other half of the span-scope pairing above: the sentinel the resolver must not
- * auto-fill is one this schema genuinely rejects, so a regression in either file alone
- * still fails a test here.
- */
-describe("PythonCodeDetailsSpanFormSchema", () => {
-  const metric = "def score(input, spans): return []";
-
-  it("rejects the bare spans sentinel that trace scope allows", () => {
-    expect(
-      PythonCodeDetailsSpanFormSchema.safeParse({
-        metric,
-        arguments: { input: "input", spans: "spans" },
-      }).success,
-    ).toBe(false);
-  });
-
-  it("accepts the arguments the span resolver actually produces", () => {
-    // `spans` left blank by the resolver is still required to be pointed at a real path
-    // before submit; the user maps it explicitly, as with any non-reserved parameter.
-    expect(
-      PythonCodeDetailsSpanFormSchema.safeParse({
-        metric,
-        arguments: { input: "input", spans: "metadata.spans" },
-      }).success,
-    ).toBe(true);
   });
 });

--- a/apps/opik-frontend/src/lib/llm.test.ts
+++ b/apps/opik-frontend/src/lib/llm.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveTraceEvaluatorVariableDefault } from "./llm";
 import {
+  reservedPythonMetricVariablesForScope,
+  resolveTraceEvaluatorVariableDefault,
+} from "./llm";
+import {
+  RESERVED_SPAN_EVALUATOR_VARIABLES,
   RESERVED_SPAN_LLM_JUDGE_VARIABLES,
   RESERVED_TRACE_EVALUATOR_VARIABLES,
   RESERVED_TRACE_LLM_JUDGE_VARIABLES,
 } from "@/constants/llm";
+import { PythonCodeDetailsSpanFormSchema } from "@/v2/pages-shared/automations/AddEditRuleDialog/schema";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 
 /**
@@ -95,6 +100,21 @@ describe("resolveTraceEvaluatorVariableDefault", () => {
     ).toBe("output.custom.path");
   });
 
+  it("does not auto-fill spans on span scope, where the form schema rejects the sentinel", () => {
+    // A span-scoped `def score(input, spans)` must leave `spans` unmapped. Auto-filling the
+    // trace sentinel would fail PythonCodeDetailsSpanFormSchema (asserted below) while
+    // LLMPromptMessagesVariables hid the offending row, leaving the dialog unsubmittable
+    // with nothing to correct.
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "spans",
+        undefined,
+        EVALUATORS_RULE_SCOPE.span,
+        RESERVED_SPAN_EVALUATOR_VARIABLES,
+      ),
+    ).toBe("");
+  });
+
   it("preserves a deliberate empty-string mapping rather than re-applying the sentinel", () => {
     // Treating "" as "not set" would silently clobber an API caller's explicit
     // `spans: ""` on every prompt re-parse.
@@ -112,5 +132,48 @@ describe("resolveTraceEvaluatorVariableDefault", () => {
         RESERVED_TRACE_LLM_JUDGE_VARIABLES,
       ),
     ).toBe("");
+  });
+});
+
+describe("reservedPythonMetricVariablesForScope", () => {
+  it("reserves spans on trace scope, where the scorer injects it", () => {
+    expect(
+      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.trace),
+    ).toEqual(RESERVED_TRACE_EVALUATOR_VARIABLES);
+  });
+
+  it("reserves nothing on span scope, so no sentinel is auto-filled or hidden", () => {
+    expect(
+      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.span),
+    ).toEqual(RESERVED_SPAN_EVALUATOR_VARIABLES);
+  });
+});
+
+/**
+ * The other half of the span-scope pairing above: the sentinel the resolver must not
+ * auto-fill is one this schema genuinely rejects, so a regression in either file alone
+ * still fails a test here.
+ */
+describe("PythonCodeDetailsSpanFormSchema", () => {
+  const metric = "def score(input, spans): return []";
+
+  it("rejects the bare spans sentinel that trace scope allows", () => {
+    expect(
+      PythonCodeDetailsSpanFormSchema.safeParse({
+        metric,
+        arguments: { input: "input", spans: "spans" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts the arguments the span resolver actually produces", () => {
+    // `spans` left blank by the resolver is still required to be pointed at a real path
+    // before submit; the user maps it explicitly, as with any non-reserved parameter.
+    expect(
+      PythonCodeDetailsSpanFormSchema.safeParse({
+        metric,
+        arguments: { input: "input", spans: "metadata.spans" },
+      }).success,
+    ).toBe(true);
   });
 });

--- a/apps/opik-frontend/src/lib/llm.test.ts
+++ b/apps/opik-frontend/src/lib/llm.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveTraceEvaluatorVariableDefault } from "./llm";
+import {
+  RESERVED_SPAN_LLM_JUDGE_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+} from "@/constants/llm";
+import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+
+/**
+ * Covers the sentinel auto-fill that decides whether a reserved variable name
+ * (`spans` / `trace` / `span`) is pre-mapped to its sentinel or left blank for the
+ * user to point at a custom path. This used to be gated by the agentic-tools
+ * feature toggle; with the toggle removed the auto-fill is unconditional, so these
+ * assertions are what pins the behaviour down.
+ */
+describe("resolveTraceEvaluatorVariableDefault", () => {
+  it("auto-fills the spans sentinel on trace scope", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "spans",
+        undefined,
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("spans");
+  });
+
+  it("auto-fills the trace sentinel on trace scope for LLM judges", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "trace",
+        undefined,
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("trace");
+  });
+
+  it("auto-fills the span sentinel on span scope", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "span",
+        undefined,
+        EVALUATORS_RULE_SCOPE.span,
+        RESERVED_SPAN_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("span");
+  });
+
+  it("does not auto-fill trace for Python metrics, whose backend only handles spans", () => {
+    // The default reserved set deliberately omits `trace`: auto-mapping it would
+    // inject a value the Python scorer ignores.
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "trace",
+        undefined,
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_EVALUATOR_VARIABLES,
+      ),
+    ).toBe("");
+  });
+
+  it("leaves non-reserved names blank", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "my_custom_var",
+        undefined,
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("");
+  });
+
+  it("does not auto-fill on thread scope, which uses {{context}} instead", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "spans",
+        undefined,
+        EVALUATORS_RULE_SCOPE.thread,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("");
+  });
+
+  it("preserves a mapping the user already set", () => {
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "spans",
+        "output.custom.path",
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("output.custom.path");
+  });
+
+  it("preserves a deliberate empty-string mapping rather than re-applying the sentinel", () => {
+    // Treating "" as "not set" would silently clobber an API caller's explicit
+    // `spans: ""` on every prompt re-parse.
+    expect(
+      resolveTraceEvaluatorVariableDefault(
+        "spans",
+        "",
+        EVALUATORS_RULE_SCOPE.trace,
+        RESERVED_TRACE_LLM_JUDGE_VARIABLES,
+      ),
+    ).toBe("");
+  });
+});

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -317,18 +317,11 @@ export const parseChatTemplateToLLMMessages = (
  * {@link RESERVED_SPAN_LLM_JUDGE_VARIABLES} ({@code span}) on span scope. The
  * Python-metric editors keep the default, because the Python scorer backend only
  * injects `spans`.
- *
- * <p>The auto-fill is gated by {@code agenticToolsEnabled} (FT
- * {@code agentic_tools_enabled}). When the feature is off, reserved names behave
- * like any other variable — no sentinel is filled in, leaving the user free to map
- * to a real path. Mirrors the BE: `shouldFetchSpans` and the `{{spans}}` /
- * `{{trace}}` substitution are also gated by the same toggle.
  */
 export const resolveTraceEvaluatorVariableDefault = (
   variableName: string,
   currentMapping: string | undefined,
   scope: EVALUATORS_RULE_SCOPE,
-  agenticToolsEnabled: boolean,
   reservedVariables: Readonly<
     Record<string, string>
   > = RESERVED_TRACE_EVALUATOR_VARIABLES,
@@ -341,9 +334,8 @@ export const resolveTraceEvaluatorVariableDefault = (
     return currentMapping;
   }
   if (
-    agenticToolsEnabled &&
-    (scope === EVALUATORS_RULE_SCOPE.trace ||
-      scope === EVALUATORS_RULE_SCOPE.span)
+    scope === EVALUATORS_RULE_SCOPE.trace ||
+    scope === EVALUATORS_RULE_SCOPE.span
   ) {
     return reservedVariables[variableName] ?? "";
   }

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -8,10 +8,7 @@ import {
   TextPart,
 } from "@/types/llm";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import {
-  RESERVED_SPAN_EVALUATOR_VARIABLES,
-  RESERVED_TRACE_EVALUATOR_VARIABLES,
-} from "@/constants/llm";
+import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { generateRandomString } from "@/lib/utils";
 
 export const generateDefaultLLMPromptMessage = (
@@ -306,23 +303,6 @@ export const parseChatTemplateToLLMMessages = (
     return [];
   }
 };
-
-/**
- * The reserved-variable set a Python-metric editor must pass for {@code scope}.
- *
- * <p>Span scope gets the empty {@link RESERVED_SPAN_EVALUATOR_VARIABLES}: a span has no
- * sub-spans, and {@code PythonCodeDetailsSpanFormSchema} accepts only
- * {@code input}/{@code output}/{@code metadata} paths — so auto-filling the trace
- * {@code spans} sentinel would fail validation on a row the sentinel filter hides from
- * the mapping list, leaving the dialog unsubmittable with nothing visible to correct.
- * Thread scope has no argument mapping at all, so the value is unused there.
- */
-export const reservedPythonMetricVariablesForScope = (
-  scope: EVALUATORS_RULE_SCOPE,
-): Readonly<Record<string, string>> =>
-  scope === EVALUATORS_RULE_SCOPE.span
-    ? RESERVED_SPAN_EVALUATOR_VARIABLES
-    : RESERVED_TRACE_EVALUATOR_VARIABLES;
 
 /**
  * Resolve the value for one template variable in an LLM-as-judge / Python-metric

--- a/apps/opik-frontend/src/lib/llm.ts
+++ b/apps/opik-frontend/src/lib/llm.ts
@@ -8,7 +8,10 @@ import {
   TextPart,
 } from "@/types/llm";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
+import {
+  RESERVED_SPAN_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+} from "@/constants/llm";
 import { generateRandomString } from "@/lib/utils";
 
 export const generateDefaultLLMPromptMessage = (
@@ -305,18 +308,38 @@ export const parseChatTemplateToLLMMessages = (
 };
 
 /**
+ * The reserved-variable set a Python-metric editor must pass for {@code scope}.
+ *
+ * <p>Span scope gets the empty {@link RESERVED_SPAN_EVALUATOR_VARIABLES}: a span has no
+ * sub-spans, and {@code PythonCodeDetailsSpanFormSchema} accepts only
+ * {@code input}/{@code output}/{@code metadata} paths — so auto-filling the trace
+ * {@code spans} sentinel would fail validation on a row the sentinel filter hides from
+ * the mapping list, leaving the dialog unsubmittable with nothing visible to correct.
+ * Thread scope has no argument mapping at all, so the value is unused there.
+ */
+export const reservedPythonMetricVariablesForScope = (
+  scope: EVALUATORS_RULE_SCOPE,
+): Readonly<Record<string, string>> =>
+  scope === EVALUATORS_RULE_SCOPE.span
+    ? RESERVED_SPAN_EVALUATOR_VARIABLES
+    : RESERVED_TRACE_EVALUATOR_VARIABLES;
+
+/**
  * Resolve the value for one template variable in an LLM-as-judge / Python-metric
  * rule. Existing user-supplied mapping wins; otherwise on trace or span scope a
  * reserved variable auto-fills to its sentinel value (so {{spans}} / {{trace}} on
  * trace scope and {{span}} on span scope work without the user picking a path);
  * otherwise empty. Centralized so the rule-detail editors stay in sync.
  *
- * <p>{@code reservedVariables} defaults to the shared {@code spans}-only set; the
- * LLM-judge editors pass the scope-appropriate set —
+ * <p>{@code reservedVariables} defaults to the shared {@code spans}-only set, but every
+ * caller passes the set matching its rule type AND scope, because a name reserved in one
+ * combination is an invalid mapping in another. LLM judges pass
  * {@link RESERVED_TRACE_LLM_JUDGE_VARIABLES} (adds {@code trace}) on trace scope and
- * {@link RESERVED_SPAN_LLM_JUDGE_VARIABLES} ({@code span}) on span scope. The
- * Python-metric editors keep the default, because the Python scorer backend only
- * injects `spans`.
+ * {@link RESERVED_SPAN_LLM_JUDGE_VARIABLES} ({@code span}) on span scope. Python metrics
+ * pass {@link RESERVED_TRACE_EVALUATOR_VARIABLES} on trace scope — the scorer backend
+ * only injects {@code spans}, so {@code trace} is deliberately absent — and the empty
+ * {@link RESERVED_SPAN_EVALUATOR_VARIABLES} on span scope, where a span has no sub-spans
+ * and the form schema rejects the {@code spans} sentinel outright.
  */
 export const resolveTraceEvaluatorVariableDefault = (
   variableName: string,

--- a/apps/opik-frontend/src/types/feature-toggles.ts
+++ b/apps/opik-frontend/src/types/feature-toggles.ts
@@ -15,12 +15,6 @@ export enum FeatureToggleKeys {
   SPAN_LLM_AS_JUDGE_ENABLED = "span_llm_as_judge_enabled",
   SPAN_USER_DEFINED_METRIC_PYTHON_ENABLED = "span_user_defined_metric_python_enabled",
   COST_INTELLIGENCE_ENABLED = "cost_intelligence_enabled",
-  // Gates the spans-in-LLM-judge feature: agentic-tools loop AND the {{spans}}
-  // template substitution in trace-scope rules. When off, FE editors stop
-  // auto-filling `spans → "spans"` and keep the row visible/editable so the user
-  // can map `spans` to a custom path like any other variable; backend mirrors
-  // by skipping the SpanService fetch + injecting "[]" into {{spans}}.
-  AGENTIC_TOOLS_ENABLED = "agentic_tools_enabled",
   // LLM Provider feature flags
   OPENAI_PROVIDER_ENABLED = "openai_provider_enabled",
   ANTHROPIC_PROVIDER_ENABLED = "anthropic_provider_enabled",

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/LLMJudgeRuleDetails.tsx
@@ -50,8 +50,6 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { updateProviderConfig } from "@/lib/modelUtils";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
-import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 const MESSAGE_TYPE_OPTIONS = [
   {
@@ -142,9 +140,6 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
-  const agenticToolsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
-  );
 
   const templates = LLM_PROMPT_TEMPLATES[scope];
 
@@ -220,7 +215,6 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
             v,
             variables[v],
             currentScope,
-            agenticToolsEnabled,
             reservedVariables,
           );
         });
@@ -231,7 +225,7 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
         parsingVariablesError,
       );
     },
-    [agenticToolsEnabled],
+    [],
   );
 
   return (
@@ -453,11 +447,9 @@ const LLMJudgeRuleDetails: React.FC<LLMJudgeRuleDetailsProps> = ({
                     type={autocompleteType}
                     includeIntermediateNodes
                     reservedSentinels={
-                      agenticToolsEnabled
-                        ? isSpanScope
-                          ? RESERVED_SPAN_LLM_JUDGE_VARIABLES
-                          : RESERVED_TRACE_LLM_JUDGE_VARIABLES
-                        : undefined
+                      isSpanScope
+                        ? RESERVED_SPAN_LLM_JUDGE_VARIABLES
+                        : RESERVED_TRACE_LLM_JUDGE_VARIABLES
                     }
                   />
                 </>

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,10 +12,8 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import {
-  reservedPythonMetricVariablesForScope,
-  resolveTraceEvaluatorVariableDefault,
-} from "@/lib/llm";
+import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
+import { reservedPythonMetricVariablesForScope } from "./helpers";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -15,8 +15,6 @@ import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
 import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
 import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
-import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
-import { FeatureToggleKeys } from "@/types/feature-toggles";
 
 type PythonCodeRuleDetailsProps = {
   form: UseFormReturn<EvaluationRuleFormType>;
@@ -34,9 +32,6 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
   const scope = form.watch("scope");
   const isThreadScope = scope === EVALUATORS_RULE_SCOPE.thread;
   const isSpanScope = scope === EVALUATORS_RULE_SCOPE.span;
-  const agenticToolsEnabled = useIsFeatureEnabled(
-    FeatureToggleKeys.AGENTIC_TOOLS_ENABLED,
-  );
 
   // Determine the type for autocomplete based on scope
   const autocompleteType = isSpanScope
@@ -76,7 +71,6 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                                   v,
                                   currentArguments[v],
                                   scope,
-                                  agenticToolsEnabled,
                                 );
                             });
                         } catch (e) {
@@ -127,11 +121,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                reservedSentinels={
-                  agenticToolsEnabled
-                    ? RESERVED_TRACE_EVALUATOR_VARIABLES
-                    : undefined
-                }
+                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/PythonCodeRuleDetails.tsx
@@ -12,8 +12,10 @@ import { Label } from "@/ui/label";
 import { useCodemirrorTheme } from "@/hooks/useCodemirrorTheme";
 import { parsePythonMethodParameters } from "@/lib/pythonArgumentsParser";
 import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
-import { RESERVED_TRACE_EVALUATOR_VARIABLES } from "@/constants/llm";
-import { resolveTraceEvaluatorVariableDefault } from "@/lib/llm";
+import {
+  reservedPythonMetricVariablesForScope,
+  resolveTraceEvaluatorVariableDefault,
+} from "@/lib/llm";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 
 type PythonCodeRuleDetailsProps = {
@@ -37,6 +39,10 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
   const autocompleteType = isSpanScope
     ? TRACE_DATA_TYPE.spans
     : TRACE_DATA_TYPE.traces;
+
+  // Scope-appropriate reserved set, as LLMJudgeRuleDetails does — `spans` is a
+  // trace-scope sentinel that span scope's schema rejects.
+  const reservedVariables = reservedPythonMetricVariablesForScope(scope);
 
   return (
     <>
@@ -71,6 +77,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                                   v,
                                   currentArguments[v],
                                   scope,
+                                  reservedVariables,
                                 );
                             });
                         } catch (e) {
@@ -121,7 +128,7 @@ const PythonCodeRuleDetails: React.FC<PythonCodeRuleDetailsProps> = ({
                 datasetColumnNames={datasetColumnNames}
                 type={autocompleteType}
                 includeIntermediateNodes
-                reservedSentinels={RESERVED_TRACE_EVALUATOR_VARIABLES}
+                reservedSentinels={reservedVariables}
               />
             );
           }}

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/helpers.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/helpers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { reservedPythonMetricVariablesForScope } from "./helpers";
+import { PythonCodeDetailsSpanFormSchema } from "./schema";
+import {
+  RESERVED_SPAN_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+} from "@/constants/llm";
+import { EVALUATORS_RULE_SCOPE } from "@/types/automations";
+
+describe("reservedPythonMetricVariablesForScope", () => {
+  it("reserves spans on trace scope, where the scorer injects it", () => {
+    expect(
+      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.trace),
+    ).toEqual(RESERVED_TRACE_EVALUATOR_VARIABLES);
+  });
+
+  it("reserves nothing on span scope, so no sentinel is auto-filled or hidden", () => {
+    expect(
+      reservedPythonMetricVariablesForScope(EVALUATORS_RULE_SCOPE.span),
+    ).toEqual(RESERVED_SPAN_EVALUATOR_VARIABLES);
+  });
+});
+
+/**
+ * The other half of the span-scope pairing above: the sentinel the resolver must not
+ * auto-fill is one this schema genuinely rejects, so a regression in either file alone
+ * still fails a test here.
+ */
+describe("PythonCodeDetailsSpanFormSchema", () => {
+  const metric = "def score(input, spans): return []";
+
+  it("rejects the bare spans sentinel that trace scope allows", () => {
+    expect(
+      PythonCodeDetailsSpanFormSchema.safeParse({
+        metric,
+        arguments: { input: "input", spans: "spans" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("accepts the arguments the span resolver actually produces", () => {
+    // `spans` left blank by the resolver is still required to be pointed at a real path
+    // before submit; the user maps it explicitly, as with any non-reserved parameter.
+    expect(
+      PythonCodeDetailsSpanFormSchema.safeParse({
+        metric,
+        arguments: { input: "input", spans: "metadata.spans" },
+      }).success,
+    ).toBe(true);
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/helpers.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/helpers.ts
@@ -5,6 +5,10 @@ import {
   EVALUATORS_RULE_TYPE,
   UI_EVALUATORS_RULE_TYPE,
 } from "@/types/automations";
+import {
+  RESERVED_SPAN_EVALUATOR_VARIABLES,
+  RESERVED_TRACE_EVALUATOR_VARIABLES,
+} from "@/constants/llm";
 import { Filter } from "@/types/filters";
 import { ColumnData } from "@/types/shared";
 
@@ -84,3 +88,20 @@ export const normalizeFilters = (
     };
   }) as Filter[];
 };
+
+/**
+ * The reserved-variable set a Python-metric editor must pass for {@code scope}.
+ *
+ * <p>Span scope gets the empty {@link RESERVED_SPAN_EVALUATOR_VARIABLES}: a span has no
+ * sub-spans, and {@code PythonCodeDetailsSpanFormSchema} accepts only
+ * {@code input}/{@code output}/{@code metadata} paths — so auto-filling the trace
+ * {@code spans} sentinel would fail validation on a row the sentinel filter hides from
+ * the mapping list, leaving the dialog unsubmittable with nothing visible to correct.
+ * Thread scope has no argument mapping at all, so the value is unused there.
+ */
+export const reservedPythonMetricVariablesForScope = (
+  scope: EVALUATORS_RULE_SCOPE,
+): Readonly<Record<string, string>> =>
+  scope === EVALUATORS_RULE_SCOPE.span
+    ? RESERVED_SPAN_EVALUATOR_VARIABLES
+    : RESERVED_TRACE_EVALUATOR_VARIABLES;


### PR DESCRIPTION
## Details

Removes `TOGGLE_AGENTIC_TOOLS_ENABLED` / `serviceToggles.agenticToolsEnabled` and makes the agentic-tools path on LLM-as-judge online scoring unconditional. Supersedes #7950, which only flipped the image default — this removes the switch entirely.

The toggle gated the agentic tool loop, the `{{trace}}` / `{{span}}` / `{{spans}}` template substitutions, and the thread route-before-fetch sizing. Comet-hosted environments already pin it `true` in their chart values, so **their behavior is unchanged**. Self-hosted installs inherited the image default of `"false"`; for them the agentic path is now permanently on.

### Removal pattern

Follows `fa9aeb9c91` and `b48e63b1e8` (OPIK-6434). Both of those initially kept the removed field on `ServiceTogglesConfig` as `@Deprecated` "for SDK response-shape compat", and review rejected that as active tech debt — the field lives only in Fern-*generated* SDK types with no hand-written consumer, so the nightly regen drops it for free. This PR does the full removal accordingly.

The Java field and both YAML entries move together on purpose: deleting the `config.yml` line while leaving the `@NotNull boolean` breaks Dropwizard config binding at startup, which is the CI failure `b48e63b1e8` hit and had to fix in a follow-up commit.

### Dead code removed

Two things became unreachable once the toggle was gone, so they went with it:

- `buildSentinelStructureRequests` (span scorer) — only reachable with the toggle off, where `{{span}}` rendered as `{}`
- `OnlineScoringEngine.prepareSpanLlmRequest(code, span, strategy, structureJson)` — the uncapped 4-arg overload whose sole caller was the above, plus its two unit tests (one asserted the `{}` rendering, which can no longer occur)

### Consequences

**No kill switch any more.** If the agentic loop misbehaves in a customer environment — runaway tool loops, cost spikes, ClickHouse load — there is no config rollback, only a code revert and redeploy.

What survives is a *partial* lever: `ONLINE_SCORING_AGENTIC_TOOLS_THRESHOLD_TOKENS` (50000) and `ONLINE_SCORING_AGENTIC_TOOLS_MAX_PRELOAD_MB` (32). Raising the threshold suppresses **size-based** escalation only — it does not stop the `{{trace}}` / `{{span}}` declarative triggers, the experimentId test-suite path, or the span pre-fetch.

**New unconditional I/O per evaluation** (previously skipped entirely when off):

| Path | Now always runs |
|---|---|
| Trace judge | `getByTraceIds` whenever the provider supports tool-calling (OpenAI / Anthropic / Gemini / OpenRouter / Vertex / Bedrock), regardless of prompt content |
| Thread judge | `getSpansSizeByTraceIds` (ClickHouse aggregate) **and** `hasAnyAttachmentByEntityIds` |
| Thread Python metric | `getSpansSizeByTraceIds`, plus a bounded span fetch under the preload cap |
| Span judge | attachment fetch whenever `{{span}}` is referenced |

**Behavior change worth calling out for self-hosted:** thread-scope Python metrics now receive an **enriched** context — spans nested under each assistant message — instead of plain `[{role, content}]`. Keys are added rather than removed, so iteration still works, but a user metric asserting on exact dict shape could break.

**API/SDK:** `agenticToolsEnabled` disappears from `GET /v1/private/toggles/` (`ServiceTogglesResource`), while both checked-in OpenAPI specs (`sdks/code_generation/fern/openapi/openapi.yaml`, `apps/opik-documentation/documentation/fern/openapi/opik.yaml`) still list it under `required`, and the generated Python type (`sdks/python/src/opik/rest_api/types/service_toggles_config.py`) still declares it a non-`Optional` bool. Those are refreshed by the nightly `sdks_generate_openapi_spec_and_fern_code.yml` — `schedule: cron '0 0 * * 1-5'` plus `workflow_dispatch`, with no PR-triggered job diffing the spec — so the drift self-heals on the next weeknight run rather than failing CI here. Verified narrow: no hand-written SDK code calls that endpoint (grep over `sdks/{python,typescript}/src/opik` excluding `rest_api/` is empty); it is the frontend's runtime toggle fetch. An old SDK explicitly calling `service_toggles.get_service_toggles()` against a new server would raise a pydantic `ValidationError`. Same trade-off accepted in `b48e63b1e8`, where review rejected keeping the field as `@Deprecated` compat residue.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Mapped every toggle reference, applied the removal across backend/frontend/tests, mined the two prior toggle-removal PRs for the house pattern, ran and triaged the suites below.
- Human verification: Code review of the diff pending.

## Testing

Run from `apps/opik-backend`, on this branch's base (57 commits newer than where the change was authored — patch applied cleanly with `--3way`, and a fresh grep confirmed the newer base added no new toggle usages).

| Suite | Result |
|---|---|
| `OnlineScoringLlmAsJudgeScorerTest` + `OnlineScoringSpanLlmAsJudgeScorerTest` + `OnlineScoringTraceThreadLlmAsJudgeScorerTest` + `OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest` (together) | ✅ 73/73 |
| `OnlineScoringEngineTest` | ✅ 91/91 |
| `TraceThreadOnlineScoringAgenticToolsE2ETest` | ✅ 1/1 |
| `TraceThreadOnlineScoringSamplerListenerIntegrationTest` | ✅ 6/6 |
| `OnlineScoringSpanSamplerIntegrationTest` | ✅ 2/2 |
| Frontend `tsc` / `eslint` / `prettier` | ✅ clean |

### Two test-robustness fixes included

Both are latent bugs that this change reliably exposes rather than newly introduces:

1. **`OnlineScoringEngineTest.testFilteringEvaluatorsByTraceMetadata`** hoisted its `ArgumentCaptor` outside the `Awaitility.untilAsserted` lambda. Every poll re-captured all prior invocations, so `getAllValues()` grew monotonically (6 → 12 → … → 555 observed) and the `hasSize(6)` assertion could never recover from a single missed poll. The captor is now created inside the lambda. The extra trace-path span fetch is what made that first poll miss reliably — the 555 items were the same 6 distinct scores repeating.

2. **`TraceThreadOnlineScoringAgenticToolsE2ETest`** dereferenced `feedbackScores()` before asserting non-null. `untilAsserted` retries `AssertionError` but propagates a raw `NPE`, so the window between the "Evaluating threadId" log and score persistence failed the test outright instead of being retried.

### Not attributable to this change

- `CostIntelligenceIngestionTest` failed only when sharing a JVM with other classes; passes 17/17 alone. Unrelated feature, no overlap with this diff.
- `TraceThreadOnlineScoringSamplerListenerIntegrationTest` once died in a Liquibase migration at class setup (stale ZooKeeper vs local ClickHouse enum, `WARM`/`WARN`) with zero tests executed; passes 6/6 alone. This diff contains no migration files.

Not run: SDK suites — untouched by a backend config removal.

## Documentation

N/A. No docs, chart values, or chart README reference `TOGGLE_AGENTIC_TOOLS_ENABLED` — `grep` over `deployment/`, `apps/opik-documentation/`, and the helm values returns nothing, so there is no documented default to correct. The only remaining references to `agenticToolsEnabled` anywhere in the repo are the two generated OpenAPI specs and the Fern SDK types, which the nightly `sdks_generate_openapi_spec_and_fern_code.yml` regenerates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

