### PR TITLE
[OPIK-8123] [FE] fix: keep sorting and search in the experiment items export query

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
@@ -78,6 +78,8 @@ const useExperimentItemsData = ({
       datasetId,
       experimentsIds,
       filters,
+      sorting,
+      search,
       truncate,
       page,
       size,


### PR DESCRIPTION
## Details

When sorting is enabled in the experiment table, exporting is unreliable and does not download all the rows selected.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8123

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Located the cause and applied the two-line change in `useExperimentItemsData.ts`.
- Human verification: Author reviewed the diff.

## Testing

- Manual: open a Compare Experiments page with more than 100 items, sort a column or enter a search term, select all rows on the page, then export to CSV. The file contains all selected rows.
- No automated test added (agreed as out of scope for this fix).

## Documentation

N/A
