### PR TITLE
[OPIK-7708] [QA] Proposed e2e spec from the #8066 exploration: concurrent grouped dataset-item batches commit one version

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1624,20 +1624,13 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     UUID batchGroupId = batch.batchGroupId();
 
                     if (batchGroupId == null) {
-                        // No batch_group_id: mutate the latest version (backwards compatibility).
-                        // This reads and re-points the dataset's mutable 'latest' pointer, which is
-                        // exactly what withDatasetVersionLock exists to serialize (OPIK-7264).
+                        // No batch_group_id: mutate the latest version (backwards compatibility)
                         log.info("Mutating latest version for dataset '{}' (no batch_group_id)", datasetId);
-                        // Mono.defer is load-bearing: mutateLatestVersionWithInsert reads 'latest'
-                        // eagerly in its method body, so passing the call directly would perform that
-                        // read BEFORE the lock is acquired and reintroduce the OPIK-7264 race.
                         return withDatasetVersionLock(datasetId, Mono.defer(
                                 () -> mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName)));
                     }
 
-                    // batch_group_id provided: only the first batch of the group mints a version and
-                    // touches 'latest'. handleGroupedInsertion takes the lock for that branch alone, so
-                    // the appends that follow are not serialized behind it (OPIK-7708).
+                    // batch_group_id provided: create new version with batch grouping
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
@@ -2335,27 +2328,12 @@ class DatasetItemServiceImpl implements DatasetItemService {
         return findGroupVersion(batchGroupId, datasetId, workspaceId)
                 .flatMap(optionalVersion -> {
                     if (optionalVersion.isPresent()) {
-                        // Version exists - append items to it.
-                        //
-                        // OPIK-7708: this branch runs WITHOUT withDatasetVersionLock. Appending into a
-                        // version an earlier batch of the same group already created neither reads nor
-                        // re-points the dataset's mutable 'latest' pointer, which is the only thing that
-                        // lock exists to serialize (OPIK-7264). The version counters it touches are
-                        // applied as signed deltas in a single atomic statement (OPIK-7707), so they do
-                        // not depend on the lock for mutual exclusion either.
-                        //
-                        // Holding the lock here serialized every batch of a multi-batch upload behind the
-                        // first one: for a 119k-row single insert() that is 119 of 120 batches queued for
-                        // no reason. Measured: uploading the same rows across 4 datasets (4 independent
-                        // lock keys) was 2.03x faster than into 1, which is the cost this removes.
+                        // Version exists - append items to it
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
                         return appendToGroupVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
                     }
-                    // First batch of the group mints the version and flips 'latest', so it must be
-                    // serialized. Re-check inside the lock: without it two concurrent first-batches
-                    // could both observe "absent" above and mint two versions for one batch_group_id.
                     return withDatasetVersionLock(datasetId,
                             findGroupVersion(batchGroupId, datasetId, workspaceId)
                                     .flatMap(recheck -> {
@@ -2381,15 +2359,6 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
-    /**
-     * Appends items into a version that already exists for this batch group, completing empty because the
-     * caller only mints a {@link DatasetVersion} on the create path.
-     * <p>
-     * Deferred on purpose: every current caller invokes this inside a {@code flatMap}, but returning an
-     * eagerly-assembled Mono is the shape that put the {@code latest} read outside the lock in
-     * {@code mutateLatestVersionWithInsert}. Deferring keeps this safe if it is ever passed directly to
-     * {@code withDatasetVersionLock}.
-     */
     private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
         return Mono.defer(() -> insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -1616,7 +1616,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
         }
 
         return getDatasetId(batch)
-                .flatMap(datasetId -> withDatasetVersionLock(datasetId, Mono.deferContextual(ctx -> {
+                .flatMap(datasetId -> Mono.deferContextual(ctx -> {
 
                     String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
                     String userName = ctx.get(RequestContext.USER_NAME);
@@ -1624,16 +1624,24 @@ class DatasetItemServiceImpl implements DatasetItemService {
                     UUID batchGroupId = batch.batchGroupId();
 
                     if (batchGroupId == null) {
-                        // No batch_group_id: mutate the latest version (backwards compatibility)
+                        // No batch_group_id: mutate the latest version (backwards compatibility).
+                        // This reads and re-points the dataset's mutable 'latest' pointer, which is
+                        // exactly what withDatasetVersionLock exists to serialize (OPIK-7264).
                         log.info("Mutating latest version for dataset '{}' (no batch_group_id)", datasetId);
-                        return mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName);
+                        // Mono.defer is load-bearing: mutateLatestVersionWithInsert reads 'latest'
+                        // eagerly in its method body, so passing the call directly would perform that
+                        // read BEFORE the lock is acquired and reintroduce the OPIK-7264 race.
+                        return withDatasetVersionLock(datasetId, Mono.defer(
+                                () -> mutateLatestVersionWithInsert(batch, datasetId, workspaceId, userName)));
                     }
 
-                    // batch_group_id provided: create new version with batch grouping
+                    // batch_group_id provided: only the first batch of the group mints a version and
+                    // touches 'latest'. handleGroupedInsertion takes the lock for that branch alone, so
+                    // the appends that follow are not serialized behind it (OPIK-7708).
                     log.info("Creating version with batch grouping for dataset '{}', batch_group_id: '{}'", datasetId,
                             batchGroupId);
                     return handleGroupedInsertion(batchGroupId, batch, datasetId, workspaceId, userName);
-                })))
+                }))
                 .then();
     }
 
@@ -2324,26 +2332,59 @@ class DatasetItemServiceImpl implements DatasetItemService {
      */
     private Mono<DatasetVersion> handleGroupedInsertion(UUID batchGroupId, DatasetItemBatch batch,
             UUID datasetId, String workspaceId, String userName) {
-        return Mono.fromCallable(() -> versionService.findByBatchGroupId(batchGroupId, datasetId, workspaceId))
-                .subscribeOn(Schedulers.boundedElastic())
+        return findGroupVersion(batchGroupId, datasetId, workspaceId)
                 .flatMap(optionalVersion -> {
                     if (optionalVersion.isPresent()) {
-                        // Version exists - append items to it
+                        // Version exists - append items to it.
+                        //
+                        // OPIK-7708: this branch runs WITHOUT withDatasetVersionLock. Appending into a
+                        // version an earlier batch of the same group already created neither reads nor
+                        // re-points the dataset's mutable 'latest' pointer, which is the only thing that
+                        // lock exists to serialize (OPIK-7264). The version counters it touches are
+                        // applied as signed deltas in a single atomic statement (OPIK-7707), so they do
+                        // not depend on the lock for mutual exclusion either.
+                        //
+                        // Holding the lock here serialized every batch of a multi-batch upload behind the
+                        // first one: for a 119k-row single insert() that is 119 of 120 batches queued for
+                        // no reason. Measured: uploading the same rows across 4 datasets (4 independent
+                        // lock keys) was 2.03x faster than into 1, which is the cost this removes.
                         var existingVersion = optionalVersion.get();
                         log.info("Appending '{}' items to existing version '{}' for batch_group_id '{}'",
                                 batch.items().size(), existingVersion.id(), batchGroupId);
-                        return insertItemsIntoVersion(batch, datasetId, existingVersion.id(), workspaceId, userName)
-                                .then(Mono.<DatasetVersion>empty());
-                    } else {
-                        // No version with this batch_group_id - create new one
-                        log.info("Creating new version with batch_group_id '{}' for dataset '{}'",
-                                batchGroupId, datasetId);
-                        return saveItemsWithVersion(batch, datasetId, batchGroupId)
-                                .contextWrite(ctx -> ctx
-                                        .put(RequestContext.WORKSPACE_ID, workspaceId)
-                                        .put(RequestContext.USER_NAME, userName));
+                        return appendToGroupVersion(batch, datasetId, existingVersion.id(), workspaceId, userName);
                     }
+                    // First batch of the group mints the version and flips 'latest', so it must be
+                    // serialized. Re-check inside the lock: without it two concurrent first-batches
+                    // could both observe "absent" above and mint two versions for one batch_group_id.
+                    return withDatasetVersionLock(datasetId,
+                            findGroupVersion(batchGroupId, datasetId, workspaceId)
+                                    .flatMap(recheck -> {
+                                        if (recheck.isPresent()) {
+                                            log.info(
+                                                    "Version for batch_group_id '{}' was created concurrently; appending '{}' items",
+                                                    batchGroupId, batch.items().size());
+                                            return appendToGroupVersion(batch, datasetId, recheck.get().id(),
+                                                    workspaceId, userName);
+                                        }
+                                        log.info("Creating new version with batch_group_id '{}' for dataset '{}'",
+                                                batchGroupId, datasetId);
+                                        return saveItemsWithVersion(batch, datasetId, batchGroupId)
+                                                .contextWrite(ctx -> ctx
+                                                        .put(RequestContext.WORKSPACE_ID, workspaceId)
+                                                        .put(RequestContext.USER_NAME, userName));
+                                    }));
                 });
+    }
+
+    private Mono<Optional<DatasetVersion>> findGroupVersion(UUID batchGroupId, UUID datasetId, String workspaceId) {
+        return Mono.fromCallable(() -> versionService.findByBatchGroupId(batchGroupId, datasetId, workspaceId))
+                .subscribeOn(Schedulers.boundedElastic());
+    }
+
+    private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
+            String workspaceId, String userName) {
+        return insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName)
+                .then(Mono.<DatasetVersion>empty());
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemService.java
@@ -2360,7 +2360,7 @@ class DatasetItemServiceImpl implements DatasetItemService {
                             findGroupVersion(batchGroupId, datasetId, workspaceId)
                                     .flatMap(recheck -> {
                                         if (recheck.isPresent()) {
-                                            log.info(
+                                            log.debug(
                                                     "Version for batch_group_id '{}' was created concurrently; appending '{}' items",
                                                     batchGroupId, batch.items().size());
                                             return appendToGroupVersion(batch, datasetId, recheck.get().id(),
@@ -2381,9 +2381,18 @@ class DatasetItemServiceImpl implements DatasetItemService {
                 .subscribeOn(Schedulers.boundedElastic());
     }
 
+    /**
+     * Appends items into a version that already exists for this batch group, completing empty because the
+     * caller only mints a {@link DatasetVersion} on the create path.
+     * <p>
+     * Deferred on purpose: every current caller invokes this inside a {@code flatMap}, but returning an
+     * eagerly-assembled Mono is the shape that put the {@code latest} read outside the lock in
+     * {@code mutateLatestVersionWithInsert}. Deferring keeps this safe if it is ever passed directly to
+     * {@code withDatasetVersionLock}.
+     */
     private Mono<DatasetVersion> appendToGroupVersion(DatasetItemBatch batch, UUID datasetId, UUID versionId,
             String workspaceId, String userName) {
-        return insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName)
+        return Mono.defer(() -> insertItemsIntoVersion(batch, datasetId, versionId, workspaceId, userName))
                 .then(Mono.<DatasetVersion>empty());
     }
 

--- a/deployment/helm_chart/opik/templates/configmap-backend.yaml
+++ b/deployment/helm_chart/opik/templates/configmap-backend.yaml
@@ -9,6 +9,7 @@ metadata:
     {{- include "opik.labels" $ | nindent 4 }}
 data:
   {{- if eq $key "backend" }}
+  OPIK_VERSION: {{ .Values.component.backend.image.tag }}
   {{- if $.Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ $.Values.minio.auth.rootUser | quote }}
   AWS_SECRET_ACCESS_KEY: {{ $.Values.minio.auth.rootPassword | quote }}

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -503,6 +503,7 @@ areas:
       - datasets/dataset-items.spec.ts
       - datasets/dataset-items-filter-scope.spec.ts
       - datasets/dataset-version-counters.spec.ts
+      - datasets/dataset-version-concurrent-batches.spec.ts
     capabilities:
       list-datasets:          { covered: true,  tier: t1-smoke }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -51,6 +51,17 @@ export interface DatasetItemWithTagsRef {
   tags: string[];
 }
 
+/**
+ * One row of a `PUT /v1/private/datasets/items` batch, in the shape the REST
+ * body wants it — `id` is the upsert key, so re-sending it with different
+ * `data` is what the backend counts as a modification rather than an addition.
+ */
+export interface DatasetItemWriteBody {
+  id: string;
+  source: 'manual';
+  data: Record<string, unknown>;
+}
+
 /** A raw REST answer, kept as status + message so a negative path can assert both. */
 export interface RawApiResult {
   status: number;
@@ -434,7 +445,7 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
    * exists for the same reason (the pinned SDK can't express the call).
    */
   const rawFetch = async (
-    method: 'GET' | 'POST' | 'PATCH',
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH',
     path: string,
     opts: { query?: URLSearchParams; body?: unknown } = {},
   ): Promise<RawApiResult & { json: unknown }> => {
@@ -793,6 +804,44 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         ids.push(...content.map((item) => String(item.id)));
         if (content.length < pageSize) return ids;
       }
+    },
+
+    /**
+     * Release every batch in `batches` at `PUT /v1/private/datasets/items` at
+     * once, all carrying the same `batchGroupId`, and answer what each one
+     * returned.
+     *
+     * The concurrency is the point, so the requests are all built in one
+     * synchronous pass before any of them is awaited: node's fetch dispatcher
+     * has no per-origin connection cap, so N in-flight requests take N sockets
+     * and the backend sees them arrive together rather than in a queue. Driving
+     * the endpoint here rather than through `Dataset.insert(num_threads=N)`
+     * makes that a property of the test: the SDK only parallelises when the
+     * backend's `/is-alive/ver` parses as semver >= 2.2.8, and silently uploads
+     * sequentially otherwise — so a spec that raced through the SDK would stop
+     * racing, without failing, on any estate whose OPIK_VERSION is `latest`.
+     *
+     * Statuses come back rather than being thrown on, because "every batch was
+     * accepted" is part of the contract: a losing racer answering 409 or 500 is
+     * exactly the regression a caller is looking for, and the pinned SDK would
+     * surface it as an opaque throw with no body.
+     */
+    async putDatasetItemBatchesConcurrently(args: {
+      datasetId: string;
+      batchGroupId: string;
+      batches: DatasetItemWriteBody[][];
+    }): Promise<RawApiResult[]> {
+      const inFlight = args.batches.map((items) =>
+        rawFetch('PUT', '/v1/private/datasets/items', {
+          body: {
+            dataset_id: args.datasetId,
+            batch_group_id: args.batchGroupId,
+            items,
+          },
+        }),
+      );
+      const settled = await Promise.all(inFlight);
+      return settled.map((r) => ({ status: r.status, message: r.message }));
     },
 
     /**

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -6,6 +6,7 @@ export {
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
   type DatasetItemWithTagsRef,
+  type DatasetItemWriteBody,
   type DatasetVersionRef,
   type RawApiResult,
   type BackendSort,

--- a/tests_end_to_end/e2e/fixtures/concurrent-batch-dataset.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/concurrent-batch-dataset.fixture.ts
@@ -1,0 +1,129 @@
+import { test as baseTest } from './dashboard-cleanup.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7 } from '../core/backend';
+
+/** Items in the committed baseline version the concurrent batches then modify. */
+export const BASELINE_ITEM_COUNT = 600;
+
+export interface ConcurrentBatchDatasetRef {
+  id: string;
+  name: string;
+  projectId: string;
+  /**
+   * The ids stored by the baseline version, minted here rather than read back.
+   * A batch that re-sends one of these with different content is what the
+   * backend counts as a modification, so a test needs them exactly.
+   */
+  baselineItemIds: string[];
+}
+
+export interface ConcurrentBatchDatasetFixtures {
+  concurrentBatchDataset: ConcurrentBatchDatasetRef;
+}
+
+function baselineItem(id: string, index: number): Record<string, unknown> {
+  return {
+    id,
+    input: `baseline question ${index}`,
+    expected_output: `baseline answer ${index}`,
+  };
+}
+
+/**
+ * A dataset holding exactly one committed version of `BASELINE_ITEM_COUNT`
+ * items whose ids the test knows.
+ *
+ * This is the precondition for the version-contention path: with a baseline in
+ * place, a later group of batches can be split into ones that re-send known ids
+ * (modifications) and ones that carry fresh ids (additions), so the resulting
+ * version's `items_total` / `items_added` / `items_modified` are three
+ * different numbers and no counter can pass by coincidence.
+ *
+ * The seed goes through the Python SDK bridge, so `v1` is created the way a
+ * user creates it. The fixture then asserts, via the API, that the baseline
+ * really is one version of exactly that size before the test runs: a UI or
+ * counter assertion sitting on top of a seed that silently half-landed is a
+ * test that cannot fail.
+ *
+ * The dataset is deleted here rather than in the test — datasets do not cascade
+ * with the project, and a mid-test failure would otherwise leak a few thousand
+ * items.
+ */
+export const test = baseTest.extend<ConcurrentBatchDatasetFixtures>({
+  concurrentBatchDataset: async (
+    { sdkClient, backendClient, project, testNamespace },
+    use,
+    testInfo,
+  ) => {
+    const name = `${testNamespace}-concurrent-batches`;
+    const baselineItemIds = Array.from({ length: BASELINE_ITEM_COUNT }, () => uuid7());
+
+    const created = await sdkClient.python.createDataset({
+      project_name: project.name,
+      name,
+      description: 'baseline version for concurrent grouped batch uploads',
+    });
+
+    await sdkClient.python.insertDatasetItems({
+      project_name: project.name,
+      dataset_name: name,
+      items: baselineItemIds.map(baselineItem),
+    });
+
+    const versions = await backendClient.getDatasetVersions(created.id);
+    if (versions.length !== 1) {
+      throw new Error(
+        `[concurrentBatchDataset fixture] expected 1 baseline version, got ${versions.length}`,
+      );
+    }
+    const [baseline] = versions;
+    if (
+      baseline.itemsTotal !== BASELINE_ITEM_COUNT ||
+      baseline.itemsAdded !== BASELINE_ITEM_COUNT ||
+      baseline.itemsModified !== 0
+    ) {
+      throw new Error(
+        `[concurrentBatchDataset fixture] baseline ${baseline.versionName} is ` +
+          `${baseline.itemsTotal}/${baseline.itemsAdded}/${baseline.itemsModified} ` +
+          `(total/added/modified), expected ${BASELINE_ITEM_COUNT}/${BASELINE_ITEM_COUNT}/0`,
+      );
+    }
+
+    // The ids are the fixture's contract with the test: if the SDK had not
+    // honoured them as upsert keys, every "modifying" batch would silently add
+    // instead, and the counters the test asserts would be wrong for a reason
+    // that has nothing to do with concurrency.
+    const storedIds = new Set(await backendClient.listDatasetItemIds(created.id));
+    const missing = baselineItemIds.filter((id) => !storedIds.has(id));
+    if (storedIds.size !== BASELINE_ITEM_COUNT || missing.length > 0) {
+      throw new Error(
+        `[concurrentBatchDataset fixture] stored ${storedIds.size} ids, ` +
+          `${missing.length} of the seeded ids missing`,
+      );
+    }
+
+    const ref: ConcurrentBatchDatasetRef = {
+      id: created.id,
+      name: created.name,
+      projectId: project.id,
+      baselineItemIds,
+    };
+
+    await testInfo.attach('opik.concurrentBatchDataset', {
+      body: JSON.stringify({ ...ref, baselineItemIds: `${BASELINE_ITEM_COUNT} ids` }, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteDataset(created.id);
+      } catch (err) {
+        console.warn(`[concurrentBatchDataset fixture] delete warning for ${name}:`, err);
+      }
+    }
+  },
+});
+
+export { expect } from './dashboard-cleanup.fixture';

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './dashboard-cleanup.fixture';
+export { test, expect } from './concurrent-batch-dataset.fixture';
 export type {
   OauthProviderSeed,
   ProviderKeysFixture,
@@ -105,4 +105,9 @@ export type {
   TraceAttachmentsFixtures,
 } from './trace-attachments.fixture';
 export type { DashboardCleanupFixtures } from './dashboard-cleanup.fixture';
+export type {
+  ConcurrentBatchDatasetRef,
+  ConcurrentBatchDatasetFixtures,
+} from './concurrent-batch-dataset.fixture';
+export { BASELINE_ITEM_COUNT } from './concurrent-batch-dataset.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/pom/dataset-items.page.ts
+++ b/tests_end_to_end/e2e/pom/dataset-items.page.ts
@@ -157,6 +157,23 @@ export class DatasetItemsPage {
     return this.versionHistoryRow(versionName).locator('[data-cell-id$="_items_total"]');
   }
 
+  /**
+   * The "Changes" cell of a version row — the added / modified / deleted chips,
+   * as one locator so a caller can assert the whole cell rather than hunting
+   * for the chip it expects. An extra chip is as wrong as a missing one: a
+   * version that reports a deletion it never made is a counter bug, and a
+   * per-chip assertion would pass straight through it.
+   *
+   * Addressed by the table's `data-cell-id` for the same reason as
+   * `versionItemCount`, and at cell rather than chip level because the chips
+   * are bare `Tag` divs with no testid and no accessible name. Unlike "Item
+   * count" these numbers are NOT thousands-separated — the cell prints the raw
+   * counters — so callers should match on a regex over the cell's text.
+   */
+  versionChangeSummary(versionName: string): Locator {
+    return this.versionHistoryRow(versionName).locator('[data-cell-id$="_change_summary"]');
+  }
+
   async search(term: string): Promise<void> {
     return test.step(`Search items for "${term}"`, async () => {
       await this.page.getByTestId('search-input').fill(term);

--- a/tests_end_to_end/e2e/tests/datasets/dataset-version-concurrent-batches.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-version-concurrent-batches.spec.ts
@@ -1,0 +1,186 @@
+import { test, expect } from '@e2e/fixtures';
+import { BASELINE_ITEM_COUNT } from '@e2e/fixtures';
+import { uuid7 } from '@e2e/core/backend';
+import type { DatasetItemWriteBody, DatasetVersionRef } from '@e2e/core/backend';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+
+/**
+ * Many batches sharing one `batch_group_id`, sent at the same time, must commit
+ * exactly ONE dataset version whose counters describe every item they carried
+ * (OPIK-7708, which narrowed the dataset version lock to version creation).
+ *
+ * `dataset-version-counters.spec.ts` already asserts that a multi-batch
+ * `insert()` collapses into one version, and it is the spec that owns
+ * `datasets.version-history-view`. What it cannot guarantee is the axis this
+ * change moved. It reaches concurrency only through
+ * `insert(..., num_threads=8)`, and the SDK opens that gate only when the
+ * backend's `/is-alive/ver` parses as semver >= 2.2.8 — which a locally built
+ * docker-compose backend, whose OPIK_VERSION defaults to `latest`, never does.
+ * On such an estate that spec passes without two requests ever overlapping.
+ *
+ * Driving `PUT /v1/private/datasets/items` directly makes the race a property
+ * of the test rather than of the backend's version string, and raises it from
+ * two batches to eight. The failure mode being hunted is silent wrongness under
+ * contention, not a visible error: eight batches minting eight versions, or a
+ * version reporting more items than the dataset holds because two racers each
+ * counted the same row as new. Both would render as a plausible number on the
+ * Version history tab that nobody can tell is wrong.
+ *
+ * Shape of the batches: two of the eight re-send the baseline version's ids
+ * with changed content (modifications) and six carry fresh ids (additions), so
+ * total / added / modified are three different numbers.
+ */
+
+const CONCURRENT_BATCHES = 8;
+const BATCH_SIZE = 300;
+/** The batches that re-send baseline ids; the rest carry ids nothing has seen. */
+const MODIFYING_BATCHES = 2;
+
+const EXPECTED_MODIFIED = MODIFYING_BATCHES * BATCH_SIZE;
+const EXPECTED_ADDED = (CONCURRENT_BATCHES - MODIFYING_BATCHES) * BATCH_SIZE;
+const EXPECTED_TOTAL = BASELINE_ITEM_COUNT + EXPECTED_ADDED;
+
+// The modifying batches must cover the baseline exactly. If they ever stopped
+// doing so, `items_modified` would still be a number the assertions could be
+// bent to match, and the spec would quietly stop testing modification at all.
+if (EXPECTED_MODIFIED !== BASELINE_ITEM_COUNT) {
+  throw new Error(
+    `dataset-version-concurrent-batches: ${MODIFYING_BATCHES} x ${BATCH_SIZE} modifying items ` +
+      `must equal the fixture's baseline of ${BASELINE_ITEM_COUNT}`,
+  );
+}
+
+const EXPECTED_VERSIONS = [
+  {
+    versionName: 'v1',
+    itemsTotal: BASELINE_ITEM_COUNT,
+    itemsAdded: BASELINE_ITEM_COUNT,
+    itemsModified: 0,
+    itemsDeleted: 0,
+    isLatest: false,
+  },
+  {
+    versionName: 'v2',
+    itemsTotal: EXPECTED_TOTAL,
+    itemsAdded: EXPECTED_ADDED,
+    itemsModified: EXPECTED_MODIFIED,
+    itemsDeleted: 0,
+    isLatest: true,
+  },
+];
+
+function byVersionName(versions: DatasetVersionRef[]) {
+  return [...versions].sort((a, b) => a.versionName.localeCompare(b.versionName));
+}
+
+/**
+ * The chips the "Changes" cell renders, in the order the cell emits them:
+ * added, then modified, then deleted, each omitted when its counter is zero.
+ * Anchored so an extra chip — a deletion this test never made — fails.
+ */
+function changeSummaryPattern(added: number, modified: number): RegExp {
+  const chips = [`\\+\\s*${added}`];
+  if (modified > 0) chips.push(`~\\s*${modified}`);
+  return new RegExp(`^\\s*${chips.join('\\s*')}\\s*$`);
+}
+
+test.describe(
+  'Dataset versions — concurrent grouped batches',
+  { tag: ['@t3-nightly', '@area:datasets'] },
+  () => {
+    /** 600 seeded items plus 2400 uploaded ones outrun the default budget. */
+    test.slow();
+
+    test(
+      'Eight batches sharing one group id, released together, commit one version whose counters match the items stored, and the Version history tab renders them',
+      { tag: ['@cap:datasets.version-history-view'] },
+      async ({ concurrentBatchDataset, project, backendClient, page }) => {
+        const { id: datasetId, baselineItemIds } = concurrentBatchDataset;
+        const batchGroupId = uuid7();
+
+        const batches: DatasetItemWriteBody[][] = Array.from(
+          { length: CONCURRENT_BATCHES },
+          (_, batchIndex) => {
+            const modifying = batchIndex < MODIFYING_BATCHES;
+            const revision = modifying ? 'revised' : 'added';
+            return Array.from({ length: BATCH_SIZE }, (_, offset) => {
+              const index = batchIndex * BATCH_SIZE + offset;
+              return {
+                // A modifying batch re-sends a baseline id, so the backend
+                // upserts it; the rest mint ids the dataset has never held.
+                id: modifying ? baselineItemIds[index] : uuid7(),
+                source: 'manual' as const,
+                data: {
+                  input: `${revision} question ${index}`,
+                  expected_output: `${revision} answer ${index}`,
+                },
+              };
+            });
+          },
+        );
+
+        await test.step('All eight batches are accepted when released together', async () => {
+          const responses = await backendClient.putDatasetItemBatchesConcurrently({
+            datasetId,
+            batchGroupId,
+            batches,
+          });
+          // Asserted as the whole list rather than "none failed": a losing
+          // racer answering 409 or 500 is the regression, and comparing the
+          // full array surfaces the backend's message for whichever batch lost.
+          expect(responses, 'every concurrent batch answers 204 with no body').toEqual(
+            Array.from({ length: CONCURRENT_BATCHES }, () => ({ status: 204, message: '' })),
+          );
+        });
+
+        await test.step('The group committed exactly one new version, with the counters it should', async () => {
+          const versions = await backendClient.getDatasetVersions(datasetId);
+          // Eight batches, one group, two versions — the baseline and the one
+          // this group committed. Eight versions is what an unnarrowed lock or
+          // a lost check-lock-recheck would produce, and asserting the whole
+          // list is what catches it; a `find()` for v2 would not.
+          expect(byVersionName(versions), 'the batch group folds into a single version').toEqual(
+            EXPECTED_VERSIONS,
+          );
+        });
+
+        await test.step('The version total agrees with the items actually stored', async () => {
+          const itemIds = await backendClient.listDatasetItemIds(datasetId);
+          // Both halves matter. A racer that double-counted a fresh id would
+          // report more than the dataset holds; one whose write was lost would
+          // report the right number over fewer rows.
+          expect(itemIds, 'no item was dropped or stored twice').toHaveLength(EXPECTED_TOTAL);
+          expect(new Set(itemIds).size, 'every stored id is distinct').toBe(EXPECTED_TOTAL);
+        });
+
+        await test.step('The Version history tab renders two rows with those counters', async () => {
+          const datasets = new DatasetsPage(page);
+          await datasets.goto(project.id);
+          await datasets.waitForReady();
+          const items = await datasets.openDatasetByName(concurrentBatchDataset.name);
+          await items.waitForReady();
+          await items.openVersionHistory();
+
+          for (const expected of EXPECTED_VERSIONS) {
+            // Resolve the row before reading its cells: an ambiguous match
+            // should fail here rather than silently assert the wrong version.
+            await expect(
+              items.versionHistoryRow(expected.versionName),
+              `exactly one ${expected.versionName} row`,
+            ).toHaveCount(1);
+
+            await expect(
+              items.versionItemCount(expected.versionName),
+              `${expected.versionName} item count`,
+            ).toHaveText(expected.itemsTotal.toLocaleString('en-US'));
+
+            await expect(
+              items.versionChangeSummary(expected.versionName),
+              `${expected.versionName} change summary`,
+            ).toHaveText(changeSummaryPattern(expected.itemsAdded, expected.itemsModified));
+          }
+        });
+      },
+    );
+  },
+);


### PR DESCRIPTION
## Where this came from

Exploratory testing of **comet-ml/opik#8066** — *[BE] perf: narrow the dataset version lock to version creation* (OPIK-7708) — against that PR's own deployed environment, `https://pr-8066.dev.comet.com` (`2.2.45-6495`, OSS, workspace `default`). A human-driven exploration verified the flow by hand there first: 8-way × 4 runs and 16-way × 3 runs of concurrent grouped batches, all released on a barrier, plus a cell-by-cell comparison of the Version history tab against `GET /v1/private/datasets/{id}/versions`. This PR turns the one strong candidate from that exploration into a permanent spec.

**Base branch: `YarivHashaiComet/OPIK-7708/narrow-dataset-version-lock`, not `main`.** opik#8066 is still open, so the rewritten version-creation path this spec drives only exists on that branch. Targeting `main` would mean asserting behaviour that is not there yet. The spec was written and run against its head commit `44577793bf0265153131c31f7e1028aa5b574497`. When #8066 merges, this should be retargeted to `main` and re-run — `main` will have moved on.

## What was added

**`tests_end_to_end/e2e/tests/datasets/dataset-version-concurrent-batches.spec.ts`** — `@t3-nightly` `@area:datasets` `@cap:datasets.version-history-view`

Eight batches of 300 items sharing one `batch_group_id`, all released together at `PUT /v1/private/datasets/items` on top of a committed 600-item baseline version. Two batches re-send the baseline ids with changed content, six carry fresh UUIDv7 ids. It asserts:

1. every one of the eight batches answers `204` — a losing racer returning 409 or 500 is a regression, so the full response list is compared rather than "none failed";
2. the group commits **exactly two versions** — the baseline and one new one. Eight batches minting eight versions is what a lost check-lock-recheck looks like, and the whole version list is compared, not a `find()` for `v2`;
3. the new version reports `items_total 2400 / items_added 1800 / items_modified 600` — three different numbers, so no counter can pass by coincidence;
4. the dataset actually holds 2400 rows and 2400 **distinct** ids — a racer that double-counted a fresh id reports more than the dataset holds; one whose write was lost reports the right number over fewer rows;
5. the Version history tab renders `600` and `2,400` as "Item count" and `+ 1800` / `~ 600` as the Changes chips, with each version row resolving to exactly one element.

### Why this is not already covered

`datasets.version-history-view` is already `covered: true` and `dataset-version-counters.spec.ts` owns it — so this spec claims **no new coverage**, and the taxonomy change below is only the `specs:` list entry. It is still worth having, for one reason:

that spec reaches concurrency only through `insert(..., num_threads=8)`, and the Python SDK opens that gate only when the backend's `/is-alive/ver` parses as semver ≥ 2.2.8. A locally built docker-compose backend defaults `OPIK_VERSION` to `latest`, `SemanticVersion.parse` throws, and the SDK silently uploads sequentially — so on such an estate the existing spec passes **without two requests ever overlapping**. (On the deployed PR env it does race, at 2-way; the exploration confirmed the two batches went out on two different pool threads.) Driving the endpoint directly makes the race a property of the test rather than of the backend's version string, and raises it from two batches to eight.

Overlap was measured, not assumed: with node's fetch dispatcher all eight requests were in flight together for **559 ms** on this environment, completing between 564 ms and 3773 ms.

### Supporting changes

- **`fixtures/concurrent-batch-dataset.fixture.ts`** (new) — seeds a 600-item baseline version through the Python SDK bridge with ids minted up front, then asserts *via the API* that the baseline really is one version of exactly 600/600/0 and that every seeded id is stored, before the test runs. A counter assertion sitting on a seed that half-landed is a test that cannot fail. Owns the dataset's deletion (datasets do not cascade with the project) and honours `shouldLeaveArtifacts`. Chained and re-exported like the existing fixtures.
- **`core/backend/client.ts`** — `putDatasetItemBatchesConcurrently()`, which builds all N requests in one synchronous pass and returns each status rather than throwing, plus the `DatasetItemWriteBody` type and `PUT` on the existing `rawFetch`.
- **`pom/dataset-items.page.ts`** — `versionChangeSummary()`, addressing the Changes cell by the shared `DataTable`'s `data-cell-id` (the same handle `versionItemCount` already uses). At cell rather than chip level because the chips are bare `Tag` divs with no testid and no accessible name; the assertion is an anchored regex over the whole cell, so an extra chip — a deletion the test never made — fails.
- **`coverage/taxonomy.yaml`** — spec added to the `datasets` area's `specs:` list. Nothing flipped to `covered: true`: `version-history-view` was already covered at `t2-cuj`, and this spec asserts the same capability from a different angle rather than a new one. No `@cap:` key was invented.

## Verification

Run against `https://pr-8066.dev.comet.com` from `tests_end_to_end/e2e/`:

| Check | Command | Result |
|---|---|---|
| New spec | `npx playwright test tests/datasets/dataset-version-concurrent-batches.spec.ts --retries=0` | **1 passed** (9.9 s) |
| Stability | same, `--repeat-each=3 --workers=1` | **3 passed**, no flakes |
| Shared POM / fixture-chain regression | `npx playwright test tests/datasets/ --retries=0` | **9 passed** (whole directory) |
| Tag lint | `python3 tests_end_to_end/coverage/tag_lint.py --taxonomy … --estate tests_end_to_end` | `55 specs checked, 1 exempt, 0 problem(s)` |
| Types | `npx tsc --noEmit` | see note below |

Two notes on the environment, neither caused by this change:

- `npx tsc --noEmit` fails before it reaches any source file: the checked-in `tsconfig.json` sets `baseUrl`, which TypeScript 7.0.2 (the version `package.json` pins via `^7.0.2`) has removed. Typechecking with an equivalent config that drops `baseUrl` reports only one pre-existing error — a duplicate `deleteDashboard` identifier in `core/backend/client.ts` — and nothing in the files added here. Both look like pre-existing issues worth a separate fix; deliberately not touched in a QA spec PR.
- The environment is an OSS install (no auth) on a `*.comet.com` hostname, and the TypeScript SDK requires `OPIK_API_KEY` for any host ending in `comet.com`. The runs above set a placeholder value; the backend ignores it. This is a quirk of running an OSS deployment on that hostname, not of the suite.

## What was deliberately not written

The exploration produced **1** proposable candidate; **2** further findings were reported but deliberately not turned into specs:

- **`helm template` of `deployment/helm_chart/opik` fails outright with #8066 applied.** Reproduced with high confidence: the new `OPIK_VERSION: {{ .Values.component.backend.image.tag }}` line sits inside a `range` that rebinds `.`, so `.Values` is nil — every sibling line in that template already uses `$.Values` for exactly this reason. The same chart with `origin/main`'s configmap renders cleanly (8599 lines). This is a real regression, but it is chart rendering, not a product flow: it belongs in CI as a `helm template` / `helm lint` gate on the chart, not in the Playwright e2e estate. Reported separately rather than proposed here.
- **`OPIK_VERSION` reaching the backend and opening the SDK's parallel-insert gate on k8s.** Needs an environment deployed from `deployment/helm_chart` with a semver `component.backend.image.tag`, where `GET /is-alive/ver` can be asserted to equal that tag. Not reachable from this runner — only the chart's rendering was.

---

🤖 Generated by the QA PR test radar (release QA side flow) from the exploration of comet-ml/opik#8066. **It needs human review before merge** — an unreviewed generated spec that asserts the wrong thing is worse than no spec, because it will be trusted. No reviewers requested; a human promotes this out of draft.

<!-- comet-qa-test-radar: propose -->
