### PR TITLE
[NA] [DOCS] [FE] Point the Opik skill prompts at /opik-instrument

### DIFF
--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -83,7 +83,7 @@ For quickstarts, installs, and any sequential procedure. `title` on each `<Step>
   <Step title="Run the integration">
     Once the skill is installed, you can add tracing using the following prompt:
     ```
-    Instrument my agent with Opik using the /instrument command.
+    Instrument my agent with Opik using the /opik-instrument command.
     ```
   </Step>
 </Steps>

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
@@ -42,7 +42,7 @@ tracing manually with the SDK.
       <Step title="Run the integration">
         Ask your coding agent to instrument your code:
         ```
-        Instrument my agent with Opik using the /instrument command.
+        Instrument my agent with Opik using the /opik-instrument command.
         ```
 
         The agent will read your code, pick the right Opik integration, and add tracing.

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
@@ -74,7 +74,7 @@ With Opik, you can:
     Then ask your coding agent:
 
     ```
-    Instrument my agent with Opik using the /instrument command.
+    Instrument my agent with Opik using the /opik-instrument command.
     ```
 
     This works with Claude Code, Cursor, Codex, OpenCode, and other coding agents. You can also instrument manually with the SDK:

--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/getting-started.mdx
@@ -32,7 +32,7 @@ to its trace.
       <Step title="Run the integration">
         Once the skill is installed, you can integrate with Opik using the following prompt:
         ```
-        Version my prompts in Opik using the /instrument command.
+        Version my prompts in Opik using the /opik-instrument command.
         ```
       </Step>
     </Steps>

--- a/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
@@ -262,7 +262,7 @@ stack and follow the three steps to log your first trace:
       <Step title="Run the integration">
         Once the skill is installed, you can integrate with Opik using the following prompt:
         ```
-        Instrument my agent with Opik using the /instrument command.
+        Instrument my agent with Opik using the /opik-instrument command.
         ```
       </Step>
     </Steps>

--- a/apps/opik-frontend/src/v2/pages-shared/onboarding/InstallWithAITab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/onboarding/InstallWithAITab.tsx
@@ -24,7 +24,7 @@ const InstallWithAITab: React.FC<InstallWithAITabProps> = ({
   const workspaceName = useActiveWorkspaceName();
 
   const projectPart = agentName ? `, project name "${agentName}"` : "";
-  const prompt = `Instrument my agent with Opik using the /instrument command. Make sure you use workspace "${workspaceName}"${projectPart} and API key "${
+  const prompt = `Instrument my agent with Opik using the /opik-instrument command. Make sure you use workspace "${workspaceName}"${projectPart} and API key "${
     apiKey ?? "<YOUR_API_KEY>"
   }".`;
 


### PR DESCRIPTION
> **Draft until [comet-ml/opik-mcp#171](https://github.com/comet-ml/opik-mcp/pull/171) merges and the pack sync to `comet-ml/opik-skills` lands.** Until then `/opik-instrument` does not exist, and merging this would point users at a command that isn't there yet.

## Details

The published Opik skills are being namespaced under an `opik-` prefix in [comet-ml/opik-mcp#171](https://github.com/comet-ml/opik-mcp/pull/171), because `evaluate` and `instrument` claimed unnamespaced names in a global namespace where the installer resolves a collision by overwriting — no prompt, no diff, no backup. Once that lands, every place telling a user to type `/instrument` breaks, and breaks *silently*: a user who has any other `instrument` skill installed gets that one instead, which is the exact collision the rename exists to prevent, triggered by our own onboarding copy.

This replaces `using the /instrument command` with `using the /opik-instrument command` in the five places that refer to the **skill**, plus the onboarding dialog's copy-button prompt.

- `fern/docs-v2/quickstart.mdx`, `observability/getting-started.mdx`, `observability/overview.mdx`, `prompt_engineering/getting-started.mdx` — the four user-facing pages
- `.agents/skills/write-docs/SKILL.md` — the canonical snippet docs authors copy; without it the old command regenerates into new pages
- `apps/opik-frontend/src/v2/pages-shared/onboarding/InstallWithAITab.tsx` — the only non-docs file. Same defect on the highest-traffic surface; leaving it would have the product's own copy button contradict the docs beside it. Flagging since it routes to different reviewers — happy to split it out.

**Ollie's `/instrument` is a different command and is deliberately untouched** — it's an action button in the Ollie sidebar on the Agent Runner page, unrelated to the skill pack. Left alone: `AgentRunnerEmptyState.tsx`, `tests_end_to_end/e2e/pom/ollie.page.ts`, `e2e/tests/ollie/ollie-connect.spec.ts`, `e2e/agents/README.md`. Also untouched: OpenTelemetry `instrumentation/` paths across the integrations docs, and the SDK's own `evaluation/evaluate.ts`.

Related but not resolved here: OPIK_7621.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- `[NA]` — no ticket; this is follow-on cleanup for the skills rename in comet-ml/opik-mcp#171. Happy to file one or retitle with a key if preferred.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: located the affected call sites, applied the string replacement, drafted this description. No logic or structural changes — six single-line text edits.
- Human verification: pending reviewer sign-off. The scoping decision that needs a human eye is which `/instrument` occurrences belong to the skill versus Ollie's separate sidebar command; the reasoning and the full untouched list are spelled out above so that call can be checked directly.

## Testing

Scoping was verified mechanically rather than by a test run, since the change is six text edits with no logic:

- `grep -rl "using the /instrument command"` before the edit returned exactly the six files changed here, and `grep -c` on both Ollie sites returned `0` — so the pattern provably separates the skill's command from Ollie's.
- After the edit, `grep -rn "/instrument\b"` across `*.mdx`/`*.md`/`*.ts`/`*.tsx` returns only Ollie sites and OpenTelemetry package paths.
- `grep` for `InstallWithAITab` / `Instrument my agent` across `*.test.*`, `*.spec.*`, `*.snap` found no test or snapshot asserting the prompt string.

CI on this branch: `lint (🌐 eslint — frontend)` passed; `lint (🌐 typecheck — frontend)` and `Test on Node 20` were still running at the time of writing.

Not run locally, with reasons:
- Frontend build/typecheck — the edit is a one-line string literal inside an existing template literal; CI covers it.
- Fern docs build — text-only changes inside existing code fences, no MDX structure touched.

**Unrelated pre-existing CI failure:** `Checks with ai-spend plugin` (Frontend Private Plugin Checks) fails with prettier errors in `src/plugins/ai-spend/lib/policySettings.test.ts` and `manifest.ts`, neither of which this PR touches. That workflow has been failing on unrelated branches since ~10:00 today (`jacquesverre/OPIK-8105-quick-filter-view-handoff`, `andreic/OPIK-8102-gemini-thinking-config`) and last succeeded at 03:29. Not introduced here.

## Documentation

This PR *is* the documentation change. No further docs updates are needed — the install command itself (`npx skills add comet-ml/opik-skills`) is unchanged, since only the skill names inside the pack move, not the pack name.

One thing left alone deliberately: `prompt_engineering/getting-started.mdx` now reads "Version my prompts in Opik using the /opik-instrument command." Pairing prompt versioning with the instrument skill is pre-existing and not wrong (the skill takes a `migrate_prompts` option), but it reads oddly. I did the mechanical rename only rather than rewriting the guidance — worth a separate look.
