### PR TITLE
[OPIK-8109] [BE] fix: bound dataset items page read by page size

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -413,7 +413,51 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             AND dataset_item_id IN :itemIds
             """;
 
+    /**
+     * Reads one page of a dataset version.
+     * <p>
+     * Resolved in two phases so the wide {@code data} column never enters a sort. The table's ordering key is
+     * {@code (workspace_id, dataset_id, dataset_version_id, id)}, so ordering by {@code dataset_item_id} cannot
+     * use {@code optimize_read_in_order} and forces a full blocking sort over the whole version. Carrying
+     * {@code data} through that sort makes peak memory scale with the version's total payload rather than with
+     * the page size: a 120k-item version at ~138 KiB per item peaked at 30 GiB and returned 500 (OPIK-8109).
+     * <p>
+     * Phase 1 resolves the page's {@code dataset_item_id}s from narrow columns only; phase 2 fetches the payload
+     * for just those ids, served by the {@code dataset_item_id} skip indexes from migration {@code 000074}.
+     * Truncation stays in phase 2 so the image regex runs over the page instead of the whole version.
+     * <p>
+     * Three invariants hold this together. Each one broke a draft of this query, and each has a regression test
+     * in {@code DatasetItemVersionPaginationTest}:
+     * <ol>
+     *   <li>Both phases order by {@code dataset_item_id DESC} first. A mismatch reorders the page.</li>
+     *   <li>The ordering's leading key, {@code dataset_item_id}, is unique per output row after
+     *       {@code LIMIT 1 BY dataset_item_id}, so the page order is fully determined and the trailing
+     *       timestamp only picks a winner among duplicate rows for the same id. If custom sorting is ever
+     *       added here, the sort must still <em>end</em> in {@code dataset_item_id}: with a non-unique sort
+     *       key and no unique tiebreak, the two phases sort different column sets and can order tied rows
+     *       differently.</li>
+     *   <li>Phase 2 repeats {@code dataset_item_filters}. Without it, an id selected in phase 1 via a superseded
+     *       row that matches the filter resolves in phase 2 to the newest row for that id, which may not match,
+     *       returning rows the caller filtered out.</li>
+     * </ol>
+     */
     private static final String SELECT_DATASET_ITEM_VERSIONS = """
+            WITH page AS (
+                SELECT dataset_item_id
+                FROM dataset_item_versions
+                WHERE dataset_id = :datasetId
+                AND dataset_version_id = :versionId
+                AND workspace_id = :workspace_id
+                <if(lastRetrievedId)>AND dataset_item_id \\< :lastRetrievedId<endif>
+                <if(dataset_item_filters)>AND (<dataset_item_filters>)<endif>
+                ORDER BY dataset_item_id DESC, item_last_updated_at DESC
+                LIMIT 1 BY dataset_item_id
+                <if(lastRetrievedId)>
+                LIMIT :limit
+                <else>
+                LIMIT :limit OFFSET :offset
+                <endif>
+            )
             SELECT
                 dataset_item_id AS id,
                 dataset_id,
@@ -434,15 +478,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             WHERE dataset_id = :datasetId
             AND dataset_version_id = :versionId
             AND workspace_id = :workspace_id
-            <if(lastRetrievedId)>AND dataset_item_id \\< :lastRetrievedId<endif>
             <if(dataset_item_filters)>AND (<dataset_item_filters>)<endif>
+            AND dataset_item_id IN (SELECT dataset_item_id FROM page)
             ORDER BY dataset_item_id DESC, last_updated_at DESC
             LIMIT 1 BY dataset_item_id
-            <if(lastRetrievedId)>
-            LIMIT :limit
-            <else>
-            LIMIT :limit OFFSET :offset
-            <endif>
             """;
 
     private static final String SELECT_DATASET_ITEM_VERSIONS_COUNT = """

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -55,11 +55,14 @@ import com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesServic
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Injector;
 import com.redis.testcontainers.RedisContainer;
+import io.r2dbc.spi.Result;
+import io.r2dbc.spi.Statement;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -75,12 +78,14 @@ import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -156,6 +161,7 @@ class DatasetVersionResourceTest {
     private SpanResourceClient spanResourceClient;
     private TransactionTemplate mySqlTemplate;
     private ExperimentAggregatesService experimentAggregatesService;
+    private TransactionTemplateAsync clickHouseTemplate;
 
     @BeforeAll
     void setUpAll(ClientSupport client, TransactionTemplate mySqlTemplate, Injector injector) {
@@ -171,6 +177,7 @@ class DatasetVersionResourceTest {
         traceResourceClient = new TraceResourceClient(client, baseURI);
         spanResourceClient = new SpanResourceClient(client, baseURI);
         experimentAggregatesService = injector.getInstance(ExperimentAggregatesService.class);
+        clickHouseTemplate = injector.getInstance(TransactionTemplateAsync.class);
     }
 
     @AfterAll
@@ -5769,4 +5776,150 @@ class DatasetVersionResourceTest {
             assertThat(latestItemCount(datasetId)).isEqualTo(1L + 3L);
         }
     }
+
+    @Nested
+    @DisplayName("Page reads bounded by page size (OPIK-8109):")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class BoundedPageReads {
+
+        private void createTaggedItems(UUID datasetId, int count, String tag) {
+            var items = IntStream.range(0, count)
+                    .mapToObj(i -> DatasetItem.builder()
+                            .id(null)
+                            .source(DatasetItemSource.MANUAL)
+                            .data(Map.of(
+                                    "tag", JsonUtils.readTree("\"" + tag + "\""),
+                                    "input", JsonUtils.readTree("\"row-" + i + "\"")))
+                            .build())
+                    .toList();
+
+            datasetResourceClient.createDatasetItems(DatasetItemBatch.builder()
+                    .datasetId(datasetId)
+                    .items(items)
+                    .batchGroupId(UUID.randomUUID())
+                    .build(), TEST_WORKSPACE, API_KEY);
+        }
+
+        /**
+         * Adds a second, newer physical row for every item in a version, with {@code data['tag']} rewritten.
+         * <p>
+         * The engine's deduplication key is {@code (workspace_id, dataset_id, dataset_version_id, id)}, so two
+         * rows sharing a {@code dataset_item_id} but holding different physical {@code id}s are never collapsed
+         * by a merge. That is exactly why the read deduplicates with {@code LIMIT 1 BY dataset_item_id} rather
+         * than by {@code id}, and it is the only state in which the two-phase read's filter handling is
+         * observable: with the filter applied only when resolving the page's ids, the superseding row is what
+         * gets returned.
+         */
+        private void addSupersedingRow(UUID datasetId, UUID versionId, String newTag) {
+            String sql = """
+                    INSERT INTO dataset_item_versions
+                        (id, dataset_item_id, dataset_id, dataset_version_id, data, source,
+                         item_created_at, item_last_updated_at, item_created_by, item_last_updated_by,
+                         created_at, last_updated_at, created_by, last_updated_by, workspace_id)
+                    SELECT
+                        toString(generateUUIDv4()),
+                        dataset_item_id,
+                        dataset_id,
+                        dataset_version_id,
+                        mapUpdate(data, map('tag', :new_tag)),
+                        source,
+                        item_created_at,
+                        item_last_updated_at + toIntervalSecond(60),
+                        item_created_by,
+                        item_last_updated_by,
+                        created_at,
+                        last_updated_at + toIntervalSecond(60),
+                        created_by,
+                        last_updated_by,
+                        workspace_id
+                    FROM dataset_item_versions
+                    WHERE workspace_id = :workspace_id
+                    AND dataset_id = :dataset_id
+                    AND dataset_version_id = :version_id
+                    """;
+
+            clickHouseTemplate.nonTransaction(connection -> {
+                Statement statement = connection.createStatement(sql)
+                        .bind("new_tag", "\"" + newTag + "\"")
+                        .bind("dataset_id", datasetId.toString())
+                        .bind("version_id", versionId.toString())
+                        .bind("workspace_id", WORKSPACE_ID);
+
+                Mono<? extends Result> result = Mono.from(statement.execute());
+                return result;
+            }).block();
+        }
+
+        @Test
+        @DisplayName("Filtered page never returns a row that fails the filter, even when a newer row supersedes it")
+        void filteredPage__whenSupersedingRowFailsTheFilter__thenItIsNotReturned() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 3, "keep");
+            var version = getLatestVersion(datasetId);
+
+            // Two rows per item now: the original tagged "keep", and a newer one tagged "superseded".
+            addSupersedingRow(datasetId, version.id(), "superseded");
+
+            var filter = new DatasetItemFilter(DatasetItemField.DATA, Operator.CONTAINS, "tag", "keep");
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                    API_KEY,
+                    TEST_WORKSPACE);
+
+            assertThat(page.content()).isNotEmpty();
+            assertThat(page.content())
+                    .as("""
+                            Filters are applied before deduplication, so a filtered page only ever contains rows \
+                            that match. If phase 2 of the two-phase read omits the filters, the id is selected \
+                            from the matching older row but resolved to the newer one, and the caller receives \
+                            rows it filtered out.""")
+                    .allSatisfy(item -> assertThat(item.data().get("tag").asText())
+                            .contains("keep")
+                            .doesNotContain("superseded"));
+        }
+
+        @Test
+        @DisplayName("Pages are ordered by id descending and disjoint across the whole version")
+        void pages__areOrderedAndDisjoint() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 25);
+
+            var seen = new ArrayList<UUID>();
+            for (int page = 1; page <= 3; page++) {
+                var content = datasetResourceClient.getDatasetItems(
+                        datasetId, page, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE).content();
+
+                assertThat(content)
+                        .as("page %d must be ordered by id descending, matching the query's leading sort key",
+                                page)
+                        .isSortedAccordingTo(
+                                Comparator.comparing((DatasetItem item) -> item.id().toString()).reversed());
+
+                content.forEach(item -> seen.add(item.id()));
+            }
+
+            assertThat(seen)
+                    .as("paging through the version must visit every item exactly once")
+                    .hasSize(25)
+                    .doesNotHaveDuplicates();
+        }
+
+        @Test
+        @DisplayName("truncate=true returns the page, since truncation runs over the page not the version")
+        void truncatedPage__isReturned() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("page", 1, "size", 3, "truncate", true),
+                    API_KEY,
+                    TEST_WORKSPACE);
+
+            assertThat(page.content()).hasSize(3);
+            assertThat(page.total()).isEqualTo(5);
+        }
+    }
+
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
@@ -1,0 +1,132 @@
+package com.comet.opik.domain;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.lang.reflect.Field;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the shape of {@code SELECT_DATASET_ITEM_VERSIONS} (OPIK-8109).
+ * <p>
+ * The query reads a page of a dataset version in two phases so the wide {@code data} column never enters a
+ * sort. Before this shape, a single-phase query sorted the whole version with {@code data} attached: on a
+ * 120k-item version at ~138 KiB per item that peaked at 30 GiB and returned 500, even for {@code LIMIT 1}.
+ * <p>
+ * These assertions are structural on purpose. The memory behaviour they protect only manifests at dataset
+ * sizes far beyond what an integration test can build, so the cheap, deterministic guard is to assert the
+ * query keeps the payload out of phase 1 and that the three invariants below still hold. Each invariant
+ * broke a draft of the query during OPIK-8109.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("SELECT_DATASET_ITEM_VERSIONS query shape (OPIK-8109):")
+class DatasetItemVersionQueryShapeTest {
+
+    /** Matches the {@code data} column but not {@code dataset_id}, {@code dataset_item_id}, {@code data_hash}. */
+    private static final Pattern BARE_DATA_COLUMN = Pattern.compile("\\bdata\\b");
+
+    private static String sql;
+    private static String phaseOne;
+    private static String phaseTwo;
+
+    @BeforeAll
+    static void readQuery() throws Exception {
+        Class<?> dao = Class.forName("com.comet.opik.domain.DatasetItemVersionDAOImpl");
+        Field field = dao.getDeclaredField("SELECT_DATASET_ITEM_VERSIONS");
+        field.setAccessible(true);
+        sql = (String) field.get(null);
+
+        // The CTE is closed by a line containing only ')'. Everything before it is phase 1.
+        Matcher close = Pattern.compile("(?m)^\\s*\\)\\s*$").matcher(sql);
+        assertThat(close.find())
+                .as("query must contain a closing paren for the 'page' CTE")
+                .isTrue();
+        phaseOne = sql.substring(0, close.start());
+        phaseTwo = sql.substring(close.end());
+    }
+
+    @Test
+    @DisplayName("phase 1 resolves the page from narrow columns, without the data payload")
+    void phaseOne__doesNotSelectThePayload() {
+        assertThat(sql.stripLeading()).startsWith("WITH page AS (");
+
+        assertThat(BARE_DATA_COLUMN.matcher(phaseOne).find())
+                .as("""
+                        phase 1 must not reference the 'data' column. Pulling the payload into the phase that \
+                        sorts is exactly the OPIK-8109 regression: peak memory then scales with the version's \
+                        total payload instead of the page size.""")
+                .isFalse();
+
+        assertThat(BARE_DATA_COLUMN.matcher(phaseTwo).find())
+                .as("phase 2 is what actually returns the payload")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("the page size is applied in phase 1, before any payload is read")
+    void pageSize__isAppliedBeforeFetchingThePayload() {
+        assertThat(phaseOne).contains(":limit");
+        assertThat(phaseTwo)
+                .as("phase 2 is already bounded by the ids from phase 1; a second LIMIT would mask a bug")
+                .doesNotContain(":limit")
+                .doesNotContain(":offset");
+        assertThat(phaseTwo).contains("dataset_item_id IN (SELECT dataset_item_id FROM page)");
+    }
+
+    @Test
+    @DisplayName("invariant 1: both phases order by dataset_item_id DESC first")
+    void invariantOne__bothPhasesShareTheLeadingSortKey() {
+        assertThat(orderByOf(phaseOne)).startsWith("dataset_item_id DESC");
+        assertThat(orderByOf(phaseTwo)).startsWith("dataset_item_id DESC");
+    }
+
+    @Test
+    @DisplayName("invariant 2: the leading sort key is made unique by LIMIT 1 BY dataset_item_id")
+    void invariantTwo__leadingSortKeyIsUniquePerRow() {
+        assertThat(phaseOne).contains("LIMIT 1 BY dataset_item_id");
+        assertThat(phaseTwo).contains("LIMIT 1 BY dataset_item_id");
+    }
+
+    @Test
+    @DisplayName("invariant 3: phase 2 repeats the dataset item filters")
+    void invariantThree__phaseTwoRepeatsTheFilters() {
+        assertThat(occurrences(phaseOne, "<dataset_item_filters>")).isEqualTo(1);
+        assertThat(occurrences(phaseTwo, "<dataset_item_filters>"))
+                .as("""
+                        phase 2 must re-apply the filters. Without them, an id selected in phase 1 via an older \
+                        row that matches the filter resolves in phase 2 to the newest row for that id, which may \
+                        not match, so the caller receives rows it filtered out.""")
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("truncation runs in phase 2, over the page rather than the whole version")
+    void truncation__appliesToThePageOnly() {
+        assertThat(phaseOne)
+                .as("""
+                        the image regex must not run in the sorting phase: replaceRegexpAll expands every value \
+                        before substring trims it, which is why truncate=true was the worst case, not a \
+                        mitigation.""")
+                .doesNotContain("<if(truncate)>");
+        assertThat(phaseTwo).contains("<if(truncate)>");
+    }
+
+    private static String orderByOf(String phase) {
+        Matcher m = Pattern.compile("ORDER BY (.+)").matcher(phase);
+        assertThat(m.find()).as("phase must have an ORDER BY").isTrue();
+        return m.group(1).trim();
+    }
+
+    private static int occurrences(String haystack, String needle) {
+        int count = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+}


### PR DESCRIPTION
## Details

The dataset items page returned 500 for versions with large payloads. `SELECT_DATASET_ITEM_VERSIONS` ordered by `dataset_item_id`, which is not in the table's ordering key `(workspace_id, dataset_id, dataset_version_id, id)`, so `optimize_read_in_order` could not apply and ClickHouse sorted the whole version through a blocking `MergeSortingTransform` with the wide `data` column attached — peak memory scaled with the version's total payload rather than the page size, so requesting one row cost the same as requesting all of them. This resolves the page in two phases: phase 1 picks the page's `dataset_item_id`s from narrow columns only, phase 2 fetches the payload for just those ids.

- Truncation moves to phase 2 so the image regex runs over the page instead of the whole version. `replaceRegexpAll` expands every value before `substring` trims it, which is why `truncate=true` was the worst case rather than a mitigation — it failed **12/12** times at a p50 of 29.85 GiB, and now completes in 25 ms.
- Phase 2's `dataset_item_id IN (...)` is served by the `dataset_item_id` skip indexes added in migration `000074`, which an `ORDER BY` could never use.
- No schema change, no migration, and no change to the template variables, so the calling code and its bindings are untouched. Repeating `<dataset_item_filters>` in phase 2 follows the existing pattern in `SELECT_DATASET_ITEM_VERSIONS_WITH_EXPERIMENT_ITEMS`, which already renders it four times against a single bind.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-8109

Related, not resolved here: escalation CUST_6941; the ordering originates in OPIK_4518 (#5370), which replaced the sort-key-aligned `ORDER BY` with `ORDER BY dataset_item_id` and deferred the projection intended to compensate — a projection that cannot ship, since ClickHouse rejects `ADD PROJECTION` on `ReplacingMergeTree`. The experiment-comparison read path has the same unbounded shape and is tracked separately.

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code CLI
  - Model(s): Claude Opus 5
  - Scope: Root-cause investigation, SQL design, implementation, tests
  - Human verification: Query plans and cost compared on ClickHouse 26.3.16; page contents verified row-identical against the previous query on the affected production dataset across seven offsets, comparing every column including payloads; each invariant's test confirmed to fail when its invariant is removed.

## Testing

`mvn test -Dtest='DatasetVersionResourceTest,DatasetsResourceTest,DatasetItemVersionQueryShapeTest'` — **569 tests, 0 failures** (433 + 130 + 6). Local, testcontainers, macOS. `DatasetsResourceTest` covers `GET /datasets/{id}/items` including the filter-on-`data`, search and `StreamDatasetItems` paths, so the duplicated filter SQL and the restructured `lastRetrievedId` cursor branch are both exercised by pre-existing tests.

**New tests.** `DatasetItemVersionQueryShapeTest` (6 tests, 9 ms) asserts the query's shape by reflection: no bare `data` in phase 1, `:limit` only in phase 1, `<dataset_item_filters>` exactly once per phase, both phases leading with `dataset_item_id DESC`, truncation confined to phase 2. These are structural on purpose — the memory behaviour only manifests at dataset sizes an integration test cannot build, so the cheap deterministic guard is the shape. `DatasetVersionResourceTest$BoundedPageReads` (3 tests) covers the behaviour: a filtered page when a newer row supersedes the matching one, page ordering and disjointness across a version, and `truncate=true`.

**Mutation-checked.** Removing the phase-2 filter and nothing else fails exactly two tests — `filteredPage__whenSupersedingRowFailsTheFilter__thenItIsNotReturned` and `invariantThree__phaseTwoRepeatsTheFilters` — while the other 7 stay green. Under the mutation the filtered page returns rows tagged `superseded` against a filter for `keep`, i.e. rows the caller filtered out. Restored, all 9 pass.

**Measured on the affected production dataset** (119,903 items, ~138 KiB each, 15.8 GiB), page of 10:

| shape | read_bytes | peak memory | outcome |
|---|---|---|---|
| before | 15.83 GiB | 29.97 GiB | 500 |
| after | 19.70 MiB | 14.01 MiB | ok |
| after, `truncate=true` | 19.70 MiB | 18.15 MiB | ok |
| after, sort on a `data` key | 15.84 GiB | 810.13 MiB | ok |
| after, filter on `data` | 15.79 GiB | 2.02 GiB | ok |

Worth a reviewer's attention: filters and sorts derived from `data` still stream the payload to evaluate the predicate, so their peak stays payload-proportional at roughly 5–13%. Comfortable against a 30 GiB cap, but not unbounded — a dataset ~15× larger with a payload filter would reach it again. The default list shape (no sort, no filter) is payload-independent.

**Not run:** the frontend suite (no FE changes), and no video — the change is a single query rewrite with no visible UI change beyond the page loading at all.

## Documentation

None. Internal query shape only; no API or schema change. The invariants that keep the two phases correct are documented in javadoc on the query constant, where the next person to edit it will see them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
