### PR TITLE
[OPIK-8105] [QA] Proposed e2e specs from the #8037 exploration: quick attribute filter handoff

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -248,6 +248,7 @@ areas:
       - trace-explore/trace-spans-depth.spec.ts
       - trace-explore/trace-delete.spec.ts
       - trace-explore/trace-filters.spec.ts
+      - trace-explore/quick-filter-handoff.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -258,7 +259,7 @@ areas:
       span-model-cost-tokens: { covered: true,  tier: t2-cuj }
       trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
-      toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
+      toggle-spans-view:      { covered: true,  tier: t2-cuj, note: "Reached via the details panel's quick attribute filter, which moves the table to Spans; the toggle's own click is asserted only as the return trip to Traces" }
       filter-traces:          { covered: true,  tier: t2-cuj }
       configure-columns:      { covered: false }
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1192,6 +1192,31 @@ export function makeBackendClient(apiKey: string | null = null) {
     },
 
     /**
+     * Spans visible for a project under `filters`, as `{id, name}` —
+     * `GET /v1/private/spans`. The name comes back alongside the id because the
+     * SDK bridge's `createNestedTrace` answers with the trace id and a span
+     * count but no span ids, so a seed that needs to assert on exact span ids
+     * has to resolve them by the names it chose.
+     *
+     * Same `filters` shape as `listTraceIds`, which is what lets a fixture prove
+     * server-side that a filter really discriminates before a spec asserts the
+     * same narrowing in the browser.
+     */
+    async listSpans(
+      args: { projectId: string; traceId?: string; filters?: BackendFilter[]; size?: number },
+    ): Promise<Array<{ id: string; name: string }>> {
+      const page = await opik.api.spans.getSpansByProject({
+        projectId: args.projectId,
+        size: args.size ?? 200,
+        page: 1,
+        truncate: true,
+        ...(args.traceId ? { traceId: args.traceId } : {}),
+        ...(args.filters?.length ? { filters: JSON.stringify(args.filters) } : {}),
+      });
+      return (page.content ?? []).map((s) => ({ id: String(s.id), name: String(s.name ?? '') }));
+    },
+
+    /**
      * Create a trace with an explicit id and `source`. The SDK bridge always
      * emits `source=sdk`; the optimization-trial overlay filters on
      * `source=optimization`, so a trial-log fixture cannot be built through the

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './bystander.fixture';
+export { test, expect } from './quick-filter-attributes.fixture';
 export type {
   OauthProviderSeed,
   ProviderKeysFixture,
@@ -94,4 +94,10 @@ export type {
   TokenUsageSpansFixtures,
 } from './token-usage-spans.fixture';
 export type { AutomationRulesCleanupFixtures } from './automation-rules.fixture';
+export type {
+  QuickFilterSpanRef,
+  QuickFilterTraceRef,
+  QuickFilterAttributesRef,
+  QuickFilterAttributesFixtures,
+} from './quick-filter-attributes.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/quick-filter-attributes.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/quick-filter-attributes.fixture.ts
@@ -1,0 +1,222 @@
+import { test as baseTest, expect } from './bystander.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import type { BackendFilter } from '../core/backend';
+
+export interface QuickFilterSpanRef {
+  id: string;
+  name: string;
+}
+
+export interface QuickFilterTraceRef {
+  id: string;
+  name: string;
+  /** `alpha` | `beta` | `gamma` — also the span's `span_owner` metadata value. */
+  suffix: string;
+  /** Value of the trace's `trace_env` metadata attribute. */
+  traceEnv: string;
+  spans: { retrieve: QuickFilterSpanRef; generate: QuickFilterSpanRef };
+}
+
+export interface QuickFilterAttributesRef {
+  traces: QuickFilterTraceRef[];
+  /** Span metadata key/value the quick-filter click hands off (`stage: retrieve`). */
+  spanStage: { key: string; value: string };
+  /** Second span metadata key, used to prove a handoff appends rather than overwrites. */
+  spanOwner: { key: string; value: string };
+  /** Trace metadata key/value, for the mirror direction (Spans -> Traces). */
+  traceEnvAttribute: { key: string; value: string };
+  /** Every seeded span id, in no particular order. */
+  allSpanIds: string[];
+  /** The span ids a `metadata.stage contains retrieve` filter must return — and only these. */
+  stageSpanIds: string[];
+  /** The one span id that survives `stage contains retrieve` AND `span_owner contains <value>`. */
+  stageAndOwnerSpanId: string;
+  /** The trace ids a `metadata.trace_env contains prod` filter must return — and only these. */
+  traceEnvTraceIds: string[];
+}
+
+export interface QuickFilterAttributesFixtures {
+  quickFilterAttributes: QuickFilterAttributesRef;
+}
+
+const STAGE_KEY = 'stage';
+const STAGE_VALUE = 'retrieve';
+const OTHER_STAGE_VALUE = 'generate';
+const OWNER_KEY = 'span_owner';
+const TRACE_ENV_KEY = 'trace_env';
+const TRACE_ENV_VALUE = 'prod';
+
+/**
+ * Three traces, each with a `retrieve` and a `generate` child span. Attributes
+ * are staggered so every filter the quick-filter handoff can write narrows to a
+ * *different*, non-trivial subset — a handoff that dropped its row, or wrote it
+ * against the wrong field, would return everything and fail the assertion
+ * rather than quietly passing:
+ *
+ *   span   metadata.stage      contains "retrieve" -> 3 of 6 spans
+ *   span   metadata.span_owner contains "beta"     -> 1 of those 3
+ *   trace  metadata.trace_env  contains "prod"     -> 2 of 3 traces
+ *
+ * `span_owner` is what makes the append case assertable: it is a key the first
+ * handoff knows nothing about, so a second handoff that overwrote instead of
+ * appending would leave 3 rows in the table rather than 1.
+ */
+const SEEDS: Array<{ suffix: string; traceEnv: string }> = [
+  { suffix: 'alpha', traceEnv: TRACE_ENV_VALUE },
+  { suffix: 'beta', traceEnv: TRACE_ENV_VALUE },
+  { suffix: 'gamma', traceEnv: 'staging' },
+];
+
+/** The seed whose `span_owner` the append test hands off as its second filter. */
+const OWNER_VALUE = 'beta';
+
+const metadataFilter = (key: string, value: string): BackendFilter => ({
+  field: 'metadata',
+  type: 'dictionary',
+  operator: 'contains',
+  key,
+  value,
+});
+
+export const test = baseTest.extend<QuickFilterAttributesFixtures>({
+  quickFilterAttributes: async (
+    { sdkClient, backendClient, project, testNamespace },
+    use,
+    testInfo,
+  ) => {
+    const traces: QuickFilterTraceRef[] = [];
+
+    for (const seed of SEEDS) {
+      const traceName = `${testNamespace}-${seed.suffix}`;
+      const spanNames = {
+        retrieve: `${traceName}-${STAGE_VALUE}`,
+        generate: `${traceName}-${OTHER_STAGE_VALUE}`,
+      };
+
+      const created = await sdkClient.python.createNestedTrace({
+        project_name: project.name,
+        name: traceName,
+        input: { query: `question from ${seed.suffix}` },
+        output: { answer: `answer from ${seed.suffix}` },
+        metadata: { [TRACE_ENV_KEY]: seed.traceEnv },
+        spans: [
+          {
+            name: spanNames.retrieve,
+            type: 'general',
+            input: { step: STAGE_VALUE },
+            output: { done: true },
+            metadata: { [STAGE_KEY]: STAGE_VALUE, [OWNER_KEY]: seed.suffix },
+          },
+          {
+            name: spanNames.generate,
+            type: 'general',
+            input: { step: OTHER_STAGE_VALUE },
+            output: { done: true },
+            metadata: { [STAGE_KEY]: OTHER_STAGE_VALUE, [OWNER_KEY]: seed.suffix },
+          },
+        ],
+      });
+
+      // The bridge answers with the trace id and a span count but no span ids,
+      // and these specs assert on exact span ids in the Spans table — so resolve
+      // them by the names chosen above.
+      const spans = await backendClient.listSpans({
+        projectId: project.id,
+        traceId: created.id,
+      });
+      const byName = (name: string): QuickFilterSpanRef => {
+        const matches = spans.filter((s) => s.name === name);
+        if (matches.length !== 1) {
+          throw new Error(
+            `[quickFilterAttributes fixture] expected exactly 1 span named "${name}" under trace ${created.id}, got ${matches.length}`,
+          );
+        }
+        return matches[0];
+      };
+
+      traces.push({
+        id: created.id,
+        name: created.name,
+        suffix: seed.suffix,
+        traceEnv: seed.traceEnv,
+        spans: { retrieve: byName(spanNames.retrieve), generate: byName(spanNames.generate) },
+      });
+    }
+
+    const stageSpanIds = traces.map((t) => t.spans.retrieve.id);
+    const ownerTrace = traces.find((t) => t.suffix === OWNER_VALUE);
+    if (!ownerTrace) {
+      throw new Error(`[quickFilterAttributes fixture] no seed with suffix "${OWNER_VALUE}"`);
+    }
+
+    const ref: QuickFilterAttributesRef = {
+      traces,
+      spanStage: { key: STAGE_KEY, value: STAGE_VALUE },
+      spanOwner: { key: OWNER_KEY, value: OWNER_VALUE },
+      traceEnvAttribute: { key: TRACE_ENV_KEY, value: TRACE_ENV_VALUE },
+      allSpanIds: traces.flatMap((t) => [t.spans.retrieve.id, t.spans.generate.id]),
+      stageSpanIds,
+      stageAndOwnerSpanId: ownerTrace.spans.retrieve.id,
+      traceEnvTraceIds: traces.filter((t) => t.traceEnv === TRACE_ENV_VALUE).map((t) => t.id),
+    };
+
+    // Prove server-side that the seed really discriminates before any spec
+    // opens a browser over it. A UI assertion sitting on a fixture whose
+    // metadata never landed is a test that cannot fail — and it would read as
+    // coverage forever. Polled because the write is eventually consistent.
+    await expect
+      .poll(
+        async () =>
+          (
+            await backendClient.listSpans({
+              projectId: project.id,
+              filters: [metadataFilter(STAGE_KEY, STAGE_VALUE)],
+            })
+          )
+            .map((s) => s.id)
+            .sort(),
+        { timeout: 30_000, message: 'seeded spans filtered by metadata.stage' },
+      )
+      .toEqual([...stageSpanIds].sort());
+
+    const stageAndOwner = await backendClient.listSpans({
+      projectId: project.id,
+      filters: [metadataFilter(STAGE_KEY, STAGE_VALUE), metadataFilter(OWNER_KEY, OWNER_VALUE)],
+    });
+    expect(stageAndOwner.map((s) => s.id)).toEqual([ref.stageAndOwnerSpanId]);
+
+    await expect
+      .poll(
+        async () =>
+          (
+            await backendClient.listTraceIds({
+              projectId: project.id,
+              filters: [metadataFilter(TRACE_ENV_KEY, TRACE_ENV_VALUE)],
+            })
+          ).sort(),
+        { timeout: 30_000, message: 'seeded traces filtered by metadata.trace_env' },
+      )
+      .toEqual([...ref.traceEnvTraceIds].sort());
+
+    await testInfo.attach('opik.quickFilterAttributes', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    // Deleting the project does not take its traces with it, and the
+    // run-prefix sweep in global-teardown only knows about experiments,
+    // datasets and projects — so the traces (and with them their spans) are
+    // deleted here, where teardown runs on pass, fail and timeout alike.
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteTraces(traces.map((t) => t.id));
+      } catch (err) {
+        console.warn('[quickFilterAttributes fixture] trace delete warning:', err);
+      }
+    }
+  },
+});
+
+export { expect } from './bystander.fixture';

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -5,6 +5,18 @@ import { ThreadPanelPage } from './thread-panel.page';
 
 export type ExplainKind = 'error' | 'duration' | 'cost';
 
+/**
+ * One row of a Logs view's filter state as it is written into the URL, with the
+ * client-generated `id` dropped (see LogsPage.readFilterRows).
+ */
+export interface LogsFilterRow {
+  field: string;
+  type?: string;
+  operator: string;
+  key?: string;
+  value: string;
+}
+
 // Maps an explain kind to the Traces table column id (used in data-cell-id)
 // and the owl trigger's aria-label, per apps/opik-frontend/src/plugins/comet/explain/registry.ts.
 const EXPLAIN_COLUMN: Record<ExplainKind, string> = {
@@ -86,6 +98,25 @@ export class LogsPage {
       const env = loadEnvConfig();
       const url = `${env.baseUrl}/${env.workspace}/projects/${this.projectId}/logs?trace=${traceId}`;
       await this.page.goto(url);
+      return new TracePanelPage(this.page, traceId);
+    });
+  }
+
+  /**
+   * Open a trace's panel by clicking its row, rather than by navigating to
+   * `?trace=<id>` the way `openTraceById` does.
+   *
+   * The distinction matters whenever the test's subject lives in the URL: the
+   * quick-filter handoff writes `spans_filters` into the query string of the
+   * view it is *not* on, and a `page.goto()` rebuilt from projectId alone would
+   * drop it. Clicking mutates the existing URL, which is also what a user does.
+   */
+  async openTraceRow(traceId: string): Promise<TracePanelPage> {
+    return test.step(`Open trace ${traceId} from its row`, async () => {
+      const row = this.traceRow(traceId);
+      await row.waitFor({ state: 'visible' });
+      await row.click();
+      await this.page.waitForURL((url) => url.searchParams.get('trace') === traceId);
       return new TracePanelPage(this.page, traceId);
     });
   }
@@ -414,6 +445,112 @@ export class LogsPage {
     return test.step('Clear all filters', async () => {
       await this.clearAllFiltersButton.click();
       await this.clearAllFiltersButton.waitFor({ state: 'hidden' });
+    });
+  }
+
+  // --- Logs type toggle (Threads / Traces / Spans) ---
+
+  /** The Threads/Traces/Spans tab toggle for "Traces". */
+  get tracesTab(): Locator {
+    return this.page.getByRole('radio', { name: 'Traces' });
+  }
+
+  /** The Threads/Traces/Spans tab toggle for "Spans". */
+  get spansTab(): Locator {
+    return this.page.getByRole('radio', { name: 'Spans' });
+  }
+
+  /**
+   * Switch the table to Spans/Traces/Threads and wait for `logsType` to settle.
+   *
+   * The toggle sits behind the details panel's modal overlay (the panel marks
+   * the rest of the page `aria-hidden`), so close the panel before calling this.
+   */
+  async switchLogsType(logsType: 'traces' | 'spans' | 'threads'): Promise<void> {
+    return test.step(`Switch the Logs table to ${logsType}`, async () => {
+      const tab = { traces: this.tracesTab, spans: this.spansTab, threads: this.threadsTab }[
+        logsType
+      ];
+      await tab.click();
+      await this.page.waitForURL((url) => url.searchParams.get('logsType') === logsType);
+    });
+  }
+
+  /** The `logsType` the URL currently selects. Absent means the default, Traces. */
+  currentLogsType(): string {
+    return new URL(this.page.url()).searchParams.get('logsType') ?? 'traces';
+  }
+
+  /** The `page` query parameter as a number, or null when it isn't set. */
+  currentPageParam(): number | null {
+    const raw = new URL(this.page.url()).searchParams.get('page');
+    return raw === null ? null : Number(raw);
+  }
+
+  /**
+   * The filter rows a Logs view is carrying in the URL (`traces_filters` /
+   * `spans_filters`), or **null** when the parameter is absent entirely.
+   *
+   * Null and `[]` are deliberately distinct: "the origin view's filters were
+   * never touched" is a different fact from "they were written as empty", and
+   * collapsing the two would let an overwrite pass.
+   *
+   * Each row's client-generated `id` is dropped — it is a fresh nonce per click
+   * and nothing user-visible depends on it.
+   */
+  readFilterRows(view: 'traces' | 'spans'): LogsFilterRow[] | null {
+    const raw = new URL(this.page.url()).searchParams.get(`${view}_filters`);
+    if (raw === null) return null;
+    const parsed = JSON.parse(raw) as Array<LogsFilterRow & { id?: string }>;
+    return parsed.map(({ id: _id, ...row }) => row);
+  }
+
+  /**
+   * The number shown in the count metrics card while the Spans tab is active.
+   * The Spans view reuses the Traces view's count-card testid, so this is the
+   * same read as `countTraces()` — named separately so a spec says which
+   * entity it means.
+   */
+  async countSpans(): Promise<number> {
+    return test.step('Read span count', async () => {
+      const valueEl = this.page.getByTestId('metrics-card-count-value');
+      await valueEl.waitFor({ state: 'visible' });
+      const text = (await valueEl.textContent()) ?? '';
+      const digits = text.replace(/\D/g, '');
+      return digits ? Number(digits) : 0;
+    });
+  }
+
+  /** Wait for the Spans table to be ready, gated on a specific span's row. */
+  async waitForSpansReady(spanId: string): Promise<void> {
+    return test.step(`Wait for the Spans table to show span ${spanId}`, async () => {
+      await this.spanRow(spanId).waitFor({ state: 'visible' });
+    });
+  }
+
+  /**
+   * Rows of the Spans table. The Spans view reuses the shared DataTable, so a
+   * row's `data-row-id` is the span id — the same hook `traceRow` keys on.
+   */
+  get spanRows(): Locator {
+    return this.page.locator('tr[data-row-id]');
+  }
+
+  /** A span row, keyed by span id. */
+  spanRow(spanId: string): Locator {
+    return this.page.locator(`tr[data-row-id="${spanId}"]`);
+  }
+
+  /** The span ids currently rendered in the Spans table, in table order. */
+  async readSpanIdsInOrder(): Promise<string[]> {
+    return test.step('Read span IDs in table order', async () => {
+      await this.spanRows.first().waitFor({ state: 'visible' });
+      const ids: string[] = [];
+      for (const row of await this.spanRows.all()) {
+        const id = await row.getAttribute('data-row-id');
+        if (id) ids.push(id);
+      }
+      return ids;
     });
   }
 

--- a/tests_end_to_end/e2e/pom/trace-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/trace-panel.page.ts
@@ -1,4 +1,4 @@
-import { test, type Page, type Locator } from '@playwright/test';
+import { test, expect, type Page, type Locator } from '@playwright/test';
 
 export class TracePanelPage {
   constructor(
@@ -176,6 +176,53 @@ export class TracePanelPage {
     const tag = this.feedbackScoreTag(scoreName);
     await tag.waitFor({ state: 'visible' });
     return (await tag.getByTestId('feedback-score-tag-value').textContent())?.trim() ?? '';
+  }
+
+  // --- Quick attribute filters ---
+
+  /**
+   * The inline quick-filter affordance on one attribute line of the Details
+   * tab's Input / Output / Metadata viewers.
+   *
+   * `destination` is the accessible name the button carries, and it is a real
+   * assertion rather than a locator detail: the label names the table the click
+   * will filter ("Filter spans by this attribute" when a span is selected,
+   * "…traces…" otherwise), so asking for the wrong one fails instead of
+   * clicking the right icon for the wrong reason.
+   *
+   * Scoping to `.cm-line` is deliberate and, for now, unavoidable. The button
+   * itself has a role and an accessible name, but every filterable attribute in
+   * the panel carries the *same* name, so the line is the only thing that says
+   * which attribute. The line is rendered imperatively by CodeMirror (see
+   * `quickFilterExtension.ts`), not by a React component a `data-testid` could
+   * be added to. It is matched by content rather than position — anchored and
+   * exact, so `stage: retrieve` cannot also match `stage: retrieve-later` — and
+   * the caller asserts the lookup resolved to exactly one line.
+   */
+  quickFilterButton(attributeLine: string, destination: 'traces' | 'spans'): Locator {
+    const anchored = new RegExp(`^${attributeLine.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`);
+    return this.root
+      .locator('.cm-line')
+      .filter({ hasText: anchored })
+      .getByRole('button', { name: `Filter ${destination} by this attribute` });
+  }
+
+  /**
+   * Click the quick-filter icon on an attribute line.
+   *
+   * Only clicks — it deliberately does not wait for an outcome, because the two
+   * outcomes differ: an in-place apply leaves the table where it is, while a
+   * handoff moves it to the other view. The caller waits for the one it expects.
+   */
+  async quickFilterAttribute(
+    attributeLine: string,
+    destination: 'traces' | 'spans',
+  ): Promise<void> {
+    return test.step(`Quick-filter "${attributeLine}" into the ${destination} view`, async () => {
+      const button = this.quickFilterButton(attributeLine, destination);
+      await expect(button).toHaveCount(1);
+      await button.click();
+    });
   }
 
   /** Rendered input text inside the panel's Details tab. */

--- a/tests_end_to_end/e2e/tests/trace-explore/quick-filter-handoff.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/quick-filter-handoff.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage, type LogsFilterRow } from '@e2e/pom/logs.page';
+import type { TracePanelPage } from '@e2e/pom/trace-panel.page';
+import type { QuickFilterAttributesRef } from '@e2e/fixtures';
+
+/**
+ * The details panel's quick-filter icon sits on attributes that belong to the
+ * selected span, but the panel can be opened from the Traces tab — where the
+ * span table that owns such a filter is not mounted. The filter is therefore
+ * written into the other view's URL state by hand and the table follows.
+ *
+ * Both tests assert the exact surviving row ids rather than a count alone. A
+ * handoff that dropped its row, or wrote it against the wrong field, leaves the
+ * user on a table that still renders — just with the wrong rows in it — so
+ * "the table changed" is not evidence the filter was carried across.
+ */
+test.describe('Quick attribute filter handoff', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  /** The row the handoff must write for a `metadata.<key>` attribute. */
+  const metadataRow = (key: string, value: string): LogsFilterRow => ({
+    field: 'metadata',
+    type: 'dictionary',
+    operator: 'contains',
+    key,
+    value,
+  });
+
+  /**
+   * Open a trace from the Traces table, select one of its spans, and quick-filter
+   * one of that span's metadata attributes into the Spans view.
+   *
+   * Rows are opened by click rather than by URL, because `spans_filters` lives in
+   * the query string the handoff just wrote and a rebuilt URL would drop it.
+   */
+  const handOffSpanAttribute = async (
+    logs: LogsPage,
+    seed: QuickFilterAttributesRef,
+    suffix: string,
+    attribute: { key: string; value: string },
+  ): Promise<TracePanelPage> => {
+    const trace = seed.traces.find((t) => t.suffix === suffix);
+    if (!trace) {
+      throw new Error(`handOffSpanAttribute: the seed carries no trace with suffix "${suffix}"`);
+    }
+
+    const panel = await logs.openTraceRow(trace.id);
+    await panel.waitForFullyLoaded();
+    await panel.selectSpan(trace.spans.retrieve.name);
+    await panel.quickFilterAttribute(`${attribute.key}: ${attribute.value}`, 'spans');
+    await expect.poll(() => logs.currentLogsType()).toBe('spans');
+    return panel;
+  };
+
+  test(
+    'Quick-filtering a span attribute from the Traces tab moves the table to Spans and narrows to the matching spans',
+    { tag: ['@cap:traces.toggle-spans-view'] },
+    async ({ quickFilterAttributes, project, page }) => {
+      const logs = new LogsPage(page);
+      const { spanStage, stageSpanIds, traces } = quickFilterAttributes;
+
+      await test.step('Open Logs on the Traces tab with every seeded trace listed', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        await expect(logs.traceRows).toHaveCount(traces.length);
+        expect(logs.currentLogsType()).toBe('traces');
+      });
+
+      const panel = await test.step('Select a span and quick-filter its metadata attribute', async () =>
+        handOffSpanAttribute(logs, quickFilterAttributes, 'alpha', spanStage));
+
+      await test.step('The filter lands in the Spans view, and only there', async () => {
+        await expect
+          .poll(() => logs.readFilterRows('spans'))
+          .toEqual([metadataRow(spanStage.key, spanStage.value)]);
+        // The origin view's own filters must be left alone — asserted as
+        // "never written" rather than "empty", which an overwrite would satisfy.
+        expect(logs.readFilterRows('traces')).toBeNull();
+        // The destination shows a fresh result set, so the page the user was on
+        // would land them past the end of it.
+        expect(logs.currentPageParam()).toBe(1);
+      });
+
+      await test.step('The Logs type toggle has moved to Spans', async () => {
+        // The panel is modal — the rest of the page is aria-hidden until it closes.
+        await panel.close();
+        await expect(logs.spansTab).toHaveAttribute('aria-checked', 'true');
+        await expect(logs.tracesTab).toHaveAttribute('aria-checked', 'false');
+      });
+
+      await test.step('The Spans table holds exactly the matching spans', async () => {
+        await logs.waitForSpansReady(stageSpanIds[0]);
+        await expect(logs.spanRows).toHaveCount(stageSpanIds.length);
+        for (const spanId of stageSpanIds) {
+          await expect(logs.spanRow(spanId)).toBeVisible();
+        }
+        // The sibling `generate` spans share every other attribute, so they are
+        // what separates a real filter from a table that merely re-rendered.
+        for (const trace of traces) {
+          await expect(logs.spanRow(trace.spans.generate.id)).toBeHidden();
+        }
+        expect(await logs.countSpans()).toBe(stageSpanIds.length);
+      });
+    },
+  );
+
+  test(
+    'A handed-off filter appends to the destination and a repeat of it does not duplicate',
+    { tag: ['@cap:traces.toggle-spans-view'] },
+    async ({ quickFilterAttributes, project, page }) => {
+      const logs = new LogsPage(page);
+      const { spanStage, spanOwner, stageSpanIds, stageAndOwnerSpanId, traces } =
+        quickFilterAttributes;
+      const stageRow = metadataRow(spanStage.key, spanStage.value);
+      const ownerRow = metadataRow(spanOwner.key, spanOwner.value);
+
+      await test.step('Hand off a first span filter from the Traces tab', async () => {
+        await logs.goto(project.id);
+        await logs.waitForReady();
+        const panel = await handOffSpanAttribute(logs, quickFilterAttributes, 'alpha', spanStage);
+        await panel.close();
+
+        await expect.poll(() => logs.readFilterRows('spans')).toEqual([stageRow]);
+        await logs.waitForSpansReady(stageSpanIds[0]);
+        await expect(logs.spanRows).toHaveCount(stageSpanIds.length);
+      });
+
+      await test.step('Return to the Traces tab, which is still unfiltered', async () => {
+        await logs.switchLogsType('traces');
+        await logs.waitForReady();
+        expect(logs.readFilterRows('traces')).toBeNull();
+        await expect(logs.traceRows).toHaveCount(traces.length);
+        // The handed-off filter is held for the Spans view, not thrown away.
+        expect(logs.readFilterRows('spans')).toEqual([stageRow]);
+      });
+
+      await test.step('Hand off a second filter, on a key the first knows nothing about', async () => {
+        const panel = await handOffSpanAttribute(logs, quickFilterAttributes, 'beta', spanOwner);
+        await panel.close();
+
+        // Appended, not overwritten: the first row survives, in place.
+        await expect.poll(() => logs.readFilterRows('spans')).toEqual([stageRow, ownerRow]);
+        await logs.waitForSpansReady(stageAndOwnerSpanId);
+        await expect(logs.spanRows).toHaveCount(1);
+        await expect(logs.spanRow(stageAndOwnerSpanId)).toBeVisible();
+        expect(await logs.countSpans()).toBe(1);
+      });
+
+      await test.step('Repeating the identical handoff leaves the filter and the table unchanged', async () => {
+        await logs.switchLogsType('traces');
+        await logs.waitForReady();
+        const panel = await handOffSpanAttribute(logs, quickFilterAttributes, 'beta', spanOwner);
+        await panel.close();
+
+        await expect.poll(() => logs.readFilterRows('spans')).toEqual([stageRow, ownerRow]);
+        await logs.waitForSpansReady(stageAndOwnerSpanId);
+        await expect(logs.spanRows).toHaveCount(1);
+        expect(await logs.countSpans()).toBe(1);
+      });
+    },
+  );
+});


### PR DESCRIPTION
**Generated by the QA test-radar side flow (test-proposal step). It is a draft and needs human review before merge — nothing here has been reviewed by a person.**

## Where this came from

Exploratory testing of [opik#8037](https://github.com/comet-ml/opik/pull/8037) (`[OPIK-8105] [FE] fix: send quick attribute filters to the view that owns them`). A human-driven exploration worked the flow end to end on that PR's **own** deployed environment (`pr-8037.dev.comet.com`, `2.2.42-6454`, OSS install, workspace `default`) before any spec was written; it reported 7 items working and 1 suspicious. This PR turns the two **strong** candidates from that exploration into permanent specs.

**This targets the PR's branch, not `main`.** At the time of writing, #8037 is **open** and `jacquesverre/OPIK-8105-quick-filter-view-handoff` still exists, with head `c42caf7c29afaf182db1be1f35170bebd91369d4` — the commit this branch is cut from and the commit the specs were run against. The behaviour under test only exists in that PR: on `main` the quick-filter click has no handoff path at all, so `useLogsQuickAttributeFilter.ts` isn't there and the spec would fail. Merging this into `main` before #8037 lands would break CI. If #8037 is ever closed rather than merged, close this too.

## What the specs cover

**`tests_end_to_end/e2e/tests/trace-explore/quick-filter-handoff.spec.ts`** — `@t2-cuj`, `@area:traces`, `@cap:traces.toggle-spans-view` (previously `covered: false`, noted as "only Traces+Threads covered").

Two tests, one per behaviour worth failing separately.

### 1. Quick-filtering a span attribute from the Traces tab moves the table to Spans and narrows to the matching spans

This is the seam the PR's own unit tests stop short of. `useLogsQuickAttributeFilter.test.ts` pins the hook at the hook boundary; nothing runs a handed-off row against a real spans table. The failure mode it guards is silent: a row whose `field`/`type` the spans list rejects leaves the user on an empty table with no error, and a unit suite green.

What it asserts, in order:

1. Logs opens on Traces with all three seeded traces listed.
2. A child span is selected in the tree (the `?span=` param is what decides which view owns the filter).
3. Clicking the `stage: retrieve` metadata icon flips `logsType` to `spans`.
4. `spans_filters` carries **exactly one** row — `field=metadata, type=dictionary, operator=contains, key=stage, value=retrieve` — asserted as the whole array, so a leaked extra row fails.
5. `traces_filters` is still **absent**. Asserted as "never written", not "empty": collapsing null and `[]` would let an overwrite of the origin view's filters pass.
6. `page` is reset to `1` — the destination shows a fresh result set, so the page the user was on would land them past the end of it.
7. The toggle now reads Spans (`aria-checked`), and Traces does not.
8. The Spans table holds **exactly** the three `retrieve` spans, by id, with each sibling `generate` span asserted hidden and the count card asserted too. A row count alone would not catch a filter that returned the right number of wrong rows.

### 2. A handed-off filter appends to the destination and a repeat of it does not duplicate

The handoff writer merges into a view that is **not mounted**, by hand, through a URL param and a `localStorage` pinned-chip key (`useLogsQuickAttributeFilter.ts`, `useHandoffWriter`). Append-vs-overwrite and the dedupe predicate are exactly where a hand-rolled merge breaks, and a drop would silently discard a filter the user had already set.

After the first handoff it returns to the Traces tab (by clicking the toggle — **not** by navigating, because the handed-off filter lives in the query string a rebuilt URL would drop), asserts the origin view is genuinely untouched and still lists all three traces, then hands off a second filter on `span_owner` — a key the first handoff knows nothing about. `spans_filters` must be `[stage, span_owner]` with the first row unchanged, and the table must narrow from 3 spans to exactly 1. Repeating the identical click must leave both at exactly that.

### Supporting changes

- **`fixtures/quick-filter-attributes.fixture.ts`** (new) — three traces, each with a `retrieve` and a `generate` child span, metadata staggered so every filter the handoff can write narrows to a *different*, non-trivial subset (`stage` → 3 of 6 spans, `+span_owner` → 1 of those 3, `trace_env` → 2 of 3 traces). A handoff that dropped its row would return everything and fail, rather than quietly passing.

  It **proves it can discriminate before the browser opens**: the same filters are read back through the API and asserted to return exactly those ids. A UI assertion sitting on a seed whose metadata never landed is a test that cannot fail, and it would read as coverage forever. Seeded through the SDK bridge; teardown deletes the traces in the fixture (deleting a project does not take its traces with it, and the run-prefix sweep in `global-teardown.ts` doesn't know about spans) and honours `shouldLeaveArtifacts`.
- **`core/backend/client.ts`** — `listSpans()`. The bridge's `createNestedTrace` answers with the trace id and a span count but no span ids, and these specs assert on exact span ids; this resolves them by name and is also what lets the fixture cross-check a span filter server-side.
- **`pom/logs.page.ts`** — `openTraceRow()` (click-based, for the reason above), the logs-type toggle (`tracesTab` / `spansTab` / `switchLogsType`), span rows keyed on `data-row-id`, `countSpans()`, and `readFilterRows()` / `currentLogsType()` / `currentPageParam()` for the URL state that *is* the subject here.
- **`pom/trace-panel.page.ts`** — `quickFilterAttribute()`. The button's accessible name is the destination-naming hint, so the POM takes `'traces' | 'spans'` and asking for the wrong one fails rather than clicking the right icon for the wrong reason.
- **`coverage/taxonomy.yaml`** — spec added to the `traces` `specs:` list; `toggle-spans-view` flipped to `covered: true, tier: t2-cuj` with a note scoping what is actually asserted (the view is reached via the handoff; the toggle's own click is exercised only as the return trip to Traces).

## Verification

Run from `tests_end_to_end/e2e/` against the exploration's environment — `OPIK_DEPLOYMENT=oss`, `OPIK_BASE_URL=https://pr-8037.dev.comet.com`, workspace `default` — at this branch's head.

| check | command | result |
|---|---|---|
| the new spec | `npx playwright test tests/trace-explore/quick-filter-handoff.spec.ts` | **2 passed** (16.5s) |
| the whole area (shared POMs touched) | `npx playwright test tests/trace-explore/` | **20 passed** (1.2m) |
| tags | `python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end` | `51 specs checked, 1 exempt, 0 problem(s)` |
| types | `tsc --noEmit -p tsconfig.json` | **0 errors** — but see the caveat below |

Two environment notes, neither of which affects CI:

- **`tsc` had to be run with TypeScript 5.9, not the pinned 7.0.2.** `tests_end_to_end/e2e/tsconfig.json` sets `baseUrl`, which TS 7 removed, so `npx tsc --noEmit` fails with `TS5102` on this branch **and on `main` alike** — it is pre-existing and nothing to do with this change, so I have not "fixed" it here. Under TS 5.9 the suite typechecks clean.
- **`OPIK_API_KEY` had to be set to a dummy value** for the run. The TS SDK requires an API key whenever the host ends in `comet.com`, and this OSS install is served from `pr-8037.dev.comet.com` — an artefact of testing against a PR deployment, not of the specs. CI runs against `localhost:5173` and is unaffected.

## What I deliberately did not write

- **The third candidate — quick-filtering a trace attribute from the Threads tab.** The exploration verified it works and flagged it `weak` itself, for the right reason: no `threads` capability describes filtering, and the nearest uncovered key, `threads.thread-actions-panel`, is about the panel's *actions*, not about a filter handoff. Claiming it would mark a capability covered that nothing tested, and a capability marked covered is never re-derived. It is a genuinely distinct code path (`ThreadsTab` passes no `values`/`applyValue`/`pinChip`, so the hook has nothing local to fall back on and must hand off or silently do nothing) and worth covering — but it needs a capability key that fits first. Happy to add it as a third test here if a reviewer names one.
- **The suspicious finding: the destination-naming confirmation tooltip.** The exploration found that `"Filter applied to Spans"` / `"…to Traces"` — the affordance this PR set out to add — **never renders**, because the handoff's `onLogsTypeChange` remounts the tab and tears down the CodeMirror `EditorView` (and with it the `QuickFilterTooltip` that `activate()` had just called `showApplied()` on). Functionally the handoff is correct and the table moving is itself feedback, so this is cosmetic — but the confirmation half is dead code in practice. A spec asserting it would fail today, so it is not in this PR. Worth a test once the remount question is decided.

## Reviewer notes

- `pom/trace-panel.page.ts` scopes the quick-filter button to `.cm-line`. Every filterable attribute in the panel carries the *same* accessible name, so the line is the only thing that says which attribute — and the line is rendered imperatively by CodeMirror (`quickFilterExtension.ts`), not by a React component a `data-testid` could go on. It is matched by content, anchored and exact, never by position, and the lookup is asserted to resolve to exactly one element. If you would rather have a `data-testid` stamped on the widget in `quickFilterExtension.ts`, say so and I will move it there.
- The specs never assert on the client-generated `id` inside a filter row — it is a fresh nonce per click.

<!-- comet-qa-test-radar: propose -->


[OPIK-8105]: https://comet-ml.atlassian.net/browse/OPIK-8105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ