### PR TITLE
[OPIK-8102] [BE] build: bump google-cloud-vertexai to 1.52.0 for thinking config

### DIFF
--- a/apps/opik-backend/pom.xml
+++ b/apps/opik-backend/pom.xml
@@ -26,6 +26,7 @@
         <liquibase-clickhouse.version>0.7.2</liquibase-clickhouse.version>
         <clickhouse-java.version>0.10.0</clickhouse-java.version>
         <google-protobuf.version>4.36.0</google-protobuf.version>
+        <google-cloud-vertexai.version>1.52.0</google-cloud-vertexai.version>
         <org.mapstruct.version>1.6.3</org.mapstruct.version>
         <testcontainers.version>2.0.2</testcontainers.version>
         <uuid.java.generator.version>5.2.0</uuid.java.generator.version>
@@ -235,6 +236,24 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-vertex-ai-gemini</artifactId>
+        </dependency>
+
+        <!--
+            Overrides the 1.27.0 that langchain4j-vertex-ai-gemini pins transitively: GenerationConfig only gained
+            the thinking_config field in 1.52.0, and Gemini thinking cannot be configured without it.
+            The excluded org.jetbrains:annotations is a downgrade to 13.0, whose @NotNull lacks TYPE_USE and so
+            fails to compile the test sources' type-context usages.
+        -->
+        <dependency>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-vertexai</artifactId>
+            <version>${google-cloud-vertexai.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Details

Overrides the `google-cloud-vertexai` version that `langchain4j-vertex-ai-gemini` pins transitively (1.27.0) with 1.52.0, so Gemini thinking can be configured on the Vertex provider. Opik builds a protobuf `GenerationConfig` and hands it to a `GenerativeModel`, and 1.27.0's `GenerationConfig` has no `thinking_config` field — 1.52.0 adds `GenerationConfig.ThinkingConfig` (`thinking_budget`, `include_thoughts`).

This is a prerequisite only — it adds no behaviour. The feature that consumes it follows in a separate PR.

- langchain4j's `VertexAiGeminiChatModel` builder exposes no thinking option either, and Opik bypasses that builder anyway (two-arg constructor + protobuf config), so the protobuf is the only lever.
- The `org.jetbrains:annotations` exclusion is **required, not incidental**. Without it the bump downgrades that artifact 17.0.0 → 13.0, whose `@NotNull` lacks `TYPE_USE`; the first failure is `annotation @org.jetbrains.annotations.NotNull not applicable in this type context` (`FindTraceThreadsResourceTest.java:535`) and javac's recovery then emits ~200 misleading `cannot find symbol` errors on Lombok-generated members. With the exclusion, `annotations` resolves back to 17.0.0.

### Reviewer note: blast radius

The bump pulls 74 transitive deltas. Worth a second opinion on the shared surfaces, since other Google-cloud consumers in the app share them:

- **new**: `com.google.genai:google-genai:1.47.0`, `org.java-websocket:Java-WebSocket:1.6.0`
- `io.grpc:*` 1.71.0 → 1.76.3 (incl. `grpc-netty-shaded`, `grpc-xds`)
- `google-http-client` 1.47.1 → 2.1.0 (major)
- `gson` 2.8.9 → 2.12.1, `gax` 2.68.0 → 2.76.0, `google-auth-library` 1.37.1 → 1.43.0
- **dropped**: `javax.annotation:javax.annotation-api:1.3.2`, `org.checkerframework:checker-qual:3.49.0`

`protobuf-java` stays at the repo-pinned 4.36.0. Note 1.52.0's generated classes extend `GeneratedMessage` rather than `GeneratedMessageV3`; protobuf-java 4.x ships both and the provider suites pass, so this is compatible — but it's the thing to check first if anything odd surfaces.

Alternatives considered and rejected: injecting the field via `GenerationConfig.Builder.setUnknownFields(...)` with a hardcoded protobuf tag number (silently wrong if the tag changes, effectively untestable); routing Vertex Gemini through `langchain4j-google-ai-gemini` (wrong auth model — Vertex uses service-account credentials and regional endpoints, AI Studio uses an API key).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-8102 (prerequisite only — this PR does not resolve the ticket; the feature that does follows separately)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-5
- Scope: Dependency investigation (identifying the missing `thinking_config` field and the `org.jetbrains:annotations` downgrade), the pom change, and this description.
- Human verification: Author reviewed the diff and the dependency delta; the bump is going to a principal engineer for review of the transitive blast radius before merge.

## Testing

Commands run in `apps/opik-backend`:

- `mvn dependency:tree -Dincludes='com.google.cloud:google-cloud-vertexai,com.google.api.grpc:proto-google-cloud-vertexai-v1,org.jetbrains:annotations'` → resolves `google-cloud-vertexai:1.52.0`, `proto-google-cloud-vertexai-v1:1.52.0`, `org.jetbrains:annotations:17.0.0:test`. BUILD SUCCESS.
- `mvn clean test-compile` → 0 errors. (For contrast: 200 errors without the exclusion, 0 on the unmodified pom — this is how the `annotations` downgrade was isolated.)
- `mvn test -Dtest='com.comet.opik.infrastructure.llm.**'` → **1077 tests, 0 failures, 0 errors**. Covers the full Vertex, Gemini, Anthropic, OpenAI and custom-LLM suites, i.e. everything touching the changed dependency.
- `mvn spotless:check` → clean.

Verified the missing field directly rather than inferring it: `unzip -l` + `javap` on `proto-google-cloud-vertexai-v1` shows no `ThinkingConfig` class and no thinking setter on `GenerationConfig.Builder` in 1.27.0, and both present in 1.52.0.

Not run: full `mvn verify`. It fails on this machine for unrelated local infrastructure reasons (ClickHouse/Testcontainers — ZooKeeper replicated-table state, container startup timeouts, Liquibase changeset `000017`). Notably the log contained **zero** `NoSuchMethodError`, `NoClassDefFoundError` or `IncompatibleClassChangeError`, and nothing referencing vertexai/protobuf/grpc/gson/genai — which is what a binary-incompatible bump would produce. **Relying on CI to run the full suite on clean infrastructure.**

## Documentation

None — no user-facing or API change.
