### PR TITLE
[OPIK-7957] [FE] fix: block whitespace-only annotation queue names and prevent data loss

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -133,6 +133,7 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
     const { lock_timeout_minutes, ...rest } = formData;
     return {
       ...rest,
+      name: formData.name.trim(),
       project_id: formData.project_id,
       lock_timeout_seconds: lock_timeout_minutes * 60,
     };

--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -117,8 +117,11 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
     },
   });
 
-  const { mutate: createMutate } = useAnnotationQueueCreateMutation();
-  const { mutate: updateMutate } = useAnnotationQueueUpdateMutation();
+  const { mutate: createMutate, isPending: isCreatePending } =
+    useAnnotationQueueCreateMutation();
+  const { mutate: updateMutate, isPending: isUpdatePending } =
+    useAnnotationQueueUpdateMutation();
+  const isSubmitting = isCreatePending || isUpdatePending;
 
   const isEdit = Boolean(defaultQueue);
   const title = isEdit
@@ -380,7 +383,11 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit" onClick={form.handleSubmit(onSubmit)}>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            onClick={form.handleSubmit(onSubmit)}
+          >
             {submitText}
           </Button>
         </DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -57,6 +57,7 @@ const formSchema = z.object({
   project_id: z.string().min(1, "Project is required"),
   name: z
     .string()
+    .trim()
     .min(1, "Name is required")
     .max(255, "Name cannot exceed 255 characters"),
   description: z.string().optional(),
@@ -151,9 +152,13 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
       {
         annotationQueue: getQueue(),
       },
-      { onSuccess: onQueueCreatedEdited },
+      {
+        onSuccess: (queue) => {
+          onQueueCreatedEdited(queue);
+          setOpen(false);
+        },
+      },
     );
-    setOpen(false);
   }, [createMutate, getQueue, onQueueCreatedEdited, setOpen]);
 
   const editQueue = useCallback(() => {
@@ -164,9 +169,13 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
           ...getQueue(),
         },
       },
-      { onSuccess: onQueueCreatedEdited },
+      {
+        onSuccess: (queue) => {
+          onQueueCreatedEdited(queue);
+          setOpen(false);
+        },
+      },
     );
-    setOpen(false);
   }, [updateMutate, defaultQueue?.id, getQueue, onQueueCreatedEdited, setOpen]);
 
   const onSubmit = useCallback(


### PR DESCRIPTION
## Details
Whitespace-only annotation queue names passed client-side validation, got rejected by the API with a 422, and closed the dialog anyway — discarding everything the user had typed. This adds `.trim()` to the name validation (blocking whitespace-only submissions before any request is sent), keeps the dialog open until the create/update mutation actually succeeds, trims the name in the submitted payload (the schema's `.trim()` only affected validation, not the value read via `form.getValues()`), and disables the submit button while a create/update is in flight to prevent a double-submit race introduced by no longer closing the dialog synchronously.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-7957

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: full implementation
- Human verification: manual testing against a local dev environment (repro + fix verification for the original bug, a payload-trim edge case, and a double-submit race), code review

## Testing
Manually verified against a local dev stack (Docker services + backend + frontend) using the Traces "Add to > Annotation queue" flow:
- Typed a whitespace-only name (`"   "`) and submitted: dialog stayed open with inline "Name is required", and confirmed via backend logs that no `POST /v1/private/annotation-queues/` request was sent.
- Typed a name padded with whitespace (`"  Foo  "`): confirmed the queue is now saved trimmed (`"Foo"`), not with the surrounding spaces.
- Simulated a slow network to confirm the submit button disables while the mutation is pending, and that a rapid double-click only fires one request and creates one queue.
- Full happy path: valid name + instructions submitted successfully, dialog closed, "Items added to annotation queue" toast shown, queue created via API with the trace attached.

No automated frontend tests exist for this dialog; `npm run lint`/`npm run typecheck` pass for the changed file (`apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx`).

## Documentation
N/A
