### PR TITLE
[NA] [FE] docs: clarify vLLM custom provider /v1 URL and custom-llm model prefix routing

### DIFF
--- a/apps/opik-frontend/src/constants/providers.ts
+++ b/apps/opik-frontend/src/constants/providers.ts
@@ -104,7 +104,7 @@ export const PROVIDERS: PROVIDERS_TYPE = {
     apiKeyName: "CUSTOM_PROVIDER_API_KEY",
     defaultModel: "",
     description:
-      "You can configure any OpenAI API-compatible provider (vLLM, \nOllama, etc.) using the standardized OpenAI API interface.",
+      "Any OpenAI-compatible Chat Completions host (e.g. vLLM). Use base URL ending in /v1 and model id custom-llm/<provider>/<model>.",
   },
 };
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/ManageAIProviderDialog/CustomProviderDetails.tsx
@@ -86,7 +86,7 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
               <FormMessage />
               <Description>
                 {
-                  "Use `{model}` as a placeholder in the URL if your gateway expects the model name in the path — Opik substitutes the selected model at request time. The model name is interpolated raw, so values containing `/` (e.g. HuggingFace-style names) will become extra path segments."
+                  "Base URL for the OpenAI-compatible Chat Completions API. Must end with /v1 (e.g. https://api.pzero.studio/v1). Do not include /chat/completions. Origin without /v1 will 404. Use `{model}` as a placeholder if your gateway expects the model name in the path."
                 }
               </Description>
             </FormItem>
@@ -116,8 +116,10 @@ const CustomProviderDetails: React.FC<CustomProviderDetailsProps> = ({
               </FormControl>
               <FormMessage />
               <Description>
-                Comma-separated list of available models. Example:{" "}
-                {`"gpt-4o, gpt-4o-mini, llama-3.1-70b"`}
+                Comma-separated bare catalog ids (e.g. deepseek-v4-flash). Opik
+                stores them as custom-llm/&lt;provider&gt;/&lt;model&gt; and
+                routes via that prefix; bare or openai/ prefixed ids will not
+                route to this provider.
               </Description>
             </FormItem>
           );


### PR DESCRIPTION
## Details
Clarifies the vLLM / Custom provider configuration so users point an OpenAI-compatible Chat Completions host correctly: the base URL must end with `/v1` and model ids are referenced as `custom-llm/<provider>/<catalog-id>` in Playground and Online Evaluation. Bare or `openai/`-prefixed ids do not route to the custom provider.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- Resolves #8049

## Testing
- `git diff --check` — pass (no whitespace errors)
- Manual trace of CustomLlmModelNameChecker, LlmProviderFactoryImpl routing and frontend convertCustomProviderModels — consistent before and after
- Frontend lint, typecheck, Vitest and build to be verified in CI (docs-only, no runtime change)

## Documentation
- Updated Custom provider description and dialog help text to document the `/v1` and `custom-llm/` requirements