### PR TITLE
[issue-7693] [BE] fix: include authored_feedback_scores in workspace-level feedback metric queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -80,11 +80,37 @@ public interface WorkspaceMetricsDAO {
 class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
 
     private static final String GET_FEEDBACK_SCORES_SUMMARY = """
+            WITH feedback_scores_deduped AS (
+                SELECT entity_id, name, value, project_id, last_updated_at, author, source_queue_id
+                FROM (
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      <if(project_ids)> AND project_id IN :project_ids <endif>
+                    UNION ALL
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           author, source_queue_id
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      <if(project_ids)> AND project_id IN :project_ids <endif>
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
+            ), feedback_scores_final AS (
+                SELECT entity_id, name,
+                       if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value
+                FROM feedback_scores_deduped
+                GROUP BY entity_id, name
+            )
             SELECT
                 AVGIf(fs.value, t.id >= :id_start AND t.id \\<= :id_end) AS current,
                 AVGIf(fs.value, t.id >= :id_prior_start AND t.id \\< :id_start) AS previous,
                 fs.name
-            FROM feedback_scores fs final
+            FROM feedback_scores_final fs
             JOIN (
                 SELECT
                     id
@@ -96,9 +122,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                   AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_prior_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
             ) t ON t.id = fs.entity_id
-            WHERE workspace_id = :workspace_id
-                <if(project_ids)> AND project_id IN :project_ids <endif>
-                AND entity_type = 'trace'
             GROUP BY fs.name;
             """;
 
@@ -117,11 +140,38 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             """;
 
     private static final String GET_FEEDBACK_SCORES_DAILY_BY_PROJECT = """
-            WITH feedback_scores_daily AS (
+            WITH feedback_scores_deduped AS (
+                SELECT entity_id, name, value, project_id, last_updated_at, author, source_queue_id
+                FROM (
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      AND name = :name
+                    UNION ALL
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           author, source_queue_id
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND project_id IN :project_ids
+                      AND name = :name
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
+            ), feedback_scores_final AS (
+                SELECT entity_id, name, project_id,
+                       if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value
+                FROM feedback_scores_deduped
+                GROUP BY entity_id, name, project_id
+            ), feedback_scores_daily AS (
                 SELECT fs.project_id AS project_id,
                        toStartOfInterval(t.start_time, toIntervalDay(1)) AS bucket,
                        if(COUNT(1) = 0, NULL, avg(fs.value)) AS value
-                FROM feedback_scores fs final
+                FROM feedback_scores_final fs
                 JOIN (
                     SELECT
                         id,
@@ -134,10 +184,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                       AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                       AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 ) t ON t.id = fs.entity_id
-                WHERE workspace_id = :workspace_id
-                  AND project_id IN :project_ids
-                  AND entity_type = 'trace'
-                  AND name = :name
                 GROUP BY fs.project_id, bucket
                 ORDER BY fs.project_id, bucket
                 WITH FILL
@@ -155,10 +201,35 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             """;
 
     private static final String GET_FEEDBACK_SCORES_DAILY = """
-            WITH feedback_scores_daily AS (
+            WITH feedback_scores_deduped AS (
+                SELECT entity_id, name, value, project_id, last_updated_at, author, source_queue_id
+                FROM (
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           last_updated_by AS author,
+                           CAST('' AS FixedString(36)) AS source_queue_id
+                    FROM feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND name = :name
+                    UNION ALL
+                    SELECT entity_id, name, value, project_id, last_updated_at,
+                           author, source_queue_id
+                    FROM authored_feedback_scores
+                    WHERE entity_type = 'trace'
+                      AND workspace_id = :workspace_id
+                      AND name = :name
+                )
+                ORDER BY last_updated_at DESC
+                LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
+            ), feedback_scores_final AS (
+                SELECT entity_id, name,
+                       if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value
+                FROM feedback_scores_deduped
+                GROUP BY entity_id, name
+            ), feedback_scores_daily AS (
                 SELECT toStartOfInterval(t.start_time, toIntervalDay(1)) AS bucket,
                        if(COUNT(1) = 0, NULL, avg(fs.value)) AS value
-                FROM feedback_scores fs final
+                FROM feedback_scores_final fs
                 JOIN (
                     SELECT
                         id,
@@ -170,9 +241,6 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                       AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                       AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 ) t ON t.id = fs.entity_id
-                WHERE workspace_id = :workspace_id
-                  AND entity_type = 'trace'
-                  AND name = :name
                 GROUP BY bucket
                 ORDER BY bucket
                 WITH FILL

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -98,13 +98,13 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                       AND workspace_id = :workspace_id
                       <if(project_ids)> AND project_id IN :project_ids <endif>
                 )
-                ORDER BY last_updated_at DESC
+                ORDER BY last_updated_at DESC, entity_id DESC
                 LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
-                SELECT entity_id, name,
+                SELECT entity_id, name, project_id,
                        if(count() = 1, any(value), toDecimal64(avg(value), 9)) AS value
                 FROM feedback_scores_deduped
-                GROUP BY entity_id, name
+                GROUP BY entity_id, name, project_id
             )
             SELECT
                 AVGIf(fs.value, t.id >= :id_start AND t.id \\<= :id_end) AS current,
@@ -113,7 +113,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             FROM feedback_scores_final fs
             JOIN (
                 SELECT
-                    id
+                    id, project_id
                 FROM traces final
                 WHERE workspace_id = :workspace_id
                   <if(project_ids)> AND project_id IN :project_ids <endif>
@@ -121,7 +121,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                   AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'))
                   AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_prior_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
-            ) t ON t.id = fs.entity_id
+            ) t ON t.id = fs.entity_id AND t.project_id = fs.project_id
             GROUP BY fs.name;
             """;
 
@@ -160,7 +160,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                       AND project_id IN :project_ids
                       AND name = :name
                 )
-                ORDER BY last_updated_at DESC
+                ORDER BY last_updated_at DESC, entity_id DESC
                 LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT entity_id, name, project_id,
@@ -219,7 +219,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                       AND workspace_id = :workspace_id
                       AND name = :name
                 )
-                ORDER BY last_updated_at DESC
+                ORDER BY last_updated_at DESC, entity_id DESC
                 LIMIT 1 BY project_id, entity_id, name, author, source_queue_id
             ), feedback_scores_final AS (
                 SELECT entity_id, name,
@@ -312,7 +312,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
     // Shared with ProjectMetricsDAO via SpanMetricsQueries. Workspace aggregation queries an explicit set of
     // projects: WorkspaceMetricsService resolves the "all projects" request into every project id up front, so the
     // predicate is always a bounded `project_id IN :project_ids` list that prunes on the spans primary key
-    // (workspace_id, project_id, ...) — never an unconstrained workspace-wide scan.
+    // (workspace_id, project_id, ...) � never an unconstrained workspace-wide scan.
     // Span filtering is reused from ProjectMetricsDAO's SPAN_FILTERED_PREFIX (above), but the output is shaped in the
     // workspace-native style like GET_COSTS_DAILY: each row is a finished series {project_id, name, data}, where data is
     // a groupArray(tuple(bucket, value)). No breakdown => one series per usage key; with a provider/model breakdown =>


### PR DESCRIPTION
## Summary

Fixes #7693

The three workspace feedback-score queries in `WorkspaceMetricsDAO`
(`GET_FEEDBACK_SCORES_SUMMARY`, `GET_FEEDBACK_SCORES_DAILY`, and
`GET_FEEDBACK_SCORES_DAILY_BY_PROJECT`) read only from `feedback_scores`.
Online-scoring scores written to `authored_feedback_scores` were therefore
invisible on the workspace-level metrics dashboard, even though the same
project-level queries in `ProjectMetricsDAO` and `SpanMetricsQueries` already
union both tables correctly.

## Changes

For each of the three affected queries, the direct `FROM feedback_scores fs FINAL`
is replaced with the same `UNION ALL` + deduplication pattern used by
`ProjectMetricsDAO`:

1. **CTE `feedback_scores_deduped`** — unions `feedback_scores` and
   `authored_feedback_scores`, then applies
   `ORDER BY last_updated_at DESC LIMIT 1 BY project_id, entity_id, name, author, source_queue_id`
   to keep the most-recent row per (entity, metric name, author, queue).

2. **CTE `feedback_scores_final`** — aggregates with
   `if(count() = 1, any(value), toDecimal64(avg(value), 9)) GROUP BY entity_id, name`
   to produce one merged value per (trace, metric name) when the same score
   was submitted by multiple authors.

3. The existing `JOIN` with `traces final` and the `WITH FILL` / `groupArray`
   aggregations are left unchanged.

The `name = :name` early-filter is pushed down into the UNION CTEs for the
daily variants (where a specific metric name is always provided) to avoid
scanning unneeded rows.

## Test plan

- [ ] Run existing `WorkspaceMetricsResourceTest` / related integration tests
- [ ] Manually verify: create a trace with an online-scoring rule that emits to
  `authored_feedback_scores`, then check the workspace-level Feedback Scores
  chart shows the score