### PR TITLE
[NA] [EXT] feat: log Cursor token usage, cost and model to Opik

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/cursor.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/cursor.mdx
@@ -75,6 +75,22 @@ The extension automatically registers an Opik MCP (Model Context Protocol) serve
 
 The MCP server integration is enabled by default and requires no additional configuration. For more details about the MCP server, see the [opik-mcp package](https://www.npmjs.com/package/opik-mcp).
 
+## Token usage and cost
+
+Each logged conversation turn also records how many tokens it used and what it cost. You will
+see the model, the prompt and completion tokens, the cache read and write tokens, and an
+estimated cost on the LLM span of every trace.
+
+These numbers come from Cursor itself, using the Cursor account you are already signed in to.
+You do not need a separate API key, and you do not need to be a team admin.
+
+The token counts arrive a few seconds after the conversation is logged, so a trace may briefly
+appear without them. A turn that did not result in a billable request, such as one you
+cancelled, keeps its trace but has no usage attached.
+
+To turn this off, set `Opik: Usage Enrichment Enabled` to false in the extension settings. Your
+conversations are still logged, just without token counts or cost.
+
 ## Viewing your conversations
 
 Once the extension is installed and configured, all your conversations will be available in the `cursor` project in Opik. To

--- a/extensions/cursor/.vscodeignore
+++ b/extensions/cursor/.vscodeignore
@@ -14,6 +14,8 @@ node_modules/**
 .eslintrc.json
 .prettierrc
 .github/**
+.claude/**
+scripts/**
 *.vsix
 test/**
 .npmignore

--- a/extensions/cursor/package-lock.json
+++ b/extensions/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opik",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "dependencies": {
         "@sentry/node": "^10.38.0",
         "glob": "^11.1.0",

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -4,7 +4,7 @@
   "description": "Export your chat history from Cursor to Opik.",
   "repository": "https://github.com/comet-ml/opik",
   "publisher": "opik",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "preview": false,
   "engines": {
     "vscode": "^1.90.0"
@@ -66,6 +66,16 @@
         }
       },
       {
+        "title": "Usage Tracking",
+        "properties": {
+          "opik.usageEnrichment.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Fetch token counts and cost from Cursor and attach them to the logged spans. Uses your existing Cursor sign-in; no extra credentials are needed. Turn this off to log conversations without usage."
+          }
+        }
+      },
+      {
         "title": "Advanced",
         "properties": {
           "opik.enableDebugLogs": {
@@ -88,7 +98,8 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "verify-usage": "node scripts/verify-usage.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/extensions/cursor/scripts/verify-usage.js
+++ b/extensions/cursor/scripts/verify-usage.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * End-to-end check of the Cursor usage pipeline, without the extension host.
+ * Reads the newest local conversation, fetches its usage from Cursor, runs the
+ * compiled attribution, and reconciles the per-turn totals against the API.
+ *
+ * Usage: npm run compile && node scripts/verify-usage.js [composerId]
+ */
+const os = require('os');
+const path = require('path');
+const Module = require('module');
+
+const originalLoad = Module._load;
+Module._load = function (request) {
+  if (request === 'vscode') {
+    return { workspace: { getConfiguration: () => ({ get: (_key, fallback) => fallback }) } };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { attributeUsageToTurns } = require('../out/cursor/usage.js');
+const { executeQuery } = require('../out/cursor/sqlite.js');
+
+const DB = path.join(
+  os.homedir(),
+  'Library/Application Support/Cursor/User/globalStorage/state.vscdb'
+);
+
+const query = (sql) => executeQuery(DB, sql);
+
+async function rpc(method, token, body) {
+  const response = await fetch(`https://api2.cursor.sh/aiserver.v1.DashboardService/${method}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+      'connect-protocol-version': '1',
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} -> ${response.status} ${await response.text()}`);
+  }
+  return response.json();
+}
+
+(async () => {
+  const token = (await query(`SELECT value FROM ItemTable WHERE key='cursorAuth/accessToken'`))[0]?.value;
+  if (!token) {
+    console.error('No Cursor access token found. Sign in to Cursor first.');
+    process.exit(1);
+  }
+  console.log(`token: present (${token.length} chars)`);
+
+  const me = await rpc('GetMe', token, {});
+  console.log(`user: ${me.email}  userId=${me.userId}  teamAdmin=${me.isTeamAdmin}`);
+
+  const composerId =
+    process.argv[2] ||
+    (await query(
+      `SELECT composerId FROM composerHeaders WHERE composerId != 'empty-state-draft'
+       ORDER BY lastUpdatedAt DESC LIMIT 1`
+    ))[0]?.composerId;
+  if (!composerId) {
+    console.error('No conversation found.');
+    process.exit(1);
+  }
+
+  const raw = (await query(`SELECT value FROM cursorDiskKV WHERE key='composerData:${composerId}'`))[0];
+  const composer = JSON.parse(raw.value);
+  console.log(`\nconversation: ${composerId}`);
+  console.log(`name: ${composer.name}`);
+  console.log(`model: ${composer.modelConfig?.modelName}`);
+
+  // Read from the bubble rows, the same source the extension uses. Older
+  // conversations have no createdAt on the header entries.
+  const bubbleRows = await query(
+    `SELECT json_extract(value, '$.createdAt') AS createdAt FROM cursorDiskKV
+     WHERE key >= 'bubbleId:${composerId}:' AND key < 'bubbleId:${composerId};'
+     AND json_extract(value, '$.type') = 1`
+  );
+  const turnStarts = [
+    ...new Set(bubbleRows.map((r) => Date.parse(r.createdAt)).filter((v) => !Number.isNaN(v))),
+  ].sort((a, b) => a - b);
+  if (turnStarts.length === 0) {
+    console.error('No user turns with timestamps in this conversation.');
+    process.exit(1);
+  }
+
+  const result = await rpc('GetFilteredUsageEvents', token, {
+    userId: me.userId,
+    startDate: String(turnStarts[0] - 60_000),
+    endDate: String(Date.now() + 60_000),
+    page: 1,
+    pageSize: 100,
+  });
+  const events = (result.usageEventsDisplay || []).filter((e) => e.conversationId === composerId);
+  console.log(`turns: ${turnStarts.length}   usage events: ${events.length}\n`);
+
+  const attributed = attributeUsageToTurns(turnStarts, events);
+  const sum = { input: 0, output: 0, cacheRead: 0, cents: 0 };
+  let covered = 0;
+
+  turnStarts.forEach((start, i) => {
+    const usage = attributed.get(i);
+    const at = new Date(start).toLocaleTimeString();
+    if (!usage) {
+      console.log(`  turn ${i + 1} [${at}] no usage event`);
+      return;
+    }
+    covered++;
+    sum.input += usage.inputTokens;
+    sum.output += usage.outputTokens;
+    sum.cacheRead += usage.cacheReadTokens;
+    sum.cents += usage.chargedCents;
+    console.log(
+      `  turn ${i + 1} [${at}] reqs=${usage.requestCount} in=${usage.inputTokens} ` +
+        `out=${usage.outputTokens} cacheR=${usage.cacheReadTokens} ` +
+        `cents=${usage.chargedCents.toFixed(4)} model=${usage.models.join(',')}`
+    );
+  });
+
+  const total = events.reduce(
+    (acc, e) => ({
+      input: acc.input + (e.tokenUsage?.inputTokens ?? 0),
+      output: acc.output + (e.tokenUsage?.outputTokens ?? 0),
+      cacheRead: acc.cacheRead + (e.tokenUsage?.cacheReadTokens ?? 0),
+      cents: acc.cents + (e.chargedCents ?? 0),
+    }),
+    { input: 0, output: 0, cacheRead: 0, cents: 0 }
+  );
+
+  const reconciled =
+    sum.input === total.input &&
+    sum.output === total.output &&
+    sum.cacheRead === total.cacheRead &&
+    Math.abs(sum.cents - total.cents) < 1e-9;
+
+  const signatures = [];
+  turnStarts.forEach((_s, i) => {
+    const u = attributed.get(i);
+    if (u) signatures.push(`${u.inputTokens}/${u.outputTokens}/${u.cacheReadTokens}`);
+  });
+  const duplicates = signatures.length - new Set(signatures).size;
+
+  console.log(`\ncoverage:   ${covered}/${turnStarts.length} turns`);
+  console.log(`duplicates: ${duplicates} turns share an identical usage payload`);
+  console.log(`attributed: in=${sum.input} out=${sum.output} cacheR=${sum.cacheRead} cents=${sum.cents.toFixed(4)}`);
+  console.log(`api total:  in=${total.input} out=${total.output} cacheR=${total.cacheRead} cents=${total.cents.toFixed(4)}`);
+  console.log(`reconcile:  ${reconciled ? 'PASS' : 'FAIL'}`);
+  process.exit(reconciled && duplicates === 0 ? 0 : 1);
+})().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -115,9 +115,6 @@ export class CursorService {
       
       throw error; // Re-throw to let the caller handle it
     } finally {
-      // Always reset the processing flag, even if an error occurs
-      this.isProcessing = false;
-
       // Runs even when the upload above failed, so pending turns from earlier
       // cycles still get their usage.
       try {
@@ -128,6 +125,12 @@ export class CursorService {
       } catch (usageError) {
         captureException(usageError);
         console.error('Error enriching cursor usage:', usageError);
+      } finally {
+        // Held through enrichment, not released before it. Two overlapping
+        // interval callbacks would otherwise run tick() at the same time, and a
+        // late write of the pending list would drop turns that track() queued
+        // in between, leaving those spans without usage forever.
+        this.isProcessing = false;
       }
     }
 

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -1,15 +1,24 @@
 import * as vscode from 'vscode';
-import { findAndReturnNewTraces } from './sessionManager';
-import { logTracesToOpik } from '../opik';
+import { findAndReturnNewTraces, resolveStateDbPath } from './sessionManager';
+import { applyTurnUsage, logTracesToOpik } from '../opik';
 import { getSessionInfo, updateSessionInfo, getLastSyncedAt, updateLastSyncedAt } from '../state';
 import { captureException } from '../sentry';
+import { UsageEnricher } from './usage';
 
 export class CursorService {
   private context: vscode.ExtensionContext;
   private isProcessing: boolean = false;
+  private usageEnricher: UsageEnricher;
+  private apiKey: string | undefined;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
+    this.usageEnricher = new UsageEnricher(context, async (pending, usage) => {
+      if (!this.apiKey) {
+        throw new Error('No API key available to patch span usage');
+      }
+      await applyTurnUsage(this.apiKey, pending, usage);
+    });
   }
 
   /**
@@ -23,6 +32,7 @@ export class CursorService {
     }
 
     this.isProcessing = true;
+    this.apiKey = apiKey;
     let numberOfTracesLogged = 0;
     let sessionInfo = getSessionInfo(this.context);
     const lastSyncedAt = getLastSyncedAt(this.context);
@@ -53,14 +63,8 @@ export class CursorService {
         if (tracesData.length > 0) {
           console.log(`📤 Logging ${tracesData.length} cursor traces to Opik`);
           
-          // Use a generic session ID for BI logging since we now have multiple composer sessions
-          const biSessionId = 'cursor-multi-session';
-          
-          try {
-            await logTracesToOpik(apiKey, tracesData);
-          } catch (opikError) {
-            throw opikError;
-          }
+          const loggedTurns = await logTracesToOpik(apiKey, tracesData);
+          this.usageEnricher.track(loggedTurns);
           
           // Update session info for each composer session
           Object.entries(updatedSessionInfo).forEach(([sessionId, sessionData]) => {
@@ -113,6 +117,18 @@ export class CursorService {
     } finally {
       // Always reset the processing flag, even if an error occurs
       this.isProcessing = false;
+
+      // Runs even when the upload above failed, so pending turns from earlier
+      // cycles still get their usage.
+      try {
+        const stateDbPath = resolveStateDbPath(vsInstallationPath);
+        if (stateDbPath) {
+          await this.usageEnricher.tick(stateDbPath);
+        }
+      } catch (usageError) {
+        captureException(usageError);
+        console.error('Error enriching cursor usage:', usageError);
+      }
     }
 
     return numberOfTracesLogged;

--- a/extensions/cursor/src/cursor/sessionManager.ts
+++ b/extensions/cursor/src/cursor/sessionManager.ts
@@ -104,11 +104,16 @@ function processConversationBubbles(
 
     // First pass: assign sequential timestamps to all bubbles
     const bubblesWithTimestamps = conversation.bubbles.map((bubble: any, index: number) => {
-        // Check if bubble has actual timing information
+        // Modern Cursor bubbles carry no timingInfo or timestamp, only an ISO
+        // createdAt. Without it every timestamp below is fabricated from
+        // conversation.createdAt, which makes trace times and usage attribution
+        // wrong, so createdAt is the primary source here.
+        const createdAtMs = bubble.createdAt ? Date.parse(bubble.createdAt) : NaN;
         const actualTime = bubble.timingInfo?.clientEndTime || 
                           bubble.timingInfo?.clientSettleTime ||
                           bubble.timingInfo?.clientRpcSendTime ||
-                          bubble.timestamp;
+                          bubble.timestamp ||
+                          (Number.isNaN(createdAtMs) ? undefined : createdAtMs);
         
         if (actualTime) {
             currentTimestamp = actualTime;
@@ -181,8 +186,11 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
         // Find all composer chats updated between last sync and current sync time
         // This prevents race conditions by using a consistent time window
         // Using > (not >=) to avoid duplicates, and <= (not <) to avoid gaps
+        // Prefix ranges instead of LIKE: LIKE is case-insensitive so SQLite cannot
+        // use the index on key and scans the whole table, including the hundreds of
+        // megabytes of agentKv and bubble rows.
         const composerQuery = `SELECT key, value FROM cursorDiskKV 
-                WHERE key LIKE 'composerData%' 
+                WHERE key >= 'composerData' AND key < 'composerDatb'
                 AND json_extract(value, '$.lastUpdatedAt') > ${lastSyncedAtWithBuffer}
                 AND json_extract(value, '$.lastUpdatedAt') <= ${currentSyncTime}
                 AND (json_extract(value, '$.status') = 'completed' 
@@ -231,7 +239,7 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
         // This dramatically reduces data transfer by filtering at the database level
         const bubbleQuery = `
             SELECT key, value FROM cursorDiskKV 
-            WHERE ${composerIds.map((id: string) => `key LIKE 'bubbleId:${id}:%'`).join(' OR ')}
+            WHERE ${composerIds.map((id: string) => `(key >= 'bubbleId:${id}:' AND key < 'bubbleId:${id};')`).join(' OR ')}
         `;
         
         const allBubbleRows = await executeQueryPaginated(dbPath, bubbleQuery, 100);
@@ -320,6 +328,7 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
                     lastSendTime: composerData.lastUpdatedAt || composerData.createdAt,
                     composerId: threadId,
                     createdAt: composerData.createdAt,
+                    model: composerData.modelConfig?.modelName,
                     bubbleCount: bubbles.length
                 });
             } catch (parseErr) {
@@ -340,6 +349,25 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
  * Find all state.vscdb files in the given globalStorage directories
  */
 
+export function resolveStateDbPath(VSInstallationPath: string): string | null {
+    const globalStoragePaths = findFolder(VSInstallationPath, 'globalStorage');
+
+    if (globalStoragePaths.length > 1) {
+        const error = new Error(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`);
+        captureException(error);
+        console.warn(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`)
+    }
+
+    if (globalStoragePaths.length === 0) {
+        const error = new Error("Could not find global SQLite state DB.");
+        captureException(error);
+        console.warn("Could not find global SQLite state DB.")
+        return null;
+    }
+
+    return path.join(globalStoragePaths[0], 'state.vscdb');
+}
+
 export async function findAndReturnNewTraces(
     context: vscode.ExtensionContext, 
     VSInstallationPath: string, 
@@ -348,26 +376,12 @@ export async function findAndReturnNewTraces(
     currentSyncTime: number
 ) {
     const opikProjectName: string = vscode.workspace.getConfiguration().get('opik.projectName') || 'default';
-    
-    const globalStoragePaths = findFolder(VSInstallationPath, 'globalStorage');
-    
-    if (globalStoragePaths.length > 1) {
-        const error = new Error(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`);
-        captureException(error);
-        console.warn(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`)
-    }
-    
-    if (globalStoragePaths.length === 0) {
-        const error = new Error("Could not find global SQLite state DB.");
-        captureException(error);
-        console.warn("Could not find global SQLite state DB.")
+
+    const stateDbPath = resolveStateDbPath(VSInstallationPath);
+    if (!stateDbPath) {
         return null;
     }
-    
-    // Look for state.vscdb file inside the globalStorage directory
-    const globalStoragePath = globalStoragePaths[0];
-    const stateDbPath = path.join(globalStoragePath, 'state.vscdb');
-    
+
     if (!fs.existsSync(stateDbPath)) {
         const error = new Error(`Could not find global SQLite state DB at path: ${stateDbPath}`);
         captureException(error);
@@ -468,25 +482,6 @@ function createTraceFromBubbleGroup(
         return null;
     }
 
-    // Calculate token usage from AI messages
-    let totalPromptTokens = 0;
-    let totalCompletionTokens = 0;
-    let hasTokenCounts = false;
-    
-    aiMessages.forEach(msg => {
-        if (msg.tokenCount && (msg.tokenCount.inputTokens || msg.tokenCount.outputTokens)) {
-            totalPromptTokens += msg.tokenCount.inputTokens || 0;
-            totalCompletionTokens += msg.tokenCount.outputTokens || 0;
-            hasTokenCounts = true;
-        }
-    });
-    
-    const usage = hasTokenCounts ? {
-        prompt_tokens: totalPromptTokens,
-        completion_tokens: totalCompletionTokens,
-        total_tokens: totalPromptTokens + totalCompletionTokens
-    } : undefined;
-
     // Extract timestamp from the resolved timestamps
     const firstUserMessage = userMessages[0];
     const lastAiMessage = aiMessages[aiMessages.length - 1];
@@ -535,24 +530,19 @@ function createTraceFromBubbleGroup(
         tags.push("historical");
     }
 
-    const traceData: any = {
+    return {
         name: "cursor-chat",
         project_name: opikProjectName,
         start_time: new Date(startTime).toISOString(),
         end_time: new Date(endTime).toISOString(),
+        turn_start_ms: startTime,
+        model: conversation.model,
         input: { input: userContent },
         output: { output: assistantContent },
         thread_id: conversation.composerId,
         tags: tags,
         metadata: metadata
     };
-
-    // Only include usage if we have token counts
-    if (usage) {
-        traceData.usage = usage;
-    }
-
-    return traceData;
 }
 
 /**

--- a/extensions/cursor/src/cursor/sqlite.ts
+++ b/extensions/cursor/src/cursor/sqlite.ts
@@ -41,6 +41,33 @@ export function findSqlite3Binary(): string {
     return 'sqlite3';
 }
 
+const UNIT_SEPARATOR = '\x1f';
+const RECORD_SEPARATOR = '\x1e';
+
+function parseAsciiOutput(stdout: string): any[] {
+    if (!stdout) {
+        return [];
+    }
+
+    const records = stdout.split(RECORD_SEPARATOR);
+    while (records.length > 0 && records[records.length - 1] === '') {
+        records.pop();
+    }
+    if (records.length < 2) {
+        return [];
+    }
+
+    const columns = records[0].split(UNIT_SEPARATOR);
+    return records.slice(1).map(record => {
+        const cells = record.split(UNIT_SEPARATOR);
+        const row: Record<string, string> = {};
+        columns.forEach((column, index) => {
+            row[column] = cells[index] ?? '';
+        });
+        return row;
+    });
+}
+
 /**
  * Execute a SQL query against a SQLite database using the native sqlite3 CLI
  * @param dbPath Path to the SQLite database file
@@ -58,20 +85,23 @@ export async function executeQuery(dbPath: string, query: string): Promise<any[]
     }
     
     try {
-        // Execute sqlite3 with JSON output mode
-        // -json flag outputs results as JSON array
-        // -readonly opens database in read-only mode (safer)
+        // -ascii is used instead of -json because the JSON writer in the sqlite3
+        // shipped with macOS is quadratic in cell length: one 561KB value takes
+        // 17s to serialize and a 5.5MB result set takes 56s, which blew the
+        // timeout below. -ascii emits raw cells separated by 0x1F/0x1E, which no
+        // value in the Cursor database contains, and runs in 50ms.
         const { stdout, stderr } = await execFileAsync(
             sqlite3Binary,
             [
-                '-json',        // Output as JSON
+                '-ascii',       // Unit/record separated output, no escaping cost
+                '-header',      // First record carries the column names
                 '-readonly',    // Read-only mode
                 dbPath,         // Database file path
                 query           // SQL query
             ],
             {
-                maxBuffer: 100 * 1024 * 1024, // 100MB buffer for large result sets
-                timeout: 30000 // 30 second timeout
+                maxBuffer: 512 * 1024 * 1024,
+                timeout: 120000
             }
         );
         
@@ -80,17 +110,7 @@ export async function executeQuery(dbPath: string, query: string): Promise<any[]
             console.warn(`SQLite stderr: ${stderr}`);
         }
         
-        // Parse JSON output
-        if (!stdout || stdout.trim() === '') {
-            return [];
-        }
-        
-        try {
-            const results = JSON.parse(stdout);
-            return Array.isArray(results) ? results : [];
-        } catch (parseError) {
-            throw new Error(`Failed to parse SQLite JSON output: ${parseError}`);
-        }
+        return parseAsciiOutput(stdout);
         
     } catch (error: any) {
         // Enhance error message for common issues
@@ -103,8 +123,10 @@ export async function executeQuery(dbPath: string, query: string): Promise<any[]
             );
         }
         
-        if (error.code === 'ETIMEDOUT') {
-            throw new Error(`SQLite query timeout after 30 seconds: ${query.substring(0, 100)}...`);
+        // execFile reports a timeout kill as signal SIGTERM with a null code,
+        // not as ETIMEDOUT, so both shapes have to be recognised here.
+        if (error.code === 'ETIMEDOUT' || (error.killed && error.signal === 'SIGTERM')) {
+            throw new Error(`SQLite query timed out: ${query.substring(0, 100)}...`);
         }
         
         // Re-throw with context

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -1,0 +1,289 @@
+import * as vscode from 'vscode';
+import { executeQuery } from './sqlite';
+import { getPendingUsage, updatePendingUsage } from '../state';
+import { PendingUsage, TurnUsage } from '../interface';
+import { debugLog } from '../utils';
+
+const API_HOST = 'https://api2.cursor.sh';
+const SERVICE = 'aiserver.v1.DashboardService';
+
+const POLL_SCHEDULE_MS = [5000, 5000, 10000, 30000, 60000, 300000, 300000];
+
+// The usage event is stamped when the request completes, so it always falls
+// after its own user bubble and before the next one. A grace window wider than
+// the gap between two turns makes a later turn swallow an earlier turn's event.
+const CLOCK_GRACE_MS = 0;
+
+interface UsageEventDisplay {
+    timestamp: string;
+    model: string;
+    conversationId?: string;
+    chargedCents?: number;
+    tokenUsage?: {
+        inputTokens?: number;
+        outputTokens?: number;
+        cacheReadTokens?: number;
+        cacheWriteTokens?: number;
+    };
+}
+
+async function readAccessToken(stateDbPath: string): Promise<string | undefined> {
+    const rows = await executeQuery(
+        stateDbPath,
+        `SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken'`
+    );
+    const raw = rows[0]?.value;
+    return typeof raw === 'string' && raw.trim() ? raw.trim() : undefined;
+}
+
+async function rpc<T>(method: string, token: string, body: unknown): Promise<T> {
+    const response = await fetch(`${API_HOST}/${SERVICE}/${method}`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${token}`,
+            'connect-protocol-version': '1',
+        },
+        body: JSON.stringify(body ?? {}),
+    });
+
+    if (!response.ok) {
+        throw new Error(`${method} failed: ${response.status} ${await response.text()}`);
+    }
+    return await response.json() as T;
+}
+
+export async function getCursorUserId(stateDbPath: string): Promise<number | undefined> {
+    const token = await readAccessToken(stateDbPath);
+    if (!token) {
+        return undefined;
+    }
+    const me = await rpc<{ userId?: number }>('GetMe', token, {});
+    return me.userId;
+}
+
+async function fetchUsageByConversation(
+    stateDbPath: string,
+    userId: number,
+    startMs: number,
+    endMs: number
+): Promise<Map<string, UsageEventDisplay[]>> {
+    const token = await readAccessToken(stateDbPath);
+    const byConversation = new Map<string, UsageEventDisplay[]>();
+    if (!token) {
+        return byConversation;
+    }
+
+    for (let page = 1; page <= 20; page++) {
+        const result = await rpc<{
+            totalUsageEventsCount?: number;
+            usageEventsDisplay?: UsageEventDisplay[];
+        }>('GetFilteredUsageEvents', token, {
+            userId,
+            startDate: String(startMs),
+            endDate: String(endMs),
+            page,
+            pageSize: 100,
+        });
+
+        const events = result.usageEventsDisplay ?? [];
+        for (const event of events) {
+            if (!event.conversationId) {
+                continue;
+            }
+            const list = byConversation.get(event.conversationId) ?? [];
+            list.push(event);
+            byConversation.set(event.conversationId, list);
+        }
+
+        if (events.length === 0 || page * 100 >= (result.totalUsageEventsCount ?? 0)) {
+            break;
+        }
+    }
+    return byConversation;
+}
+
+/**
+ * Real start time of every user turn in a conversation, oldest first.
+ *
+ * Attribution needs the complete and stable set of turn boundaries. Deriving
+ * them from the pending list instead is wrong, because that list shrinks as
+ * turns get patched, which moves the boundaries and re-attributes events that
+ * were already counted.
+ */
+async function readUserTurnStarts(stateDbPath: string, composerId: string): Promise<number[]> {
+    const rows = await executeQuery(
+        stateDbPath,
+        `SELECT json_extract(value, '$.createdAt') AS createdAt FROM cursorDiskKV
+         WHERE key >= 'bubbleId:${composerId}:' AND key < 'bubbleId:${composerId};'
+         AND json_extract(value, '$.type') = 1`
+    );
+
+    const starts = rows
+        .map(row => Date.parse(row.createdAt))
+        .filter(value => !Number.isNaN(value));
+
+    return [...new Set(starts)].sort((a, b) => a - b);
+}
+
+export function attributeUsageToTurns(
+    turnStartsMs: number[],
+    events: UsageEventDisplay[]
+): Map<number, TurnUsage> {
+    const sorted = [...events].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+    const attributed = new Map<number, TurnUsage>();
+
+    for (const event of sorted) {
+        const at = Number(event.timestamp) + CLOCK_GRACE_MS;
+
+        let turn = -1;
+        for (let i = 0; i < turnStartsMs.length; i++) {
+            if (turnStartsMs[i] > at) {
+                break;
+            }
+            turn = i;
+        }
+        if (turn < 0) {
+            continue;
+        }
+
+        const accumulated = attributed.get(turn) ?? {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            chargedCents: 0,
+            requestCount: 0,
+            models: [],
+        };
+
+        const usage = event.tokenUsage ?? {};
+        accumulated.inputTokens += usage.inputTokens ?? 0;
+        accumulated.outputTokens += usage.outputTokens ?? 0;
+        accumulated.cacheReadTokens += usage.cacheReadTokens ?? 0;
+        accumulated.cacheWriteTokens += usage.cacheWriteTokens ?? 0;
+        accumulated.chargedCents += event.chargedCents ?? 0;
+        accumulated.requestCount += 1;
+        if (event.model && !accumulated.models.includes(event.model)) {
+            accumulated.models.push(event.model);
+        }
+        attributed.set(turn, accumulated);
+    }
+    return attributed;
+}
+
+export class UsageEnricher {
+    private userId: number | undefined;
+    private userIdLookupFailed = false;
+
+    constructor(
+        private context: vscode.ExtensionContext,
+        private applyUsage: (pending: PendingUsage, usage: TurnUsage) => Promise<void>
+    ) {}
+
+    isEnabled(): boolean {
+        return vscode.workspace.getConfiguration().get<boolean>('opik.usageEnrichment.enabled', true);
+    }
+
+    track(turns: Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>[]) {
+        if (!this.isEnabled() || turns.length === 0) {
+            return;
+        }
+        const pending = getPendingUsage(this.context);
+        const known = new Set(pending.map(item => `${item.composerId}:${item.turnStartMs}`));
+
+        for (const turn of turns) {
+            if (known.has(`${turn.composerId}:${turn.turnStartMs}`)) {
+                continue;
+            }
+            pending.push({ ...turn, attempt: 0, nextAttemptAt: Date.now() + POLL_SCHEDULE_MS[0] });
+        }
+        updatePendingUsage(this.context, pending);
+    }
+
+    async tick(stateDbPath: string): Promise<void> {
+        if (!this.isEnabled()) {
+            return;
+        }
+
+        const pending = getPendingUsage(this.context);
+        const now = Date.now();
+        const due = pending.filter(item => item.nextAttemptAt <= now);
+        if (due.length === 0) {
+            return;
+        }
+
+        if (this.userId === undefined) {
+            if (this.userIdLookupFailed) {
+                return;
+            }
+            try {
+                this.userId = await getCursorUserId(stateDbPath);
+            } catch (error) {
+                debugLog('[usage] GetMe failed', String(error));
+            }
+            if (this.userId === undefined) {
+                this.userIdLookupFailed = true;
+                return;
+            }
+        }
+
+        const from = Math.min(...due.map(item => item.turnStartMs)) - 60000;
+        let byConversation: Map<string, UsageEventDisplay[]>;
+        try {
+            byConversation = await fetchUsageByConversation(stateDbPath, this.userId, from, now + 60000);
+        } catch (error) {
+            debugLog('[usage] GetFilteredUsageEvents failed', String(error));
+            for (const item of due) {
+                item.nextAttemptAt = now + 30000;
+            }
+            updatePendingUsage(this.context, pending);
+            return;
+        }
+
+        const startsCache = new Map<string, number[]>();
+        const remaining: PendingUsage[] = [];
+
+        for (const item of pending) {
+            if (item.nextAttemptAt > now) {
+                remaining.push(item);
+                continue;
+            }
+
+            let starts = startsCache.get(item.composerId);
+            if (!starts) {
+                starts = await readUserTurnStarts(stateDbPath, item.composerId);
+                startsCache.set(item.composerId, starts);
+            }
+
+            const index = starts.indexOf(item.turnStartMs);
+            const usage = index < 0
+                ? undefined
+                : attributeUsageToTurns(starts, byConversation.get(item.composerId) ?? []).get(index);
+
+            if (index < 0) {
+                debugLog('[usage] turn start not found in conversation', {
+                    composerId: item.composerId,
+                    turnStartMs: item.turnStartMs,
+                    starts,
+                });
+            }
+
+            if (usage) {
+                try {
+                    await this.applyUsage(item, usage);
+                    continue;
+                } catch (error) {
+                    debugLog('[usage] failed to patch span', String(error));
+                }
+            }
+
+            item.attempt += 1;
+            if (item.attempt < POLL_SCHEDULE_MS.length) {
+                item.nextAttemptAt = now + POLL_SCHEDULE_MS[item.attempt];
+                remaining.push(item);
+            }
+        }
+        updatePendingUsage(this.context, remaining);
+    }
+}

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -53,26 +53,18 @@ async function rpc<T>(method: string, token: string, body: unknown): Promise<T> 
     return await response.json() as T;
 }
 
-export async function getCursorUserId(stateDbPath: string): Promise<number | undefined> {
-    const token = await readAccessToken(stateDbPath);
-    if (!token) {
-        return undefined;
-    }
+async function fetchUserId(token: string): Promise<number | undefined> {
     const me = await rpc<{ userId?: number }>('GetMe', token, {});
     return me.userId;
 }
 
 async function fetchUsageByConversation(
-    stateDbPath: string,
+    token: string,
     userId: number,
     startMs: number,
     endMs: number
 ): Promise<Map<string, UsageEventDisplay[]>> {
-    const token = await readAccessToken(stateDbPath);
     const byConversation = new Map<string, UsageEventDisplay[]>();
-    if (!token) {
-        return byConversation;
-    }
 
     for (let page = 1; page <= 20; page++) {
         const result = await rpc<{
@@ -174,7 +166,7 @@ export function attributeUsageToTurns(
 
 export class UsageEnricher {
     private userId: number | undefined;
-    private userIdLookupFailed = false;
+    private userIdToken: string | undefined;
 
     constructor(
         private context: vscode.ExtensionContext,
@@ -201,6 +193,26 @@ export class UsageEnricher {
         updatePendingUsage(this.context, pending);
     }
 
+    // Keyed by token so that switching Cursor accounts re-resolves instead of
+    // pairing a stale user id with a new token.
+    private async resolveUserId(token: string): Promise<number | undefined> {
+        if (this.userId !== undefined && this.userIdToken === token) {
+            return this.userId;
+        }
+
+        try {
+            const userId = await fetchUserId(token);
+            if (userId !== undefined) {
+                this.userId = userId;
+                this.userIdToken = token;
+            }
+            return userId;
+        } catch (error) {
+            debugLog('[usage] GetMe failed, will retry', String(error));
+            return undefined;
+        }
+    }
+
     async tick(stateDbPath: string): Promise<void> {
         if (!this.isEnabled()) {
             return;
@@ -213,25 +225,27 @@ export class UsageEnricher {
             return;
         }
 
-        if (this.userId === undefined) {
-            if (this.userIdLookupFailed) {
-                return;
-            }
-            try {
-                this.userId = await getCursorUserId(stateDbPath);
-            } catch (error) {
-                debugLog('[usage] GetMe failed', String(error));
-            }
-            if (this.userId === undefined) {
-                this.userIdLookupFailed = true;
-                return;
-            }
+        // Read once per tick and reuse, so the user id and the token always come
+        // from the same sign-in.
+        const token = await readAccessToken(stateDbPath);
+        if (!token) {
+            // Cursor may not have written its token yet, for example when the
+            // extension activates before sign-in completes. Retrying on the next
+            // tick is correct; latching a failure here would disable enrichment
+            // for the rest of the session.
+            debugLog('[usage] no Cursor access token available yet, will retry');
+            return;
+        }
+
+        const userId = await this.resolveUserId(token);
+        if (userId === undefined) {
+            return;
         }
 
         const from = Math.min(...due.map(item => item.turnStartMs)) - 60000;
         let byConversation: Map<string, UsageEventDisplay[]>;
         try {
-            byConversation = await fetchUsageByConversation(stateDbPath, this.userId, from, now + 60000);
+            byConversation = await fetchUsageByConversation(token, userId, from, now + 60000);
         } catch (error) {
             debugLog('[usage] GetFilteredUsageEvents failed', String(error));
             for (const item of due) {

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -19,14 +19,31 @@ export interface TraceData {
     project_name?: string;
     start_time: string; // ISO 8601 format
     end_time?: string; // ISO 8601 format
+    turn_start_ms: number;
+    model?: string;
     input: any;
     output: any;
     thread_id?: string;
     tags?: string[];
-    usage?: {
-        completion_tokens?: number;
-        prompt_tokens?: number;
-        total_tokens?: number;
-    };
     metadata?: any;
+}
+
+export interface TurnUsage {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    chargedCents: number;
+    requestCount: number;
+    models: string[];
+}
+
+export interface PendingUsage {
+    composerId: string;
+    turnStartMs: number;
+    traceId: string;
+    spanId: string;
+    projectName: string;
+    attempt: number;
+    nextAttemptAt: number;
 }

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -1,37 +1,37 @@
 import * as vscode from 'vscode';
-import { TraceData } from './interface';
+import { PendingUsage, TraceData, TurnUsage } from './interface';
 import { captureException } from './sentry';
 
-export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Promise<void> {
-    if (traces.length === 0) return;
-    
+type LoggedTurn = Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>;
+
+async function createClient(apiKey: string) {
+    const config = vscode.workspace.getConfiguration();
+    const { Opik } = await import('opik');
+
+    return new Opik({
+        apiKey: apiKey,
+        apiUrl: config.get<string>('opik.apiUrl', 'https://www.comet.com/opik/api'),
+        workspaceName: config.get<string>('opik.workspace', 'default'),
+    });
+}
+
+export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Promise<LoggedTurn[]> {
+    if (traces.length === 0) {
+        return [];
+    }
+
     console.log(`📦 Processing ${traces.length} traces using Opik SDK`);
-    
+    const loggedTurns: LoggedTurn[] = [];
+
     try {
-        // Get configuration values
-        const config = vscode.workspace.getConfiguration();
-        const apiUrl = config.get<string>('opik.apiUrl', 'https://www.comet.com/opik/api');
-        const workspace = config.get<string>('opik.workspace', 'default');
+        const client = await createClient(apiKey);
 
-        // Dynamically import Opik SDK
-        const { Opik } = await import('opik');
-
-        // Initialize Opik client
-        const client = new Opik({
-            apiKey: apiKey,
-            apiUrl: apiUrl,
-            workspaceName: workspace
-        });
-        
-        // Process traces using the SDK
         for (const traceData of traces) {
-            // Add metadata to indicate source
             const metadata = {
                 ...(traceData.metadata || {}),
                 created_from: "cursor-extension"
             };
-            
-            // Create trace using SDK
+
             const trace = client.trace({
                 name: traceData.name,
                 projectName: traceData.project_name,
@@ -43,39 +43,41 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
                 metadata: metadata,
                 threadId: traceData.thread_id
             });
-            
-            // Create LLM span with usage data if available
-            if (traceData.usage && (traceData.usage.completion_tokens || traceData.usage.prompt_tokens || traceData.usage.total_tokens)) {
-                const span = trace.span({
-                    name: traceData.name,
-                    type: 'llm',
-                    input: traceData.input,
-                    output: traceData.output,
-                    startTime: new Date(traceData.start_time),
-                    endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-                    usage: {
-                        completionTokens: traceData.usage.completion_tokens || 0,
-                        promptTokens: traceData.usage.prompt_tokens || 0,
-                        totalTokens: traceData.usage.total_tokens || 0
-                    },
-                    tags: traceData.tags,
-                    metadata: traceData.metadata
+
+            // The span is created without usage. Cursor only exposes token counts
+            // a few seconds later over its usage API, so UsageEnricher patches it.
+            const span = trace.span({
+                name: traceData.name,
+                type: 'llm',
+                model: traceData.model,
+                provider: 'cursor',
+                input: traceData.input,
+                output: traceData.output,
+                startTime: new Date(traceData.start_time),
+                endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+                tags: traceData.tags,
+                metadata: traceData.metadata
+            });
+            // Deliberately not calling span.end()/trace.end(): both overwrite
+            // endTime with the current time, which would replace the real Cursor
+            // turn end with the upload time.
+
+            if (traceData.thread_id) {
+                loggedTurns.push({
+                    composerId: traceData.thread_id,
+                    turnStartMs: traceData.turn_start_ms,
+                    traceId: trace.data.id,
+                    spanId: span.data.id,
+                    projectName: traceData.project_name ?? 'default',
                 });
-                
-                // End the span
-                span.end();
             }
-            
-            // End the trace
-            trace.end();
         }
-        
-        // Flush all data to Opik
+
         console.log(`📤 Flushing ${traces.length} traces to Opik`);
         await client.flush();
-        
         console.log(`🎉 All ${traces.length} traces processed successfully using Opik SDK!`);
-        
+
+        return loggedTurns;
     } catch (error) {
         captureException(error);
         console.error('Error processing traces with Opik SDK:', error);
@@ -83,3 +85,31 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
     }
 }
 
+export async function applyTurnUsage(
+    apiKey: string,
+    pending: PendingUsage,
+    usage: TurnUsage
+): Promise<void> {
+    const client = await createClient(apiKey);
+
+    await client.api.spans.updateSpan(pending.spanId, {
+        traceId: pending.traceId,
+        projectName: pending.projectName,
+        model: usage.models[0],
+        provider: 'cursor',
+        usage: {
+            prompt_tokens: usage.inputTokens,
+            completion_tokens: usage.outputTokens,
+            total_tokens: usage.inputTokens + usage.outputTokens,
+            cache_read_input_tokens: usage.cacheReadTokens,
+            cache_creation_input_tokens: usage.cacheWriteTokens,
+        },
+        totalEstimatedCost: usage.chargedCents / 100,
+    });
+
+    console.log(
+        `💰 Patched span ${pending.spanId}: ${usage.inputTokens} in / ${usage.outputTokens} out ` +
+        `/ ${usage.cacheReadTokens} cache read, ${usage.chargedCents.toFixed(4)}c ` +
+        `across ${usage.requestCount} request(s)`
+    );
+}

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -93,18 +93,20 @@ export async function applyTurnUsage(
     const client = await createClient(apiKey);
 
     await client.api.spans.updateSpan(pending.spanId, {
-        traceId: pending.traceId,
-        projectName: pending.projectName,
-        model: usage.models[0],
-        provider: 'cursor',
-        usage: {
-            prompt_tokens: usage.inputTokens,
-            completion_tokens: usage.outputTokens,
-            total_tokens: usage.inputTokens + usage.outputTokens,
-            cache_read_input_tokens: usage.cacheReadTokens,
-            cache_creation_input_tokens: usage.cacheWriteTokens,
+        body: {
+            traceId: pending.traceId,
+            projectName: pending.projectName,
+            model: usage.models[0],
+            provider: 'cursor',
+            usage: {
+                prompt_tokens: usage.inputTokens,
+                completion_tokens: usage.outputTokens,
+                total_tokens: usage.inputTokens + usage.outputTokens,
+                cache_read_input_tokens: usage.cacheReadTokens,
+                cache_creation_input_tokens: usage.cacheWriteTokens,
+            },
+            totalEstimatedCost: usage.chargedCents / 100,
         },
-        totalEstimatedCost: usage.chargedCents / 100,
     });
 
     console.log(

--- a/extensions/cursor/src/state.ts
+++ b/extensions/cursor/src/state.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { SessionInfo } from './interface';
+import { PendingUsage, SessionInfo } from './interface';
 
 export function getSessionInfo(context: vscode.ExtensionContext): Record<string, SessionInfo> {
   return context.globalState.get<Record<string, SessionInfo>>('sessionInfo', {});
@@ -39,8 +39,17 @@ export function updateLastSyncedAt(context: vscode.ExtensionContext, timestamp: 
   context.globalState.update('lastSyncedAt', timestamp);
 }
 
+export function getPendingUsage(context: vscode.ExtensionContext): PendingUsage[] {
+  return context.globalState.get<PendingUsage[]>('pendingUsage', []);
+}
+
+export function updatePendingUsage(context: vscode.ExtensionContext, pending: PendingUsage[]) {
+  context.globalState.update('pendingUsage', pending);
+}
+
 export function resetExtensionState(context: vscode.ExtensionContext) {
   context.globalState.update('sessionInfo', undefined);
   context.globalState.update('lastSyncTime', null);
   context.globalState.update('lastSyncedAt', undefined);
+  context.globalState.update('pendingUsage', undefined);
 }


### PR DESCRIPTION
## Details

Cursor stopped populating `bubble.tokenCount` in February 2026, so the extension had been writing LLM spans with zero tokens and no cost. Token counts, cache usage, cost and model now come from Cursor's usage API and are attached to the span a few seconds after the turn is uploaded.

- Usage is fetched with the user's existing Cursor sign-in. No extra credentials, and **no admin role** — verified against a plain `TEAM_ROLE_MEMBER` account. It also works for users with no team.
- `conversationId` from the API equals the local `composerId`, so the join needs no heuristics. Verified 11/11 across 200 days of history.
- Each usage event is attributed to exactly one turn, using the conversation's complete list of real user-turn start times.
- Three pre-existing bugs surfaced and are fixed here, plus a packaging leak, all described below.

Fixed along the way:
- **Fabricated trace times.** Modern Cursor bubbles carry no `timingInfo` or `timestamp` (0 of 15 in a sample), so `processConversationBubbles` always fell into its synthetic `+1000ms` ladder. Every `start_time` was invented. Now read from `bubble.createdAt`.
- **`end_time` always equal to the upload time.** `Trace.end()` and `Span.end()` overwrite `endTime` with `new Date()`. Those calls are removed, since the real times are supplied at construction.
- **`.claude/settings.local.json` was being published.** `.vscodeignore` excluded `src/**` but not `.claude/**`, so the file was bundled into every vsix. It is present in `opik-0.3.1.vsix` as `extension/.claude/settings.local.json` and contains an absolute home-directory path, so it has been shipping to users since at least September 2025. Now excluded, along with the new `scripts/**`. Verified with `vsce pack`: the 0.4.0 artifact is 21 files with no `.claude`, no `scripts/`, and no path leak in any file.
- **SQLite query timeout.** `sqlite3 -json` on macOS is quadratic in cell length: one 561KB value takes 17s and a 5.5MB result set takes 56s, blowing the 30s timeout. Switched to `-ascii` with a small parser, and replaced `LIKE 'prefix%'` with prefix ranges so the index on `key` is usable. The failing query went from a 30s timeout to 72ms.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Reverse engineering of the Cursor local store and usage RPCs; all code in this PR (`src/cursor/usage.ts`, `scripts/verify-usage.js`, and the edits to `opik.ts`, `sessionManager.ts`, `sqlite.ts`, `cursorService.ts`, `interface.ts`, `state.ts`, `package.json`); PR description.
- Human verification: Author ran the extension in the Cursor extension host against a live account, sent messages across several conversations, and confirmed the spans in Opik. Author caught the duplicate-attribution bug by reading the logged data, which led to the attribution rewrite.

## Testing

Commands run, all from `extensions/cursor`:

```
npm run compile     # tsc, clean
npm run lint        # 0 errors, 9 warnings (all pre-existing in sessionManager.ts)
npm run esbuild     # bundles clean
npm run verify-usage
```

`npm run verify-usage` is added in this PR. It runs the whole pipeline except the Opik write: reads the newest local conversation, fetches its usage, runs the compiled attribution, and asserts both that per-turn totals reconcile against the API and that no two turns share a usage payload. It exits non-zero on either failure.

Scenarios validated:
- **Reconciliation.** Per-turn sums equal the API totals exactly, over 200 days of history: 32 turns, 29 events, 29 turns enriched, 0 orphans (~91% coverage; turns with no chargeable request are left without usage by design).
- **No double counting.** A regression was found during review: two spans in one thread received the whole conversation's total. Root cause was deriving turn boundaries from the shrinking pending list. After the fix, a 5-turn conversation yields 5 distinct payloads summing to the API total, and repeat ticks patch nothing (idempotent).
- **Rapid turns.** Five messages sent 2-4 seconds apart. This is what exposed the clock-grace bug; a grace window wider than the gap between turns makes a later turn swallow an earlier one's events. Grace is now 0, since the event is stamped at request completion.
- **Availability lag.** Measured at 3.8s, 5.0s and 6.6s by polling before sending. The backoff schedule starts at 5s.
- **Rate limiting.** A 15-request burst at ~109 req/min was not throttled; median latency 524ms. The adaptive schedule costs 2-4 requests per turn and nothing when idle.
- **Query performance.** The previously failing query now returns 75 rows and 5.5MB in 72ms, with all 75 values round-tripping as valid JSON.
- **Parser safety.** Zero rows in `composerData`, `bubbleId` or `ItemTable` contain the `0x1F`/`0x1E` separators used by `-ascii`.

Not run: there is no automated test suite in this extension (`pretest` exists but no tests are defined), so all of the above is manual plus the new `verify-usage` script. Adding real tests is worth a follow-up.

Environment: macOS 15, Cursor 3.17.19, system sqlite3 3.51.0, Node 22.

## Documentation

Added a "Token usage and cost" section to `apps/opik-documentation/documentation/fern/docs-v2/integrations/cursor.mdx`, covering what is recorded, that it uses the existing Cursor sign-in with no extra key and no admin role, the few-second delay before usage appears, turns that carry no usage, and the setting to disable it.

Only the v2 page is updated. The v1 tree is being removed in separate in-flight work, so editing it would conflict.

### Release note

This bumps the extension to 0.4.0. Publishing is the usual two steps: merge to `main`, then manually dispatch the **Publish Cursor Extension** workflow, which packages with `vsce pack` and pushes to Open VSX.

Two things reviewers should weigh:

1. `GetFilteredUsageEvents` on `api2.cursor.sh` is a **private, undocumented endpoint**. Cursor can change or remove it. Every call is wrapped so a failure logs, retries on a backoff, and then gives up; the worst case is a trace with no usage, never broken tracing. `npm run verify-usage` is the canary.
2. The extension reads the Cursor session token from the local `state.vscdb` and sends it only to `api2.cursor.sh`, which issued it. The host is hard-coded deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
