### PR TITLE
[NA] [CI] fix: capture BE logs under the real compose project name

### DIFF
--- a/.github/workflows/guardrails_e2e_tests.yml
+++ b/.github/workflows/guardrails_e2e_tests.yml
@@ -134,8 +134,10 @@ jobs:
       - name: Keep BE log in case of failure
         if: failure()
         run: |
-          docker logs opik-backend-1 > ${{ github.workspace }}/opik-backend_guardrails_p${{matrix.python_version}}.log || true
-          docker logs opik-guardrails-backend-1 > ${{ github.workspace }}/opik-guardrails-backend_p${{matrix.python_version}}.log || true
+          cd ${{ github.workspace }}
+          source scripts/worktree-utils.sh && init_worktree_ports
+          docker logs "${COMPOSE_PROJECT_NAME}-backend-1" > ${{ github.workspace }}/opik-backend_guardrails_p${{matrix.python_version}}.log 2>&1 || true
+          docker logs "${COMPOSE_PROJECT_NAME}-guardrails-backend-1" > ${{ github.workspace }}/opik-guardrails-backend_p${{matrix.python_version}}.log 2>&1 || true
 
       - name: Attach BE log
         if: failure()

--- a/.github/workflows/load_tests.yml
+++ b/.github/workflows/load_tests.yml
@@ -227,7 +227,9 @@ jobs:
       - name: Keep BE log in case of failure
         if: failure()
         run: |
-          docker logs opik-backend-1 > ${{ github.workspace }}/opik-backend.log
+          cd ${{ github.workspace }}
+          source scripts/worktree-utils.sh && init_worktree_ports
+          docker logs "${COMPOSE_PROJECT_NAME}-backend-1" > ${{ github.workspace }}/opik-backend.log 2>&1 || true
 
       - name: Attach BE log
         if: failure()

--- a/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/python_sdk_compatibility_v1_e2e_tests.yml
@@ -164,7 +164,9 @@ jobs:
         - name: Keep BE log in case of failure
           if: failure()
           run: |
-            docker logs opik-backend-1 > ${{ github.workspace }}/opik-backend_compat_v1_p${{matrix.python_version}}.log
+            cd ${{ github.workspace }}
+            source scripts/worktree-utils.sh && init_worktree_ports
+            docker logs "${COMPOSE_PROJECT_NAME}-backend-1" > ${{ github.workspace }}/opik-backend_compat_v1_p${{matrix.python_version}}.log 2>&1 || true
 
         - name: Attach BE log
           if: failure()

--- a/.github/workflows/python_sdk_e2e_tests.yml
+++ b/.github/workflows/python_sdk_e2e_tests.yml
@@ -177,7 +177,9 @@ jobs:
         - name: Keep BE log in case of failure
           if: failure()
           run: |
-            docker logs opik-backend-1 > ${{ github.workspace }}/opik-backend_p${{matrix.python_version}}.log
+            cd ${{ github.workspace }}
+            source scripts/worktree-utils.sh && init_worktree_ports
+            docker logs "${COMPOSE_PROJECT_NAME}-backend-1" > ${{ github.workspace }}/opik-backend_p${{matrix.python_version}}.log 2>&1 || true
 
         - name: Attach BE log
           if: failure()


### PR DESCRIPTION
## Details

The `Keep BE log in case of failure` steps in four E2E workflows hardcode `docker logs opik-backend-1`, but `opik.sh` derives container names from `COMPOSE_PROJECT_NAME`, which `scripts/worktree-utils.sh` sets to `opik-<worktree-id>`. On a GitHub runner the checkout is `/home/runner/work/opik/opik`, so the worktree id is `opik` and the real container is `opik-opik-backend-1`.

Every capture therefore failed with `Error response from daemon: No such container: opik-backend-1` and uploaded an empty (180-byte) artifact — losing the diagnostics for exactly the failures the step exists to explain, and emitting a second `##[error]` that obscures the real one.

- Derive the container name the same way `opik.sh` does, by sourcing `worktree-utils.sh` and calling `init_worktree_ports`.
- Fold stderr into the captured log (`2>&1`) so JVM/startup output on stderr is not dropped.
- Add `|| true` on the two sites that lacked it, so a diagnostic step never fails the job on its own.

Files: `python_sdk_e2e_tests.yml`, `python_sdk_compatibility_v1_e2e_tests.yml`, `guardrails_e2e_tests.yml`, `load_tests.yml`.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A — CI-only fix, no ticket.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Diagnosed the empty backend-log artifact on a failed E2E run, traced the container-name derivation through `opik.sh` → `scripts/worktree-utils.sh`, and applied the four workflow edits.
- Human verification: Author reviewed the diff and the reproduction below.

## Testing

Reproduced the name derivation locally, matching what CI produces:

```
$ bash -c 'source scripts/worktree-utils.sh; init_worktree_ports; echo "${COMPOSE_PROJECT_NAME}-backend-1"'
opik-opik-backend-1
```

That is exactly the container name in the failing run's logs (`Container opik-opik-backend-1  Starting`), versus the `opik-backend-1` the steps were asking for.

Simulated the patched step body under Actions' `bash -e {0}` semantics with no container running, confirming it exits 0 rather than failing the job:

```
$ bash -e -c 'cd $PWD; source scripts/worktree-utils.sh && init_worktree_ports; docker logs "${COMPOSE_PROJECT_NAME}-backend-1" > /tmp/be.log 2>&1 || true; echo $?'
0
```

All four workflows re-validated as parseable YAML (`yaml.safe_load`).

Not run: the workflows themselves only execute this step under `if: failure()`, so end-to-end confirmation requires an actual E2E failure. Evidence of the current breakage is in run [33002967582](https://github.com/comet-ml/opik/actions/runs/33002967582) (empty `opik-backend-log-compat-v1-p3.10` artifact, 180 bytes).

## Documentation

No documentation changes — internal CI only.
