### PR TITLE
[NA] [QA] Proposed e2e specs: annotation queue name validation (from the opik#8056 exploration)

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -133,6 +133,7 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
     const { lock_timeout_minutes, ...rest } = formData;
     return {
       ...rest,
+      name: formData.name.trim(),
       project_id: formData.project_id,
       lock_timeout_seconds: lock_timeout_minutes * 60,
     };

--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -117,8 +117,11 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
     },
   });
 
-  const { mutate: createMutate } = useAnnotationQueueCreateMutation();
-  const { mutate: updateMutate } = useAnnotationQueueUpdateMutation();
+  const { mutate: createMutate, isPending: isCreatePending } =
+    useAnnotationQueueCreateMutation();
+  const { mutate: updateMutate, isPending: isUpdatePending } =
+    useAnnotationQueueUpdateMutation();
+  const isSubmitting = isCreatePending || isUpdatePending;
 
   const isEdit = Boolean(defaultQueue);
   const title = isEdit
@@ -380,7 +383,11 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
           <DialogClose asChild>
             <Button variant="outline">Cancel</Button>
           </DialogClose>
-          <Button type="submit" onClick={form.handleSubmit(onSubmit)}>
+          <Button
+            type="submit"
+            disabled={isSubmitting}
+            onClick={form.handleSubmit(onSubmit)}
+          >
             {submitText}
           </Button>
         </DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/annotation-queues/AddEditAnnotationQueueDialog.tsx
@@ -57,6 +57,7 @@ const formSchema = z.object({
   project_id: z.string().min(1, "Project is required"),
   name: z
     .string()
+    .trim()
     .min(1, "Name is required")
     .max(255, "Name cannot exceed 255 characters"),
   description: z.string().optional(),
@@ -151,9 +152,13 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
       {
         annotationQueue: getQueue(),
       },
-      { onSuccess: onQueueCreatedEdited },
+      {
+        onSuccess: (queue) => {
+          onQueueCreatedEdited(queue);
+          setOpen(false);
+        },
+      },
     );
-    setOpen(false);
   }, [createMutate, getQueue, onQueueCreatedEdited, setOpen]);
 
   const editQueue = useCallback(() => {
@@ -164,9 +169,13 @@ const AddEditAnnotationQueueDialog: React.FunctionComponent<
           ...getQueue(),
         },
       },
-      { onSuccess: onQueueCreatedEdited },
+      {
+        onSuccess: (queue) => {
+          onQueueCreatedEdited(queue);
+          setOpen(false);
+        },
+      },
     );
-    setOpen(false);
   }, [updateMutate, defaultQueue?.id, getQueue, onQueueCreatedEdited, setOpen]);
 
   const onSubmit = useCallback(

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -606,14 +606,19 @@ areas:
     specs:
       - annotation-queues/annotation-queue-scoring.spec.ts
       - annotation-queues/annotation-queue-delete.spec.ts
+      - annotation-queues/annotation-queue-name-validation.spec.ts
     capabilities:
       score-queue-item:        { covered: true,  tier: t2-cuj }
       score-with-reason:       { covered: true,  tier: t2-cuj }
       skip-item:               { covered: true,  tier: t2-cuj }
       scores-reach-traces:     { covered: true,  tier: t2-cuj, note: "SDK-verified" }
       list-queues:             { covered: false }
-      create-queue:            { covered: false }
-      edit-queue:              { covered: false }
+      # Name validation and trimming only — the dialog is driven end to end
+      # (whitespace-only rejected client-side, padded name stored trimmed), but
+      # the rest of the create/edit form (scope, feedback definitions,
+      # annotators per item, lock timeout) is still untested. opik PR #8056.
+      create-queue:            { covered: true,  tier: t2-cuj, note: "create dialog name validation + trim; other form fields untested" }
+      edit-queue:              { covered: true,  tier: t2-cuj, note: "edit dialog name validation + trim from both entry points (row actions, detail page); other form fields untested" }
       # Second case in this spec is a test.fail() known failure for OPIK-7903
       # (deleted-queue URL loads forever instead of showing a not-found state).
       # Fixing that bug turns the run red until the annotation is removed.

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1794,6 +1794,53 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
     },
 
     /**
+     * Every annotation queue in one project — the exact read the queues list
+     * page performs, with the same `project_id` filter the FE builds in
+     * `generateProjectFilters`.
+     *
+     * Goes through `rawFetch` rather than the pinned SDK because
+     * `findAnnotationQueues` exposes only `name`/`page`/`size`. A name search
+     * cannot answer "did a queue get created under a name I did NOT choose",
+     * which is precisely what a create-validation test has to assert: a
+     * whitespace-only submit that leaks through would land a queue named
+     * `"   "`, and any prefix search would report it as absent.
+     *
+     * Returns `total` alongside the rows so a caller can assert the whole
+     * answer (count AND collection length), not just that its own queue is
+     * somewhere in it.
+     */
+    async listAnnotationQueuesForProject(
+      projectId: string,
+    ): Promise<{ total: number; queues: ProjectRef[] }> {
+      const filters: BackendFilter[] = [
+        { field: 'project_id', type: 'string', operator: '=', key: '', value: projectId },
+      ];
+      const query = new URLSearchParams({
+        size: '500',
+        filters: JSON.stringify(filters),
+      });
+      const { status, message, json } = await rawFetch(
+        'GET',
+        '/v1/private/annotation-queues',
+        { query },
+      );
+      if (status !== 200) {
+        throw new Error(
+          `listAnnotationQueuesForProject(${projectId}) failed: ${status} ${message}`,
+        );
+      }
+      const body = (json ?? {}) as { total?: unknown; content?: unknown };
+      const content = Array.isArray(body.content) ? body.content : [];
+      return {
+        total: typeof body.total === 'number' ? body.total : content.length,
+        queues: content.map((q) => {
+          const row = q as { id?: unknown; name?: unknown };
+          return { id: String(row.id), name: String(row.name) };
+        }),
+      };
+    },
+
+    /**
      * Fetch the studio run's logs. The backend returns a presigned URL to a
      * gzipped log object (the optimizer subprocess stdout); this resolves it and
      * gunzips the content.

--- a/tests_end_to_end/e2e/fixtures/annotation-queue.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/annotation-queue.fixture.ts
@@ -18,6 +18,7 @@ export interface AnnotationQueueRef {
 
 export interface AnnotationQueueFixtures {
   annotationQueue: AnnotationQueueRef;
+  registerAnnotationQueueCleanup: (id: string, name: string) => void;
 }
 
 const TRACE_COUNT = 3;
@@ -69,6 +70,33 @@ export const test = baseTest.extend<AnnotationQueueFixtures>({
         await backendClient.deleteAnnotationQueue(created.id);
       } catch (err) {
         console.warn(`[annotationQueue fixture] delete warning for ${queueName}:`, err);
+      }
+    }
+  },
+
+  /**
+   * Teardown for queues a test creates through the UI, whose ids only exist
+   * mid-test. A seed fixture can't predict them, and a trailing cleanup step in
+   * the test body is skipped the moment an earlier assertion throws — exactly
+   * when the environment is dirtiest.
+   *
+   * Needed because annotation queues cascade with nothing: not the `project`
+   * fixture's delete, and not the run-prefix sweep in `global-teardown.ts`
+   * either when the name under test is deliberately NOT prefixed (a padded or
+   * whitespace name is the whole point of the create-validation spec).
+   */
+  registerAnnotationQueueCleanup: async ({ backendClient }, use, testInfo) => {
+    const registry: Array<{ id: string; name: string }> = [];
+    await use((id, name) => {
+      registry.push({ id, name });
+    });
+    if (!shouldLeaveArtifacts(testInfo)) {
+      for (const { id, name } of registry) {
+        try {
+          await backendClient.deleteAnnotationQueue(id);
+        } catch (err) {
+          console.warn(`[registerAnnotationQueueCleanup] delete warning for ${name}:`, err);
+        }
       }
     }
   },

--- a/tests_end_to_end/e2e/pom/annotation-queue.page.ts
+++ b/tests_end_to_end/e2e/pom/annotation-queue.page.ts
@@ -2,6 +2,94 @@ import { expect, test, type Locator, type Page } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 import { TracePanelPage } from './trace-panel.page';
 
+/**
+ * The create/edit annotation queue dialog — one component
+ * (`AddEditAnnotationQueueDialog`) reached from three entry points: the queues
+ * list "Create queue" button, a queue row's Edit action, and the queue-detail
+ * "Edit" button. Only the title and submit label differ between modes, so the
+ * mode is a constructor argument rather than two near-identical classes.
+ */
+export class AnnotationQueueDialog {
+  private static readonly TITLES = {
+    create: 'Create a new annotation queue',
+    edit: 'Edit annotation queue',
+  } as const;
+
+  private static readonly SUBMIT_LABELS = {
+    create: 'Create annotation queue',
+    edit: 'Update annotation queue',
+  } as const;
+
+  constructor(
+    private readonly page: Page,
+    private readonly mode: 'create' | 'edit',
+  ) {}
+
+  /**
+   * Scoped by its own title so the two modes never resolve to each other's
+   * dialog — the row-actions cell mounts an edit dialog on every row, and the
+   * list page mounts a create dialog, so `getByRole('dialog')` alone is
+   * ambiguous the moment either is open.
+   */
+  get root(): Locator {
+    return this.page.getByRole('dialog').filter({
+      has: this.page.getByRole('heading', {
+        name: AnnotationQueueDialog.TITLES[this.mode],
+        exact: true,
+      }),
+    });
+  }
+
+  /** `exact` matters: "Number of annotators per item" also contains "Name". */
+  get nameInput(): Locator {
+    return this.root.getByLabel('Name', { exact: true });
+  }
+
+  get submitButton(): Locator {
+    return this.root.getByRole('button', {
+      name: AnnotationQueueDialog.SUBMIT_LABELS[this.mode],
+      exact: true,
+    });
+  }
+
+  /** The zod `.trim().min(1)` message, rendered by the Name field's FormMessage. */
+  get nameRequiredError(): Locator {
+    return this.root.getByText('Name is required', { exact: true });
+  }
+
+  async waitForReady(): Promise<void> {
+    return test.step(`Wait for the ${this.mode} annotation queue dialog`, async () => {
+      await this.nameInput.waitFor({ state: 'visible' });
+    });
+  }
+
+  async fillName(name: string): Promise<void> {
+    return test.step(`Set the queue name to "${name}"`, async () => {
+      await this.nameInput.fill(name);
+    });
+  }
+
+  async submit(): Promise<void> {
+    return test.step(`Submit the ${this.mode} annotation queue dialog`, async () => {
+      await this.submitButton.click();
+    });
+  }
+
+  /**
+   * Submit, then wait for the dialog to go away.
+   *
+   * The dialog now closes only in the mutation's `onSuccess` (opik#8056), so
+   * "hidden" is a real signal that the write landed — not, as before, a
+   * synchronous close that happened whatever the server answered.
+   */
+  async submitAndExpectClosed(): Promise<void> {
+    return test.step(`Submit the ${this.mode} dialog and wait for it to close`, async () => {
+      await this.submitButton.click();
+      await expect(this.root).toBeHidden();
+    });
+  }
+}
+
 /** The project-scoped queues list at /projects/$projectId/annotation-queues. */
 export class AnnotationQueuesPage {
   constructor(private readonly page: Page) {}
@@ -41,6 +129,36 @@ export class AnnotationQueuesPage {
 
   get emptyState(): Locator {
     return this.page.getByText('No annotation queues yet');
+  }
+
+  /**
+   * The header "Create queue" button, which renders whether or not the project
+   * already has queues — unlike the empty state's "Create your first queue",
+   * which disappears as soon as one exists.
+   */
+  async openCreateDialog(): Promise<AnnotationQueueDialog> {
+    return test.step('Open the create annotation queue dialog', async () => {
+      await this.page.getByRole('button', { name: 'Create queue', exact: true }).click();
+      const dialog = new AnnotationQueueDialog(this.page, 'create');
+      await dialog.waitForReady();
+      return dialog;
+    });
+  }
+
+  /**
+   * Open a queue's edit dialog from its row kebab menu. Scoped by row first, the
+   * same way `deleteQueue` is, so the menu belongs to the queue under test.
+   */
+  async openEditDialog(queueId: string): Promise<AnnotationQueueDialog> {
+    return test.step(`Open the edit dialog for annotation queue ${queueId}`, async () => {
+      const row = this.queueRow(queueId);
+      await row.waitFor({ state: 'visible' });
+      await row.getByRole('button', { name: 'Actions menu' }).click();
+      await this.page.getByRole('menuitem', { name: 'Edit' }).click();
+      const dialog = new AnnotationQueueDialog(this.page, 'edit');
+      await dialog.waitForReady();
+      return dialog;
+    });
   }
 
   /**
@@ -101,6 +219,32 @@ export class AnnotationQueuePage {
    */
   get queueItemsTab(): Locator {
     return this.page.getByRole('tab', { name: 'Queue items' });
+  }
+
+  /**
+   * The page's `<h1>`, which renders the queue name in full.
+   *
+   * This is the only place in the UI that does: the list's Name column
+   * truncates the text server-side of the ellipsis, so a padded name and its
+   * trimmed twin render identically there and the row label cannot tell them
+   * apart.
+   */
+  get queueNameHeading(): Locator {
+    return this.page.getByRole('heading', { level: 1 });
+  }
+
+  /**
+   * Open the edit dialog from the detail page's own Edit button — a second
+   * mount of the same dialog as the list's row action, and a separate entry
+   * point that can regress on its own.
+   */
+  async openEditDialog(): Promise<AnnotationQueueDialog> {
+    return test.step('Open the edit dialog from the queue detail page', async () => {
+      await this.page.getByRole('button', { name: 'Edit', exact: true }).click();
+      const dialog = new AnnotationQueueDialog(this.page, 'edit');
+      await dialog.waitForReady();
+      return dialog;
+    });
   }
 
   /**

--- a/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-name-validation.spec.ts
+++ b/tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-name-validation.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '@e2e/fixtures';
+import { AnnotationQueuePage, AnnotationQueuesPage } from '@e2e/pom/annotation-queue.page';
+
+/**
+ * Name handling in the create/edit annotation queue dialog (opik#8056, OPIK-7957).
+ *
+ * Two behaviours that live ONLY in the frontend, which is why they need a UI
+ * test rather than an API one. Measured against this environment's backend
+ * before the specs were written:
+ *
+ *   - `POST /v1/private/annotation-queues` with `name: "   "` answers 422
+ *     (`@NotBlank` on AnnotationQueue.name). The dialog must never send it —
+ *     pre-fix it did, and then closed anyway, discarding what the user typed.
+ *   - `POST` with `name: "  padded  "` answers 201 and reads back WITH the
+ *     padding. The backend does not trim, so a trimmed record can only have
+ *     come from the dialog's own `name: formData.name.trim()`.
+ *
+ * Each test therefore drives the dialog and reads the result back through the
+ * API: the queues list truncates the Name column, so a row label cannot tell a
+ * padded name from its trimmed twin.
+ */
+test.describe('Annotation queue — name validation and trimming', { tag: ['@t2-cuj', '@area:annotation-queues'] }, () => {
+  const WHITESPACE_NAME = '     ';
+
+  test(
+    'Creating a queue rejects a whitespace-only name and trims a padded one',
+    { tag: ['@cap:annotation-queues.create-queue'] },
+    async ({ project, backendClient, registerAnnotationQueueCleanup, testNamespace, page }) => {
+      const paddedName = `  ${testNamespace}-created  `;
+      const trimmedName = `${testNamespace}-created`;
+      const queuesPage = new AnnotationQueuesPage(page);
+
+      await test.step('Confirm the seeded project starts with no queues', async () => {
+        // The baseline every later count is read against. If the project were
+        // not actually empty, "exactly one queue, and it is mine" below could
+        // pass over someone else's row.
+        const before = await backendClient.listAnnotationQueuesForProject(project.id);
+        expect(before.total).toBe(0);
+        expect(before.queues).toHaveLength(0);
+      });
+
+      const dialog = await test.step('Open the create queue dialog', async () => {
+        await queuesPage.goto(project.id);
+        await queuesPage.waitForReady();
+        return queuesPage.openCreateDialog();
+      });
+
+      await test.step('Submitting a whitespace-only name is blocked in the dialog', async () => {
+        await dialog.fillName(WHITESPACE_NAME);
+        await dialog.submit();
+
+        await expect(dialog.nameRequiredError).toBeVisible();
+        await expect(dialog.root).toBeVisible();
+        // Asserted after the inline error, deliberately. The error only renders
+        // because zod rejected the value client-side, so by the time it is up no
+        // create request can still be in flight — which is what makes this read
+        // a real check rather than a race the API happens to win.
+        const after = await backendClient.listAnnotationQueuesForProject(project.id);
+        expect(after.total).toBe(0);
+        expect(after.queues).toHaveLength(0);
+      });
+
+      await test.step('Submitting a padded name closes the dialog', async () => {
+        await dialog.fillName(paddedName);
+        await dialog.submitAndExpectClosed();
+      });
+
+      const created = await test.step('The stored queue name carries no padding', async () => {
+        await expect
+          .poll(
+            async () => (await backendClient.listAnnotationQueuesForProject(project.id)).total,
+            { message: 'the created queue should be the only queue in the project' },
+          )
+          .toBe(1);
+
+        const listed = await backendClient.listAnnotationQueuesForProject(project.id);
+        expect(listed.queues).toHaveLength(1);
+        const [queue] = listed.queues;
+        registerAnnotationQueueCleanup(queue.id, queue.name);
+        expect(queue.name).toBe(trimmedName);
+        return queue;
+      });
+
+      await test.step('The queue detail header renders the trimmed name', async () => {
+        const detailPage = new AnnotationQueuePage(page);
+        await detailPage.goto(project.id, created.id);
+        await detailPage.waitForReady();
+        await expect(detailPage.queueNameHeading).toHaveCount(1);
+        await expect(detailPage.queueNameHeading).toHaveText(trimmedName);
+      });
+    },
+  );
+
+  test(
+    'Editing a queue from the list rejects a whitespace-only name and trims a padded one',
+    { tag: ['@cap:annotation-queues.edit-queue'] },
+    async ({ annotationQueue, backendClient, testNamespace, page }) => {
+      const paddedName = `  ${testNamespace}-renamed  `;
+      const trimmedName = `${testNamespace}-renamed`;
+      const queuesPage = new AnnotationQueuesPage(page);
+
+      const dialog = await test.step('Open the edit dialog from the queue row', async () => {
+        await queuesPage.goto(annotationQueue.projectId);
+        await queuesPage.waitForReady();
+        return queuesPage.openEditDialog(annotationQueue.id);
+      });
+
+      await test.step('The dialog is prefilled with the current name', async () => {
+        await expect(dialog.nameInput).toHaveValue(annotationQueue.name);
+      });
+
+      await test.step('Submitting a whitespace-only name is blocked and changes nothing', async () => {
+        await dialog.fillName(WHITESPACE_NAME);
+        await dialog.submit();
+
+        await expect(dialog.nameRequiredError).toBeVisible();
+        await expect(dialog.root).toBeVisible();
+        const unchanged = await backendClient.getAnnotationQueue(annotationQueue.id);
+        expect(unchanged).not.toBeNull();
+        expect(unchanged?.name).toBe(annotationQueue.name);
+      });
+
+      await test.step('Submitting a padded name closes the dialog', async () => {
+        await dialog.fillName(paddedName);
+        await dialog.submitAndExpectClosed();
+      });
+
+      await test.step('The renamed queue is stored without padding', async () => {
+        await expect
+          .poll(
+            async () => (await backendClient.getAnnotationQueue(annotationQueue.id))?.name,
+            { message: 'the edit should land on the queue record' },
+          )
+          .toBe(trimmedName);
+
+        // The rename must not have forked a second queue in the project: the
+        // seeded one, renamed, is the whole answer.
+        const listed = await backendClient.listAnnotationQueuesForProject(
+          annotationQueue.projectId,
+        );
+        expect(listed.total).toBe(1);
+        expect(listed.queues).toHaveLength(1);
+        expect(listed.queues[0].id).toBe(annotationQueue.id);
+      });
+    },
+  );
+
+  test(
+    'Editing a queue from its detail page trims a padded name in the header',
+    { tag: ['@cap:annotation-queues.edit-queue'] },
+    async ({ annotationQueue, backendClient, testNamespace, page }) => {
+      // A second mount of the same dialog, from a different entry point and over
+      // a different header. The list row cannot show this at all (the Name
+      // column truncates); the detail h1 renders the name in full, so it is the
+      // one place a padded name is visibly distinguishable from a trimmed one.
+      const paddedName = `  ${testNamespace}-detail  `;
+      const trimmedName = `${testNamespace}-detail`;
+      const detailPage = new AnnotationQueuePage(page);
+
+      await test.step('Open the queue detail page on its seeded name', async () => {
+        await detailPage.goto(annotationQueue.projectId, annotationQueue.id);
+        await detailPage.waitForReady();
+        await expect(detailPage.queueNameHeading).toHaveCount(1);
+        await expect(detailPage.queueNameHeading).toHaveText(annotationQueue.name);
+      });
+
+      await test.step('Rename it with a padded name from the detail Edit button', async () => {
+        const dialog = await detailPage.openEditDialog();
+        await expect(dialog.nameInput).toHaveValue(annotationQueue.name);
+        await dialog.fillName(paddedName);
+        await dialog.submitAndExpectClosed();
+      });
+
+      await test.step('The header renders the trimmed name', async () => {
+        await expect(detailPage.queueNameHeading).toHaveText(trimmedName);
+      });
+
+      await test.step('The stored record carries no padding either', async () => {
+        const stored = await backendClient.getAnnotationQueue(annotationQueue.id);
+        expect(stored).not.toBeNull();
+        expect(stored?.name).toBe(trimmedName);
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Details

**Generated by the QA release/PR exploration side flow (`release-test-proposal`). It has had no human review — please review before merging.**

Three `@t2-cuj` e2e specs covering annotation queue **name validation and trimming**, turned into permanent tests from an exploration of opik#8056 (`OPIK_7957`, "block whitespace-only annotation queue names and prevent data loss"). A human drove each of these flows by hand on that PR's own deployed environment (`pr-8056.dev.comet.com`, build `2.2.45-8056-merge-3138`) before any of it was written down.

### ⚠️ This PR targets opik#8056's branch, not `main`

`--base nata/OPIK-7957/whitespace-bug-fix`, deliberately. The behaviour these specs assert **does not exist on `main` yet** — the trim and the deferred dialog close are opik#8056's own diff, so the same specs would fail on `main`. Retarget to `main` once opik#8056 merges (no spec changes needed).

### Why these assertions can only pass because of opik#8056

Measured directly against the environment's API, so a green run cannot be credited to the wrong layer:

| Backend on its own | Result |
|---|---|
| `POST /v1/private/annotation-queues` with `name: "     "` | **422** `name must not be blank` |
| `POST` with `name: "  padded  "` | **201**, and `GET` reads it back as `'  padded  '` — padding intact |

The backend does **not** trim, and it **does** reject blank names. So a trimmed stored record can only have come from the dialog's `name: formData.name.trim()`, and a whitespace-only submit that never reaches the server can only be `zod .trim().min(1)`. Both are in opik#8056's diff.

## Per-spec detail

All three live in `tests_end_to_end/e2e/tests/annotation-queues/annotation-queue-name-validation.spec.ts`.

### 1. `Creating a queue rejects a whitespace-only name and trims a padded one` — `@cap:annotation-queues.create-queue`

Seeds a bare project via the SDK, opens the queues list, and drives the **Create queue** dialog.

- Whitespace-only name → inline "Name is required", dialog stays open, and the project's queue list is still empty on the API.
- Padded name → dialog closes, and the project holds **exactly one** queue whose `name` has no padding.
- The queue-detail `<h1>` renders the trimmed name in full.

**Result: passed.**

### 2. `Editing a queue from the list rejects a whitespace-only name and trims a padded one` — `@cap:annotation-queues.edit-queue`

Uses the existing `annotationQueue` fixture, then opens **Edit** from the row's actions menu.

- Name field is prefilled with the seeded name.
- Whitespace-only → "Name is required", dialog stays open, and the API record's name is **unchanged**.
- Padded → dialog closes, the record's name is exactly the trimmed value, and the project still holds exactly one queue (the rename did not fork a second one).

**Result: passed.**

### 3. `Editing a queue from its detail page trims a padded name in the header` — `@cap:annotation-queues.edit-queue`

The same dialog from its **second** entry point — the detail page's own Edit button — asserted over the detail `<h1>` and the API record.

This one exists because the list's Name column truncates (`cuj-20260828-1514…`), so a row label genuinely cannot tell a padded name from its trimmed twin. The detail header is the only place in the UI that renders the name in full.

**Result: passed.**

## Verification

Run against the PR's own deployed environment (`OPIK_BASE_URL=https://pr-8056.dev.comet.com`, `OPIK_DEPLOYMENT=oss`, workspace `default`), from `tests_end_to_end/e2e`:

```bash
npx playwright test tests/annotation-queues/annotation-queue-name-validation.spec.ts --reporter=list
#   3 passed (21.8s)   — all three green on the first run
```

Because this change touches a shared POM (`pom/annotation-queue.page.ts`), the whole feature directory was re-run too:

```bash
npx playwright test tests/annotation-queues/ --reporter=list
#   7 passed (43.3s)   — the sibling delete + scoring specs are unaffected
#   (the reported ✘ is the pre-existing test.fail() known failure for OPIK_7903)
```

Tag lint:

```bash
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
#   tag-lint: 55 specs checked, 1 exempt, 0 problem(s)
```

Typecheck: clean for every file in this change. Note that `npx tsc --noEmit` currently fails on `tsconfig.json(13,5): Option 'baseUrl' has been removed` — a **pre-existing** incompatibility between the pinned `typescript@^7.0.2` and the committed `tsconfig.json`, present on `main` and unrelated to this PR. Typechecking with `baseUrl` removed reports nothing in any file touched here (the only two remaining errors are the pre-existing duplicate `deleteDashboard` identifiers in `core/backend/client.ts`).

## Supporting changes

| File | Why |
|---|---|
| `pom/annotation-queue.page.ts` | New `AnnotationQueueDialog` POM for the shared create/edit dialog; `openCreateDialog()` / `openEditDialog()` on the list page, `openEditDialog()` + `queueNameHeading` on the detail page. Additive — no existing member changed. |
| `core/backend/client.ts` | `listAnnotationQueuesForProject()`. The pinned SDK's `findAnnotationQueues` only takes `name`/`page`/`size`, and a name search **cannot** answer "did a queue get created under a name I did not choose" — a leaked whitespace submit would land a queue called `"   "` and any prefix search would report it absent. Uses the same `project_id` filter the FE builds in `generateProjectFilters`, and returns `total` alongside the rows so callers assert the whole answer, not just that their own row is in it. |
| `fixtures/annotation-queue.fixture.ts` | `registerAnnotationQueueCleanup`, a register-callback fixture for the queue spec 1 creates through the UI (its id only exists mid-test). Annotation queues cascade with neither the `project` fixture nor the run-prefix sweep in `global-teardown.ts`, and the padded/whitespace names under test are deliberately not prefix-sweepable. Honours `shouldLeaveArtifacts`. |
| `coverage/taxonomy.yaml` | Spec added to the area's `specs:` list; `create-queue` and `edit-queue` flipped to `covered: true, tier: t2-cuj`. Both carry a `note:` scoping the claim to **name handling only** — the rest of the dialog (scope, feedback definitions, annotators per item, lock timeout) is still untested. |

## What I deliberately did not write

The exploration produced **three** candidates. One was dropped:

- **"A failed create keeps the dialog open with the entered data"** (`ui`, marked `weak`). The flow is real and was driven end to end — a 500 injected on `POST …/annotation-queues/` left the dialog open with Name *and* Instructions intact, and a delayed response left Submit `disabled` mid-flight, which is the third thing opik#8056 fixes. It needs a **failure-injection fixture** the estate does not have (`page.route`-based), and whether to add one is a reviewer's call about the estate's direction, not something a generated PR should decide. Dropped rather than faked another way.

  If someone picks it up: the request URL carries a **trailing slash** — `/api/v1/private/annotation-queues/`. A `**/v1/private/annotation-queues` route pattern silently does not match, the real request goes through, and the test passes for the wrong reason. Use `**/v1/private/annotation-queues/**`.

  Consequently the submit-button-disabled-while-pending half of opik#8056 is **not covered** by this PR.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

Adds e2e coverage for the change in opik#8056 (`OPIK_7957`). Resolves nothing on its own.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (QA test-radar `release-test-proposal` side flow)
- Model(s): Claude Opus 5
- Scope: full implementation — specs, POM, fixture, backend client method, taxonomy update
- Human verification: **none yet.** The flows were verified by hand on `pr-8056.dev.comet.com` during exploration, and the specs were run green against that same environment, but no human has reviewed this code. That is what the draft status is for.

<!-- comet-qa-test-radar: propose -->
