### PR TITLE
[NA] [DOCS] docs: point AI-assistant users at the MCP server where they already are

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/evaluate_your_llm.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/evaluate_your_llm.mdx
@@ -319,6 +319,19 @@ be able to compare multiple experiments side by side.
   <img src="/img/evaluation/evaluation_results.png" />
 </Frame>
 
+<Tip>
+  **Recommended if you build with an AI coding assistant.** One command — `opik configure` —
+  installs both the [MCP server](/mcp-server) and the Opik skills, and your assistant can then run
+  the evaluation between its own development iterations, read the scores back, and keep going until
+  they stop improving. Each run lands as an experiment you can compare side by side.
+
+  An example prompt:
+
+  *"Evaluate my agent against the qa-regression dataset with Opik, then improve the prompt and
+  re-run the evaluation until the hallucination score stops improving. Show me each experiment's
+  scores as you go."*
+</Tip>
+
 ## Advanced usage
 
 ### Missing arguments for scoring methods

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -787,3 +787,15 @@ For large bulk operations:
   For very large datasets, bulk operations are processed in batches. The UI remains
   responsive during processing, and you'll see progress indicators for long-running operations.
 </Tip>
+<Tip>
+  **Recommended if you build with an AI coding assistant.** Assembling a dataset by hand is the
+  slowest part of setting up an evaluation. One command — `opik configure` — installs both the
+  [MCP server](/mcp-server) and the Opik skills, and your assistant can then create the dataset and
+  fill it in for you — writing the first cases from scratch, or, if you are already logging traces,
+  pulling them from the ones that scored badly.
+
+  An example prompt:
+
+  *"Build an Opik dataset from the traces scored below 0.7 on answer relevance, fill in the expected
+  answers, then evaluate my agent against it."*
+</Tip>

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/building_evaluation_suites.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/building_evaluation_suites.mdx
@@ -7,7 +7,7 @@ og:title: Building Test Suites — Opik
 title: Building Test Suites
 ---
 
-Test suites grow as you debug and improve your agent. There are three ways to build them: with Ollie, through the UI, or via the SDK.
+Test suites grow as you debug and improve your agent. There are three ways to build them: with Ollie, through the UI, or via the SDK — and if you build with an AI coding assistant, it can drive any of them for you.
 
 ## With Ollie
 
@@ -306,3 +306,15 @@ You can also override the policy for individual items:
   }]);
   ```
 </CodeBlocks>
+
+<Tip>
+  **Recommended if you build with an AI coding assistant.** One command — `opik configure` —
+  installs both the [MCP server](/mcp-server) and the Opik skills, and your assistant can then run
+  the suite itself between development iterations: change the prompt, run the suite, read the
+  scores, change again — instead of you doing that loop by hand.
+
+  An example prompt:
+
+  *"Add this failing trace to my customer-support-qa suite, then iterate on the prompt until the
+  suite passes — run the suite after each change and show me the scores."*
+</Tip>

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/evaluate_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/evaluate_agents.mdx
@@ -396,6 +396,7 @@ From here, you might want to:
 - Optimize your prompts to drive better agent behavior with **[Prompt Optimization](/development/optimization-runs/overview)**.
 - Monitor agents in production to catch regressions, errors, and drift in real-time with **[Production Monitoring](/tracing/dashboards/production_monitoring)**.
 - Add **[Guardrails](/guardrails/guardrails)** for security, content safety, and sensitive data leakage prevention, ensuring your agents behave responsibly even in dynamic environments.
+- Hand this whole loop to your AI coding assistant with the **[MCP server](/mcp-server)** — it can read the traces, change the code, and re-run the evaluation between its own iterations.
 
 Each of these steps builds on the foundation you’ve set: observability, evaluation, and continuous iteration.
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/getting-started.mdx
@@ -174,3 +174,15 @@ Opik provides two approaches to evaluation. Choose the one that fits your use ca
     and the [Metrics](/evaluation/metrics/overview) section for all available metrics.
   </Tab>
 </Tabs>
+
+<Tip>
+  **Recommended if you build with an AI coding assistant.** Either approach can be run by your
+  assistant rather than by you. One command — `opik configure` — installs both the
+  [MCP server](/mcp-server) and the Opik skills, and evaluation becomes part of its development
+  loop: it changes the code, runs the suite or the evaluation, reads the scores, and iterates.
+
+  An example prompt:
+
+  *"Set up an Opik evaluation for this agent, then improve the agent and re-run the evaluation after
+  each change, showing me the scores each time."*
+</Tip>

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/overview.mdx
@@ -78,3 +78,4 @@ Opik provides two complementary approaches to evaluation:
 - [Concepts](/evaluation/concepts) — Understand Test Suites vs Datasets & Metrics
 - [Building Test Suites](/evaluation/advanced/building-test-suites) — Create and manage suites via the SDK, UI, or Ollie
 - [Debugging agents with Ollie](/tracing/debug-agents) — The full workflow for turning production failures into test cases
+- [MCP server](/mcp-server) — Let your AI coding assistant add cases to a suite and run evaluations for you

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
@@ -14,6 +14,13 @@ title: Observability for OpenAI Codex with Opik
 Use this guide if you run Codex (CLI/IDE/app) and want its OTEL trace exporter to send telemetry to Opik.
 
 <Callout type="info">
+  This guide covers telemetry flowing **from Codex to Opik**. For the other direction — letting Codex
+  read your traces, score outputs and run evaluations — register the
+  [Opik MCP server](/mcp-server) with it. One command, `opik configure`, installs the server and the
+  Opik skills. The two are independent, and you can use either or both.
+</Callout>
+
+<Callout type="info">
 The block structure below follows the current Codex runtime config shape used in local `config.toml` (`[otel.trace_exporter.otlp-http]`).
 </Callout>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/debug_agents.mdx
@@ -98,6 +98,19 @@ debugging scenarios:
 - *"What's the average latency for traces in this project over the past week?"*
 - *"Which prompts are used by the most experiments?"*
 
+<Tip>
+  **Recommended if you build with an AI coding assistant.** Ollie runs this loop from the Opik
+  dashboard. To run the same loop from your editor — where the code actually is — one command,
+  `opik configure`, installs both the [MCP server](/mcp-server) and the Opik skills. Your assistant
+  can then search your traces, find the failing one, change the code, and re-run your suite to
+  confirm the fix.
+
+  An example prompt:
+
+  *"Find the traces from the last day where the agent ignored the provided context, work out what
+  they have in common, fix it, and verify with my test suite."*
+</Tip>
+
 ## Next steps
 
 - [Ollie overview](/ollie) — Full introduction to Ollie's capabilities and setup

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/diagnostics.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/diagnostics.mdx
@@ -78,5 +78,7 @@ scans are paused.
 - [Ollie overview](/ollie): what Ollie can do and how to set it up
 - [Debugging agents with Ollie](/tracing/debug-agents): take a single failing trace from root
   cause to verified fix
+- [MCP server](/mcp-server): give your AI coding assistant full visibility of your application, so it
+  can pick up a detected issue, fix it in your editor, and verify with your test suite
 - [Alerts](/production/alerts/alerts): get notified in Slack, PagerDuty, or a custom webhook for
   specific events

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/getting-started.mdx
@@ -168,10 +168,13 @@ full execution path of a request, including all nested spans, inputs, outputs, a
 </Frame>
 
 You can use [Ollie](/ollie) to analyze your traces, identify issues in your agent's
-behavior, and get actionable suggestions for improvement.
+behavior, and get actionable suggestions for improvement. To do the same from your own editor,
+connect your AI coding assistant with the [Opik MCP server](/mcp-server) — it reads these traces
+directly, so you can ask about them where you are already working.
 
 ## Next steps
 
 - [Concepts](/tracing/concepts) — Learn about traces, spans, threads, and feedback scores
 - [Log traces](/tracing/advanced/log_traces) — In-depth guide on customizing what gets logged
 - [Cost tracking](/tracing/advanced/cost_tracking) — Monitor token usage and spending
+- [MCP server](/mcp-server) — Ask your coding assistant about these traces from your editor

--- a/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/observability/overview.mdx
@@ -137,3 +137,4 @@ Opik has first-class support for 30+ frameworks in Python, TypeScript, and OpenT
 - [Concepts](/tracing/concepts) — Understand traces, spans, threads, and feedback scores
 - [Debugging agents with Ollie](/tracing/debug-agents) — Use AI-assisted root-cause analysis
 - [Cost tracking](/tracing/advanced/cost_tracking) — Monitor token usage and spending
+- [MCP server](/mcp-server) — Read these traces from your AI coding assistant, without leaving your editor

--- a/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/ollie.mdx
@@ -124,4 +124,7 @@ Open Ollie from anywhere in the Opik UI and start asking. Traces, code, reruns, 
   <Card title="Test suites" href="/evaluation/overview" icon="fa-regular fa-check-double">
     Build the regression net Ollie will populate for you.
   </Card>
+  <Card title="MCP server" href="/mcp-server" icon="fa-regular fa-network-wired">
+    The same loop from your own editor: connect your AI coding assistant to Opik.
+  </Card>
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/getting-started.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/getting-started.mdx
@@ -222,3 +222,15 @@ multimodal content, and template engines.
   });
   ```
 </CodeBlocks>
+
+<Tip>
+  **Recommended if you build with an AI coding assistant.** One command — `opik configure` —
+  installs both the [MCP server](/mcp-server) and the Opik skills, and your assistant can then
+  version prompts here as it edits them, and measure whether a change actually helped instead of
+  you judging by eye.
+
+  An example prompt:
+
+  *"Rewrite this system prompt to cut hallucinations, save each attempt to the Opik prompt library,
+  and evaluate every version against my dataset so we can see which one wins."*
+</Tip>

--- a/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/prompt_engineering/overview.mdx
@@ -40,3 +40,4 @@ latest.
 - [Text and chat prompts](/development/prompt-library/prompt-types) — When to use each, multimodal content, template engines, and searching
 - [Version control](/development/prompt-library/version-control) — Create and compare versions
 - [Prompt playground](/development/prompt-playground) — Test prompt variants side-by-side across models, without writing code
+- [MCP server](/mcp-server) — Let your AI coding assistant version prompts here as it edits them, and measure which version wins

--- a/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/quickstart.mdx
@@ -301,6 +301,13 @@ After running your application, you will start seeing your traces in Opik and yo
 
 If you don't see traces appearing, reach out to us on [Slack](https://chat.comet.com) or raise an issue on [GitHub](https://github.com/comet-ml/opik/issues) and we'll help you troubleshoot.
 
+<Tip>
+  **Recommended if you build with an AI coding assistant.** Connect your assistant (Claude Code,
+  Codex, Cursor and more) to Opik and it can read these traces, score outputs and run evaluations
+  from chat — keeping observability where you are already working. One command — `opik configure` —
+  installs both the MCP server and the Opik skills; see [MCP server](/mcp-server).
+</Tip>
+
 ## Next steps
 
 Now that you have logged your first traces, here's what to explore next:
@@ -312,3 +319,5 @@ Now that you have logged your first traces, here's what to explore next:
 3. [Opik's evaluation metrics](/evaluation/metrics/overview): Opik provides a suite of evaluation
    metrics (Hallucination, Answer Relevance, Context Recall, etc.) that you can use to score your
    LLM responses.
+4. [Opik's MCP server](/mcp-server): Connect your AI coding assistant to Opik so it can read traces,
+   log scores and run evaluations without you leaving your editor.

--- a/apps/opik-documentation/documentation/fern/docs-v2/reference/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/reference/overview.mdx
@@ -27,4 +27,8 @@ guides on how to use Opik, check out our [cookbook](/integrations/overview) inst
     API reference documentation for all SDK methods
     </Card>
 
+    <Card title="MCP server" icon="fa-regular fa-network-wired" href="/mcp-server">
+    Tools your AI coding assistant can call to read traces, score outputs and run evaluations
+    </Card>
+
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/overview.mdx
@@ -78,6 +78,13 @@ os.environ["OPIK_BASE_URL"] = "http://localhost:5173/api"
 
 To learn more about how to manage you local Opik deployment, you can refer to our [local deployment guide](/self-host/local_deployment).
 
+<Tip>
+  **Connecting an AI coding assistant.** Self-hosted and local deployments use the local
+  [Opik MCP server](/mcp-server), run through `uvx` and pointed at your own instance — there is no
+  hosted server involved and no browser sign-in. `opik mcp configure` sets it up for your assistant
+  (Claude Code, Codex, Cursor and more).
+</Tip>
+
 ## SDK version compatibility
 
 For self-hosted deployments, we recommend keeping the Opik server and SDKs on the latest versions for best compatibility. The Python SDK (`opik`), TypeScript SDK (`opik`), and Opik Agent Optimizer SDK (`opik-optimizer`) are designed to work with the latest Opik server release. Older SDK versions may not support newer server features, and newer SDK versions may require a minimum server version. Check the [changelog](https://www.comet.com/docs/opik/changelog) for version-specific compatibility notes.


### PR DESCRIPTION
## Details

The MCP page is not hard to find — it sits third in Getting Started and draws 278 visitors a month. The gap is upstream: **2,412 visitors a month pass through pages that never mention it**. The quickstart, the second most visited page in the docs, runs `opik configure` three times and mentioned MCP zero times — and that command is what offers to set the server up.

This adds one placement per feature area (not per page), each a short tip with an example prompt, promoting the flow of connecting a coding agent to Opik and letting it run quality checks between its own development iterations.

- **Setup-level pointers**: quickstart, self-host overview, evaluation overview
- **Reading traces / finding failures from the editor**: observability getting-started, debugging agents, diagnostics
- **Running the suite or evaluation between iterations**: evaluation getting-started, building test suites, datasets & experiments
- **Preparing a dataset**: from traces that scored below a threshold
- **Iterating on a prompt**: versioning each attempt and comparing them

Three deliberate constraints:

- Every tip lands **after** the feature beside it has been explained, so none interrupt a reader who doesn't yet know what the page is about. On the two long pages that means the end of the main walkthrough rather than end of file.
- The opening sentence and setup clause are **byte-identical everywhere**, so rewording is one find-and-replace rather than eleven edits. Fern partials were the obvious tool but take no props, and the per-page prompt is the whole value.
- **No prompt names a slash command.** The skill pack installs as `evaluate` / `instrument` via `opik configure`, but as `opik-evaluate` / `opik-instrument` via `npx skills add` — a documented command would be wrong for half of readers. Natural language works either way, since agents match skills on description.

Traffic figures are PostHog `$pageview` data, unique visitors, 30 days to 31 Aug 2026.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Traffic analysis, placement selection, and all prose in the 11 changed files.
- Human verification: Wording, placement and example prompts reviewed and revised by @alexkuzmik across several passes.

## Testing

Docs-only change; no runtime code touched.

- `pre-commit run --files <the 11 changed .mdx files>` — passes (all applicable hooks skip, as expected for MDX-only)
- Verified `<Tip>` open/close balance in every changed file, including the 10 pre-existing tips in `evaluate_your_llm.mdx` and `manage_datasets.mdx`
- Verified the `/mcp-server` slug resolves in `docs.yml` and that `/mcp-server` matches the link convention already used in `home.mdx`
- Confirmed `<Tip>` is an established component (used in 113 files) rather than a new one
- Checked that the referenced concepts exist rather than being plausible: `answer_relevance.mdx` is a real metric page, and `manage_datasets.mdx` already documents pulling feedback scores from traces as ground truth
- Not run: no Fern preview build (requires org auth locally). Worth a look at the deploy preview for the two long pages, `evaluate_your_llm.mdx` and `manage_datasets.mdx`.

## Documentation

This PR *is* the documentation change.

Two pre-existing issues noticed while working here, **not fixed** in this PR:

- `prompt_engineering/getting-started.mdx:47` instructs readers to *"Version my prompts in Opik using the `/opik-instrument` command"* — the **instrument** skill invoked for a prompt-versioning task, which looks like a copy-paste from the quickstart's AI-integration tab.
- `self-host/overview.mdx` tells users to set `OPIK_BASE_URL`, while the CLI reads `OPIK_URL_OVERRIDE`.