### PR TITLE
[NA] [BE] fix: register cohere, novita and cloudflare as canonical providers so their model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -56,7 +56,10 @@ public class CostService {
             Map.entry("sambanova", "sambanova"),
             Map.entry("nebius", "nebius"),
             Map.entry("snowflake", "snowflake"),
-            Map.entry("deepinfra", "deepinfra"));
+            Map.entry("deepinfra", "deepinfra"),
+            Map.entry("cohere", "cohere"),
+            Map.entry("novita", "novita"),
+            Map.entry("cloudflare", "cloudflare"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1062,4 +1062,52 @@ class CostServiceTest {
                                 "original_usage.prompt_tokens_details.cached_tokens", 300),
                         "0.005709"));
     }
+
+    /**
+     * Covers registering {@code cohere} as a canonical provider so that the non-zero-cost entries in
+     * {@code model_prices_and_context_window.json} tagged with {@code litellm_provider: "cohere"} are
+     * no longer silently dropped at load time. No Cohere model publishes cache rates today, so all
+     * Cohere requests route through {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesCohereModels() {
+        // command: input 1e-06, output 2e-06
+        // 1000 * 1e-06 + 200 * 2e-06 = 0.0014
+        BigDecimal cost = CostService.calculateCost("command", "cohere",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.0014");
+    }
+
+    /**
+     * Covers registering {@code novita} as a canonical provider so that the non-zero-cost entries in
+     * {@code model_prices_and_context_window.json} tagged with {@code litellm_provider: "novita"} are
+     * no longer silently dropped at load time. No Novita model publishes cache rates today, so all
+     * Novita requests route through {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesNovitaModels() {
+        // novita/zai-org/autoglm-phone-9b-multilingual: input 3.5e-08, output 1.38e-07
+        // 1000 * 3.5e-08 + 200 * 1.38e-07 = 0.0000626
+        BigDecimal cost = CostService.calculateCost("novita/zai-org/autoglm-phone-9b-multilingual", "novita",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.0000626");
+    }
+
+    /**
+     * Covers registering {@code cloudflare} as a canonical provider so that the non-zero-cost entries
+     * in {@code model_prices_and_context_window.json} tagged with {@code litellm_provider: "cloudflare"}
+     * are no longer silently dropped at load time. No Cloudflare model publishes cache rates today, so
+     * all Cloudflare requests route through {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @Test
+    void calculateCostHandlesCloudflareModels() {
+        // cloudflare/@cf/meta/llama-2-7b-chat-fp16: input 1.923e-06, output 1.923e-06
+        // 1000 * 1.923e-06 + 200 * 1.923e-06 = 0.0023076
+        BigDecimal cost = CostService.calculateCost("cloudflare/@cf/meta/llama-2-7b-chat-fp16", "cloudflare",
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo("0.0023076");
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` did not include `cohere`, `novita` or `cloudflare`, so every priced model those providers ship in `model_prices_and_context_window.json` was dropped at load time and their spans fell back to zero cost. This registers all three as canonical providers (identity mapping, same as the existing entries) so their prices load. None of the three publishes cache rates today, so they route through the default `textGenerationCost` calculator.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude
- Scope: full change (mapping entries plus regression tests)
- Human verification: cost math checked against the exact per-token rates in model_prices_and_context_window.json; provider-key resolution traced through buildRuntimeKey and findModelPrice to confirm the same path used by the already-merged snowflake and deepinfra registrations

## Testing

Added three regression tests in `CostServiceTest` (`calculateCostHandlesCohereModels`, `calculateCostHandlesNovitaModels`, `calculateCostHandlesCloudflareModels`), each asserting a real model from each provider now returns a non-zero cost equal to prompt and completion tokens billed at the provider's configured rates. The tests fail before the mapping entries are added (cost resolves to zero) and pass after. Run with `mvn test -Dtest=CostServiceTest` in `apps/opik-backend`.

## Documentation
