### PR TITLE
[OPIK-7605] [BE] [FE] fix: surface out-of-credits on Explain and diagnostics runs

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AgentInsightsJob.java
@@ -32,6 +32,13 @@ public record AgentInsightsJob(
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) Instant lastUpdatedAt,
         @Schema(accessMode = Schema.AccessMode.READ_ONLY) String lastUpdatedBy) {
 
+    public static class FailureReason {
+        // The trigger was rejected because the organization can't afford the run. No pod was allocated.
+        public static final String OUT_OF_CREDITS = "out_of_credits";
+        // The trigger never reached Ollie, so Ollie cannot report this itself.
+        public static final String DID_NOT_START = "did_not_start";
+    }
+
     @RequiredArgsConstructor
     @Getter
     public enum Status {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriber.java
@@ -1,9 +1,11 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.AgentInsightsJob;
 import com.comet.opik.domain.AgentInsightsJobService;
 import com.comet.opik.domain.AgentInsightsMetrics;
 import com.comet.opik.domain.AgentInsightsReportClient;
 import com.comet.opik.domain.AgentInsightsReportMessage;
+import com.comet.opik.domain.AgentInsightsTriggerException;
 import com.comet.opik.infrastructure.AgentInsightsReportConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import jakarta.inject.Inject;
@@ -97,16 +99,18 @@ public class AgentInsightsReportSubscriber extends BaseRedisSubscriber<AgentInsi
                     // reportId is carried on the message as the idempotency key if downstream dedup is added.
                     log.error("Failed to trigger Agent Insights report, dropping reportId='{}', project='{}'",
                             message.reportId(), message.projectId(), throwable);
-                    // Ollie never ran, so it can't report this itself: record "did not start" so the UI stops.
-                    markDidNotStart(message, throwable);
+                    // Ollie never ran, so it can't report this itself: record the reason so the UI stops.
+                    markRunFailed(message, throwable);
                     return Mono.empty();
                 });
     }
 
-    private void markDidNotStart(AgentInsightsReportMessage message, Throwable throwable) {
+    private void markRunFailed(AgentInsightsReportMessage message, Throwable throwable) {
+        String reason = throwable instanceof AgentInsightsTriggerException triggerFailure
+                ? triggerFailure.getReason()
+                : AgentInsightsJob.FailureReason.DID_NOT_START;
         try {
-            jobService.markRunFailed(message.workspaceId(), message.projectId(), "did_not_start",
-                    throwable.getMessage());
+            jobService.markRunFailed(message.workspaceId(), message.projectId(), reason, throwable.getMessage());
         } catch (Exception e) {
             log.warn("Failed to record run failure for reportId='{}', project='{}'",
                     message.reportId(), message.projectId(), e);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsJobService.java
@@ -107,7 +107,8 @@ public class AgentInsightsJobService {
                                     error);
                             // Publisher-side failure: the run never reaches Ollie (which would otherwise report
                             // its own failure), so record it here too, or the UI spins until the client timeout.
-                            markRunFailed(workspaceId, projectId, "did_not_start",
+                            markRunFailed(workspaceId, projectId,
+                                    AgentInsightsJob.FailureReason.DID_NOT_START,
                                     "Failed to enqueue diagnostics run");
                         });
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsTriggerException.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/AgentInsightsTriggerException.java
@@ -1,0 +1,26 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.AgentInsightsJob;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * An Agent Insights trigger that was refused by the platform, carrying the {@link AgentInsightsJob.FailureReason}
+ * to record for the run.
+ *
+ * <p>The daily report's equivalent classification hands the reason back through a {@code Consumer<String>},
+ * because {@code OrchestratorClient} triggers asynchronously and has no return path. This client is
+ * synchronous and its caller drives the failure metric and the at-most-once drop off the reactive error
+ * channel, so the reason travels on the exception instead. The principle is the same either way: the client
+ * names the reason, and the caller only records it.
+ */
+@Getter
+public class AgentInsightsTriggerException extends IllegalStateException {
+
+    private final String reason;
+
+    public AgentInsightsTriggerException(@NonNull String reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/PlatformAgentInsightsReportClient.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/PlatformAgentInsightsReportClient.java
@@ -1,5 +1,6 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.AgentInsightsJob;
 import com.comet.opik.infrastructure.AgentInsightsReportConfig;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -53,9 +54,14 @@ public class PlatformAgentInsightsReportClient implements AgentInsightsReportCli
         try (Response response = httpClient.target(config.getTriggerUrl())
                 .request(MediaType.APPLICATION_JSON)
                 .post(Entity.json(payload))) {
+            if (response.getStatus() == Response.Status.PAYMENT_REQUIRED.getStatusCode()) {
+                throw new AgentInsightsTriggerException(AgentInsightsJob.FailureReason.OUT_OF_CREDITS,
+                        "Agent Insights trigger rejected for report '%s': insufficient credits"
+                                .formatted(reportId));
+            }
             if (response.getStatus() >= 300) {
                 // Signal failure to the subscriber, which logs and drops the run (at-most-once).
-                throw new IllegalStateException(
+                throw new AgentInsightsTriggerException(AgentInsightsJob.FailureReason.DID_NOT_START,
                         "Agent Insights trigger returned %d for report '%s'".formatted(response.getStatus(),
                                 reportId));
             }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/AgentInsightsReportSubscriberTest.java
@@ -1,0 +1,104 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.AgentInsightsJob;
+import com.comet.opik.domain.AgentInsightsJobService;
+import com.comet.opik.domain.AgentInsightsReportClient;
+import com.comet.opik.domain.AgentInsightsReportMessage;
+import com.comet.opik.domain.AgentInsightsTriggerException;
+import com.comet.opik.infrastructure.AgentInsightsReportConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RedissonReactiveClient;
+import reactor.test.StepVerifier;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Covers the seam between the trigger client and the run-failure record: which reason the subscriber
+ * persists for a failed trigger. The client names the reason and the subscriber records it, so a
+ * regression here is invisible to both {@code PlatformAgentInsightsReportClientTest} (which stops at the
+ * exception) and {@code AgentInsightsJobsResourceTest} (which starts at the stored row).
+ *
+ * <p>These also pin the assumption the mapping rests on: {@code Mono.fromRunnable} delivers the exception to
+ * {@code onErrorResume} unwrapped, so the {@code instanceof} still matches.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Agent Insights Report Subscriber")
+class AgentInsightsReportSubscriberTest {
+
+    private static final String WORKSPACE_ID = "workspace-id";
+    private static final UUID PROJECT_ID = UUID.randomUUID();
+
+    @Mock
+    private AgentInsightsReportConfig config;
+    @Mock
+    private ServiceTogglesConfig serviceToggles;
+    @Mock
+    private RedissonReactiveClient redisson;
+    @Mock
+    private AgentInsightsReportClient reportClient;
+    @Mock
+    private AgentInsightsJobService jobService;
+
+    private AgentInsightsReportSubscriber subscriber;
+
+    @BeforeEach
+    void setUp() {
+        subscriber = new AgentInsightsReportSubscriber(config, serviceToggles, redisson, reportClient, jobService);
+    }
+
+    private static AgentInsightsReportMessage message() {
+        Instant periodEnd = Instant.now();
+        return new AgentInsightsReportMessage("report-1", PROJECT_ID, WORKSPACE_ID,
+                periodEnd.minusSeconds(86_400), periodEnd, "manual");
+    }
+
+    private void failTriggerWith(RuntimeException failure) {
+        doThrow(failure).when(reportClient)
+                .triggerAgentInsights(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("A credit rejection is recorded as out of credits, not as a run that never started")
+    void processEvent__triggerRejectedForCredits__recordsOutOfCredits() {
+        failTriggerWith(new AgentInsightsTriggerException(AgentInsightsJob.FailureReason.OUT_OF_CREDITS,
+                "insufficient credits"));
+
+        StepVerifier.create(subscriber.processEvent(message())).verifyComplete();
+
+        verify(jobService).markRunFailed(eq(WORKSPACE_ID), eq(PROJECT_ID),
+                eq(AgentInsightsJob.FailureReason.OUT_OF_CREDITS), eq("insufficient credits"));
+    }
+
+    @Test
+    @DisplayName("A transport failure the client never classified is recorded as did not start")
+    void processEvent__triggerThrowsUnclassified__recordsDidNotStart() {
+        // Not an AgentInsightsTriggerException: the call never reached the platform, so no reason was named.
+        failTriggerWith(new IllegalStateException("connection refused"));
+
+        StepVerifier.create(subscriber.processEvent(message())).verifyComplete();
+
+        verify(jobService).markRunFailed(eq(WORKSPACE_ID), eq(PROJECT_ID),
+                eq(AgentInsightsJob.FailureReason.DID_NOT_START), eq("connection refused"));
+    }
+
+    @Test
+    @DisplayName("An accepted trigger records no failure")
+    void processEvent__triggerAccepted__recordsNoFailure() {
+        StepVerifier.create(subscriber.processEvent(message())).verifyComplete();
+
+        verify(jobService, never()).markRunFailed(any(), any(), any(), any());
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/PlatformAgentInsightsReportClientTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/PlatformAgentInsightsReportClientTest.java
@@ -1,0 +1,93 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.AgentInsightsJob;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.infrastructure.AgentInsightsReportConfig;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Platform Agent Insights Report Client")
+class PlatformAgentInsightsReportClientTest {
+
+    private static final String TRIGGER_PATH = "/opik/ollie/generate-agent-insights";
+
+    private WireMockUtils.WireMockRuntime wireMock;
+    private Client httpClient;
+    private PlatformAgentInsightsReportClient client;
+
+    @BeforeAll
+    void setUp() {
+        wireMock = WireMockUtils.startWireMock();
+        // Production injects the Dropwizard-configured client; register the app mapper so the payload
+        // serializes the same way here (a bare client has no JSR-310 support and fails on the period bounds).
+        httpClient = ClientBuilder.newClient().register(new JacksonJsonProvider(JsonUtils.getMapper()));
+
+        var config = new AgentInsightsReportConfig();
+        config.setTriggerUrl(wireMock.runtimeInfo().getHttpBaseUrl() + TRIGGER_PATH);
+        client = new PlatformAgentInsightsReportClient(httpClient, config);
+    }
+
+    @AfterAll
+    void tearDown() {
+        httpClient.close();
+        wireMock.server().stop();
+    }
+
+    private void stubTriggerStatus(int status) {
+        wireMock.server().stubFor(post(urlPathEqualTo(TRIGGER_PATH)).willReturn(aResponse().withStatus(status)));
+    }
+
+    private void trigger() {
+        client.triggerAgentInsights(UUID.randomUUID().toString(), UUID.randomUUID(), "workspace-id",
+                Instant.now().minusSeconds(86_400), Instant.now(), "manual");
+    }
+
+    @Test
+    @DisplayName("A 402 rejection is named out of credits, so the run is not recorded as never started")
+    void triggerAgentInsights__paymentRequired__namesOutOfCredits() {
+        stubTriggerStatus(402);
+
+        assertThatExceptionOfType(AgentInsightsTriggerException.class)
+                .isThrownBy(this::trigger)
+                .extracting(AgentInsightsTriggerException::getReason)
+                .isEqualTo(AgentInsightsJob.FailureReason.OUT_OF_CREDITS);
+    }
+
+    @Test
+    @DisplayName("Any other non-2xx is named as a run that did not start")
+    void triggerAgentInsights__otherError__namesDidNotStart() {
+        stubTriggerStatus(500);
+
+        // Pins the reason, not just the exception type: both failures share one type now, so asserting the
+        // type alone would let a server error be reported to the user as a billing problem.
+        assertThatExceptionOfType(AgentInsightsTriggerException.class)
+                .isThrownBy(this::trigger)
+                .extracting(AgentInsightsTriggerException::getReason)
+                .isEqualTo(AgentInsightsJob.FailureReason.DID_NOT_START);
+    }
+
+    @Test
+    @DisplayName("An accepted trigger does not throw")
+    void triggerAgentInsights__accepted__doesNotThrow() {
+        stubTriggerStatus(202);
+
+        assertThatNoException().isThrownBy(this::trigger);
+    }
+}

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.test.ts
@@ -567,6 +567,29 @@ describe("explainStore", () => {
     expect(entry.text).toBe("real");
   });
 
+  it("tells a user who ran out of credits to add credits, not to retry", () => {
+    // The console reports credit exhaustion as `out_of_credits`. Without copy for it the popover fell back
+    // to the generic "unavailable" path and told the user to try again shortly, which can never work.
+    const emit = vi.fn();
+    reset(emit);
+    useExplainStore.getState().explain(target("e1"));
+    const { explainId } = Object.values(useExplainStore.getState().entries)[0];
+
+    // A raw message distinct from the host copy, so this proves the code resolved rather than
+    // the message merely falling through.
+    handleConsoleEvent("explain:error", {
+      explainId,
+      code: "out_of_credits",
+      message: "upstream said 402",
+    });
+
+    const entry = useExplainStore.getState().entries[key("e1")];
+    expect(entry.phase).toBe("error");
+    expect(entry.error).toBe(
+      "You're out of LLM credits. Add credits and try again.",
+    );
+  });
+
   it("does not resolve a prototype-key error code to a Function (renders a safe string)", () => {
     // `code` is free-form off the bridge; a bare ERROR_COPY[code] lookup would
     // return Object.prototype.constructor (a Function) for code:"constructor",

--- a/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
+++ b/apps/opik-frontend/src/plugins/comet/explain/explainStore.ts
@@ -59,6 +59,7 @@ const ERROR_COPY = {
   timeout: "Ollie took too long to respond. Try again.",
   unavailable: "Ollie is unavailable right now. Try again shortly.",
   rate_limited: "Too many requests right now. Try again in a moment.",
+  out_of_credits: "You're out of LLM credits. Add credits and try again.",
 } as const;
 type ErrorCode = keyof typeof ERROR_COPY;
 


### PR DESCRIPTION
## Details

A user who ran out of LLM credits was told something else on both Ollie surfaces. The Explain popover had no copy for `out_of_credits` and fell through to the raw upstream message, and a diagnostics run rejected for insufficient credits was recorded as `did_not_start` — which the UI renders as "the run was never picked up (the service may have been restarting)", inviting a retry that will be rejected the same way.

- Explain now maps `out_of_credits` like every other error code. Unlike the rest, the copy asks for credits rather than a retry, because retrying is exactly what cannot help.
- The Agent Insights trigger client now names the reason for every refusal, the way the daily report's `OrchestratorClient` already does, and the subscriber records what it is handed instead of inferring it from an exception type.
- Both reasons opik itself records now live on `AgentInsightsJob.FailureReason`, mirroring `OllieReport.FailureReason`. That also retires a hardcoded `"did_not_start"` string that predates this change.
- The reason travels on `AgentInsightsTriggerException` rather than through a `Consumer`, because this client is synchronous and its caller drives the failure metric and the at-most-once drop off the reactive error channel — a callback would make a failed trigger look like a success. The principle is the same either way: the client names the reason, the caller only records it.

The Ollie-side halves — Explain reporting the code at all, and the insights classifier no longer calling credit exhaustion rate limiting — ship in `ollie-assist`. The trigger-time credit pre-check that produces the 402 mapped here ships in `comet-backend`.

Deploy note: this change should land before the `comet-backend` pre-check. Without the mapping here, a credit-rejected trigger records `did_not_start` and surfaces the original bug on a new path.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7605
- Resolves OPIK-7606

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: code review + local test runs

## Testing

Commands run:
- `mvn test -Dtest=PlatformAgentInsightsReportClientTest` — 3/3. New WireMock-backed test covering the trigger classification: 402 names `out_of_credits`, any other non-2xx names `did_not_start`, 202 does not throw. The tests assert the reason rather than the exception type, since both failures now share one type — asserting the type alone would let a server error be reported to the user as a billing problem.
- `mvn test -Dtest=AgentInsightsJobsResourceTest` — 16/16, covering the failure-reason storage and retrieval path the subscriber writes into.
- `npx vitest run src/plugins/comet/explain` — 53/53, including a new case asserting an `explain:error` with `code: "out_of_credits"` renders the host copy. It deliberately sends a different raw message, so the test proves the code resolved rather than the message falling through.
- `mvn compile`, `mvn spotless:check`, `npm run lint`, `npm run typecheck` — all clean, re-run after rebasing onto latest main.

Not run: the end-to-end path, which needs real credit exhaustion from the provider plus a provisioned Ollie pod and the console bridge. Neither is reproducible locally, so it will be verified in dev using the repro from the tickets (a workspace with no Ollie credits). Note the two diagnostics paths need separate exercise: a fully drained org always hits the trigger-time rejection, so the mid-run path stays unexercised unless the org runs dry partway.

## Documentation

N/A — no user-facing docs affected. Rationale for the design choices is in the code comments and commit message.
