### PR TITLE
[issue-7936] [SDK] fix: cap search polling sleep to the remaining timeout budget

### DIFF
--- a/sdks/typescript/src/opik/utils/searchHelpers.ts
+++ b/sdks/typescript/src/opik/utils/searchHelpers.ts
@@ -60,8 +60,13 @@ export async function searchAndWaitForDone<T>(
       return result;
     }
 
-    // Sleep before next attempt
-    await new Promise((resolve) => setTimeout(resolve, sleepTime));
+    // Sleep before next attempt, capped to the remaining timeout budget so we
+    // never intentionally oversleep past the caller-provided waitForTimeout
+    // (e.g. a long poll interval must not make a short timeout wait longer).
+    const remainingTime = waitForTimeout - elapsedTime;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(sleepTime, remainingTime))
+    );
   }
 }
 

--- a/sdks/typescript/tests/searchHelpers.test.ts
+++ b/sdks/typescript/tests/searchHelpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { searchAndWaitForDone } from "@/utils/searchHelpers";
+
+describe("searchAndWaitForDone", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("returns immediately once the condition is satisfied (unchanged behavior)", async () => {
+    const searchFn = vi.fn().mockResolvedValue([1, 2, 3]);
+    const result = await searchAndWaitForDone(searchFn, 2, 100, 5000);
+    expect(result).toEqual([1, 2, 3]);
+    expect(searchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("never sleeps past the caller-provided timeout when the poll interval is longer (regression for #7936)", async () => {
+    // waitForTimeout=100ms but sleepTime=5000ms: the old code slept the full
+    // 5s before re-checking, so a short timeout waited far longer than requested.
+    const searchFn = vi.fn().mockResolvedValue([]);
+    const promise = searchAndWaitForDone(searchFn, 1, 100, 5000);
+
+    // The capped sleep resolves at the timeout budget (100ms), not the poll interval.
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expect(promise).resolves.toEqual([]);
+    // initial poll + one re-check after the budget was exhausted
+    expect(searchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-polls with the full interval while the budget remains, and caps only the final sleep", async () => {
+    const searchFn = vi.fn().mockResolvedValue([]);
+    const promise = searchAndWaitForDone(searchFn, 1, 1600, 500);
+
+    await vi.advanceTimersByTimeAsync(1600);
+
+    await expect(promise).resolves.toEqual([]);
+    // sleeps 500 + 500 + 500 + capped(100) = 1600 -> 5 polls
+    expect(searchFn).toHaveBeenCalledTimes(5);
+  });
+});


### PR DESCRIPTION
## Details

Fixes `searchAndWaitForDone` in `sdks/typescript/src/opik/utils/searchHelpers.ts` so it no longer sleeps for the full polling interval when less time remains in the caller-provided `waitForTimeout`. The sleep is now capped with `Math.min(sleepTime, waitForTimeout - elapsedTime)`, so a short timeout no longer waits far longer than requested (e.g. `waitForTimeout=100, sleepTime=5000` now returns ~100ms instead of ~5s).

- Only the polling-loop sleep is changed; the "satisfied immediately" and "budget exhausted" return paths are unchanged.
- Keeps full-interval polling while the budget remains, and caps only the final sleep.

## Change checklist

- No user facing
- No documentation update

## Issues

- Resolves #7936

Note: there is an existing Draft PR #7960 (jstar0) with a similar intent. This PR provides an independent, tested implementation. Maintainers: happy to close this and help get #7960 over the line instead, if preferred — either way the goal is one merged fix.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code (Anthropic CLI) as the implementation agent
- Model(s): Claude (deepseek-v4-flash-vision backend)
- Scope: the fix in `searchHelpers.ts` + the regression test in `tests/searchHelpers.test.ts` were authored with AI assistance; no third-party code copied.
- Human verification: human author should review and approve before merge.

## Testing

- `npx vitest run tests/searchHelpers.test.ts` → 3 tests passed (deterministic fake-timers).
- `npx eslint 'src/opik/utils/searchHelpers.ts' 'tests/searchHelpers.test.ts'` → clean (exit 0).
- Scenarios validated:
  - immediate satisfaction returns as soon as the result count is met;
  - long poll interval (sleepTime=5000) vs short timeout (waitForTimeout=100) no longer oversleeps;
  - full-interval polling with a capped final sleep.
- Note: the full TypeScript SDK suite was not run in this environment; the focused unit tests and lint were run locally.

## Documentation

n/a
