### PR TITLE
[OPIK-8125] [QA] Proposed e2e spec from the #8031 exploration: untruncated experiment-comparison export

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -562,6 +562,7 @@ areas:
       - experiments/experiments-compare.spec.ts
       - experiments/experiment-logs-date-window.spec.ts
       - experiments/compare-json-key-sorting.spec.ts
+      - experiments/compare-export-truncation.spec.ts
       - experiments/experiment-delete.spec.ts
     capabilities:
       list-experiments:        { covered: true,  tier: t1-smoke }
@@ -573,7 +574,7 @@ areas:
       insights-tab:            { covered: false }
       configuration-tab:       { covered: false }
       logs-tab:                { covered: true,  tier: t1-smoke, note: "experiment traces inline; replaced the Go to logs tag" }
-      export-comparison:       { covered: false }
+      export-comparison:       { covered: true,  tier: t2-cuj, note: "CSV + JSON export of the selected compare rows, asserted untruncated against both truncation limits (OPIK-8125)" }
       delete-experiment:       { covered: true,  tier: t2-cuj }
 
     visual:

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -59,6 +59,24 @@ export interface RawApiResult {
   location?: string | null;
 }
 
+/** One experiment's contribution to a row of the experiment-comparison grid. */
+export interface CompareExperimentItemRef {
+  experimentId: string;
+  /**
+   * The linked trace's `output` payload, unflattened. Kept raw because the
+   * endpoint's own type is a union — an object, an array of objects, or a bare
+   * string — and any shaped type here would have to guess which one arrived.
+   */
+  output: unknown;
+}
+
+/** One row of the experiment-comparison grid: a dataset item plus its experiment items. */
+export interface CompareItemRef {
+  id: string;
+  data: Record<string, unknown>;
+  experimentItems: CompareExperimentItemRef[];
+}
+
 /** One row of the dataset's Version history tab. */
 export interface DatasetVersionRef {
   versionName: string;
@@ -775,6 +793,38 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         ...(args.sorting?.length ? { sorting: JSON.stringify(args.sorting) } : {}),
       });
       return (page.content ?? []).map((item) => String(item.id));
+    },
+
+    /**
+     * The experiment-comparison rows themselves — same endpoint as
+     * `listCompareItemIds`, but with `truncate` under the caller's control and
+     * the payloads kept.
+     *
+     * `listCompareItemIds` hard-codes `truncate: true` because it only asserts
+     * order. Here the payload *is* the answer: the grid reads this endpoint
+     * truncated and the export reads it whole, so a caller has to be able to ask
+     * for both and compare them.
+     */
+    async listCompareItems(args: {
+      datasetId: string;
+      experimentIds: string[];
+      truncate: boolean;
+      size?: number;
+    }): Promise<CompareItemRef[]> {
+      const page = await opik.api.datasets.findDatasetItemsWithExperimentItems(args.datasetId, {
+        experimentIds: JSON.stringify(args.experimentIds),
+        size: args.size ?? 100,
+        page: 1,
+        truncate: args.truncate,
+      });
+      return (page.content ?? []).map((item) => ({
+        id: String(item.id),
+        data: (item.data ?? {}) as Record<string, unknown>,
+        experimentItems: (item.experimentItems ?? []).map((experimentItem) => ({
+          experimentId: String(experimentItem.experimentId),
+          output: experimentItem.output,
+        })),
+      }));
     },
 
     /**

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -6,6 +6,8 @@ export {
   type DatasetItemRef,
   type DatasetItemWithTagsRef,
   type DatasetVersionRef,
+  type CompareItemRef,
+  type CompareExperimentItemRef,
   type RawApiResult,
   type BackendSort,
   type MetricSeries,

--- a/tests_end_to_end/e2e/fixtures/grouped-dataset.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/grouped-dataset.fixture.ts
@@ -1,4 +1,4 @@
-import { test as baseTest } from './json-output-experiment.fixture';
+import { test as baseTest } from './long-value-experiment.fixture';
 import { shouldLeaveArtifacts } from '../core/artifacts';
 
 /** The `data` key the filter scopes on. */
@@ -120,4 +120,4 @@ export const test = baseTest.extend<GroupedDatasetFixtures>({
   },
 });
 
-export { expect } from './json-output-experiment.fixture';
+export { expect } from './long-value-experiment.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -86,6 +86,17 @@ export {
   JSON_SORT_PREFIXES,
   LABEL_COLUMN,
 } from './json-output-experiment.fixture';
+export type {
+  LongValueLabel,
+  LongValueRowRef,
+  LongValueExperimentRef,
+  LongValueExperimentFixtures,
+} from './long-value-experiment.fixture';
+export {
+  SLIM_STRING_MAX_LENGTH,
+  SLIM_TRUNCATION_SUFFIX,
+  DATASET_TRUNCATION_SIZE,
+} from './long-value-experiment.fixture';
 export type { GroupedDatasetRef, GroupedDatasetFixtures } from './grouped-dataset.fixture';
 export { GROUP_COLUMN, TARGET_GROUP } from './grouped-dataset.fixture';
 export type {

--- a/tests_end_to_end/e2e/fixtures/long-value-experiment.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/long-value-experiment.fixture.ts
@@ -1,0 +1,277 @@
+import { test as baseTest } from './json-output-experiment.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7 } from '../core/backend';
+
+/**
+ * The backend's two independent truncation limits, both of which the compare
+ * grid's `truncate=true` read applies and its export must not.
+ *
+ * They are deliberately different mechanisms, and a value that trips one does
+ * not necessarily trip the other:
+ *  - the experiment item's trace `output` is slimmed by
+ *    `TruncationUtils.DEFAULT_SLIM_STRING_MAX_LENGTH` (1 000) and gains a
+ *    literal `...` suffix, so a truncated value is 1 003 characters long;
+ *  - the dataset item's `data` map is cut by
+ *    `responseFormatting.truncationSize` (10 001, `OPIK_RESPONSE_TRUNCATION_
+ *    CHAR_LIMIT`) with **no** suffix, so a truncated value is exactly 10 001
+ *    characters and looks perfectly ordinary.
+ */
+export const SLIM_STRING_MAX_LENGTH = 1_000;
+export const SLIM_TRUNCATION_SUFFIX = '...';
+export const DATASET_TRUNCATION_SIZE = 10_001;
+
+/** The three rows the fixture seeds, named for where they sit against those limits. */
+export type LongValueLabel = 'short' | 'long' | 'huge';
+
+export interface LongValueRowRef {
+  label: LongValueLabel;
+  itemId: string;
+  traceId: string;
+  /** The dataset item's `input`, as seeded — whole. */
+  input: string;
+  /** The linked trace's `output.output`, as seeded — whole. */
+  output: string;
+}
+
+export interface LongValueExperimentRef {
+  datasetId: string;
+  datasetName: string;
+  experimentId: string;
+  experimentName: string;
+  /** All three rows, in insertion order. */
+  rows: LongValueRowRef[];
+  /** Under every limit: neither its input nor its output is ever truncated. */
+  short: LongValueRowRef;
+  /** Output over the 1 000-char slim limit; input under the 10 001-char dataset limit. */
+  long: LongValueRowRef;
+  /** Both input and output over the 10 001-char dataset limit. */
+  huge: LongValueRowRef;
+}
+
+export interface LongValueExperimentFixtures {
+  longValueExperiment: LongValueExperimentRef;
+}
+
+/**
+ * A deterministic string of at least `minLength` characters.
+ *
+ * Every word is numbered, so a truncated copy and a whole one differ visibly at
+ * the tail rather than only in length — and the `-END` marker means "did this
+ * value arrive complete?" can be asked of a CSV by substring alone.
+ *
+ * Deliberately free of commas, quotes and newlines: the CSV assertions compare
+ * the seeded text against the file as written, and a value the CSV writer had
+ * to quote or escape would no longer appear in it verbatim.
+ */
+const filler = (marker: string, minLength: number): string => {
+  const parts = [`${marker}-START`];
+  let length = parts[0].length;
+  for (let i = 0; length < minLength; i++) {
+    const word = `${marker}-w${String(i).padStart(5, '0')}`;
+    parts.push(word);
+    length += word.length + 1;
+  }
+  parts.push(`${marker}-END`);
+  return parts.join(' ');
+};
+
+/**
+ * The seed. Lengths are chosen to straddle both limits — see the constants
+ * above — and the fixture asserts they really do before the values are written,
+ * because a seed that fell under a limit would make every downstream assertion
+ * pass against a build with the truncation bug still in it.
+ */
+const SEED: Array<{ label: LongValueLabel; input: string; output: string }> = [
+  {
+    label: 'short',
+    input: 'short-input-value',
+    output: 'short-output-value',
+  },
+  {
+    label: 'long',
+    input: filler('LONGIN', 2_000),
+    output: filler('LONGOUT', 2_400),
+  },
+  {
+    label: 'huge',
+    input: filler('HUGEIN', 11_500),
+    output: filler('HUGEOUT', 11_500),
+  },
+];
+
+/**
+ * One experiment over three dataset items whose values straddle the backend's
+ * two truncation limits.
+ *
+ * This is the shape OPIK-8125 is about: the comparison grid reads these rows
+ * truncated (so the long values render cut) while Export must read them whole.
+ * Both halves have to be seeded — a dataset input alone tops out at the 10 001
+ * limit and an experiment output alone at 1 000, and the fix has to hold for
+ * both.
+ *
+ * Traces are written through the REST client rather than the SDK bridge for the
+ * same reason `jsonOutputExperiment` does it: the bridge's nested-trace helper
+ * resolves the id it returns with a `search_traces` per call, which is both
+ * slower and rate-limited, and writing the id means no read-back is needed.
+ *
+ * Teardown lives here so it survives a mid-test failure: experiments and
+ * datasets do not cascade with project deletion, and traces do not go away with
+ * the experiment.
+ */
+export const test = baseTest.extend<LongValueExperimentFixtures>({
+  longValueExperiment: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const datasetName = `${testNamespace}-trunc-ds`;
+    const experimentName = `${testNamespace}-trunc-exp`;
+
+    // Assert the seed before writing it: these lengths are the whole reason the
+    // fixture discriminates, and a filler that came up short would leave a spec
+    // that cannot fail.
+    const requireSeed = (condition: boolean, why: string): void => {
+      if (!condition) throw new Error(`[longValueExperiment fixture] ${why}`);
+    };
+    const seedFor = (label: LongValueLabel): { input: string; output: string } => {
+      const row = SEED.find((candidate) => candidate.label === label);
+      if (!row) throw new Error(`[longValueExperiment fixture] no seed row labelled ${label}`);
+      return row;
+    };
+    const short = seedFor('short');
+    const long = seedFor('long');
+    const huge = seedFor('huge');
+    requireSeed(
+      short.input.length < SLIM_STRING_MAX_LENGTH && short.output.length < SLIM_STRING_MAX_LENGTH,
+      'the short row must sit under every truncation limit, so it can prove a whole value is left alone',
+    );
+    for (const [label, row] of [
+      ['long', long],
+      ['huge', huge],
+    ] as const) {
+      requireSeed(
+        row.output.length > SLIM_STRING_MAX_LENGTH,
+        `the ${label} output is ${row.output.length} chars — it must exceed the ` +
+          `${SLIM_STRING_MAX_LENGTH}-char slim limit to be truncated at all`,
+      );
+    }
+    requireSeed(
+      long.input.length < DATASET_TRUNCATION_SIZE,
+      `the long input is ${long.input.length} chars — it must stay under the ` +
+        `${DATASET_TRUNCATION_SIZE}-char dataset limit, so it can show that limit is not applied blindly`,
+    );
+    requireSeed(
+      huge.input.length > DATASET_TRUNCATION_SIZE && huge.output.length > DATASET_TRUNCATION_SIZE,
+      `the huge row must exceed the ${DATASET_TRUNCATION_SIZE}-char dataset limit on both axes`,
+    );
+
+    const dataset = await sdkClient.python.createDataset({
+      project_name: project.name,
+      name: datasetName,
+      description: 'Export of experiment comparison rows must not truncate',
+      items: SEED.map((row) => ({
+        label: row.label,
+        input: row.input,
+        expected_output: row.label,
+      })) as unknown as Array<Record<string, unknown>>,
+    });
+
+    // Read the ids back rather than generating them, and key them by the label
+    // column so nothing downstream depends on the insertion order.
+    const storedItems = await backendClient.getDatasetItems(dataset.id);
+    const itemIdByLabel = new Map<string, string>();
+    for (const item of storedItems) {
+      const label = item.data.label;
+      if (typeof label !== 'string') {
+        throw new Error(`[longValueExperiment fixture] dataset item ${item.id} has no string "label"`);
+      }
+      itemIdByLabel.set(label, item.id);
+    }
+    if (itemIdByLabel.size !== SEED.length) {
+      throw new Error(
+        `[longValueExperiment fixture] expected ${SEED.length} distinct labels, got ${itemIdByLabel.size}`,
+      );
+    }
+
+    const rows: LongValueRowRef[] = [];
+    for (const row of SEED) {
+      const itemId = itemIdByLabel.get(row.label);
+      if (!itemId) throw new Error(`[longValueExperiment fixture] no dataset item for label ${row.label}`);
+      const traceId = await backendClient.createTraceWithSource({
+        id: uuid7(),
+        projectName: project.name,
+        name: `${testNamespace}-${row.label}`,
+        source: 'sdk',
+        input: { input: row.input },
+        output: { output: row.output },
+      });
+      rows.push({ label: row.label, itemId, traceId, input: row.input, output: row.output });
+    }
+
+    const experimentId = uuid7();
+    await backendClient.createExperiment({
+      id: experimentId,
+      name: experimentName,
+      datasetName,
+      projectName: project.name,
+    });
+    await backendClient.createExperimentItems(
+      rows.map((row) => ({ experimentId, datasetItemId: row.itemId, traceId: row.traceId })),
+    );
+
+    const byLabel = (label: LongValueLabel): LongValueRowRef => {
+      const row = rows.find((candidate) => candidate.label === label);
+      if (!row) throw new Error(`[longValueExperiment fixture] no seeded row labelled ${label}`);
+      return row;
+    };
+
+    const ref: LongValueExperimentRef = {
+      datasetId: dataset.id,
+      datasetName,
+      experimentId,
+      experimentName,
+      rows,
+      short: byLabel('short'),
+      long: byLabel('long'),
+      huge: byLabel('huge'),
+    };
+
+    // Attach the shape, not the payloads: the seeded strings run to ~12 000
+    // characters each and would bury the rest of the trace.
+    await testInfo.attach('opik.longValueExperiment', {
+      body: JSON.stringify(
+        {
+          datasetId: ref.datasetId,
+          datasetName,
+          experimentId,
+          experimentName,
+          rows: rows.map((row) => ({
+            label: row.label,
+            itemId: row.itemId,
+            traceId: row.traceId,
+            inputLength: row.input.length,
+            outputLength: row.output.length,
+          })),
+        },
+        null,
+        2,
+      ),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      const safe = async (what: string, fn: () => Promise<unknown>): Promise<void> => {
+        try {
+          await fn();
+        } catch (err) {
+          console.warn(`[longValueExperiment fixture] delete warning for ${what}:`, err);
+        }
+      };
+      // Experiment before the dataset it references; traces last, because they
+      // do not go away with the experiment.
+      await safe(`experiment ${experimentId}`, () => backendClient.deleteExperiment(experimentId));
+      await safe(`dataset ${datasetName}`, () => backendClient.deleteDataset(dataset.id));
+      await safe('traces', () => backendClient.deleteTraces(rows.map((row) => row.traceId)));
+    }
+  },
+});
+
+export { expect } from './json-output-experiment.fixture';

--- a/tests_end_to_end/e2e/pom/compare-experiments.page.ts
+++ b/tests_end_to_end/e2e/pom/compare-experiments.page.ts
@@ -1,3 +1,4 @@
+import * as fs from 'node:fs/promises';
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
@@ -202,6 +203,63 @@ export class CompareExperimentsPage {
       );
       await this.page.goto(url.toString());
       await this.itemRows.first().waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * The full rendered text of one grid cell, addressed by row id and column id
+   * (`data_input`, `output_output`) rather than by position — column order here
+   * is user-configurable and persisted, so an index would read the wrong cell
+   * for anyone who had reordered the grid.
+   *
+   * Unlike `readItemOutput`, this reads the whole cell rather than one
+   * experiment's band, which is what single-experiment mode renders.
+   */
+  async readCellText(datasetItemId: string, columnId: string): Promise<string> {
+    return test.step(`read cell "${columnId}" of item ${datasetItemId}`, async () => {
+      const cell = this.page.locator(`td[data-cell-id="${datasetItemId}_${columnId}"]`);
+      await expect(cell, `cell "${columnId}" of item ${datasetItemId}`).toHaveCount(1);
+      await expect(cell, `cell "${columnId}" of item ${datasetItemId}`).toBeVisible();
+      return ((await cell.textContent()) ?? '').trim();
+    });
+  }
+
+  /** Tick the selection checkbox on one dataset item's row. */
+  async selectItemRow(datasetItemId: string): Promise<void> {
+    await test.step(`select the row for item ${datasetItemId}`, async () => {
+      const row = this.page.locator(`tbody tr[data-row-id="${datasetItemId}"]`);
+      await expect(row, `row for item ${datasetItemId}`).toHaveCount(1);
+      await row.getByRole('checkbox', { name: 'Select row' }).click();
+    });
+  }
+
+  /**
+   * Export the selected rows through the toolbar's Export menu and return the
+   * downloaded file's contents.
+   *
+   * The trigger is an icon-only button with no accessible name and no
+   * `data-testid`, so it is addressed by the icon it renders — its identity, not
+   * its position. A `data-testid` on `ExportToButton` would be the better handle
+   * and is worth adding; it is not added here because this spec has to run
+   * against already-built deployments, where a fresh front-end attribute does
+   * not exist yet. `toHaveCount(1)` guards against the locator widening.
+   */
+  async exportAs(format: 'CSV' | 'JSON'): Promise<string> {
+    return test.step(`export the selected rows as ${format}`, async () => {
+      const trigger = this.page
+        .locator('button[aria-haspopup="menu"]')
+        .filter({ has: this.page.locator('svg.lucide-download') });
+      await expect(trigger, 'the Export menu trigger').toHaveCount(1);
+      await expect(trigger, 'the Export menu trigger is enabled once rows are selected').toBeEnabled();
+
+      const downloadPromise = this.page.waitForEvent('download');
+      await trigger.click();
+      await this.page.getByRole('menuitem', { name: `Export as ${format}` }).click();
+      const download = await downloadPromise;
+
+      const failure = await download.failure();
+      expect(failure, `the ${format} download completed`).toBeNull();
+      return fs.readFile(await download.path(), 'utf8');
     });
   }
 

--- a/tests_end_to_end/e2e/tests/experiments/compare-export-truncation.spec.ts
+++ b/tests_end_to_end/e2e/tests/experiments/compare-export-truncation.spec.ts
@@ -1,0 +1,241 @@
+import { test, expect } from '@e2e/fixtures';
+import {
+  DATASET_TRUNCATION_SIZE,
+  SLIM_STRING_MAX_LENGTH,
+  SLIM_TRUNCATION_SUFFIX,
+} from '@e2e/fixtures';
+import type { CompareItemRef } from '@e2e/core/backend';
+import { CompareExperimentsPage } from '@e2e/pom/compare-experiments.page';
+
+/**
+ * Exporting experiment-comparison rows downloads the whole value, not the
+ * truncated copy the grid renders (OPIK-8125).
+ *
+ * The export used to reuse the table's own query, so it inherited the table's
+ * `truncate` flag and wrote cut values into the file. What makes this worth a
+ * permanent test is that it is silent: the grid looks identical either way — it
+ * is *supposed* to show truncated text — and the only place the defect appears
+ * is inside a downloaded file, on the path people take precisely when they want
+ * the data whole. Nothing errors, nothing is missing, and a 1 000-character
+ * answer is long enough to look complete.
+ *
+ * `experiments.export-comparison` was previously uncovered.
+ * `experiments-compare.spec.ts` drives the same grid but seeds single-character
+ * outputs, so it would pass unchanged against a truncating export.
+ *
+ * Two limits are exercised because they are two different mechanisms and the
+ * fix has to hold for both: the experiment output is slimmed at 1 000
+ * characters with a `...` suffix, and the dataset item's data map is cut at
+ * 10 001 with no suffix at all. See the fixture for the details.
+ *
+ * The first step asserts, through the API, that the truncated read really does
+ * cut these values before the browser is opened — without it a green export
+ * assertion would prove nothing, because a seed that fell under both limits
+ * round-trips whole through a broken build too.
+ */
+
+/** Every list read the compare grid issues, as its `truncate` query param. */
+const COMPARE_ITEMS_PATH = /\/items\/experiments\/items$/;
+
+const rowById = (rows: CompareItemRef[], itemId: string): CompareItemRef => {
+  const row = rows.find((candidate) => candidate.id === itemId);
+  expect(row, `the compare read returned a row for dataset item ${itemId}`).toBeDefined();
+  return row as CompareItemRef;
+};
+
+/** The dataset item's `input` as one compare row carries it. */
+const datasetInput = (row: CompareItemRef): string => {
+  const value = row.data.input;
+  expect(typeof value, `row ${row.id} carries a string data.input`).toBe('string');
+  return value as string;
+};
+
+/** The `output.output` string one compare row carries for its single experiment item. */
+const experimentOutput = (row: CompareItemRef): string => {
+  expect(row.experimentItems, `row ${row.id} has exactly one experiment item`).toHaveLength(1);
+  const output = row.experimentItems[0].output;
+  expect(output, `row ${row.id} carries an output payload`).toBeTruthy();
+  const value = (output as Record<string, unknown>).output;
+  expect(typeof value, `row ${row.id} carries a string output.output`).toBe('string');
+  return value as string;
+};
+
+/** The rows of a JSON export, asserted into shape rather than cast into it. */
+const jsonExportRows = (body: string): Array<Record<string, unknown>> => {
+  const parsed: unknown = JSON.parse(body);
+  expect(Array.isArray(parsed), 'the JSON export is an array of rows').toBe(true);
+  return parsed as Array<Record<string, unknown>>;
+};
+
+const exportedField = (row: Record<string, unknown>, key: string): string => {
+  const value = row[key];
+  expect(typeof value, `the exported row carries a string "${key}"`).toBe('string');
+  return value as string;
+};
+
+test.describe('Experiment comparison export — truncation', { tag: ['@t2-cuj', '@area:experiments'] }, () => {
+  /**
+   * Seeding ~28 000 characters of dataset and trace payload, waiting for the
+   * experiment linkage to settle, then driving two downloads runs past the
+   * default budget against a cloud backend — and the overrun surfaces as a
+   * timeout on whichever step happened to be last, which reads like a product
+   * failure and is not one. Declared on the describe so it covers fixture setup.
+   */
+  test.slow();
+
+  test(
+    'exporting the selected rows writes the whole value the grid shows truncated',
+    { tag: ['@cap:experiments.export-comparison'] },
+    async ({ longValueExperiment, project, backendClient, page }) => {
+      const { datasetId, experimentId, rows, short, long, huge } = longValueExperiment;
+
+      const readCompareItems = (truncate: boolean): Promise<CompareItemRef[]> =>
+        backendClient.listCompareItems({ datasetId, experimentIds: [experimentId], truncate });
+
+      await test.step('The fixture discriminates: the truncated read really does cut these values', async () => {
+        // The experiment-item linkage is eventually consistent, so poll the
+        // untruncated read until every seeded row is joined to its trace output.
+        // Polling the *joined* read covers both writes at once: this shape can
+        // only appear once the linkage exists and the trace output is queryable.
+        await expect
+          .poll(
+            async () => {
+              const items = await readCompareItems(false);
+              return items.filter((item) => item.experimentItems.length === 1).length;
+            },
+            { timeout: 120_000, intervals: [1_000, 2_000, 5_000] },
+          )
+          .toBe(rows.length);
+
+        const whole = await readCompareItems(false);
+        expect(whole, 'the untruncated read returns exactly the seeded rows').toHaveLength(rows.length);
+        for (const row of rows) {
+          const read = rowById(whole, row.itemId);
+          expect(datasetInput(read), `${row.label} input, read untruncated`).toBe(row.input);
+          expect(experimentOutput(read), `${row.label} output, read untruncated`).toBe(row.output);
+        }
+
+        const cut = await readCompareItems(true);
+        expect(cut, 'the truncated read returns exactly the seeded rows').toHaveLength(rows.length);
+
+        // The experiment-output axis: over 1 000 characters is slimmed to
+        // 1 000 + a literal "..." suffix.
+        for (const row of [long, huge]) {
+          const truncatedOutput = experimentOutput(rowById(cut, row.itemId));
+          expect(truncatedOutput, `${row.label} output, read truncated`).toHaveLength(
+            SLIM_STRING_MAX_LENGTH + SLIM_TRUNCATION_SUFFIX.length,
+          );
+          expect(truncatedOutput.endsWith(SLIM_TRUNCATION_SUFFIX), `${row.label} output carries the "..." suffix`)
+            .toBe(true);
+          expect(truncatedOutput, `${row.label} output is not the whole value`).not.toBe(row.output);
+        }
+
+        // The dataset-input axis: a different limit, ten times larger, with no
+        // suffix — so only the `huge` row is cut, and it is cut to exactly the
+        // limit.
+        expect(datasetInput(rowById(cut, huge.itemId)), 'huge input, read truncated').toHaveLength(
+          DATASET_TRUNCATION_SIZE,
+        );
+        expect(datasetInput(rowById(cut, long.itemId)), 'long input sits under the dataset limit and is left whole')
+          .toBe(long.input);
+        expect(experimentOutput(rowById(cut, short.itemId)), 'the short output is left whole either way')
+          .toBe(short.output);
+      });
+
+      // Record the `truncate` flag of every compare-items list read the page
+      // issues, so the export can be asserted at its cause (its own untruncated
+      // request) and not only at its symptom (the file's contents).
+      const listReadFlags: Array<string | null> = [];
+      page.on('request', (request) => {
+        const url = new URL(request.url());
+        if (COMPARE_ITEMS_PATH.test(url.pathname)) {
+          listReadFlags.push(url.searchParams.get('truncate'));
+        }
+      });
+
+      const compare = new CompareExperimentsPage(page, project.id, datasetId, [experimentId]);
+
+      await test.step('Open the compare Results tab', async () => {
+        await compare.gotoResults();
+        await compare.waitForResultsReady();
+        expect(await compare.countItemRows(), 'every seeded item has a row').toBe(rows.length);
+        expect(listReadFlags, 'the grid asks for its rows truncated').toContain('true');
+      });
+
+      await test.step('The grid renders the truncated copy, on both axes', async () => {
+        const renderedOutput = await compare.readCellText(long.itemId, 'output_output');
+        expect(renderedOutput, 'the long output cell shows the slimmed value').toHaveLength(
+          SLIM_STRING_MAX_LENGTH + SLIM_TRUNCATION_SUFFIX.length,
+        );
+        expect(renderedOutput.endsWith(SLIM_TRUNCATION_SUFFIX), 'the long output cell ends in "..."').toBe(true);
+
+        expect(
+          await compare.readCellText(huge.itemId, 'data_input'),
+          'the huge input cell shows the value cut at the dataset limit',
+        ).toHaveLength(DATASET_TRUNCATION_SIZE);
+      });
+
+      await test.step('Select the two long rows, leaving the short row unselected', async () => {
+        await compare.selectItemRow(long.itemId);
+        await compare.selectItemRow(huge.itemId);
+      });
+
+      await test.step('The JSON export holds exactly those two rows, whole', async () => {
+        const flagsBefore = listReadFlags.length;
+        const body = await compare.exportAs('JSON');
+        expect(
+          listReadFlags.slice(flagsBefore),
+          'the export issued its own untruncated read rather than reusing the grid\'s',
+        ).toContain('false');
+
+        const exported = jsonExportRows(body);
+        expect(exported, 'only the selected rows are exported').toHaveLength(2);
+
+        const byInput = new Map(exported.map((row) => [exportedField(row, 'dataset.input'), row]));
+        expect(
+          [...byInput.keys()].sort(),
+          'the exported inputs are exactly the two selected ones, byte for byte',
+        ).toEqual([long.input, huge.input].sort());
+
+        for (const row of [long, huge]) {
+          const exportedRow = byInput.get(row.input);
+          expect(exportedRow, `the ${row.label} row is in the export`).toBeDefined();
+          expect(
+            exportedField(exportedRow as Record<string, unknown>, 'output.output'),
+            `${row.label} output, exported`,
+          ).toBe(row.output);
+        }
+
+        expect(body.includes(short.input), 'the unselected row must not leak into the export').toBe(false);
+        expect(
+          exported.some((row) =>
+            Object.values(row).some(
+              (value) => typeof value === 'string' && value.endsWith(SLIM_TRUNCATION_SUFFIX),
+            ),
+          ),
+          'no exported value carries a truncation suffix',
+        ).toBe(false);
+      });
+
+      await test.step('The CSV export holds the same two rows, whole', async () => {
+        const flagsBefore = listReadFlags.length;
+        const body = await compare.exportAs('CSV');
+        expect(
+          listReadFlags.slice(flagsBefore),
+          'the export issued its own untruncated read rather than reusing the grid\'s',
+        ).toContain('false');
+
+        // The seeded values carry no comma, quote or newline, so the writer has
+        // nothing to escape and they appear in the file verbatim — which is why
+        // a substring check is a fair test of "arrived whole" here.
+        expect(body.trim().split('\n'), 'a header row and exactly the two selected rows').toHaveLength(3);
+        for (const row of [long, huge]) {
+          expect(body.includes(row.input), `${row.label} input, exported whole`).toBe(true);
+          expect(body.includes(row.output), `${row.label} output, exported whole`).toBe(true);
+        }
+        expect(body.includes(short.input), 'the unselected row must not leak into the export').toBe(false);
+        expect(body.includes(SLIM_TRUNCATION_SUFFIX), 'no exported value carries a truncation suffix').toBe(false);
+      });
+    },
+  );
+});


### PR DESCRIPTION
**Generated by the release QA side flow (test-proposal step). It is a draft and needs human review before merge — nothing here has been reviewed by a person.**

## Where this came from

Exploratory testing of [opik#8031](https://github.com/comet-ml/opik/pull/8031) (`[OPIK-8125] [FE] fix: export experiment items without truncation`). A human-driven exploration verified the flow end to end on that PR's own deployed environment (`pr-8031.dev.comet.com`, `2.2.42-8031-merge-3115`, OSS install, workspace `default`) before any spec was written. This PR turns the one strong candidate from that exploration into a permanent spec.

**Base note.** The task I was given said #8031 was still open with its head branch alive, and told me to target `jacques/OPIK-8125-export-truncation` in that case. That snapshot was stale: #8031 **merged at 2026-08-27T09:38:47Z** as `bfa4ced0ef7217c5f98af301c369700b8efd22d1`, and the head branch has since been deleted (`git ls-remote --heads origin` no longer lists it). So this targets **`main`**, where the fix already lives. The spec was written against the PR's head commit `96dec07ec2335de21a0516aa32f9553cdd6e776d` and then rebased onto current `main` (`472c30818`) before being run again — see "Verification" for exactly what ran where.

## What the spec covers

**`tests_end_to_end/e2e/tests/experiments/compare-export-truncation.spec.ts`** — `@t2-cuj`, `@area:experiments`, `@cap:experiments.export-comparison` (previously `covered: false`).

One test: *exporting the selected rows writes the whole value the grid shows truncated*.

The change under test is a single React Query param — the export refetch now passes `truncate: false` instead of inheriting the table's flag — so the only way to see it is to press Export and read the file. What makes it worth a permanent test is that it is **silent**: the grid renders identically in the broken and the fixed build (it is *supposed* to show truncated text), nothing errors, nothing is missing, and a 1 000-character answer is long enough to look complete. The defect only exists inside a downloaded file, on the path people take precisely when they want the data whole.

What it asserts, in order:

1. **The fixture discriminates**, through the API, before a browser is opened: the same rows read with `truncate=false` come back byte-identical to the seed, and read with `truncate=true` come back cut. Without this a green export assertion would prove nothing — a seed that fell under both limits round-trips whole through a broken build too.
2. The grid itself still renders the truncated copy, on both axes.
3. Selecting two of the three rows and exporting **JSON** yields exactly two rows, whose `dataset.input` and `output.output` are string-equal to the seeded values, with no `...` suffix anywhere and the unselected row absent.
4. The same for **CSV**: a header plus exactly two rows, each seeded string present verbatim, the unselected row's input absent.
5. Each export issued **its own** compare-items read carrying `truncate=false`, rather than reusing the grid's truncated one — the regression asserted at its cause as well as its symptom, following the pattern `experiment-logs-date-window.spec.ts` already uses in this area.

**Two truncation limits, not one.** They are separate mechanisms and the fix has to hold for both, so the fixture seeds both:

| axis | limit | suffix | seeded |
|---|---|---|---|
| experiment output (`output.output`) | `TruncationUtils.DEFAULT_SLIM_STRING_MAX_LENGTH` = 1 000 | `...` (so a cut value is 1 003 chars) | ~2 400 and ~11 500 chars |
| dataset item `data` map (`dataset.input`) | `responseFormatting.truncationSize` = 10 001 | **none** — a cut value looks perfectly ordinary | ~2 000 (under, control) and ~11 500 (over) |

A 2 000-character dataset input is *not* truncated, so a spec that only seeded that would have passed against the pre-fix build on the dataset axis. The `long` row is deliberately kept under the dataset limit to act as that control.

`experiments-compare.spec.ts` drives the same grid but seeds single-character outputs, so it would pass unchanged against a truncating export.

### Supporting changes

- **`fixtures/long-value-experiment.fixture.ts`** (new) — one experiment over three dataset items straddling both limits. Seeded through the SDK bridge (dataset) and the REST client (traces + experiment linkage), the same shape `jsonOutputExperiment` uses and for the same reason. It asserts its own seed lengths against both limits before writing, so a filler that came up short fails loudly instead of leaving a spec that cannot fail. Teardown lives in the fixture (experiment → dataset → traces) and honours `shouldLeaveArtifacts`. Chained between `jsonOutputExperiment` and `groupedDataset`.
- **`core/backend`** — `listCompareItems()`, the compare-items read with `truncate` under the caller's control and the payloads kept. The existing `listCompareItemIds()` hard-codes `truncate: true` because it only asserts order; here the payload *is* the answer.
- **`pom/compare-experiments.page.ts`** — `selectItemRow()`, `readCellText()` (by row id + column id, never by position — column order is user-configurable and persisted), and `exportAs('CSV' | 'JSON')`, which drives the toolbar menu and returns the captured download's contents.
- **`coverage/taxonomy.yaml`** — spec added to the `experiments` `specs:` list; `export-comparison` flipped to `covered: true, tier: t2-cuj`.

## Verification

Run from `tests_end_to_end/e2e/` against the exploration's environment, `OPIK_DEPLOYMENT=oss`, `OPIK_BASE_URL=https://pr-8031.dev.comet.com`, workspace `default`.

| check | command | result |
|---|---|---|
| the new spec | `npx playwright test tests/experiments/compare-export-truncation.spec.ts` | **1 passed** (7.0s) |
| the whole area (shared POM touched) | `npx playwright test tests/experiments/` | **10 passed** (58.7s) |
| tags | `python3 tests_end_to_end/coverage/tag_lint.py --taxonomy … --estate tests_end_to_end` | `52 specs checked, 1 exempt, 0 problem(s)` |
| types | `npx tsc --noEmit` | **0 errors** — but see the caveat below |

Both Playwright runs above were executed **after** rebasing onto current `main`, so the estate code under test is `main`'s.

**Two honest caveats about "against main":**

1. The *application* those runs hit is the PR's own deployment, which carries this fix but was built before `472c30818` (`[OPIK-8109] [BE] fix: bound dataset items page read by page size`) — the one commit to land on `main` since. That change rewrites `SELECT_DATASET_ITEM_VERSIONS`, a different query path from the compare-items endpoint this spec reads, so it is not expected to interact; but I could not deploy `main` itself, so that is reasoning, not a run. The first CI run on this PR is the real check.
2. `npx tsc --noEmit` as documented in `.agents/skills/writing-e2e-tests/SKILL.md` currently fails on `main` before reaching any source file: `tsconfig.json(13,5): error TS5102: Option 'baseUrl' has been removed`, from the pinned `typescript@7.0.2`. I got the 0-error result above by extending the repo tsconfig with `paths` rewritten and `types: ["node"]`, which typechecks the whole estate cleanly, including these files. **This is pre-existing and not caused by this PR** — it reproduces on unmodified `main` — but it means the skill's own typecheck step is currently a no-op for everyone, and it is worth fixing separately.

## What I deliberately did not write

The exploration produced **two** candidates. One was written; **one was dropped**:

- **"Export is identical whether or not workspace table truncation is enabled"** (marked `weak` by the exploration). It is the tightest regression-lock available — the pre-fix export changed with the workspace preference, and the exploration confirmed the CSV and JSON download byte-identical (matching md5) with truncation on and off. It is dropped because driving it needs a **workspace-level** preference flip, which is shared state that this suite's per-test fixtures do not isolate: it would corrupt any spec running in parallel against the same workspace, and leave the workspace dirty if the test died mid-flip. It also largely duplicates the assertion the shipped spec already makes. Worth revisiting if the estate grows a safe way to scope a workspace preference to one test.

## Follow-up worth doing (not done here)

`ExportToButton` renders an icon-only trigger with no accessible name and no `data-testid`, so the POM addresses it by the icon it renders, guarded with `toHaveCount(1)`. A `data-testid` on that shared component is the better handle and conventions ask for one in the same change — I did not add it because this spec had to be *run* against an already-built deployment, where a brand-new front-end attribute does not exist, and an unrunnable spec is worse than a CSS selector. A reviewer adding that attribute and switching the POM to `getByTestId` in a follow-up would be a straight improvement.

---

Source PR: [comet-ml/opik#8031](https://github.com/comet-ml/opik/pull/8031) · OPIK-8125



[OPIK-8125]: https://comet-ml.atlassian.net/browse/OPIK-8125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OPIK-8109]: https://comet-ml.atlassian.net/browse/OPIK-8109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- comet-qa-test-radar: propose -->