### PR TITLE
[OPIK-7315] document the version tie the confirm-keys re-check cannot resolve

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1410,6 +1410,11 @@ CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/verify.sh --database o
 ./scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces
 ```
 
+> **A version tie can make this gate mismatch, and can also make it pass.** If a key carries two or more rows with an
+> identical `last_updated_at`, `FINAL` has no winner and the comparison for that key is arbitrary in both directions. It
+> is not rollback-specific despite where it is written up: see "a version tie" under *Verifying after a rollback* for the
+> shape and the confirming read, ignoring that section's `cutover_start` test, which has no meaning before the `EXCHANGE`.
+>
 > **Detach it, and expect tens of minutes.** The bounded compare walks one window per week over both
 > tables. On a large table that is minutes per window on the busy weeks and well over half an hour in
 > total, so run it under `nohup`/`screen` rather than an interactive shell that may be interrupted. It is
@@ -1480,17 +1485,33 @@ from the successor *entirely* is the real signal — that is a copy gap, and it 
 often this bites tracks how much pre-existing data the workload rewrites; for many it is none, which is why the weekly
 bound is still worth passing.
 
-**A third shape, which the confirm-keys re-check cannot resolve: a version tie.** Its premise — that filtering on the
-sorting key lets `FINAL` return the true winner — holds only while versions differ. When a key carries two or more rows
-with an **identical** `last_updated_at`, the `ReplacingMergeTree` version column, there is no winner: `FINAL` picks
-arbitrarily, and because the two tables' part layouts differ, each side can pick a different row. The key is then counted
-as `genuinely_differing_keys` even where both tables hold the same data.
+**A third shape, which the confirm-keys re-check cannot resolve: a version tie.** This one is not rollback-specific — it
+can hit the pre-`EXCHANGE` gate too (see "Verifying the migration"), where the `cutover_start` test below does not apply.
 
-Its signature is **equal row counts with a differing checksum**, and neither rule above fits it — the key is present on
-both sides *and* its `last_updated_at` predates `cutover_start`. Deciding it needs the key's full set of versions read
-from both tables without `FINAL`, which no shipped driver does; `--drill-down` reads one `FINAL` row per key and stops at
-100 keys, so it cannot show a tie. **Treat such a week as unresolved and escalate rather than passing it:** a non-unique
-top version makes the comparison arbitrary, which is not the same as benign.
+Its premise — that filtering on the sorting key lets `FINAL` return the true winner — holds only while versions differ.
+When a key carries two or more rows with an **identical** `last_updated_at`, the `ReplacingMergeTree` version column,
+there is no winner: `FINAL` picks arbitrarily, and because the two tables' part layouts differ, each side may or may not
+land on the same row. **Arbitrary cuts both ways, and the second direction is the dangerous one:**
+
+- the picks differ, and the key is reported in `genuinely_differing_keys` even though both tables hold the same data;
+- the picks coincide, and the key is confirmed as matching **even if one side is missing a version** — a real copy gap.
+  So a `0` from the re-check, and any `OK — superseded-version artifact` verdict built on it, is not conclusive while
+  ties exist.
+
+`--drill-down` cannot show a tie: it reads one `FINAL` row per key and stops at 100. Confirm one by reading the key's
+versions from both tables without `FINAL` — a read-only diagnostic, not a procedure step:
+
+```sql
+SELECT 'src' AS side, created_at, last_updated_at, _part FROM <old-table> WHERE (workspace_id, project_id, id) = (…)
+UNION ALL
+SELECT 'dst' AS side, created_at, last_updated_at, _part FROM <new-table> WHERE (workspace_id, project_id, id) = (…)
+ORDER BY side, created_at;
+```
+
+A **non-unique top `last_updated_at` on either side** means the comparison for that key was arbitrary. Then compare the
+two version sets: identical sets mean the copy is faithful and only the tie-break differed; a version present on one
+side only is the copy gap, whatever the re-check said. If the sets cannot be established, treat the week as unresolved
+and escalate rather than passing it — arbitrary is not the same as benign.
 
 > **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat.** `traces_pre_cutover_backup` is a
 > **frozen** snapshot as of `cutover_start`, but live `traces` keeps taking writes the instant the buffer drains — so

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1480,6 +1480,18 @@ from the successor *entirely* is the real signal — that is a copy gap, and it 
 often this bites tracks how much pre-existing data the workload rewrites; for many it is none, which is why the weekly
 bound is still worth passing.
 
+**A third shape, which the confirm-keys re-check cannot resolve: a version tie.** Its premise — that filtering on the
+sorting key lets `FINAL` return the true winner — holds only while versions differ. When a key carries two or more rows
+with an **identical** `last_updated_at`, the `ReplacingMergeTree` version column, there is no winner: `FINAL` picks
+arbitrarily, and because the two tables' part layouts differ, each side can pick a different row. The key is then counted
+as `genuinely_differing` even where both tables hold the same data.
+
+Its signature is **equal row counts with a differing checksum**, and neither rule above fits it — the key is present on
+both sides *and* its `last_updated_at` predates `cutover_start`. Deciding it needs the key's full set of versions read
+from both tables without `FINAL`, which no shipped driver does; `--drill-down` reads one `FINAL` row per key and stops at
+100 keys, so it cannot show a tie. **Treat such a week as unresolved and escalate rather than passing it:** a non-unique
+top version makes the comparison arbitrary, which is not the same as benign.
+
 > **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat.** `traces_pre_cutover_backup` is a
 > **frozen** snapshot as of `cutover_start`, but live `traces` keeps taking writes the instant the buffer drains — so
 > the **current (live) week will legitimately show a mismatch** (the live table is a superset of the frozen backup by

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1489,9 +1489,9 @@ bound is still worth passing.
 can hit the pre-`EXCHANGE` gate too (see "Verifying the migration"), where the `cutover_start` test below does not apply.
 
 Its premise — that filtering on the sorting key lets `FINAL` return the true winner — holds only while versions differ.
-When a key carries two or more rows with an **identical** `last_updated_at`, the `ReplacingMergeTree` version column,
-there is no winner: `FINAL` picks arbitrarily, and because the two tables' part layouts differ, each side may or may not
-land on the same row. **Arbitrary cuts both ways, and the second direction is the dangerous one:**
+`last_updated_at` is the `ReplacingMergeTree` version column, so when two or more rows for a key carry the **same**
+value there is nothing left to rank them by: `FINAL` picks arbitrarily, and because the two tables' part layouts differ,
+each side may or may not land on the same row. **Arbitrary cuts both ways, and the second direction is the dangerous one:**
 
 - the picks differ, and the key is reported in `genuinely_differing_keys` even though both tables hold the same data;
 - the picks coincide, and the key is confirmed as matching **even if one side is missing a version** — a real copy gap.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1484,7 +1484,7 @@ bound is still worth passing.
 sorting key lets `FINAL` return the true winner — holds only while versions differ. When a key carries two or more rows
 with an **identical** `last_updated_at`, the `ReplacingMergeTree` version column, there is no winner: `FINAL` picks
 arbitrarily, and because the two tables' part layouts differ, each side can pick a different row. The key is then counted
-as `genuinely_differing` even where both tables hold the same data.
+as `genuinely_differing_keys` even where both tables hold the same data.
 
 Its signature is **equal row counts with a differing checksum**, and neither rule above fits it — the key is present on
 both sides *and* its `last_updated_at` predates `cutover_start`. Deciding it needs the key's full set of versions read

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -209,7 +209,8 @@ SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- LIMITATION: this cannot resolve a VERSION TIE. The reasoning below holds only while versions differ. When a key
 -- carries two or more rows with an identical last_updated_at, FINAL has no winner to return: it picks arbitrarily, and
 -- the two tables' part layouts differ, so each side can pick a different row. Such a key is counted as genuinely
--- differing even where both tables hold the same data. Signature: equal row counts with a differing checksum. Deciding
+-- differing (genuinely_differing_keys) even where both tables hold the same data. Signature: equal row counts with a
+-- differing checksum. Deciding
 -- it needs each side's full version SET, which this query does not read -- see the runbook's triage section.
 --
 -- 0  = every differing key has identical live rows on both sides -> superseded-version artifact, not a

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -206,6 +206,12 @@ SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- granules holding the key, so FINAL always sees all versions of it and returns the true winner. The
 -- window bounds are used only to pick the candidate keys, never to decide the verdict.
 --
+-- LIMITATION: this cannot resolve a VERSION TIE. The reasoning below holds only while versions differ. When a key
+-- carries two or more rows with an identical last_updated_at, FINAL has no winner to return: it picks arbitrarily, and
+-- the two tables' part layouts differ, so each side can pick a different row. Such a key is counted as genuinely
+-- differing even where both tables hold the same data. Signature: equal row counts with a differing checksum. Deciding
+-- it needs each side's full version SET, which this query does not read -- see the runbook's triage section.
+--
 -- 0  = every differing key has identical live rows on both sides -> superseded-version artifact, not a
 --      data difference (the live row is still compared, and must match, in the week its winner lands in).
 -- >0 = that many keys genuinely differ -> real fidelity failure.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -201,9 +201,10 @@ SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- once, far enough apart to land in different created_at weeks, can trigger it; trace ids are
 -- client-supplied, so a re-sent id is ordinary rather than exotic.
 --
--- LIMITATION, which bounds the argument that follows: this cannot resolve a VERSION TIE. When a key carries two or more
--- rows with an identical last_updated_at, FINAL has no winner to return -- it picks arbitrarily, and the two tables'
--- part layouts differ, so each side may or may not land on the same row. Arbitrary cuts BOTH ways, and the second is the
+-- LIMITATION, which bounds the argument that follows: this cannot resolve a VERSION TIE. last_updated_at is the
+-- ReplacingMergeTree version column, so when two or more rows for a key carry the same value there is nothing left to
+-- rank them by: FINAL picks arbitrarily, and the two tables' part layouts differ, so each side may or may not land on
+-- the same row. Arbitrary cuts BOTH ways, and the second is the
 -- dangerous one:
 --   * the picks differ -> the key is reported in genuinely_differing_keys even where both tables hold the same data;
 --   * the picks coincide -> the key is confirmed as matching even if one side is MISSING a version, which is a real

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -201,17 +201,21 @@ SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1;
 -- once, far enough apart to land in different created_at weeks, can trigger it; trace ids are
 -- client-supplied, so a re-sent id is ordinary rather than exotic.
 --
--- Why this re-check is trustworthy. It filters ONLY on (workspace_id, project_id, id) -- the sorting key,
+-- LIMITATION, which bounds the argument that follows: this cannot resolve a VERSION TIE. When a key carries two or more
+-- rows with an identical last_updated_at, FINAL has no winner to return -- it picks arbitrarily, and the two tables'
+-- part layouts differ, so each side may or may not land on the same row. Arbitrary cuts BOTH ways, and the second is the
+-- dangerous one:
+--   * the picks differ -> the key is reported in genuinely_differing_keys even where both tables hold the same data;
+--   * the picks coincide -> the key is confirmed as matching even if one side is MISSING a version, which is a real
+--     copy gap. A 0 from this block is therefore not conclusive while ties exist, and neither is an
+--     "OK -- superseded-version artifact" verdict built on it.
+-- Deciding a tied key needs each side's full version SET, which this query does not read. The runbook's triage section
+-- carries the check; do not infer the shape from row counts here, which this block does not output.
+--
+-- Why this re-check is trustworthy WHERE VERSIONS DIFFER. It filters ONLY on (workspace_id, project_id, id) -- the sorting key,
 -- which IS the dedup key. That predicate cannot hide a version from FINAL: every part contributes the
 -- granules holding the key, so FINAL always sees all versions of it and returns the true winner. The
 -- window bounds are used only to pick the candidate keys, never to decide the verdict.
---
--- LIMITATION: this cannot resolve a VERSION TIE. The reasoning below holds only while versions differ. When a key
--- carries two or more rows with an identical last_updated_at, FINAL has no winner to return: it picks arbitrarily, and
--- the two tables' part layouts differ, so each side can pick a different row. Such a key is counted as genuinely
--- differing (genuinely_differing_keys) even where both tables hold the same data. Signature: equal row counts with a
--- differing checksum. Deciding
--- it needs each side's full version SET, which this query does not read -- see the runbook's triage section.
 --
 -- 0  = every differing key has identical live rows on both sides -> superseded-version artifact, not a
 --      data difference (the live row is still compared, and must match, in the week its winner lands in).


### PR DESCRIPTION
## Details

A fidelity compare on an internal test environment reported a week with **equal row counts** and `genuinely_differing_keys=1`, on a key both tables held identically. Read without `FINAL`, both sides carried **both** versions with the same `last_updated_at` — the `ReplacingMergeTree` version column — so `FINAL` had no winner to return, and the two part layouts (unpartitioned vs `id_at`-partitioned) broke the tie differently.

Two documentation problems:

- **The confirm-keys re-check overstates its guarantee.** Its header says filtering on the sorting key means `FINAL` "returns the true winner". That holds only while versions differ. On a tie it reports a false positive, in the query whose purpose is removing them.
- **The runbook's triage rules cover neither shape.** The documented cases are "present on both sides with `last_updated_at >= cutover_start`" (benign) and "absent from the successor" (a copy gap). A tie is present on both sides *and* predates `cutover_start`, so the rules leave it looking unexplained.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7315

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the limitation note in `000005_verify_migration.sql` and the triage branch in the runbook.
- Human verification: the diagnosis was confirmed against a live instance (below).

## Testing

Documentation only; no code path changes, so no test changes.

The diagnosis was verified by reading the differing key on both sides **without** `FINAL`: two rows per side, identical `last_updated_at`, `created_at` values minutes apart, differing only by the expected ns→us truncation. Row counts matched on both sides, which is the signature the new triage branch tells an operator to look for.

## Documentation

- `scripts/db-app-analytics/000005_verify_migration.sql` — the limitation sits immediately above the claim it qualifies, so a reader of the guarantee sees its bound.
- `README.md` — a third triage shape: the recognition signature, the fact that no shipped driver can confirm it (`--drill-down` reads one `FINAL` row per key and stops at 100), and the safe action meanwhile — treat the week as unresolved rather than passing it.

## Deliberately not in this PR

Teaching the query to classify ties. Two designs were considered; the better one is **not** the one this PR's earlier revision sketched:

- comparing the full version **set** per key proves faithfulness, but needs the row-hash expression a third time per side in a file that already carries fourteen copies, and changes the gate's output shape;
- reporting a non-unique top version as **inconclusive** rather than genuinely-differing needs no hash duplication and cannot produce a false negative, since inconclusive is not a pass. It is the smaller and safer change, and the one worth making.

Either way the driver and its test move with it, so it belongs in its own change rather than appended to a doc fix.
