### PR TITLE
[NA] [DOCS] docs: set the style for PR descriptions in agent rules

### DIFF
--- a/.agents/commands/comet/_pr-description-sync.md
+++ b/.agents/commands/comet/_pr-description-sync.md
@@ -51,7 +51,7 @@ Clean up `$TMP` on exit.
 Apply the same logic as `/comet:create-pr` Step 6 (Extract Change Information) and Step 7 (Pre-fill PR Template). In particular:
 
 - Fill every `##` section defined in `.github/pull_request_template.md`. Sections not applicable to this PR get `N/A`, never get removed.
-- Re-derive the **Details** summary from the diff and commit messages.
+- Re-derive the **Details** section from the diff and commit messages in the style set by `/comet:create-pr` Step 7 — what changes for a user, short, bulleted, authoritative, no summary of the diff. Keep the shape the section already uses (Before / After, flat list, or a couple of lines) unless the change no longer fits it.
 - Re-derive the **Change checklist** from the file types changed (e.g., user-facing checked when UI files changed; documentation checked when `*.md` / `*.mdx` changed).
 - Keep the existing **Issues** ticket reference if present (e.g., `OPIK-6296`); if missing, infer from branch name.
 - Keep the existing **AI-WATERMARK** answers verbatim — never silently flip `yes`↔`no`.

--- a/.agents/commands/comet/create-pr.md
+++ b/.agents/commands/comet/create-pr.md
@@ -181,7 +181,20 @@ This workflow will:
   - **Fill every `##` section** in the template — the PR linter requires all sections to be present
   - If a section is not applicable, write "N/A" rather than removing it
 - **Section guidance**:
-  - **Details**: Implementation summary from git analysis (replace the HTML comment placeholder)
+  - **Details**: Replace the HTML comment placeholder with what changes for a user. A reviewer reads the diff for the code; this section tells them what is different when they use the product. Style:
+
+    - **Short.** Most PRs need 3–10 bullets. If it runs longer, the section is doing the diff's job — cut it.
+    - **Bullets, not prose paragraphs.** One behavior per bullet. Nest one level for sub-cases.
+    - **Authoritative.** State what happens: "The run is scored once." Not "This should now mean that the run will be scored once."
+    - **No fluff.** No motivation paragraph, no "this PR …", no approach summary, no benefits list, no restating the diff.
+    - **Observable behavior first.** What the UI shows, what the API returns, what gets scored, stored or logged. Name a class, method or file only when the behavior makes no sense without it.
+
+    Pick the shape that fits the change — do not force one:
+
+    - **Before / After bullet lists** when a behavior changed and the contrast is the point.
+    - **A flat bullet list** for a new capability, where there is no "before".
+    - **One or two lines** when users cannot see the change (refactor, dependency bump) — say what is unchanged and what improved, then stop.
+
   - **Change checklist**: Auto-check based on file types changed (user-facing for UI changes, documentation for docs)
   - **Issues**: Link to Jira ticket (e.g., `OPIK-2180`) or GitHub issue, or "NA" for hotfixes. List every ticket this PR **resolves** here with a normal hyphenated key.
   - **Jira key convention across the whole body** (see git-workflow rule): the GitHub for Jira app links any `OPIK-<digits>` it finds in the PR body to that ticket's Development panel, and the link can't be removed. So in **all** sections (Details, Testing, etc.) and in commit messages: tickets this PR **resolves** keep the hyphen (`OPIK-1234`) — links/URLs fine and wanted. Tickets **related but not resolved** here (escalations, references to older tickets — anything not in the title/branch) must be written with an underscore (`OPIK_7000`) and with **no** Jira URL (the URL contains the hyphenated key and links anyway). Apply this when generating every section below.

--- a/.agents/rules/git-workflow.mdc
+++ b/.agents/rules/git-workflow.mdc
@@ -28,6 +28,36 @@ Follow-up commits (preferred):
 ## PR Title
 `[<TICKET-KEY>] [COMPONENT] <type>: description`
 
+## PR Body
+Follow `.github/pull_request_template.md` — read the FULL template file before drafting.
+CI (`pr-lint`) fails the PR if any of these exact headings is missing:
+`## Details`, `## Change checklist`, `## Issues`, `## Testing`, `## Documentation`.
+Fill in `## AI-WATERMARK` too (Tools, Model(s), Scope, Human verification).
+Never substitute your own structure (e.g. `## Summary` / `## Test Plan`).
+A section that does not apply gets `N/A` — never delete a heading.
+
+### `## Details` — style
+Write what changes for a user. A reviewer reads the diff for the code; this section
+tells them what is different when they use the product.
+
+- **Short.** Most PRs need 3–10 bullets. If it runs longer, the section is doing the
+  diff's job — cut it.
+- **Bullets, not prose paragraphs.** One behavior per bullet. Nest one level for sub-cases.
+- **Authoritative.** State what happens: "The run is scored once." Not "This should now
+  mean that the run will be scored once."
+- **No fluff.** No motivation paragraph, no "this PR …", no approach summary, no
+  benefits list, no restating the diff.
+- **Observable behavior first.** What the UI shows, what the API returns, what gets
+  scored, stored or logged. Name a class, method or file only when the behavior makes
+  no sense without it.
+
+Pick the shape that fits the change — do not force one:
+
+- **Before / After bullet lists** when a behavior changed and the contrast is the point.
+- **A flat bullet list** for a new capability, where there is no "before".
+- **One or two lines** when users cannot see the change (refactor, dependency bump) —
+  say what is unchanged and what improved, then stop.
+
 ## Jira Key References (commit messages & PR body)
 The GitHub for Jira app links a PR to a ticket's Development panel whenever it finds an issue key matching `[A-Z][A-Z0-9]+-\d+` (project key, literal hyphen, digits) in the branch name, PR title, PR body, or any commit message. It matches on the regex alone — it cannot tell "this PR resolves the ticket" from "this just mentions it" — and the resulting link cannot be removed afterward. So free text must only contain hyphenated keys for tickets the PR actually resolves.
 

--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -17,6 +17,24 @@ Use the repository template at `.github/pull_request_template.md` — read the F
 
 Also fill in the template's `## AI-WATERMARK` section (yes/no; if yes: Tools, Model(s), Scope, Human verification). Never invent a different structure such as `## Summary` / `## Test Plan`.
 
+A section that does not apply gets `N/A` — never delete a heading.
+
+### `## Details` — style
+
+Write what changes for a user. A reviewer reads the diff for the code; this section tells them what is different when they use the product.
+
+- **Short.** Most PRs need 3–10 bullets. If it runs longer, the section is doing the diff's job — cut it.
+- **Bullets, not prose paragraphs.** One behavior per bullet. Nest one level for sub-cases.
+- **Authoritative.** State what happens: "The run is scored once." Not "This should now mean that the run will be scored once."
+- **No fluff.** No motivation paragraph, no "this PR …", no approach summary, no benefits list, no restating the diff.
+- **Observable behavior first.** What the UI shows, what the API returns, what gets scored, stored or logged. Name a class, method or file only when the behavior makes no sense without it.
+
+Pick the shape that fits the change — do not force one:
+
+- **Before / After bullet lists** when a behavior changed and the contrast is the point.
+- **A flat bullet list** for a new capability, where there is no "before".
+- **One or two lines** when users cannot see the change (refactor, dependency bump) — say what is unchanged and what improved, then stop.
+
 ## Changelog Entry
 
 ```markdown

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -263,6 +263,24 @@ Use the repository template at `.github/pull_request_template.md` — read the F
 
 Also fill in the template's `## AI-WATERMARK` section (yes/no; if yes: Tools, Model(s), Scope, Human verification). Never invent a different structure such as `## Summary` / `## Test Plan`.
 
+A section that does not apply gets `N/A` — never delete a heading.
+
+### `## Details` — style
+
+Write what changes for a user. A reviewer reads the diff for the code; this section tells them what is different when they use the product.
+
+- **Short.** Most PRs need 3–10 bullets. If it runs longer, the section is doing the diff's job — cut it.
+- **Bullets, not prose paragraphs.** One behavior per bullet. Nest one level for sub-cases.
+- **Authoritative.** State what happens: "The run is scored once." Not "This should now mean that the run will be scored once."
+- **No fluff.** No motivation paragraph, no "this PR …", no approach summary, no benefits list, no restating the diff.
+- **Observable behavior first.** What the UI shows, what the API returns, what gets scored, stored or logged. Name a class, method or file only when the behavior makes no sense without it.
+
+Pick the shape that fits the change — do not force one:
+
+- **Before / After bullet lists** when a behavior changed and the contrast is the point.
+- **A flat bullet list** for a new capability, where there is no "before".
+- **One or two lines** when users cannot see the change (refactor, dependency bump) — say what is unchanged and what improved, then stop.
+
 ## Internationalized READMEs
 
 `readme_CN.md`, `readme_ES.md`, `readme_FR.md`, `readme_DE.md` are AI machine-translated from the English `README.md`.


### PR DESCRIPTION
## Details

**Before**

- The rules said "follow the PR template" and nothing about how to write inside it.
- `## Details` came out as a long prose summary of the diff, with a motivation paragraph and a benefits list.
- `.claude/rules/git-workflow.md` carried a hand-edited `## PR Body` block that was missing from its `.agents/` source, so the next `make claude` would have deleted it.

**After**

- `## Details` has a stated style: short (3–10 bullets), bulleted, authoritative, and about behavior a user can observe. Motivation paragraphs, "this PR …", approach summaries, benefits lists and diff restatements are named as things to cut.
- Three shapes are offered — Before / After lists, a flat bullet list, or one or two lines — and the agent picks the one that fits instead of forcing a fixed template.
- The guidance reaches every surface that writes a description: the always-on git rule, `/comet:create-pr`, the `_pr-description-sync` sub-skill, and the `documentation` and `write-docs` skills.
- A re-sync keeps the shape a PR already uses, so it no longer rewrites a hand-picked format.
- The `## PR Body` block now lives in `.agents/rules/git-workflow.mdc`, so `make claude` regenerates it instead of dropping it.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- NA — repository tooling change, no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: the author set the requirements and reviewed the rule text; the style was derived from the author's own feedback in earlier sessions.

## Testing

- `make claude` and `make codex` — regenerated `.claude/rules/`, `.claude/commands/`, `.claude/skills/` and `AGENTS.override.md` from the `.agents/` sources. Confirmed the new `## PR Body` block survives the sync and that the stale `.claude/commands/comet/create-pr.md` copy is refreshed.
- Checked that no hook in `.pre-commit-config.yaml` matches `.agents/**` — every hook is gated by a `files:` regex scoped to `sdks/`, `apps/`, `scripts/precommit-*`, Dockerfiles, YAML or `.github`.
- This PR description was written under the new rule.
- Not run: `pre-commit` itself. The binary is not installed on this machine, and no hook applies to the changed paths.

## Documentation

N/A — the change is agent configuration under `.agents/`, not product documentation.
