### PR TITLE
[NA] [SDK] fix: stop bedrock and mistral stream wrappers from swallowing exceptions in finally

### DIFF
--- a/sdks/python/src/opik/integrations/bedrock/invoke_model/stream_wrappers.py
+++ b/sdks/python/src/opik/integrations/bedrock/invoke_model/stream_wrappers.py
@@ -44,36 +44,34 @@ def wrap_invoke_model_response(
             error_info = error_info_collector.collect(exception)
             raise exception
         finally:
-            if not hasattr(self, "opik_tracked_instance"):
-                return None
+            if hasattr(self, "opik_tracked_instance"):
+                delattr(self, "opik_tracked_instance")
 
-            delattr(self, "opik_tracked_instance")
-
-            if error_info is None and result is not None:
-                try:
-                    parsed_body = json.loads(result)
-                    output = {
-                        "body": parsed_body,
-                        "ResponseMetadata": response_metadata,
-                    }
-                    LOGGER.debug(
-                        "Successfully parsed response body with keys: %s",
-                        list(parsed_body.keys()),
-                    )
-                except (json.JSONDecodeError, TypeError) as e:
-                    LOGGER.debug("Failed to parse response body as JSON: %s", e)
+                if error_info is None and result is not None:
+                    try:
+                        parsed_body = json.loads(result)
+                        output = {
+                            "body": parsed_body,
+                            "ResponseMetadata": response_metadata,
+                        }
+                        LOGGER.debug(
+                            "Successfully parsed response body with keys: %s",
+                            list(parsed_body.keys()),
+                        )
+                    except (json.JSONDecodeError, TypeError) as e:
+                        LOGGER.debug("Failed to parse response body as JSON: %s", e)
+                        output = {"body": {}, "ResponseMetadata": response_metadata}
+                else:
+                    LOGGER.debug("Error occurred or result is None, using empty body")
                     output = {"body": {}, "ResponseMetadata": response_metadata}
-            else:
-                LOGGER.debug("Error occurred or result is None, using empty body")
-                output = {"body": {}, "ResponseMetadata": response_metadata}
 
-            finally_callback(
-                output=output,
-                error_info=error_info,
-                generators_span_to_end=span_to_end,
-                generators_trace_to_end=trace_to_end,
-                capture_output=True,
-            )
+                finally_callback(
+                    output=output,
+                    error_info=error_info,
+                    generators_span_to_end=span_to_end,
+                    generators_trace_to_end=trace_to_end,
+                    capture_output=True,
+                )
 
     botocore.response.StreamingBody.read = wrapped_read
     streaming_body.opik_tracked_instance = True

--- a/sdks/python/src/opik/integrations/mistral/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/mistral/stream_patchers.py
@@ -51,22 +51,20 @@ def patch_sync_event_stream(
             error_info = error_info_collector.collect(exception)
             raise exception
         finally:
-            if not hasattr(self, "opik_tracked_instance"):
-                return
-
-            delattr(self, "opik_tracked_instance")
-            output = (
-                generations_aggregator(accumulated_items)
-                if error_info is None
-                else None
-            )
-            finally_callback(
-                output=output,
-                error_info=error_info,
-                capture_output=True,
-                generators_span_to_end=self.span_to_end,
-                generators_trace_to_end=self.trace_to_end,
-            )
+            if hasattr(self, "opik_tracked_instance"):
+                delattr(self, "opik_tracked_instance")
+                output = (
+                    generations_aggregator(accumulated_items)
+                    if error_info is None
+                    else None
+                )
+                finally_callback(
+                    output=output,
+                    error_info=error_info,
+                    capture_output=True,
+                    generators_span_to_end=self.span_to_end,
+                    generators_trace_to_end=self.trace_to_end,
+                )
 
     stream_cls.__iter__ = wrapper
 
@@ -107,22 +105,20 @@ def patch_async_event_stream(
             error_info = error_info_collector.collect(exception)
             raise exception
         finally:
-            if not hasattr(self, "opik_tracked_instance"):
-                return
-
-            delattr(self, "opik_tracked_instance")
-            output = (
-                generations_aggregator(accumulated_items)
-                if error_info is None
-                else None
-            )
-            finally_callback(
-                output=output,
-                error_info=error_info,
-                capture_output=True,
-                generators_span_to_end=self.span_to_end,
-                generators_trace_to_end=self.trace_to_end,
-            )
+            if hasattr(self, "opik_tracked_instance"):
+                delattr(self, "opik_tracked_instance")
+                output = (
+                    generations_aggregator(accumulated_items)
+                    if error_info is None
+                    else None
+                )
+                finally_callback(
+                    output=output,
+                    error_info=error_info,
+                    capture_output=True,
+                    generators_span_to_end=self.span_to_end,
+                    generators_trace_to_end=self.trace_to_end,
+                )
 
     stream_cls.__aiter__ = wrapper
 

--- a/sdks/python/tests/library_integration/bedrock/test_invoke_model.py
+++ b/sdks/python/tests/library_integration/bedrock/test_invoke_model.py
@@ -648,3 +648,52 @@ def test_bedrock_invoke_model__mistral___streaming__happyflow(fake_backend):
     )
     assert len(fake_backend.trace_trees) == 1
     assert_equal(expected_trace, fake_backend.trace_trees[0])
+
+
+def test_bedrock_invoke_model__untracked_client_read_after_tracked_call__payload_returned(
+    fake_backend,
+):
+    """Regression test for `return None` inside `finally`.
+
+    track_bedrock patches `read` on botocore's shared StreamingBody class, so
+    every response body in the process runs through the wrapper once a tracked
+    invoke_model call has been made - including bodies belonging to untracked
+    clients and to other AWS services. A `return` in `finally` overrides the
+    value returned by `try`, so an untracked read used to hand back None
+    instead of the payload.
+    """
+    request_body = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 50,
+        "temperature": 0.1,
+        "messages": [{"role": "user", "content": "Hello, how are you?"}],
+    }
+
+    tracked_client = track_bedrock(
+        boto3.client("bedrock-runtime", region_name="us-east-1")
+    )
+    tracked_response = tracked_client.invoke_model(
+        modelId=ANTHROPIC_MODEL,
+        body=json.dumps(request_body),
+        contentType="application/json",
+        accept="application/json",
+    )
+    assert json.loads(tracked_response["body"].read())
+
+    untracked_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    untracked_response = untracked_client.invoke_model(
+        modelId=ANTHROPIC_MODEL,
+        body=json.dumps(request_body),
+        contentType="application/json",
+        accept="application/json",
+    )
+
+    payload = untracked_response["body"].read()
+
+    assert payload is not None
+    assert json.loads(payload)
+
+    opik.flush_tracker()
+
+    # Only the tracked call is logged; the untracked one must not be.
+    assert len(fake_backend.trace_trees) == 1

--- a/sdks/python/tests/library_integration/mistral/test_mistral.py
+++ b/sdks/python/tests/library_integration/mistral/test_mistral.py
@@ -245,6 +245,116 @@ def test_mistral_chat_stream_async__happyflow(fake_backend):
     assert_equal(EXPECTED_TRACE_TREE, fake_backend.trace_trees[0])
 
 
+def _fail_mid_stream(stream) -> None:
+    """Make a real mistralai stream raise partway through iteration.
+
+    ``EventStream.__next__`` pulls from ``self.generator``, so swapping that
+    generator injects a mid-stream failure (a dropped connection, say) into a
+    genuine stream object without touching the class opik patched.
+    """
+
+    def failing_generator():
+        yield from ()
+        raise RuntimeError("stream-blew-up")
+
+    stream.generator = failing_generator()
+
+
+def test_mistral_chat_stream__untracked_stream_fails_after_class_patched__error_propagates(
+    fake_backend,
+):
+    """Regression test for the `return` inside `finally`.
+
+    opik patches ``__iter__`` on mistralai's stream class, so once any tracked
+    stream has been consumed every stream in the process runs through the
+    wrapper - including streams from untracked clients. A `return` in `finally`
+    swallowed the in-flight exception, so an untracked stream that failed
+    mid-iteration finished silently instead of raising.
+    """
+    tracked_client = track_mistral(
+        mistralai.Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+    )
+    for _ in tracked_client.chat.stream(
+        model=MODEL_FOR_TESTS, messages=MESSAGES, max_tokens=10
+    ):
+        pass
+
+    untracked_client = mistralai.Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+    untracked_stream = untracked_client.chat.stream(
+        model=MODEL_FOR_TESTS, messages=MESSAGES, max_tokens=10
+    )
+    _fail_mid_stream(untracked_stream)
+
+    with pytest.raises(RuntimeError, match="stream-blew-up"):
+        for _ in untracked_stream:
+            pass
+
+    opik.flush_tracker()
+
+    # Only the tracked stream is logged; the untracked one must not be.
+    assert len(fake_backend.trace_trees) == 1
+
+
+def test_mistral_chat_stream_async__untracked_stream_fails_after_class_patched__error_propagates(
+    fake_backend,
+):
+    """Async variant of the regression test above."""
+    tracked_client = track_mistral(
+        mistralai.Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+    )
+
+    async def async_call():
+        async for _ in await tracked_client.chat.stream_async(
+            model=MODEL_FOR_TESTS, messages=MESSAGES, max_tokens=10
+        ):
+            pass
+
+        untracked_client = mistralai.Mistral(api_key=os.environ["MISTRAL_API_KEY"])
+        untracked_stream = await untracked_client.chat.stream_async(
+            model=MODEL_FOR_TESTS, messages=MESSAGES, max_tokens=10
+        )
+
+        async def failing_generator():
+            for _ in ():
+                yield
+            raise RuntimeError("stream-blew-up")
+
+        untracked_stream.generator = failing_generator()
+
+        with pytest.raises(RuntimeError, match="stream-blew-up"):
+            async for _ in untracked_stream:
+                pass
+
+    asyncio.run(async_call())
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+
+
+def test_mistral_chat_stream__tracked_stream_fails_mid_iteration__error_propagates_and_error_info_logged(
+    fake_backend,
+):
+    """The tracked path must keep working: the exception still propagates and
+    the span is closed with error_info."""
+    client = track_mistral(mistralai.Mistral(api_key=os.environ["MISTRAL_API_KEY"]))
+
+    stream = client.chat.stream(model=MODEL_FOR_TESTS, messages=MESSAGES, max_tokens=10)
+    _fail_mid_stream(stream)
+
+    with pytest.raises(RuntimeError, match="stream-blew-up"):
+        for _ in stream:
+            pass
+
+    opik.flush_tracker()
+
+    assert len(fake_backend.trace_trees) == 1
+    logged_span = fake_backend.trace_trees[0].spans[0]
+    assert logged_span.output is None
+    assert logged_span.error_info["exception_type"] == "RuntimeError"
+    assert "stream-blew-up" in logged_span.error_info["message"]
+
+
 def test_mistral_chat_complete__custom_provider__provider_logged_but_usage_still_parsed(
     fake_backend,
 ):


### PR DESCRIPTION
## Details

The bedrock and mistral stream wrappers install class-level patches and used an early `return` inside a `finally` block to skip cleanup for non-tracked streams. A `return` in `finally` discards any in-flight exception, so once a tracked call installed the patch, non-tracked streams that errored mid-iteration completed silently. Fix: invert the guard so cleanup nests under `if hasattr(...)` and no `return` remains in any `finally` — tracked streams behave exactly as before.

- **Bedrock is worse than a lost exception — it silently corrupts data.** The patch target is `botocore.response.StreamingBody.read`, botocore's *shared* class used by every boto3 response body, and the `try` block does `return result`. A `return None` in `finally` **overrides the returned value**, so after one traced `invoke_model` call every non-tracked `read()` in the process — an S3 object, a Lambda payload — handed back `None` instead of its payload:
  ```
  === BEFORE opik patches anything ===
  read() -> b'hello-s3-object'
  === AFTER opik traced ONE bedrock call ===
  tracked read()   -> b'{"completion": "hi"}'
  unrelated read() -> None          <<< payload silently replaced with None
  ```
- **Mistral** patches `__iter__`/`__aiter__` on the stream's class; these are generators with no return value to clobber, so the impact is exception swallowing only.

This is the same bug and the same fix that #7981 applies to the anthropic integration — **credit to @trakshan-mishra for finding the pattern there.** I found these two while reviewing that PR. The two PRs touch disjoint files, so they can merge in either order. After both land, an AST scan over `sdks/python/src/opik` finds no `return`/`break`/`continue` in any `finally` block.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: found both bugs while reviewing #7981, wrote the fix and the regression tests
- Human verification: diff reviewed; tests confirmed to fail on unfixed source and pass with the fix (see Testing)

## Testing

- **Commands run:**
  - `pytest tests/library_integration/mistral/` → **18 passed** (15 existing + 3 new), real Mistral API
  - `pre-commit run --files <4 changed files>` → ruff, ruff-format, mypy, whitespace hooks all **Passed**
- **Regression proof (mistral):** with the fix reverted and the tests unchanged, the two `untracked_stream_fails_after_class_patched` tests **fail** (exception swallowed) and pass again with the fix. The `tracked_stream_fails_mid_iteration` test passes both ways by design — it guards the tracked path against regressions in the refactor.
- **Bedrock data-loss bug** reproduced directly against real `botocore.response.StreamingBody` objects (output above); verified fixed by the same script.
- **Test placement:** both tests extend the existing library-integration suites. The mistral ones make real streaming calls, then inject a deterministic mid-stream failure by swapping `EventStream.generator` (which is what `__next__` pulls from) on a genuine stream object — a real dropped-connection stands in without monkeypatching the patched class.
- **Not verified locally:** `test_bedrock_invoke_model__untracked_client_read_after_tracked_call__payload_returned` needs real AWS Bedrock credentials, which I don't have — the `AWS_PROFILE` here fails with `PartialCredentialsError`. It collects cleanly and is modelled on the existing verified `..._anthropic___happyflow` test in the same file (same client, model, and request body); the mechanism it asserts is the one reproduced above. **Please confirm it goes green in CI.**

## Documentation

No documentation changes needed — this is an internal bug fix with no public API or behaviour change for correctly-tracked streams.
