### PR TITLE
[OPIK-8125] [FE] fix: export experiment items without truncation

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/experiments/useExperimentItemsData.ts
@@ -80,7 +80,7 @@ const useExperimentItemsData = ({
       filters,
       sorting,
       search,
-      truncate,
+      truncate: false,
       page,
       size,
     },


### PR DESCRIPTION
## Details

When truncation is enabled for the workspace, exporting rows from the experiment table downloads the shortened cell values shown in the table instead of the full input and output values.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8125

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Located the cause and applied the one-line change in `useExperimentItemsData.ts`.
- Human verification: Author reviewed the diff.

## Testing

- Manual: on a workspace with truncation enabled, open a Compare Experiments page with items longer than the truncation limit, select rows, then export to CSV. The file holds the full values.
- No automated test added.

## Documentation

N/A
