### PR TITLE
[OPIK-7940] [CI] test: scope the token-auth e2e specs to local deployments

### DIFF
--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -11,6 +11,7 @@
  *    MOCK_AUTH_URL_FOR_BACKEND=http://host.docker.internal:9878 (and make sure the backend
  *    runs with LLM_PROVIDER_TOKEN_AUTH_DESTINATION_GUARD=relaxed, as the compose file ships).
  */
+import { loadEnvConfig } from '../config/env.config';
 import { AuthConfigCheckError, checkProviderAuthConfig } from './provider-keys';
 
 export const MOCK_AUTH_PORT = parseInt(process.env.MOCK_AUTH_PORT ?? '9878', 10);
@@ -66,10 +67,12 @@ const UNREACHABLE_PATTERNS = [/could not reach/i, /destination/i];
  * backend's own test-connection endpoint (which performs the fetch server-side) turns that into
  * a skip that names the cause.
  *
- * Only two outcomes are a skip: the deployment lacks the endpoint, or the backend cannot reach
- * the destination. Everything else — auth, permissions, rejected credentials, a malformed
- * reply — is a real problem this suite must not hide behind a green run, so it propagates and
- * fails the setup. Resolves to null when the backend CAN reach the mock.
+ * Skips a remote deployment outright: the mock is bound to the test runner, so only an `oss`
+ * (local) backend can ever reach it. Beyond that, two probe outcomes are a skip — the
+ * deployment lacks the endpoint, or the backend cannot reach the destination. Everything
+ * else — auth, permissions, rejected credentials, a malformed reply — is a real problem this
+ * suite must not hide behind a green run, so it propagates and fails the setup. Resolves to
+ * null when the backend CAN reach the mock.
  *
  * Cached: the answer is a property of the deployment, and every spec in the area asks.
  */
@@ -77,6 +80,14 @@ let mockAuthGate: Promise<string | null> | undefined;
 
 export function mockAuthSkipReason(): Promise<string | null> {
   mockAuthGate ??= (async () => {
+    // The mock runs on the test runner, so only a backend on that same host can reach it.
+    // A remote deployment never can — that is a property of the topology, not a
+    // misconfiguration to diagnose, so say so instead of probing an endpoint that cannot pass.
+    const { deployment } = loadEnvConfig();
+    if (deployment !== 'oss') {
+      return `dynamic token auth needs a backend that can reach the host-run mock token service; the ${deployment} deployment cannot`;
+    }
+
     try {
       // A bare auth_config needs no stored provider: the backend runs the token fetch and
       // answers 200 with the lifetime when the URL is reachable.


### PR DESCRIPTION
## Details

The mock OAuth2 token service is bound to the test runner (Playwright's `webServer`), so only a backend on that same host can reach it. A **remote** deployment never can — which made the four token-auth specs structurally unable to pass on the cloud tier, where they failed on a missing "Connection successful" toast on every run ([launch 100896](https://comet.testops.cloud/launch/100896)).

State that constraint directly instead of letting the reachability probe skip incidentally: a non-`oss` deployment returns a reason naming the topology, and never probes an endpoint that cannot pass. The probe stays for the local case it was written for.

Without this, once #7988 reaches the cloud tier those four specs would turn into permanent silent skips there — a probe failure reads as "something is misconfigured", when the truth is "this tier cannot run these specs". Same pattern the Ollie specs already use for `features.ollie`.

Paired stopgap: comet-ml/comet-automation-tests#359 excludes them at the workflow level so the cloud tier goes green on its next run, rather than waiting for this to reach a deployed release.

The `local` tier is unaffected and already green after comet-ml/comet-automation-tests#357 — [launch 100900](https://comet.testops.cloud/launch/100900) shows all five `ai-providers` tests passing, four marked `fixed`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-7940

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Diagnosed the cloud-tier failures, wrote the deployment scoping, ran the verification below.
- Human verification: Diagnosis traced to the pinned checkout ref and workflow source; diff and test outcomes reviewed by the author.

## Testing

```bash
npx tsc --noEmit -p tsconfig.json
```
```bash
npx playwright test tests/ai-providers/ --grep @t1-smoke --reporter=line --workers=2
```

Scenarios validated:

- **Typecheck** — clean (exit 0).
- **Remote deployments skip, without probing** — driven directly with `OPIK_DEPLOYMENT=cloud` and `self-hosted` while `OPIK_BASE_URL` pointed at a dead port. Both returned the scope reason *instantly*; had the probe run, the dead port would have surfaced as a connection error. Confirms the early return short-circuits before any network call.
  - `cloud: dynamic token auth needs a backend that can reach the host-run mock token service; the cloud deployment cannot`
  - `self-hosted: … the self-hosted deployment cannot`
- **Local unchanged** — `oss` against a live dockerized Opik still takes the probe path and reports the endpoint-absent reason (this container predates `/auth-config/test`): `5 skipped`, exit 0.
- **Collection** — `--list` still reports all 5 tests in 2 files; nothing is hidden from discovery.
- **Lint** — `pre-commit run --files tests_end_to_end/e2e/core/mock-auth.ts` exits 0.

Not run: the specs' green path on a deployment new enough to have the endpoint. My local Opik predates it, so the pass-through branch is covered by the post-merge tier, where these specs pass.

Environment: macOS, Docker Compose Opik (`localhost:5173`), Playwright chromium.

## Documentation

No user-facing change; the constraint is documented at the gate in `core/mock-auth.ts`.
