### PR TITLE
[NA] [FE] chore: use the trimmed search term in the export queries

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
@@ -660,7 +660,7 @@ const TraceLogsView: React.FunctionComponent<TraceLogsViewProps> = ({
       filters: effectiveFilters,
       page: page as number,
       size: size as number,
-      search: searchText,
+      search: trimmedSearch,
       truncate: false,
       fromTime: intervalStart,
       toTime: intervalEnd,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -595,7 +595,7 @@ export const ThreadsTab: React.FC<ThreadsTabProps> = ({
       filters: threadChipFilters,
       page: page as number,
       size: size as number,
-      search: search as string,
+      search: trimmedSearch,
       truncate: false,
       fromTime: intervalStart,
       toTime: intervalEnd,

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -877,7 +877,7 @@ export const TracesSpansTab: React.FC<TracesSpansTabProps> = ({
       filters: effectiveFilters,
       page: page as number,
       size: size as number,
-      search: search as string,
+      search: trimmedSearch,
       truncate: false,
       fromTime: intervalStart,
       toTime: intervalEnd,


### PR DESCRIPTION
## Details

Nit — no user impact expected.

In the traces, spans and threads tables the table query sends `search: trimmedSearch` while the export query sends the raw `search`. The row sets stay equal, because the backend applies `StringUtils.trimToNull` but this might not be the case in the future. The export queries now send the same trimmed term as their table query.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Three one-line changes to the export queries in `TracesSpansTab.tsx`, `ThreadsTab.tsx` and `TraceLogsView.tsx`.
- Human verification: Author reviewed the diff.

## Testing

- No behavior change to verify: the backend normalizes the search term, so both spellings return the same rows.
- Manual smoke check: enter a search term with leading or trailing spaces in the Traces, Spans and Threads tables, select rows, then export. The exported rows match the table.

## Documentation

N/A
