### PR TITLE
[OPIK-7596] [BE] fix: hide internal workspaces from the MCP OAuth consent list

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_API_KEY;
 import static com.comet.opik.api.ReactServiceErrorResponse.MISSING_WORKSPACE;
@@ -54,6 +55,10 @@ class RemoteAuthService implements AuthService {
     // GenericType instances are thread-safe and expensive to build, so reuse a single instance.
     private static final GenericType<List<WorkspaceIdNameResponse>> WORKSPACE_LIST_TYPE = new GenericType<>() {
     };
+
+    // Comet-internal workspaces are named by wrapping the name in double underscores. A user may technically belong to
+    // one, but it must never be targetable from an agent.
+    private static final Pattern INTERNAL_WORKSPACE_NAME = Pattern.compile("^__.+__$");
 
     private static final Map<String, Set<String>> PUBLIC_ENDPOINTS = new HashMap<>() {
         {
@@ -220,7 +225,7 @@ class RemoteAuthService implements AuthService {
                 throw toSessionAuthException(response);
             }
             return response.readEntity(WORKSPACE_LIST_TYPE).stream()
-                    .filter(workspace -> !isDefaultWorkspace(workspace.workspaceName()))
+                    .filter(workspace -> isEligibleWorkspace(workspace.workspaceName()))
                     .map(workspace -> WorkspaceInfo.builder()
                             .id(workspace.workspaceId())
                             .name(workspace.workspaceName())
@@ -256,7 +261,9 @@ class RemoteAuthService implements AuthService {
     @Override
     public UserWorkspace authorizeWorkspace(Cookie sessionToken, @NonNull String workspaceName) {
         requireSession(sessionToken);
-        if (isDefaultWorkspace(workspaceName)) {
+        // Mirrors the filtering applied when listing: hiding a workspace from the consent screen is cosmetic unless a
+        // hand-crafted consent submission naming it is rejected too.
+        if (!isEligibleWorkspace(workspaceName)) {
             throw new ClientErrorException(NOT_ALLOWED_TO_ACCESS_WORKSPACE, Response.Status.FORBIDDEN);
         }
         try (var response = client.target(URI.create(reactServiceUrl.url()))
@@ -561,6 +568,16 @@ class RemoteAuthService implements AuthService {
 
     private boolean isDefaultWorkspace(String workspaceName) {
         return ProjectService.DEFAULT_WORKSPACE_NAME.equalsIgnoreCase(workspaceName);
+    }
+
+    /**
+     * Reports whether a workspace may be offered to, and consented for, an OAuth client. Blank names are rejected
+     * because the react service is the source of the list and a name is what identifies the workspace downstream.
+     */
+    private boolean isEligibleWorkspace(String workspaceName) {
+        return StringUtils.isNotBlank(workspaceName)
+                && !isDefaultWorkspace(workspaceName)
+                && !INTERNAL_WORKSPACE_NAME.matcher(workspaceName).matches();
     }
 
     private String getWorkspaceId(String workspaceName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.co.jemos.podam.api.PodamFactory;
 
@@ -604,14 +605,21 @@ class RemoteAuthServiceTest {
     }
 
     @Test
-    void testListEligibleWorkspaces__filtersDefaultWorkspaceAndMapsToWorkspaceInfo() throws JsonProcessingException {
+    void testListEligibleWorkspaces__filtersDefaultAndInternalWorkspacesAndMapsToWorkspaceInfo()
+            throws JsonProcessingException {
         var sessionTokenValue = "session-" + UUID.randomUUID();
         var production = podamFactory.manufacturePojo(WorkspaceInfo.class);
         var staging = podamFactory.manufacturePojo(WorkspaceInfo.class);
+        // only the full wrapping marks a workspace internal, a lone prefix or suffix does not
+        var prefixed = WorkspaceInfo.builder().id("ws-prefixed").name("__prefixed").build();
+        var suffixed = WorkspaceInfo.builder().id("ws-suffixed").name("suffixed__").build();
         var responseJson = OBJECT_MAPPER.writeValueAsString(Arrays.asList(
-                Map.of("workspaceId", production.id(), "workspaceName", production.name()),
+                workspaceEntry(production),
                 Map.of("workspaceId", "ws-default", "workspaceName", DEFAULT_WORKSPACE_NAME),
-                Map.of("workspaceId", staging.id(), "workspaceName", staging.name())));
+                Map.of("workspaceId", "ws-internal", "workspaceName", "__internal__"),
+                workspaceEntry(prefixed),
+                workspaceEntry(suffixed),
+                workspaceEntry(staging)));
         WIRE_MOCK.server().stubFor(get(urlPathEqualTo("/workspaces"))
                 .withQueryParam("withoutExtendedData", equalTo("true"))
                 .withCookie(RequestContext.SESSION_COOKIE, equalTo(sessionTokenValue))
@@ -619,7 +627,7 @@ class RemoteAuthServiceTest {
 
         var result = remoteAuthService.listEligibleWorkspaces(sessionCookie(sessionTokenValue));
 
-        assertThat(result).containsExactly(production, staging);
+        assertThat(result).containsExactly(production, prefixed, suffixed, staging);
     }
 
     @Test
@@ -676,12 +684,13 @@ class RemoteAuthServiceTest {
                 .hasMessage(NOT_LOGGED_USER);
     }
 
-    @Test
-    void testAuthorizeWorkspace__whenDefaultWorkspace__thenForbidden() {
+    @ParameterizedTest
+    @ValueSource(strings = {DEFAULT_WORKSPACE_NAME, "__internal__", "__a__", "  "})
+    void testAuthorizeWorkspace__whenNotEligible__thenForbidden(String workspaceName) {
         var sessionTokenValue = "session-" + UUID.randomUUID();
 
         assertThatThrownBy(() -> remoteAuthService.authorizeWorkspace(
-                sessionCookie(sessionTokenValue), DEFAULT_WORKSPACE_NAME))
+                sessionCookie(sessionTokenValue), workspaceName))
                 .isExactlyInstanceOf(ClientErrorException.class)
                 .hasMessage(NOT_ALLOWED_TO_ACCESS_WORKSPACE);
     }
@@ -710,6 +719,10 @@ class RemoteAuthServiceTest {
                 .quotas(authResponse.quotas())
                 .build();
         assertThat(requestContext).isEqualTo(expectedRequestContext);
+    }
+
+    private static Map<String, String> workspaceEntry(WorkspaceInfo workspace) {
+        return Map.of("workspaceId", workspace.id(), "workspaceName", workspace.name());
     }
 
     private static Cookie sessionCookie(String value) {


### PR DESCRIPTION
## Details

Comet-internal workspaces — named by wrapping the name in double underscores — were offered on the hosted MCP consent screen alongside a user's real workspaces. A user may technically belong to one, but it should never be targetable from an agent, so they add noise and invite mis-selection.

The eligibility rules that already excluded the default workspace are folded into a single `isEligibleWorkspace` predicate, which now also rejects internal and blank names, and is applied in both places that need it:

- `listEligibleWorkspaces` — internal workspaces never reach the consent screen (the ticket's acceptance criterion).
- `authorizeWorkspace` — a hand-crafted consent submission naming an internal workspace is rejected too. Filtering only the list would leave the guard cosmetic: the submitted `workspace_name` is what actually mints the authorization code. Both sides now read from one predicate, so they cannot drift apart.

Rejections reuse the existing `NOT_ALLOWED_TO_ACCESS_WORKSPACE` / 403 — identical to the response for a workspace the user simply does not belong to — so nothing leaks about which internal workspaces exist.

Scoped to the MCP OAuth path only. Normal Opik UI session authentication (`authenticateUsingSessionToken`) is deliberately untouched, since blocking internal workspaces there would break internal users browsing the UI.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7596

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (source change + tests)
- Human verification: code review + local test run

## Testing

`mvn test -Dtest='RemoteAuthServiceTest,OAuthAuthorizeResourceTest,AuthServiceImplTest'` — 77 tests, all passing. `mvn spotless:check` clean. Local process mode, macOS.

Scenarios covered by the unit tests (WireMock-backed, in `RemoteAuthServiceTest`):

- Listing filters out both the default workspace and an internal one, and maps the rest to `WorkspaceInfo` in order.
- Lookalike names are **not** treated as internal — only the full wrapping counts, so `__prefixed` and `suffixed__` stay eligible. This guards against over-filtering real workspaces.
- `authorizeWorkspace` returns 403 for the default workspace, an internal one, the minimal internal form, and a blank name (parameterized).
- Existing listing/authorize behaviour (no session, remote 401/403/500) re-verified unchanged.

Not run: a live end-to-end pass against the hosted MCP consent screen, which needs a deployed environment with real internal workspaces. The consent-screen path is covered indirectly by `OAuthAuthorizeResourceTest`.

## Documentation

N/A — no user-facing documentation changes; the behaviour is an internal filtering rule on the consent screen.
