### PR TITLE
[NA] [BE] fix: bind dataset item filters to item-level columns in page and count

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -427,7 +427,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * Truncation stays in phase 2 so the image regex runs over the page instead of the whole version.
      * <p>
      * Three invariants hold this together. Each one broke a draft of this query, and each has a regression test
-     * in {@code DatasetItemVersionPaginationTest}:
+     * in {@code DatasetItemVersionQueryShapeTest}:
      * <ol>
      *   <li>Both phases order by {@code dataset_item_id DESC} first. A mismatch reorders the page.</li>
      *   <li>The ordering's leading key, {@code dataset_item_id}, is unique per output row after
@@ -439,18 +439,36 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      *   <li>Phase 2 repeats {@code dataset_item_filters}. Without it, an id selected in phase 1 via a superseded
      *       row that matches the filter resolves in phase 2 to the newest row for that id, which may not match,
      *       returning rows the caller filtered out.</li>
+     *   <li>Phase 1 projects the same aliases as phase 2. ClickHouse binds {@code WHERE} and {@code ORDER BY} to
+     *       {@code SELECT} aliases, and the dataset item filters emit bare {@code id}, {@code created_at},
+     *       {@code last_updated_at}, {@code created_by} and {@code last_updated_by}. Drop the aliases and those
+     *       predicates bind to this table's physical columns instead: on a version whose rows were snapshotted
+     *       long after the items were authored, a {@code created_at} filter returned 175 items where the correct
+     *       answer was 0.</li>
      * </ol>
      */
     private static final String SELECT_DATASET_ITEM_VERSIONS = """
             WITH page AS (
-                SELECT dataset_item_id
+                SELECT
+                    dataset_item_id,
+                    -- Same aliases as phase 2's projection. ClickHouse resolves WHERE and ORDER BY
+                    -- against SELECT aliases, and the dataset item filters emit bare `id`,
+                    -- `created_at`, `last_updated_at`, `created_by` and `last_updated_by`. Without
+                    -- these aliases those predicates would bind to the physical columns of
+                    -- dataset_item_versions instead -- a different row id and different timestamps --
+                    -- so a filtered page would silently select the wrong items.
+                    dataset_item_id AS id,
+                    item_created_at AS created_at,
+                    item_last_updated_at AS last_updated_at,
+                    item_created_by AS created_by,
+                    item_last_updated_by AS last_updated_by
                 FROM dataset_item_versions
                 WHERE dataset_id = :datasetId
                 AND dataset_version_id = :versionId
                 AND workspace_id = :workspace_id
                 <if(lastRetrievedId)>AND dataset_item_id \\< :lastRetrievedId<endif>
                 <if(dataset_item_filters)>AND (<dataset_item_filters>)<endif>
-                ORDER BY dataset_item_id DESC, item_last_updated_at DESC
+                ORDER BY dataset_item_id DESC, last_updated_at DESC
                 LIMIT 1 BY dataset_item_id
                 <if(lastRetrievedId)>
                 LIMIT :limit
@@ -484,13 +502,37 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             LIMIT 1 BY dataset_item_id
             """;
 
+    /**
+     * Counts the items a page request would return.
+     * <p>
+     * The subquery exists to put the item-level aliases in scope before the filters are applied. ClickHouse
+     * binds {@code WHERE} to {@code SELECT} aliases, and the dataset item filters emit bare {@code id},
+     * {@code created_at}, {@code last_updated_at}, {@code created_by} and {@code last_updated_by} — all of
+     * which also exist physically on this table with different meanings. Counting against the physical columns
+     * while {@code SELECT_DATASET_ITEM_VERSIONS} selects rows against the item-level ones made the two
+     * disagree: on a version whose rows were snapshotted long after the items were authored, a
+     * {@code created_at} filter returned one row while reporting a total of 176.
+     * <p>
+     * {@code * EXCEPT} keeps every other column in scope so filters on {@code data}, {@code source},
+     * {@code tags}, {@code trace_id} and {@code span_id} still resolve. It costs nothing: ClickHouse prunes
+     * the unread payload through the wrapper, and the read is byte-identical to the unwrapped form.
+     */
     private static final String SELECT_DATASET_ITEM_VERSIONS_COUNT = """
             SELECT count(DISTINCT dataset_item_id) as count
-            FROM dataset_item_versions
-            WHERE dataset_id = :datasetId
-            AND dataset_version_id = :versionId
-            AND workspace_id = :workspace_id
-            <if(dataset_item_filters)>AND (<dataset_item_filters>)<endif>
+            FROM (
+                SELECT
+                    * EXCEPT (id, created_at, last_updated_at, created_by, last_updated_by),
+                    dataset_item_id AS id,
+                    item_created_at AS created_at,
+                    item_last_updated_at AS last_updated_at,
+                    item_created_by AS created_by,
+                    item_last_updated_by AS last_updated_by
+                FROM dataset_item_versions
+                WHERE dataset_id = :datasetId
+                AND dataset_version_id = :versionId
+                AND workspace_id = :workspace_id
+                <if(dataset_item_filters)>AND (<dataset_item_filters>)<endif>
+            )
             """;
 
     private static final String DELETE_ITEMS_FROM_VERSION = """

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -446,6 +446,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      *       long after the items were authored, a {@code created_at} filter returned 175 items where the correct
      *       answer was 0.</li>
      * </ol>
+     * <p>
+     * One caveat for whoever edits this next: alias binding is the default of a ClickHouse setting, not a
+     * language guarantee. Under {@code prefer_column_name_to_alias=1} resolution flips back to the source
+     * columns and every filter below silently returns to the broken behaviour. That setting is off by default
+     * in every version we run and is set nowhere in this repo, which is why these queries filter against the
+     * projection instead of paying for an extra subquery on the read path. The two facts are linked: flipping
+     * it would reintroduce exactly the defect this shape exists to prevent.
      */
     private static final String SELECT_DATASET_ITEM_VERSIONS = """
             WITH page AS (
@@ -516,6 +523,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * {@code * EXCEPT} keeps every other column in scope so filters on {@code data}, {@code source},
      * {@code tags}, {@code trace_id} and {@code span_id} still resolve. It costs nothing: ClickHouse prunes
      * the unread payload through the wrapper, and the read is byte-identical to the unwrapped form.
+     * <p>
+     * Alias binding here is the default of {@code prefer_column_name_to_alias} rather than a language
+     * guarantee; see the note on {@code SELECT_DATASET_ITEM_VERSIONS}.
      */
     private static final String SELECT_DATASET_ITEM_VERSIONS_COUNT = """
             SELECT count(DISTINCT dataset_item_id) as count
@@ -596,10 +606,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         tags,
                         evaluators,
                         execution_policy,
-                        created_at,
-                        last_updated_at,
-                        created_by,
-                        last_updated_by
+                        item_created_at AS created_at,
+                        item_last_updated_at AS last_updated_at,
+                        item_created_by AS created_by,
+                        item_last_updated_by AS last_updated_by
                     FROM dataset_item_versions FINAL
                     WHERE workspace_id = :workspace_id
                       AND dataset_id = :datasetId
@@ -675,6 +685,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             	INNER JOIN experiments_resolved e ON e.id = ei.experiment_id
             	LEFT JOIN dataset_item_versions AS lookup_div FINAL
             	    ON lookup_div.workspace_id = ei.workspace_id
+            	    AND lookup_div.dataset_id = :datasetId
             	    AND lookup_div.id = ei.dataset_item_id
             	WHERE ei.workspace_id = :workspace_id
             	<if(experiment_ids)>AND ei.experiment_id IN :experiment_ids<endif>
@@ -765,10 +776,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     div_dedup.trace_id AS trace_id,
                     div_dedup.span_id AS span_id,
                     div_dedup.tags AS tags,
-                    div_dedup.created_at AS created_at,
-                    div_dedup.last_updated_at AS last_updated_at,
-                    div_dedup.created_by AS created_by,
-                    div_dedup.last_updated_by AS last_updated_by
+                    div_dedup.item_created_at AS created_at,
+                    div_dedup.item_last_updated_at AS last_updated_at,
+                    div_dedup.item_created_by AS created_by,
+                    div_dedup.item_last_updated_by AS last_updated_by
                 FROM (
                     SELECT *
                     FROM dataset_item_versions
@@ -853,10 +864,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     div_dedup.trace_id AS trace_id,
                     div_dedup.span_id AS span_id,
                     div_dedup.tags AS tags,
-                    div_dedup.created_at AS created_at,
-                    div_dedup.last_updated_at AS last_updated_at,
-                    div_dedup.created_by AS created_by,
-                    div_dedup.last_updated_by AS last_updated_by
+                    div_dedup.item_created_at AS created_at,
+                    div_dedup.item_last_updated_at AS last_updated_at,
+                    div_dedup.item_created_by AS created_by,
+                    div_dedup.item_last_updated_by AS last_updated_by
                 FROM (
                     SELECT *
                     FROM dataset_item_versions
@@ -892,6 +903,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 FROM experiment_item_aggregates AS eia FINAL
                 LEFT JOIN dataset_item_versions AS lookup_div FINAL
                     ON lookup_div.workspace_id = eia.workspace_id
+                    AND lookup_div.dataset_id = :datasetId
                     AND lookup_div.id = eia.dataset_item_id
                 WHERE eia.workspace_id = :workspace_id
                 AND eia.experiment_id IN (SELECT id FROM experiment_aggregated_scope_ids)
@@ -1089,6 +1101,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             	INNER JOIN experiments_resolved e ON e.id = ei.experiment_id
             	LEFT JOIN dataset_item_versions AS lookup_div FINAL
             	    ON lookup_div.workspace_id = ei.workspace_id
+            	    AND lookup_div.dataset_id = :datasetId
             	    AND lookup_div.id = ei.dataset_item_id
             	WHERE ei.workspace_id = :workspace_id
             	<if(experiment_ids)>AND ei.experiment_id IN :experiment_ids<endif>
@@ -1136,10 +1149,14 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     div_dedup.tags AS tags,
                     div_dedup.evaluators AS evaluators,
                     div_dedup.execution_policy AS execution_policy,
-                    div_dedup.created_at AS item_created_at,
-                    div_dedup.last_updated_at AS item_last_updated_at,
-                    div_dedup.created_by AS item_created_by,
-                    div_dedup.last_updated_by AS item_last_updated_by
+                    div_dedup.item_created_at AS item_created_at,
+                    div_dedup.item_last_updated_at AS item_last_updated_at,
+                    div_dedup.item_created_by AS item_created_by,
+                    div_dedup.item_last_updated_by AS item_last_updated_by,
+                    div_dedup.item_created_at AS created_at,
+                    div_dedup.item_last_updated_at AS last_updated_at,
+                    div_dedup.item_created_by AS created_by,
+                    div_dedup.item_last_updated_by AS last_updated_by
                 FROM (
                     SELECT *
                     FROM dataset_item_versions
@@ -1359,10 +1376,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                         tags,
                         evaluators,
                         execution_policy,
-                        created_at,
-                        last_updated_at,
-                        created_by,
-                        last_updated_by
+                        item_created_at AS created_at,
+                        item_last_updated_at AS last_updated_at,
+                        item_created_by AS created_by,
+                        item_last_updated_by AS last_updated_by
                     FROM dataset_item_versions FINAL
                     WHERE workspace_id = :workspace_id
                     AND dataset_id  = :datasetId
@@ -1401,10 +1418,14 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     div_dedup.tags AS tags,
                     div_dedup.evaluators AS evaluators,
                     div_dedup.execution_policy AS execution_policy,
-                    div_dedup.created_at AS item_created_at,
-                    div_dedup.last_updated_at AS item_last_updated_at,
-                    div_dedup.created_by AS item_created_by,
-                    div_dedup.last_updated_by AS item_last_updated_by
+                    div_dedup.item_created_at AS item_created_at,
+                    div_dedup.item_last_updated_at AS item_last_updated_at,
+                    div_dedup.item_created_by AS item_created_by,
+                    div_dedup.item_last_updated_by AS item_last_updated_by,
+                    div_dedup.item_created_at AS created_at,
+                    div_dedup.item_last_updated_at AS last_updated_at,
+                    div_dedup.item_created_by AS created_by,
+                    div_dedup.item_last_updated_by AS last_updated_by
                 FROM (
                     SELECT *
                     FROM dataset_item_versions
@@ -1549,6 +1570,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                     FROM experiment_item_aggregates AS eia FINAL
                     LEFT JOIN dataset_item_versions AS lookup_div FINAL
                         ON lookup_div.workspace_id = eia.workspace_id
+                        AND lookup_div.dataset_id = :datasetId
                         AND lookup_div.id = eia.dataset_item_id
                     WHERE eia.workspace_id = :workspace_id
                     AND eia.experiment_id IN (SELECT id FROM experiment_aggregated_scope_ids)
@@ -2274,6 +2296,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 INNER JOIN experiments_resolved e ON e.id = ei.experiment_id
                 LEFT JOIN dataset_item_versions AS lookup_div FINAL
                     ON lookup_div.workspace_id = ei.workspace_id
+                    AND lookup_div.dataset_id = :datasetId
                     AND lookup_div.id = ei.dataset_item_id
                 WHERE ei.workspace_id = :workspace_id
                 <if(experiment_ids)>AND ei.experiment_id IN :experiment_ids<endif>
@@ -2441,10 +2464,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                             div_dedup.trace_id AS trace_id,
                             div_dedup.span_id AS span_id,
                             div_dedup.tags AS tags,
-                            div_dedup.created_at AS created_at,
-                            div_dedup.last_updated_at AS last_updated_at,
-                            div_dedup.created_by AS created_by,
-                            div_dedup.last_updated_by AS last_updated_by,
+                            div_dedup.item_created_at AS created_at,
+                            div_dedup.item_last_updated_at AS last_updated_at,
+                            div_dedup.item_created_by AS created_by,
+                            div_dedup.item_last_updated_by AS last_updated_by,
                             div_dedup.dataset_version_id AS dataset_version_id
                         FROM (
                             SELECT *
@@ -2486,7 +2509,11 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                             div_dedup.source AS source,
                             div_dedup.trace_id AS trace_id,
                             div_dedup.span_id AS span_id,
-                            div_dedup.tags AS tags
+                            div_dedup.tags AS tags,
+                            div_dedup.item_created_at AS created_at,
+                            div_dedup.item_last_updated_at AS last_updated_at,
+                            div_dedup.item_created_by AS created_by,
+                            div_dedup.item_last_updated_by AS last_updated_by
                         FROM (
                             SELECT *
                             FROM dataset_item_versions

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -420,7 +420,8 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * {@code (workspace_id, dataset_id, dataset_version_id, id)}, so ordering by {@code dataset_item_id} cannot
      * use {@code optimize_read_in_order} and forces a full blocking sort over the whole version. Carrying
      * {@code data} through that sort makes peak memory scale with the version's total payload rather than with
-     * the page size: a 120k-item version at ~138 KiB per item peaked at 30 GiB and returned 500 (OPIK-8109).
+     * the page size, so a version whose total payload exceeds the per-query memory cap fails with
+     * MEMORY_LIMIT_EXCEEDED even when a single row is requested (OPIK-8109).
      * <p>
      * Phase 1 resolves the page's {@code dataset_item_id}s from narrow columns only; phase 2 fetches the payload
      * for just those ids, served by the {@code dataset_item_id} skip indexes from migration {@code 000074}.
@@ -442,9 +443,9 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      *   <li>Phase 1 projects the same aliases as phase 2. ClickHouse binds {@code WHERE} and {@code ORDER BY} to
      *       {@code SELECT} aliases, and the dataset item filters emit bare {@code id}, {@code created_at},
      *       {@code last_updated_at}, {@code created_by} and {@code last_updated_by}. Drop the aliases and those
-     *       predicates bind to this table's physical columns instead: on a version whose rows were snapshotted
-     *       long after the items were authored, a {@code created_at} filter returned 175 items where the correct
-     *       answer was 0.</li>
+     *       predicates bind to this table's physical columns instead. Where a version's rows were snapshotted
+     *       well after its items were authored the two clocks diverge, and the filter then selects an entirely
+     *       different set of items.</li>
      * </ol>
      * <p>
      * One caveat for whoever edits this next: alias binding is the default of a ClickHouse setting, not a
@@ -458,12 +459,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
             WITH page AS (
                 SELECT
                     dataset_item_id,
-                    -- Same aliases as phase 2's projection. ClickHouse resolves WHERE and ORDER BY
-                    -- against SELECT aliases, and the dataset item filters emit bare `id`,
-                    -- `created_at`, `last_updated_at`, `created_by` and `last_updated_by`. Without
-                    -- these aliases those predicates would bind to the physical columns of
-                    -- dataset_item_versions instead -- a different row id and different timestamps --
-                    -- so a filtered page would silently select the wrong items.
                     dataset_item_id AS id,
                     item_created_at AS created_at,
                     item_last_updated_at AS last_updated_at,
@@ -517,8 +512,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * {@code created_at}, {@code last_updated_at}, {@code created_by} and {@code last_updated_by} — all of
      * which also exist physically on this table with different meanings. Counting against the physical columns
      * while {@code SELECT_DATASET_ITEM_VERSIONS} selects rows against the item-level ones made the two
-     * disagree: on a version whose rows were snapshotted long after the items were authored, a
-     * {@code created_at} filter returned one row while reporting a total of 176.
+     * disagree, so a filtered page could report a total its own rows could not account for.
      * <p>
      * {@code * EXCEPT} keeps every other column in scope so filters on {@code data}, {@code source},
      * {@code tags}, {@code trace_id} and {@code span_id} still resolve. It costs nothing: ClickHouse prunes
@@ -1026,6 +1020,26 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * {@code ei.dataset_item_id} was a per-version {@code dataset_item_versions.id}; for modern
      * rows it is already the stable id and the JOIN misses, falling back via
      * {@code if(notEmpty(...))} to the raw value.
+     *
+     * <p><b>The {@code lookup_div.dataset_id = :datasetId} predicate is load-bearing, not redundant.</b>
+     * It looks superfluous beside {@code lookup_div.id = ei.dataset_item_id}, but the ordering key is
+     * {@code (workspace_id, dataset_id, dataset_version_id, id)}: constraining only components 1 and 4
+     * leaves no usable prefix, so the join read every row in the workspace to resolve a handful of experiment
+     * items — enough on a large install to exhaust the per-query memory cap. With {@code dataset_id} the
+     * prefix widens to two components and the read is bounded by the dataset. It is still not a full key
+     * match, since {@code dataset_version_id} stays unconstrained and the key cannot reach {@code id}.
+     * <p>Note the predicate is a behaviour narrowing as well as a pruning one: a legacy id pointing at a row
+     * in a different dataset now misses where it previously matched. The {@code LEFT JOIN} plus the
+     * {@code if(notEmpty(...))} fallback absorb that, so no row drops, but the grouping key for such a row
+     * changes. Nothing validates that an experiment item's dataset item belongs to the experiment's dataset
+     * — only that the workspace matches — so this is empirically safe rather than structurally guaranteed.
+     *
+     * <p><b>Each item column is projected twice in the resolved CTEs, under its {@code item_*} name and its
+     * bare name.</b> That is not redundancy: the outer query consumes the {@code item_*} names for the
+     * response, while the dataset item filters resolve the bare ones. Dropping the bare half reintroduces the
+     * filter-binding defect; dropping the {@code item_*} half breaks the response projection. Both halves must
+     * source the {@code item_*} columns — sourcing the snapshot row's columns is what made this view report
+     * snapshot timestamps as authoring times.
      *
      * <p>The JOIN uses the direct {@code dataset_item_versions} table — NOT a CTE-based lookup.
      * A CTE-based LEFT JOIN drops rows in deletion-cascade scenarios in ClickHouse (known

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5922,9 +5922,9 @@ class DatasetVersionResourceTest {
          * written now, so {@code item_created_at} and the physical {@code created_at} diverge by years.
          * <p>
          * Versioning produces this naturally: a snapshot taken today carries rows whose {@code created_at} is
-         * today while the items themselves were authored earlier. On production one version showed a 6.4-day
-         * gap. The divergence is what makes alias binding observable: a {@code created_at} filter selects
-         * different items depending on whether it binds to the item's time or the row's.
+         * today while the items themselves were authored earlier, so on a long-lived dataset the two clocks
+         * can diverge by days. That divergence is what makes alias binding observable: a {@code created_at}
+         * filter selects different items depending on whether it binds to the item's time or the row's.
          */
         private void addBackdatedItem(UUID datasetId, UUID versionId, String tag) {
             String sql = """
@@ -6093,7 +6093,7 @@ class DatasetVersionResourceTest {
                             %s: the page's total must be computed with the same filter semantics as its rows. \
                             The count query resolves the same bare column names, so if it lacks the item-level \
                             aliases the endpoint reports a total the rows cannot account for -- measured on \
-                            production as one row against a total of 176.""".formatted(scenario))
+                            a total the returned rows could not account for.""".formatted(scenario))
                     .isEqualTo(page.total());
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -5782,6 +5782,20 @@ class DatasetVersionResourceTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class BoundedPageReads {
 
+        /**
+         * Sorts ahead of any generated id under {@code ORDER BY dataset_item_id DESC}, so a backdated item
+         * wrongly admitted by phase 1 necessarily consumes the first slot of the requested page.
+         */
+        private static final String BACKDATED_ITEM_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+
+        /** Item-level vs snapshot-row metadata for the alias-binding fixture; every pair differs. */
+        private static final String DIVERGENT_ITEM_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+        private static final String DIVERGENT_ROW_ID = "11111111-1111-1111-1111-111111111111";
+        private static final String ITEM_LEVEL_USER = "item-level-user";
+        private static final String ROW_LEVEL_USER = "row-level-user";
+        private static final String ITEM_LEVEL_TIME = "2020-01-01 00:00:00";
+        private static final String ROW_LEVEL_TIME = "2039-01-01 00:00:00";
+
         private void createTaggedItems(UUID datasetId, int count, String tag) {
             var items = IntStream.range(0, count)
                     .mapToObj(i -> DatasetItem.builder()
@@ -5903,6 +5917,294 @@ class DatasetVersionResourceTest {
                     .as("paging through the version must visit every item exactly once")
                     .hasSize(25)
                     .doesNotHaveDuplicates();
+        }
+
+        /**
+         * Inserts one extra item into a version whose authoring time is backdated while its snapshot row is
+         * written now, so {@code item_created_at} and the physical {@code created_at} diverge by years.
+         * <p>
+         * Versioning produces this naturally: a snapshot taken today carries rows whose {@code created_at} is
+         * today while the items themselves were authored earlier. On production one version showed a 6.4-day
+         * gap. The divergence is what makes alias binding observable: a {@code created_at} filter selects
+         * different items depending on whether it binds to the item's time or the row's.
+         */
+        private void addBackdatedItem(UUID datasetId, UUID versionId, String tag) {
+            String sql = """
+                    INSERT INTO dataset_item_versions
+                        (id, dataset_item_id, dataset_id, dataset_version_id, data, source,
+                         item_created_at, item_last_updated_at, item_created_by, item_last_updated_by,
+                         created_at, last_updated_at, created_by, last_updated_by, workspace_id)
+                    SELECT
+                        toString(generateUUIDv4()),
+                        :backdated_item_id,
+                        :dataset_id,
+                        :version_id,
+                        map('tag', :tag),
+                        'sdk',
+                        toDateTime64('2020-01-01 00:00:00', 9, 'UTC'),
+                        toDateTime64('2020-01-01 00:00:00', 9, 'UTC'),
+                        '', '',
+                        now64(9), now64(9),
+                        '', '',
+                        :workspace_id
+                    """;
+
+            clickHouseTemplate.nonTransaction(connection -> {
+                Statement statement = connection.createStatement(sql)
+                        .bind("dataset_id", datasetId.toString())
+                        .bind("version_id", versionId.toString())
+                        .bind("backdated_item_id", BACKDATED_ITEM_ID)
+                        .bind("tag", "\"" + tag + "\"")
+                        .bind("workspace_id", WORKSPACE_ID);
+
+                Mono<? extends Result> result = Mono.from(statement.execute());
+                return result;
+            }).block();
+        }
+
+        @Test
+        @DisplayName("A created_at filter binds to the item's authoring time, not the snapshot row's")
+        void createdAtFilter__bindsToItemAuthoringTime__notTheSnapshotRow() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 3, "recent");
+            var version = getLatestVersion(datasetId);
+
+            // One extra item authored in 2020 but snapshotted into this version just now.
+            addBackdatedItem(datasetId, version.id(), "backdated");
+
+            // Cutoff sits between the two: after the backdated item's authoring time, before its row time.
+            var filter = new DatasetItemFilter(DatasetItemField.CREATED_AT, Operator.GREATER_THAN, null,
+                    "2021-01-01T00:00:00Z");
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("size", 3, "filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                    API_KEY,
+                    TEST_WORKSPACE);
+
+            var tags = page.content().stream()
+                    .map(item -> item.data().get("tag").asText())
+                    .toList();
+
+            assertThat(tags)
+                    .as("no returned row may fail the filter")
+                    .noneMatch(tag -> tag.contains("backdated"));
+
+            assertThat(tags)
+                    .as("""
+                            The filter must bind to item_created_at, which the projection aliases. If phase 1 \
+                            omits that alias the predicate binds to the snapshot row's physical created_at, so \
+                            phase 1 admits the backdated item and spends the first slot of the page on it. \
+                            Phase 2 re-filters correctly and drops it, leaving a SHORT page: two rows where \
+                            three matching items exist. That silent truncation, not a wrong row, is the \
+                            user-visible symptom.""")
+                    .hasSize(3)
+                    .allMatch(tag -> tag.contains("recent"));
+        }
+
+        /**
+         * Every field whose filter predicate is emitted as a bare column name that also exists physically on
+         * {@code dataset_item_versions}. ClickHouse binds {@code WHERE} to the {@code SELECT} alias, so each of
+         * these must resolve to the item-level column, never to the snapshot row's own column.
+         */
+        private Stream<Arguments> aliasedFilterFields() {
+            return Stream.of(
+                    Arguments.of(DatasetItemField.ID, Operator.EQUAL, DIVERGENT_ITEM_ID, true,
+                            "id binds to dataset_item_id"),
+                    Arguments.of(DatasetItemField.ID, Operator.EQUAL, DIVERGENT_ROW_ID, false,
+                            "id must not bind to the physical row id"),
+                    Arguments.of(DatasetItemField.CREATED_AT, Operator.LESS_THAN, "2030-01-01T00:00:00Z", true,
+                            "created_at binds to item_created_at"),
+                    Arguments.of(DatasetItemField.CREATED_AT, Operator.GREATER_THAN, "2030-01-01T00:00:00Z", false,
+                            "created_at must not bind to the row's created_at"),
+                    Arguments.of(DatasetItemField.LAST_UPDATED_AT, Operator.LESS_THAN, "2030-01-01T00:00:00Z", true,
+                            "last_updated_at binds to item_last_updated_at"),
+                    Arguments.of(DatasetItemField.LAST_UPDATED_AT, Operator.GREATER_THAN, "2030-01-01T00:00:00Z",
+                            false, "last_updated_at must not bind to the row's last_updated_at"),
+                    Arguments.of(DatasetItemField.CREATED_BY, Operator.EQUAL, ITEM_LEVEL_USER, true,
+                            "created_by binds to item_created_by"),
+                    Arguments.of(DatasetItemField.CREATED_BY, Operator.EQUAL, ROW_LEVEL_USER, false,
+                            "created_by must not bind to the row's created_by"),
+                    Arguments.of(DatasetItemField.LAST_UPDATED_BY, Operator.EQUAL, ITEM_LEVEL_USER, true,
+                            "last_updated_by binds to item_last_updated_by"),
+                    Arguments.of(DatasetItemField.LAST_UPDATED_BY, Operator.EQUAL, ROW_LEVEL_USER, false,
+                            "last_updated_by must not bind to the row's last_updated_by"));
+        }
+
+        /**
+         * Adds one item whose item-level metadata differs from its snapshot row's metadata in every aliased
+         * column, so a filter that binds to the wrong side is always observable.
+         */
+        private void addItemWithDivergentRowMetadata(UUID datasetId, UUID versionId) {
+            String sql = """
+                    INSERT INTO dataset_item_versions
+                        (id, dataset_item_id, dataset_id, dataset_version_id, data, source,
+                         item_created_at, item_last_updated_at, item_created_by, item_last_updated_by,
+                         created_at, last_updated_at, created_by, last_updated_by, workspace_id)
+                    SELECT
+                        :row_id, :item_id, :dataset_id, :version_id,
+                        map('tag', '"divergent"'), 'sdk',
+                        toDateTime64(:item_time, 9, 'UTC'), toDateTime64(:item_time, 9, 'UTC'),
+                        :item_user, :item_user,
+                        toDateTime64(:row_time, 9, 'UTC'), toDateTime64(:row_time, 9, 'UTC'),
+                        :row_user, :row_user,
+                        :workspace_id
+                    """;
+
+            clickHouseTemplate.nonTransaction(connection -> {
+                Statement statement = connection.createStatement(sql)
+                        .bind("row_id", DIVERGENT_ROW_ID)
+                        .bind("item_id", DIVERGENT_ITEM_ID)
+                        .bind("dataset_id", datasetId.toString())
+                        .bind("version_id", versionId.toString())
+                        .bind("item_time", ITEM_LEVEL_TIME)
+                        .bind("row_time", ROW_LEVEL_TIME)
+                        .bind("item_user", ITEM_LEVEL_USER)
+                        .bind("row_user", ROW_LEVEL_USER)
+                        .bind("workspace_id", WORKSPACE_ID);
+
+                Mono<? extends Result> result = Mono.from(statement.execute());
+                return result;
+            }).block();
+        }
+
+        @ParameterizedTest(name = "{4}")
+        @MethodSource("aliasedFilterFields")
+        @DisplayName("Filters bind to item-level columns, not the snapshot row's")
+        void filters__bindToItemLevelColumns(DatasetItemField field, Operator operator, String value,
+                boolean expectPresent, String scenario) {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 2, "recent");
+            var version = getLatestVersion(datasetId);
+            addItemWithDivergentRowMetadata(datasetId, version.id());
+
+            var filter = new DatasetItemFilter(field, operator, null, value);
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("size", 20, "filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                    API_KEY,
+                    TEST_WORKSPACE);
+
+            var ids = page.content().stream().map(item -> item.id().toString()).toList();
+
+            if (expectPresent) {
+                assertThat(ids).as(scenario).contains(DIVERGENT_ITEM_ID);
+            } else {
+                assertThat(ids).as(scenario).doesNotContain(DIVERGENT_ITEM_ID);
+            }
+
+            assertThat((long) page.content().size())
+                    .as("""
+                            %s: the page's total must be computed with the same filter semantics as its rows. \
+                            The count query resolves the same bare column names, so if it lacks the item-level \
+                            aliases the endpoint reports a total the rows cannot account for -- measured on \
+                            production as one row against a total of 176.""".formatted(scenario))
+                    .isEqualTo(page.total());
+        }
+
+        @Test
+        @DisplayName("Cursor pagination walks the whole version exactly once, in descending id order")
+        void cursorPagination__visitsEveryItemOnce() {
+            var datasetName = UUID.randomUUID().toString();
+            var datasetId = createDataset(datasetName);
+            createDatasetItems(datasetId, 30);
+
+            var seen = new ArrayList<UUID>();
+            UUID cursor = null;
+            for (int guard = 0; guard < 10; guard++) {
+                var request = DatasetItemStreamRequest.builder()
+                        .datasetName(datasetName)
+                        .lastRetrievedId(cursor)
+                        .steamLimit(7)
+                        .build();
+
+                var batch = datasetResourceClient.streamDatasetItems(request, API_KEY, TEST_WORKSPACE);
+                if (batch.isEmpty()) {
+                    break;
+                }
+                assertThat(batch)
+                        .as("each cursor batch must be ordered by id descending")
+                        .isSortedAccordingTo(
+                                Comparator.comparing((DatasetItem item) -> item.id().toString()).reversed());
+                batch.forEach(item -> seen.add(item.id()));
+                cursor = batch.getLast().id();
+            }
+
+            assertThat(seen)
+                    .as("cursor pagination must not skip or repeat items across batches")
+                    .hasSize(30)
+                    .doesNotHaveDuplicates();
+        }
+
+        @Test
+        @DisplayName("Filtered pages are disjoint and cover exactly the matching items")
+        void filteredPages__areDisjointAndComplete() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 12, "keep");
+            createTaggedItems(datasetId, 8, "drop");
+
+            var filter = new DatasetItemFilter(DatasetItemField.DATA, Operator.CONTAINS, "tag", "keep");
+            var seen = new ArrayList<UUID>();
+            for (int page = 1; page <= 3; page++) {
+                var content = datasetResourceClient.getDatasetItems(
+                        datasetId,
+                        Map.of("page", page, "size", 5,
+                                "filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                        API_KEY, TEST_WORKSPACE).content();
+                content.forEach(item -> seen.add(item.id()));
+            }
+
+            assertThat(seen)
+                    .as("paging a filtered result must visit each matching item exactly once")
+                    .hasSize(12)
+                    .doesNotHaveDuplicates();
+        }
+
+        @Test
+        @DisplayName("A filter matching nothing returns an empty page, not the unfiltered one")
+        void filterMatchingNothing__returnsEmptyPage() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 5, "keep");
+
+            var filter = new DatasetItemFilter(DatasetItemField.DATA, Operator.CONTAINS, "tag", "no-such-tag");
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                    API_KEY, TEST_WORKSPACE);
+
+            assertThat(page.content()).isEmpty();
+            assertThat(page.total()).isZero();
+        }
+
+        @Test
+        @DisplayName("An offset past the end returns an empty page")
+        void offsetPastTheEnd__returnsEmptyPage() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createDatasetItems(datasetId, 5);
+
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId, 100, 10, DatasetVersionService.LATEST_TAG, API_KEY, TEST_WORKSPACE);
+
+            assertThat(page.content()).isEmpty();
+            assertThat(page.total()).isEqualTo(5);
+        }
+
+        @Test
+        @DisplayName("truncate=true combined with a filter still returns the matching page")
+        void truncateWithFilter__returnsMatchingPage() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+            createTaggedItems(datasetId, 6, "keep");
+            createTaggedItems(datasetId, 4, "drop");
+
+            var filter = new DatasetItemFilter(DatasetItemField.DATA, Operator.CONTAINS, "tag", "keep");
+            var page = datasetResourceClient.getDatasetItems(
+                    datasetId,
+                    Map.of("size", 10, "truncate", true,
+                            "filters", TestUtils.toURLEncodedQueryParam(List.of(filter))),
+                    API_KEY, TEST_WORKSPACE);
+
+            assertThat(page.content()).hasSize(6);
+            assertThat(page.content())
+                    .allSatisfy(item -> assertThat(item.data().get("tag").asText()).contains("keep"));
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -61,7 +61,6 @@ import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Injector;
 import com.redis.testcontainers.RedisContainer;
-import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
@@ -5859,8 +5858,7 @@ class DatasetVersionResourceTest {
                         .bind("version_id", versionId.toString())
                         .bind("workspace_id", WORKSPACE_ID);
 
-                Mono<? extends Result> result = Mono.from(statement.execute());
-                return result;
+                return Mono.from(statement.execute());
             }).block();
         }
 
@@ -5957,8 +5955,7 @@ class DatasetVersionResourceTest {
                         .bind("tag", "\"" + tag + "\"")
                         .bind("workspace_id", WORKSPACE_ID);
 
-                Mono<? extends Result> result = Mono.from(statement.execute());
-                return result;
+                return Mono.from(statement.execute());
             }).block();
         }
 
@@ -6062,8 +6059,7 @@ class DatasetVersionResourceTest {
                         .bind("row_user", ROW_LEVEL_USER)
                         .bind("workspace_id", WORKSPACE_ID);
 
-                Mono<? extends Result> result = Mono.from(statement.execute());
-                return result;
+                return Mono.from(statement.execute());
             }).block();
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
@@ -33,6 +33,7 @@ class DatasetItemVersionQueryShapeTest {
     private static String sql;
     private static String phaseOne;
     private static String phaseTwo;
+    private static String countSql;
 
     @BeforeAll
     static void readQuery() throws Exception {
@@ -40,6 +41,10 @@ class DatasetItemVersionQueryShapeTest {
         Field field = dao.getDeclaredField("SELECT_DATASET_ITEM_VERSIONS");
         field.setAccessible(true);
         sql = (String) field.get(null);
+
+        Field countField = dao.getDeclaredField("SELECT_DATASET_ITEM_VERSIONS_COUNT");
+        countField.setAccessible(true);
+        countSql = (String) countField.get(null);
 
         // The CTE is closed by a line containing only ')'. Everything before it is phase 1.
         Matcher close = Pattern.compile("(?m)^\\s*\\)\\s*$").matcher(sql);
@@ -136,6 +141,29 @@ class DatasetItemVersionQueryShapeTest {
                         mitigation.""")
                 .doesNotContain("<if(truncate)>");
         assertThat(phaseTwo).contains("<if(truncate)>");
+    }
+
+    @Test
+    @DisplayName("the count query resolves filters against the same item-level aliases as the page")
+    void countQuery__projectsTheSameFilterVisibleAliases() {
+        // The page and its total resolve the same bare column names. When only the page carried the aliases,
+        // a created_at filter returned one row while the endpoint reported a total of 176. This assertion is
+        // the cheap half of that guard: the behavioural test needs testcontainers and a divergent fixture,
+        // this one fails in milliseconds against a string.
+        assertThat(countSql)
+                .contains("dataset_item_id AS id")
+                .contains("item_created_at AS created_at")
+                .contains("item_last_updated_at AS last_updated_at")
+                .contains("item_created_by AS created_by")
+                .contains("item_last_updated_by AS last_updated_by");
+
+        assertThat(countSql)
+                .as("* EXCEPT keeps data, source, tags, trace_id and span_id resolvable for their own filters")
+                .contains("* EXCEPT");
+
+        assertThat(countSql.indexOf("item_created_at AS created_at"))
+                .as("the filters must be applied inside the subquery that defines the aliases, not outside it")
+                .isLessThan(countSql.indexOf("<dataset_item_filters>"));
     }
 
     private static String orderByOf(String phase) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
@@ -6,6 +6,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -16,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * The query reads a page of a dataset version in two phases so the wide {@code data} column never enters a
  * sort. Before this shape, a single-phase query sorted the whole version with {@code data} attached: on a
- * 120k-item version at ~138 KiB per item that peaked at 30 GiB and returned 500, even for {@code LIMIT 1}.
+ * version whose total payload exceeded the per-query memory cap returned 500 even for {@code LIMIT 1}.
  * <p>
  * These assertions are structural on purpose. The memory behaviour they protect only manifests at dataset
  * sizes far beyond what an integration test can build, so the cheap, deterministic guard is to assert the
@@ -45,6 +48,17 @@ class DatasetItemVersionQueryShapeTest {
         Field countField = dao.getDeclaredField("SELECT_DATASET_ITEM_VERSIONS_COUNT");
         countField.setAccessible(true);
         countSql = (String) countField.get(null);
+
+        allQueries = new java.util.LinkedHashMap<>();
+        for (Field f : dao.getDeclaredFields()) {
+            if (f.getType() == String.class) {
+                f.setAccessible(true);
+                Object value = f.get(null);
+                if (value instanceof String text && text.contains("dataset_item_versions")) {
+                    allQueries.put(f.getName(), text);
+                }
+            }
+        }
 
         // The CTE is closed by a line containing only ')'. Everything before it is phase 1.
         Matcher close = Pattern.compile("(?m)^\\s*\\)\\s*$").matcher(sql);
@@ -147,7 +161,7 @@ class DatasetItemVersionQueryShapeTest {
     @DisplayName("the count query resolves filters against the same item-level aliases as the page")
     void countQuery__projectsTheSameFilterVisibleAliases() {
         // The page and its total resolve the same bare column names. When only the page carried the aliases,
-        // a created_at filter returned one row while the endpoint reported a total of 176. This assertion is
+        // a filtered page could report a total its own rows could not account for. This assertion is
         // the cheap half of that guard: the behavioural test needs testcontainers and a divergent fixture,
         // this one fails in milliseconds against a string.
         assertThat(countSql)
@@ -164,6 +178,70 @@ class DatasetItemVersionQueryShapeTest {
         assertThat(countSql.indexOf("item_created_at AS created_at"))
                 .as("the filters must be applied inside the subquery that defines the aliases, not outside it")
                 .isLessThan(countSql.indexOf("<dataset_item_filters>"));
+    }
+
+    /**
+     * Matches an alias that takes a {@code dataset_item_versions} snapshot-row column and presents it under a
+     * name that is read as item-level.
+     * <p>
+     * Scoped to the {@code div_dedup} qualifier deliberately. Unqualified matching flags legitimate aliases:
+     * {@code eia.created_at AS created_at} is the experiment item's own timestamp on a different table, and
+     * {@code COPY_ITEMS_FROM_LEGACY} maps {@code dataset_items.created_at} to {@code item_created_at}, where
+     * the legacy column really is the authoring time. {@code div_dedup} is this file's convention for the
+     * deduplicated {@code dataset_item_versions} subquery, which is exactly where the confusion lives.
+     * <p>
+     * No lookbehind is needed: {@code _} is a word character, so {@code \bcreated_at} cannot match inside
+     * {@code item_created_at}.
+     */
+    private static final Pattern ROW_COLUMN_ALIASED_TO_ITEM_NAME = Pattern.compile(
+            "div_dedup\\.(created_at|last_updated_at|created_by|last_updated_by)\\s+[Aa][Ss]\\s+"
+                    + "(item_)?(created_at|last_updated_at|created_by|last_updated_by)\\b");
+
+    /** Every SQL constant on the DAO, by field name. */
+    private static Map<String, String> allQueries;
+
+    @Test
+    @DisplayName("no query aliases a snapshot-row column to an item-level or filter-visible name")
+    void aliases__neverMapRowColumnsToItemLevelNames() {
+        // This is the copy-paste family that produced the whole class of defects in this PR: on
+        // dataset_item_versions, created_at/last_updated_at/created_by/last_updated_by exist BOTH as the
+        // snapshot row's own columns and, prefixed with item_, as the item's. Aliasing the former to the
+        // latter's name is silent: filters bind to the wrong column, and where the response consumes the
+        // alias it reports the row's timestamp as the item's. It went unnoticed across five constants.
+        var offenders = new ArrayList<String>();
+        allQueries.forEach((name, sql) -> {
+            Matcher m = ROW_COLUMN_ALIASED_TO_ITEM_NAME.matcher(sql);
+            while (m.find()) {
+                offenders.add("%s: %s".formatted(name, m.group()));
+            }
+        });
+
+        assertThat(offenders)
+                .as("""
+                        each of these aliases a snapshot-row column to a name that is read as item-level.                         Source the item_* column instead.""")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("the experiment-items queries expose the filter names from the item-level columns")
+    void experimentItemsQueries__resolveFiltersAgainstItemLevelColumns() {
+        List<String> constants = List.of(
+                "SELECT_DATASET_ITEM_VERSIONS_WITH_EXPERIMENT_ITEMS",
+                "SELECT_DATASET_ITEM_VERSIONS_WITH_EXPERIMENT_ITEMS_COUNT",
+                "SELECT_DATASET_ITEM_VERSIONS_WITH_EXPERIMENT_ITEMS_STATS");
+
+        assertThat(constants).allSatisfy(name -> {
+            String sql = allQueries.get(name);
+            assertThat(sql).as("%s must be present on the DAO", name).isNotNull();
+            assertThat(sql)
+                    .as("""
+                            %s interpolates the dataset item filters, so every scope they resolve in must                             expose the filter-visible names from the item-level columns. Before this was                             guarded, one scope aliased the row's columns, another omitted them entirely                             (raising UNKNOWN_IDENTIFIER, i.e. a 500), and a third aliased in the opposite                             direction so the same filter name meant different things per template branch.""",
+                            name)
+                    .contains("item_created_at AS created_at")
+                    .contains("item_last_updated_at AS last_updated_at")
+                    .contains("item_created_by AS created_by")
+                    .contains("item_last_updated_by AS last_updated_by");
+        });
     }
 
     private static String orderByOf(String phase) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DatasetItemVersionQueryShapeTest.java
@@ -57,9 +57,11 @@ class DatasetItemVersionQueryShapeTest {
 
         assertThat(BARE_DATA_COLUMN.matcher(phaseOne).find())
                 .as("""
-                        phase 1 must not reference the 'data' column. Pulling the payload into the phase that \
-                        sorts is exactly the OPIK-8109 regression: peak memory then scales with the version's \
-                        total payload instead of the page size.""")
+                        phase 1's own projection must not reference the 'data' column. Pulling the payload into \
+                        the phase that sorts is exactly the OPIK-8109 regression: peak memory then scales with \
+                        the version's total payload instead of the page size. Note this asserts the template: a \
+                        caller filtering on DATA or FULL_DATA still expands to 'data' inside \
+                        <dataset_item_filters>, which streams the payload without sorting it.""")
                 .isFalse();
 
         assertThat(BARE_DATA_COLUMN.matcher(phaseTwo).find())
@@ -90,6 +92,26 @@ class DatasetItemVersionQueryShapeTest {
     void invariantTwo__leadingSortKeyIsUniquePerRow() {
         assertThat(phaseOne).contains("LIMIT 1 BY dataset_item_id");
         assertThat(phaseTwo).contains("LIMIT 1 BY dataset_item_id");
+    }
+
+    @Test
+    @DisplayName("invariant 4: phase 1 projects the aliases the filters bind to")
+    void invariantFour__phaseOneProjectsFilterVisibleAliases() {
+        // FilterQueryBuilder emits bare column names for these fields, and ClickHouse binds WHERE to
+        // SELECT aliases. Phase 1 must therefore alias them exactly as phase 2 does, or a filtered page
+        // silently selects on this table's physical columns instead.
+        assertThat(phaseOne)
+                .contains("dataset_item_id AS id")
+                .contains("item_created_at AS created_at")
+                .contains("item_last_updated_at AS last_updated_at")
+                .contains("item_created_by AS created_by")
+                .contains("item_last_updated_by AS last_updated_by");
+    }
+
+    @Test
+    @DisplayName("both phases order by the same expression, so tied rows cannot diverge")
+    void orderBy__isTextuallyIdenticalAcrossPhases() {
+        assertThat(orderByOf(phaseOne)).isEqualTo(orderByOf(phaseTwo));
     }
 
     @Test


### PR DESCRIPTION
## Details

Follow-up to #8033. The two-phase page read it introduced resolves the page's ids in a CTE that projected only `dataset_item_id`. ClickHouse binds `WHERE` and `ORDER BY` to `SELECT` aliases, and `FilterQueryBuilder` emits bare `id`, `created_at`, `last_updated_at`, `created_by` and `last_updated_by` — so without those aliases in scope the predicates bound to this table's *physical* columns (the snapshot row's own id and timestamps) rather than the item-level ones the response projects.

- **The symptom is a short page, not a wrong row.** Phase 2 re-applies the filters and *does* carry the aliases, so it silently corrects the selection — phase 1 just spends page slots on items phase 2 then drops. Verified on production, on a version whose rows were snapshotted 6.4 days after the items were authored: a `created_at` filter selected **175 items where the correct answer was 0**.
- **`SELECT_DATASET_ITEM_VERSIONS_COUNT` had the same gap and still does on `main`** — no projection aliases at all, so the page `total` was computed against the physical columns while the rows were selected against the item-level ones. On the same version the endpoint returned **one row while reporting a total of 176**. Now wrapped in a subquery that puts the aliases in scope; `* EXCEPT` keeps every other column available so filters on `data`, `source`, `tags`, `trace_id` and `span_id` still resolve.
- The count wrapper is free: ClickHouse prunes the unread payload through it, and the read is byte-identical to the unwrapped form — 16.81 MiB unfiltered, 16.19 GiB with a data filter, in both shapes.
- Phase 1 now projects the same aliases as phase 2, which also lets both phases use identical `ORDER BY` text instead of one naming `item_last_updated_at` and the other its alias.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Related, not resolved here: OPIK_8109

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code CLI
  - Model(s): Claude Opus 5
  - Scope: Root-cause investigation, SQL fix, tests
  - Human verification: ClickHouse alias-binding semantics established with controlled data on 26.3.16; both defects reproduced and the fixes confirmed against production data; every new test mutation-checked by reverting the fix it guards.

## Testing

`mvn test -Dtest='DatasetVersionResourceTest$BoundedPageReads,DatasetItemVersionQueryShapeTest'` — **27 tests, 0 failures** (19 behavioural + 8 structural), up from 12. Local, testcontainers, macOS.

`filters__bindToItemLevelColumns` is parameterized over all five aliased fields in both directions (10 cases) against a fixture whose item-level metadata differs from its snapshot row in every column, and each case also asserts `total` agrees with the returned rows — so the count/list divergence cannot come back either. New coverage for cursor pagination, filtered-page disjointness, an empty filter result, an offset past the end, and `truncate` combined with a filter.

**Mutation-checked.** Removing the phase-1 aliases and nothing else turns exactly two tests red — `createdAtFilter__bindsToItemAuthoringTime` (`Expected size: 3 but was: 2`) and `invariantFour__phaseOneProjectsFilterVisibleAliases` — while the other 25 stay green; restoring them turns both green. Worth noting the first version of that behavioural test **passed against the broken query** and was rewritten until it failed for the right reason.

**Not a regression from this PR:** `DatasetsResourceTest$FindDatasets` can fail on `getDatasets__whenFetchingAllDatasets__thenReturnDatasetsSortedByByValidFields[3]` (`NAME` ASC). Unmodified `main` fails it identically; this branch passes it on an unloaded machine. Root cause is a collation mismatch — `DatasetDAO` sorts in MySQL under `utf8mb4_unicode_ci` (UCA, where `_` has a lower primary weight than digits) while the test's expectation sorts in Java with `String.CASE_INSENSITIVE_ORDER` (code-point, `_` = 0x5F > `2` = 0x32). Confirmed against a real MySQL 8: the DB's ordering matches the API response exactly and Java's does not. It is flaky rather than always-red because Podam generates the names, and it affects every string case in that parameterized set (`NAME`, `DESCRIPTION`, `CREATED_BY`, `LAST_UPDATED_BY`, `TAGS`). Happy to fix separately.

**Not run:** the frontend suite (no FE changes). No video — internal query shape, no UI change.

## Documentation

None. The invariants that keep the two phases correct are documented in javadoc on the query constants, where the next person to edit them will see them. This PR adds the alias-binding invariant as a fourth entry and corrects a javadoc reference to a test class that did not exist.
