### PR TITLE
[OPIK-7315] give verify.sh a receive-timeout, and stop the four call sites drifting

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1402,8 +1402,9 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 > total, so run it under `nohup`/`screen` rather than an interactive shell that may be interrupted. It is
 > read-only and idempotent, so an interruption cannot damage anything. It does **not** follow that a re-run covers the
 > same windows: both bounds are read live from the old-schema table — `toMonday(min(created_at))` for the anchor and
-> `max(created_at)` for the last week — so on a table still taking writes, or one retention is pruning, the offsets move
-> under you.
+> `max(created_at)` for the last week — so on a table still taking writes, or one that retention is pruning, the offsets
+> move under you. Both are read once, at startup: rows written after that are outside the horizon the run computed,
+> and are the delta's business rather than the compare's.
 >
 > **Resume with `--from-week`; do not restart from 0.** Idempotent does not mean free: a restart repeats
 > every window already compared. Each window either reports a line or has not run, so the resume point is

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1400,15 +1400,23 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 > **Detach it, and expect tens of minutes.** The bounded compare walks one window per week over both
 > tables. On a large table that is minutes per window on the busy weeks and well over half an hour in
 > total, so run it under `nohup`/`screen` rather than an interactive shell that may be interrupted. It is
-> read-only and idempotent, so an interruption cannot damage anything, and because the bound is fixed by
-> `cutover_start` it covers the same windows whenever it is re-run.
+> read-only and idempotent, so an interruption cannot damage anything. It does **not** follow that a re-run covers the
+> same windows: both bounds are read live from the old-schema table — `toMonday(min(created_at))` for the anchor and
+> `max(created_at)` for the last week — so on a table still taking writes, or one retention is pruning, the offsets move
+> under you.
 >
 > **Resume with `--from-week`; do not restart from 0.** Idempotent does not mean free: a restart repeats
 > every window already compared. Each window either reports a line or has not run, so the resume point is
 > the last reported week plus the **stride** — plus one only at the default `--weeks-stride 1` — and the same
 > stride must be passed again, or the resumed run samples different windows than the run it continues. The
-> offsets are anchored on `toMonday(min(created_at))` of the old-schema table, so confirm a resumed run's
-> first window is the one you expect before treating its output as continuous with an earlier log.
+> offsets are anchored as above, so confirm a resumed run's first window is the one you expect before treating its
+> output as continuous with an earlier log — if the anchor has moved, the logs describe different windows and must not be
+> read as one run.
+>
+> **A resumed run does not by itself discharge the pre-`EXCHANGE` gate.** That gate (see the exit checklist) requires a
+> full compare with no narrowing, and each `PASSED` line reports only the windows *that run* compared. Split runs satisfy
+> it only if their windows together cover every week **and** the anchor held throughout; if either is in doubt, re-run
+> whole. Resuming is for the long post-rollback compare, where the bound is deliberately partial anyway.
 >
 > **A mismatching week costs a second, slower query.** On `ok=0` the driver re-checks the differing keys on
 > the sorting key to separate a real mismatch from a superseded-version artifact. That re-check can stall for
@@ -1473,6 +1481,8 @@ bound is still worth passing.
 infeasible, sample and still get high confidence:
 - `--sample-mod N` compares a deterministic 1/N `id` sample — the *same* rows on both sides, so like-for-like.
 - `--weeks-stride S` compares every S-th weekly partition (partition-pruned, so genuinely cheaper).
+- `--receive-timeout N` raises the client's per-packet wait (default 1800, against ClickHouse's 300). The
+  post-mismatch confirm-keys re-check can stall past the stock value and abort the compare at the first mismatch.
 - `--from-week` / `--to-week` bound the range by **0-based week offset** (integers from the anchor Monday, not dates;
   `--to-week` is inclusive) — e.g. verify the most recent weeks fully, older weeks sampled.
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1413,10 +1413,11 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 > output as continuous with an earlier log — if the anchor has moved, the logs describe different windows and must not be
 > read as one run.
 >
-> **A resumed run does not by itself discharge the pre-`EXCHANGE` gate.** That gate (see the exit checklist) requires a
-> full compare with no narrowing, and each `PASSED` line reports only the windows *that run* compared. Split runs satisfy
-> it only if their windows together cover every week **and** the anchor held throughout; if either is in doubt, re-run
-> whole. Resuming is for the long post-rollback compare, where the bound is deliberately partial anyway.
+> **Never resume the pre-`EXCHANGE` gate run — restart it.** That gate (see the exit checklist) requires one full compare
+> with no narrowing, and it is the last backstop before an irreversible step. Two runs whose windows happen to add up are
+> only equivalent if the anchor held throughout, which is not something anyone can confirm under pressure; a `PASSED`
+> line now states the range it covered, so a stitched-together pass is visible rather than arguable. Resume is for the
+> exploratory compares and the long post-rollback one, where the bound is deliberately partial anyway.
 >
 > **A mismatching week costs a second, slower query.** On `ok=0` the driver re-checks the differing keys on
 > the sorting key to separate a real mismatch from a superseded-version artifact. That re-check can stall for

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -466,8 +466,8 @@ the `traceColumnsNonNullable` flip").
 On rollback, after swapping the Nullable original back, revert the flag to `false` **and** run that repair.
 
 **Trace-delete partition pruning needs no flip at all (OPIK-6901).** A trace `DELETE` binds itself to the weekly
-partitions its own ids resolve to instead of being planned against every part of the table — on prod-test, 12 ids
-rewrote 3,928 parts / 5.40 TiB before this. There is **no flag, no ordering constraint, and nothing to revert on
+partitions its own ids resolve to instead of being planned against every part of the table, so a handful of ids no
+longer rewrites the whole table. There is **no flag, no ordering constraint, and nothing to revert on
 rollback**: the predicate is emitted unconditionally, and one rendered statement is correct against the original and
 against the successor alike.
 
@@ -1403,17 +1403,18 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 > read-only and idempotent, so an interruption cannot damage anything, and because the bound is fixed by
 > `cutover_start` it covers the same windows whenever it is re-run.
 >
-> **Resume with `--from-week`; do not restart from 0.** Idempotent does not mean free: on a large table a
-> restart repeats hours of scanning. Every window either reports a line or did not run, so the resume point
-> is the last reported week plus one. The offsets are anchored on `toMonday(min(created_at))` of the
-> old-schema table, so confirm a resumed run's first window is the one you expect before treating its output
-> as continuous with an earlier log.
+> **Resume with `--from-week`; do not restart from 0.** Idempotent does not mean free: a restart repeats
+> every window already compared. Each window either reports a line or has not run, so the resume point is
+> the last reported week plus the **stride** — plus one only at the default `--weeks-stride 1` — and the same
+> stride must be passed again, or the resumed run samples different windows than the run it continues. The
+> offsets are anchored on `toMonday(min(created_at))` of the old-schema table, so confirm a resumed run's
+> first window is the one you expect before treating its output as continuous with an earlier log.
 >
-> **A mismatching week costs a second, quieter query.** On `ok=0` the driver re-checks the differing keys on
-> the sorting key to separate a real mismatch from a superseded-version artifact, and that query builds its
-> candidate set before emitting anything. On a multi-million-row week the silence can exceed ClickHouse's
-> 300s `receive_timeout` default, which aborts the whole compare at the first mismatching week. `verify.sh`
-> therefore defaults to `1800`; raise it further with `--receive-timeout` if a window still trips it.
+> **A mismatching week costs a second, slower query.** On `ok=0` the driver re-checks the differing keys on
+> the sorting key to separate a real mismatch from a superseded-version artifact. That re-check can stall for
+> longer than ClickHouse's 300s `receive_timeout` default even where the window compare did not, which aborts
+> the whole compare at the first mismatching week. `verify.sh` therefore defaults to `1800`; raise it with
+> `--receive-timeout` if a window still trips it.
 >
 > **Two steps need privileges the rollback grant set does not give.** Plan for them before the window,
 > because both surface at the end when the pressure is highest:

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1400,8 +1400,20 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 > **Detach it, and expect tens of minutes.** The bounded compare walks one window per week over both
 > tables. On a large table that is minutes per window on the busy weeks and well over half an hour in
 > total, so run it under `nohup`/`screen` rather than an interactive shell that may be interrupted. It is
-> read-only and idempotent: an interrupted run costs nothing, and because the bound is fixed by
+> read-only and idempotent, so an interruption cannot damage anything, and because the bound is fixed by
 > `cutover_start` it covers the same windows whenever it is re-run.
+>
+> **Resume with `--from-week`; do not restart from 0.** Idempotent does not mean free: on a large table a
+> restart repeats hours of scanning. Every window either reports a line or did not run, so the resume point
+> is the last reported week plus one. The offsets are anchored on `toMonday(min(created_at))` of the
+> old-schema table, so confirm a resumed run's first window is the one you expect before treating its output
+> as continuous with an earlier log.
+>
+> **A mismatching week costs a second, quieter query.** On `ok=0` the driver re-checks the differing keys on
+> the sorting key to separate a real mismatch from a superseded-version artifact, and that query builds its
+> candidate set before emitting anything. On a multi-million-row week the silence can exceed ClickHouse's
+> 300s `receive_timeout` default, which aborts the whole compare at the first mismatching week. `verify.sh`
+> therefore defaults to `1800`; raise it further with `--receive-timeout` if a window still trips it.
 >
 > **Two steps need privileges the rollback grant set does not give.** Plan for them before the window,
 > because both surface at the end when the pressure is highest:

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -249,9 +249,9 @@ if [[ "$checked" == "0" ]]; then
     exit 1
 fi
 if [[ "$artifacts" != "0" ]]; then
-    log "PASSED: all $checked windows match (sample 1/$SAMPLE_MOD); $artifacts window(s) held a superseded-version"
+    log "PASSED: all $checked windows match (weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD); $artifacts window(s) held a superseded-version"
     log "        artifact only — a key written more than once lands its stale version in an earlier created_at week on"
     log "        one side. Live data is identical on both sides; nothing to fix (see the confirm-keys block)."
 else
-    log "PASSED: all $checked windows match (sample 1/$SAMPLE_MOD)."
+    log "PASSED: all $checked windows match (weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD)."
 fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -28,15 +28,13 @@
 #                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
 #                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
 #                             the password out of argv).
-#   --receive-timeout N       seconds clickhouse-client waits for the NEXT packet from the server before giving up
-#                             (SETTINGS receive_timeout). Default 1800, well above ClickHouse's own 300. This bounds
-#                             SILENCE, not query duration: a long compare stays alive because the server keeps sending
-#                             progress packets. What overruns 300 is a query with a long quiet phase — the post-mismatch
-#                             confirm-keys re-check, which builds its candidate-key set before emitting anything, and on a
-#                             multi-million-row week can exceed it. That aborts the whole compare on the first mismatching
-#                             week, so the default here is deliberately generous. The cost is that a genuinely dead
-#                             connection now takes this long to surface; for a read-only, resumable compare that runs for
-#                             hours, losing the run to a transient quiet phase is the worse failure.
+#   --receive-timeout N       seconds clickhouse-client waits for the next packet from the server before giving up
+#                             (SETTINGS receive_timeout). Default 1800, against ClickHouse's own 300. It bounds the GAP
+#                             between packets, not total query time: a window compare running well past 300s does not
+#                             trip it, while the post-mismatch confirm-keys re-check can — so under the stock default the
+#                             first mismatching week aborts the whole run. The cost of a generous value is that a
+#                             genuinely dead connection takes that long to surface; for a read-only, resumable compare,
+#                             losing a long run to a transient stall is the worse failure.
 #   --old-table NAME    old-schema table (Nullable, nanosecond). Default traces. After the EXCHANGE: traces_pre_cutover_backup.
 #   --new-table NAME    new-schema table (sentinels, microsecond). Default traces_local_v2. After the EXCHANGE: traces.
 #                       After a stage B/C ROLLBACK the defaults do not apply at all — traces_local_v2 no longer exists, so a
@@ -69,7 +67,7 @@ FROM_WEEK=0
 TO_WEEK=""
 WEEKS_STRIDE=1              # 1 = every week; S skips to every S-th weekly partition for a quick, pruned pass
 DRILL_DOWN=0
-RECEIVE_TIMEOUT=1800        # seconds of SILENCE tolerated from the server, not query duration. See --receive-timeout.
+RECEIVE_TIMEOUT=1800        # seconds tolerated between server packets, not total query time. See --receive-timeout.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -28,6 +28,15 @@
 #                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
 #                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
 #                             the password out of argv).
+#   --receive-timeout N       seconds clickhouse-client waits for the NEXT packet from the server before giving up
+#                             (SETTINGS receive_timeout). Default 1800, well above ClickHouse's own 300. This bounds
+#                             SILENCE, not query duration: a long compare stays alive because the server keeps sending
+#                             progress packets. What overruns 300 is a query with a long quiet phase — the post-mismatch
+#                             confirm-keys re-check, which builds its candidate-key set before emitting anything, and on a
+#                             multi-million-row week can exceed it. That aborts the whole compare on the first mismatching
+#                             week, so the default here is deliberately generous. The cost is that a genuinely dead
+#                             connection now takes this long to surface; for a read-only, resumable compare that runs for
+#                             hours, losing the run to a transient quiet phase is the worse failure.
 #   --old-table NAME    old-schema table (Nullable, nanosecond). Default traces. After the EXCHANGE: traces_pre_cutover_backup.
 #   --new-table NAME    new-schema table (sentinels, microsecond). Default traces_local_v2. After the EXCHANGE: traces.
 #                       After a stage B/C ROLLBACK the defaults do not apply at all — traces_local_v2 no longer exists, so a
@@ -60,6 +69,7 @@ FROM_WEEK=0
 TO_WEEK=""
 WEEKS_STRIDE=1              # 1 = every week; S skips to every S-th weekly partition for a quick, pruned pass
 DRILL_DOWN=0
+RECEIVE_TIMEOUT=1800        # seconds of SILENCE tolerated from the server, not query duration. See --receive-timeout.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -71,6 +81,7 @@ while [[ $# -gt 0 ]]; do
         --to-week) TO_WEEK="${2:?"$1 requires a value"}"; shift 2 ;;
         --weeks-stride) WEEKS_STRIDE="${2:?"$1 requires a value"}"; shift 2 ;;
         --drill-down) DRILL_DOWN=1; shift ;;
+        --receive-timeout) RECEIVE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
@@ -88,12 +99,20 @@ done
 [[ "$SAMPLE_MOD" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --sample-mod must be a positive integer." >&2; exit 2; }
 [[ "$FROM_WEEK" =~ ^[0-9]+$ ]] || { echo "ERROR: --from-week must be a non-negative integer." >&2; exit 2; }
 [[ "$WEEKS_STRIDE" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --weeks-stride must be a positive integer." >&2; exit 2; }
+[[ "$RECEIVE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --receive-timeout must be a positive integer (seconds)." >&2; exit 2; }
 [[ -z "$TO_WEEK" || "$TO_WEEK" == last-sealed || "$TO_WEEK" =~ ^[0-9]+$ ]] \
     || { echo "ERROR: --to-week must be a non-negative integer or 'last-sealed'." >&2; exit 2; }
 [[ -f "$VERIFY_SQL" ]] || { echo "ERROR: cannot find verify SQL at $VERIFY_SQL" >&2; exit 2; }
 
+# One place for the connection and client-side options, so the four call sites below cannot drift — in particular so
+# --receive-timeout applies to the confirm-keys re-check and the drill-down, not only to the window compare.
+CH_ARGS=()
+[[ -z "$CH_HOST" ]] || CH_ARGS+=(--host "$CH_HOST")
+[[ -z "$CH_PORT" ]] || CH_ARGS+=(--port "$CH_PORT")
+CH_ARGS+=(--database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --receive_timeout="$RECEIVE_TIMEOUT")
+
 ch() {
-    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --query "$1"
+    clickhouse-client "${CH_ARGS[@]}" --query "$1"
 }
 
 log() {
@@ -117,19 +136,19 @@ render_block() {
 
 # Verdict TSV row for one window: src_rows dst_rows src_checksum dst_checksum ok
 compare_window() {
-    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block compare "$1" "$2")"
+    clickhouse-client "${CH_ARGS[@]}" --multiquery --query "$(render_block compare "$1" "$2")"
 }
 
 # Per-key differences for one window (only run on a mismatch, under --drill-down).
 drill_down_window() {
-    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block drill-down "$1" "$2")"
+    clickhouse-client "${CH_ARGS[@]}" --multiquery --query "$(render_block drill-down "$1" "$2")"
 }
 
 # Count of keys in one window that GENUINELY differ, re-checked on the sorting key so FINAL cannot hide a
 # version (see the confirm-keys block for why a created_at window can surface a superseded row on one side
 # only). 0 means the window's difference is a superseded-version artifact, not a data difference.
 confirm_keys_window() {
-    clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:verify' --multiquery --query "$(render_block confirm-keys "$1" "$2")"
+    clickhouse-client "${CH_ARGS[@]}" --multiquery --query "$(render_block confirm-keys "$1" "$2")"
 }
 
 ROWS="$(ch "SELECT count() FROM $OLD_TABLE")"


### PR DESCRIPTION
## Details

`verify.sh` had no way to raise the ClickHouse client socket timeout, and a long fidelity compare was lost to it. On `ok=0` the driver re-checks the differing keys on the sorting key, to separate a real mismatch from a superseded-version artifact. That re-check can stall for longer than ClickHouse's 300s `receive_timeout` default even where the window compare did not — and because it runs before the week's verdict is known, the stall aborts the **entire** compare at the first mismatching week, discarding every window still unchecked.

- **`--receive-timeout N`, default `1800`.** A named flag, matching how `backfill.sh` exposes `--max-insert-block-size` and friends, rather than a generic settings passthrough. The default is opinionated on purpose: 300 is wrong for this workload, so an operator who does not know to pass the flag still gets a compare that finishes.
- **The connection prefix was duplicated across four `clickhouse-client` invocations** (`ch`, compare, drill-down, confirm-keys), now factored into one `CH_ARGS` array. Without that the flag would reach only the sites someone remembered to edit, and the site that needs it is the confirm-keys re-check rather than the window compare.

What is measured, and worth keeping straight: `receive_timeout` bounds the **gap between packets**, not total query time. A window compare running well past 300s does not trip it; the re-check can. The cost of a generous default is that a genuinely dead connection takes that long to surface, which for a read-only, resumable compare is the better trade than losing a long run to a transient stall.

**Follow-up, deliberately not here:** `rollback.sh` has the same exposure across its own client invocations, and the sentinel repair's `mutations_sync = 2` blocks for as long as the mutation runs — the same shape as OPIK_8141, where the client gave up and the server carried on. It is excluded because #8046 is open and approved against `rollback.sh`, and editing it now would conflict. It follows once that lands.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7315

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the `verify.sh` flag and `CH_ARGS` refactor, and the README corrections.
- Human verification: reviewed by the author; the runs below were executed against a live multi-replica ClickHouse.

## Testing

Run against a live ClickHouse (26.3), not a container.

**The flag reaches the client** — forced low, the failure is the same error the stock default produced, with the value substituted:

```
$ ./verify.sh --database <db> --host <host> --receive-timeout 1 --from-week 0 --to-week 0
Error on processing query: Timeout exceeded while receiving data from server.
Waited for 1 seconds, timeout is 1 seconds.
```

**No regression on the normal path** — one bounded window, default timeout, `PASSED: all 1 windows match (sample 1/1)`, with a row count identical to the same window in an earlier full run.

**Validation** rejects `0`, `abc`, `-5` and `1 ; rm`, one message each. `bash -n` clean.

**Not run:** a full multi-week compare on this build. A compare is currently walking the remaining weeks on the pre-change revision with the timeout supplied externally, exercising the same code path by the same mechanism.

## Documentation

`data-migrations/traces-local-v2-cutover/README.md`:

- the "Detach it" admonition claimed *"an interrupted run costs nothing"* — true of the estate, false of the wall clock. It now points at `--from-week`, and states the resume rule correctly: the last reported week plus the **stride**, with the same stride passed again, since the loop advances by `--weeks-stride` and a bare +1 would sample different windows.
- nothing warned that a mismatching week costs a second, slower query. It now does, with the timeout default named.
- the trace-delete pruning note carried a part count and an on-disk size measured in a real environment. Removed; the engineering point does not depend on the figures.
