### PR TITLE
[NA] [EXT] fix: include cache tokens in reported prompt and total tokens

### DIFF
--- a/extensions/cursor/package-lock.json
+++ b/extensions/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opik",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@sentry/node": "^10.38.0",
         "glob": "^11.1.0",

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -4,7 +4,7 @@
   "description": "Export your chat history from Cursor to Opik.",
   "repository": "https://github.com/comet-ml/opik",
   "publisher": "opik",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "preview": false,
   "engines": {
     "vscode": "^1.90.0"

--- a/extensions/cursor/scripts/verify-usage.js
+++ b/extensions/cursor/scripts/verify-usage.js
@@ -20,6 +20,7 @@ Module._load = function (request) {
 
 const { attributeUsageToTurns } = require('../out/cursor/usage.js');
 const { executeQuery } = require('../out/cursor/sqlite.js');
+const { toSpanUsage } = require('../out/opik.js');
 
 const DB = path.join(
   os.homedir(),
@@ -113,10 +114,15 @@ async function rpc(method, token, body) {
     sum.output += usage.outputTokens;
     sum.cacheRead += usage.cacheReadTokens;
     sum.cents += usage.chargedCents;
+    const emitted = toSpanUsage(usage);
     console.log(
       `  turn ${i + 1} [${at}] reqs=${usage.requestCount} in=${usage.inputTokens} ` +
         `out=${usage.outputTokens} cacheR=${usage.cacheReadTokens} ` +
         `cents=${usage.chargedCents.toFixed(4)} model=${usage.models.join(',')}`
+    );
+    console.log(
+      `        -> opik prompt_tokens=${emitted.prompt_tokens} ` +
+        `completion_tokens=${emitted.completion_tokens} total_tokens=${emitted.total_tokens}`
     );
   });
 
@@ -143,12 +149,32 @@ async function rpc(method, token, body) {
   });
   const duplicates = signatures.length - new Set(signatures).size;
 
+  // Assert the exact mapping that applyTurnUsage sends, not a copy of it. Cursor
+  // reports inputTokens excluding cache, so prompt_tokens must include the cache
+  // tokens or the reported totals undercount by several times.
+  let mappingOk = true;
+  turnStarts.forEach((_s, i) => {
+    const u = attributed.get(i);
+    if (!u) return;
+    const emitted = toSpanUsage(u);
+    const expectedPrompt = u.inputTokens + u.cacheReadTokens + u.cacheWriteTokens;
+    if (
+      emitted.prompt_tokens !== expectedPrompt ||
+      emitted.total_tokens !== expectedPrompt + u.outputTokens ||
+      emitted.cache_read_input_tokens !== u.cacheReadTokens
+    ) {
+      mappingOk = false;
+      console.log(`  turn ${i + 1}: MAPPING MISMATCH ${JSON.stringify(emitted)}`);
+    }
+  });
+
   console.log(`\ncoverage:   ${covered}/${turnStarts.length} turns`);
   console.log(`duplicates: ${duplicates} turns share an identical usage payload`);
+  console.log(`mapping:    ${mappingOk ? 'prompt_tokens includes cache tokens' : 'MISMATCH'}`);
   console.log(`attributed: in=${sum.input} out=${sum.output} cacheR=${sum.cacheRead} cents=${sum.cents.toFixed(4)}`);
   console.log(`api total:  in=${total.input} out=${total.output} cacheR=${total.cacheRead} cents=${total.cents.toFixed(4)}`);
   console.log(`reconcile:  ${reconciled ? 'PASS' : 'FAIL'}`);
-  process.exit(reconciled && duplicates === 0 ? 0 : 1);
+  process.exit(reconciled && duplicates === 0 && mappingOk ? 0 : 1);
 })().catch((error) => {
   console.error(error.message);
   process.exit(1);

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -85,6 +85,27 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
     }
 }
 
+/**
+ * Cursor reports inputTokens excluding cache, the same way Anthropic does, so
+ * prompt_tokens has to add the cache tokens back in. See the equivalent in the
+ * Python SDK, llm_usage/anthropic_usage.py get_billable_tokens(). Reporting the
+ * cache figures separately as well is the house convention, not double counting.
+ *
+ * Exported so that scripts/verify-usage.js asserts this exact mapping rather
+ * than a copy of it.
+ */
+export function toSpanUsage(usage: TurnUsage): Record<string, number> {
+    const promptTokens = usage.inputTokens + usage.cacheReadTokens + usage.cacheWriteTokens;
+
+    return {
+        prompt_tokens: promptTokens,
+        completion_tokens: usage.outputTokens,
+        total_tokens: promptTokens + usage.outputTokens,
+        cache_read_input_tokens: usage.cacheReadTokens,
+        cache_creation_input_tokens: usage.cacheWriteTokens,
+    };
+}
+
 export async function applyTurnUsage(
     apiKey: string,
     pending: PendingUsage,
@@ -92,26 +113,23 @@ export async function applyTurnUsage(
 ): Promise<void> {
     const client = await createClient(apiKey);
 
+    const spanUsage = toSpanUsage(usage);
+
     await client.api.spans.updateSpan(pending.spanId, {
         body: {
             traceId: pending.traceId,
             projectName: pending.projectName,
             model: usage.models[0],
             provider: 'cursor',
-            usage: {
-                prompt_tokens: usage.inputTokens,
-                completion_tokens: usage.outputTokens,
-                total_tokens: usage.inputTokens + usage.outputTokens,
-                cache_read_input_tokens: usage.cacheReadTokens,
-                cache_creation_input_tokens: usage.cacheWriteTokens,
-            },
+            usage: spanUsage,
             totalEstimatedCost: usage.chargedCents / 100,
         },
     });
 
     console.log(
-        `💰 Patched span ${pending.spanId}: ${usage.inputTokens} in / ${usage.outputTokens} out ` +
-        `/ ${usage.cacheReadTokens} cache read, ${usage.chargedCents.toFixed(4)}c ` +
+        `💰 Patched span ${pending.spanId}: ${spanUsage.prompt_tokens} prompt ` +
+        `(${usage.inputTokens} fresh + ${usage.cacheReadTokens} cache read + ${usage.cacheWriteTokens} cache write) ` +
+        `/ ${usage.outputTokens} completion, ${usage.chargedCents.toFixed(4)}c ` +
         `across ${usage.requestCount} request(s)`
     );
 }


### PR DESCRIPTION
## Details

Cursor reports `inputTokens` excluding cache, the same way Anthropic does. The span was written with `prompt_tokens` set to `inputTokens` alone, so an agentic turn that read 140k tokens from cache reported **28,726** total tokens instead of **169,142** — a 5.9x undercount. Cost was never affected, because Cursor's `chargedCents` already prices every token.

- `prompt_tokens` now adds cache read and cache write back in, matching `get_billable_tokens()` in `sdks/python/src/opik/llm_usage/anthropic_usage.py:40`. The cache figures are still reported separately, which is the house convention (see `opik_usage.py:150`) and not double counting.
- The mapping moved into an exported `toSpanUsage()` so `scripts/verify-usage.js` asserts the real mapping instead of a copy.

Follows #7998, which is already merged. Ships as extension 0.4.1.

### Reported case

Trace `01a03d17-7063-71ce-ad81-a67c98ee321e`, one user message and 39 assistant messages:

| Field | Before | After |
|---|---|---|
| `prompt_tokens` | 26,591 | **167,007** |
| `completion_tokens` | 2,135 | 2,135 |
| `total_tokens` | 28,726 | **169,142** |
| `cache_read_input_tokens` | 140,416 | 140,416 |
| `total_estimated_cost` | 0.2724 | 0.2724 (unchanged) |

For the record, two things this was **not**. Cursor emits exactly one usage event for the whole agentic turn, and the span copied it faithfully, so attribution was not at fault. And the event does cover the whole loop rather than the final call: Cursor's own accounting put the final prompt at 38,179 tokens, while the event reports 167,007 prompt tokens, roughly 4.4x that, consistent with several round trips.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Diagnosis of the undercount, the `toSpanUsage()` change in `src/opik.ts`, the mapping assertion in `scripts/verify-usage.js`, the version bump, and this PR description.
- Human verification: Reported by the author from a real logged trace. Author confirmed cost looked correct while token counts did not, which is what localised the fault to the mapping rather than to attribution.

## Testing

```
npm run compile     # tsc, clean
npm run lint        # 0 errors, 9 warnings (all pre-existing in sessionManager.ts)
npm run esbuild     # bundles clean
npm run verify-usage
```

`verify-usage` now prints the emitted mapping per turn and fails if `prompt_tokens` omits cache tokens, if `total_tokens` is not `prompt + completion`, or if the cache fields do not round-trip. It previously reconciled only against Cursor's own event totals, which is why it passed while the Opik mapping was wrong.

End-to-end against the real API with the reported values, patching a span and reading it back:

```
opik sdk: 1.10.9
💰 Patched span ...: 167007 prompt (26591 fresh + 140416 cache read + 0 cache write)
   / 2135 completion, 27.2400c across 1 request(s)
read back http 200
  usage: {"total_tokens":169142,"completion_tokens":2135,"prompt_tokens":167007,
          "cache_creation_input_tokens":0,"cache_read_input_tokens":140416}
  total_estimated_cost: 0.2724
PATCH SHAPE OK
```

Regression check unchanged on a five-turn conversation: 5/5 coverage, 0 duplicate payloads, `reconcile: PASS`, `mapping: prompt_tokens includes cache tokens`.

Not run: there is still no automated test suite in this extension, so the above is manual plus the `verify-usage` script.

Environment: macOS 15, Cursor 3.17.19, opik SDK 1.10.9, Node 22.

## Documentation

No change needed. The docs section added in #7998 describes what is recorded without quoting a token convention.

Worth flagging for whoever reviews: spans written by 0.4.0 keep the undercounted `prompt_tokens` and `total_tokens`. Nothing here backfills them, so any token rollup spanning both versions will be inconsistent. Cost is correct in both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
