### PR TITLE
DND-1580: restore the Star History chart in all five READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,13 @@ Opik allows you to evaluate your LLM application during development through [Dat
 
 If you find Opik useful, please consider giving us a star! Your support helps us grow our community and continue improving the product.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+<a href="https://github.com/comet-ml/opik">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&theme=dark&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+  </picture>
+</a>
 
 <a id="-contributing"></a>
 ## 🤝 Contributing

--- a/readme_CN.md
+++ b/readme_CN.md
@@ -389,7 +389,13 @@ Opik 允许你在开发阶段通过[数据集](https://www.comet.com/docs/opik/e
 
 如果你觉得 Opik 有用，请考虑给我们点个 star！你的支持将帮助我们壮大社区并持续改进产品。
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+<a href="https://github.com/comet-ml/opik">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&theme=dark&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+  </picture>
+</a>
 
 <a id="-contributing"></a>
 ## 🤝 参与贡献

--- a/readme_DE.md
+++ b/readme_DE.md
@@ -389,7 +389,13 @@ Mit Opik können Sie Ihre LLM-Anwendung während der Entwicklung anhand von [Dat
 
 Wenn Sie Opik nützlich finden, geben Sie uns bitte einen Stern! Ihre Unterstützung hilft uns, unsere Community wachsen zu lassen und das Produkt weiter zu verbessern.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+<a href="https://github.com/comet-ml/opik">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&theme=dark&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+  </picture>
+</a>
 
 <a id="-contributing"></a>
 ## 🤝 Mitwirken

--- a/readme_ES.md
+++ b/readme_ES.md
@@ -388,7 +388,13 @@ Opik te permite evaluar tu aplicación de LLM durante el desarrollo a través de
 
 Si Opik te resulta útil, ¡considera darnos una estrella! Tu apoyo nos ayuda a hacer crecer nuestra comunidad y a seguir mejorando el producto.
 
-[![Gráfico del historial de estrellas](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+<a href="https://github.com/comet-ml/opik">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&theme=dark&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <img alt="Gráfico del historial de estrellas" src="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+  </picture>
+</a>
 
 <a id="-contributing"></a>
 ## 🤝 Contribuir

--- a/readme_FR.md
+++ b/readme_FR.md
@@ -389,7 +389,13 @@ Opik vous permet d'évaluer votre application LLM pendant le développement grâ
 
 Si vous trouvez Opik utile, envisagez de nous donner une étoile ! Votre soutien nous aide à faire grandir notre communauté et à continuer d'améliorer le produit.
 
-[![Graphique de l'historique des étoiles](https://api.star-history.com/svg?repos=comet-ml/opik&type=Date)](https://github.com/comet-ml/opik)
+<a href="https://github.com/comet-ml/opik">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&theme=dark&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+    <img alt="Graphique de l'historique des étoiles" src="https://api.star-history.com/chart?repos=comet-ml/opik&type=date&legend=top-left&sealed_token=BX74aJIfWUI5DCa9TnADwC6ULxwX2VtdZ6HviPALqS8Xcj3YntZYQ5vqr3EDa9erLGMfhUiQUemd2nNzerMfbZ7IUGKi8sY0oySymsC61B4kjAauFD79uTCuroSJ1DiPL6T_rU-3VVPAfz81jfZ7OaZ5duanlAUQ89Lmd2alCmLPC_cGPiP-FOYtGQHW" />
+  </picture>
+</a>
 
 <a id="-contributing"></a>
 ## 🤝 Contribuer


### PR DESCRIPTION
## What

Restores the "Star Us on GitHub" chart in all five READMEs using the official Star History token embed.

Jira: [DND-1580](https://comet-ml.atlassian.net/browse/DND-1580)

## Why it broke

GitHub restricted stargazer `starred_at` data on 2026-06-30 to a repository's own admins and collaborators. The old URL (`api.star-history.com/svg?repos=comet-ml/opik&type=Date`) still returns HTTP 200, but the SVG's only content is a notice reading *"GitHub restricted access to star data"* — so the chart looked broken rather than missing.

## What changed

The single chart line in each of the 5 READMEs (`README.md`, `readme_CN.md`, `readme_DE.md`, `readme_ES.md`, `readme_FR.md`) is replaced with the generated token embed, as a `<picture>` block so the chart follows the reader's light/dark theme.

Two deliberate choices:

- **The click-through `<a href>` points at `https://github.com/comet-ml/opik`**, not at star-history.com. Star History's generated snippet points it at their own site; per DND-1580 the click-through stays on GitHub.
- **Each translated README keeps its own localized `alt` text** (`Gráfico del historial de estrellas`, `Graphique de l'historique des étoiles`).

## Verification

The embedded URL was checked to serve real data, not an empty frame or the restriction notice — light and dark variants both:

- date ticks `2024 | 2025 | 2026`, y-axis `5K | 10K | 15K | 20K` (consistent with the actual ~21.6k stars)
- a 412-character data-series path; legend reads `comet-ml/opik`
- zero occurrences of the restriction notice

Worth noting for future retries: Star History's "Generate embed code" button performs **no validation** — it encrypts whatever string is pasted and builds a URL. A working-looking embed is not evidence the token or repo is correct, so the rendered chart has to be checked directly.

## Token

- Fine-grained PAT on a **machine/bot account**, scoped to `comet-ml/opik` only.
- GitHub requires `metadata=read` **and `contents=write`** for the stargazers endpoint (confirmed via the `x-accepted-github-permissions` response header). `metadata=read` alone returns `403 Resource not accessible by personal access token`.
- **Expires 2027-08-27.** Rotation reminder to be set; the chart breaks when it lapses.

## Accepted trade-off, and the follow-up

The README carries an encrypted form of the token, which Star History's server decrypts in memory on every README view (their stated policy is "never stored, never logged" — unverifiable). Because GitHub now requires `contents=write`, that credential is **push-capable on this repo**, which is a broader exposure than the read-only star data originally envisaged in DND-1580.

This is the agreed interim fix. The intended follow-up is to generate the SVG in CI and commit it, removing both the third-party runtime dependency and the token — a workflow's own `GITHUB_TOKEN` can be granted exactly `contents: write`, is ephemeral, and never leaves GitHub.

## Note

This supersedes external PR #7851, which repointed the chart at a third-party host and was rejected. See DND-1580 for the findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DND-1580]: https://comet-ml.atlassian.net/browse/DND-1580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ