### PR TITLE
[OPIK-8060] [BE] [FE] fix: report the best trial's latency and cost in the runs list

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OptimizationDAO.java
@@ -702,13 +702,50 @@ class OptimizationDAOImpl implements OptimizationDAO {
                 WHERE ef.experiment_type NOT IN ('mini-batch', 'mutation')
             ), objective_scores_per_experiment AS (
                 SELECT
-                    ef.optimization_id,
-                    esp.experiment_id,
-                    esp.value AS objective_score
-                FROM experiment_scores_parsed esp
-                INNER JOIN experiments_final ef ON esp.experiment_id = ef.id
-                INNER JOIN optimization_final o ON ef.optimization_id = o.id
-                WHERE esp.name = o.objective_name
+                    optimization_id,
+                    experiment_id,
+                    /*
+                     * Mirrors the run page's precedence (getObjectiveScoreValue): the trace-derived feedback
+                     * score wins, the experiment-level score is the fallback.
+                     *
+                     * toNullable is load-bearing, not decoration. candidate_metrics LEFT JOINs this CTE and
+                     * guards the weighted average with isNotNull(objective_score); under join_use_nulls = 0
+                     * an unmatched non-Nullable Float64 arrives as 0, which makes that guard always true and
+                     * scores every unscored candidate a real 0. Every candidate then ties, the best_* rollups
+                     * fall through to their earliest-created tie-break, and "best" collapses onto the
+                     * baseline - so the runs list reported the baseline's latency and cost with a 0% delta
+                     * while the run page reported the genuine best trial (OPIK-8060). duration_p50 in
+                     * experiment_durations is Nullable for the same reason.
+                     */
+                    toNullable(argMin(objective_score, source_rank)) AS objective_score
+                FROM (
+                    /*
+                     * Dataset runs - Studio runs and every SDK optimizer. The objective is a per-trace
+                     * feedback score averaged per experiment, and leaving it out was the OPIK-8060 defect:
+                     * these runs populate no experiment_scores at all, so the CTE matched nothing for them.
+                     */
+                    SELECT
+                        ef.optimization_id AS optimization_id,
+                        ef.id AS experiment_id,
+                        fs.feedback_scores[o.objective_name] AS objective_score,
+                        0 AS source_rank
+                    FROM experiments_final ef
+                    INNER JOIN optimization_final o ON ef.optimization_id = o.id
+                    INNER JOIN feedback_scores_agg fs ON ef.id = fs.experiment_id
+                    WHERE mapContains(fs.feedback_scores, o.objective_name)
+                    UNION ALL
+                    -- Test-suite runs, where the objective is scored at the experiment level.
+                    SELECT
+                        ef.optimization_id AS optimization_id,
+                        esp.experiment_id AS experiment_id,
+                        esp.value AS objective_score,
+                        1 AS source_rank
+                    FROM experiment_scores_parsed esp
+                    INNER JOIN experiments_final ef ON esp.experiment_id = ef.id
+                    INNER JOIN optimization_final o ON ef.optimization_id = o.id
+                    WHERE esp.name = o.objective_name
+                )
+                GROUP BY optimization_id, experiment_id
             ), candidate_metrics AS (
                 SELECT
                     ec.optimization_id AS optim_id,
@@ -722,6 +759,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     sum(ed.total_estimated_cost)
                         / nullIf(sum(ed.trace_count), 0)
                         AS per_trace_cost,
+                    sum(ed.trace_count) AS evaluated_count,
                     min(ec.experiment_created_at) AS earliest_created_at
                 FROM experiment_candidates ec
                 LEFT JOIN objective_scores_per_experiment ospe
@@ -729,19 +767,58 @@ class OptimizationDAOImpl implements OptimizationDAO {
                     AND ec.optimization_id = ospe.optimization_id
                 LEFT JOIN experiment_durations ed ON ec.experiment_id = ed.experiment_id
                 GROUP BY ec.optimization_id, ec.candidate_id
+            /*
+             * How many items a full evaluation covers in this run, taken from the baseline. Deliberately
+             * baseline-derived rather than a max() over all candidates, matching the run page's
+             * getExpectedItemCount: a candidate groups all of its experiments and sums their counts, so one
+             * double-counted candidate would inflate the threshold and prune every genuinely-complete trial.
+             */
+            ), candidate_expectations AS (
+                SELECT
+                    optim_id,
+                    argMin(evaluated_count, earliest_created_at) AS expected_count
+                FROM candidate_metrics
+                GROUP BY optim_id
+            /*
+             * Which candidates may win "best". A candidate that scored fewer items than a full evaluation
+             * covers holds a partial average, which is not a result and must not win - the same gate the run
+             * page applies (OPIK-7460, isStillEvaluating). Without it the two views disagree even once both
+             * read the same scores: an optimizer that evaluates most trials on a subset (GEPA and friends)
+             * leaves the runs list crowning a 5-of-12 trial while the run page reports the best fully
+             * evaluated one (OPIK-8060).
+             *
+             * A zero expectation means "unknown" and fails open, and when nothing is complete the whole set
+             * stays eligible, so a run never loses its best marker.
+             */
+            ), candidate_eligibility AS (
+                SELECT
+                    cm.*,
+                    ce.expected_count = 0 OR cm.evaluated_count >= ce.expected_count AS is_complete
+                FROM candidate_metrics cm
+                INNER JOIN candidate_expectations ce ON cm.optim_id = ce.optim_id
+            ), candidate_pools AS (
+                SELECT optim_id, max(is_complete) AS has_complete
+                FROM candidate_eligibility
+                GROUP BY optim_id
             ), candidate_rollup AS (
                 SELECT
-                    optim_id AS optimization_id,
-                    maxIf(weighted_score, isNotNull(weighted_score)) AS best_score,
+                    cel.optim_id AS optimization_id,
+                    maxIf(weighted_score, in_pool AND isNotNull(weighted_score)) AS best_score,
                     argMinIf(weighted_duration, tuple(-weighted_score, earliest_created_at),
-                        isNotNull(weighted_score)) AS best_duration,
+                        in_pool AND isNotNull(weighted_score)) AS best_duration,
                     argMinIf(per_trace_cost, tuple(-weighted_score, earliest_created_at),
-                        isNotNull(weighted_score)) AS best_cost,
+                        in_pool AND isNotNull(weighted_score)) AS best_cost,
                     argMin(weighted_score, earliest_created_at) AS baseline_score,
                     argMin(weighted_duration, earliest_created_at) AS baseline_duration,
                     argMin(per_trace_cost, earliest_created_at) AS baseline_cost
-                FROM candidate_metrics
-                GROUP BY optim_id
+                FROM (
+                    -- The baseline defines the threshold, so it is complete by construction and the
+                    -- baseline_* rollups below stay an unfiltered argMin over every candidate.
+                    SELECT cel.*, if(cp.has_complete, cel.is_complete, 1) AS in_pool
+                    FROM candidate_eligibility cel
+                    INNER JOIN candidate_pools cp ON cel.optim_id = cp.optim_id
+                ) AS cel
+                GROUP BY cel.optim_id
             ), optimization_tagged_trace_ids AS (
                 SELECT id, project_id
                 FROM traces
@@ -860,7 +937,7 @@ class OptimizationDAOImpl implements OptimizationDAO {
      * The {@link #FIND} projection for the case where no optimization in scope has an experiment. Every
      * aggregate in {@link #FIND} except {@code total_optimization_cost} is derived from
      * {@code experiments_final}, so with no experiments they all collapse to their empty-input values and the
-     * fifteen-CTE pipeline reads nothing useful. The literals below reproduce those values and their exact
+     * whole CTE pipeline reads nothing useful. The literals below reproduce those values and their exact
      * declared types.
      * <p>
      * {@code total_optimization_cost} is the exception and must be computed for real (OPIK-7521): it also sums

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OptimizationsResourceTest.java
@@ -1646,6 +1646,197 @@ class OptimizationsResourceTest {
                     });
         }
 
+        /**
+         * A dataset run - what the Studio and every SDK optimizer produce. The objective is scored per trace
+         * as a feedback score and written to no experiment_scores column at all, so the candidate rollups have
+         * to read it from the traces.
+         * <p>
+         * Every other test here that asserts a real best_* builds its trials with experimentScores, i.e. the
+         * test-suite shape, which is why OPIK-8060 survived: reading only experiment_scores left every
+         * candidate in a dataset run unscored, they all tied, the best_* rollups fell through to their
+         * earliest-created tie-break, and "best" collapsed onto the baseline. The runs list then reported the
+         * baseline's latency and cost with a 0% delta while the run page reported the genuine best trial.
+         */
+        @Test
+        @DisplayName("Get optimizer by id when the objective is scored on traces, then best comes from the best-scoring candidate")
+        void getById__whenObjectiveScoredOnTraces__bestComesFromBestScoringCandidate() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            mockTargetWorkspace(apiKey, workspaceName, UUID.randomUUID().toString());
+
+            var datasetName = "dataset-run-" + UUID.randomUUID();
+            var datasetId = datasetResourceClient.createDataset(
+                    Dataset.builder().name(datasetName).build(), apiKey, workspaceName);
+
+            List<DatasetItem> items = PodamFactoryUtils.manufacturePojoList(podamFactory, DatasetItem.class);
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetId(datasetId).items(items).build(), workspaceName, apiKey);
+
+            var objectiveName = "levenshtein_ratio";
+            var optimizationId = optimizationResourceClient.create(
+                    optimizationResourceClient.createPartialOptimization()
+                            .datasetId(datasetId)
+                            .datasetName(datasetName)
+                            .objectiveName(objectiveName)
+                            .build(),
+                    apiKey, workspaceName);
+
+            Project project = podamFactory.manufacturePojo(Project.class).toBuilder()
+                    .name("Experiment-%s".formatted(datasetName))
+                    .build();
+            projectResourceClient.createProject(project, apiKey, workspaceName);
+
+            // The baseline is slow and expensive and scores badly; the winner is created later and beats it on
+            // all three. Whole-second durations and integer costs keep both branches of bigDecimalComparator
+            // (absolute tolerance, then integer part) agreeing on which candidate a value came from.
+            var baselineTrial = createDatasetTrial(datasetId, datasetName, optimizationId, apiKey, workspaceName);
+            var winnerTrial = createDatasetTrial(datasetId, datasetName, optimizationId, apiKey, workspaceName);
+
+            var baselineDuration = BigDecimal.valueOf(9);
+            var baselineCost = BigDecimal.valueOf(9);
+            var winnerDuration = BigDecimal.valueOf(1);
+            var winnerCost = BigDecimal.valueOf(1);
+
+            scoreTrial(baselineTrial, items, project, apiKey, workspaceName, 9, baselineCost, objectiveName,
+                    BigDecimal.valueOf(0.2));
+            scoreTrial(winnerTrial, items, project, apiKey, workspaceName, 1, winnerCost, objectiveName,
+                    BigDecimal.valueOf(0.8));
+
+            await().atMost(10, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        var actual = optimizationResourceClient.get(optimizationId, apiKey, workspaceName, 200);
+
+                        assertThat(actual.numTrials()).isEqualTo(2L);
+
+                        // The scores must survive the trip at all - they were a flat 0 before the fix.
+                        assertThat(actual.bestObjectiveScore()).isNotNull();
+                        assertThat(actual.bestObjectiveScore().doubleValue()).isCloseTo(0.8, within(1e-6));
+                        assertThat(actual.baselineObjectiveScore()).isNotNull();
+                        assertThat(actual.baselineObjectiveScore().doubleValue()).isCloseTo(0.2, within(1e-6));
+
+                        // best_* must come from the winner, and baseline_* from the baseline. Asserting they
+                        // merely differ would still pass if both rollups drifted onto the same wrong candidate.
+                        StatsUtils.assertBigDecimalEquals(actual.bestDuration(), winnerDuration);
+                        StatsUtils.assertBigDecimalEquals(actual.bestCost(), winnerCost);
+                        StatsUtils.assertBigDecimalEquals(actual.baselineDuration(), baselineDuration);
+                        StatsUtils.assertBigDecimalEquals(actual.baselineCost(), baselineCost);
+                    });
+        }
+
+        /**
+         * A candidate that evaluated fewer items than a full evaluation covers holds a partial average, which
+         * is not a result and must not win - the gate the run page applies (OPIK-7460, isStillEvaluating).
+         * Optimizers that evaluate most trials on a subset (GEPA and friends) make this the common case, and
+         * without the same gate here the runs list crowned a subset trial while the run page reported the best
+         * fully evaluated one - the two views still disagreeing after the scores themselves were fixed
+         * (OPIK-8060).
+         */
+        @Test
+        @DisplayName("Get optimizer by id when a partially evaluated candidate scores highest, then best skips it")
+        void getById__whenTopCandidateIsPartiallyEvaluated__bestSkipsIt() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            mockTargetWorkspace(apiKey, workspaceName, UUID.randomUUID().toString());
+
+            var datasetName = "partial-eval-" + UUID.randomUUID();
+            var datasetId = datasetResourceClient.createDataset(
+                    Dataset.builder().name(datasetName).build(), apiKey, workspaceName);
+
+            List<DatasetItem> items = PodamFactoryUtils.manufacturePojoList(podamFactory, DatasetItem.class);
+            datasetResourceClient.createDatasetItems(
+                    DatasetItemBatch.builder().datasetId(datasetId).items(items).build(), workspaceName, apiKey);
+
+            var objectiveName = "levenshtein_ratio";
+            var optimizationId = optimizationResourceClient.create(
+                    optimizationResourceClient.createPartialOptimization()
+                            .datasetId(datasetId)
+                            .datasetName(datasetName)
+                            .objectiveName(objectiveName)
+                            .build(),
+                    apiKey, workspaceName);
+
+            Project project = podamFactory.manufacturePojo(Project.class).toBuilder()
+                    .name("Experiment-%s".formatted(datasetName))
+                    .build();
+            projectResourceClient.createProject(project, apiKey, workspaceName);
+
+            var baselineTrial = createDatasetTrial(datasetId, datasetName, optimizationId, apiKey, workspaceName);
+            // Created before the complete trial, so under a score tie it would also win the tie-break - the
+            // gate, not the ordering, is what has to keep it out.
+            var partialTrial = createDatasetTrial(datasetId, datasetName, optimizationId, apiKey, workspaceName);
+            var completeTrial = createDatasetTrial(datasetId, datasetName, optimizationId, apiKey, workspaceName);
+
+            // The baseline covers every item, which is what defines a full evaluation for this run.
+            scoreTrial(baselineTrial, items, project, apiKey, workspaceName, 9, BigDecimal.valueOf(9),
+                    objectiveName, BigDecimal.valueOf(0.2));
+            // Top score, fastest, cheapest - and only one item deep, so none of that counts.
+            scoreTrial(partialTrial, items.subList(0, 1), project, apiKey, workspaceName, 1, BigDecimal.valueOf(1),
+                    objectiveName, BigDecimal.valueOf(0.9));
+            scoreTrial(completeTrial, items, project, apiKey, workspaceName, 4, BigDecimal.valueOf(4),
+                    objectiveName, BigDecimal.valueOf(0.5));
+
+            await().atMost(10, TimeUnit.SECONDS)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .untilAsserted(() -> {
+                        var actual = optimizationResourceClient.get(optimizationId, apiKey, workspaceName, 200);
+
+                        assertThat(actual.numTrials()).isEqualTo(3L);
+
+                        // 0.5, not the partial candidate's 0.9.
+                        assertThat(actual.bestObjectiveScore()).isNotNull();
+                        assertThat(actual.bestObjectiveScore().doubleValue()).isCloseTo(0.5, within(1e-6));
+
+                        StatsUtils.assertBigDecimalEquals(actual.bestDuration(), BigDecimal.valueOf(4));
+                        StatsUtils.assertBigDecimalEquals(actual.bestCost(), BigDecimal.valueOf(4));
+                        StatsUtils.assertBigDecimalEquals(actual.baselineDuration(), BigDecimal.valueOf(9));
+                        StatsUtils.assertBigDecimalEquals(actual.baselineCost(), BigDecimal.valueOf(9));
+                    });
+        }
+
+        /** A trial that is its own candidate and carries no experiment-level score. */
+        private Experiment createDatasetTrial(UUID datasetId, String datasetName, UUID optimizationId,
+                String apiKey, String workspaceName) {
+            var trial = experimentResourceClient.createPartialExperiment()
+                    .datasetId(datasetId)
+                    .datasetName(datasetName)
+                    .optimizationId(optimizationId)
+                    .type(ExperimentType.TRIAL)
+                    .metadata(JsonUtils.getJsonNodeFromString(JsonUtils.writeValueAsString(
+                            Map.of("candidate_id", UUID.randomUUID().toString()))))
+                    .build();
+            experimentResourceClient.create(trial, apiKey, workspaceName);
+            return trial;
+        }
+
+        /**
+         * Backs a trial with one trace and one span per item, every trace lasting {@code durationSeconds} and
+         * every span costing {@code costPerSpan}, then scores each trace with the objective. Per-trace cost
+         * reduces to the span cost and the duration p50 to the single distinct duration, so the candidate's
+         * rolled-up figures are exactly these arguments.
+         */
+        private void scoreTrial(Experiment trial, List<DatasetItem> datasetItems, Project project, String apiKey,
+                String workspaceName, long durationSeconds, BigDecimal costPerSpan, String objectiveName,
+                BigDecimal score) {
+            var traceEnd = Instant.now().minusSeconds(1);
+            var traces = createTracesSpansAndItems(trial, datasetItems, project, apiKey, workspaceName,
+                    traceEnd.minusSeconds(durationSeconds), traceEnd, costPerSpan);
+
+            traceResourceClient.feedbackScores(
+                    traces.stream()
+                            .map(trace -> podamFactory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                                    .projectName(project.name())
+                                    .id(trace.id())
+                                    .name(objectiveName)
+                                    .value(score)
+                                    .build())
+                            .map(FeedbackScoreBatchItem.class::cast)
+                            .toList(),
+                    apiKey, workspaceName);
+        }
+
         private List<Trace> createTracesSpansAndItems(Experiment experiment, List<DatasetItem> datasetItems,
                 Project project, String apiKey, String workspaceName,
                 Instant traceStart, Instant traceEnd, BigDecimal costPerSpan) {

--- a/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationColumns.ts
+++ b/apps/opik-frontend/src/v2/pages/OptimizationPage/useOptimizationColumns.ts
@@ -109,7 +109,12 @@ export const useOptimizationColumns = ({
       },
       {
         id: "runtime_cost",
-        label: "Opt. cost",
+        // Per-trial cost of a single evaluated case, which is what runtimeCost
+        // holds — the same figure the Overview card labels "Runtime cost". It
+        // was labelled "Opt. cost" here, the name the runs list uses for a whole
+        // run's total spend, so one header stood for a per-case rate on this
+        // page and a lifetime total one screen away (OPIK-8060).
+        label: "Runtime cost",
         type: COLUMN_TYPE.cost,
         size: 130,
         accessorFn: (row) => row.runtimeCost,

--- a/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.tsx
+++ b/apps/opik-frontend/src/v2/pages/OptimizationsPage/OptimizationsColumns.tsx
@@ -124,10 +124,17 @@ export const DEFAULT_COLUMNS: ColumnData<Optimization>[] = [
     cell: OptimizationCostCell as never,
   },
   {
+    // The id stays "opt_cost" so saved column selection, order and width
+    // survive the rename.
     id: "opt_cost",
-    label: "Opt. cost",
+    // Named for what it measures — a whole run's one-time spend — and matching
+    // the run page's overview card. The former "Opt. cost" was an abbreviation
+    // that also read as the run page's per-case column, so one header stood for
+    // two different quantities a screen apart (OPIK-8060). Wider than its metric
+    // siblings because the unabbreviated label needs the room.
+    label: "Optimization cost",
     type: COLUMN_TYPE.cost,
-    size: DEFAULT_METRIC_COLUMN_WIDTH,
+    size: 160,
     accessorFn: (row) => row.total_optimization_cost,
     cell: OptimizationTotalCostCell as never,
   },


### PR DESCRIPTION
## Details

The Optimization runs list reported the **baseline** trial's latency and cost as the run's best result, with a flat `0%` delta on every row, while the run details page reported the genuine best trial (e.g. `0% / 3.2s` in the list vs `-60% / 1.3s` on the run page for the same run). Two independent causes in the optimization summary query, plus a column-naming collision that made the numbers look self-contradictory.

- **The objective score was read from the wrong place.** The candidate rollups sourced it only from the experiment-level `experiment_scores` column. Dataset runs — Studio runs and every SDK optimizer — score per trace instead and populate no `experiment_scores` at all, so no candidate had a score. And because `join_use_nulls = 0` makes an unmatched non-`Nullable` `LEFT JOIN` column arrive as `0` rather than `NULL`, the `isNotNull()` guard was inert and every candidate was scored a real `0`. All candidates tied, so the `best_*` rollups fell through to their earliest-created tie-break — which is the baseline. The score is now read from the per-experiment trace feedback scores first with the experiment-level score as fallback (mirroring the run page's `getObjectiveScoreValue` precedence) and stays `Nullable`, so the guard means something.
- **The completeness gate was missing.** The run page excludes candidates that evaluated fewer items than a full evaluation covers, because a partial average is not a result (`OPIK_7460`). The query had no such rule, so even with correct scores it could crown a trial that had only covered part of the test set — which optimizers that evaluate most trials on a subset make the common case, not an edge case. `best_*` is now restricted to candidates that covered at least as many items as the baseline, falling back to the whole set when nothing has completed, so a run never loses its best marker.
- **`Opt. cost` meant two different things.** In the runs list it was a whole run's total spend; in the run page's trials table it was the cost of a single evaluated case — the same figure that page's own overview card calls `Runtime cost`. One header, two quantities, one screen apart. The list column is now **`Optimization cost`** (matching the run page's overview card) and the trials column **`Runtime cost`** (matching that page's card and chart tooltip). Column ids are unchanged, so saved column selection, order and width survive the rename; the list column was widened to 160px to fit the unabbreviated label.

**Reviewer note — one deliberate behaviour change.** Runs with no scored trials (errored runs, or runs whose chosen objective was never scored) now report no best latency or cost instead of the baseline's figure mislabelled as the best. In the reproduction environment that is 11 of 38 runs moving from a number to `-`. This is the truthful answer and the UI already renders it, but it will read as "lost data" without context. Whole-run spend is unaffected.

No data is wrong at rest — traces, scores and costs were all recorded correctly, only the summary reading of them was off, so affected runs display correctly as soon as this ships. Nothing needs backfilling.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8060

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation — investigation, query fix, regression tests, column renames
- Human verification: author-directed investigation and review, including the column naming decisions; behaviour confirmed by hand in a local deployment before and after the change

## Testing

Backend (from `apps/opik-backend`):

```bash
mvn -o compile -DskipTests
mvn -o spotless:check
mvn -o test -Dtest='OptimizationsResourceTest,OptimizationsResourceFindProjectOptimizationsTest'
```

Frontend (from `apps/opik-frontend`):

```bash
npm run lint
npm run typecheck
npx vitest run src/v2/pages/OptimizationsPage/OptimizationsColumns.test.ts \
               src/v2/pages/OptimizationPage/useOptimizationColumns.test.ts
```

Scenarios validated:

- **Two new regression tests**, one per cause, added to `OptimizationsResourceTest$GetOptimizerById`:
  - a dataset-shaped run whose objective is scored on traces rather than at the experiment level — asserts `best_*` comes from the best-scoring candidate and `baseline_*` from the baseline, rather than both collapsing onto the baseline;
  - a run where the top-scoring candidate is only partially evaluated — asserts `best_*` skips it in favour of the best fully evaluated candidate.
- **Both new tests were confirmed to fail without the fix**: reverted the query to its `main` state, rebuilt, and both failed on the awaited assertions; they pass with the fix applied. Every pre-existing test that asserts a real `bestDuration`/`bestCost` builds its trials with `experimentScores`, i.e. the experiment-level shape — which is why this went unnoticed, and what the first new test covers.
- **End-to-end in a local deployment**, against a real 25-trial GEPA run: the runs list and the run details page now agree exactly (`1.3s` at `-60%`, `$0.0009`), where before the list showed `3.2s` / `$0.0010` at `0%`. Verified through the API and in the browser, on both the runs list and the run page's Overview and Trials tabs.
- **Regressions checked across the whole local dataset**: 27 of 38 runs report latency/cost; before the change 27/27 showed `best == baseline`, after it 12 show a real delta and the 15 that remain flat were each confirmed to be legitimately flat (their baseline genuinely ties for best on a complete evaluation).
- **Renamed columns** verified rendering in the browser on both screens, with the list header measured for truncation at its new width.

Environment: local dev stack (`scripts/dev-runner.sh`, backend and frontend as processes, Dockerised MySQL/ClickHouse/Redis), macOS, Chromium.

Not run: the full `apps/opik-backend` `mvn test` suite. It is a long-running integration suite and contended with the running local stack for Docker resources; the two test classes covering the changed query were run instead (75 tests, all passing), after rebasing onto the latest `main`.

## Documentation

N/A — no documentation references these columns or the affected values (checked across `*.md`, `*.mdx`, `*.ts`, `*.tsx`, `*.py`, `*.java`).
