### PR TITLE
[NA] [EXT] feat: log cursor tool calls and model calls as nested spans

### DIFF
--- a/extensions/cursor/NESTED-SPANS.md
+++ b/extensions/cursor/NESTED-SPANS.md
@@ -1,0 +1,463 @@
+# Nested spans for the Cursor extension
+
+Sections 1 and 2 record the data this design is based on. Sections 3 and 4
+describe what was built.
+
+## 1. Where we were
+
+The extension writes one trace and one span for each user turn.
+
+- `src/cursor/sessionManager.ts` groups the bubbles of a composer into turns.
+  One turn is one user bubble plus all the assistant bubbles that follow it.
+- `createTraceFromBubbleGroup()` joins the text of the assistant bubbles into a
+  single string. It strips the markers `⛢Thought☤`, `⛢Action☤` and
+  `⛢RawAction☤`.
+- `src/opik.ts` `logTracesToOpik()` creates the trace, then one child span with
+  `type: 'llm'`.
+- `src/cursor/usage.ts` `UsageEnricher` patches that span later with the token
+  counts and the cost from the Cursor usage API.
+
+The raw bubbles are copied into `metadata.userMessages` and
+`metadata.aiMessages`. Nothing in the UI reads them, and they can be very large.
+
+**Result:** you see the question and the final answer. You do not see which
+tools ran, what they returned, how long each step took, or where the agent
+failed.
+
+## 2. What the real data contains
+
+I scanned the local Cursor database:
+`~/Library/Application Support/Cursor/User/globalStorage/state.vscdb`.
+It holds **19,691 bubbles**. The numbers below come from that scan.
+
+### 2.1 Field coverage
+
+| Field | Bubbles | Share | Meaning |
+| --- | --- | --- | --- |
+| `createdAt` | 19,690 | 100% | ISO time, millisecond precision |
+| `type` | 19,690 | 100% | `1` = user, `2` = assistant |
+| `capabilityType` | 12,332 | 62.6% | `15` = tool call, `30` = thinking |
+| `toolFormerData` | 11,139 | 56.6% | the tool call record |
+| `text` | 6,949 | 35.3% | message text |
+| `usageUuid` | 5,912 | 30.0% | groups all bubbles of one turn |
+| `thinking` | 2,183 | 11.1% | reasoning text |
+| `thinkingDurationMs` | 2,177 | 11.1% | exact duration of the reasoning |
+| `requestId` | 2,131 | 10.8% | request id of the turn |
+| `modelInfo` | 2,131 | 10.8% | `{ modelName }` |
+| `codeBlocks` | 1,225 | 6.2% | code the model proposed |
+| `contextWindowStatusAtCreation` | 931 | 4.7% | tokens used and token limit |
+| `timingInfo` | 666 | 3.4% | client start, send, settle and end time |
+| `todos` | 136 | 0.7% | the to-do list state |
+| `webCitations` | 30 | 0.2% | web sources |
+| `errorDetails` | 26 | 0.1% | message and stack trace of a failure |
+| `turnDurationMs` | 32 | 0.2% | duration of the whole turn |
+
+`tokenCount` is present on 97.5% of the bubbles but is `0/0` almost everywhere.
+Only the last bubble of a turn carries the real value, for example
+`{"inputTokens": 91311, "outputTokens": 4017}`.
+
+### 2.2 The shape of `toolFormerData`
+
+| Key | Present | Content |
+| --- | --- | --- |
+| `tool` | always | numeric tool id, stable across Cursor versions |
+| `name` | almost always | tool name, **not** stable across versions |
+| `toolCallId` | always | provider tool call id, for example `toolu_…` |
+| `modelCallId` | always | id of the model call that made this tool call |
+| `toolIndex` | always | position of the call inside the model call |
+| `status` | always | see below |
+| `rawArgs` | 99.6% | the arguments the model sent, as JSON |
+| `params` | 99.6% | the arguments after Cursor parsed them |
+| `result` | 89.6% | the tool result, as JSON |
+| `additionalData` | 70% | review data, sandbox policy, match counts |
+| `userDecision` | 12.7% | `accepted` (1,334) or `rejected` (10) |
+| `error` | rare | the error object |
+
+Status values across all tool calls:
+`completed` 9,269, `loading` 320, `error` 179, `cancelled` 134.
+
+### 2.3 Tool names by numeric id
+
+The `name` changed between Cursor versions. The numeric `tool` id did not.
+Use the id as the source of truth and the name as the label.
+
+| id | Names seen in the data |
+| --- | --- |
+| 8 | `file_search` |
+| 9 | `semantic_search_full`, `codebase_search` |
+| 11 | `delete_file` |
+| 15 | `run_terminal_cmd`, `run_terminal_command_v2`, `bash` |
+| 18 | `web_search` |
+| 19 | `mcp_<server>_<tool>` (all MCP tools) |
+| 30 | `read_lints` |
+| 35 | `todo_write` |
+| 38 | `edit_file_v2`, `search_replace`, `apply_patch`, `write` |
+| 39 | `list_dir`, `list_dir_v2` |
+| 40 | `read_file_v2`, `read_file`, `read` |
+| 41 | `ripgrep_raw_search`, `grep`, `rg` |
+| 42 | `glob_file_search`, `glob` |
+| 43 | `create_plan` |
+| 48 | `task_v2` (sub-agent) |
+| 51 | `ask_question` |
+| 57 | `web_fetch` |
+| 90 | ACP tools: `execute`, `read`, `edit` |
+
+**Trap:** 1,237 ordinary bubbles carry
+`toolFormerData: {"additionalData": {"status": "error"}}` and nothing else.
+These are **not** tool calls. Treat a bubble as a tool call only when
+`toolFormerData.tool` or `toolFormerData.name` is present.
+
+### 2.4 A real turn
+
+This is one turn from composer `9bb91e1f`, model `gpt-5.2-codex`:
+
+```
+00:24:06.778  USER + TEXT     req=c401a2ba
+00:24:06.912  cap=30  THINK 2129 ms
+00:24:11.383  cap=--  TEXT
+00:24:12.281  cap=15  TOOL read_file
+00:24:12.281  cap=30  THINK 3781 ms
+00:24:18.948  cap=--  TEXT
+00:24:19.513  cap=15  TOOL write
+00:24:19.513  cap=30  THINK 1032 ms
+00:24:49.478  cap=15  TOOL run_terminal_cmd
+00:24:56.769  cap=15  TOOL read_lints
+00:24:59.947  cap=15  TOOL read_file
+00:25:04.536  cap=--  TEXT
+00:25:05.396  cap=15  TOOL run_terminal_cmd
+00:26:15.680  cap=--  TEXT
+00:27:08.353  cap=15  TOOL todo_write
+00:27:12.616  cap=--  TEXT   tok=91311/4017
+```
+
+Three facts follow from this.
+
+1. Cursor writes a bubble when its step **finishes**. So `createdAt` is the end
+   time of the step, not the start time.
+2. A thinking bubble and the tool bubble beside it share the same `createdAt`.
+   Cursor flushes them together.
+3. The token count of the whole turn lands on the last bubble.
+
+### 2.5 Payload size
+
+Median bubble size is 2.8 KB. The tail is long.
+
+| Tool | Calls | Median result | p90 result | Max result |
+| --- | --- | --- | --- | --- |
+| `mcp_…_browser_take_screenshot` | 120 | 157 KB | 238 KB | 905 KB |
+| `semantic_search_full` | 178 | 132 KB | 165 KB | 185 KB |
+| `search_replace` | 669 | 13 KB | 42 KB | 290 KB |
+| `apply_patch` | 180 | 9 KB | 96 KB | 99 KB |
+| `write` | 151 | 8 KB | 30 KB | 57 KB |
+| `read_file` | 1,276 | 3.5 KB | 20 KB | 585 KB |
+| `run_terminal_cmd` | 1,035 | 0.5 KB | 4 KB | 24 KB |
+
+The largest single bubble is **13.5 MB**. The TypeScript SDK caps a batch at
+20 MB. Truncation is not optional.
+
+### 2.6 Can we get token usage for each LLM call?
+
+**No. Cursor does not record it.** Three independent checks say the same thing.
+
+1. **The bubbles.** Only **477 of 19,691** bubbles (2.4%) carry a non-zero
+   `tokenCount`. There is exactly **one for each turn**, and it always sits on
+   the last bubble of that turn. Composer `9bb91e1f` has 41 turns and 38 such
+   bubbles.
+
+2. **The values are turn totals, not call totals.** For composer `9bb91e1f`:
+
+   | Turn | Bubbles | Position of the token bubble | `inputTokens` | `outputTokens` |
+   | --- | --- | --- | --- | --- |
+   | 4 | 9 | 9 of 9 | 66,309 | 1,099 |
+   | 5 | 26 | 26 of 26 | 91,311 | 4,017 |
+   | 6 | 48 | 48 of 48 | 124,201 | 14,976 |
+   | 13 | 60 | 60 of 60 | 170,431 | 11,518 |
+   | 15 | 6 | 6 of 6 | 67,946 | 939 |
+
+   `inputTokens` grows with the conversation and drops at turn 15, which is
+   where Cursor compacted the context. It is the prompt size of the last model
+   call in the turn, not a sum over the calls.
+
+3. **The usage API is turn-granular too.** `composerData.usageData` for that
+   composer reads
+   `{"claude-4.5-opus-high-thinking": {"costInCents": 2463, "amount": 46}}`.
+   That is **46 billed requests for 41 turns**, while the same composer made
+   several hundred model calls. `GetFilteredUsageEvents` bills one request for
+   one user turn, not one for each model call.
+
+So an `llm` span for each model call is possible, but only **one span in each
+turn can carry real usage**. Do not divide the turn total across the calls.
+That invents numbers.
+
+## 3. What was built
+
+### 3.1 Shape
+
+The trace keeps the same `input` and `output`. One `llm_turn` span sits under it
+and carries the token usage of the whole turn. Everything else nests under
+`llm_turn`, in time order.
+
+```
+trace  "cursor-chat"                    input = the question, output = the answer
+└── span  llm_turn   type=llm           same input and output, carries the usage
+    ├── span  assistant      type=llm       model call 1: reasoning + text
+    ├── span  read_file      type=tool
+    ├── span  assistant      type=llm       model call 2
+    ├── span  search_replace type=tool
+    ├── span  search_replace type=tool      dispatched in parallel
+    ├── span  assistant      type=llm       model call 3
+    └── span  cursor-error   type=general   from errorDetails
+```
+
+A real turn from composer `9bb91e1f`, printed by the replay script:
+
+```
+── turn 2  (9 spans)  "What about: https://ai-sdk.dev/docs/reference/…"
+   llm     assistant          +   0s    4523ms    1.0KB
+   tool    read_file          +   5s    1306ms    6.3KB
+   llm     assistant          +   6s    3855ms    3.7KB
+   tool    search_replace     +  10s     725ms    4.4KB
+   tool    search_replace     +  10s     725ms    4.1KB
+   tool    search_replace     +  11s    4698ms    4.1KB
+   tool    search_replace     +  15s    3927ms    6.8KB
+   llm     assistant          +  22s    5344ms     332B
+   tool    run_terminal_cmd   +  27s     648ms    2.1KB  ERROR
+```
+
+Keeping `llm_turn` costs one span and buys three things: `UsageEnricher` needs
+no change at all, the turn total has one honest home, and the trace still reads
+as a single question and answer when the child spans are collapsed.
+
+### 3.2 Where one LLM call starts and ends
+
+Cursor records no group id for a model call. `usageUuid` is one for each **turn**
+(measured: always exactly 1 per turn). `serverBubbleId` is one for each
+**bubble**, not for each call. `modelCallId` exists only on tool bubbles.
+
+The structure itself is regular. This is one real turn from composer
+`9bb91e1f`, in header order:
+
+```
+00:24:06.778  USER
+00:24:06.912  THINK   2129 ms      ┐ model call 1
+00:24:11.383  TEXT                 │
+00:24:12.281  TOOL read_file       ┘
+00:24:12.281  THINK   3781 ms      ┐ model call 2
+00:24:18.948  TEXT                 │
+00:24:19.513  TOOL write           ┘
+```
+
+Cursor flushes the tool bubble and the reasoning of the **next** call together,
+which is why they share a timestamp to within 25 ms.
+
+**Cut rule** (`splitIntoModelCalls` in `src/cursor/modelCalls.ts`). Walk the turn
+in order and keep a current group. Start a new group when either of these is
+true:
+
+- the bubble is `thinking` or `message`, and the current group already holds a
+  tool bubble;
+- the bubble is a tool call whose `modelCallId` differs from the one already in
+  the current group, **and** its timestamp differs too. The timestamp test keeps
+  tools dispatched in parallel together.
+
+This covers both shapes in the data: reasoning models (`9bb91e1f`, 275 thinking
+bubbles) cut at each `thinking`, and non-reasoning models (`32f1ff14`, 0 thinking
+bubbles) cut at each `text`.
+
+A model call with no reasoning and no text left no record of its own duration,
+so no `llm` span is emitted for it. Its tool spans still carry `model_call_id`.
+
+### 3.3 Timing
+
+Cursor writes a bubble when its step **finishes**, so `createdAt` is an end time
+and there is no start time anywhere (`assignWindows` in `modelCalls.ts`):
+
+- `end` = `createdAt`.
+- `start` = the end of the step before it.
+- Bubbles that share a timestamp were dispatched together and share a start.
+- A `thinking` bubble uses its exact `thinkingDurationMs`, clamped so a negative
+  value (the data contains `-1000`) collapses to zero instead of running
+  backwards.
+- `timingInfo` wins when present. It is the only exact pair Cursor records, on
+  3.4% of bubbles.
+- A reasoning bubble flushed at the same millisecond as the tool before it
+  starts when that tool **ended**, never when it started. Without this rule the
+  `llm` span overlaps the tool span exactly.
+- An error bubble is a point event: `start` equals `end`, and it does not move
+  the cursor for the step after it.
+
+### 3.4 Bubble order
+
+`fullConversationHeadersOnly` is the order Cursor shows, and it is deliberately
+incomplete. Composer `9bb91e1f` holds 833 bubbles for 748 headers: the extra
+ones come from branches the user edited away.
+
+`orderBubbles` in `src/cursor/bubbleOrder.ts` therefore lets the headers decide
+what belongs to the conversation, with one exception. Cursor never lists the
+error bubbles that record a failed request, and the old code sorted every
+unlisted bubble to the end, which attached them to the last turn. Those go in by
+time instead, and one outside the time range of the headers is dropped, because
+it belongs to a turn that no longer exists.
+
+### 3.5 Field mapping
+
+**`llm` span** — one for each model call:
+
+| Span field | Source |
+| --- | --- |
+| `name` | `assistant` |
+| `model` | `modelInfo.modelName`, else `composerData.modelConfig.modelName` |
+| `provider` | `cursor` |
+| `output` | `{ thinking, text, tool_calls: [{ name, arguments }] }` |
+| `metadata.thinking_duration_ms` | sum of `thinkingDurationMs` |
+| `metadata.context_tokens_used` | `contextWindowStatusAtCreation.tokensUsed` |
+| `metadata.context_token_limit` | `contextWindowStatusAtCreation.tokenLimit` |
+
+There is no `input`. Cursor never stores the prompt it sent, and a
+reconstruction would be a guess.
+
+**`tool` span** — one for each tool bubble:
+
+| Span field | Source |
+| --- | --- |
+| `name` | `toolFormerData.name`, else `TOOL_ID_NAMES[tool]` |
+| `input` | `JSON.parse(rawArgs)`, else `params` |
+| `output` | `JSON.parse(result)` |
+| `errorInfo` | set when `status` is `error` or `cancelled` |
+| `metadata` | `status`, `tool_id`, `tool_call_id`, `model_call_id`, `user_decision`, `exit_code` |
+
+**`general` span** — one for each bubble that carries `errorDetails`. The
+messages are real failures: `PING timed out`, `Network disconnected`,
+`Request higher limits to continue using Cursor`, `Model name is not valid: "auto"`.
+
+### 3.6 Where the usage goes
+
+The `llm_turn` span carries it, and only it.
+
+Cursor records tokens once per turn and never per model call, so no other
+placement is honest. The backend sums span usage into the trace
+(`sumMap(s.usage)` in `TraceDAO.java`), so the trace total is right either way.
+
+`PendingUsage.spanId` still names the `llm_turn` span, so `UsageEnricher` and
+`applyTurnUsage()` are untouched.
+
+### 3.7 Truncation
+
+`truncateForSpan` caps each `input` and `output` at
+`opik.detailedSpans.maxPayloadChars` (default 10,000). Longer payloads keep the
+first 60% and the last 40%, joined by a marker, and the span records
+`input_truncated` / `output_truncated` with the original length.
+
+Any base64 run longer than 1,000 characters is replaced by `[binary, N bytes]`
+**before** the size check. Browser screenshot results have a median size of
+157 KB and a maximum of 905 KB, and one bubble in the database is 13.5 MB.
+
+### 3.8 Trace output
+
+The trace output is the messages the assistant wrote with the name of every tool
+call in between, in the order they happened (`buildTurnOutput` in
+`spanBuilder.ts`). Consecutive tool calls stay on adjacent lines so a long run
+stays compact. Reasoning is left out. The `llm_turn` span shows the same string.
+
+```
+Good catch! Looking at the AI SDK documentation…
+
+[read_file]
+
+I see! The property is now `inputSchema` instead of `parameters`.
+
+[search_replace]
+[search_replace]
+[search_replace]
+[search_replace]
+
+Now let me run the tests to validate the fix:
+
+[run_terminal_cmd]
+```
+
+The name comes from `toolFormerData.name`, or from `TOOL_ID_NAMES` when a Cursor
+version has dropped it.
+
+This also removes the old reason for dropping a turn. A turn that ends on a tool
+call with no closing message is common, and it used to be discarded for having
+an empty output. It now reads `[read_file]\n[grep]`.
+
+### 3.9 Trace metadata
+
+`metadata.userMessages` and `metadata.aiMessages` are gone. The spans now hold
+that data in a readable form, and the raw copy was the largest part of the
+payload. The trace instead carries `mode`, `isAgentic`, `createdOnBranch`,
+`contextTokensUsed`, `contextTokenLimit`, `filesChangedCount`,
+`totalLinesAdded` and `totalLinesRemoved` from the composer record.
+
+## 4. Files
+
+| File | Role |
+| --- | --- |
+| `src/cursor/bubbleKinds.ts` | classify a bubble; map a numeric tool id to a name |
+| `src/cursor/bubbleOrder.ts` | conversation order, including the unlisted error bubbles |
+| `src/cursor/modelCalls.ts` | time windows and the model call cut rule |
+| `src/cursor/spanBuilder.ts` | build the span list; truncation |
+| `src/cursor/sessionManager.ts` | call the builder; trimmed trace metadata |
+| `src/opik.ts` | `llm_turn` span plus its children |
+| `src/interface.ts` | `SpanData`, and `spans` on `TraceData` |
+| `scripts/test-spans.js` | 33 unit tests (`npm run test-spans`) |
+| `scripts/replay-composer.js` | print the span tree for a real composer, no upload |
+
+### Settings
+
+- `opik.detailedSpans.enabled`, default `true`.
+- `opik.detailedSpans.maxPayloadChars`, default `10000`.
+- `opik.detailedSpans.maxSpansPerTurn`, default `200`. Above the cap the first
+  and last spans are kept and a `truncated-steps` span records the number
+  dropped.
+
+## 5. Risks and how they are handled
+
+| Risk | Handling |
+| --- | --- |
+| A very large tool result blows the batch limit | `truncateForSpan` (3.7). Verified against the browser screenshot tools, whose results drop from 157 KB to 9.9 KB |
+| Secrets inside terminal output or file content | Truncation reduces the volume but does not redact. `opik.detailedSpans.enabled` is the off switch |
+| The cut rule for model calls is a heuristic | Cursor gives no group id. Unit tested against both conversation shapes, and checked with the replay script |
+| Only the `llm_turn` span carries usage | This matches what Cursor records. The trace total is still right, because the backend sums the span usage |
+| A turn is still running when the sync fires | The composer query already skips composers that are not `completed` and were touched in the last 5 minutes |
+| A new Cursor version renames a tool | `TOOL_ID_NAMES` keeps the label correct from the numeric id |
+| More spans mean more upload volume | Measured: the span payload is smaller than the raw bubble copy it replaces. See 6 |
+
+## 6. What was verified
+
+**Unit tests** — `npm run test-spans`, 33 tests, all passing. They cover the
+placeholder `toolFormerData` trap, both forms of the `type` field, the tool id
+map, the timing rules (parallel dispatch, a negative thinking duration, the
+tool-and-reasoning timestamp collision, the error point event), both cut
+shapes, truncation, the binary strip, the span cap, all four bubble ordering
+cases, and the interleaved trace output.
+
+**Replay against real conversations** — `node scripts/replay-composer.js <id>`
+builds the trace and the spans from the local database and prints them without
+uploading. It flags a negative duration, a span that starts before its turn, and
+a span that starts before the span above it.
+
+Run over the 30 largest conversations in the database, **9,330 spans**, the
+result is **2 warnings**, both in one composer where Cursor's own bubble order
+goes backwards by 6 s and 2 s. No negative durations anywhere.
+
+Payload, per composer:
+
+| Composer | Spans | Span payload | Raw bubbles the old metadata carried |
+| --- | --- | --- | --- |
+| `9bb91e1f` | 613 (286 llm, 324 tool, 3 general) | 1.97 MB | 6.20 MB |
+| `32f1ff14` | 844 (366 llm, 477 tool, 1 general) | 1.92 MB | 15.98 MB |
+| `8f6dd4ee` | 296 (73 llm, 223 tool) | 1.13 MB | 8.04 MB |
+| `5ea1babd` | 340 (143 llm, 197 tool) | 0.67 MB | 1.90 MB |
+
+Dropping `metadata.userMessages` / `metadata.aiMessages` more than pays for the
+new spans.
+
+**Still to do, in a live session:** confirm in the Opik UI that the span tree
+renders as a waterfall and that the `UsageEnricher` patch lands on `llm_turn`.
+Also read the `across N request(s)` line that `applyTurnUsage()` logs. If `N` is
+1 almost every time, the design in 3.6 is final. If `N` is often greater than 1,
+the turn usage could be split across the child `llm` spans by matching each
+event timestamp to a span window.

--- a/extensions/cursor/package-lock.json
+++ b/extensions/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opik",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "dependencies": {
         "@sentry/node": "^10.38.0",
         "glob": "^11.1.0",

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -4,7 +4,7 @@
   "description": "Export your chat history from Cursor to Opik.",
   "repository": "https://github.com/comet-ml/opik",
   "publisher": "opik",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "preview": false,
   "engines": {
     "vscode": "^1.90.0"
@@ -76,6 +76,26 @@
         }
       },
       {
+        "title": "Detailed Spans",
+        "properties": {
+          "opik.detailedSpans.enabled": {
+            "type": "boolean",
+            "default": true,
+            "markdownDescription": "Log every step of a Cursor turn as a nested span: one `llm` span per model call, one `tool` span per tool call, and a `general` span for each Cursor error. Turn this off to log only the question and the answer."
+          },
+          "opik.detailedSpans.maxPayloadChars": {
+            "type": "number",
+            "default": 10000,
+            "markdownDescription": "Maximum size of the input and the output of a single span, in characters. Larger payloads keep their start and their end, and the middle is replaced by a marker."
+          },
+          "opik.detailedSpans.maxSpansPerTurn": {
+            "type": "number",
+            "default": 200,
+            "markdownDescription": "Maximum number of child spans for a single turn. Above this number the first and the last spans are kept, and a `truncated-steps` span records how many were dropped."
+          }
+        }
+      },
+      {
         "title": "Advanced",
         "properties": {
           "opik.enableDebugLogs": {
@@ -99,7 +119,8 @@
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
     "test": "vscode-test",
-    "verify-usage": "node scripts/verify-usage.js"
+    "verify-usage": "node scripts/verify-usage.js",
+    "test-spans": "node --test scripts/test-spans.js"
   },
   "devDependencies": {
     "@types/mocha": "^10.0.10",

--- a/extensions/cursor/scripts/replay-composer.js
+++ b/extensions/cursor/scripts/replay-composer.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * Build the trace and the span tree for a real Cursor conversation and print
+ * them. Nothing is uploaded. This is the fastest way to check the span shape,
+ * the durations and the payload sizes against real data.
+ *
+ * Usage: npm run compile && node scripts/replay-composer.js [composerId] [--full]
+ *        node scripts/replay-composer.js --list
+ */
+const os = require('os');
+const path = require('path');
+const Module = require('module');
+
+const originalLoad = Module._load;
+Module._load = function (request) {
+  if (request === 'vscode') {
+    return {
+      workspace: { getConfiguration: () => ({ get: (_key, fallback) => fallback }) },
+      extensions: { getExtension: () => undefined },
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+
+const { executeQuery } = require('../out/cursor/sqlite.js');
+const { groupBubblesByType } = require('../out/cursor/sessionManager.js');
+const { buildSpans, buildTurnOutput, DEFAULT_SPAN_OPTIONS } = require('../out/cursor/spanBuilder.js');
+const { orderBubbles } = require('../out/cursor/bubbleOrder.js');
+
+const DB = path.join(
+  os.homedir(),
+  'Library/Application Support/Cursor/User/globalStorage/state.vscdb'
+);
+
+const query = (sql) => executeQuery(DB, sql);
+const full = process.argv.includes('--full');
+
+function fmtBytes(n) {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / 1024 / 1024).toFixed(2)}MB`;
+}
+
+function size(value) {
+  return value === undefined ? 0 : Buffer.byteLength(JSON.stringify(value));
+}
+
+async function listComposers() {
+  const rows = await query(`
+    SELECT key,
+           json_extract(value,'$.name') AS name,
+           json_extract(value,'$.lastUpdatedAt') AS updated
+    FROM cursorDiskKV
+    WHERE key >= 'composerData' AND key < 'composerDatb'
+    ORDER BY updated DESC LIMIT 20`);
+  for (const row of rows) {
+    const id = String(row.key).split(':')[1];
+    console.log(`${id}  ${new Date(Number(row.updated)).toISOString()}  ${row.name ?? ''}`);
+  }
+}
+
+async function loadConversation(composerId) {
+  const composerRows = await query(
+    `SELECT value FROM cursorDiskKV WHERE key = 'composerData:${composerId}'`
+  );
+  if (!composerRows.length) {
+    throw new Error(`No composer found with id ${composerId}`);
+  }
+  const composerData = JSON.parse(composerRows[0].value);
+
+  const bubbleRows = await query(
+    `SELECT key, value FROM cursorDiskKV
+     WHERE key >= 'bubbleId:${composerId}:' AND key < 'bubbleId:${composerId};'`
+  );
+
+  const byId = new Map();
+  for (const row of bubbleRows) {
+    const chatData = JSON.parse(row.value);
+    const id = String(row.key).split(':')[2];
+    byId.set(id, {
+      ...chatData,
+      id,
+      type: chatData.type === 1 ? 'user' : chatData.type === 2 ? 'ai' : 'unknown',
+      text: chatData.text || chatData.content || '',
+      resolvedTimestamp: Date.parse(chatData.createdAt) || composerData.createdAt,
+    });
+  }
+
+  const ordered = orderBubbles([...byId.values()], composerData.fullConversationHeadersOnly);
+
+  return {
+    conversation: {
+      chatTitle: composerData.name,
+      composerId,
+      createdAt: composerData.createdAt,
+      model: composerData.modelConfig?.modelName,
+      bubbleCount: ordered.length,
+      unifiedMode: composerData.unifiedMode,
+      isAgentic: composerData.isAgentic,
+      createdOnBranch: composerData.createdOnBranch,
+      contextTokensUsed: composerData.contextTokensUsed,
+      contextTokenLimit: composerData.contextTokenLimit,
+    },
+    bubbles: ordered,
+    usageData: composerData.usageData,
+  };
+}
+
+(async () => {
+  if (process.argv.includes('--list')) {
+    await listComposers();
+    return;
+  }
+
+  let composerId = process.argv[2];
+  if (!composerId || composerId.startsWith('--')) {
+    const rows = await query(`
+      SELECT key FROM cursorDiskKV
+      WHERE key >= 'composerData' AND key < 'composerDatb'
+      ORDER BY json_extract(value,'$.lastUpdatedAt') DESC LIMIT 1`);
+    composerId = String(rows[0].key).split(':')[1];
+  }
+
+  const { conversation, bubbles, usageData } = await loadConversation(composerId);
+  const groups = groupBubblesByType(bubbles);
+
+  console.log(`composer:  ${composerId}`);
+  console.log(`title:     ${conversation.chatTitle}`);
+  console.log(`model:     ${conversation.model}   mode: ${conversation.unifiedMode}`);
+  console.log(`bubbles:   ${bubbles.length}   turns: ${groups.length}`);
+  console.log(`usageData: ${JSON.stringify(usageData ?? {})}`);
+  console.log();
+
+  const totals = { spans: 0, llm: 0, tool: 0, general: 0, bytes: 0, truncated: 0 };
+  const rawBytes = Buffer.byteLength(JSON.stringify(bubbles));
+
+  groups.forEach((group, index) => {
+    if (!group.userMessages.length || !group.aiMessages.length) {
+      return;
+    }
+    const spans = buildSpans(group, conversation, DEFAULT_SPAN_OPTIONS);
+    const turnStart = group.userMessages[0].resolvedTimestamp;
+    const question = (group.userMessages[0].text || '').replace(/\s+/g, ' ').slice(0, 70);
+    let previousStart = turnStart;
+
+    console.log(`── turn ${index + 1}  (${spans.length} spans)  "${question}"`);
+
+    if (full) {
+      console.log('   trace output:');
+      for (const line of buildTurnOutput(group.aiMessages).split('\n')) {
+        console.log(`     | ${line.slice(0, 100)}`);
+      }
+      console.log();
+    }
+
+    for (const span of spans) {
+      const ms = span.endTime.getTime() - span.startTime.getTime();
+      const offset = span.startTime.getTime() - turnStart;
+      const bytes = size(span.input) + size(span.output);
+      const flags = [
+        span.errorInfo ? 'ERROR' : '',
+        span.metadata?.output_truncated || span.metadata?.input_truncated ? 'trunc' : '',
+      ].filter(Boolean).join(',');
+
+      console.log(
+        `   ${String(span.type).padEnd(7)} ${String(span.name).padEnd(26)}` +
+        ` +${String(Math.round(offset / 1000)).padStart(4)}s` +
+        ` ${String(ms).padStart(7)}ms` +
+        ` ${fmtBytes(bytes).padStart(8)}` +
+        (flags ? `  ${flags}` : '')
+      );
+
+      if (full) {
+        if (span.input !== undefined) console.log(`      in : ${JSON.stringify(span.input).slice(0, 300)}`);
+        if (span.output !== undefined) console.log(`      out: ${JSON.stringify(span.output).slice(0, 300)}`);
+      }
+
+      totals.spans += 1;
+      totals[span.type] += 1;
+      totals.bytes += bytes;
+      if (flags.includes('trunc')) totals.truncated += 1;
+
+      if (ms < 0) {
+        console.log(`      !! negative duration`);
+      }
+      if (span.startTime.getTime() < turnStart) {
+        console.log(`      !! starts before the turn`);
+      }
+      if (span.startTime.getTime() < previousStart - 1000) {
+        console.log(`      !! starts ${Math.round((previousStart - span.startTime.getTime()) / 1000)}s before the span above`);
+      }
+      previousStart = Math.max(previousStart, span.startTime.getTime());
+    }
+    console.log();
+  });
+
+  console.log('─'.repeat(60));
+  console.log(`spans:        ${totals.spans}  (llm ${totals.llm}, tool ${totals.tool}, general ${totals.general})`);
+  console.log(`span payload: ${fmtBytes(totals.bytes)}   truncated spans: ${totals.truncated}`);
+  console.log(`raw bubbles:  ${fmtBytes(rawBytes)}  (what the old metadata copy used to carry)`);
+})().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});

--- a/extensions/cursor/scripts/test-spans.js
+++ b/extensions/cursor/scripts/test-spans.js
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for the span builder and the bubble ordering.
+ * The fixtures copy the shapes found in a real Cursor database.
+ *
+ * Usage: npm run compile && npm run test-spans
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { classifyBubble, toolName, TOOL_ID_NAMES } = require('../out/cursor/bubbleKinds.js');
+const { assignWindows, splitIntoModelCalls } = require('../out/cursor/modelCalls.js');
+const { buildSpans, buildTurnOutput, truncateForSpan, DEFAULT_SPAN_OPTIONS } = require('../out/cursor/spanBuilder.js');
+const { orderBubbles } = require('../out/cursor/bubbleOrder.js');
+
+const T0 = Date.parse('2026-01-10T19:57:00.000Z');
+const at = (seconds, ms = 0) => new Date(T0 + seconds * 1000 + ms).toISOString();
+
+const user = (seconds, text) => ({ id: `u${seconds}`, type: 'user', text, createdAt: at(seconds) });
+const think = (seconds, durationMs, text = 'reasoning') => ({
+    id: `k${seconds}`, type: 'ai', capabilityType: 30, createdAt: at(seconds),
+    thinking: { text }, thinkingDurationMs: durationMs, thinkingStyle: 1,
+});
+const message = (seconds, text) => ({ id: `m${seconds}`, type: 'ai', createdAt: at(seconds), text });
+const tool = (seconds, name, modelCallId, extra = {}) => ({
+    id: `t${seconds}-${name}`, type: 'ai', capabilityType: 15, createdAt: at(seconds), text: '',
+    toolFormerData: {
+        tool: 40, name, modelCallId, toolCallId: `call-${name}`, status: 'completed',
+        rawArgs: JSON.stringify({ target_file: `${name}.ts` }),
+        result: JSON.stringify({ contents: 'ok' }),
+        ...extra,
+    },
+});
+const errorBubble = (seconds, msg) => ({
+    id: `e${seconds}`, type: 'ai', createdAt: at(seconds), text: '',
+    errorDetails: { message: msg, requestId: 'req-1', stackTrace: 'at x\nat y' },
+});
+
+const conversation = { composerId: 'c1', model: 'claude-4.5-opus-high', createdAt: T0 };
+const kinds = (windows) => windows.map(w => w.kind);
+
+test('a placeholder toolFormerData is not a tool call', () => {
+    // 1237 of 19691 real bubbles carry exactly this and are ordinary messages.
+    const bubble = { type: 'ai', text: 'hello', toolFormerData: { additionalData: { status: 'error' } } };
+    assert.equal(classifyBubble(bubble), 'message');
+});
+
+test('classifyBubble handles both forms of the type field', () => {
+    assert.equal(classifyBubble({ type: 1, text: 'hi' }), 'user');
+    assert.equal(classifyBubble({ type: 'user', text: 'hi' }), 'user');
+});
+
+test('a tool call wins over the thinking on the same bubble', () => {
+    const bubble = { type: 'ai', thinking: { text: 'x' }, toolFormerData: { tool: 40, name: 'read_file' } };
+    assert.equal(classifyBubble(bubble), 'tool');
+});
+
+test('an error bubble is classified even with a placeholder toolFormerData', () => {
+    const bubble = errorBubble(1, 'Network disconnected [unknown]');
+    bubble.toolFormerData = { additionalData: { status: 'error' } };
+    assert.equal(classifyBubble(bubble), 'error');
+});
+
+test('an empty bubble is skipped', () => {
+    assert.equal(classifyBubble({ type: 'ai', text: '   ' }), 'skip');
+    assert.equal(classifyBubble(undefined), 'skip');
+});
+
+test('toolName falls back to the numeric id when the name is gone', () => {
+    assert.equal(toolName({ tool: 41, name: 'ripgrep_raw_search' }), 'ripgrep_raw_search');
+    assert.equal(toolName({ tool: 41 }), TOOL_ID_NAMES[41]);
+    assert.equal(toolName({ tool: '15' }), 'run_terminal_cmd');
+    assert.equal(toolName({}), 'unknown_tool');
+});
+
+test('a step starts where the previous step ended', () => {
+    const windows = assignWindows([message(2, 'a'), tool(5, 'read_file', 'A')], T0);
+    assert.deepEqual(kinds(windows), ['message', 'tool']);
+    assert.equal(windows[0].startMs, T0);
+    assert.equal(windows[0].endMs, T0 + 2000);
+    assert.equal(windows[1].startMs, T0 + 2000);
+    assert.equal(windows[1].endMs, T0 + 5000);
+});
+
+test('tools that share a timestamp share a start', () => {
+    const windows = assignWindows(
+        [message(2, 'a'), tool(5, 'read_file', 'A'), tool(5, 'grep', 'B')],
+        T0
+    );
+    assert.equal(windows[1].startMs, T0 + 2000);
+    assert.equal(windows[2].startMs, T0 + 2000, 'the parallel tool must not start at its own end');
+});
+
+test('thinking uses its exact duration', () => {
+    const windows = assignWindows([message(2, 'a'), think(10, 3000)], T0);
+    assert.equal(windows[1].startMs, T0 + 7000);
+    assert.equal(windows[1].endMs, T0 + 10000);
+});
+
+test('a negative thinking duration collapses to zero instead of going backwards', () => {
+    // thinkingDurationMs reaches -1000 in the real database.
+    const windows = assignWindows([message(2, 'a'), think(10, -1000)], T0);
+    assert.equal(windows[1].startMs, T0 + 10000);
+    assert.equal(windows[1].endMs, T0 + 10000);
+});
+
+test('thinking flushed with the tool before it does not overlap that tool', () => {
+    // Cursor writes the tool bubble and the next reasoning at the same instant.
+    const windows = assignWindows(
+        [message(2, 'a'), tool(9, 'read_file', 'A'), think(9, 4000)],
+        T0
+    );
+    assert.equal(windows[1].startMs, T0 + 2000);
+    assert.equal(windows[1].endMs, T0 + 9000);
+    assert.equal(windows[2].startMs, T0 + 9000, 'reasoning cannot start before the tool finished');
+    assert.equal(windows[2].endMs, T0 + 9000);
+});
+
+test('an error bubble is a point event and does not move the cursor', () => {
+    const windows = assignWindows(
+        [message(2, 'a'), errorBubble(60, 'PING timed out [unavailable]'), tool(9, 'read_file', 'A')],
+        T0
+    );
+    assert.equal(windows[1].startMs, windows[1].endMs);
+    assert.equal(windows[1].startMs, T0 + 60000);
+    assert.equal(windows[2].startMs, T0 + 2000, 'the error must not squash the next step');
+    assert.equal(windows[2].endMs, T0 + 9000);
+});
+
+test('a reasoning model is cut into one call per thinking block', () => {
+    const windows = assignWindows([
+        think(1, 500), message(2, 'a'), tool(3, 'read_file', 'A'),
+        think(3, 800), message(4, 'b'), tool(5, 'write', 'B'),
+        think(5, 400), tool(6, 'run_terminal_cmd', 'C'),
+    ], T0);
+    const calls = splitIntoModelCalls(windows);
+    assert.equal(calls.length, 3);
+    assert.deepEqual(calls.map(c => c.output.length), [2, 2, 1]);
+    assert.deepEqual(calls.map(c => c.steps.length), [1, 1, 1]);
+});
+
+test('a model without reasoning is cut at each text block', () => {
+    const windows = assignWindows([
+        message(1, 'a'), tool(2, 'read_file', 'A'),
+        message(3, 'b'), tool(4, 'grep', 'B'),
+    ], T0);
+    const calls = splitIntoModelCalls(windows);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls.map(c => c.steps.length), [1, 1]);
+});
+
+test('tools dispatched together stay in one model call', () => {
+    const windows = assignWindows([
+        message(1, 'a'), tool(4, 'read_file', 'A'), tool(4, 'grep', 'B'),
+    ], T0);
+    const calls = splitIntoModelCalls(windows);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].steps.length, 2);
+});
+
+test('a different model call at a different time starts a new call', () => {
+    const windows = assignWindows([
+        message(1, 'a'), tool(4, 'read_file', 'A'), tool(9, 'grep', 'B'),
+    ], T0);
+    assert.equal(splitIntoModelCalls(windows).length, 2);
+});
+
+test('a payload under the limit is untouched', () => {
+    const result = truncateForSpan({ a: 'short' }, 1000);
+    assert.equal(result.truncated, false);
+    assert.deepEqual(result.value, { a: 'short' });
+});
+
+test('a payload over the limit keeps its start and its end', () => {
+    const value = { head: 'H'.repeat(500), tail: 'T'.repeat(500) };
+    const result = truncateForSpan(value, 200);
+    assert.equal(result.truncated, true);
+    assert.equal(typeof result.value, 'string');
+    assert.ok(result.value.startsWith('{"head":"HHH'));
+    assert.ok(result.value.endsWith('TTT"}'));
+    assert.ok(result.value.includes('truncated'));
+    assert.ok(result.originalLength > 1000);
+});
+
+test('a base64 screenshot is replaced before the size check', () => {
+    const image = 'data:image/png;base64,' + 'A'.repeat(200000);
+    const result = truncateForSpan({ content: image }, 10000);
+    assert.equal(result.truncated, false);
+    assert.match(result.value.content, /^\[binary, \d+ bytes\]$/);
+});
+
+test('buildSpans emits llm, tool and general spans in order', () => {
+    const group = {
+        userMessages: [user(0, 'do the thing')],
+        aiMessages: [
+            think(1, 500), message(2, 'looking'), tool(6, 'read_file', 'A'),
+            think(6, 900), tool(11, 'grep', 'B'),
+            errorBubble(20, 'PING timed out [unavailable]'),
+        ],
+    };
+    const spans = buildSpans(group, conversation, DEFAULT_SPAN_OPTIONS);
+
+    assert.deepEqual(spans.map(s => s.type), ['llm', 'tool', 'llm', 'tool', 'general']);
+    assert.deepEqual(spans.map(s => s.name),
+        ['assistant', 'read_file', 'assistant', 'grep', 'cursor-error']);
+
+    assert.equal(spans[0].provider, 'cursor');
+    assert.equal(spans[0].model, 'claude-4.5-opus-high');
+    assert.equal(spans[0].input, undefined, 'Cursor does not store the prompt');
+    assert.equal(spans[0].output.thinking, 'reasoning');
+    assert.equal(spans[0].output.text, 'looking');
+    assert.deepEqual(spans[0].output.tool_calls, [{ name: 'read_file', arguments: { target_file: 'read_file.ts' } }]);
+
+    assert.deepEqual(spans[1].input, { target_file: 'read_file.ts' });
+    assert.deepEqual(spans[1].output, { contents: 'ok' });
+    assert.equal(spans[1].metadata.model_call_id, 'A');
+    assert.equal(spans[1].errorInfo, undefined);
+
+    assert.equal(spans[4].errorInfo.message, 'PING timed out [unavailable]');
+    assert.equal(spans[4].errorInfo.exceptionType, 'cursor-request-error');
+    assert.equal(spans[4].startTime.getTime(), spans[4].endTime.getTime());
+});
+
+test('a failed tool carries errorInfo', () => {
+    const group = {
+        userMessages: [user(0, 'run it')],
+        aiMessages: [
+            message(1, 'running'),
+            tool(4, 'run_terminal_cmd', 'A', { status: 'error', error: JSON.stringify('exit 1') }),
+        ],
+    };
+    const spans = buildSpans(group, conversation, DEFAULT_SPAN_OPTIONS);
+    const toolSpan = spans.find(s => s.type === 'tool');
+    assert.equal(toolSpan.errorInfo.exceptionType, 'cursor-tool-error');
+    assert.ok(toolSpan.tags.includes('error'));
+});
+
+test('a model call with only tool bubbles emits no zero width llm span', () => {
+    const group = {
+        userMessages: [user(0, 'go')],
+        aiMessages: [tool(3, 'read_file', 'A'), tool(8, 'grep', 'B')],
+    };
+    const spans = buildSpans(group, conversation, DEFAULT_SPAN_OPTIONS);
+    assert.deepEqual(spans.map(s => s.type), ['tool', 'tool']);
+});
+
+test('every span stays inside the turn and moves forward', () => {
+    const group = {
+        userMessages: [user(0, 'go')],
+        aiMessages: [think(1, 90000), message(2, 'a'), tool(6, 'read_file', 'A')],
+    };
+    for (const span of buildSpans(group, conversation, DEFAULT_SPAN_OPTIONS)) {
+        assert.ok(span.endTime.getTime() >= span.startTime.getTime(), `${span.name} runs backwards`);
+        assert.ok(span.startTime.getTime() >= T0, `${span.name} starts before the turn`);
+    }
+});
+
+test('the span cap keeps the ends and reports what was dropped', () => {
+    const aiMessages = [];
+    for (let i = 1; i <= 40; i++) {
+        aiMessages.push(message(i * 2, `step ${i}`), tool(i * 2 + 1, 'read_file', `M${i}`));
+    }
+    const spans = buildSpans({ userMessages: [user(0, 'go')], aiMessages }, conversation,
+        { maxPayloadChars: 10000, maxSpansPerTurn: 10 });
+
+    assert.equal(spans.length, 11);
+    const marker = spans.find(s => s.name === 'truncated-steps');
+    assert.equal(marker.metadata.total_span_count, 80);
+    assert.equal(marker.metadata.dropped_span_count, 70);
+});
+
+test('orderBubbles keeps the header order', () => {
+    const bubbles = [message(5, 'c'), message(1, 'a'), message(3, 'b')];
+    const headers = [{ bubbleId: 'm1' }, { bubbleId: 'm3' }, { bubbleId: 'm5' }];
+    assert.deepEqual(orderBubbles(bubbles, headers).map(b => b.id), ['m1', 'm3', 'm5']);
+});
+
+test('orderBubbles puts an unlisted error bubble in by time', () => {
+    const bubbles = [message(1, 'a'), message(9, 'c'), errorBubble(5, 'boom')];
+    const headers = [{ bubbleId: 'm1' }, { bubbleId: 'm9' }];
+    assert.deepEqual(orderBubbles(bubbles, headers).map(b => b.id), ['m1', 'e5', 'm9']);
+});
+
+test('orderBubbles drops unlisted bubbles that are not errors', () => {
+    // A composer keeps bubbles from branches the user edited away. One real
+    // composer holds 833 bubbles for 748 headers.
+    const bubbles = [message(1, 'a'), message(5, 'abandoned'), message(9, 'c')];
+    const headers = [{ bubbleId: 'm1' }, { bubbleId: 'm9' }];
+    assert.deepEqual(orderBubbles(bubbles, headers).map(b => b.id), ['m1', 'm9']);
+});
+
+test('orderBubbles drops an error from outside the retained thread', () => {
+    const bubbles = [message(100, 'a'), message(200, 'c'), errorBubble(5, 'boom')];
+    const headers = [{ bubbleId: 'm100' }, { bubbleId: 'm200' }];
+    assert.deepEqual(orderBubbles(bubbles, headers).map(b => b.id), ['m100', 'm200']);
+});
+
+test('the turn output interleaves the tool names with the messages', () => {
+    const aiMessages = [
+        think(1, 500), message(2, 'Let me check the file.'),
+        tool(6, 'read_file', 'A'), tool(6, 'grep', 'A'),
+        message(8, 'The import is missing.'),
+        tool(11, 'search_replace', 'B'),
+    ];
+    assert.equal(buildTurnOutput(aiMessages), [
+        'Let me check the file.',
+        '',
+        '[read_file]',
+        '[grep]',
+        '',
+        'The import is missing.',
+        '',
+        '[search_replace]',
+    ].join('\n'));
+});
+
+test('the turn output keeps reasoning out', () => {
+    const aiMessages = [think(1, 500, 'private reasoning'), message(2, 'done')];
+    assert.equal(buildTurnOutput(aiMessages), 'done');
+});
+
+test('a turn of only tool calls still produces an output', () => {
+    const aiMessages = [tool(3, 'read_file', 'A'), tool(8, 'grep', 'B')];
+    assert.equal(buildTurnOutput(aiMessages), '[read_file]\n[grep]');
+});
+
+test('the turn output uses the tool id when the name is gone', () => {
+    const bubble = tool(3, 'read_file', 'A');
+    delete bubble.toolFormerData.name;
+    assert.equal(buildTurnOutput([bubble]), `[${TOOL_ID_NAMES[40]}]`);
+});
+
+test('the turn output is empty when the assistant did nothing', () => {
+    assert.equal(buildTurnOutput([think(1, 500), { type: 'ai', text: '  ' }]), '');
+});

--- a/extensions/cursor/src/cursor/bubbleKinds.ts
+++ b/extensions/cursor/src/cursor/bubbleKinds.ts
@@ -1,0 +1,83 @@
+export type BubbleKind = 'user' | 'tool' | 'error' | 'thinking' | 'message' | 'skip';
+
+/**
+ * Cursor renamed most tools between versions (read_file -> read_file_v2, grep ->
+ * ripgrep_raw_search, search_replace -> edit_file_v2) but never changed the
+ * numeric id, so the id is the only stable label.
+ */
+export const TOOL_ID_NAMES: Record<number, string> = {
+    8: 'file_search',
+    9: 'codebase_search',
+    11: 'delete_file',
+    15: 'run_terminal_cmd',
+    18: 'web_search',
+    19: 'mcp_tool',
+    30: 'read_lints',
+    35: 'todo_write',
+    38: 'edit_file',
+    39: 'list_dir',
+    40: 'read_file',
+    41: 'grep',
+    42: 'glob_file_search',
+    43: 'create_plan',
+    48: 'task',
+    51: 'ask_question',
+    57: 'web_fetch',
+    90: 'acp_tool',
+};
+
+function toolId(toolFormerData: any): number | undefined {
+    const raw = toolFormerData?.tool;
+    const parsed = typeof raw === 'string' ? Number(raw) : raw;
+    return typeof parsed === 'number' && Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/**
+ * Ordinary user and text bubbles carry a placeholder
+ * `toolFormerData: {"additionalData": {"status": "error"}}` with no tool and no
+ * name. 1237 of the 19691 bubbles in a real database look like that, so the
+ * presence of the object alone does not mean the bubble is a tool call.
+ */
+export function isToolCall(bubble: any): boolean {
+    const data = bubble?.toolFormerData;
+    if (!data) {
+        return false;
+    }
+    return toolId(data) !== undefined || typeof data.name === 'string' && data.name.length > 0;
+}
+
+export function toolName(toolFormerData: any): string {
+    const name = toolFormerData?.name;
+    if (typeof name === 'string' && name.trim()) {
+        return name.trim();
+    }
+    const id = toolId(toolFormerData);
+    return (id !== undefined && TOOL_ID_NAMES[id]) || 'unknown_tool';
+}
+
+export function classifyBubble(bubble: any): BubbleKind {
+    if (!bubble) {
+        return 'skip';
+    }
+    // Raw bubbles from SQLite use the numeric type. readCursorChatDataAsync
+    // rewrites it to 'user' / 'ai' before the traces are built, so both forms
+    // reach this function.
+    if (bubble.type === 1 || bubble.type === 'user') {
+        return 'user';
+    }
+    // Checked before thinking: a bubble can carry both, and the tool call is
+    // the part that has inputs and outputs worth a span.
+    if (isToolCall(bubble)) {
+        return 'tool';
+    }
+    if (bubble.errorDetails?.message) {
+        return 'error';
+    }
+    if (bubble.thinking?.text) {
+        return 'thinking';
+    }
+    if (typeof bubble.text === 'string' && bubble.text.trim()) {
+        return 'message';
+    }
+    return 'skip';
+}

--- a/extensions/cursor/src/cursor/bubbleOrder.ts
+++ b/extensions/cursor/src/cursor/bubbleOrder.ts
@@ -1,0 +1,78 @@
+interface ConversationHeader {
+    bubbleId?: string;
+}
+
+/**
+ * Put the bubbles of a composer into conversation order.
+ *
+ * fullConversationHeadersOnly is the order Cursor shows. It is deliberately
+ * incomplete: a composer keeps bubbles from branches the user edited away, and
+ * those are left out. One real composer holds 833 bubbles for 748 headers.
+ * Splicing all of them back in scrambles the order, so the headers decide what
+ * belongs to the conversation.
+ *
+ * The one exception is the error bubbles that record a failed request. Cursor
+ * never lists them, and sorting them to the end would attach them to the last
+ * turn, so they go in by time. A bubble outside the time range of the headers
+ * belongs to a turn that no longer exists and is dropped.
+ */
+export function orderBubbles(bubbles: any[], headers: ConversationHeader[] | undefined): any[] {
+    if (!Array.isArray(headers) || headers.length === 0) {
+        return bubbles;
+    }
+
+    const orderMap = new Map<string, number>();
+    headers.forEach((header, index) => {
+        if (header.bubbleId) {
+            orderMap.set(header.bubbleId, index);
+        }
+    });
+
+    const ordered = bubbles
+        .filter(bubble => orderMap.has(bubble.id))
+        .sort((a, b) => orderMap.get(a.id)! - orderMap.get(b.id)!);
+
+    const anchors = ordered
+        .map(bubble => Date.parse(bubble.createdAt))
+        .map((time, position) => ({ time, position }))
+        .filter(anchor => !Number.isNaN(anchor.time));
+
+    if (anchors.length === 0) {
+        return ordered;
+    }
+
+    const earliest = anchors[0].time;
+    const latest = anchors[anchors.length - 1].time;
+
+    const strays = bubbles.filter(bubble => {
+        if (orderMap.has(bubble.id) || !bubble.errorDetails?.message) {
+            return false;
+        }
+        const time = Date.parse(bubble.createdAt);
+        return !Number.isNaN(time) && time >= earliest && time <= latest;
+    });
+
+    if (strays.length === 0) {
+        return ordered;
+    }
+
+    // Insert from the back so that the positions found above stay valid.
+    const insertions = strays
+        .map(bubble => {
+            const time = Date.parse(bubble.createdAt);
+            let position = 0;
+            for (const anchor of anchors) {
+                if (anchor.time <= time && anchor.position >= position) {
+                    position = anchor.position;
+                }
+            }
+            return { bubble, position };
+        })
+        .sort((a, b) => b.position - a.position);
+
+    for (const insertion of insertions) {
+        ordered.splice(insertion.position + 1, 0, insertion.bubble);
+    }
+
+    return ordered;
+}

--- a/extensions/cursor/src/cursor/modelCalls.ts
+++ b/extensions/cursor/src/cursor/modelCalls.ts
@@ -1,0 +1,151 @@
+import { BubbleKind, classifyBubble } from './bubbleKinds';
+
+export interface BubbleWindow {
+    bubble: any;
+    kind: BubbleKind;
+    startMs: number;
+    endMs: number;
+}
+
+export interface ModelCall {
+    /** thinking and message bubbles that the model produced */
+    output: BubbleWindow[];
+    /** tool calls the model requested, plus any error bubble that followed */
+    steps: BubbleWindow[];
+    startMs: number;
+    /** end of the generation itself, which is before the tools run */
+    endMs: number;
+}
+
+export function timestampOf(bubble: any): number | undefined {
+    if (typeof bubble?.resolvedTimestamp === 'number') {
+        return bubble.resolvedTimestamp;
+    }
+    const parsed = Date.parse(bubble?.createdAt ?? '');
+    return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Cursor writes a bubble when its step finishes, so createdAt is an end time and
+ * there is no start time anywhere. The start of a step is therefore the end of
+ * the previous step. Bubbles that share a timestamp were dispatched together and
+ * all get the same start.
+ */
+export function assignWindows(bubbles: any[], turnStartMs: number): BubbleWindow[] {
+    const windows: BubbleWindow[] = [];
+    // End of the last bubble with a strictly earlier timestamp. Tools dispatched
+    // together share a timestamp and must all start here.
+    let previousDistinctEnd = turnStartMs;
+    // End of the bubble immediately before this one. Cursor flushes a tool
+    // bubble and the reasoning of the next call at the same millisecond, and
+    // that reasoning cannot have started before the tool finished.
+    let previousEnd = turnStartMs;
+    let currentEnd: number | undefined;
+
+    for (const bubble of bubbles) {
+        const kind = classifyBubble(bubble);
+        if (kind === 'skip') {
+            continue;
+        }
+
+        const end = timestampOf(bubble) ?? previousEnd;
+
+        // An error bubble records a moment, not an interval, and Cursor keeps it
+        // out of the conversation order. Giving it a width would invent a
+        // duration, and letting it move the cursor would squash the next step.
+        if (kind === 'error') {
+            windows.push({ bubble, kind, startMs: end, endMs: end });
+            continue;
+        }
+
+        if (currentEnd === undefined || end > currentEnd) {
+            previousDistinctEnd = currentEnd ?? previousDistinctEnd;
+            currentEnd = end;
+        }
+
+        const floor = kind === 'tool' ? previousDistinctEnd : previousEnd;
+        let start = floor;
+
+        // timingInfo is the only exact pair Cursor records. It is on 3.4% of bubbles.
+        const sendTime = bubble.timingInfo?.clientRpcSendTime;
+        if (typeof sendTime === 'number' && sendTime > 0 && sendTime <= end) {
+            start = Math.max(floor, sendTime);
+        } else if (kind === 'thinking' && typeof bubble.thinkingDurationMs === 'number') {
+            // The duration is exact, but the data also contains negative values.
+            start = Math.max(floor, Math.min(end, end - bubble.thinkingDurationMs));
+        }
+
+        windows.push({
+            bubble,
+            kind,
+            startMs: Math.max(turnStartMs, Math.min(start, end)),
+            endMs: Math.max(turnStartMs, end),
+        });
+        previousEnd = end;
+    }
+
+    return windows;
+}
+
+/**
+ * Cursor records no group id for a model call. usageUuid is one per turn,
+ * serverBubbleId is one per bubble, and modelCallId exists only on tool bubbles.
+ * The structure is regular though: the model emits reasoning and text, then
+ * tool calls, then the loop repeats. So a new call starts wherever reasoning or
+ * text follows a tool call.
+ */
+export function splitIntoModelCalls(windows: BubbleWindow[]): ModelCall[] {
+    const calls: ModelCall[] = [];
+    let current: ModelCall | undefined;
+    let currentToolCallId: string | undefined;
+    let currentToolEnd: number | undefined;
+
+    const open = (window: BubbleWindow) => {
+        current = { output: [], steps: [], startMs: window.startMs, endMs: window.startMs };
+        currentToolCallId = undefined;
+        currentToolEnd = undefined;
+        calls.push(current);
+    };
+
+    for (const window of windows) {
+        if (window.kind === 'tool') {
+            const modelCallId = window.bubble.toolFormerData?.modelCallId;
+            const isNewCall =
+                current !== undefined &&
+                currentToolCallId !== undefined &&
+                modelCallId !== currentToolCallId &&
+                window.endMs !== currentToolEnd;
+
+            if (current === undefined || isNewCall) {
+                open(window);
+            }
+            currentToolCallId = typeof modelCallId === 'string' ? modelCallId : currentToolCallId;
+            currentToolEnd = window.endMs;
+            current!.steps.push(window);
+            continue;
+        }
+
+        if (window.kind === 'error') {
+            if (current === undefined) {
+                open(window);
+            }
+            current!.steps.push(window);
+            continue;
+        }
+
+        // thinking or message
+        if (current === undefined || current.steps.length > 0) {
+            open(window);
+        }
+        current!.output.push(window);
+        current!.endMs = Math.max(current!.endMs, window.endMs);
+    }
+
+    for (const call of calls) {
+        if (call.output.length === 0) {
+            call.endMs = call.startMs;
+        }
+    }
+
+    return calls;
+}

--- a/extensions/cursor/src/cursor/sessionManager.ts
+++ b/extensions/cursor/src/cursor/sessionManager.ts
@@ -6,8 +6,27 @@ import { SessionInfo } from "../interface";
 import { findFolder } from '../utils';
 import { captureException } from '../sentry';
 import { executeQuery, executeQueryPaginated } from './sqlite';
+import { orderBubbles } from './bubbleOrder';
+import { buildSpans, buildTurnOutput, DEFAULT_SPAN_OPTIONS, SpanBuildOptions } from './spanBuilder';
 
 import { TraceData } from "../interface";
+
+function readSpanOptions(): SpanBuildOptions | null {
+    const config = vscode.workspace.getConfiguration();
+    if (!config.get<boolean>('opik.detailedSpans.enabled', true)) {
+        return null;
+    }
+    return {
+        maxPayloadChars: config.get<number>(
+            'opik.detailedSpans.maxPayloadChars',
+            DEFAULT_SPAN_OPTIONS.maxPayloadChars
+        ),
+        maxSpansPerTurn: config.get<number>(
+            'opik.detailedSpans.maxSpansPerTurn',
+            DEFAULT_SPAN_OPTIONS.maxSpansPerTurn
+        ),
+    };
+}
 
 /**
  * Convert cursor conversations to Opik traces with per-session tracking.
@@ -303,33 +322,25 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
                 // Get bubbles for this composer
                 const bubbles = bubblesByComposer[threadId] || [];
                 
-                // Sort bubbles using fullConversationHeadersOnly order
-                if (composerData.fullConversationHeadersOnly && Array.isArray(composerData.fullConversationHeadersOnly)) {
-                    // Create a map of bubbleId to order index
-                    const orderMap = new Map();
-                    composerData.fullConversationHeadersOnly.forEach((header: any, index: number) => {
-                        if (header.bubbleId) {
-                            orderMap.set(header.bubbleId, index);
-                        }
-                    });
-                    
-                    // Sort bubbles according to the order in fullConversationHeadersOnly
-                    bubbles.sort((a, b) => {
-                        const aOrder = orderMap.get(a.id) ?? Number.MAX_SAFE_INTEGER;
-                        const bOrder = orderMap.get(b.id) ?? Number.MAX_SAFE_INTEGER;
-                        return aOrder - bOrder;
-                    });
-                }
-                
+                const orderedBubbles = orderBubbles(bubbles, composerData.fullConversationHeadersOnly);
+
                 // Add conversation
                 conversations.push({
                     chatTitle: composerData.name || `Composer Session ${index + 1}`,
-                    bubbles: bubbles,
+                    bubbles: orderedBubbles,
                     lastSendTime: composerData.lastUpdatedAt || composerData.createdAt,
                     composerId: threadId,
                     createdAt: composerData.createdAt,
                     model: composerData.modelConfig?.modelName,
-                    bubbleCount: bubbles.length
+                    bubbleCount: orderedBubbles.length,
+                    unifiedMode: composerData.unifiedMode,
+                    isAgentic: composerData.isAgentic,
+                    createdOnBranch: composerData.createdOnBranch,
+                    contextTokensUsed: composerData.contextTokensUsed,
+                    contextTokenLimit: composerData.contextTokenLimit,
+                    filesChangedCount: composerData.filesChangedCount,
+                    totalLinesAdded: composerData.totalLinesAdded,
+                    totalLinesRemoved: composerData.totalLinesRemoved
                 });
             } catch (parseErr) {
                 captureException(parseErr);
@@ -416,7 +427,7 @@ export async function findAndReturnNewTraces(
 }
 
 // Helper function to group bubbles by conversation turns
-function groupBubblesByType(bubbles: any[]) {
+export function groupBubblesByType(bubbles: any[]) {
     const groups: { userMessages: any[], aiMessages: any[] }[] = [];
     let currentGroup: { userMessages: any[], aiMessages: any[] } | null = null;
 
@@ -463,21 +474,13 @@ function createTraceFromBubbleGroup(
         .filter(content => content.trim())
         .join('\n\n');
     
-    // Extract and clean AI content inline
-    const assistantContent = aiMessages
-        .map(msg => {
-            let content = msg.text || msg.content || msg.rawText || '';
-            // Clean cursor-specific markup
-            return content
-                .replace(/⛢Thought☤[\s\S]*?⛢\/Thought☤/g, '')
-                .replace(/⛢Action☤[\s\S]*?⛢\/Action☤/g, '')
-                .replace(/⛢RawAction☤[\s\S]*?⛢\/RawAction☤/g, '')
-                .trim();
-        })
-        .filter(content => content)
-        .join('\n\n');
-    
-    // Filter out traces without proper input or output
+    // The messages the assistant wrote, with the name of every tool call in
+    // between. A turn that is only tool calls still produces an output.
+    const assistantContent = buildTurnOutput(aiMessages);
+
+    const spanOptions = readSpanOptions();
+    const spans = spanOptions ? buildSpans(group, conversation, spanOptions) : [];
+
     if (!userContent || !assistantContent) {
         return null;
     }
@@ -489,21 +492,21 @@ function createTraceFromBubbleGroup(
     const startTime = firstUserMessage.resolvedTimestamp || conversation.createdAt || Date.now();
     const endTime = lastAiMessage.resolvedTimestamp || startTime + 1000; // Add 1 second if no end time
 
-    // Create metadata inline
-    const cleanMessages = (messages: any[]) => 
-        messages.map(msg => {
-            const cleanMsg = { ...msg };
-            delete cleanMsg.delegate;
-            return cleanMsg;
-        });
-
+    // The raw bubbles used to be copied here. The child spans now hold that
+    // data in a readable form, and the copy was the largest part of the payload.
     const metadata = {
         conversationTitle: conversation.chatTitle,
         composerId: conversation.composerId,
-        userMessages: cleanMessages(userMessages),
-        aiMessages: cleanMessages(aiMessages),
         totalBubbles: conversation.bubbleCount,
         conversationCreatedAt: conversation.createdAt,
+        mode: conversation.unifiedMode,
+        isAgentic: conversation.isAgentic,
+        createdOnBranch: conversation.createdOnBranch,
+        contextTokensUsed: conversation.contextTokensUsed,
+        contextTokenLimit: conversation.contextTokenLimit,
+        filesChangedCount: conversation.filesChangedCount,
+        totalLinesAdded: conversation.totalLinesAdded,
+        totalLinesRemoved: conversation.totalLinesRemoved,
         gitInfo: gitInfo
     };
 
@@ -541,7 +544,8 @@ function createTraceFromBubbleGroup(
         output: { output: assistantContent },
         thread_id: conversation.composerId,
         tags: tags,
-        metadata: metadata
+        metadata: metadata,
+        spans: spans
     };
 }
 

--- a/extensions/cursor/src/cursor/spanBuilder.ts
+++ b/extensions/cursor/src/cursor/spanBuilder.ts
@@ -1,0 +1,343 @@
+import { SpanData } from '../interface';
+import { classifyBubble, toolName } from './bubbleKinds';
+import { assignWindows, BubbleWindow, ModelCall, splitIntoModelCalls, timestampOf } from './modelCalls';
+
+export interface SpanBuildOptions {
+    maxPayloadChars: number;
+    maxSpansPerTurn: number;
+}
+
+export const DEFAULT_SPAN_OPTIONS: SpanBuildOptions = {
+    maxPayloadChars: 10000,
+    maxSpansPerTurn: 200,
+};
+
+// Long unbroken base64 runs are screenshots. A single browser screenshot result
+// has a median size of 157 KB and a maximum of 905 KB in a real database.
+const BASE64_RUN = /^(?:data:[a-z+/-]+;base64,)?[A-Za-z0-9+/\s]{1000,}={0,2}$/;
+
+function stripBinary(value: unknown, depth = 0): unknown {
+    if (typeof value === 'string') {
+        return value.length > 1000 && BASE64_RUN.test(value)
+            ? `[binary, ${value.length} bytes]`
+            : value;
+    }
+    if (Array.isArray(value)) {
+        return depth < 12 ? value.map(item => stripBinary(item, depth + 1)) : value;
+    }
+    if (value && typeof value === 'object' && depth < 12) {
+        const result: Record<string, unknown> = {};
+        for (const [key, item] of Object.entries(value)) {
+            result[key] = stripBinary(item, depth + 1);
+        }
+        return result;
+    }
+    return value;
+}
+
+export interface Truncated {
+    value: unknown;
+    truncated: boolean;
+    originalLength: number;
+}
+
+export function truncateForSpan(value: unknown, limit: number): Truncated {
+    if (value === undefined || value === null) {
+        return { value: undefined, truncated: false, originalLength: 0 };
+    }
+
+    const cleaned = stripBinary(value);
+    const json = JSON.stringify(cleaned) ?? '';
+    if (json.length <= limit) {
+        return { value: cleaned, truncated: false, originalLength: json.length };
+    }
+
+    const head = Math.floor(limit * 0.6);
+    const tail = limit - head;
+    const text =
+        json.slice(0, head) +
+        `\n…[truncated ${json.length - limit} characters]…\n` +
+        json.slice(json.length - tail);
+
+    return { value: text, truncated: true, originalLength: json.length };
+}
+
+function safeJsonParse(raw: unknown): unknown {
+    if (typeof raw !== 'string') {
+        return raw ?? undefined;
+    }
+    const trimmed = raw.trim();
+    if (!trimmed) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(trimmed);
+    } catch {
+        return trimmed;
+    }
+}
+
+function applyPayload(
+    span: SpanData,
+    field: 'input' | 'output',
+    value: unknown,
+    limit: number
+): void {
+    const { value: payload, truncated, originalLength } = truncateForSpan(value, limit);
+    if (payload === undefined) {
+        return;
+    }
+    span[field] = payload;
+    if (truncated) {
+        span.metadata = {
+            ...span.metadata,
+            [`${field}_truncated`]: true,
+            [`${field}_original_length`]: originalLength,
+        };
+    }
+}
+
+function modelOf(call: ModelCall, conversation: any): string | undefined {
+    for (const window of [...call.output, ...call.steps]) {
+        const name = window.bubble.modelInfo?.modelName;
+        if (typeof name === 'string' && name) {
+            return name;
+        }
+    }
+    return conversation?.model;
+}
+
+function buildLlmSpan(call: ModelCall, conversation: any, options: SpanBuildOptions): SpanData {
+    const thinking = call.output
+        .filter(window => window.kind === 'thinking')
+        .map(window => window.bubble.thinking.text)
+        .join('\n\n');
+
+    const text = call.output
+        .filter(window => window.kind === 'message')
+        .map(window => window.bubble.text)
+        .join('\n\n');
+
+    const toolCalls = call.steps
+        .filter(window => window.kind === 'tool')
+        .map(window => ({
+            name: toolName(window.bubble.toolFormerData),
+            arguments: safeJsonParse(window.bubble.toolFormerData?.rawArgs)
+                ?? safeJsonParse(window.bubble.toolFormerData?.params),
+        }));
+
+    const span: SpanData = {
+        name: 'assistant',
+        type: 'llm',
+        model: modelOf(call, conversation),
+        provider: 'cursor',
+        startTime: new Date(call.startMs),
+        endTime: new Date(call.endMs),
+        tags: ['assistant'],
+    };
+
+    const thinkingMs = call.output
+        .filter(window => window.kind === 'thinking')
+        .reduce((total, window) => total + Math.max(0, window.bubble.thinkingDurationMs ?? 0), 0);
+
+    const contextStatus = call.output
+        .map(window => window.bubble.contextWindowStatusAtCreation)
+        .find(status => status?.tokenLimit);
+
+    const metadata: Record<string, unknown> = {};
+    if (thinkingMs > 0) {
+        metadata.thinking_duration_ms = thinkingMs;
+    }
+    if (contextStatus) {
+        metadata.context_tokens_used = contextStatus.tokensUsed;
+        metadata.context_token_limit = contextStatus.tokenLimit;
+    }
+    if (toolCalls.length > 0) {
+        metadata.tool_call_count = toolCalls.length;
+    }
+    if (Object.keys(metadata).length > 0) {
+        span.metadata = metadata;
+    }
+
+    // No input: Cursor never stores the prompt it sent, and a reconstruction
+    // would be a guess.
+    applyPayload(
+        span,
+        'output',
+        {
+            ...(thinking ? { thinking } : {}),
+            ...(text ? { text } : {}),
+            ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
+        },
+        options.maxPayloadChars
+    );
+
+    return span;
+}
+
+function buildToolSpan(window: BubbleWindow, options: SpanBuildOptions): SpanData {
+    const data = window.bubble.toolFormerData ?? {};
+    const status = typeof data.status === 'string' ? data.status : undefined;
+    const result = safeJsonParse(data.result);
+
+    const span: SpanData = {
+        name: toolName(data),
+        type: 'tool',
+        startTime: new Date(window.startMs),
+        endTime: new Date(window.endMs),
+        tags: ['tool', toolName(data), ...(status ? [status] : [])],
+        metadata: {
+            status,
+            tool_id: data.tool,
+            tool_call_id: data.toolCallId,
+            model_call_id: data.modelCallId,
+            ...(data.userDecision ? { user_decision: data.userDecision } : {}),
+            ...(typeof (result as any)?.exitCodeV2 === 'number'
+                ? { exit_code: (result as any).exitCodeV2 }
+                : {}),
+        },
+    };
+
+    if (status === 'error' || status === 'cancelled') {
+        const message = safeJsonParse(data.error);
+        span.errorInfo = {
+            exceptionType: `cursor-tool-${status}`,
+            message: typeof message === 'string' ? message : JSON.stringify(message ?? status),
+            traceback: '',
+        };
+    }
+
+    applyPayload(
+        span,
+        'input',
+        safeJsonParse(data.rawArgs) ?? safeJsonParse(data.params),
+        options.maxPayloadChars
+    );
+    applyPayload(span, 'output', result, options.maxPayloadChars);
+
+    return span;
+}
+
+function buildErrorSpan(window: BubbleWindow, options: SpanBuildOptions): SpanData {
+    const details = window.bubble.errorDetails ?? {};
+    const stack = truncateForSpan(details.stackTrace, options.maxPayloadChars);
+
+    return {
+        name: 'cursor-error',
+        type: 'general',
+        startTime: new Date(window.startMs),
+        endTime: new Date(window.endMs),
+        tags: ['error'],
+        errorInfo: {
+            exceptionType: 'cursor-request-error',
+            message: String(details.message ?? 'Cursor reported an error'),
+            traceback: typeof stack.value === 'string' ? stack.value : '',
+        },
+        metadata: {
+            request_id: details.requestId,
+            ...(stack.value !== undefined ? { stack_trace: stack.value } : {}),
+        },
+    };
+}
+
+/**
+ * The assistant side of a turn as one readable string: the messages it wrote,
+ * with the name of every tool call in between, in the order they happened.
+ * Consecutive tool calls stay on adjacent lines so a long run stays compact.
+ *
+ *   Let me check the file.
+ *
+ *   [read_file]
+ *   [grep]
+ *
+ *   The import is missing.
+ *
+ *   [search_replace]
+ */
+export function buildTurnOutput(aiMessages: any[]): string {
+    const blocks: string[] = [];
+    let toolRun: string[] = [];
+
+    const flushTools = () => {
+        if (toolRun.length > 0) {
+            blocks.push(toolRun.join('\n'));
+            toolRun = [];
+        }
+    };
+
+    for (const bubble of aiMessages) {
+        const kind = classifyBubble(bubble);
+
+        if (kind === 'tool') {
+            toolRun.push(`[${toolName(bubble.toolFormerData)}]`);
+            continue;
+        }
+
+        if (kind === 'message') {
+            const text = (bubble.text || bubble.content || bubble.rawText || '').trim();
+            if (text) {
+                flushTools();
+                blocks.push(text);
+            }
+        }
+    }
+
+    flushTools();
+    return blocks.join('\n\n');
+}
+
+/**
+ * Children of the llm_turn span, in time order: one llm span for each model call
+ * that produced reasoning or text, then the tool and error spans that followed it.
+ */
+export function buildSpans(
+    group: { userMessages: any[]; aiMessages: any[] },
+    conversation: any,
+    options: SpanBuildOptions = DEFAULT_SPAN_OPTIONS
+): SpanData[] {
+    const turnStartMs =
+        timestampOf(group.userMessages[0]) ?? conversation?.createdAt ?? Date.now();
+
+    const windows = assignWindows(group.aiMessages, turnStartMs);
+    const calls = splitIntoModelCalls(windows);
+    const spans: SpanData[] = [];
+
+    for (const call of calls) {
+        // A call with no reasoning and no text left no record of its own
+        // duration, so a zero width span would only add noise. Its tool spans
+        // still carry model_call_id.
+        if (call.output.length > 0) {
+            spans.push(buildLlmSpan(call, conversation, options));
+        }
+        for (const step of call.steps) {
+            spans.push(
+                step.kind === 'error'
+                    ? buildErrorSpan(step, options)
+                    : buildToolSpan(step, options)
+            );
+        }
+    }
+
+    const cap = Math.max(2, options.maxSpansPerTurn);
+    if (spans.length <= cap) {
+        return spans;
+    }
+
+    const keep = Math.floor(cap / 2);
+    const head = spans.slice(0, keep);
+    const tail = spans.slice(spans.length - keep);
+    const dropped = spans.length - head.length - tail.length;
+
+    head.push({
+        name: 'truncated-steps',
+        type: 'general',
+        startTime: head[head.length - 1].endTime,
+        endTime: tail[0].startTime,
+        tags: ['truncated'],
+        metadata: { dropped_span_count: dropped, total_span_count: spans.length },
+    });
+
+    return [...head, ...tail];
+}
+
+export { classifyBubble };

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -14,6 +14,20 @@ export interface Session {
     cursorSession?: CursorSession;
 }
 
+export interface SpanData {
+    name: string;
+    type: 'llm' | 'tool' | 'general';
+    startTime: Date;
+    endTime: Date;
+    model?: string;
+    provider?: string;
+    input?: any;
+    output?: any;
+    errorInfo?: { exceptionType: string; message: string; traceback: string };
+    metadata?: Record<string, unknown>;
+    tags?: string[];
+}
+
 export interface TraceData {
     name: string;
     project_name?: string;
@@ -26,6 +40,7 @@ export interface TraceData {
     thread_id?: string;
     tags?: string[];
     metadata?: any;
+    spans?: SpanData[];
 }
 
 export interface TurnUsage {

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -46,8 +46,15 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
 
             // The span is created without usage. Cursor only exposes token counts
             // a few seconds later over its usage API, so UsageEnricher patches it.
+            //
+            // This one span carries the usage of the whole turn on purpose.
+            // Cursor records tokens once per turn, never per model call: only
+            // 477 of 19691 bubbles in a real database hold a non-zero
+            // tokenCount, always the last bubble of a turn, and the billing API
+            // reports one request per turn too. Splitting that total across the
+            // child llm spans would invent numbers.
             const span = trace.span({
-                name: traceData.name,
+                name: 'llm_turn',
                 type: 'llm',
                 model: traceData.model,
                 provider: 'cursor',
@@ -58,6 +65,22 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
                 tags: traceData.tags,
                 metadata: traceData.metadata
             });
+
+            for (const child of traceData.spans ?? []) {
+                span.span({
+                    name: child.name,
+                    type: child.type,
+                    model: child.model,
+                    provider: child.provider,
+                    input: child.input,
+                    output: child.output,
+                    errorInfo: child.errorInfo,
+                    startTime: child.startTime,
+                    endTime: child.endTime,
+                    tags: child.tags,
+                    metadata: child.metadata
+                });
+            }
             // Deliberately not calling span.end()/trace.end(): both overwrite
             // endTime with the current time, which would replace the real Cursor
             // turn end with the upload time.


### PR DESCRIPTION
## Details

The Cursor extension logged one trace and one span per turn, so an agent run that read ten files and ran five commands showed only the question and the final answer. This logs each model call as an `llm` span and each tool call as a `tool` span, nested under an `llm_turn` span that carries the token usage.

The design is driven by a scan of a real Cursor database — 19,691 bubbles. `extensions/cursor/NESTED-SPANS.md` records the evidence behind each rule; happy to drop that file if you would rather it lived elsewhere.

```
trace  cursor-chat                       input = question, output = answer
└── span  llm_turn    type=llm           same input/output, carries the turn usage
    ├── span  assistant       type=llm       model call 1
    ├── span  read_file       type=tool
    ├── span  assistant       type=llm       model call 2
    ├── span  search_replace  type=tool
    └── span  cursor-error    type=general
```

- `llm_turn` keeps the trace input and output, so `UsageEnricher` and `applyTurnUsage()` are untouched. It is the only span with usage: Cursor records tokens once per turn and never per model call. Only 477 of 19,691 bubbles carry a non-zero `tokenCount`, always the last bubble of a turn, and the billing API reports ~1 request per turn. Splitting that total across the child spans would invent numbers.
- The trace output now interleaves the tool names with the assistant messages, so a turn reads `Let me check.` / `[read_file]` / `[grep]` / `The import is missing.`
- Tool payloads are capped at 10,000 characters and base64 images are replaced, which takes a browser screenshot result from a 157 KB median to 10 KB. One bubble in the database is 13.5 MB.
- `metadata.userMessages` and `metadata.aiMessages` are removed. Nothing read them, and they were larger than the spans that replace them.

Three fixes fall out of the real data:

- A bubble whose only `toolFormerData` is a status placeholder is not a tool call. 1,237 ordinary bubbles look like that.
- Error bubbles are absent from `fullConversationHeadersOnly`, so the old sort pushed them to the end and attached them to the wrong turn. They now go in by time. Bubbles from branches the user edited away stay out — one composer holds 833 bubbles for 748 headers.
- Reasoning flushed at the same millisecond as the tool before it used to produce an `llm` span exactly overlapping that tool span.

All of it sits behind `opik.detailedSpans.enabled`, default on. Version bumped to 0.5.0.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

No ticket. Follow-up to the cache token work in #8011.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Data analysis of the local Cursor database, the span design, the implementation, the unit tests, and the replay script.
- Human verification: The author drove the design over several rounds, chose the `llm_turn` shape, and reviewed the replay output against real conversations. The unit tests and the replay regression were run locally and pass. Not yet exercised end to end against a live Opik instance — the span tree has not been eyeballed in the UI, and the usage patch on `llm_turn` has not been confirmed there.

## Testing

Everything below was run from `extensions/cursor`.

```
npm run compile && npm run test-spans     # 33 tests, all passing
npm run lint                              # 0 errors, 9 pre-existing warnings (unchanged from main)
npm run build                             # packages a 1.03 MB vsix
```

`scripts/test-spans.js` is new and runs on `node:test`, matching the existing `verify-usage.js` pattern rather than adding a VS Code test host. It covers the placeholder `toolFormerData` trap, both forms of the `type` field, the numeric tool id map, the timing rules (parallel dispatch, a negative `thinkingDurationMs`, the tool-and-reasoning timestamp collision, the error point event), both model-call cut shapes, truncation, the base64 strip, the span cap, all four bubble ordering cases, and the interleaved trace output.

`scripts/replay-composer.js` is also new. It builds the trace and spans from a real composer and prints them without uploading, flagging negative durations, spans that start before their turn, and spans that start before the span above them.

```
node scripts/replay-composer.js --list
node scripts/replay-composer.js <composerId> --full
```

Run over the 30 largest conversations in a real database — **9,330 spans** — it reports **2 warnings**, both in one composer where Cursor's own bubble order goes backwards by 6 s and 2 s. No negative durations anywhere.

Payload measured per composer (span payload against the raw bubble copy the old metadata carried):

| Composer | Spans | Span payload | Old raw bubble copy |
| --- | --- | --- | --- |
| `9bb91e1f` | 613 (286 llm, 324 tool, 3 general) | 1.97 MB | 6.20 MB |
| `32f1ff14` | 844 (366 llm, 477 tool, 1 general) | 1.92 MB | 15.98 MB |
| `8f6dd4ee` | 296 (73 llm, 223 tool) | 1.13 MB | 8.04 MB |
| `5ea1babd` | 340 (143 llm, 197 tool) | 0.67 MB | 1.90 MB |

Both conversation shapes are covered: reasoning models such as `9bb91e1f` (275 thinking bubbles) and non-reasoning ones such as `32f1ff14` (zero).

**Not run:** the end-to-end path into a live Opik instance. That needs an API key and a running backend, and it is the one thing left to check before merge — that the span tree renders as a waterfall and that the usage patch lands on `llm_turn`.

## Documentation

Three new settings are documented in `package.json`, so they carry their own descriptions in the settings UI:

- `opik.detailedSpans.enabled` (default `true`) — the off switch, which also serves as the mitigation for terminal output or file content that a user does not want logged.
- `opik.detailedSpans.maxPayloadChars` (default `10000`).
- `opik.detailedSpans.maxSpansPerTurn` (default `200`).

`extensions/cursor/NESTED-SPANS.md` records the database findings, the span design, and the verification results. No changes to the Fern docs site — this extension is documented by its own README, which needs no update because the behaviour is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
