### PR TITLE
[NA] [BE] [FE] feat: preselect the default workspace on the MCP OAuth consent screen

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/AuthService.java
@@ -32,6 +32,7 @@ class AuthServiceImpl implements AuthService {
     private static final List<WorkspaceInfo> ELIGIBLE_WORKSPACES = List.of(WorkspaceInfo.builder()
             .id(ProjectService.DEFAULT_WORKSPACE_ID)
             .name(ProjectService.DEFAULT_WORKSPACE_NAME)
+            .isDefault(true)
             .build());
     private static final UserWorkspace AUTHORIZED_WORKSPACE = UserWorkspace.builder()
             .userName(ProjectService.DEFAULT_USER)

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/RemoteAuthService.java
@@ -10,6 +10,7 @@ import com.comet.opik.infrastructure.AuthenticationConfig;
 import com.comet.opik.infrastructure.usagelimit.Quota;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.inject.Provider;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
@@ -117,7 +118,8 @@ class RemoteAuthService implements AuthService {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
-    record WorkspaceIdNameResponse(String workspaceId, String workspaceName) {
+    record WorkspaceIdNameResponse(String workspaceId, String workspaceName,
+            @JsonProperty("default") boolean isDefault) {
     }
 
     @Builder(toBuilder = true)
@@ -224,6 +226,7 @@ class RemoteAuthService implements AuthService {
                     .map(workspace -> WorkspaceInfo.builder()
                             .id(workspace.workspaceId())
                             .name(workspace.workspaceName())
+                            .isDefault(workspace.isDefault())
                             .build())
                     .toList();
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceInfo.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/auth/WorkspaceInfo.java
@@ -1,6 +1,7 @@
 package com.comet.opik.infrastructure.auth;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
@@ -8,5 +9,5 @@ import lombok.Builder;
 @Builder(toBuilder = true)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public record WorkspaceInfo(String id, String name) {
+public record WorkspaceInfo(String id, String name, @JsonProperty("is_default") boolean isDefault) {
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/oauth/OAuthAuthorizeResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/oauth/OAuthAuthorizeResourceTest.java
@@ -11,6 +11,8 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.UserWorkspace;
 import com.comet.opik.infrastructure.auth.WorkspaceInfo;
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.dropwizard.testing.junit5.DropwizardExtensionsSupport;
 import io.dropwizard.testing.junit5.ResourceExtension;
 import jakarta.ws.rs.ClientErrorException;
@@ -217,7 +219,7 @@ class OAuthAuthorizeResourceTest {
 
     @Test
     @DisplayName("GET /authorize/context: exposes the default workspace flag the consent UI preselects on")
-    void context_exposesDefaultWorkspaceFlag() {
+    void context_exposesDefaultWorkspaceFlag() throws JsonProcessingException {
         mockClientResolution();
         when(authService.listEligibleWorkspaces(any())).thenReturn(List.of(
                 WorkspaceInfo.builder().id("ws-1").name("staging").isDefault(false).build(),
@@ -231,8 +233,15 @@ class OAuthAuthorizeResourceTest {
                 .get()) {
 
             assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-            assertThat(response.readEntity(String.class))
-                    .contains("\"id\":\"ws-1\"", "\"id\":\"ws-2\"", "\"is_default\":false", "\"is_default\":true");
+            // Compared as a whole tree rather than as independent substrings: this pins the
+            // literal is_default wire key the consent UI reads and keeps each flag bound to
+            // its own workspace, so swapping the two would fail here.
+            JsonNode workspaces = JsonUtils.getMapper()
+                    .readTree(response.readEntity(String.class))
+                    .get("workspaces");
+            assertThat(workspaces).isEqualTo(JsonUtils.getMapper().readTree("""
+                    [{"id":"ws-1","name":"staging","is_default":false},
+                     {"id":"ws-2","name":"production","is_default":true}]"""));
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/oauth/OAuthAuthorizeResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/oauth/OAuthAuthorizeResourceTest.java
@@ -216,6 +216,27 @@ class OAuthAuthorizeResourceTest {
     }
 
     @Test
+    @DisplayName("GET /authorize/context: exposes the default workspace flag the consent UI preselects on")
+    void context_exposesDefaultWorkspaceFlag() {
+        mockClientResolution();
+        when(authService.listEligibleWorkspaces(any())).thenReturn(List.of(
+                WorkspaceInfo.builder().id("ws-1").name("staging").isDefault(false).build(),
+                WorkspaceInfo.builder().id("ws-2").name("production").isDefault(true).build()));
+
+        try (Response response = EXT.target(CONTEXT_PATH)
+                .queryParam(PARAM_CLIENT_ID, CLIENT_ID)
+                .queryParam(PARAM_REDIRECT_URI, REDIRECT_URI)
+                .request()
+                .cookie(RequestContext.SESSION_COOKIE, "sess")
+                .get()) {
+
+            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+            assertThat(response.readEntity(String.class))
+                    .contains("\"id\":\"ws-1\"", "\"id\":\"ws-2\"", "\"is_default\":false", "\"is_default\":true");
+        }
+    }
+
+    @Test
     @DisplayName("GET /authorize/context: secure cookie flag tracks baseUrl scheme (http → false)")
     void context_httpBaseUrl_setsSecureCookieFalse() {
         opikConfig.getMcpOAuth().setBaseUrl("http://localhost:5173");

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/AuthServiceImplTest.java
@@ -68,6 +68,7 @@ class AuthServiceImplTest {
         assertThat(result).isEqualTo(List.of(WorkspaceInfo.builder()
                 .id(ProjectService.DEFAULT_WORKSPACE_ID)
                 .name(ProjectService.DEFAULT_WORKSPACE_NAME)
+                .isDefault(true)
                 .build()));
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/auth/RemoteAuthServiceTest.java
@@ -606,12 +606,12 @@ class RemoteAuthServiceTest {
     @Test
     void testListEligibleWorkspaces__filtersDefaultWorkspaceAndMapsToWorkspaceInfo() throws JsonProcessingException {
         var sessionTokenValue = "session-" + UUID.randomUUID();
-        var production = podamFactory.manufacturePojo(WorkspaceInfo.class);
-        var staging = podamFactory.manufacturePojo(WorkspaceInfo.class);
+        var production = podamFactory.manufacturePojo(WorkspaceInfo.class).toBuilder().isDefault(false).build();
+        var staging = podamFactory.manufacturePojo(WorkspaceInfo.class).toBuilder().isDefault(true).build();
         var responseJson = OBJECT_MAPPER.writeValueAsString(Arrays.asList(
-                Map.of("workspaceId", production.id(), "workspaceName", production.name()),
-                Map.of("workspaceId", "ws-default", "workspaceName", DEFAULT_WORKSPACE_NAME),
-                Map.of("workspaceId", staging.id(), "workspaceName", staging.name())));
+                Map.of("workspaceId", production.id(), "workspaceName", production.name(), "default", false),
+                Map.of("workspaceId", "ws-default", "workspaceName", DEFAULT_WORKSPACE_NAME, "default", false),
+                Map.of("workspaceId", staging.id(), "workspaceName", staging.name(), "default", true)));
         WIRE_MOCK.server().stubFor(get(urlPathEqualTo("/workspaces"))
                 .withQueryParam("withoutExtendedData", equalTo("true"))
                 .withCookie(RequestContext.SESSION_COOKIE, equalTo(sessionTokenValue))
@@ -620,6 +620,22 @@ class RemoteAuthServiceTest {
         var result = remoteAuthService.listEligibleWorkspaces(sessionCookie(sessionTokenValue));
 
         assertThat(result).containsExactly(production, staging);
+    }
+
+    @Test
+    void testListEligibleWorkspaces__whenDefaultFlagIsAbsent__thenNoWorkspaceIsDefault()
+            throws JsonProcessingException {
+        var sessionTokenValue = "session-" + UUID.randomUUID();
+        var workspace = podamFactory.manufacturePojo(WorkspaceInfo.class).toBuilder().isDefault(false).build();
+        var responseJson = OBJECT_MAPPER.writeValueAsString(List.of(
+                Map.of("workspaceId", workspace.id(), "workspaceName", workspace.name())));
+        WIRE_MOCK.server().stubFor(get(urlPathEqualTo("/workspaces"))
+                .withCookie(RequestContext.SESSION_COOKIE, equalTo(sessionTokenValue))
+                .willReturn(okJson(responseJson)));
+
+        var result = remoteAuthService.listEligibleWorkspaces(sessionCookie(sessionTokenValue));
+
+        assertThat(result).containsExactly(workspace);
     }
 
     @Test

--- a/apps/opik-frontend/src/api/oauth/types.ts
+++ b/apps/opik-frontend/src/api/oauth/types.ts
@@ -1,6 +1,7 @@
 export type OAuthWorkspaceInfo = {
   id: string;
   name: string;
+  is_default: boolean;
 };
 
 export type OAuthAuthorizeContext = {

--- a/apps/opik-frontend/src/shared/OAuthConsentPage/OAuthConsentPage.test.tsx
+++ b/apps/opik-frontend/src/shared/OAuthConsentPage/OAuthConsentPage.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OAuthAuthorizeContext, OAuthWorkspaceInfo } from "@/api/oauth/types";
+import useOAuthAuthorizeContext from "@/api/oauth/useOAuthAuthorizeContext";
+import useOAuthConsentMutation from "@/api/oauth/useOAuthConsentMutation";
+import OAuthConsentPage from "./OAuthConsentPage";
+
+vi.mock("@/api/oauth/useOAuthAuthorizeContext", () => ({
+  default: vi.fn(),
+}));
+vi.mock("@/api/oauth/useOAuthConsentMutation", () => ({
+  default: vi.fn(),
+}));
+
+const mutate = vi.fn();
+
+const workspace = (name: string, is_default: boolean): OAuthWorkspaceInfo => ({
+  id: `id-${name}`,
+  name,
+  is_default,
+});
+
+const renderPage = (workspaces: OAuthWorkspaceInfo[]) => {
+  const data: OAuthAuthorizeContext = {
+    client_name: "Test Client",
+    workspaces,
+    csrf_token: "csrf-1",
+  };
+  vi.mocked(useOAuthAuthorizeContext).mockReturnValue({
+    data,
+    isLoading: false,
+    isError: false,
+  } as ReturnType<typeof useOAuthAuthorizeContext>);
+
+  return render(<OAuthConsentPage />);
+};
+
+describe("OAuthConsentPage workspace preselection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The page reads the authorize params off the URL; without all of them it
+    // renders the terminal "invalid request" card instead of the picker.
+    window.history.replaceState(
+      {},
+      "",
+      "/oauth/consent?client_id=c1&redirect_uri=http%3A%2F%2Flocalhost%3A1234%2Fcb" +
+        "&response_type=code&code_challenge=chal&code_challenge_method=S256" +
+        "&resource=https%3A%2F%2Fapi.example&state=xyz",
+    );
+    vi.mocked(useOAuthConsentMutation).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useOAuthConsentMutation>);
+  });
+
+  it("preselects the default workspace rather than the first one", () => {
+    renderPage([
+      workspace("staging", false),
+      workspace("production", true),
+      workspace("sandbox", false),
+    ]);
+
+    expect(screen.getByRole("radio", { name: "production" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "staging" })).not.toBeChecked();
+  });
+
+  it("falls back to the first workspace when none is flagged default", () => {
+    renderPage([workspace("staging", false), workspace("production", false)]);
+
+    expect(screen.getByRole("radio", { name: "staging" })).toBeChecked();
+  });
+
+  it("submits the preselected default workspace without any interaction", () => {
+    renderPage([workspace("staging", false), workspace("production", true)]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace_id: "id-production",
+        workspace_name: "production",
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("lets an explicit pick override the default preselection", () => {
+    renderPage([workspace("staging", false), workspace("production", true)]);
+
+    fireEvent.click(screen.getByRole("radio", { name: "staging" }));
+
+    expect(screen.getByRole("radio", { name: "staging" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("button", { name: "Allow" }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace_id: "id-staging",
+        workspace_name: "staging",
+      }),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/opik-frontend/src/shared/OAuthConsentPage/OAuthConsentPage.tsx
+++ b/apps/opik-frontend/src/shared/OAuthConsentPage/OAuthConsentPage.tsx
@@ -73,7 +73,11 @@ const OAuthConsentPage: React.FC = () => {
 
   const data: OAuthAuthorizeContext = contextQuery.data;
   const workspaces = data.workspaces ?? [];
-  const effectiveWorkspaceId = selectedWorkspaceId ?? workspaces[0]?.id ?? null;
+  const effectiveWorkspaceId =
+    selectedWorkspaceId ??
+    workspaces.find((w) => w.is_default)?.id ??
+    workspaces[0]?.id ??
+    null;
   const canAllow =
     !consent.isPending && workspaces.length > 0 && !!effectiveWorkspaceId;
 

--- a/apps/opik-frontend/src/shared/OAuthConsentPage/helpers.test.ts
+++ b/apps/opik-frontend/src/shared/OAuthConsentPage/helpers.test.ts
@@ -165,7 +165,11 @@ describe("buildConsentRequest", () => {
 
   it("maps params, workspace, and csrf into the wire shape", () => {
     expect(
-      buildConsentRequest(params, { id: "ws-1", name: "Default" }, "csrf-123"),
+      buildConsentRequest(
+        params,
+        { id: "ws-1", name: "Default", is_default: true },
+        "csrf-123",
+      ),
     ).toEqual({
       client_id: "abc",
       redirect_uri: "https://host.example/cb",


### PR DESCRIPTION
## Details

The MCP OAuth consent screen preselected whatever workspace the eligible-workspaces endpoint happened to return first, so a user approving an AI host usually had to change the selection by hand. The default-workspace flag already exists on the upstream workspaces response — it is what the app itself uses to pick a landing workspace — but it was dropped when mapping into the consent payload.

- `WorkspaceInfo` now carries the flag as `is_default`, populated from the remote workspaces response and set on the single workspace in local/OSS deployments.
- The consent screen preselects the flagged workspace, falling back to the first workspace when none is flagged (unchanged behavior in that case).
- No change to what a user can approve: the picker still lists exactly the same workspaces, and an explicit pick still wins over the preselection.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA — no ticket; small UX fix on the consent screen.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation and tests
- Human verification: code review

## Testing

Commands run:

- `mvn test -Dtest='RemoteAuthServiceTest,AuthServiceImplTest,OAuthAuthorizeResourceTest'` — 76 tests, all passing
- `mvn compile -DskipTests` and `mvn spotless:check` — passing
- `npx vitest run src/shared/OAuthConsentPage` — 31 tests, all passing
- `npm run lint` and `npm run typecheck` — passing
- `pre-commit run --files <changed files>` — passing (spotless, eslint, typecheck, semgrep)

Scenarios covered by new/updated tests:

- Consent screen preselects the default-flagged workspace rather than the first one, and submits it with no interaction.
- Consent screen falls back to the first workspace when nothing is flagged.
- An explicit pick overrides the preselection.
- The flag survives the mapping from the remote workspaces response (fixture orders a non-default workspace first, so a positional pass would not satisfy it).
- A remote response that omits the flag entirely degrades to "nothing flagged" rather than erroring, which keeps the previous first-workspace behavior.
- `GET /oauth/authorize/context` exposes the literal `is_default` key the consent screen reads, pinning the contract between the two halves.

Each behavior test was also confirmed to fail against the pre-change code, so they are pinned to the new behavior rather than passing incidentally.

Not run: the full backend suite (unrelated to these files) and E2E, since no E2E covers the consent screen.

## Documentation

N/A — no user-visible documentation changes; the consent screen gains no new options, only a better default.
