### PR TITLE
[NA] [FE] feat: add read-only "View data" action to dataset version history rows

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionRowActionsCell.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionRowActionsCell.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { CellContext } from "@tanstack/react-table";
+import { TooltipProvider } from "@/ui/tooltip";
+import VersionRowActionsCell from "./VersionRowActionsCell";
+import useDatasetItemsList, {
+  UseDatasetItemsListResponse,
+} from "@/api/datasets/useDatasetItemsList";
+import useRestoreDatasetVersionMutation from "@/api/datasets/useRestoreDatasetVersionMutation";
+import { DATASET_ITEM_SOURCE, DatasetVersion } from "@/types/datasets";
+import { DYNAMIC_COLUMN_TYPE } from "@/types/shared";
+
+vi.mock("@/api/datasets/useDatasetItemsList", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/api/datasets/useRestoreDatasetVersionMutation", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/api/datasets/useEditDatasetVersionMutation", () => ({
+  default: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/store/TestSuiteDraftStore", () => ({
+  useHasDraft: vi.fn(() => false),
+  useClearDraft: vi.fn(),
+}));
+
+const mockUseDatasetItemsList = vi.mocked(useDatasetItemsList);
+const mockUseRestoreDatasetVersionMutation = vi.mocked(
+  useRestoreDatasetVersionMutation,
+);
+
+const mockVersion: DatasetVersion = {
+  id: "version-1",
+  dataset_id: "dataset-1",
+  version_hash: "abc123",
+  version_name: "v2",
+  items_total: 1,
+  items_added: 0,
+  items_modified: 0,
+  items_deleted: 0,
+  created_at: "2024-01-01T00:00:00Z",
+  created_by: "user",
+  last_updated_at: "2024-01-01T00:00:00Z",
+  last_updated_by: "user",
+};
+
+const mockItemsResponse: UseDatasetItemsListResponse = {
+  content: [
+    {
+      id: "item-1",
+      data: { input: "hello" },
+      source: DATASET_ITEM_SOURCE.manual,
+      created_at: "2024-01-01T00:00:00Z",
+      last_updated_at: "2024-01-01T00:00:00Z",
+    },
+  ],
+  columns: [{ name: "input", types: [DYNAMIC_COLUMN_TYPE.string] }],
+  total: 1,
+};
+
+const mockCellContext = {
+  row: { original: mockVersion },
+  column: {
+    columnDef: {
+      meta: {
+        custom: { datasetId: "dataset-1" },
+      },
+    },
+  },
+  table: { options: { meta: {} } },
+  cell: {},
+} as unknown as CellContext<DatasetVersion, unknown>;
+
+describe("VersionRowActionsCell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDatasetItemsList.mockReturnValue({
+      data: mockItemsResponse,
+      isLoading: false,
+      isPending: false,
+      isPlaceholderData: false,
+      isFetching: false,
+    } as never);
+    mockUseRestoreDatasetVersionMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as never);
+  });
+
+  it("should open the version data dialog from the actions menu", async () => {
+    render(<VersionRowActionsCell {...mockCellContext} />, {
+      wrapper: ({ children }) => <TooltipProvider>{children}</TooltipProvider>,
+    });
+
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: /actions menu/i }),
+      { button: 0, ctrlKey: false, pointerType: "mouse" },
+    );
+    fireEvent.click(await screen.findByText("View data"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Version v2 data")).toBeInTheDocument();
+    });
+    expect(mockUseDatasetItemsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId: "dataset-1",
+        versionId: "abc123",
+      }),
+      expect.objectContaining({ enabled: true }),
+    );
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionRowActionsCell.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/VersionRowActionsCell.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
 import { CellContext } from "@tanstack/react-table";
-import { MoreHorizontal, Pencil, RotateCcw } from "lucide-react";
+import { Eye, MoreHorizontal, Pencil, RotateCcw } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,11 +15,13 @@ import { isLatestVersionTag } from "@/constants/datasets";
 import useRestoreDatasetVersionMutation from "@/api/datasets/useRestoreDatasetVersionMutation";
 import { useHasDraft, useClearDraft } from "@/store/TestSuiteDraftStore";
 import EditVersionDialog from "./EditVersionDialog";
+import ViewVersionDataDialog from "./ViewVersionDataDialog";
 
 type CustomMeta = {
   datasetId: string;
 };
 
+const VIEW_KEY = 0;
 const EDIT_KEY = 1;
 const RESTORE_KEY = 2;
 
@@ -54,6 +56,13 @@ const VersionRowActionsCell: React.FC<CellContext<DatasetVersion, unknown>> = (
       className="justify-end p-0"
       stopClickPropagation
     >
+      <ViewVersionDataDialog
+        open={open === VIEW_KEY}
+        setOpen={setOpen}
+        version={version}
+        datasetId={datasetId}
+      />
+
       <EditVersionDialog
         key={`edit-${resetKeyRef.current}`}
         open={open === EDIT_KEY}
@@ -85,6 +94,14 @@ const VersionRowActionsCell: React.FC<CellContext<DatasetVersion, unknown>> = (
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-52">
+          <DropdownMenuItem
+            onClick={() => {
+              setOpen(VIEW_KEY);
+            }}
+          >
+            <Eye className="mr-2 size-4" />
+            View data
+          </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => {
               setOpen(EDIT_KEY);

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/ViewVersionDataDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/ViewVersionDataDialog.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, RenderOptions } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/ui/tooltip";
+import ViewVersionDataDialog from "./ViewVersionDataDialog";
+import useDatasetItemsList, {
+  UseDatasetItemsListResponse,
+} from "@/api/datasets/useDatasetItemsList";
+import { DATASET_ITEM_SOURCE, DatasetVersion } from "@/types/datasets";
+import { DYNAMIC_COLUMN_TYPE } from "@/types/shared";
+
+vi.mock("@/api/datasets/useDatasetItemsList", () => ({
+  default: vi.fn(),
+}));
+
+const mockUseDatasetItemsList = vi.mocked(useDatasetItemsList);
+
+const mockVersion: DatasetVersion = {
+  id: "version-1",
+  dataset_id: "dataset-1",
+  version_hash: "abc123",
+  version_name: "v2",
+  items_total: 2,
+  items_added: 0,
+  items_modified: 0,
+  items_deleted: 0,
+  created_at: "2024-01-01T00:00:00Z",
+  created_by: "user",
+  last_updated_at: "2024-01-01T00:00:00Z",
+  last_updated_by: "user",
+};
+
+const mockItemsResponse: UseDatasetItemsListResponse = {
+  content: [
+    {
+      id: "item-1",
+      data: { input: "hello", output: "world" },
+      source: DATASET_ITEM_SOURCE.manual,
+      created_at: "2024-01-01T00:00:00Z",
+      last_updated_at: "2024-01-01T00:00:00Z",
+    },
+    {
+      id: "item-2",
+      data: { input: "foo", output: "bar" },
+      source: DATASET_ITEM_SOURCE.manual,
+      created_at: "2024-01-02T00:00:00Z",
+      last_updated_at: "2024-01-02T00:00:00Z",
+    },
+  ],
+  columns: [
+    { name: "input", types: [DYNAMIC_COLUMN_TYPE.string] },
+    { name: "output", types: [DYNAMIC_COLUMN_TYPE.string] },
+  ],
+  total: 2,
+};
+
+const renderWithProviders = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, {
+    wrapper: ({ children }) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      return (
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>{children}</TooltipProvider>
+        </QueryClientProvider>
+      );
+    },
+    ...options,
+  });
+
+const renderDialog = (open = true) =>
+  renderWithProviders(
+    <ViewVersionDataDialog
+      open={open}
+      setOpen={vi.fn()}
+      datasetId="dataset-1"
+      version={mockVersion}
+    />,
+  );
+
+describe("ViewVersionDataDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDatasetItemsList.mockReturnValue({
+      data: mockItemsResponse,
+      isLoading: false,
+      isPending: false,
+      isPlaceholderData: false,
+      isFetching: false,
+    } as never);
+  });
+
+  it("should render the version name in the dialog title", () => {
+    renderDialog();
+
+    expect(screen.getByText("Version v2 data")).toBeInTheDocument();
+    expect(screen.getByText(/read-only mode/i)).toBeInTheDocument();
+  });
+
+  it("should fetch items with the version hash and render them read-only", () => {
+    renderDialog();
+
+    expect(mockUseDatasetItemsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId: "dataset-1",
+        page: 1,
+        size: 10,
+        versionId: "abc123",
+      }),
+      expect.objectContaining({ enabled: true }),
+    );
+
+    expect(screen.getAllByText("item-1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("item-2").length).toBeGreaterThan(0);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("world")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /add/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the no-data state when the version has no items", () => {
+    mockUseDatasetItemsList.mockReturnValue({
+      data: { content: [], columns: [], total: 0 },
+      isLoading: false,
+      isPending: false,
+      isPlaceholderData: false,
+      isFetching: false,
+    } as never);
+
+    renderDialog();
+
+    expect(screen.getByText("No records in this version")).toBeInTheDocument();
+  });
+
+  it("should not fetch items when the dialog is closed", () => {
+    renderDialog(false);
+
+    expect(mockUseDatasetItemsList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datasetId: "dataset-1",
+        versionId: "abc123",
+      }),
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(screen.queryByText("Version v2 data")).not.toBeInTheDocument();
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/ViewVersionDataDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/datasets/VersionHistoryTab/ViewVersionDataDialog.tsx
@@ -1,0 +1,131 @@
+import React, { useMemo, useState } from "react";
+import get from "lodash/get";
+import { keepPreviousData } from "@tanstack/react-query";
+
+import DataTable from "@/shared/DataTable/DataTable";
+import DataTableNoData from "@/shared/DataTableNoData/DataTableNoData";
+import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
+import AutodetectCell from "@/shared/DataTableCells/AutodetectCell";
+import IdCell from "@/shared/DataTableCells/IdCell";
+import TimeCell from "@/shared/DataTableCells/TimeCell";
+import {
+  Dialog,
+  DialogAutoScrollBody,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import useDatasetItemsList from "@/api/datasets/useDatasetItemsList";
+import { mapDynamicColumnTypesToColumnType } from "@/lib/filters";
+import { convertColumnDataToColumn } from "@/lib/table";
+import { DatasetItem, DatasetVersion } from "@/types/datasets";
+import {
+  COLUMN_DATA_ID,
+  COLUMN_ID_ID,
+  COLUMN_TYPE,
+  ColumnData,
+} from "@/types/shared";
+
+const getRowId = (d: DatasetItem) => d.id;
+
+type ViewVersionDataDialogProps = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  datasetId: string;
+  version: DatasetVersion;
+};
+
+const ViewVersionDataDialog: React.FC<ViewVersionDataDialogProps> = ({
+  open,
+  setOpen,
+  datasetId,
+  version,
+}) => {
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(10);
+
+  const { data, isLoading, isPlaceholderData, isFetching } =
+    useDatasetItemsList(
+      {
+        datasetId,
+        page,
+        size,
+        versionId: version.version_hash,
+      },
+      {
+        enabled: open,
+        placeholderData: keepPreviousData,
+      },
+    );
+
+  const rows = useMemo(() => data?.content ?? [], [data?.content]);
+
+  const columns = useMemo(() => {
+    const dynamicColumns: ColumnData<DatasetItem>[] = (data?.columns ?? []).map(
+      (c) =>
+        ({
+          id: `${COLUMN_DATA_ID}.${c.name}`,
+          label: c.name,
+          type: mapDynamicColumnTypesToColumnType(c.types),
+          accessorFn: (row) => get(row, ["data", c.name], ""),
+          cell: AutodetectCell as never,
+        }) as ColumnData<DatasetItem>,
+    );
+
+    const columnsData: ColumnData<DatasetItem>[] = [
+      {
+        id: COLUMN_ID_ID,
+        label: "ID",
+        type: COLUMN_TYPE.string,
+        cell: IdCell as never,
+      },
+      ...dynamicColumns,
+      {
+        id: "created_at",
+        label: "Created",
+        type: COLUMN_TYPE.time,
+        cell: TimeCell as never,
+      },
+    ];
+
+    return convertColumnDataToColumn<DatasetItem, DatasetItem>(columnsData, {});
+  }, [data?.columns]);
+
+  const isTableLoading = isLoading || (isPlaceholderData && rows.length === 0);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="flex max-h-[85vh] max-w-3xl flex-col">
+        <DialogHeader>
+          <DialogTitle>Version {version.version_name} data</DialogTitle>
+        </DialogHeader>
+
+        <DialogAutoScrollBody className="flex-1">
+          <p className="text-sm text-muted-foreground">
+            Records of this version in read-only mode.
+          </p>
+
+          <DataTable
+            columns={columns}
+            data={rows}
+            getRowId={getRowId}
+            noData={<DataTableNoData title="No records in this version" />}
+            showSkeleton={isTableLoading}
+            showLoadingOverlay={
+              !isTableLoading && isPlaceholderData && isFetching
+            }
+          />
+          <DataTablePagination
+            page={page}
+            pageChange={setPage}
+            size={size}
+            sizeChange={setSize}
+            total={data?.total ?? 0}
+          />
+        </DialogAutoScrollBody>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ViewVersionDataDialog;


### PR DESCRIPTION
## Details
The dataset Version history tab offers no way to inspect a previous version's records: the only path is restoring that version, which appends a new version just for viewing and forces another restore to get back to the latest one (#8010). This adds a read-only "View data" action to each version's row menu, opening a dialog that lists that version's records (ID, data columns, created date) with pagination and a no-data state. Viewing only calls the existing items endpoint with the version hash (the same pattern the Playground uses), so it never creates new versions or touches draft changes.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8010
- OPIK-

<!--
Jira linking: tickets this PR RESOLVES keep the hyphen (OPIK-1234) here and anywhere — they link in Jira's Development panel, which is wanted. A PR may resolve more than one ticket; list each resolved key.
Tickets RELATED but NOT resolved here (escalations, references to older tickets) must NOT link: in the sections above/below and in commit messages, write them with an underscore (OPIK_7000) and paste no Jira URL (the URL contains the hyphenated key and links anyway). See CONTRIBUTING.md.
-->


## AI-WATERMARK

AI-WATERMARK: no

## Testing
- `cd apps/opik-frontend && npx vitest run src/v2/pages-shared/datasets/VersionHistoryTab/` — 5 tests: the dialog fetches on open with the version hash and renders rows read-only, shows the no-data state, and a wiring test drives the row menu (Actions → "View data") into the dialog with the right version.
- `cd apps/opik-frontend && npx tsc --project tsconfig.json --noEmit`
- `cd apps/opik-frontend && npx eslint src/v2/pages-shared/datasets/VersionHistoryTab --max-warnings=0`
- The view path issues no mutations: it only queries `GET /v1/private/datasets/{id}/items?version=<hash>` (the same endpoint/pattern the Playground uses for versioned item lists), so viewing cannot create dataset versions.
- Not run: the full frontend test suite (component-scoped tests only in this environment) and a screen recording — not available here; the dialog reuses the exact DataTable/Dialog layout of GeneratedSamplesDialog.

## Documentation
N/A