### PR TITLE
[NA] [BE] fix: delete a project's traces from ClickHouse when the project is deleted

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/events/ProjectsDeleted.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/events/ProjectsDeleted.java
@@ -1,0 +1,22 @@
+package com.comet.opik.api.events;
+
+import com.comet.opik.infrastructure.events.BaseEvent;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Getter
+@Accessors(fluent = true)
+public class ProjectsDeleted extends BaseEvent {
+
+    private final @NonNull Set<UUID> projectIds;
+
+    public ProjectsDeleted(@NonNull Set<UUID> projectIds, @NonNull String workspaceId,
+            @NonNull String userName) {
+        super(workspaceId, userName);
+        this.projectIds = projectIds;
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectDeletedListener.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/ProjectDeletedListener.java
@@ -1,0 +1,73 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.events.ProjectsDeleted;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.google.common.eventbus.Subscribe;
+import jakarta.inject.Inject;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
+
+import java.util.Set;
+import java.util.UUID;
+
+@EagerSingleton
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class ProjectDeletedListener {
+
+    private final @NonNull TraceService traceService;
+
+    /**
+     * Handles the ProjectsDeleted event by asynchronously deleting the project's traces. Deleting a project removes
+     * only the MySQL row; this listener removes the project's traces and spans from ClickHouse through
+     * {@link TraceService#deleteByProjectId(UUID)}, so the deletion-events bridge capture and the TracesDeleted
+     * cascade (spans, feedback scores, comments, attachments) run exactly as for user-initiated trace deletes.
+     *
+     * @param event the ProjectsDeleted event containing the project IDs that were deleted
+     */
+    @Subscribe
+    public void onProjectsDeleted(@NonNull ProjectsDeleted event) {
+        Set<UUID> projectIds = event.projectIds();
+        String workspaceId = event.workspaceId();
+        String userName = event.userName();
+
+        log.info(
+                "Received ProjectsDeleted event for workspace: '{}', project count: '{}'. Processing trace deletion",
+                workspaceId, projectIds.size());
+
+        processProjectDeletion(projectIds)
+                .doOnError(error -> {
+                    log.error(
+                            "Failed to process ProjectsDeleted event for workspace: '{}', project count: '{}', error: '{}'",
+                            workspaceId, projectIds.size(), error.getMessage());
+                    log.error("Error processing project trace deletion", error);
+                })
+                .doOnSuccess(__ -> log.info(
+                        "Successfully processed ProjectsDeleted event for workspace: '{}', project count: '{}'",
+                        workspaceId, projectIds.size()))
+                .contextWrite(ctx -> ctx.put(RequestContext.WORKSPACE_ID, workspaceId)
+                        .put(RequestContext.USER_NAME, userName))
+                .subscribe();
+    }
+
+    /**
+     * Deletes the traces of each deleted project, one project at a time. A failure on one project is logged and
+     * contained so the remaining projects are still processed.
+     */
+    private Mono<Void> processProjectDeletion(Set<UUID> projectIds) {
+        log.info("Starting deletion of traces for projects, count '{}'", projectIds.size());
+
+        return Flux.fromIterable(projectIds)
+                .concatMap(projectId -> traceService.deleteByProjectId(projectId)
+                        .doOnError(error -> log.error(
+                                "Failed to delete traces for project id: '{}', error: '{}'", projectId,
+                                error.getMessage()))
+                        .onErrorResume(error -> Mono.empty()))
+                .then();
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -9,6 +9,7 @@ import com.comet.opik.api.ProjectUpdate;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
 import com.comet.opik.api.error.ErrorMessage;
+import com.comet.opik.api.events.ProjectsDeleted;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingFactoryProjects;
 import com.comet.opik.api.sorting.SortingField;
@@ -18,6 +19,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.ErrorUtils;
+import com.google.common.eventbus.EventBus;
 import com.google.inject.ImplementedBy;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
@@ -146,6 +148,7 @@ class ProjectServiceImpl implements ProjectService {
     private final @NonNull SortingFactoryProjects sortingFactory;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull AnalyticsService analyticsService;
+    private final @NonNull EventBus eventBus;
 
     private NotFoundException createNotFoundError() {
         String message = "Project not found";
@@ -318,21 +321,23 @@ class ProjectServiceImpl implements ProjectService {
         String workspaceId = requestContext.get().getWorkspaceId();
         String userName = requestContext.get().getUserName();
 
-        template.inTransaction(WRITE, handle -> {
+        boolean deleted = template.inTransaction(WRITE, handle -> {
 
             var repository = handle.attach(ProjectDAO.class);
             Optional<Project> project = repository.fetch(id, workspaceId);
 
             if (project.isEmpty()) {
-                // Void return
-                return null;
+                return false;
             }
 
             repository.delete(id, workspaceId);
 
-            // Void return
-            return null;
+            return true;
         });
+
+        if (deleted) {
+            eventBus.post(new ProjectsDeleted(Set.of(id), workspaceId, userName));
+        }
     }
 
     @Override
@@ -349,6 +354,8 @@ class ProjectServiceImpl implements ProjectService {
             handle.attach(ProjectDAO.class).delete(ids, workspaceId);
             return null;
         });
+
+        eventBus.post(new ProjectsDeleted(ids, workspaceId, userName));
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -154,6 +154,8 @@ public interface TraceDAO {
 
     Mono<Set<UUID>> getTraceIdsByThreadIds(UUID projectId, List<String> threadIds, Connection connection);
 
+    Flux<UUID> getTraceIdsByProjectId(UUID projectId, Connection connection);
+
     Mono<Trace> getPartialById(UUID id);
 
     Flux<Trace> search(int limit, TraceSearchCriteria criteria);
@@ -3158,6 +3160,14 @@ class TraceDAOImpl implements TraceDAO {
             SETTINGS log_comment = '<log_comment>'
             """;
 
+    private static final String SELECT_TRACE_IDS_BY_PROJECT_ID = """
+            SELECT DISTINCT id
+            FROM traces
+            WHERE workspace_id = :workspace_id
+            AND project_id = :project_id
+            SETTINGS log_comment = '<log_comment>'
+            """;
+
     public static final String SELECT_COUNT_TRACES_BY_PROJECT_IDS = """
             SELECT
                 count(distinct id) as count
@@ -4949,6 +4959,27 @@ class TraceDAOImpl implements TraceDAO {
                     .doFinally(signalType -> endSegment(segment))
                     .flatMapMany(result -> result.map((row, rowMetadata) -> row.get("id", UUID.class)))
                     .collect(toSet());
+        });
+    }
+
+    @Override
+    @WithSpan
+    public Flux<UUID> getTraceIdsByProjectId(@NonNull UUID projectId, @NonNull Connection connection) {
+        log.info("Getting trace IDs by project id '{}'", projectId);
+
+        return makeFluxContextAware((userName, workspaceId) -> {
+            var template = getSTWithLogComment(SELECT_TRACE_IDS_BY_PROJECT_ID, "get_trace_ids_by_project_id",
+                    workspaceId, userName, "");
+
+            var statement = connection.createStatement(template.render())
+                    .bind("project_id", projectId)
+                    .bind("workspace_id", workspaceId);
+
+            Segment segment = startSegment("traces", "Clickhouse", "getTraceIdsByProjectId");
+
+            return Mono.from(statement.execute())
+                    .doFinally(signalType -> endSegment(segment))
+                    .flatMapMany(result -> result.map((row, rowMetadata) -> row.get("id", UUID.class)));
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -66,6 +66,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.comet.opik.api.Trace.TracePage;
+import static com.comet.opik.infrastructure.FilterUtils.ANALYTICS_DELETE_BATCH_SIZE;
 import static com.comet.opik.utils.ErrorUtils.failWithNotFound;
 
 @ImplementedBy(TraceServiceImpl.class)
@@ -90,6 +91,8 @@ public interface TraceService {
     Mono<TraceDetails> getTraceDetailsById(UUID id);
 
     Mono<Void> delete(Set<UUID> ids, UUID projectId);
+
+    Mono<Void> deleteByProjectId(@NonNull UUID projectId);
 
     Mono<TracePage> find(int page, int size, TraceSearchCriteria criteria);
 
@@ -613,6 +616,32 @@ class TraceServiceImpl implements TraceService {
                         return Mono.empty();
                     });
         });
+    }
+
+    /**
+     * Deletes every trace of the project. The trace ids are streamed from ClickHouse and deleted in batches of
+     * {@value ANALYTICS_DELETE_BATCH_SIZE} so a large project never materializes its full id list in memory. Each
+     * batch flows through the regular {@code (project_id, trace_id)} delete path, so the TracesDeleted cascade
+     * (spans, feedback scores, comments, attachments) and the deletion-events bridge capture run exactly as for
+     * user-initiated trace deletes.
+     */
+    @Override
+    @WithSpan
+    public Mono<Void> deleteByProjectId(@NonNull UUID projectId) {
+        log.info("Deleting traces by project id '{}'", projectId);
+
+        return template.nonTransaction(connection -> dao.getTraceIdsByProjectId(projectId, connection)
+                .buffer(ANALYTICS_DELETE_BATCH_SIZE)
+                .concatMap(traceIds -> {
+                    log.info("Found '{}' traces for project id, proceeding with deletion", traceIds.size());
+
+                    var pairs = traceIds.stream().map(id -> Pair.of(projectId, id))
+                            .collect(Collectors.toUnmodifiableSet());
+                    return delete(pairs, connection);
+                })
+                .switchIfEmpty(Mono.fromRunnable(
+                        () -> log.info("No traces found for project id, skipping deletion")))
+                .then());
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ProjectDeletedListenerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/ProjectDeletedListenerTest.java
@@ -1,0 +1,88 @@
+package com.comet.opik.api.resources.v1.events;
+
+import com.comet.opik.api.events.ProjectsDeleted;
+import com.comet.opik.domain.TraceService;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectDeletedListenerTest {
+
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER_NAME = "admin";
+
+    private ProjectDeletedListener listener;
+
+    @Mock
+    private TraceService traceService;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ProjectDeletedListener(traceService);
+    }
+
+    @Test
+    @DisplayName("when projects deleted, then deletes traces once per project id")
+    void onProjectsDeleted__whenProjectsDeleted__thenCallsDeleteByProjectIdOncePerProject() {
+        var projectA = UUID.randomUUID();
+        var projectB = UUID.randomUUID();
+        when(traceService.deleteByProjectId(any())).thenReturn(Mono.empty());
+
+        listener.onProjectsDeleted(new ProjectsDeleted(Set.of(projectA, projectB), WORKSPACE_ID, USER_NAME));
+
+        verify(traceService).deleteByProjectId(projectA);
+        verify(traceService).deleteByProjectId(projectB);
+    }
+
+    @Test
+    @DisplayName("when projects deleted, then the downstream reactor context carries workspace id and user name")
+    void onProjectsDeleted__whenProjectsDeleted__thenContextCarriesWorkspaceIdAndUserName() {
+        var projectId = UUID.randomUUID();
+        List<String> workspaceIds = new ArrayList<>();
+        List<String> userNames = new ArrayList<>();
+        when(traceService.deleteByProjectId(any())).thenAnswer(invocation -> Mono.deferContextual(ctx -> {
+            workspaceIds.add(ctx.get(RequestContext.WORKSPACE_ID));
+            userNames.add(ctx.get(RequestContext.USER_NAME));
+            return Mono.empty();
+        }));
+
+        listener.onProjectsDeleted(new ProjectsDeleted(Set.of(projectId), WORKSPACE_ID, USER_NAME));
+
+        assertThat(workspaceIds).containsExactly(WORKSPACE_ID);
+        assertThat(userNames).containsExactly(USER_NAME);
+    }
+
+    @Test
+    @DisplayName("when deletion fails for one project, then the error is swallowed and remaining projects are processed")
+    void onProjectsDeleted__whenOneProjectDeletionFails__thenErrorSwallowedAndRemainingProjectsProcessed() {
+        var failingProject = UUID.randomUUID();
+        var succeedingProject = UUID.randomUUID();
+        when(traceService.deleteByProjectId(failingProject))
+                .thenReturn(Mono.error(new RuntimeException("Error deleting traces")));
+        when(traceService.deleteByProjectId(succeedingProject)).thenReturn(Mono.empty());
+
+        assertThatCode(() -> listener.onProjectsDeleted(
+                new ProjectsDeleted(Set.of(failingProject, succeedingProject), WORKSPACE_ID, USER_NAME)))
+                .doesNotThrowAnyException();
+
+        verify(traceService).deleteByProjectId(failingProject);
+        verify(traceService).deleteByProjectId(succeedingProject);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
@@ -1,0 +1,149 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.api.events.ProjectsDeleted;
+import com.comet.opik.api.sorting.SortingFactoryProjects;
+import com.comet.opik.domain.sorting.SortingQueryBuilder;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
+import com.google.common.eventbus.EventBus;
+import jakarta.inject.Provider;
+import org.jdbi.v3.core.Handle;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+import ru.vyarus.guicey.jdbi3.tx.TxAction;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectServiceImplTest {
+
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER_NAME = "admin";
+
+    private ProjectServiceImpl projectService;
+
+    @Mock
+    private TransactionTemplate template;
+
+    @Mock
+    private IdGenerator idGenerator;
+
+    @Mock
+    private Provider<RequestContext> requestContext;
+
+    @Mock
+    private TraceDAO traceDAO;
+
+    @Mock
+    private SortingQueryBuilder sortingQueryBuilder;
+
+    @Mock
+    private AnalyticsService analyticsService;
+
+    @Mock
+    private EventBus eventBus;
+
+    @Mock
+    private Handle handle;
+
+    @Mock
+    private ProjectDAO projectDAO;
+
+    @BeforeEach
+    void setUp() {
+        var sortingFactory = new SortingFactoryProjects();
+        projectService = new ProjectServiceImpl(
+                template,
+                idGenerator,
+                requestContext,
+                traceDAO,
+                sortingFactory,
+                sortingQueryBuilder,
+                analyticsService,
+                eventBus);
+
+        lenient().when(requestContext.get()).thenReturn(RequestContext.builder()
+                .workspaceId(WORKSPACE_ID)
+                .userName(USER_NAME)
+                .build());
+
+        lenient().when(template.inTransaction(any(), any())).thenAnswer(invocation -> {
+            TxAction<?> callback = invocation.getArgument(1);
+            return callback.execute(handle);
+        });
+        lenient().when(handle.attach(ProjectDAO.class)).thenReturn(projectDAO);
+    }
+
+    @Nested
+    @DisplayName("Delete Project:")
+    class DeleteProject {
+
+        @Test
+        @DisplayName("when project exists, then posts ProjectsDeleted event with the project id")
+        void delete__whenProjectExists__thenPostsProjectsDeleted() {
+            var projectId = UUID.randomUUID();
+            when(projectDAO.fetch(projectId, WORKSPACE_ID))
+                    .thenReturn(Optional.of(Project.builder().id(projectId).name("project").build()));
+
+            projectService.delete(projectId);
+
+            var eventCaptor = ArgumentCaptor.forClass(ProjectsDeleted.class);
+            verify(eventBus).post(eventCaptor.capture());
+            var event = eventCaptor.getValue();
+            assertThat(event.projectIds()).containsExactly(projectId);
+            assertThat(event.workspaceId()).isEqualTo(WORKSPACE_ID);
+            assertThat(event.userName()).isEqualTo(USER_NAME);
+        }
+
+        @Test
+        @DisplayName("when project does not exist, then no event is posted")
+        void delete__whenProjectDoesNotExist__thenNoEvent() {
+            var projectId = UUID.randomUUID();
+            when(projectDAO.fetch(projectId, WORKSPACE_ID)).thenReturn(Optional.empty());
+
+            projectService.delete(projectId);
+
+            verifyNoInteractions(eventBus);
+        }
+
+        @Test
+        @DisplayName("when ids not empty, then posts one ProjectsDeleted event with all ids")
+        void delete__whenIdsNotEmpty__thenPostsProjectsDeletedWithAllIds() {
+            var ids = Set.of(UUID.randomUUID(), UUID.randomUUID());
+
+            projectService.delete(ids);
+
+            var eventCaptor = ArgumentCaptor.forClass(ProjectsDeleted.class);
+            verify(eventBus).post(eventCaptor.capture());
+            var event = eventCaptor.getValue();
+            assertThat(event.projectIds()).containsExactlyInAnyOrderElementsOf(ids);
+            assertThat(event.workspaceId()).isEqualTo(WORKSPACE_ID);
+            assertThat(event.userName()).isEqualTo(USER_NAME);
+        }
+
+        @Test
+        @DisplayName("when ids empty, then no event is posted")
+        void delete__whenIdsEmpty__thenNoEvent() {
+            projectService.delete(Set.of());
+
+            verifyNoInteractions(eventBus);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,6 +49,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -340,6 +344,105 @@ class TraceServiceImplTest {
          * Set equality is order-independent, so this matches whatever order the service iterates the ids in.
          */
         private Set<Pair<UUID, UUID>> pairs(UUID projectId, Set<UUID> ids) {
+            return ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet());
+        }
+
+        private Connection mockDeleteFlow() {
+            var connection = mock(Connection.class);
+            when(template.nonTransaction(any()))
+                    .thenAnswer(invocation -> {
+                        TransactionTemplateAsync.TransactionCallback<Void> callback = invocation.getArgument(0);
+                        return callback.execute(connection);
+                    });
+            return connection;
+        }
+
+        private void verifyTracesDeletedPosted(Set<UUID> ids, UUID projectId, String workspaceId) {
+            var eventCaptor = ArgumentCaptor.forClass(TracesDeleted.class);
+            verify(eventBus).post(eventCaptor.capture());
+            var event = eventCaptor.getValue();
+            assertThat(event.traceIds()).isEqualTo(ids);
+            assertThat(event.projectId()).isEqualTo(projectId);
+            assertThat(event.workspaceId()).isEqualTo(workspaceId);
+            assertThat(event.userName()).isEqualTo(DEFAULT_USER);
+        }
+    }
+
+    @Nested
+    @DisplayName("Delete Traces By Project:")
+    class DeleteTracesByProject {
+
+        @Test
+        @DisplayName("when traces exist, then deletes them as (project, id) pairs and posts the TracesDeleted event")
+        void deleteByProjectId__whenTracesExist__thenDeletesPairsAndPostsEvent() {
+            var projectId = UUID.randomUUID();
+            var ids = List.of(idGenerator.generateId(), idGenerator.generateId());
+            var workspaceId = UUID.randomUUID().toString();
+            var connection = mockDeleteFlow();
+            var expectedPairs = pairs(projectId, ids);
+            when(traceDao.getTraceIdsByProjectId(projectId, connection)).thenReturn(Flux.fromIterable(ids));
+            when(traceDao.delete(expectedPairs, connection)).thenReturn(Mono.empty());
+
+            assertDoesNotThrow(() -> traceService
+                    .deleteByProjectId(projectId)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            verify(traceDao).delete(expectedPairs, connection);
+            verifyTracesDeletedPosted(Set.copyOf(ids), projectId, workspaceId);
+            // traceService is built with capture disabled (default config)
+            verifyNoInteractions(deletionEventDAO);
+        }
+
+        @Test
+        @DisplayName("when there are more traces than the batch size, then deletes them in sequential chunks")
+        void deleteByProjectId__whenMoreTracesThanBatchSize__thenDeletesInChunks() {
+            var projectId = UUID.randomUUID();
+            var ids = IntStream.range(0, 10001)
+                    .mapToObj(__ -> idGenerator.generateId())
+                    .toList();
+            var workspaceId = UUID.randomUUID().toString();
+            var connection = mockDeleteFlow();
+            when(traceDao.getTraceIdsByProjectId(projectId, connection)).thenReturn(Flux.fromIterable(ids));
+            when(traceDao.delete(any(), eq(connection))).thenReturn(Mono.empty());
+            when(deletionEventDAO.insert(any(), eq(DEFAULT_USER))).thenReturn(Mono.empty());
+
+            var traceService = newTraceService(DatabaseAnalyticsDataModelConfig.builder()
+                    .traceDeletionEventsCaptureEnabled(true)
+                    .build());
+            assertDoesNotThrow(() -> traceService
+                    .deleteByProjectId(projectId)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            // 10001 ids buffered in batches of 10000 -> one full chunk and one remainder chunk.
+            verify(traceDao).delete(pairs(projectId, ids.subList(0, 10000)), connection);
+            verify(traceDao).delete(pairs(projectId, ids.subList(10000, 10001)), connection);
+            verify(eventBus, times(2)).post(any(TracesDeleted.class));
+            verify(deletionEventDAO, times(2)).insert(any(), eq(DEFAULT_USER));
+        }
+
+        @Test
+        @DisplayName("when the project has no traces, then completes without deleting or posting events")
+        void deleteByProjectId__whenNoTraces__thenCompletesWithoutDeleting() {
+            var projectId = UUID.randomUUID();
+            var workspaceId = UUID.randomUUID().toString();
+            var connection = mockDeleteFlow();
+            when(traceDao.getTraceIdsByProjectId(projectId, connection)).thenReturn(Flux.empty());
+
+            assertDoesNotThrow(() -> traceService
+                    .deleteByProjectId(projectId)
+                    .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
+                            .put(RequestContext.WORKSPACE_ID, workspaceId))
+                    .block());
+
+            verify(traceDao, never()).delete(any(), any());
+            verifyNoInteractions(eventBus, deletionEventDAO);
+        }
+
+        private Set<Pair<UUID, UUID>> pairs(UUID projectId, List<UUID> ids) {
             return ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet());
         }
 


### PR DESCRIPTION
## Details

Deleting a project removed only the MySQL `projects` row, so its traces and spans stayed queryable in ClickHouse forever (reported in #7826: `select count(*) from traces where project_id = '<deleted-id>'` returned 8 traces / 57 spans after UI deletion). There was no path from project deletion to trace cleanup at any layer.

After the MySQL delete succeeds, `ProjectService` now posts a `ProjectsDeleted` event. The new `ProjectDeletedListener` streams the project's trace ids from ClickHouse in 10k batches and routes each batch through the regular `(project_id, trace_id)` delete path, so the `TracesDeleted` cascade (spans, feedback scores, comments, attachments) and the deletion-events bridge capture behave exactly as for user-initiated trace deletes.

- Trace-thread rows (`trace_threads` / `project_trace_threads`) are not cleaned by any delete path today, including per-trace deletes; that cleanup is a pre-existing gap and an explicit follow-up.
- Alerts/dashboards referencing the deleted project are workspace-level lifecycle, intentionally out of scope.
- The cascade is fire-and-forget (AsyncEventBus), the same semantics as every existing deletion listener.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7826

## AI-WATERMARK

AI-WATERMARK: no

## Testing

Commands run from `apps/opik-backend`:

- `mvn test -Dtest='ProjectServiceImplTest,ProjectDeletedListenerTest,TraceServiceImplTest'` — 17 passed, 0 failed
- `mvn test -Dtest='TraceDeletionEventArchTest,SpanDeletionEventArchTest,TraceMutationRoutingArchTest'` — 5 passed (no bypass of the deletion-events capture or mutation-table routing)
- `mvn spotless:apply`

Scenarios covered by the new tests:

- Project exists → exactly one `ProjectsDeleted` with the id/workspace/user; missing project → no event; batch delete → one event with all ids; empty ids → no event.
- Listener calls `deleteByProjectId` once per project id with the workspace/user reactor context, and survives a per-project error while processing the rest.
- 10001 traces → two 10k-bounded deletes with exact id sublists, two `TracesDeleted` events, two bridge captures (capture flag on); flag off → no bridge writes.

Not run: testcontainers/E2E against a live stack (no Docker available in this environment); full `mvn test` suite.

## Documentation

N/A — no public API, configuration option or documented behavior changes.