### PR TITLE
[OPIK-7315] fix the sentinel repair's no-window comparison, which could never run

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -659,14 +659,21 @@ if [[ "$SENTINEL_REPAIR_ONLY" == "1" ]]; then
     # Same aggregates over an all-time range. A 0 inside the window against a non-zero total is the signature of a wrong
     # window -- bounds in local time, a typo -- which otherwise reports as a clean estate and exits 0 over unrepaired rows.
     #
-    # These bounds are the DateTime64(9) representable range, NOT the DateTime64 type-family range (1900..2299) this used
-    # to pass. `created_at` is DateTime64(9), so a 2299 literal is promoted to precision 9 to be compared and raises
+    # Only the CEILING is wrong in the range this used to pass (1900..2299). `created_at` is DateTime64(9), whose ceiling
+    # is 2262-04-11 23:47:16.854775807, so a 2299 literal is promoted to precision 9 for the comparison and raises
     # DECIMAL_OVERFLOW (Code 407) every time -- which made this whole comparison dead code on every real schema, printing
-    # '?' where the operator was told to read a number. The ceiling costs the `created_at` arm nothing, since the column
-    # cannot hold a later value; it costs the `last_updated_at` arm (DateTime64(6)) only 2262..2299, unreachable for a
-    # column set from now64(). Far-future values in this dataset are far-future *ids*, which drive the successor's `id_at`
-    # partitioning -- not `created_at`, which an earlier revision of this comment conflated them with.
-    if ! sentinel_all="$(sentinel_counts '1677-09-21 00:12:44' '2262-04-11 23:47:16.854775807')"; then sentinel_all=""; fi
+    # '?' where the operator was told to read a number.
+    #
+    # The floor stays 1900-01-01. DateTime64's lower bound does NOT narrow with precision the way the upper one does, and
+    # an earlier literal below it is silently CLAMPED to it rather than rejected: toDateTime64('1677-09-21 00:12:44', 9)
+    # evaluates to 1900-01-01 00:12:44, keeping the time of day and so landing 12m44s LATER than the bound it replaced.
+    # A "true precision-9 minimum" is therefore both unnecessary and invisible, which is worse than wrong.
+    #
+    # The ceiling costs the `created_at` arm nothing, since the column cannot hold a later value; it costs the
+    # `last_updated_at` arm (DateTime64(6)) only 2262..2299, unreachable for a column set from now64(). Far-future values
+    # in this dataset are far-future *ids*, which drive the successor's `id_at` partitioning -- not `created_at`, which an
+    # earlier revision of this comment conflated them with.
+    if ! sentinel_all="$(sentinel_counts '1900-01-01 00:00:00' '2262-04-11 23:47:16.854775807')"; then sentinel_all=""; fi
     read -r all_end_time all_ttft _ _ <<< "$sentinel_all"
     [[ "$all_end_time" =~ ^[0-9]+$ ]] || { all_end_time="?"; all_ttft="?"; }
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -664,10 +664,14 @@ if [[ "$SENTINEL_REPAIR_ONLY" == "1" ]]; then
     # DECIMAL_OVERFLOW (Code 407) every time -- which made this whole comparison dead code on every real schema, printing
     # '?' where the operator was told to read a number.
     #
-    # The floor stays 1900-01-01. DateTime64's lower bound does NOT narrow with precision the way the upper one does, and
-    # an earlier literal below it is silently CLAMPED to it rather than rejected: toDateTime64('1677-09-21 00:12:44', 9)
-    # evaluates to 1900-01-01 00:12:44, keeping the time of day and so landing 12m44s LATER than the bound it replaced.
-    # A "true precision-9 minimum" is therefore both unnecessary and invisible, which is worse than wrong.
+    # The floor stays 1900-01-01, though NOT because that is the type's minimum: DateTime64(9) does represent
+    # 1677-09-21 00:12:44 onwards, per the docs, and a value built from ticks round-trips there exactly. The reason is
+    # that this bound reaches the server as a STRING, and toDateTime64('<string>', N) cannot express anything earlier --
+    # it clamps the DATE to 1900-01-01 while KEEPING the time of day, silently and in the wrong direction:
+    # '1677-09-21 00:12:44' becomes 1900-01-01 00:12:44 (12m44s later than the plain floor) and '1899-12-31 23:59:59'
+    # becomes 1900-01-01 23:59:59 (nearly a day later than asked). Reaching the true minimum would take
+    # fromUnixTimestamp64Nano() in place of the substituted literal, which this file shares with the windowed gate where
+    # the bound has to stay an operator-supplied datetime. Immaterial regardless: nothing in these columns predates 1900.
     #
     # The ceiling costs the `created_at` arm nothing, since the column cannot hold a later value; it costs the
     # `last_updated_at` arm (DateTime64(6)) only 2262..2299, unreachable for a column set from now64(). Far-future values

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -658,16 +658,29 @@ if [[ "$SENTINEL_REPAIR_ONLY" == "1" ]]; then
     fi
     # Same aggregates over an all-time range. A 0 inside the window against a non-zero total is the signature of a wrong
     # window -- bounds in local time, a typo -- which otherwise reports as a clean estate and exits 0 over unrepaired rows.
-    # 1900..2299 is the DateTime64 range, not a round number: far-future timestamps are real in this dataset
-    # (see the runbook's far-future id section), and an arbitrary ceiling would hide exactly those from the comparison.
-    if ! sentinel_all="$(sentinel_counts '1900-01-01 00:00:00' '2299-12-31 23:59:59')"; then sentinel_all=""; fi
+    #
+    # These bounds are the DateTime64(9) representable range, NOT the DateTime64 type-family range (1900..2299) this used
+    # to pass. `created_at` is DateTime64(9), so a 2299 literal is promoted to precision 9 to be compared and raises
+    # DECIMAL_OVERFLOW (Code 407) every time -- which made this whole comparison dead code on every real schema, printing
+    # '?' where the operator was told to read a number. The ceiling costs the `created_at` arm nothing, since the column
+    # cannot hold a later value; it costs the `last_updated_at` arm (DateTime64(6)) only 2262..2299, unreachable for a
+    # column set from now64(). Far-future values in this dataset are far-future *ids*, which drive the successor's `id_at`
+    # partitioning -- not `created_at`, which an earlier revision of this comment conflated them with.
+    if ! sentinel_all="$(sentinel_counts '1677-09-21 00:12:44' '2262-04-11 23:47:16.854775807')"; then sentinel_all=""; fi
     read -r all_end_time all_ttft _ _ <<< "$sentinel_all"
     [[ "$all_end_time" =~ ^[0-9]+$ ]] || { all_end_time="?"; all_ttft="?"; }
 
     echo "Sentinels IN WINDOW [$SENTINEL_WINDOW_FROM, $SENTINEL_WINDOW_TO): end_time=$before_end_time ttft=$before_ttft (of those, serving a negative duration: $before_negative)"
     echo "Same counts with no window, for comparison: end_time=$all_end_time ttft=$all_ttft"
+    # '?' means the comparison did not run, which is not the same as it running and agreeing. Say so, rather than leaving a
+    # bare '?' on a line the runbook points operators at: a check that silently did not execute reads as one that passed.
+    if [[ "$all_end_time" == "?" ]]; then
+        echo "NOTE: the no-window comparison returned no usable number, so it is not evidence either way -- neither that the" >&2
+        echo "      window is right nor that it is wrong. The gate remains the IN-WINDOW count, and the selected rows still" >&2
+        echo "      have to be reconciled by identity before a clean read is trusted." >&2
+    fi
     if (( before_end_time == 0 && before_ttft == 0 )); then
-        if [[ "$all_end_time" != "0" || "$all_ttft" != "0" ]]; then
+        if [[ "$all_end_time" =~ ^[0-9]+$ ]] && [[ "$all_end_time" != "0" || "$all_ttft" != "0" ]]; then
             echo "WARNING: nothing matches INSIDE the window, but the table holds end_time=$all_end_time ttft=$all_ttft" >&2
             echo "         outside it. That is what a wrong window looks like, and bounds in local time rather than UTC is" >&2
             echo "         the common case. Confirm the bounds are the window the flag was live in, in UTC, before reading" >&2


### PR DESCRIPTION
## Details

`rollback.sh --sentinel-repair-only` prints the sentinel counts twice — once inside the operator's window, once over an all-time range — so a zero in-window count beside a non-zero total exposes a wrong window instead of reporting a clean estate over unrepaired rows. The all-time call passed `1900-01-01 .. 2299-12-31`, commented as "the DateTime64 range". That is the range of the DateTime64 type *family*, not of `DateTime64(9)`, which is what `traces.created_at` is — ceiling `2262-04-11 23:47:16.854775807`. The `2299` literal overflows as soon as it is promoted to precision 9 for the comparison, so the check has never once returned a number on any installation.

- **Only the ceiling changes.** The floor stays `1900-01-01 00:00:00` — not because that is the type's minimum (at precision 9 `DateTime64` represents 1677-09-21 onwards, per the docs, and a tick-built value round-trips to it exactly), but because this bound reaches the server as a **string**, and `toDateTime64('<string>', N)` cannot express anything earlier: it clamps the *date* to 1900-01-01 while *keeping the time of day*, so the result is silently **later** than asked — `'1677-09-21 00:12:44'` → `1900-01-01 00:12:44`, and `'1899-12-31 23:59:59'` → `1900-01-01 23:59:59`. The ceiling has no such problem: `'2262-04-11 23:47:16.854775807'` parses to `Int64` max exactly. Upper bound expressible as a string, lower bound not. The `created_at` arm loses nothing from the new ceiling (the column cannot hold a later value); the `last_updated_at` arm (`DateTime64(6)`) nominally loses 2262..2299, unreachable for a column set from `now64()`.
- A failed comparison no longer reads as a passed one: `?` now prints an explicit note that the check did not run and is evidence neither way, and the wrong-window WARNING requires an actual number rather than interpolating `?` into itself.
- Corrected the comment that justified `2299`: the far-future values here are far-future **ids**, which drive the successor's `id_at` partitioning — not `created_at`.

Why it went unnoticed: the driver catches the failure, the run completes, and the gate (the in-window count) is unaffected. The only symptom is a `?` on a line the runbook tells operators to read.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-7315

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the `rollback.sh` change and this description; diagnosis and verification queries run against a live test estate.
- Human verification: diff reviewed locally before the PR was opened.

## Testing

Against a live multi-replica test estate, substituting both bound pairs into the shipped `000004_rollback_verify_sentinels.sql` (read-only, no driver run, so the pinned-revision guarantee for the in-flight cutover window was not disturbed):

- Old bounds `1900-01-01 .. 2299-12-31` → `Code: 407. DB::Exception: Can't compare decimal number due to overflow. (DECIMAL_OVERFLOW)`
- New ceiling (with the floor unchanged) → returns the four counts normally.
- Confirmed by isolating each literal: the floor was always fine; only the ceiling overflows, and only against the `DateTime64(9)` column. The same ceiling against the `DateTime64(6)` column succeeds — which is why one arm of the predicate hid the defect from the other.
- Confirmed the clamping behaviour directly, which is what caught the second commit's floor regression before review.
- `bash -n` clean.

Not run: the driver itself on a real repair. The repair path had already been executed at the pinned revision on that estate, and re-running a modified driver there would have voided the byte-for-byte pin the cutover window requires. The shell changes are the two message branches, exercised by inspection.

## Documentation

No runbook change. The README already tells operators to read the no-window figure; this makes that instruction executable rather than changing it.
