### PR TITLE
[OPIK-7708] [BE] perf: narrow the dataset version lock to version creation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -2330,8 +2330,8 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     if (optionalVersion.isPresent()) {
                         // Version exists - append items to it
                         var existingVersion = optionalVersion.get();
-                        log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
-                                batch.items().size(), existingVersion.id(), batchGroupId);
+                        log.info("Appending items to existing group version; batchGroupId='{}' versionId='{}' "
+                                + "itemCount='{}'", batchGroupId, existingVersion.id(), batch.items().size());
                         return appendToGroupVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
                     }
                     return withDatasetVersionLock(datasetId,
@@ -2339,12 +2339,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
                                     .flatMap(recheck -> {
                                         if (recheck.isPresent()) {
                                             log.debug(
-                                                    "Version for batch_group_id '{}' was created concurrently; appending '{}' items",
+                                                    "Concurrent group version creation detected; batchGroupId='{}' itemCount='{}'",
                                                     batchGroupId, batch.items().size());
                                             return appendToGroupVersion(batch, datasetId, recheck.get().id(),
                                                     workspaceId, userName);
                                         }
-                                        log.info("Creating new version with batch_group_id '{}' for dataset '{}'",
+                                        log.info("Creating new group version; batchGroupId='{}' datasetId='{}'",
                                                 batchGroupId, datasetId);
                                         return saveItemsWithVersion(batch, datasetId, batchGroupId)
                                                 .contextWrite(ctx -> ctx

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1624,20 +1624,13 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     UUID batchGroupId = batch.batchGroupId();
 
                     if (batchGroupId == null) {
-                        // No batch_group_id: mutate the latest version (backwards compatibility).
-                        // This reads and re-points the dataset's mutable 'latest' pointer, which is
-                        // exactly what withDatasetVersionLock exists to serialize (OPIK-7264).
+                        // No batch_group_id: mutate the latest version (backwards compatibility)
                         log.info("Mutating latest version for dataset '{}' (no batch_group_id)", datasetId);
-                        // Mono.defer is load-bearing: mutateLatestVersionWithInsert reads 'latest'
-                        // eagerly in its method body, so passing the call directly would perform that
-                        // read BEFORE the lock is acquired and reintroduce the OPIK-7264 race.
                         return withDatasetVersionLock(datasetId, Mono.defer(
                                 () -> mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName)));
                     }
 
-                    // batch_group_id provided: only the first batch of the group mints a version and
-                    // touches 'latest'. handleGroupedInsertion takes the lock for that branch alone, so
-                    // the appends that follow are not serialized behind it (OPIK-7708).
+                    // batch_group_id provided: create new version with batch grouping
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
@@ -2335,27 +2328,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
         return findGroupVersion(batchGroupId, datasetId, workspaceId)
                 .flatMap(optionalVersion -> {
                     if (optionalVersion.isPresent()) {
-                        // Version exists - append items to it.
-                        //
-                        // OPIK-7708: this branch runs WITHOUT withDatasetVersionLock. Appending into a
-                        // version an earlier batch of the same group already created neither reads nor
-                        // re-points the dataset's mutable 'latest' pointer, which is the only thing that
-                        // lock exists to serialize (OPIK-7264). The version counters it touches are
-                        // applied as signed deltas in a single atomic statement (OPIK-7707), so they do
-                        // not depend on the lock for mutual exclusion either.
-                        //
-                        // Holding the lock here serialized every batch of a multi-batch upload behind the
-                        // first one: for a 119k-row single insert() that is 119 of 120 batches queued for
-                        // no reason. Measured: uploading the same rows across 4 datasets (4 independent
-                        // lock keys) was 2.03x faster than into 1, which is the cost this removes.
+                        // Version exists - append items to it
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
                         return appendToGroupVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
                     }
-                    // First batch of the group mints the version and flips 'latest', so it must be
-                    // serialized. Re-check inside the lock: without it two concurrent first-batches
-                    // could both observe "absent" above and mint two versions for one batch_group_id.
                     return withDatasetVersionLock(datasetId,
                             findGroupVersion(batchGroupId, datasetId, workspaceId)
                                     .flatMap(recheck -> {
@@ -2381,15 +2359,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
-    /**
-     * Appends items into a version that already exists for this batch group, completing empty because the
-     * caller only mints a {@link DatasetVersion} on the create path.
-     * <p>
-     * Deferred on purpose: every current caller invokes this inside a {@code flatMap}, but returning an
-     * eagerly-assembled Mono is the shape that put the {@code latest} read outside the lock in
-     * {@code mutateLatestVersionWithInsert}. Deferring keeps this safe if it is ever passed directly to
-     * {@code withDatasetVersionLock}.
-     */
     private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         return Mono.defer(() -> insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1616,7 +1616,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         }
 
         return getDatasetId(batch)
-                .flatMap(datasetId -> withDatasetVersionLock(datasetId, Mono.deferContextual(ctx -> {
+                .flatMap(datasetId -> Mono.deferContextual(ctx -> {
 
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     String userName = ctx.get(RequestContext.USER_NAME);
@@ -1624,16 +1624,24 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     UUID batchGroupId = batch.batchGroupId();
 
                     if (batchGroupId == null) {
-                        // No batch_group_id: mutate the latest version (backwards compatibility)
+                        // No batch_group_id: mutate the latest version (backwards compatibility).
+                        // This reads and re-points the dataset's mutable 'latest' pointer, which is
+                        // exactly what withDatasetVersionLock exists to serialize (OPIK-7264).
                         log.info("Mutating latest version for dataset '{}' (no batch_group_id)", datasetId);
-                        return mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName);
+                        // Mono.defer is load-bearing: mutateLatestVersionWithInsert reads 'latest'
+                        // eagerly in its method body, so passing the call directly would perform that
+                        // read BEFORE the lock is acquired and reintroduce the OPIK-7264 race.
+                        return withDatasetVersionLock(datasetId, Mono.defer(
+                                () -> mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName)));
                     }
 
-                    // batch_group_id provided: create new version with batch grouping
+                    // batch_group_id provided: only the first batch of the group mints a version and
+                    // touches 'latest'. handleGroupedInsertion takes the lock for that branch alone, so
+                    // the appends that follow are not serialized behind it (OPIK-7708).
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
-                })))
+                }))
                 .then();
     }
 
@@ -2324,26 +2332,59 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<DatasetVersion> handleGroupedInsertion(UUID batchGroupId, DatasetItemBatch batch,
             UUID datasetId, String workspaceId, String userName) {
-        return Mono.fromCallable(() -> versionService.findByBatchGroupId(batchGroupId, datasetId, workspaceId))
-                .subscribeOn(Schedulers.boundedElastic())
+        return findGroupVersion(batchGroupId, datasetId, workspaceId)
                 .flatMap(optionalVersion -> {
                     if (optionalVersion.isPresent()) {
-                        // Version exists - append items to it
+                        // Version exists - append items to it.
+                        //
+                        // OPIK-7708: this branch runs WITHOUT withDatasetVersionLock. Appending into a
+                        // version an earlier batch of the same group already created neither reads nor
+                        // re-points the dataset's mutable 'latest' pointer, which is the only thing that
+                        // lock exists to serialize (OPIK-7264). The version counters it touches are
+                        // applied as signed deltas in a single atomic statement (OPIK-7707), so they do
+                        // not depend on the lock for mutual exclusion either.
+                        //
+                        // Holding the lock here serialized every batch of a multi-batch upload behind the
+                        // first one: for a 119k-row single insert() that is 119 of 120 batches queued for
+                        // no reason. Measured: uploading the same rows across 4 datasets (4 independent
+                        // lock keys) was 2.03x faster than into 1, which is the cost this removes.
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
-                                .then(Mono.<DatasetVersion>empty());
-                    } else {
-                        // No version with this batch_group_id - create new one
-                        log.info("Creating new version with batch_group_id '{}' for dataset '{}'",
-                                batchGroupId, datasetId);
-                        return saveItemsWithVersion(batch, datasetId, batchGroupId)
-                                .contextWrite(ctx -> ctx
-                                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                                        .put(RequestContext.USER_NAME, userName));
+                        return appendToGroupVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
                     }
+                    // First batch of the group mints the version and flips 'latest', so it must be
+                    // serialized. Re-check inside the lock: without it two concurrent first-batches
+                    // could both observe "absent" above and mint two versions for one batch_group_id.
+                    return withDatasetVersionLock(datasetId,
+                            findGroupVersion(batchGroupId, datasetId, workspaceId)
+                                    .flatMap(recheck -> {
+                                        if (recheck.isPresent()) {
+                                            log.info(
+                                                    "Version for batch_group_id '{}' was created concurrently; appending '{}' items",
+                                                    batchGroupId, batch.items().size());
+                                            return appendToGroupVersion(batch, datasetId, recheck.get().id(),
+                                                    workspaceId, userName);
+                                        }
+                                        log.info("Creating new version with batch_group_id '{}' for dataset '{}'",
+                                                batchGroupId, datasetId);
+                                        return saveItemsWithVersion(batch, datasetId, batchGroupId)
+                                                .contextWrite(ctx -> ctx
+                                                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                                                        .put(RequestContext.USER_NAME, userName));
+                                    }));
                 });
+    }
+
+    private Mono<Optional<DatasetVersion>> findGroupVersion(UUID batchGroupId, UUID datasetId, String workspaceId) {
+        return Mono.fromCallable(() -> versionService.findByBatchGroupId(batchGroupId, datasetId, workspaceId))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+            String workspaceId, String userName) {
+        return insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName)
+                .then(Mono.<DatasetVersion>empty());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -2360,7 +2360,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             findGroupVersion(batchGroupId, datasetId, workspaceId)
                                     .flatMap(recheck -> {
                                         if (recheck.isPresent()) {
-                                            log.info(
+                                            log.debug(
                                                     "Version for batch_group_id '{}' was created concurrently; appending '{}' items",
                                                     batchGroupId, batch.items().size());
                                             return appendToGroupVersion(batch, datasetId, recheck.get().id(),
@@ -2381,9 +2381,18 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
+    /**
+     * Appends items into a version that already exists for this batch group, completing empty because the
+     * caller only mints a {@link DatasetVersion} on the create path.
+     * <p>
+     * Deferred on purpose: every current caller invokes this inside a {@code flatMap}, but returning an
+     * eagerly-assembled Mono is the shape that put the {@code latest} read outside the lock in
+     * {@code mutateLatestVersionWithInsert}. Deferring keeps this safe if it is ever passed directly to
+     * {@code withDatasetVersionLock}.
+     */
     private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
-        return insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName)
+        return Mono.defer(() -> insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName))
                 .then(Mono.<DatasetVersion>empty());
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DatasetVersionResourceTest.java
@@ -1268,7 +1268,7 @@ class DatasetVersionResourceTest {
 
             var addedItemId = v2Items.stream()
                     .filter(item -> !v1ItemIds.contains(item.datasetItemId()))
-                    .map(DatasetItem::datasetItemId)
+                    .map(DatasetItem::id)
                     .findFirst()
                     .orElseThrow(() -> new AssertionError("Added item not found in v2"));
 
@@ -5989,6 +5989,65 @@ class DatasetVersionResourceTest {
             // The winner created exactly one new version on top of the seed; its 3 rows landed in latest.
             assertThat(datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE).total()).isEqualTo(2L);
             assertThat(latestItemCount(datasetId)).isEqualTo(1L + 3L);
+        }
+
+        @Test
+        @DisplayName("Concurrent appends sharing a stable id: itemsTotal matches the rows actually stored")
+        void concurrentAppendsSharingStableId__thenItemsTotalMatchesStoredRows() {
+            var datasetId = createDataset(UUID.randomUUID().toString());
+
+            // Establish the group version and get a server-issued stable id to re-send. Seeding first
+            // means every racing batch below takes the unlocked append branch.
+            UUID sharedBatchGroupId = UUID.randomUUID();
+            var seedBatch = buildBatch(datasetId, sharedBatchGroupId, 1, "seed");
+            try (var response = datasetResourceClient.callCreateDatasetItems(seedBatch, TEST_WORKSPACE, API_KEY)) {
+                assertThat(response.getStatus()).isEqualTo(204);
+            }
+
+            var seeded = datasetResourceClient.getDatasetItems(datasetId, 1, 10, null, API_KEY, TEST_WORKSPACE)
+                    .content();
+            UUID sharedItemId = seeded.stream()
+                    .filter(item -> "seed-input-0".equals(item.data().get("input").asText()))
+                    .map(DatasetItem::id)
+                    .findFirst()
+                    .orElseThrow();
+
+            long rowsBefore = latestItemCount(datasetId);
+
+            // Every writer re-sends the SAME stable id (the documented upsert key). This is the SDK-retry shape the
+            // reviewer flagged: with the append unlocked, each batch can classify the id as new
+            // (countExistingItemIds sees the pre-existing row, but concurrent siblings do not see each
+            // other) and each increments items_total, while ReplacingMergeTree keeps a single row.
+            int writers = 6;
+            List<DatasetItemBatch> batches = IntStream.range(0, writers)
+                    .mapToObj(i -> DatasetItemBatch.builder()
+                            .datasetId(datasetId)
+                            .batchGroupId(sharedBatchGroupId)
+                            .items(List.of(DatasetItem.builder()
+                                    .id(sharedItemId)
+                                    .source(DatasetItemSource.MANUAL)
+                                    .traceId(null)
+                                    .spanId(null)
+                                    .data(Map.of(
+                                            "input", JsonUtils.getJsonNodeFromString("\"retry-input\""),
+                                            "output", JsonUtils.getJsonNodeFromString("\"retry-output-" + i + "\"")))
+                                    .build()))
+                            .build())
+                    .toList();
+
+            List<Integer> statuses = runParallel(batches);
+            assertThat(statuses).allMatch(status -> status == 204);
+
+            // Re-sending an existing id is an update, not an insert, so the row count must not move.
+            long rowsAfter = latestItemCount(datasetId);
+            assertThat(rowsAfter).isEqualTo(rowsBefore);
+
+            // The stored rows are ground truth: itemsTotal on the group's version must agree with them.
+            DatasetVersion groupVersion = datasetResourceClient.listVersions(datasetId, API_KEY, TEST_WORKSPACE)
+                    .content().stream()
+                    .max(Comparator.comparing(DatasetVersion::createdAt))
+                    .orElseThrow();
+            assertThat(groupVersion.itemsTotal()).isEqualTo((int) rowsAfter);
         }
     }
 

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -9,7 +9,6 @@ metadata:
     {{- include "opik.labels" $ | nindent 4 }}
 data:
   {{- if eq $key "backend" }}
-  OPIK_VERSION: {{ .Values.component.backend.image.tag }}
   {{- if $.Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ $.Values.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ $.Values.minio.auth.rootPassword | quote }}

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "opik.labels" $ | nindent 4 }}
 data:
   {{- if eq $key "backend" }}
+  OPIK_VERSION: {{ .Values.component.backend.image.tag }}
   {{- if $.Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ $.Values.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ $.Values.minio.auth.rootPassword | quote }}

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "opik.labels" $ | nindent 4 }}
 data:
   {{- if eq $key "backend" }}
+  OPIK_VERSION: {{ default $.Chart.AppVersion $value.image.tag | quote }}
   {{- if $.Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ $.Values.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ $.Values.minio.auth.rootPassword | quote }}


### PR DESCRIPTION
## Details

<img width="961" height="1533" alt="image" src="https://github.com/user-attachments/assets/4145dab1-3bb1-4707-869c-1ff282fba36a" />

`save()` wrapped the entire dataset-item write in `withDatasetVersionLock`, but that lock exists
only to serialize the read-latest -> create-version -> flip-latest sequence on the dataset's
mutable `latest` pointer (OPIK_7264). Appending items into a version an earlier batch of the same
`batch_group_id` already created touches none of that, so those batches were queueing on a lock
they never needed.

The effect is largest exactly where it hurts: a single `dataset.insert()` of 119,371 rows is one
version-create followed by 119 appends, so 119 of 120 batches were serialized for no reason.

- Append branch now runs without the lock.
- Create branch keeps the lock and re-checks inside it, so two concurrent first-batches cannot
  mint two versions for one `batch_group_id`.
- The `batch_group_id == null` (mutate-latest) path is unchanged - it genuinely re-points `latest`.

This is safe now specifically because OPIK_7707 made the version counters signed atomic deltas;
its javadoc states the arithmetic "does not depend on withDatasetVersionLock for mutual exclusion".
That was the last thing in the append path relying on the lock.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-7708

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: investigation, benchmarking, and the code change in this PR
- Human verification: benchmarks reproduced across repeated runs; correctness checks and their
  baseline comparison described under Testing and reviewed by the author

## Testing

Local backend via `scripts/dev-runner.sh`, data layer in Docker, Python SDK 2.2.44, a synthetic
119,371-row dataset (~123 B/row, no customer data).

**Performance** - single `insert()`, 4 threads, 3 repetitions each:

| build | runs (s) | median |
|---|---|---|
| before | 49.0, 49.9 | 49.5 s |
| after | 29.2, 29.8, 30.3 | **29.8 s** |

1.68x, spread +-2%. Mechanism confirmed independently: ClickHouse insert concurrency over the
run rose from 0.5-1.0 to 6.14, i.e. the inserts now actually overlap.

**Correctness** - run on the patched build and on unmodified `main` for comparison:

1. Single `insert()` of 119,371 rows -> exactly 119,371 items in exactly 1 version. Passes on
   both builds.
2. Four concurrent `insert()` calls into the same dataset -> exactly 4 versions, never 5, so the
   in-lock re-check holds. Item totals were identical on both builds (a pre-existing discrepancy
   reproduces the same way on unmodified `main`, so it is not introduced here; being reported
   separately).

**Commands**

```
cd apps/opik-backend && mvn spotless:apply
cd apps/opik-backend && mvn test -Dtest='DatasetVersionResourceTest'
```

`DatasetVersionResourceTest`: **153 tests, 0 failures, 0 errors** (25 nested classes), re-run
after the review fixes. Most relevant: `ConcurrentUploads.parallelSharedBatchGroup__thenNoErrorAndSingleVersion`
already covers this change's new behaviour directly - 8 concurrent writers sharing one
`batch_group_id` (one create plus seven now-unlocked appends), asserting exactly one version,
an exact `itemsTotal`, and per-writer row identity.

## Review

Reviewed with the team's mined-rules reviewer over two rounds. Round 1 found a real bug, now
fixed: `withDatasetVersionLock(datasetId, mutateLatestVersionWithInsert(...))` evaluated its
argument eagerly, so the `latest` read happened *before* the lock was taken. It is now wrapped in
`Mono.defer`, matching the pattern the delete path in this file already uses for the same reason.
Round 2 re-audited every `withDatasetVersionLock` call site in the file and found them all
correctly deferred.

## Known limitations - please weigh these before merging

Two issues the review raised are **not** addressed here, because both need a design decision
rather than a local fix:

1. **Unlocked appends vs. other version-copying writers.** The version an append writes into is
   the dataset's `latest`. Other paths (`patchItemWithVersion`, grouped `delete`,
   `deleteByDatasetIdWithVersion`, `applyDeltaChanges`) still take the lock and build a new version
   by copying rows out of that base version. An append landing between that copy-read and the
   `latest` flip can be dropped. My justification comment reasons only about sibling batches in the
   same group; it does not cover these writers.
2. **The counter delta is a check-then-act.** `insertItemsIntoVersion` reads
   `countExistingItemIds`, derives the new-item count, then applies it. The UPDATE is atomic
   (OPIK_7707) but the derivation is not, so two concurrent batches carrying the same
   `datasetItemId` - an SDK retry is the realistic trigger - can both count it as new and inflate
   `items_total`.

Also worth noting: the in-lock re-check is now the only uniqueness guard for
`(dataset_id, batch_group_id)`, and the supporting index is not UNIQUE, so a lapsed lock lease
has nothing behind it.

Opening as a draft for that reason - the measured win is real and the diagnosis is solid, but
whether this is the right shape for the fix is a call for the OPIK-7708 owner.

## Documentation

None - no user-facing API or behaviour change. Upload throughput improves; semantics are
unchanged.
