### PR TITLE
[DND-1562] Make is_release honest and add a dist-tag to the opik-ts publish

### DIFF
--- a/.github/workflows/opik_wizard_publish.yml
+++ b/.github/workflows/opik_wizard_publish.yml
@@ -22,6 +22,11 @@ on:
         type: boolean
         required: false
         default: false
+      dist_tag:
+        type: string
+        required: false
+        description: "npm dist-tag to publish under (use e.g. `next` for a prerelease so `latest` does not move)"
+        default: "latest"
   workflow_call:
     inputs:
       version:
@@ -32,6 +37,10 @@ on:
         type: boolean
         required: false
         default: false
+      dist_tag:
+        type: string
+        required: false
+        default: "latest"
 
 jobs:
   publish:
@@ -40,6 +49,7 @@ jobs:
     env:
       VERSION: ${{ github.event.inputs.version || inputs.version }}
       IS_RELEASE: ${{ github.event.inputs.is_release || inputs.is_release }}
+      DIST_TAG: ${{ github.event.inputs.dist_tag || inputs.dist_tag || 'latest' }}
     defaults:
       run:
         working-directory: sdks/typescript/src/opik/configure
@@ -70,7 +80,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate version format
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: |
           if ! [[ "${{ env.VERSION }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "Error: Invalid version format '${{ env.VERSION }}'. Expected format: X.Y.Z or X.Y.Z-suffix"
@@ -78,7 +88,7 @@ jobs:
           fi
 
       - name: Update version
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: pnpm version ${{ env.VERSION }} --no-git-tag-version
 
       - name: Lint and format check
@@ -97,7 +107,7 @@ jobs:
           fi
 
       - name: Check if version already exists on NPM
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: |
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           if npm view "$PACKAGE_NAME@${{ env.VERSION }}" version 2>/dev/null; then
@@ -107,7 +117,7 @@ jobs:
           echo "Version check passed - ${{ env.VERSION }} is available"
 
       - name: Commit version changes
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: |
           git config --local user.email "github-actions@comet.com"
           git config --local user.name "github-actions"
@@ -115,12 +125,12 @@ jobs:
           git diff --staged --quiet || git commit -m "chore: update Opik Configure version to ${{ env.VERSION }}"
 
       - name: Create git tag
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: |
           git tag -a "configure-v${{ env.VERSION }}" -m "Release Opik Configure v${{ env.VERSION }}"
 
       - name: Publish to NPM
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         # Published with `npm publish`, not `pnpm publish`: OIDC trusted publishing
         # landed in pnpm 10.x (this workflow pins pnpm 9.15.5 for install/build) and
         # pnpm 11 has an open report of OIDC publishes 404-ing. `--access public` is
@@ -129,13 +139,17 @@ jobs:
         # `npm config delete` removes the `_authToken=${NODE_AUTH_TOKEN}` stub that
         # `setup-node` writes into ~/.npmrc — with no token, npm would try that empty
         # credential instead of falling back to the OIDC exchange.
+        #
+        # `--tag` defaults to `latest`; pass `next` (or similar) on a dispatch to
+        # publish a prerelease without moving `latest` — npm applies `latest` to
+        # any untagged publish, prerelease version or not.
         run: |
-          echo "Publishing $(node -p "require('./package.json').name") version ${{ env.VERSION }} to NPM..."
+          echo "Publishing $(node -p "require('./package.json').name") version ${{ env.VERSION }} to NPM under dist-tag '${DIST_TAG}'..."
           npm config delete //registry.npmjs.org/:_authToken || true
-          npm publish --access public
+          npm publish --access public --tag "${DIST_TAG}"
 
       - name: Push changes and tags
-        if: ${{ env.IS_RELEASE }}
+        if: ${{ env.IS_RELEASE == 'true' }}
         run: |
           git push origin "${REF}"
           git push origin "configure-v${{ env.VERSION }}"
@@ -154,11 +168,12 @@ jobs:
           echo ""
           echo "- **Version**: ${{ env.VERSION }}"
           echo "- **Is Release**: ${{ env.IS_RELEASE }}"
+          echo "- **Dist tag**: ${{ env.DIST_TAG }}"
           echo "- **Branch**: ${REF_NAME}"
           echo "- **Triggered by**: @${ACTOR}"
           echo ""
           if [ "${{ env.IS_RELEASE }}" == "true" ]; then
-            echo "✅ Package published to NPM: [opik-configure@${{ env.VERSION }}](https://www.npmjs.com/package/opik-configure/v/${{ env.VERSION }})"
+            echo "✅ Package published to NPM: [opik-ts@${{ env.VERSION }}](https://www.npmjs.com/package/opik-ts/v/${{ env.VERSION }}) under dist-tag \`${{ env.DIST_TAG }}\`"
             echo "✅ Git tag created: configure-v${{ env.VERSION }}"
           else
             echo "ℹ️ Dry run completed - no changes published"


### PR DESCRIPTION
## Details

`opik-ts` is the one package from the trusted-publishing migration (#7918) that has not published since — latest on npm is 0.1.3 from 2025-10-09, with no provenance — so its OIDC path is untested. Two things in this workflow make testing it unnecessarily risky; both are fixed here.

**1. `is_release: false` was not a dry run.** Every release-only step used `if: ${{ env.IS_RELEASE }}`, and in GitHub Actions expressions any non-empty string casts to `true` — including the string `"false"`. A dispatch with `is_release: false` therefore ran the version bump, the git tag, **and the publish**, while the summary printed "ℹ️ Dry run completed - no changes published". All seven conditions now compare against `'true'`, which is the form `typescript_sdk_publish.yml` and the shared composite action already use. Contained to this file — `git grep -F 'if: ${{ env.IS_RELEASE }}'` finds no other occurrence in the repo.

**2. No way to publish a prerelease without moving `latest`.** `npm publish` applies the `latest` dist-tag to any untagged publish, prerelease version or not, so a `0.1.4-rc.0` smoke test would change what `npx opik-ts` resolves to. Moving `latest` back requires `npm dist-tag add`, i.e. an interactive npm session — exactly the token dependency this migration removes. Adds a `dist_tag` input (default `latest`, on both `workflow_dispatch` and `workflow_call`), passed through as `--tag`.

Also: the summary now reports the dist-tag, and its package link no longer points at the pre-rename `opik-configure`.

With this in, testing the path is: dispatch `version: 0.1.4-rc.0`, `is_release: true`, `dist_tag: next`, then confirm with `npm view opik-ts@0.1.4-rc.0 dist.attestations` — attestations present means the OIDC path ran, since a token publish without `--provenance` produces none. If no trusted publisher is registered for `opik-ts` on npmjs.com yet, the run fails at `npm publish`, which sits *before* the `git push` of the branch and tag — so a failure leaves no version on npm and nothing pushed to the repo.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- DND-1562

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the workflow edit and this description.
- Human verification: the truthiness behaviour is documented GitHub Actions expression casting (non-empty string → true); step ordering (publish before push) was read off `main`; the `latest`-on-untagged-publish behaviour is npm's documented default.

## Testing

`yaml.safe_load` on the changed workflow — parses. No behaviour to exercise on this PR: the workflow is `workflow_dispatch`-only, so it does not run on pull requests. The change is verified by the smoke test described above, which is the point of the PR.

## Documentation

Inline comment on the publish step explains the `--tag` default and when to override it; the `dist_tag` input carries a description that shows in the dispatch form.
