### PR TITLE
[NA] [EXT] fix: prevent duplicate Cursor traces across edits

### DIFF
--- a/extensions/cursor/.gitignore
+++ b/extensions/cursor/.gitignore
@@ -1,4 +1,5 @@
 out/
+out-test/
 node_modules/
 .vscode/
 

--- a/extensions/cursor/.vscodeignore
+++ b/extensions/cursor/.vscodeignore
@@ -18,6 +18,9 @@ node_modules/**
 scripts/**
 *.vsix
 test/**
+tests/**
+out-test/**
+tsconfig.tests.json
 .npmignore
 package-lock.json
 yarn.lock

--- a/extensions/cursor/README.md
+++ b/extensions/cursor/README.md
@@ -8,7 +8,7 @@ Learn more about:
 - [Opik](https://github.com/comet-ml/opik) is an Open-Source LLM evaluation platform that allows you to keep track of all your LLM chat conversations in one place.
 - [Cursor](https://www.cursor.com/) is "the" AI Code Editor.
 
-When you use this extension, it will automatically upload your Cursor chats to Opik and make them available in the `cursor` project. You will be to view the conversations in the `thread` tab and view your token usage in the metrics tab, you'd be surprised how many tokens you consume!
+When you use this extension, it will automatically upload new Cursor chats to Opik and make them available in the `cursor` project. Existing chats are not uploaded automatically. To import them, run **Opik: Import Historical Cursor Traces** from the command palette. You can view conversations in the `thread` tab and token usage in the metrics tab.
 
 ## Installation
 
@@ -24,7 +24,7 @@ To configure the extension, open up VSCode settings (Ctrl + ,), find the setting
 
 ## Usage
 
-Once installed, there is nothing for you to do ! Just sit back and enjoy your coding experience knowing that all your chat history is saved in Opik
+Once installed, new Cursor chats are saved automatically. Historical chats are imported only when you explicitly run **Opik: Import Historical Cursor Traces** from the command palette.
 
 > 💻: This extension is currently under development 🚧. Please report any bugs on [Github](https://github.com/comet-ml/opik) if you run into any issues.
 

--- a/extensions/cursor/README.md
+++ b/extensions/cursor/README.md
@@ -26,6 +26,8 @@ To configure the extension, open up VSCode settings (Ctrl + ,), find the setting
 
 Once installed, new Cursor chats are saved automatically. Historical chats are imported only when you explicitly run **Opik: Import Historical Cursor Traces** from the command palette.
 
+Delivered request identities are retained for 180 days to prevent duplicate uploads while keeping extension state bounded. Completed edit-cost records are compacted into one aggregate during that period.
+
 > 💻: This extension is currently under development 🚧. Please report any bugs on [Github](https://github.com/comet-ml/opik) if you run into any issues.
 
 ## Local Development

--- a/extensions/cursor/package-lock.json
+++ b/extensions/cursor/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opik",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "opik",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dependencies": {
         "@sentry/node": "^10.38.0",
         "glob": "^11.1.0",

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -4,7 +4,7 @@
   "description": "Export your chat history from Cursor to Opik.",
   "repository": "https://github.com/comet-ml/opik",
   "publisher": "opik",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "preview": false,
   "engines": {
     "vscode": "^1.90.0"

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -123,7 +123,9 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
-    "test": "vscode-test",
+    "test": "npm run test:unit && npm run test-spans",
+    "test:unit": "tsc -p tsconfig.tests.json && node --test out-test/tests/*.test.js",
+    "test:extension": "vscode-test",
     "verify-usage": "node scripts/verify-usage.js",
     "test-spans": "node --test scripts/test-spans.js"
   },

--- a/extensions/cursor/package.json
+++ b/extensions/cursor/package.json
@@ -23,6 +23,11 @@
         "command": "opik.resetState",
         "title": "Reset Extension State",
         "category": "Opik"
+      },
+      {
+        "command": "opik.importHistoricalTraces",
+        "title": "Import Historical Cursor Traces",
+        "category": "Opik"
       }
     ],
     "configuration": [

--- a/extensions/cursor/scripts/test-spans.js
+++ b/extensions/cursor/scripts/test-spans.js
@@ -18,6 +18,7 @@ const {
     prepareTraceForUpload,
     requestIdForTurn,
     requestKey,
+    shouldProcessTrace,
     uuidV7Timestamp,
 } = require('../out/cursor/requestIdentity.js');
 const { aggregateTurnUsage } = require('../out/cursor/usageAggregation.js');
@@ -96,6 +97,43 @@ test('reopen skips an uploaded request and retry reuses every id', () => {
 
     acknowledgeUploadedTraces([first], ledger);
     assert.equal(prepareTraceForUpload(identityTrace('req-reopen', 'original'), ledger), null);
+});
+
+test('normal polling excludes unseen historical turns until manual import', () => {
+    const ledger = {};
+    const historical = identityTrace('req-historical', 'old-composer', T0);
+    const cutoff = T0 + 60_000;
+
+    assert.equal(shouldProcessTrace(historical, ledger, false, cutoff), false);
+    assert.equal(shouldProcessTrace(historical, ledger, true, cutoff), true);
+    assert.equal(Object.keys(ledger).length, 0);
+});
+
+test('normal polling keeps tracking known requests and future turns', () => {
+    const ledger = {};
+    const cutoff = T0 + 60_000;
+    const tracked = identityTrace('req-tracked-before-cutoff', 'composer', T0);
+    prepareTraceForUpload(tracked, ledger);
+
+    assert.equal(shouldProcessTrace(tracked, ledger, false, cutoff), true);
+    assert.equal(
+        shouldProcessTrace(identityTrace('req-future', 'composer', cutoff), ledger, false, cutoff),
+        true
+    );
+});
+
+test('project changes do not replay historical turns automatically', () => {
+    const ledger = {};
+    const cutoff = T0 + 60_000;
+    const oldProject = identityTrace('req-project-change', 'composer', T0);
+    prepareTraceForUpload(oldProject, ledger);
+
+    const newProject = identityTrace('req-project-change', 'composer', T0);
+    newProject.project_name = 'cursor-new-project';
+    newProject.request_key = requestKey(newProject.project_name, newProject.request_id);
+
+    assert.equal(shouldProcessTrace(newProject, ledger, false, cutoff), false);
+    assert.equal(shouldProcessTrace(newProject, ledger, true, cutoff), true);
 });
 
 test('fork copy gets its own timestamp-correct ids but never owns cost', () => {

--- a/extensions/cursor/scripts/test-spans.js
+++ b/extensions/cursor/scripts/test-spans.js
@@ -12,6 +12,15 @@ const { classifyBubble, toolName, TOOL_ID_NAMES } = require('../out/cursor/bubbl
 const { assignWindows, splitIntoModelCalls } = require('../out/cursor/modelCalls.js');
 const { buildSpans, buildTurnOutput, truncateForSpan, DEFAULT_SPAN_OPTIONS } = require('../out/cursor/spanBuilder.js');
 const { orderBubbles } = require('../out/cursor/bubbleOrder.js');
+const {
+    acknowledgeUploadedTraces,
+    deterministicUuidV7,
+    prepareTraceForUpload,
+    requestIdForTurn,
+    requestKey,
+    uuidV7Timestamp,
+} = require('../out/cursor/requestIdentity.js');
+const { aggregateTurnUsage } = require('../out/cursor/usageAggregation.js');
 
 const T0 = Date.parse('2026-01-10T19:57:00.000Z');
 const at = (seconds, ms = 0) => new Date(T0 + seconds * 1000 + ms).toISOString();
@@ -38,6 +47,170 @@ const errorBubble = (seconds, msg) => ({
 
 const conversation = { composerId: 'c1', model: 'claude-4.5-opus-high', createdAt: T0 };
 const kinds = (windows) => windows.map(w => w.kind);
+
+const identityTrace = (requestId, composerId, startMs = T0) => ({
+    id: '',
+    root_span_id: '',
+    request_id: requestId,
+    request_key: requestKey('cursor-tests', requestId),
+    upload_kind: 'canonical',
+    revision: 1,
+    usage_key: '',
+    cost_owner: true,
+    name: 'cursor-chat',
+    project_name: 'cursor-tests',
+    start_time: new Date(startMs).toISOString(),
+    end_time: new Date(startMs + 1000).toISOString(),
+    turn_start_ms: startMs,
+    turn_starts_ms: [startMs],
+    input: { input: 'question' },
+    output: { output: 'answer' },
+    thread_id: composerId,
+    tags: [],
+    metadata: {},
+    spans: [{
+        name: 'read_file',
+        type: 'tool',
+        startTime: new Date(startMs + 100),
+        endTime: new Date(startMs + 200),
+    }],
+});
+
+test('deterministic UUIDv7 embeds the exact event timestamp', () => {
+    const id = deterministicUuidV7(T0, 'same logical event');
+    assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+    assert.equal(uuidV7Timestamp(id), T0);
+    assert.equal(deterministicUuidV7(T0, 'same logical event'), id);
+    assert.notEqual(deterministicUuidV7(T0, 'different event'), id);
+});
+
+test('reopen skips an uploaded request and retry reuses every id', () => {
+    const ledger = {};
+    const first = prepareTraceForUpload(identityTrace('req-reopen', 'original'), ledger);
+    assert.ok(first);
+    const retry = prepareTraceForUpload(identityTrace('req-reopen', 'original'), ledger);
+    assert.equal(retry.id, first.id);
+    assert.equal(retry.root_span_id, first.root_span_id);
+    assert.equal(retry.spans[0].id, first.spans[0].id);
+    assert.ok(retry.tags.includes('cursor:retry'));
+
+    acknowledgeUploadedTraces([first], ledger);
+    assert.equal(prepareTraceForUpload(identityTrace('req-reopen', 'original'), ledger), null);
+});
+
+test('fork copy gets its own timestamp-correct ids but never owns cost', () => {
+    const ledger = {};
+    const canonical = prepareTraceForUpload(identityTrace('req-fork', 'original'), ledger);
+    acknowledgeUploadedTraces([canonical], ledger);
+
+    const fork = prepareTraceForUpload(identityTrace('req-fork', 'fork-1'), ledger);
+    assert.ok(fork);
+    assert.notEqual(fork.id, canonical.id);
+    assert.notEqual(fork.root_span_id, canonical.root_span_id);
+    assert.equal(uuidV7Timestamp(fork.id), T0);
+    assert.equal(uuidV7Timestamp(fork.root_span_id), T0);
+    assert.equal(uuidV7Timestamp(fork.spans[0].id), T0 + 100);
+    assert.equal(fork.cost_owner, false);
+    assert.ok(fork.tags.includes('cursor:fork-copy'));
+    assert.ok(fork.tags.includes('cursor:cost-excluded'));
+    assert.ok(!fork.tags.includes('cursor:retry'));
+    assert.equal(fork.metadata.canonical_trace_id, canonical.id);
+    assert.equal(fork.metadata.copied_from_thread_id, 'original');
+
+    acknowledgeUploadedTraces([fork], ledger);
+    assert.equal(prepareTraceForUpload(identityTrace('req-fork', 'fork-1'), ledger), null);
+});
+
+test('an edited request id in the same composer is a new canonical cost owner', () => {
+    const ledger = {};
+    const original = prepareTraceForUpload(identityTrace('req-before-edit', 'composer'), ledger);
+    acknowledgeUploadedTraces([original], ledger);
+    const edited = prepareTraceForUpload(identityTrace('req-after-edit', 'composer', T0 + 5000), ledger);
+
+    assert.ok(edited);
+    assert.equal(edited.upload_kind, 'canonical');
+    assert.equal(edited.cost_owner, true);
+    assert.notEqual(edited.id, original.id);
+    assert.equal(Object.keys(ledger).length, 2);
+});
+
+test('an edit with the same request id updates the canonical trace in place', () => {
+    const ledger = {};
+    const original = prepareTraceForUpload(identityTrace('req-same-id-edit', 'composer'), ledger);
+    acknowledgeUploadedTraces([original], ledger);
+
+    const editedInput = identityTrace('req-same-id-edit', 'composer', T0 + 5000);
+    editedInput.input = { input: 'edited question' };
+    editedInput.output = { output: 'edited answer' };
+    const edited = prepareTraceForUpload(editedInput, ledger);
+
+    assert.ok(edited);
+    assert.equal(edited.upload_kind, 'edit_revision');
+    assert.equal(edited.revision, 2);
+    assert.equal(edited.id, original.id);
+    assert.equal(edited.root_span_id, original.root_span_id);
+    assert.equal(edited.start_time, original.start_time);
+    assert.equal(edited.turn_start_ms, T0 + 5000);
+    assert.equal(uuidV7Timestamp(edited.id), T0);
+    assert.equal(uuidV7Timestamp(edited.spans[0].id), T0 + 5100);
+    assert.ok(edited.tags.includes('cursor:edit-revision'));
+
+    acknowledgeUploadedTraces([edited], ledger);
+    const reopened = identityTrace('req-same-id-edit', 'composer', T0 + 5000);
+    reopened.input = { input: 'edited question' };
+    reopened.output = { output: 'edited answer' };
+    assert.equal(prepareTraceForUpload(reopened, ledger), null);
+});
+
+test('editing an inherited fork trace updates that copy and makes it a cost owner', () => {
+    const ledger = {};
+    const canonical = prepareTraceForUpload(identityTrace('req-fork-edit', 'original'), ledger);
+    acknowledgeUploadedTraces([canonical], ledger);
+    const fork = prepareTraceForUpload(identityTrace('req-fork-edit', 'fork'), ledger);
+    acknowledgeUploadedTraces([fork], ledger);
+
+    const editedInput = identityTrace('req-fork-edit', 'fork', T0 + 8000);
+    editedInput.input = { input: 'fork edited question' };
+    const edited = prepareTraceForUpload(editedInput, ledger);
+
+    assert.equal(edited.upload_kind, 'fork_edit_revision');
+    assert.equal(edited.id, fork.id);
+    assert.equal(edited.root_span_id, fork.root_span_id);
+    assert.equal(edited.cost_owner, true);
+    assert.ok(edited.tags.includes('cursor:fork-edit'));
+    assert.ok(!edited.tags.includes('cursor:cost-excluded'));
+});
+
+test('usage aggregation sums edit costs once and keeps all models', () => {
+    const first = {
+        inputTokens: 10, outputTokens: 2, cacheReadTokens: 3, cacheWriteTokens: 1,
+        chargedCents: 1.25, requestCount: 1, models: ['model-a'],
+    };
+    const edit = {
+        inputTokens: 20, outputTokens: 4, cacheReadTokens: 6, cacheWriteTokens: 2,
+        chargedCents: 2.5, requestCount: 1, models: ['model-b'],
+    };
+    assert.deepEqual(aggregateTurnUsage([first, edit]), {
+        inputTokens: 30,
+        outputTokens: 6,
+        cacheReadTokens: 9,
+        cacheWriteTokens: 3,
+        chargedCents: 3.75,
+        requestCount: 2,
+        models: ['model-a', 'model-b'],
+    });
+});
+
+test('legacy request identity survives changed bubble and composer ids', () => {
+    const left = requestIdForTurn({ userMessages: [{
+        id: 'bubble-a', composerId: 'composer-a', text: 'same prompt', resolvedTimestamp: T0,
+    }] });
+    const right = requestIdForTurn({ userMessages: [{
+        id: 'bubble-b', composerId: 'composer-b', text: 'same prompt', resolvedTimestamp: T0,
+    }] });
+    assert.equal(left, right);
+    assert.match(left, /^legacy-[0-9a-f]{64}$/);
+});
 
 test('a placeholder toolFormerData is not a tool call', () => {
     // 1237 of 19691 real bubbles carry exactly this and are ordinary messages.

--- a/extensions/cursor/scripts/test-spans.js
+++ b/extensions/cursor/scripts/test-spans.js
@@ -239,14 +239,14 @@ test('usage aggregation sums edit costs once and keeps all models', () => {
     });
 });
 
-test('legacy request identity survives changed bubble and composer ids', () => {
+test('legacy request identity distinguishes independent bubble ids', () => {
     const left = requestIdForTurn({ userMessages: [{
         id: 'bubble-a', composerId: 'composer-a', text: 'same prompt', resolvedTimestamp: T0,
     }] });
     const right = requestIdForTurn({ userMessages: [{
         id: 'bubble-b', composerId: 'composer-b', text: 'same prompt', resolvedTimestamp: T0,
     }] });
-    assert.equal(left, right);
+    assert.notEqual(left, right);
     assert.match(left, /^legacy-[0-9a-f]{64}$/);
 });
 

--- a/extensions/cursor/src/cursor/composerIdentity.ts
+++ b/extensions/cursor/src/cursor/composerIdentity.ts
@@ -1,0 +1,74 @@
+export interface ComposerHeaderIdentity {
+    composerId: string;
+    composerCreatedAt: number;
+    headers: Array<{
+        bubbleId?: string;
+        type?: number;
+        createdAt?: string;
+    }>;
+}
+
+export interface CanonicalBubbleOwner {
+    composerId: string;
+    turnStartMs: number;
+    composerCreatedAt: number;
+}
+
+const CURSOR_COMPOSER_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isCursorComposerId(value: unknown): value is string {
+    return typeof value === 'string' && CURSOR_COMPOSER_ID.test(value);
+}
+
+export function composerIdFromKey(value: unknown): string | undefined {
+    if (typeof value !== 'string' || !value.startsWith('composerData:')) {
+        return undefined;
+    }
+    const composerId = value.slice('composerData:'.length);
+    return isCursorComposerId(composerId) ? composerId : undefined;
+}
+
+/**
+ * Cursor keeps the inherited user-bubble header in every fork. The earliest
+ * composer carrying that header is the durable owner of the logical request,
+ * even when only a newer fork is present in the incremental polling window.
+ */
+export function resolveCanonicalBubbleOwners(
+    composers: ComposerHeaderIdentity[]
+): Map<string, CanonicalBubbleOwner> {
+    const owners = new Map<string, CanonicalBubbleOwner>();
+
+    for (const composer of composers) {
+        if (!isCursorComposerId(composer.composerId)) {
+            continue;
+        }
+        for (const header of composer.headers) {
+            if (header.type !== 1 || typeof header.bubbleId !== 'string' || !header.bubbleId) {
+                continue;
+            }
+            const parsed = Date.parse(header.createdAt ?? '');
+            const turnStartMs = Number.isNaN(parsed) ? composer.composerCreatedAt : parsed;
+            const candidate = {
+                composerId: composer.composerId,
+                turnStartMs,
+                composerCreatedAt: composer.composerCreatedAt,
+            };
+            const current = owners.get(header.bubbleId);
+            if (!current) {
+                owners.set(header.bubbleId, candidate);
+                continue;
+            }
+            const earlierComposer = candidate.composerCreatedAt < current.composerCreatedAt ||
+                (candidate.composerCreatedAt === current.composerCreatedAt &&
+                    candidate.composerId < current.composerId)
+                ? candidate
+                : current;
+            owners.set(header.bubbleId, {
+                ...earlierComposer,
+                turnStartMs: Math.min(current.turnStartMs, candidate.turnStartMs),
+            });
+        }
+    }
+
+    return owners;
+}

--- a/extensions/cursor/src/cursor/composerIdentity.ts
+++ b/extensions/cursor/src/cursor/composerIdentity.ts
@@ -1,11 +1,13 @@
 export interface ComposerHeaderIdentity {
     composerId: string;
     composerCreatedAt: number;
-    headers: Array<{
-        bubbleId?: string;
-        type?: number;
-        createdAt?: string;
-    }>;
+    headers: unknown[];
+}
+
+interface ComposerHeader {
+    bubbleId?: string;
+    type?: number;
+    createdAt?: string;
 }
 
 export interface CanonicalBubbleOwner {
@@ -28,6 +30,10 @@ export function composerIdFromKey(value: unknown): string | undefined {
     return isCursorComposerId(composerId) ? composerId : undefined;
 }
 
+function isComposerHeader(value: unknown): value is ComposerHeader {
+    return typeof value === 'object' && value !== null;
+}
+
 /**
  * Cursor keeps the inherited user-bubble header in every fork. The earliest
  * composer carrying that header is the durable owner of the logical request,
@@ -43,7 +49,10 @@ export function resolveCanonicalBubbleOwners(
             continue;
         }
         for (const header of composer.headers) {
-            if (header.type !== 1 || typeof header.bubbleId !== 'string' || !header.bubbleId) {
+            if (!isComposerHeader(header) ||
+                header.type !== 1 ||
+                typeof header.bubbleId !== 'string' ||
+                !header.bubbleId) {
                 continue;
             }
             const parsed = Date.parse(header.createdAt ?? '');

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -12,7 +12,7 @@ import {
 import { captureException } from '../sentry';
 import { UsageEnricher } from './usage';
 import { acknowledgeUploadedTraces } from './requestIdentity';
-import { aggregateTurnUsage } from './usageAggregation';
+import { hasAppliedUsage, recordAppliedUsage } from './usageLedger';
 
 export class CursorService {
   private context: vscode.ExtensionContext;
@@ -41,9 +41,14 @@ export class CursorService {
         return;
       }
 
-      delivery.usageByRevision ??= {};
-      delivery.usageByRevision[pending.usageKey] = usage;
-      const aggregate = aggregateTurnUsage(Object.values(delivery.usageByRevision));
+      // A successful ledger update can be followed by a failed pending-queue
+      // removal. Keep that retry local: the same usage key must never be added
+      // to the aggregate or patched to Opik twice.
+      if (hasAppliedUsage(delivery, pending.usageKey)) {
+        return;
+      }
+
+      const aggregate = recordAppliedUsage(delivery, pending.usageKey, usage);
       await applyTurnUsage(this.apiKey, pending, aggregate);
       delivery.usageStatus = 'complete';
       entry.lastSeenAt = Date.now();

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -17,6 +17,7 @@ import {
   hasAppliedUsage,
   recordAppliedUsage,
   recordUsageEventOwnership,
+  usageDeliveryForComposer,
 } from './usageLedger';
 
 export class CursorService {
@@ -38,9 +39,7 @@ export class CursorService {
         return;
       }
 
-      const delivery = entry.ownerComposerId === pending.composerId
-        ? entry
-        : entry.forkCopies[pending.composerId];
+      const delivery = usageDeliveryForComposer(entry, pending.composerId);
       if (!delivery) {
         await applyTurnUsage(this.apiKey, pending, usage);
         return;
@@ -130,7 +129,7 @@ export class CursorService {
                 const entry = requestLedger[trace.request_key];
                 if (entry.ownerComposerId === trace.thread_id) {
                   entry.usageStatus = 'disabled';
-                } else if (trace.thread_id && entry.forkCopies[trace.thread_id]) {
+                } else if (trace.thread_id && entry.forkCopies?.[trace.thread_id]) {
                   entry.forkCopies[trace.thread_id].usageStatus = 'disabled';
                 }
               }

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -54,7 +54,11 @@ export class CursorService {
   /**
    * Process cursor traces and log them to Opik
    */
-  async processCursorTraces(apiKey: string, vsInstallationPath: string): Promise<number> {
+  async processCursorTraces(
+    apiKey: string,
+    vsInstallationPath: string,
+    options: { includeHistorical?: boolean; automaticCutoffAt: number }
+  ): Promise<number> {
     // Prevent concurrent processing to avoid duplicates
     if (this.isProcessing) {
       console.log('⏳ Cursor trace processing already in progress, skipping this cycle');
@@ -74,10 +78,11 @@ export class CursorService {
       const cursorResult = await findAndReturnNewTraces(
         this.context,
         vsInstallationPath,
-        sessionInfo,
         requestLedger,
         lastSyncedAt,
-        currentSyncTime
+        currentSyncTime,
+        options.includeHistorical ?? false,
+        options.automaticCutoffAt
       );
       
       if (cursorResult && cursorResult.tracesData) {

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -123,9 +123,12 @@ export class CursorService {
           await updateRequestLedger(this.context, requestLedger);
 
           const loggedTurns = await logTracesToOpik(apiKey, tracesData);
-          await this.usageEnricher.track(loggedTurns);
+          // Trace delivery is durable independently from best-effort usage
+          // queue persistence. Never re-upload a trace because the local cost
+          // work queue temporarily failed to save.
           acknowledgeUploadedTraces(tracesData, requestLedger);
           await updateRequestLedger(this.context, requestLedger);
+          await this.usageEnricher.track(loggedTurns);
           
           // Update session info for each composer session
           Object.entries(updatedSessionInfo).forEach(([sessionId, sessionData]) => {

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -1,9 +1,18 @@
 import * as vscode from 'vscode';
 import { findAndReturnNewTraces, resolveStateDbPath } from './sessionManager';
 import { applyTurnUsage, logTracesToOpik } from '../opik';
-import { getSessionInfo, updateSessionInfo, getLastSyncedAt, updateLastSyncedAt } from '../state';
+import {
+  getLastSyncedAt,
+  getRequestLedger,
+  getSessionInfo,
+  updateLastSyncedAt,
+  updateRequestLedger,
+  updateSessionInfo,
+} from '../state';
 import { captureException } from '../sentry';
 import { UsageEnricher } from './usage';
+import { acknowledgeUploadedTraces } from './requestIdentity';
+import { aggregateTurnUsage } from './usageAggregation';
 
 export class CursorService {
   private context: vscode.ExtensionContext;
@@ -17,7 +26,28 @@ export class CursorService {
       if (!this.apiKey) {
         throw new Error('No API key available to patch span usage');
       }
-      await applyTurnUsage(this.apiKey, pending, usage);
+      const ledger = getRequestLedger(this.context);
+      const entry = ledger[pending.requestKey];
+      if (!entry) {
+        await applyTurnUsage(this.apiKey, pending, usage);
+        return;
+      }
+
+      const delivery = entry.ownerComposerId === pending.composerId
+        ? entry
+        : entry.forkCopies[pending.composerId];
+      if (!delivery) {
+        await applyTurnUsage(this.apiKey, pending, usage);
+        return;
+      }
+
+      delivery.usageByRevision ??= {};
+      delivery.usageByRevision[pending.usageKey] = usage;
+      const aggregate = aggregateTurnUsage(Object.values(delivery.usageByRevision));
+      await applyTurnUsage(this.apiKey, pending, aggregate);
+      delivery.usageStatus = 'complete';
+      entry.lastSeenAt = Date.now();
+      await updateRequestLedger(this.context, ledger);
     });
   }
 
@@ -35,12 +65,20 @@ export class CursorService {
     this.apiKey = apiKey;
     let numberOfTracesLogged = 0;
     let sessionInfo = getSessionInfo(this.context);
+    const requestLedger = getRequestLedger(this.context);
     const lastSyncedAt = getLastSyncedAt(this.context);
     // Capture current time before processing to avoid race conditions
     const currentSyncTime = Date.now();
     
     try {
-      const cursorResult = await findAndReturnNewTraces(this.context, vsInstallationPath, sessionInfo, lastSyncedAt, currentSyncTime);
+      const cursorResult = await findAndReturnNewTraces(
+        this.context,
+        vsInstallationPath,
+        sessionInfo,
+        requestLedger,
+        lastSyncedAt,
+        currentSyncTime
+      );
       
       if (cursorResult && cursorResult.tracesData) {
         const { tracesData, updatedSessionInfo } = cursorResult;
@@ -62,9 +100,27 @@ export class CursorService {
         
         if (tracesData.length > 0) {
           console.log(`📤 Logging ${tracesData.length} cursor traces to Opik`);
-          
+
+          // Persist pending identities before network I/O. A failed upload is
+          // retried with exactly the same UUIDv7 ids on the next cycle.
+          if (!this.usageEnricher.isEnabled()) {
+            for (const trace of tracesData) {
+              if (trace.cost_owner && requestLedger[trace.request_key]) {
+                const entry = requestLedger[trace.request_key];
+                if (entry.ownerComposerId === trace.thread_id) {
+                  entry.usageStatus = 'disabled';
+                } else if (trace.thread_id && entry.forkCopies[trace.thread_id]) {
+                  entry.forkCopies[trace.thread_id].usageStatus = 'disabled';
+                }
+              }
+            }
+          }
+          await updateRequestLedger(this.context, requestLedger);
+
           const loggedTurns = await logTracesToOpik(apiKey, tracesData);
-          this.usageEnricher.track(loggedTurns);
+          await this.usageEnricher.track(loggedTurns);
+          acknowledgeUploadedTraces(tracesData, requestLedger);
+          await updateRequestLedger(this.context, requestLedger);
           
           // Update session info for each composer session
           Object.entries(updatedSessionInfo).forEach(([sessionId, sessionData]) => {
@@ -91,13 +147,17 @@ export class CursorService {
         } else {
           // This is normal behavior when there are no new conversations
           console.log(`ℹ️ No new cursor traces to log`);
+          // Reconciliation can still populate the ledger while migrating an
+          // installation whose already-sent traces must not be uploaded again.
+          await updateRequestLedger(this.context, requestLedger);
         }
 
-        updateSessionInfo(this.context, sessionInfo);
-        
         // Update lastSyncedAt after successful processing (even if no traces uploaded)
         // This prevents re-querying the same conversations
-        updateLastSyncedAt(this.context, currentSyncTime);
+        await Promise.all([
+          updateSessionInfo(this.context, sessionInfo),
+          updateLastSyncedAt(this.context, currentSyncTime),
+        ]);
       } else {
         const error = new Error("No cursor data returned from findAndReturnNewTraces");
         captureException(error);

--- a/extensions/cursor/src/cursor/cursorService.ts
+++ b/extensions/cursor/src/cursor/cursorService.ts
@@ -12,7 +12,12 @@ import {
 import { captureException } from '../sentry';
 import { UsageEnricher } from './usage';
 import { acknowledgeUploadedTraces } from './requestIdentity';
-import { hasAppliedUsage, recordAppliedUsage } from './usageLedger';
+import {
+  aggregateUsageWithRevision,
+  hasAppliedUsage,
+  recordAppliedUsage,
+  recordUsageEventOwnership,
+} from './usageLedger';
 
 export class CursorService {
   private context: vscode.ExtensionContext;
@@ -22,7 +27,7 @@ export class CursorService {
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
-    this.usageEnricher = new UsageEnricher(context, async (pending, usage) => {
+    this.usageEnricher = new UsageEnricher(context, async (pending, usage, eventKeys) => {
       if (!this.apiKey) {
         throw new Error('No API key available to patch span usage');
       }
@@ -45,11 +50,17 @@ export class CursorService {
       // removal. Keep that retry local: the same usage key must never be added
       // to the aggregate or patched to Opik twice.
       if (hasAppliedUsage(delivery, pending.usageKey)) {
+        recordUsageEventOwnership(delivery, pending.usageKey, eventKeys);
+        entry.lastSeenAt = Date.now();
+        await updateRequestLedger(this.context, ledger);
         return;
       }
 
-      const aggregate = recordAppliedUsage(delivery, pending.usageKey, usage);
+      // Build the absolute root total without acknowledging this revision yet.
+      // If the remote patch fails, the ledger must stay eligible for retry.
+      const aggregate = aggregateUsageWithRevision(delivery, pending.usageKey, usage);
       await applyTurnUsage(this.apiKey, pending, aggregate);
+      recordAppliedUsage(delivery, pending.usageKey, usage, eventKeys);
       delivery.usageStatus = 'complete';
       entry.lastSeenAt = Date.now();
       await updateRequestLedger(this.context, ledger);

--- a/extensions/cursor/src/cursor/ledgerRetention.ts
+++ b/extensions/cursor/src/cursor/ledgerRetention.ts
@@ -1,5 +1,5 @@
-import { RequestLedger, TurnUsage, UsageStatus } from '../interface';
-import { aggregateTurnUsage } from './usageAggregation';
+import { ForkCopyState, RequestLedger, RequestLedgerEntry, TurnUsage, UsageStatus } from '../interface';
+import { aggregateUsageByRevision } from './usageLedger';
 
 export const REQUEST_LEDGER_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
 
@@ -14,7 +14,22 @@ function compactUsageByRevision(
     if (usages.length <= 1) {
         return usageByRevision;
     }
-    return { compacted: aggregateTurnUsage(usages) };
+    return { compacted: aggregateUsageByRevision(usageByRevision) };
+}
+
+function compactDelivery(delivery: ForkCopyState | RequestLedgerEntry): void {
+    const exactKeys = Object.keys(delivery.usageByRevision ?? {})
+        .filter(key => key !== 'compacted');
+    if (exactKeys.length > 0) {
+        delivery.appliedUsageKeys = [...new Set([
+            ...(delivery.appliedUsageKeys ?? []),
+            ...exactKeys,
+        ])];
+    }
+    delivery.usageByRevision = compactUsageByRevision(
+        delivery.usageByRevision,
+        delivery.usageStatus
+    );
 }
 
 /**
@@ -27,13 +42,15 @@ export function compactRequestLedger(
     now: number = Date.now()
 ): RequestLedger {
     for (const [key, entry] of Object.entries(ledger)) {
-        entry.usageByRevision = compactUsageByRevision(entry.usageByRevision, entry.usageStatus);
+        compactDelivery(entry);
         for (const copy of Object.values(entry.forkCopies ?? {})) {
-            copy.usageByRevision = compactUsageByRevision(copy.usageByRevision, copy.usageStatus);
+            compactDelivery(copy);
         }
 
         const copies = Object.values(entry.forkCopies ?? {});
-        const traceDeliveryComplete = entry.canonicalStatus !== 'pending' &&
+        const canonicalDeliveryComplete = entry.canonicalStatus === 'uploaded' ||
+            entry.canonicalStatus === 'excluded';
+        const traceDeliveryComplete = canonicalDeliveryComplete &&
             copies.every(copy => copy.status === 'uploaded');
         // Reopening an old composer sees its bubbles again, so lastSeenAt is
         // not a useful retention clock. Use immutable Cursor event times to

--- a/extensions/cursor/src/cursor/ledgerRetention.ts
+++ b/extensions/cursor/src/cursor/ledgerRetention.ts
@@ -1,0 +1,50 @@
+import { RequestLedger, TurnUsage, UsageStatus } from '../interface';
+import { aggregateTurnUsage } from './usageAggregation';
+
+export const REQUEST_LEDGER_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
+
+function compactUsageByRevision(
+    usageByRevision: Record<string, TurnUsage> | undefined,
+    usageStatus: UsageStatus | undefined
+): Record<string, TurnUsage> | undefined {
+    if (!usageByRevision || usageStatus !== 'complete') {
+        return usageByRevision;
+    }
+    const usages = Object.values(usageByRevision);
+    if (usages.length <= 1) {
+        return usageByRevision;
+    }
+    return { compacted: aggregateTurnUsage(usages) };
+}
+
+/**
+ * Bound globalState growth while retaining six months of duplicate prevention.
+ * Completed revision costs are collapsed to one baseline; fully delivered
+ * requests older than the retention window are removed.
+ */
+export function compactRequestLedger(
+    ledger: RequestLedger,
+    now: number = Date.now()
+): RequestLedger {
+    for (const [key, entry] of Object.entries(ledger)) {
+        entry.usageByRevision = compactUsageByRevision(entry.usageByRevision, entry.usageStatus);
+        for (const copy of Object.values(entry.forkCopies ?? {})) {
+            copy.usageByRevision = compactUsageByRevision(copy.usageByRevision, copy.usageStatus);
+        }
+
+        const copies = Object.values(entry.forkCopies ?? {});
+        const traceDeliveryComplete = entry.canonicalStatus !== 'pending' &&
+            copies.every(copy => copy.status === 'uploaded');
+        // Reopening an old composer sees its bubbles again, so lastSeenAt is
+        // not a useful retention clock. Use immutable Cursor event times to
+        // keep the duplicate-prevention window truly bounded.
+        const latestEventAt = Math.max(
+            entry.latestTurnStartMs ?? entry.turnStartMs,
+            ...copies.map(copy => copy.latestTurnStartMs ?? entry.turnStartMs)
+        );
+        if (traceDeliveryComplete && now - latestEventAt > REQUEST_LEDGER_RETENTION_MS) {
+            delete ledger[key];
+        }
+    }
+    return ledger;
+}

--- a/extensions/cursor/src/cursor/requestIdentity.ts
+++ b/extensions/cursor/src/cursor/requestIdentity.ts
@@ -1,0 +1,285 @@
+import { createHash } from 'crypto';
+
+import { ForkCopyState, RequestLedger, TraceData } from '../interface';
+
+/** Build an RFC 9562 UUIDv7 whose embedded timestamp is the event time. */
+export function deterministicUuidV7(timestampMs: number, identity: string): string {
+    const timestamp = Math.max(0, Math.min(Math.trunc(timestampMs), 0xffffffffffff));
+    const entropy = createHash('sha256').update(identity).digest();
+    const bytes = Buffer.alloc(16);
+
+    bytes.writeUIntBE(timestamp, 0, 6);
+    entropy.copy(bytes, 6, 0, 10);
+    bytes[6] = (bytes[6] & 0x0f) | 0x70;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+
+    const hex = bytes.toString('hex');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function uuidV7Timestamp(uuid: string): number {
+    return Number.parseInt(uuid.replace(/-/g, '').slice(0, 12), 16);
+}
+
+export function requestKey(projectName: string, requestId: string): string {
+    return `${projectName}\u0000${requestId}`;
+}
+
+export function requestIdForTurn(group: { userMessages: any[] }): string {
+    const cursorRequestId = group.userMessages.find(message =>
+        typeof message.requestId === 'string' && message.requestId.trim()
+    )?.requestId;
+
+    if (cursorRequestId) {
+        return cursorRequestId;
+    }
+
+    // Old Cursor versions did not persist requestId. The timestamp and prompt
+    // survive a fork even though bubble ids do not, so this remains stable for
+    // historical conversations without making identical prompts collide.
+    const first = group.userMessages[0] ?? {};
+    const parsedTimestamp = Date.parse(first.createdAt ?? '');
+    const timestamp = first.resolvedTimestamp ?? (Number.isNaN(parsedTimestamp) ? 0 : parsedTimestamp);
+    const content = group.userMessages
+        .map(message => message.text || message.content || message.rawText || '')
+        .join('\n\n');
+    const digest = createHash('sha256')
+        .update(`${timestamp}\u0000${content}`)
+        .digest('hex');
+    return `legacy-${digest}`;
+}
+
+export function traceFingerprint(trace: TraceData): string {
+    return createHash('sha256')
+        .update(JSON.stringify([trace.turn_start_ms, trace.input, trace.output]))
+        .digest('hex');
+}
+
+function usageKey(trace: TraceData): string {
+    return `${trace.request_key}\u0000${trace.thread_id}\u0000${trace.turn_start_ms}`;
+}
+
+function assignChildSpanIds(trace: TraceData): void {
+    for (const [index, span] of (trace.spans ?? []).entries()) {
+        span.id = deterministicUuidV7(
+            span.startTime.getTime(),
+            `cursor:child:${trace.id}:${trace.turn_start_ms}:${index}:${span.type}:${span.name}`
+        );
+    }
+}
+
+function decorateCanonical(
+    trace: TraceData,
+    revision: number,
+    originalTurnStartMs: number,
+    retry: boolean
+): void {
+    const isEdit = revision > 1;
+    trace.upload_kind = isEdit ? 'edit_revision' : 'canonical';
+    trace.revision = revision;
+    trace.cost_owner = true;
+    trace.usage_key = usageKey(trace);
+    trace.tags = [
+        ...(trace.tags ?? []),
+        'cursor:canonical',
+        ...(isEdit ? ['cursor:edit-revision'] : []),
+        ...(retry ? ['cursor:retry'] : []),
+    ];
+    trace.metadata = {
+        ...(trace.metadata ?? {}),
+        request_id: trace.request_id,
+        upload_kind: trace.upload_kind,
+        cost_owner: true,
+        revision,
+        original_turn_start_ms: originalTurnStartMs,
+        revision_turn_start_ms: trace.turn_start_ms,
+        ...(retry ? { retry: true } : {}),
+    };
+    assignChildSpanIds(trace);
+}
+
+function decorateFork(
+    trace: TraceData,
+    copy: ForkCopyState,
+    canonicalTraceId: string,
+    copiedFromThreadId: string,
+    retry: boolean
+): void {
+    const revision = copy.revision ?? 1;
+    const isEdit = revision > 1;
+    trace.upload_kind = isEdit ? 'fork_edit_revision' : 'fork_copy';
+    trace.revision = revision;
+    trace.cost_owner = isEdit;
+    trace.usage_key = usageKey(trace);
+    trace.tags = [
+        ...(trace.tags ?? []),
+        'cursor:fork-copy',
+        ...(isEdit ? ['cursor:fork-edit', 'cursor:cost-owner'] : ['cursor:cost-excluded']),
+        ...(retry ? ['cursor:retry'] : []),
+    ];
+    trace.metadata = {
+        ...(trace.metadata ?? {}),
+        request_id: trace.request_id,
+        source_request_id: trace.request_id,
+        canonical_trace_id: canonicalTraceId,
+        copied_from_thread_id: copiedFromThreadId,
+        upload_kind: trace.upload_kind,
+        cost_owner: trace.cost_owner,
+        revision,
+        original_turn_start_ms: copy.originalTurnStartMs ?? copy.latestTurnStartMs ?? trace.turn_start_ms,
+        revision_turn_start_ms: trace.turn_start_ms,
+        ...(retry ? { retry: true } : {}),
+    };
+    assignChildSpanIds(trace);
+}
+
+/**
+ * Classify a trace against the durable ledger and assign stable UUIDv7 ids.
+ * Returns null for a request revision already delivered to the same UI thread.
+ */
+export function prepareTraceForUpload(trace: TraceData, ledger: RequestLedger): TraceData | null {
+    const key = trace.request_key;
+    const existing = ledger[key];
+    const fingerprint = traceFingerprint(trace);
+    const now = Date.now();
+
+    if (!existing) {
+        trace.id = deterministicUuidV7(
+            trace.turn_start_ms,
+            `cursor:trace:canonical:${trace.project_name}:${trace.request_id}`
+        );
+        trace.root_span_id = deterministicUuidV7(
+            trace.turn_start_ms,
+            `cursor:span:canonical:${trace.project_name}:${trace.request_id}`
+        );
+        decorateCanonical(trace, 1, trace.turn_start_ms, false);
+
+        ledger[key] = {
+            requestId: trace.request_id,
+            projectName: trace.project_name ?? 'default',
+            ownerComposerId: trace.thread_id!,
+            turnStartMs: trace.turn_start_ms,
+            latestTurnStartMs: trace.turn_start_ms,
+            canonicalTraceId: trace.id,
+            canonicalRootSpanId: trace.root_span_id,
+            canonicalStatus: 'pending',
+            canonicalFingerprint: fingerprint,
+            canonicalRevision: 1,
+            usageStatus: 'pending',
+            usageByRevision: {},
+            forkCopies: {},
+            lastSeenAt: now,
+        };
+        return trace;
+    }
+
+    existing.lastSeenAt = now;
+    existing.forkCopies ??= {};
+    if (existing.ownerComposerId === trace.thread_id) {
+        const lastTurnStart = existing.latestTurnStartMs ?? existing.turnStartMs;
+        const changed = existing.canonicalFingerprint
+            ? existing.canonicalFingerprint !== fingerprint
+            : lastTurnStart !== trace.turn_start_ms;
+
+        if (!changed && existing.canonicalStatus === 'uploaded') {
+            // Populate fields introduced after the first request-ledger release.
+            existing.canonicalFingerprint ??= fingerprint;
+            existing.latestTurnStartMs ??= trace.turn_start_ms;
+            existing.canonicalRevision ??= 1;
+            existing.usageByRevision ??= {};
+            return null;
+        }
+
+        if (changed) {
+            existing.canonicalRevision = (existing.canonicalRevision ?? 1) + 1;
+            existing.canonicalFingerprint = fingerprint;
+            existing.latestTurnStartMs = trace.turn_start_ms;
+            existing.canonicalStatus = 'pending';
+            existing.usageStatus = 'pending';
+        }
+
+        trace.id = existing.canonicalTraceId;
+        trace.root_span_id = existing.canonicalRootSpanId;
+        // A logical request keeps its original UUIDv7 timestamp and table
+        // position. The current revision time remains in turn_start_ms and in
+        // metadata for usage attribution and auditability.
+        trace.start_time = new Date(existing.turnStartMs).toISOString();
+        decorateCanonical(
+            trace,
+            existing.canonicalRevision ?? 1,
+            existing.turnStartMs,
+            !changed
+        );
+        return trace;
+    }
+
+    const composerId = trace.thread_id!;
+    let copy = existing.forkCopies[composerId];
+    let changed = false;
+    let created = false;
+    if (!copy) {
+        created = true;
+        copy = {
+            traceId: deterministicUuidV7(
+                existing.turnStartMs,
+                `cursor:trace:fork:${trace.project_name}:${trace.request_id}:${composerId}`
+            ),
+            rootSpanId: deterministicUuidV7(
+                existing.turnStartMs,
+                `cursor:span:fork:${trace.project_name}:${trace.request_id}:${composerId}`
+            ),
+            status: 'pending',
+            fingerprint,
+            latestTurnStartMs: trace.turn_start_ms,
+            originalTurnStartMs: trace.turn_start_ms,
+            revision: 1,
+            usageStatus: 'disabled',
+            usageByRevision: {},
+        };
+        existing.forkCopies[composerId] = copy;
+    } else {
+        const lastTurnStart = copy.latestTurnStartMs ?? existing.turnStartMs;
+        changed = copy.fingerprint ? copy.fingerprint !== fingerprint : lastTurnStart !== trace.turn_start_ms;
+        if (!changed && copy.status === 'uploaded') {
+            copy.fingerprint ??= fingerprint;
+            copy.latestTurnStartMs ??= trace.turn_start_ms;
+            copy.revision ??= 1;
+            copy.usageByRevision ??= {};
+            return null;
+        }
+        if (changed) {
+            copy.revision = (copy.revision ?? 1) + 1;
+            copy.fingerprint = fingerprint;
+            copy.latestTurnStartMs = trace.turn_start_ms;
+            copy.status = 'pending';
+            copy.usageStatus = 'pending';
+        }
+    }
+
+    trace.id = copy.traceId;
+    trace.root_span_id = copy.rootSpanId;
+    trace.start_time = new Date(existing.turnStartMs).toISOString();
+    decorateFork(
+        trace,
+        copy,
+        existing.canonicalTraceId,
+        existing.ownerComposerId,
+        !created && !changed && copy.status === 'pending'
+    );
+    return trace;
+}
+
+export function acknowledgeUploadedTraces(traces: TraceData[], ledger: RequestLedger): void {
+    for (const trace of traces) {
+        const entry = ledger[trace.request_key];
+        if (!entry) {
+            continue;
+        }
+        if (trace.upload_kind === 'canonical' || trace.upload_kind === 'edit_revision') {
+            entry.canonicalStatus = 'uploaded';
+        } else if (trace.thread_id && entry.forkCopies[trace.thread_id]) {
+            entry.forkCopies[trace.thread_id].status = 'uploaded';
+        }
+        entry.lastSeenAt = Date.now();
+    }
+}

--- a/extensions/cursor/src/cursor/requestIdentity.ts
+++ b/extensions/cursor/src/cursor/requestIdentity.ts
@@ -55,6 +55,18 @@ export function traceFingerprint(trace: TraceData): string {
         .digest('hex');
 }
 
+/** Normal polling only sends turns created after tracking began. */
+export function shouldProcessTrace(
+    trace: TraceData,
+    ledger: RequestLedger,
+    includeHistorical: boolean,
+    automaticCutoffAt: number
+): boolean {
+    return includeHistorical ||
+        trace.turn_start_ms >= automaticCutoffAt ||
+        ledger[trace.request_key] !== undefined;
+}
+
 function usageKey(trace: TraceData): string {
     return `${trace.request_key}\u0000${trace.thread_id}\u0000${trace.turn_start_ms}`;
 }

--- a/extensions/cursor/src/cursor/requestIdentity.ts
+++ b/extensions/cursor/src/cursor/requestIdentity.ts
@@ -34,9 +34,9 @@ export function requestIdForTurn(group: { userMessages: any[] }): string {
         return cursorRequestId;
     }
 
-    // Old Cursor versions did not persist requestId. The timestamp and prompt
-    // survive a fork even though bubble ids do not, so this remains stable for
-    // historical conversations without making identical prompts collide.
+    // Old Cursor versions did not persist requestId. Include the turn's bubble
+    // identity so independent legacy turns with identical timestamps and text
+    // cannot be merged into one request.
     const first = group.userMessages[0] ?? {};
     const parsedTimestamp = Date.parse(first.createdAt ?? '');
     const timestamp = first.resolvedTimestamp ?? (Number.isNaN(parsedTimestamp) ? 0 : parsedTimestamp);
@@ -44,7 +44,7 @@ export function requestIdForTurn(group: { userMessages: any[] }): string {
         .map(message => message.text || message.content || message.rawText || '')
         .join('\n\n');
     const digest = createHash('sha256')
-        .update(`${timestamp}\u0000${content}`)
+        .update(`${first.id ?? ''}\u0000${timestamp}\u0000${content}`)
         .digest('hex');
     return `legacy-${digest}`;
 }
@@ -68,14 +68,14 @@ export function shouldProcessTrace(
 }
 
 function usageKey(trace: TraceData): string {
-    return `${trace.request_key}\u0000${trace.thread_id}\u0000${trace.turn_start_ms}`;
+    return `${trace.request_key}\u0000${trace.thread_id}\u0000${trace.turn_start_ms}\u0000${trace.revision}`;
 }
 
 function assignChildSpanIds(trace: TraceData): void {
     for (const [index, span] of (trace.spans ?? []).entries()) {
         span.id = deterministicUuidV7(
             span.startTime.getTime(),
-            `cursor:child:${trace.id}:${trace.turn_start_ms}:${index}:${span.type}:${span.name}`
+            `cursor:child:${trace.id}:${trace.turn_start_ms}:${trace.revision}:${index}:${span.type}:${span.name}`
         );
     }
 }
@@ -151,38 +151,44 @@ function decorateFork(
  */
 export function prepareTraceForUpload(trace: TraceData, ledger: RequestLedger): TraceData | null {
     const key = trace.request_key;
-    const existing = ledger[key];
+    let existing = ledger[key];
     const fingerprint = traceFingerprint(trace);
     const now = Date.now();
 
     if (!existing) {
+        const ownerComposerId = trace.canonical_thread_id ?? trace.thread_id!;
+        const canonicalTurnStartMs = trace.canonical_turn_start_ms ?? trace.turn_start_ms;
         trace.id = deterministicUuidV7(
-            trace.turn_start_ms,
+            canonicalTurnStartMs,
             `cursor:trace:canonical:${trace.project_name}:${trace.request_id}`
         );
         trace.root_span_id = deterministicUuidV7(
-            trace.turn_start_ms,
+            canonicalTurnStartMs,
             `cursor:span:canonical:${trace.project_name}:${trace.request_id}`
         );
-        decorateCanonical(trace, 1, trace.turn_start_ms, false);
 
         ledger[key] = {
             requestId: trace.request_id,
             projectName: trace.project_name ?? 'default',
-            ownerComposerId: trace.thread_id!,
-            turnStartMs: trace.turn_start_ms,
-            latestTurnStartMs: trace.turn_start_ms,
+            ownerComposerId,
+            turnStartMs: canonicalTurnStartMs,
+            latestTurnStartMs: canonicalTurnStartMs,
             canonicalTraceId: trace.id,
             canonicalRootSpanId: trace.root_span_id,
-            canonicalStatus: 'pending',
-            canonicalFingerprint: fingerprint,
+            canonicalStatus: ownerComposerId === trace.thread_id ? 'pending' : 'excluded',
+            canonicalFingerprint: ownerComposerId === trace.thread_id ? fingerprint : undefined,
             canonicalRevision: 1,
             usageStatus: 'pending',
             usageByRevision: {},
             forkCopies: {},
             lastSeenAt: now,
         };
-        return trace;
+        existing = ledger[key];
+
+        if (ownerComposerId === trace.thread_id) {
+            decorateCanonical(trace, 1, canonicalTurnStartMs, false);
+            return trace;
+        }
     }
 
     existing.lastSeenAt = now;
@@ -231,6 +237,7 @@ export function prepareTraceForUpload(trace: TraceData, ledger: RequestLedger): 
     let created = false;
     if (!copy) {
         created = true;
+        const firstSeenAsEditedFork = trace.turn_start_ms !== existing.turnStartMs;
         copy = {
             traceId: deterministicUuidV7(
                 existing.turnStartMs,
@@ -243,9 +250,9 @@ export function prepareTraceForUpload(trace: TraceData, ledger: RequestLedger): 
             status: 'pending',
             fingerprint,
             latestTurnStartMs: trace.turn_start_ms,
-            originalTurnStartMs: trace.turn_start_ms,
-            revision: 1,
-            usageStatus: 'disabled',
+            originalTurnStartMs: existing.turnStartMs,
+            revision: firstSeenAsEditedFork ? 2 : 1,
+            usageStatus: firstSeenAsEditedFork ? 'pending' : 'disabled',
             usageByRevision: {},
         };
         existing.forkCopies[composerId] = copy;

--- a/extensions/cursor/src/cursor/sessionManager.ts
+++ b/extensions/cursor/src/cursor/sessionManager.ts
@@ -2,12 +2,13 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { SessionInfo } from "../interface";
+import { RequestLedger, SessionInfo } from "../interface";
 import { findFolder } from '../utils';
 import { captureException } from '../sentry';
 import { executeQuery, executeQueryPaginated } from './sqlite';
 import { orderBubbles } from './bubbleOrder';
 import { buildSpans, buildTurnOutput, DEFAULT_SPAN_OPTIONS, SpanBuildOptions } from './spanBuilder';
+import { prepareTraceForUpload, requestIdForTurn, requestKey } from './requestIdentity';
 
 import { TraceData } from "../interface";
 
@@ -29,27 +30,37 @@ function readSpanOptions(): SpanBuildOptions | null {
 }
 
 /**
- * Convert cursor conversations to Opik traces with per-session tracking.
- * Each composer session maintains its own progress tracking to avoid duplicate uploads.
- * 
- * Strategy:
- *   - Never synced conversations: Upload entire conversation
- *   - Already synced, no new messages: Skip (avoid duplicates)
- *   - Already synced, has new messages: Upload new messages only
+ * Convert Cursor conversations to Opik traces using requestId as the durable
+ * identity. Per-composer state is retained only to migrate installations from
+ * versions that predate the request ledger.
  * 
  * @param conversations Array of conversation objects from cursor database
  * @param opikProjectName Project name for Opik
  * @param sessionInfo Existing session info with per-composer tracking
  * @returns Object containing traces and updated session info
  */
-async function convertConversationsToTraces(conversations: any[], opikProjectName: string, sessionInfo: Record<string, SessionInfo>) {
+async function convertConversationsToTraces(
+    conversations: any[],
+    opikProjectName: string,
+    sessionInfo: Record<string, SessionInfo>,
+    requestLedger: RequestLedger
+) {
     const tracesData: TraceData[] = [];
     const updatedSessionInfo: Record<string, { lastMessageId?: string; lastMessageTime?: number }> = {};
 
     // Get git info once for all traces (performance optimization)
     const gitInfo = await getGitInfo();
+    const migrateLegacySessions = Object.keys(requestLedger).length === 0 &&
+        Object.values(sessionInfo).some(info => info.lastUploadId !== undefined);
 
-    for (const conversation of conversations) {
+    // A fork is created after its source composer. Processing oldest composers
+    // first makes the original request the canonical cost owner when both are
+    // first discovered in the same polling cycle.
+    const orderedConversations = [...conversations].sort((left, right) =>
+        Number(left.createdAt ?? 0) - Number(right.createdAt ?? 0)
+    );
+
+    for (const conversation of orderedConversations) {
         if (!conversation.bubbles || !Array.isArray(conversation.bubbles) || conversation.bubbles.length === 0) {
             console.log(`⏭️  Skipping composer ${conversation.composerId} - no bubbles`);
             continue;
@@ -57,36 +68,14 @@ async function convertConversationsToTraces(conversations: any[], opikProjectNam
 
         const composerId = conversation.composerId;
         const sessionId = `cursor-composer-${composerId}`;
-        const lastUploadId = sessionInfo[sessionId]?.lastUploadId;
-        
-        // Check if there are new messages
-        const latestMessage = conversation.bubbles[conversation.bubbles.length - 1];
-        const neverSynced = !lastUploadId;
-        const hasNewMessagesSinceSync = lastUploadId && latestMessage && latestMessage.id !== lastUploadId;
-        
-        // Skip if already synced and no new messages
-        if (!neverSynced && !hasNewMessagesSinceSync) {
-            console.log(`⏭️  Skipping composer ${composerId} - no new messages (latest: ${latestMessage?.id}, last uploaded: ${lastUploadId})`);
-            continue; // Skip - no new messages and already synced
-        }
-
-        // Determine processing strategy:
-        // - If never synced (no lastUploadId): upload entire conversation
-        // - If previously synced: upload only new messages after lastUploadId
-        const uploadEntireConversation = lastUploadId === undefined;
-        
-        if (uploadEntireConversation) {
-            console.log(`📤 Processing entire conversation for composer ${composerId} (never synced)`);
-        } else {
-            console.log(`📤 Processing new messages for composer ${composerId} after message ${lastUploadId}`);
-        }
+        console.log(`📤 Reconciling composer ${composerId} against the request ledger`);
         
         const conversationTraces = processConversationBubbles(
             conversation, 
             opikProjectName, 
-            uploadEntireConversation,
-            lastUploadId,
-            gitInfo // Pass git info to bubble processing
+            gitInfo,
+            requestLedger,
+            migrateLegacySessions ? sessionInfo[sessionId] : undefined
         );
         
         tracesData.push(...conversationTraces.traces);
@@ -108,14 +97,13 @@ async function convertConversationsToTraces(conversations: any[], opikProjectNam
 function processConversationBubbles(
     conversation: any, 
     opikProjectName: string, 
-    uploadEntireConversation: boolean, 
-    lastUploadId: string | undefined,
-    gitInfo: { branch?: string; commit?: string; remote?: string; repoName?: string } | null
+    gitInfo: { branch?: string; commit?: string; remote?: string; repoName?: string } | null,
+    requestLedger: RequestLedger,
+    legacySession?: SessionInfo
 ) {
     const traces: TraceData[] = [];
     let lastMessageId: string | undefined = undefined;
     let lastMessageTime: number | undefined = undefined;
-    let shouldAppend = uploadEntireConversation;
 
     // Initialize sequential timestamp starting from conversation createdAt
     let currentTimestamp = conversation.createdAt || Date.now();
@@ -148,8 +136,15 @@ function processConversationBubbles(
     });
 
     const bubbleGroups = groupBubblesByType(bubblesWithTimestamps);
+    const turnStartsMs = bubbleGroups
+        .filter(group => group.userMessages.length > 0)
+        .map(group => group.userMessages[0].resolvedTimestamp as number);
+    const legacyTargetIndex = legacySession?.lastUploadId
+        ? bubbleGroups.findIndex(group => [...group.userMessages, ...group.aiMessages]
+            .some(message => message.id === legacySession.lastUploadId))
+        : -1;
 
-    for (const group of bubbleGroups) {
+    for (const [groupIndex, group] of bubbleGroups.entries()) {
         // Always update lastMessageId to track our processing position
         const lastMessage = group.aiMessages.length > 0 
             ? group.aiMessages[group.aiMessages.length - 1]
@@ -158,28 +153,38 @@ function processConversationBubbles(
         lastMessageId = lastMessage.id;
         lastMessageTime = lastMessage.resolvedTimestamp;
 
-        // If we're uploading the entire conversation, process all groups
-        // If we're uploading incrementally, find where to start from lastUploadId
-        if (!shouldAppend) {
-            // Check both user and AI messages for the lastUploadId
-            const hasTargetMessage = [...group.userMessages, ...group.aiMessages]
-                .some(msg => msg.id === lastUploadId);
-            
-            if (hasTargetMessage) {
-                shouldAppend = true;
-                continue; // Skip this group since it was already processed
-            }
-        }
-
-        if (!shouldAppend) {
-            continue; // Still haven't reached the point where we left off
-        }
-
         // Only upload complete conversations (both user and AI messages)
         if (group.userMessages.length > 0 && group.aiMessages.length > 0) {
-            const trace = createTraceFromBubbleGroup(group, conversation, opikProjectName, gitInfo);
+            const trace = createTraceFromBubbleGroup(
+                group,
+                conversation,
+                opikProjectName,
+                gitInfo,
+                turnStartsMs
+            );
             if (trace) {
-                traces.push(trace);
+                const prepared = prepareTraceForUpload(trace, requestLedger);
+                if (prepared) {
+                    const wasPreviouslyUploaded = legacySession !== undefined && (
+                        (legacyTargetIndex >= 0 && groupIndex <= legacyTargetIndex) ||
+                        (legacyTargetIndex < 0 && legacySession.lastUploadTime !== undefined &&
+                            lastMessageTime !== undefined &&
+                            lastMessageTime <= legacySession.lastUploadTime)
+                    );
+                    if (wasPreviouslyUploaded) {
+                        // Older releases generated random ids, so these ids are
+                        // bookkeeping aliases only. Marking delivery prevents an
+                        // upgrade, reopen, or later fork from re-uploading them.
+                        if (prepared.upload_kind === 'canonical') {
+                            requestLedger[prepared.request_key].canonicalStatus = 'uploaded';
+                        } else if (prepared.thread_id) {
+                            requestLedger[prepared.request_key]
+                                .forkCopies[prepared.thread_id].status = 'uploaded';
+                        }
+                    } else {
+                        traces.push(prepared);
+                    }
+                }
             }
         }
         // Note: We still track incomplete conversations but don't upload them
@@ -383,6 +388,7 @@ export async function findAndReturnNewTraces(
     context: vscode.ExtensionContext, 
     VSInstallationPath: string, 
     sessionInfo: Record<string, SessionInfo>,
+    requestLedger: RequestLedger,
     lastSyncedAt: number,
     currentSyncTime: number
 ) {
@@ -404,7 +410,12 @@ export async function findAndReturnNewTraces(
             
             if (conversations && Array.isArray(conversations) && conversations.length > 0) {
                 // Convert conversations to Opik traces with per-session tracking
-                const result = await convertConversationsToTraces(conversations, opikProjectName, sessionInfo);
+                const result = await convertConversationsToTraces(
+                    conversations,
+                    opikProjectName,
+                    sessionInfo,
+                    requestLedger
+                );
                 
                 return {
                     tracesData: result.tracesData,
@@ -464,7 +475,8 @@ function createTraceFromBubbleGroup(
     group: { userMessages: any[], aiMessages: any[] },
     conversation: any,
     opikProjectName: string,
-    gitInfo: { branch?: string; commit?: string; remote?: string; repoName?: string } | null
+    gitInfo: { branch?: string; commit?: string; remote?: string; repoName?: string } | null,
+    turnStartsMs: number[]
 ): TraceData | null {
     const { userMessages, aiMessages } = group;
     
@@ -533,12 +545,22 @@ function createTraceFromBubbleGroup(
         tags.push("historical");
     }
 
+    const requestId = requestIdForTurn(group);
     return {
+        id: '',
+        root_span_id: '',
+        request_id: requestId,
+        request_key: requestKey(opikProjectName, requestId),
+        upload_kind: 'canonical',
+        revision: 1,
+        usage_key: '',
+        cost_owner: true,
         name: "cursor-chat",
         project_name: opikProjectName,
         start_time: new Date(startTime).toISOString(),
         end_time: new Date(endTime).toISOString(),
         turn_start_ms: startTime,
+        turn_starts_ms: turnStartsMs,
         model: conversation.model,
         input: { input: userContent },
         output: { output: assistantContent },

--- a/extensions/cursor/src/cursor/sessionManager.ts
+++ b/extensions/cursor/src/cursor/sessionManager.ts
@@ -9,6 +9,7 @@ import { executeQuery, executeQueryPaginated } from './sqlite';
 import { orderBubbles } from './bubbleOrder';
 import { buildSpans, buildTurnOutput, DEFAULT_SPAN_OPTIONS, SpanBuildOptions } from './spanBuilder';
 import { prepareTraceForUpload, requestIdForTurn, requestKey, shouldProcessTrace } from './requestIdentity';
+import { composerIdFromKey, resolveCanonicalBubbleOwners } from './composerIdentity';
 
 import { TraceData } from "../interface";
 
@@ -221,7 +222,10 @@ async function readCursorChatDataAsync(
         composerRows.forEach((row: any) => {
             try {
                 const composerData = JSON.parse(row.value);
-                const composerId = row.key.split(':')[1];
+                const composerId = composerIdFromKey(row.key);
+                if (!composerId) {
+                    return;
+                }
                 console.log(`  → Composer ${composerId}: updated at ${composerData.lastUpdatedAt}, status: ${composerData.status}`);
             } catch (e) {
                 // Ignore parse errors
@@ -231,10 +235,7 @@ async function readCursorChatDataAsync(
         // Extract composer IDs from the keys (format: composerData:<composerId>)
         const composerIds = composerRows
             .map((row: any) => {
-                if (typeof row.key === 'string') {
-                    return row.key.split(':')[1];
-                }
-                return null;
+                return composerIdFromKey(row.key) ?? null;
             })
             .filter((id: string | null) => id !== null);
         
@@ -244,6 +245,37 @@ async function readCursorChatDataAsync(
         }
         
         console.log(`🔍 Fetching bubbles for ${composerIds.length} active composer(s)`);
+
+        // Resolve fork ownership from Cursor's durable conversation headers,
+        // not from whichever composer happened to be updated in this poll.
+        // Only the compact header projection is read for inactive composers.
+        const identityRows = await executeQuery(dbPath, `
+            SELECT key,
+                   json_extract(value, '$.createdAt') AS createdAt,
+                   json_extract(value, '$.fullConversationHeadersOnly') AS headers
+            FROM cursorDiskKV
+            WHERE key >= 'composerData' AND key < 'composerDatb'
+        `);
+        const canonicalOwners = resolveCanonicalBubbleOwners(identityRows.flatMap((row: any) => {
+            const composerId = composerIdFromKey(row.key);
+            if (!composerId) {
+                return [];
+            }
+            try {
+                const headers = JSON.parse(row.headers || '[]');
+                const numericCreatedAt = Number(row.createdAt);
+                const parsedCreatedAt = Date.parse(row.createdAt ?? '');
+                return [{
+                    composerId,
+                    composerCreatedAt: Number.isFinite(numericCreatedAt)
+                        ? numericCreatedAt
+                        : (Number.isNaN(parsedCreatedAt) ? 0 : parsedCreatedAt),
+                    headers: Array.isArray(headers) ? headers : [],
+                }];
+            } catch {
+                return [];
+            }
+        }));
         
         // Build optimized query to only fetch bubbles for relevant composers
         // Bubble key format: bubbleId:<composerId>:<bubbleId>
@@ -260,17 +292,33 @@ async function readCursorChatDataAsync(
         const bubblesByComposer: Record<string, any[]> = {};
         
         allBubbleRows.forEach((bubbleRow: any) => {
-            if (!bubbleRow.value) return;
+            if (!bubbleRow.value) {
+                return;
+            }
             
             try {
                 const key = bubbleRow.key;
-                if (typeof key !== 'string') return;
-                const composerId = key.split(':')[1];
+                if (typeof key !== 'string') {
+                    return;
+                }
+                const keyParts = key.split(':');
+                const composerId = keyParts[1];
+                if (!composerIds.includes(composerId)) {
+                    return;
+                }
+                const bubbleId = keyParts[2];
+                if (!bubbleId) {
+                    return;
+                }
                 const value = bubbleRow.value;
-                if (typeof value !== 'string') return;
+                if (typeof value !== 'string') {
+                    return;
+                }
                 const chatData = JSON.parse(value);
                 
-                if (!chatData) return;
+                if (!chatData) {
+                    return;
+                }
                 
                 if (!bubblesByComposer[composerId]) {
                     bubblesByComposer[composerId] = [];
@@ -279,7 +327,9 @@ async function readCursorChatDataAsync(
                 // Structure the bubble data
                 const bubble = {
                     ...chatData,
-                    id: key.split(':')[2], // Extract bubble ID
+                    id: bubbleId,
+                    canonicalComposerId: canonicalOwners.get(bubbleId)?.composerId,
+                    canonicalTurnStartMs: canonicalOwners.get(bubbleId)?.turnStartMs,
                     type: chatData.type === 1 ? 'user' : chatData.type === 2 ? 'ai' : 'unknown',
                     text: chatData.text || chatData.content || '',
                     content: chatData.text || chatData.content || '',
@@ -298,7 +348,9 @@ async function readCursorChatDataAsync(
         composerRows.forEach((composerRow: any, index: number) => {
             try {
                 const value = composerRow.value;
-                if (typeof value !== 'string') return;
+                if (typeof value !== 'string') {
+                    return;
+                }
                 const composerData = JSON.parse(value);
                 
                 // Handle null composerData
@@ -308,8 +360,13 @@ async function readCursorChatDataAsync(
                 }
                 
                 const key = composerRow.key;
-                if (typeof key !== 'string') return;
-                const threadId = key.split(':')[1];
+                if (typeof key !== 'string') {
+                    return;
+                }
+                const threadId = composerIdFromKey(key);
+                if (!threadId) {
+                    return;
+                }
                 
                 // Get bubbles for this composer
                 const bubbles = bubblesByComposer[threadId] || [];
@@ -358,13 +415,13 @@ export function resolveStateDbPath(VSInstallationPath: string): string | null {
     if (globalStoragePaths.length > 1) {
         const error = new Error(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`);
         captureException(error);
-        console.warn(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`)
+        console.warn(`More than one global storage folder found - Should not happen - ${globalStoragePaths}`);
     }
 
     if (globalStoragePaths.length === 0) {
         const error = new Error("Could not find global SQLite state DB.");
         captureException(error);
-        console.warn("Could not find global SQLite state DB.")
+        console.warn("Could not find global SQLite state DB.");
         return null;
     }
 
@@ -390,7 +447,7 @@ export async function findAndReturnNewTraces(
     if (!fs.existsSync(stateDbPath)) {
         const error = new Error(`Could not find global SQLite state DB at path: ${stateDbPath}`);
         captureException(error);
-        console.warn("Could not find global SQLite state DB.")
+        console.warn("Could not find global SQLite state DB.");
         return null;
     } else {
         try {
@@ -555,6 +612,8 @@ function createTraceFromBubbleGroup(
         end_time: new Date(endTime).toISOString(),
         turn_start_ms: startTime,
         turn_starts_ms: turnStartsMs,
+        canonical_thread_id: firstUserMessage.canonicalComposerId,
+        canonical_turn_start_ms: firstUserMessage.canonicalTurnStartMs,
         model: conversation.model,
         input: { input: userContent },
         output: { output: assistantContent },

--- a/extensions/cursor/src/cursor/sessionManager.ts
+++ b/extensions/cursor/src/cursor/sessionManager.ts
@@ -2,13 +2,13 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 
-import { RequestLedger, SessionInfo } from "../interface";
+import { RequestLedger } from "../interface";
 import { findFolder } from '../utils';
 import { captureException } from '../sentry';
 import { executeQuery, executeQueryPaginated } from './sqlite';
 import { orderBubbles } from './bubbleOrder';
 import { buildSpans, buildTurnOutput, DEFAULT_SPAN_OPTIONS, SpanBuildOptions } from './spanBuilder';
-import { prepareTraceForUpload, requestIdForTurn, requestKey } from './requestIdentity';
+import { prepareTraceForUpload, requestIdForTurn, requestKey, shouldProcessTrace } from './requestIdentity';
 
 import { TraceData } from "../interface";
 
@@ -31,28 +31,25 @@ function readSpanOptions(): SpanBuildOptions | null {
 
 /**
  * Convert Cursor conversations to Opik traces using requestId as the durable
- * identity. Per-composer state is retained only to migrate installations from
- * versions that predate the request ledger.
+ * identity. Normal polling excludes previously unseen turns from before the
+ * automatic tracking cutoff; the manual import command includes them.
  * 
  * @param conversations Array of conversation objects from cursor database
  * @param opikProjectName Project name for Opik
- * @param sessionInfo Existing session info with per-composer tracking
  * @returns Object containing traces and updated session info
  */
 async function convertConversationsToTraces(
     conversations: any[],
     opikProjectName: string,
-    sessionInfo: Record<string, SessionInfo>,
-    requestLedger: RequestLedger
+    requestLedger: RequestLedger,
+    includeHistorical: boolean,
+    automaticCutoffAt: number
 ) {
     const tracesData: TraceData[] = [];
     const updatedSessionInfo: Record<string, { lastMessageId?: string; lastMessageTime?: number }> = {};
 
     // Get git info once for all traces (performance optimization)
     const gitInfo = await getGitInfo();
-    const migrateLegacySessions = Object.keys(requestLedger).length === 0 &&
-        Object.values(sessionInfo).some(info => info.lastUploadId !== undefined);
-
     // A fork is created after its source composer. Processing oldest composers
     // first makes the original request the canonical cost owner when both are
     // first discovered in the same polling cycle.
@@ -75,7 +72,8 @@ async function convertConversationsToTraces(
             opikProjectName, 
             gitInfo,
             requestLedger,
-            migrateLegacySessions ? sessionInfo[sessionId] : undefined
+            includeHistorical,
+            automaticCutoffAt
         );
         
         tracesData.push(...conversationTraces.traces);
@@ -99,7 +97,8 @@ function processConversationBubbles(
     opikProjectName: string, 
     gitInfo: { branch?: string; commit?: string; remote?: string; repoName?: string } | null,
     requestLedger: RequestLedger,
-    legacySession?: SessionInfo
+    includeHistorical: boolean,
+    automaticCutoffAt: number
 ) {
     const traces: TraceData[] = [];
     let lastMessageId: string | undefined = undefined;
@@ -139,12 +138,7 @@ function processConversationBubbles(
     const turnStartsMs = bubbleGroups
         .filter(group => group.userMessages.length > 0)
         .map(group => group.userMessages[0].resolvedTimestamp as number);
-    const legacyTargetIndex = legacySession?.lastUploadId
-        ? bubbleGroups.findIndex(group => [...group.userMessages, ...group.aiMessages]
-            .some(message => message.id === legacySession.lastUploadId))
-        : -1;
-
-    for (const [groupIndex, group] of bubbleGroups.entries()) {
+    for (const group of bubbleGroups) {
         // Always update lastMessageId to track our processing position
         const lastMessage = group.aiMessages.length > 0 
             ? group.aiMessages[group.aiMessages.length - 1]
@@ -163,27 +157,12 @@ function processConversationBubbles(
                 turnStartsMs
             );
             if (trace) {
+                if (!shouldProcessTrace(trace, requestLedger, includeHistorical, automaticCutoffAt)) {
+                    continue;
+                }
                 const prepared = prepareTraceForUpload(trace, requestLedger);
                 if (prepared) {
-                    const wasPreviouslyUploaded = legacySession !== undefined && (
-                        (legacyTargetIndex >= 0 && groupIndex <= legacyTargetIndex) ||
-                        (legacyTargetIndex < 0 && legacySession.lastUploadTime !== undefined &&
-                            lastMessageTime !== undefined &&
-                            lastMessageTime <= legacySession.lastUploadTime)
-                    );
-                    if (wasPreviouslyUploaded) {
-                        // Older releases generated random ids, so these ids are
-                        // bookkeeping aliases only. Marking delivery prevents an
-                        // upgrade, reopen, or later fork from re-uploading them.
-                        if (prepared.upload_kind === 'canonical') {
-                            requestLedger[prepared.request_key].canonicalStatus = 'uploaded';
-                        } else if (prepared.thread_id) {
-                            requestLedger[prepared.request_key]
-                                .forkCopies[prepared.thread_id].status = 'uploaded';
-                        }
-                    } else {
-                        traces.push(prepared);
-                    }
+                    traces.push(prepared);
                 }
             }
         }
@@ -197,7 +176,12 @@ function processConversationBubbles(
 /**
  * Read cursor chat data from SQLite database (asynchronous version)
  */
-async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number, currentSyncTime: number): Promise<any> {
+async function readCursorChatDataAsync(
+    stateDbPath: string,
+    lastSyncedAt: number,
+    currentSyncTime: number,
+    includeHistorical: boolean
+): Promise<any> {
     // Use the database directly with -readonly flag (no expensive copy operation)
     // The sqlite3 binary with -readonly flag is safe and handles locks gracefully
     
@@ -213,10 +197,13 @@ async function readCursorChatDataAsync(stateDbPath: string, lastSyncedAt: number
         // Prefix ranges instead of LIKE: LIKE is case-insensitive so SQLite cannot
         // use the index on key and scans the whole table, including the hundreds of
         // megabytes of agentKv and bubble rows.
+        const timeFilter = includeHistorical
+            ? ''
+            : `AND json_extract(value, '$.lastUpdatedAt') > ${lastSyncedAtWithBuffer}
+                AND json_extract(value, '$.lastUpdatedAt') <= ${currentSyncTime}`;
         const composerQuery = `SELECT key, value FROM cursorDiskKV 
                 WHERE key >= 'composerData' AND key < 'composerDatb'
-                AND json_extract(value, '$.lastUpdatedAt') > ${lastSyncedAtWithBuffer}
-                AND json_extract(value, '$.lastUpdatedAt') <= ${currentSyncTime}
+                ${timeFilter}
                 AND (json_extract(value, '$.status') = 'completed' 
                      OR (json_extract(value, '$.status') != 'completed' 
                          AND json_extract(value, '$.lastUpdatedAt') < ${fiveMinutesAgo}))`;
@@ -387,10 +374,11 @@ export function resolveStateDbPath(VSInstallationPath: string): string | null {
 export async function findAndReturnNewTraces(
     context: vscode.ExtensionContext, 
     VSInstallationPath: string, 
-    sessionInfo: Record<string, SessionInfo>,
     requestLedger: RequestLedger,
     lastSyncedAt: number,
-    currentSyncTime: number
+    currentSyncTime: number,
+    includeHistorical: boolean,
+    automaticCutoffAt: number
 ) {
     const opikProjectName: string = vscode.workspace.getConfiguration().get('opik.projectName') || 'default';
 
@@ -406,15 +394,21 @@ export async function findAndReturnNewTraces(
         return null;
     } else {
         try {
-            const conversations = await readCursorChatDataAsync(stateDbPath, lastSyncedAt, currentSyncTime);
+            const conversations = await readCursorChatDataAsync(
+                stateDbPath,
+                lastSyncedAt,
+                currentSyncTime,
+                includeHistorical
+            );
             
             if (conversations && Array.isArray(conversations) && conversations.length > 0) {
                 // Convert conversations to Opik traces with per-session tracking
                 const result = await convertConversationsToTraces(
                     conversations,
                     opikProjectName,
-                    sessionInfo,
-                    requestLedger
+                    requestLedger,
+                    includeHistorical,
+                    automaticCutoffAt
                 );
                 
                 return {

--- a/extensions/cursor/src/cursor/stateMigration.ts
+++ b/extensions/cursor/src/cursor/stateMigration.ts
@@ -1,0 +1,7 @@
+export function resolveAutomaticTraceCutoff(
+    lastSyncedAt: number | undefined,
+    legacyLastSyncTime: number | null,
+    now: number
+): number {
+    return lastSyncedAt ?? legacyLastSyncTime ?? now;
+}

--- a/extensions/cursor/src/cursor/traceDelivery.ts
+++ b/extensions/cursor/src/cursor/traceDelivery.ts
@@ -1,0 +1,180 @@
+import { PendingUsage, TraceData } from '../interface';
+
+export type LoggedTurn = Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>;
+
+export interface TraceDeliveryClient {
+    api: {
+        traces: {
+            updateTrace(id: string, request: any): Promise<unknown>;
+        };
+        spans: {
+            updateSpan(id: string, request: any): Promise<unknown>;
+            createSpans(request: any): Promise<unknown>;
+        };
+    };
+    trace(data: any): {
+        span(data: any): unknown;
+    };
+    flush(): Promise<void>;
+}
+
+function isRevision(trace: TraceData): boolean {
+    return trace.upload_kind === 'edit_revision' || trace.upload_kind === 'fork_edit_revision';
+}
+
+async function updateTraceRevision(
+    client: TraceDeliveryClient,
+    traceData: TraceData,
+    metadata: Record<string, unknown>
+): Promise<void> {
+    const projectName = traceData.project_name ?? 'default';
+
+    // Keep the original trace/root start time and UUIDv7 table position. The
+    // latest edited input/output and end time replace the visible turn data.
+    await client.api.traces.updateTrace(traceData.id, {
+        body: {
+            projectName,
+            name: traceData.name,
+            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+            input: traceData.input,
+            output: traceData.output,
+            metadata,
+            tags: traceData.tags,
+            threadId: traceData.thread_id,
+        },
+    });
+
+    await client.api.spans.updateSpan(traceData.root_span_id, {
+        body: {
+            traceId: traceData.id,
+            projectName,
+            name: 'llm_turn',
+            type: 'llm',
+            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+            model: traceData.model,
+            provider: 'cursor',
+            input: traceData.input,
+            output: traceData.output,
+            metadata: traceData.metadata,
+            tags: traceData.tags,
+        },
+    });
+
+    // Revision children are appended as an audit trail. Their UUIDv7 values
+    // embed the actual edit-event times, while the root remains a single turn.
+    if (traceData.spans && traceData.spans.length > 0) {
+        await client.api.spans.createSpans({
+            spans: traceData.spans.map(child => ({
+                id: child.id,
+                traceId: traceData.id,
+                parentSpanId: traceData.root_span_id,
+                projectName,
+                name: child.name,
+                type: child.type,
+                model: child.model,
+                provider: child.provider,
+                input: child.input,
+                output: child.output,
+                errorInfo: child.errorInfo,
+                startTime: child.startTime,
+                endTime: child.endTime,
+                tags: child.tags,
+                metadata: {
+                    ...(child.metadata ?? {}),
+                    edit_revision: traceData.revision,
+                    revision_turn_start_ms: traceData.turn_start_ms,
+                },
+            })),
+        });
+    }
+}
+
+export async function deliverTracesWithClient(
+    client: TraceDeliveryClient,
+    traces: TraceData[]
+): Promise<LoggedTurn[]> {
+    const loggedTurns: LoggedTurn[] = [];
+
+    for (const traceData of traces) {
+        const metadata = {
+            ...(traceData.metadata || {}),
+            created_from: 'cursor-extension',
+        };
+
+        if (isRevision(traceData)) {
+            await updateTraceRevision(client, traceData, metadata);
+        } else {
+            const trace = client.trace({
+                id: traceData.id,
+                name: traceData.name,
+                projectName: traceData.project_name,
+                input: traceData.input,
+                output: traceData.output,
+                startTime: new Date(traceData.start_time),
+                endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+                tags: traceData.tags,
+                metadata,
+                threadId: traceData.thread_id,
+            });
+
+            // The root carries the whole turn usage because Cursor bills once
+            // per turn rather than once per model-call child span.
+            trace.span({
+                id: traceData.root_span_id,
+                name: 'llm_turn',
+                type: 'llm',
+                model: traceData.model,
+                provider: 'cursor',
+                input: traceData.input,
+                output: traceData.output,
+                startTime: new Date(traceData.start_time),
+                endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+                tags: traceData.tags,
+                metadata: traceData.metadata,
+            });
+
+            for (const child of traceData.spans ?? []) {
+                trace.span({
+                    id: child.id,
+                    parentSpanId: traceData.root_span_id,
+                    name: child.name,
+                    type: child.type,
+                    model: child.model,
+                    provider: child.provider,
+                    input: child.input,
+                    output: child.output,
+                    errorInfo: child.errorInfo,
+                    startTime: child.startTime,
+                    endTime: child.endTime,
+                    tags: child.tags,
+                    metadata: child.metadata,
+                });
+            }
+
+            // Do not call span.end()/trace.end(): both replace the Cursor end
+            // timestamp with the upload time.
+        }
+
+        // Plain fork copies are cost-excluded. Canonical turns and edited fork
+        // revisions own the usage generated in their own composer.
+        if (traceData.thread_id && traceData.cost_owner) {
+            loggedTurns.push({
+                usageKey: traceData.usage_key,
+                requestId: traceData.request_id,
+                requestKey: traceData.request_key,
+                composerId: traceData.thread_id,
+                turnStartMs: traceData.turn_start_ms,
+                turnEndMs: traceData.end_time
+                    ? new Date(traceData.end_time).getTime()
+                    : undefined,
+                turnStartsMs: traceData.turn_starts_ms,
+                traceId: traceData.id,
+                spanId: traceData.root_span_id,
+                projectName: traceData.project_name ?? 'default',
+            });
+        }
+    }
+
+    await client.flush();
+    return loggedTurns;
+}

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -5,29 +5,18 @@ import { PendingUsage, TurnUsage } from '../interface';
 import { debugLog } from '../utils';
 import { mergePendingUsage } from './usageQueue';
 import { isCursorComposerId } from './composerIdentity';
+import {
+    attributeUsageToPending,
+    PendingUsageAttribution,
+    UsageEventDisplay,
+} from './usageAttribution';
+
+export { attributeUsageToTurns } from './usageAttribution';
 
 const API_HOST = 'https://api2.cursor.sh';
 const SERVICE = 'aiserver.v1.DashboardService';
 
 const POLL_SCHEDULE_MS = [5000, 5000, 10000, 30000, 60000, 300000, 300000];
-
-// The usage event is stamped when the request completes, so it always falls
-// after its own user bubble and before the next one. A grace window wider than
-// the gap between two turns makes a later turn swallow an earlier turn's event.
-const CLOCK_GRACE_MS = 0;
-
-interface UsageEventDisplay {
-    timestamp: string;
-    model: string;
-    conversationId?: string;
-    chargedCents?: number;
-    tokenUsage?: {
-        inputTokens?: number;
-        outputTokens?: number;
-        cacheReadTokens?: number;
-        cacheWriteTokens?: number;
-    };
-}
 
 async function readAccessToken(stateDbPath: string): Promise<string | undefined> {
     const rows = await executeQuery(
@@ -122,52 +111,6 @@ async function readUserTurnStarts(stateDbPath: string, composerId: string): Prom
         .filter(value => !Number.isNaN(value));
 
     return [...new Set(starts)].sort((a, b) => a - b);
-}
-
-export function attributeUsageToTurns(
-    turnStartsMs: number[],
-    events: UsageEventDisplay[]
-): Map<number, TurnUsage> {
-    const sorted = [...events].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
-    const attributed = new Map<number, TurnUsage>();
-
-    for (const event of sorted) {
-        const at = Number(event.timestamp) + CLOCK_GRACE_MS;
-
-        let turn = -1;
-        for (let i = 0; i < turnStartsMs.length; i++) {
-            if (turnStartsMs[i] > at) {
-                break;
-            }
-            turn = i;
-        }
-        if (turn < 0) {
-            continue;
-        }
-
-        const accumulated = attributed.get(turn) ?? {
-            inputTokens: 0,
-            outputTokens: 0,
-            cacheReadTokens: 0,
-            cacheWriteTokens: 0,
-            chargedCents: 0,
-            requestCount: 0,
-            models: [],
-        };
-
-        const usage = event.tokenUsage ?? {};
-        accumulated.inputTokens += usage.inputTokens ?? 0;
-        accumulated.outputTokens += usage.outputTokens ?? 0;
-        accumulated.cacheReadTokens += usage.cacheReadTokens ?? 0;
-        accumulated.cacheWriteTokens += usage.cacheWriteTokens ?? 0;
-        accumulated.chargedCents += event.chargedCents ?? 0;
-        accumulated.requestCount += 1;
-        if (event.model && !accumulated.models.includes(event.model)) {
-            accumulated.models.push(event.model);
-        }
-        attributed.set(turn, accumulated);
-    }
-    return attributed;
 }
 
 export class UsageEnricher {
@@ -272,6 +215,7 @@ export class UsageEnricher {
         }
 
         const startsCache = new Map<string, number[]>();
+        const attributionCache = new Map<string, PendingUsageAttribution>();
         const remaining: PendingUsage[] = [];
 
         for (const item of pending) {
@@ -280,31 +224,31 @@ export class UsageEnricher {
                 continue;
             }
 
-            let currentStarts = startsCache.get(item.composerId);
-            if (!currentStarts) {
-                currentStarts = await readUserTurnStarts(stateDbPath, item.composerId);
-                startsCache.set(item.composerId, currentStarts);
-            }
-            // Keep the immutable boundaries captured when the request was sent,
-            // while also adding later turns. This survives message edits without
-            // letting a pending earlier turn swallow usage from a newer turn.
-            const starts = [...new Set([
-                ...currentStarts,
-                ...(item.turnStartsMs ?? [item.turnStartMs]),
-            ])].sort((a, b) => a - b);
-
-            const index = starts.indexOf(item.turnStartMs);
-            const usage = index < 0
-                ? undefined
-                : attributeUsageToTurns(starts, byConversation.get(item.composerId) ?? []).get(index);
-
-            if (index < 0) {
-                debugLog('[usage] turn start not found in conversation', {
-                    composerId: item.composerId,
-                    turnStartMs: item.turnStartMs,
+            let attribution = attributionCache.get(item.composerId);
+            if (!attribution) {
+                let currentStarts = startsCache.get(item.composerId);
+                if (!currentStarts) {
+                    currentStarts = await readUserTurnStarts(stateDbPath, item.composerId);
+                    startsCache.set(item.composerId, currentStarts);
+                }
+                const composerPending = pending.filter(candidate =>
+                    candidate.composerId === item.composerId
+                );
+                const starts = [...new Set([
+                    ...currentStarts,
+                    ...composerPending.flatMap(candidate =>
+                        candidate.turnStartsMs ?? [candidate.turnStartMs]
+                    ),
+                ])].sort((a, b) => a - b);
+                attribution = attributeUsageToPending(
+                    composerPending,
                     starts,
-                });
+                    byConversation.get(item.composerId) ?? []
+                );
+                attributionCache.set(item.composerId, attribution);
             }
+
+            const usage = attribution.usageByKey.get(item.usageKey);
 
             if (usage) {
                 try {
@@ -313,6 +257,10 @@ export class UsageEnricher {
                 } catch (error) {
                     debugLog('[usage] failed to patch span', String(error));
                 }
+            }
+
+            if (attribution.settledKeys.has(item.usageKey)) {
+                continue;
             }
 
             item.attempt += 1;

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -177,20 +177,23 @@ export class UsageEnricher {
         return vscode.workspace.getConfiguration().get<boolean>('opik.usageEnrichment.enabled', true);
     }
 
-    track(turns: Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>[]) {
+    async track(turns: Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>[]): Promise<void> {
         if (!this.isEnabled() || turns.length === 0) {
             return;
         }
         const pending = getPendingUsage(this.context);
-        const known = new Set(pending.map(item => `${item.composerId}:${item.turnStartMs}`));
+        const known = new Set(pending.map(item =>
+            item.usageKey || item.requestKey || `${item.composerId}:${item.turnStartMs}`
+        ));
 
         for (const turn of turns) {
-            if (known.has(`${turn.composerId}:${turn.turnStartMs}`)) {
+            if (known.has(turn.usageKey)) {
                 continue;
             }
             pending.push({ ...turn, attempt: 0, nextAttemptAt: Date.now() + POLL_SCHEDULE_MS[0] });
+            known.add(turn.usageKey);
         }
-        updatePendingUsage(this.context, pending);
+        await updatePendingUsage(this.context, pending);
     }
 
     // Keyed by token so that switching Cursor accounts re-resolves instead of
@@ -251,7 +254,7 @@ export class UsageEnricher {
             for (const item of due) {
                 item.nextAttemptAt = now + 30000;
             }
-            updatePendingUsage(this.context, pending);
+            await updatePendingUsage(this.context, pending);
             return;
         }
 
@@ -264,11 +267,18 @@ export class UsageEnricher {
                 continue;
             }
 
-            let starts = startsCache.get(item.composerId);
-            if (!starts) {
-                starts = await readUserTurnStarts(stateDbPath, item.composerId);
-                startsCache.set(item.composerId, starts);
+            let currentStarts = startsCache.get(item.composerId);
+            if (!currentStarts) {
+                currentStarts = await readUserTurnStarts(stateDbPath, item.composerId);
+                startsCache.set(item.composerId, currentStarts);
             }
+            // Keep the immutable boundaries captured when the request was sent,
+            // while also adding later turns. This survives message edits without
+            // letting a pending earlier turn swallow usage from a newer turn.
+            const starts = [...new Set([
+                ...currentStarts,
+                ...(item.turnStartsMs ?? [item.turnStartMs]),
+            ])].sort((a, b) => a - b);
 
             const index = starts.indexOf(item.turnStartMs);
             const usage = index < 0
@@ -293,11 +303,10 @@ export class UsageEnricher {
             }
 
             item.attempt += 1;
-            if (item.attempt < POLL_SCHEDULE_MS.length) {
-                item.nextAttemptAt = now + POLL_SCHEDULE_MS[item.attempt];
-                remaining.push(item);
-            }
+            const delayIndex = Math.min(item.attempt, POLL_SCHEDULE_MS.length - 1);
+            item.nextAttemptAt = now + POLL_SCHEDULE_MS[delayIndex];
+            remaining.push(item);
         }
-        updatePendingUsage(this.context, remaining);
+        await updatePendingUsage(this.context, remaining);
     }
 }

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -3,7 +3,11 @@ import { executeQuery } from './sqlite';
 import { getPendingUsage, getRequestLedger, updatePendingUsage } from '../state';
 import { PendingUsage, TurnUsage } from '../interface';
 import { debugLog } from '../utils';
-import { mergePendingUsage, shouldKeepPendingUsage } from './usageQueue';
+import {
+    canAttributePendingUsage,
+    mergePendingUsage,
+    shouldKeepPendingUsage,
+} from './usageQueue';
 import { isCursorComposerId } from './composerIdentity';
 import {
     attributeUsageToPending,
@@ -184,7 +188,9 @@ export class UsageEnricher {
             Date.now()
         );
         const now = Date.now();
-        const due = pending.filter(item => item.nextAttemptAt <= now);
+        const due = pending.filter(item =>
+            canAttributePendingUsage(item) && item.nextAttemptAt <= now
+        );
         if (due.length === 0) {
             return;
         }
@@ -224,6 +230,11 @@ export class UsageEnricher {
         const remaining: PendingUsage[] = [];
 
         for (const item of pending) {
+            if (!canAttributePendingUsage(item)) {
+                debugLog('[usage] quarantining ambiguous legacy pending record');
+                remaining.push(item);
+                continue;
+            }
             if (item.nextAttemptAt > now) {
                 remaining.push(item);
                 continue;
@@ -237,6 +248,7 @@ export class UsageEnricher {
                     startsCache.set(item.composerId, currentStarts);
                 }
                 const composerPending = pending.filter(candidate =>
+                    canAttributePendingUsage(candidate) &&
                     candidate.composerId === item.composerId
                 );
                 const starts = [...new Set([

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -3,6 +3,8 @@ import { executeQuery } from './sqlite';
 import { getPendingUsage, updatePendingUsage } from '../state';
 import { PendingUsage, TurnUsage } from '../interface';
 import { debugLog } from '../utils';
+import { mergePendingUsage } from './usageQueue';
+import { isCursorComposerId } from './composerIdentity';
 
 const API_HOST = 'https://api2.cursor.sh';
 const SERVICE = 'aiserver.v1.DashboardService';
@@ -104,6 +106,10 @@ async function fetchUsageByConversation(
  * were already counted.
  */
 async function readUserTurnStarts(stateDbPath: string, composerId: string): Promise<number[]> {
+    if (!isCursorComposerId(composerId)) {
+        debugLog('[usage] invalid Cursor composer id', composerId);
+        return [];
+    }
     const rows = await executeQuery(
         stateDbPath,
         `SELECT json_extract(value, '$.createdAt') AS createdAt FROM cursorDiskKV
@@ -167,6 +173,7 @@ export function attributeUsageToTurns(
 export class UsageEnricher {
     private userId: number | undefined;
     private userIdToken: string | undefined;
+    private volatilePending = new Map<string, Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>>();
 
     constructor(
         private context: vscode.ExtensionContext,
@@ -181,19 +188,21 @@ export class UsageEnricher {
         if (!this.isEnabled() || turns.length === 0) {
             return;
         }
-        const pending = getPendingUsage(this.context);
-        const known = new Set(pending.map(item =>
-            item.usageKey || item.requestKey || `${item.composerId}:${item.turnStartMs}`
-        ));
-
-        for (const turn of turns) {
-            if (known.has(turn.usageKey)) {
-                continue;
+        const nextAttemptAt = Date.now() + POLL_SCHEDULE_MS[0];
+        const pending = mergePendingUsage(getPendingUsage(this.context), turns, nextAttemptAt);
+        try {
+            await updatePendingUsage(this.context, pending);
+            for (const turn of turns) {
+                this.volatilePending.delete(turn.usageKey);
             }
-            pending.push({ ...turn, attempt: 0, nextAttemptAt: Date.now() + POLL_SCHEDULE_MS[0] });
-            known.add(turn.usageKey);
+        } catch (error) {
+            // Trace delivery has already succeeded. Keep the cost work in
+            // memory and retry persistence from tick() without re-uploading it.
+            for (const turn of turns) {
+                this.volatilePending.set(turn.usageKey, turn);
+            }
+            debugLog('[usage] failed to persist pending usage, will retry', String(error));
         }
-        await updatePendingUsage(this.context, pending);
     }
 
     // Keyed by token so that switching Cursor accounts re-resolves instead of
@@ -221,7 +230,11 @@ export class UsageEnricher {
             return;
         }
 
-        const pending = getPendingUsage(this.context);
+        const pending = mergePendingUsage(
+            getPendingUsage(this.context),
+            [...this.volatilePending.values()],
+            Date.now()
+        );
         const now = Date.now();
         const due = pending.filter(item => item.nextAttemptAt <= now);
         if (due.length === 0) {
@@ -308,5 +321,6 @@ export class UsageEnricher {
             remaining.push(item);
         }
         await updatePendingUsage(this.context, remaining);
+        this.volatilePending.clear();
     }
 }

--- a/extensions/cursor/src/cursor/usage.ts
+++ b/extensions/cursor/src/cursor/usage.ts
@@ -1,15 +1,16 @@
 import * as vscode from 'vscode';
 import { executeQuery } from './sqlite';
-import { getPendingUsage, updatePendingUsage } from '../state';
+import { getPendingUsage, getRequestLedger, updatePendingUsage } from '../state';
 import { PendingUsage, TurnUsage } from '../interface';
 import { debugLog } from '../utils';
-import { mergePendingUsage } from './usageQueue';
+import { mergePendingUsage, shouldKeepPendingUsage } from './usageQueue';
 import { isCursorComposerId } from './composerIdentity';
 import {
     attributeUsageToPending,
     PendingUsageAttribution,
     UsageEventDisplay,
 } from './usageAttribution';
+import { appliedUsageEventOwners } from './usageLedger';
 
 export { attributeUsageToTurns } from './usageAttribution';
 
@@ -120,7 +121,11 @@ export class UsageEnricher {
 
     constructor(
         private context: vscode.ExtensionContext,
-        private applyUsage: (pending: PendingUsage, usage: TurnUsage) => Promise<void>
+        private applyUsage: (
+            pending: PendingUsage,
+            usage: TurnUsage,
+            eventKeys: string[]
+        ) => Promise<void>
     ) {}
 
     isEnabled(): boolean {
@@ -243,23 +248,33 @@ export class UsageEnricher {
                 attribution = attributeUsageToPending(
                     composerPending,
                     starts,
-                    byConversation.get(item.composerId) ?? []
+                    byConversation.get(item.composerId) ?? [],
+                    appliedUsageEventOwners(getRequestLedger(this.context), item.composerId)
                 );
                 attributionCache.set(item.composerId, attribution);
             }
 
             const usage = attribution.usageByKey.get(item.usageKey);
+            let applyFailed = false;
 
             if (usage) {
                 try {
-                    await this.applyUsage(item, usage);
+                    await this.applyUsage(
+                        item,
+                        usage,
+                        attribution.eventKeysByUsageKey.get(item.usageKey) ?? []
+                    );
                     continue;
                 } catch (error) {
+                    applyFailed = true;
                     debugLog('[usage] failed to patch span', String(error));
                 }
             }
 
-            if (attribution.settledKeys.has(item.usageKey)) {
+            if (!shouldKeepPendingUsage(
+                applyFailed,
+                attribution.settledKeys.has(item.usageKey)
+            )) {
                 continue;
             }
 

--- a/extensions/cursor/src/cursor/usageAggregation.ts
+++ b/extensions/cursor/src/cursor/usageAggregation.ts
@@ -20,3 +20,7 @@ export function aggregateTurnUsage(usages: TurnUsage[]): TurnUsage {
         models: [],
     });
 }
+
+export function latestUsageModel(usage: TurnUsage): string | undefined {
+    return usage.models[usage.models.length - 1];
+}

--- a/extensions/cursor/src/cursor/usageAggregation.ts
+++ b/extensions/cursor/src/cursor/usageAggregation.ts
@@ -1,0 +1,22 @@
+import { TurnUsage } from '../interface';
+
+/** Sum independently billed revisions without counting any revision twice. */
+export function aggregateTurnUsage(usages: TurnUsage[]): TurnUsage {
+    return usages.reduce<TurnUsage>((total, usage) => ({
+        inputTokens: total.inputTokens + usage.inputTokens,
+        outputTokens: total.outputTokens + usage.outputTokens,
+        cacheReadTokens: total.cacheReadTokens + usage.cacheReadTokens,
+        cacheWriteTokens: total.cacheWriteTokens + usage.cacheWriteTokens,
+        chargedCents: total.chargedCents + usage.chargedCents,
+        requestCount: total.requestCount + usage.requestCount,
+        models: [...new Set([...total.models, ...usage.models])],
+    }), {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        chargedCents: 0,
+        requestCount: 0,
+        models: [],
+    });
+}

--- a/extensions/cursor/src/cursor/usageAttribution.ts
+++ b/extensions/cursor/src/cursor/usageAttribution.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'crypto';
+
 import { PendingUsage, TurnUsage } from '../interface';
 
 // The usage event is stamped when the request completes, so it always falls
@@ -20,6 +22,7 @@ export interface UsageEventDisplay {
 
 export interface PendingUsageAttribution {
     usageByKey: Map<string, TurnUsage>;
+    eventKeysByUsageKey: Map<string, string[]>;
     settledKeys: Set<string>;
 }
 
@@ -85,6 +88,52 @@ function completionMarker(item: Pick<PendingUsage, 'turnStartMs' | 'turnEndMs'>)
         : item.turnStartMs;
 }
 
+type PendingAttributionItem = Pick<
+    PendingUsage,
+    'usageKey' | 'requestKey' | 'turnStartMs' | 'turnEndMs'
+>;
+
+function requestChain(item: PendingAttributionItem): string {
+    return item.requestKey || item.usageKey;
+}
+
+function compareCandidates(left: PendingAttributionItem, right: PendingAttributionItem): number {
+    return completionMarker(left) - completionMarker(right) ||
+        usageRevision(left.usageKey) - usageRevision(right.usageKey) ||
+        requestChain(left).localeCompare(requestChain(right)) ||
+        left.usageKey.localeCompare(right.usageKey);
+}
+
+function eventSignature(event: UsageEventDisplay): string {
+    return JSON.stringify([
+        event.timestamp,
+        event.model,
+        event.chargedCents ?? 0,
+        event.tokenUsage?.inputTokens ?? 0,
+        event.tokenUsage?.outputTokens ?? 0,
+        event.tokenUsage?.cacheReadTokens ?? 0,
+        event.tokenUsage?.cacheWriteTokens ?? 0,
+    ]);
+}
+
+function identifiedEvents(events: UsageEventDisplay[]): Array<{
+    event: UsageEventDisplay;
+    eventKey: string;
+}> {
+    const occurrences = new Map<string, number>();
+    return [...events]
+        .sort((a, b) => Number(a.timestamp) - Number(b.timestamp))
+        .map(event => {
+            const signature = eventSignature(event);
+            const occurrence = occurrences.get(signature) ?? 0;
+            occurrences.set(signature, occurrence + 1);
+            const eventKey = createHash('sha256')
+                .update(`${signature}\u0000${occurrence}`)
+                .digest('hex');
+            return { event, eventKey };
+        });
+}
+
 /**
  * Partition Cursor usage events across pending revisions without sharing an
  * event between usage keys. Revision completion times split edits that retain
@@ -92,9 +141,10 @@ function completionMarker(item: Pick<PendingUsage, 'turnStartMs' | 'turnEndMs'>)
  * chronological assignment preserves the exact total cost once.
  */
 export function attributeUsageToPending(
-    pending: Pick<PendingUsage, 'usageKey' | 'turnStartMs' | 'turnEndMs'>[],
+    pending: PendingAttributionItem[],
     turnStartsMs: number[],
-    events: UsageEventDisplay[]
+    events: UsageEventDisplay[],
+    claimedEventOwners: ReadonlyMap<string, string> = new Map()
 ): PendingUsageAttribution {
     const starts = [...new Set([
         ...turnStartsMs,
@@ -107,18 +157,25 @@ export function attributeUsageToPending(
         candidatesByTurn.set(item.turnStartMs, candidates);
     }
     for (const candidates of candidatesByTurn.values()) {
-        candidates.sort((left, right) =>
-            completionMarker(left) - completionMarker(right) ||
-            usageRevision(left.usageKey) - usageRevision(right.usageKey) ||
-            left.usageKey.localeCompare(right.usageKey)
-        );
+        candidates.sort(compareCandidates);
     }
 
     const usageByKey = new Map<string, TurnUsage>();
-    const latestAttributedIndexByTurn = new Map<number, number>();
-    const sortedEvents = [...events].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+    const eventKeysByUsageKey = new Map<string, string[]>();
+    const pendingByUsageKey = new Map(pending.map(item => [item.usageKey, item]));
 
-    for (const event of sortedEvents) {
+    for (const { event, eventKey } of identifiedEvents(events)) {
+        const claimedOwner = claimedEventOwners.get(eventKey);
+        if (claimedOwner) {
+            if (pendingByUsageKey.has(claimedOwner)) {
+                accumulateUsage(usageByKey, claimedOwner, event);
+                const ownedKeys = eventKeysByUsageKey.get(claimedOwner) ?? [];
+                ownedKeys.push(eventKey);
+                eventKeysByUsageKey.set(claimedOwner, ownedKeys);
+            }
+            continue;
+        }
+
         const at = Number(event.timestamp) + CLOCK_GRACE_MS;
         let turnStart: number | undefined;
         for (const start of starts) {
@@ -142,24 +199,31 @@ export function attributeUsageToPending(
             continue;
         }
 
-        accumulateUsage(usageByKey, candidates[targetIndex].usageKey, event);
-        latestAttributedIndexByTurn.set(
-            turnStart,
-            Math.max(latestAttributedIndexByTurn.get(turnStart) ?? -1, targetIndex)
-        );
+        const usageKey = candidates[targetIndex].usageKey;
+        accumulateUsage(usageByKey, usageKey, event);
+        const ownedKeys = eventKeysByUsageKey.get(usageKey) ?? [];
+        ownedKeys.push(eventKey);
+        eventKeysByUsageKey.set(usageKey, ownedKeys);
     }
 
     const settledKeys = new Set<string>(usageByKey.keys());
-    // If a later revision already has an event, earlier pending revisions with
-    // no separately identifiable event cannot be allowed to consume the same
-    // bucket on a later tick. Settle them without adding cost; the later event
-    // already preserves the exact composer total once.
-    for (const [turnStart, latestIndex] of latestAttributedIndexByTurn) {
-        const candidates = candidatesByTurn.get(turnStart) ?? [];
-        for (let index = 0; index <= latestIndex; index++) {
-            settledKeys.add(candidates[index].usageKey);
+    // Collapse only earlier edits from the same durable request chain. An
+    // unrelated request sharing the same millisecond must remain pending for
+    // its own event instead of being silently settled.
+    for (const targetKey of usageByKey.keys()) {
+        const target = pendingByUsageKey.get(targetKey);
+        if (!target) {
+            continue;
+        }
+        const chain = (candidatesByTurn.get(target.turnStartMs) ?? [])
+            .filter(candidate => requestChain(candidate) === requestChain(target))
+            .sort(compareCandidates);
+        for (const candidate of chain) {
+            if (compareCandidates(candidate, target) <= 0) {
+                settledKeys.add(candidate.usageKey);
+            }
         }
     }
 
-    return { usageByKey, settledKeys };
+    return { usageByKey, eventKeysByUsageKey, settledKeys };
 }

--- a/extensions/cursor/src/cursor/usageAttribution.ts
+++ b/extensions/cursor/src/cursor/usageAttribution.ts
@@ -1,0 +1,165 @@
+import { PendingUsage, TurnUsage } from '../interface';
+
+// The usage event is stamped when the request completes, so it always falls
+// after its own user bubble and before the next one. A grace window wider than
+// the gap between two turns makes a later turn swallow an earlier turn's event.
+const CLOCK_GRACE_MS = 0;
+
+export interface UsageEventDisplay {
+    timestamp: string;
+    model: string;
+    conversationId?: string;
+    chargedCents?: number;
+    tokenUsage?: {
+        inputTokens?: number;
+        outputTokens?: number;
+        cacheReadTokens?: number;
+        cacheWriteTokens?: number;
+    };
+}
+
+export interface PendingUsageAttribution {
+    usageByKey: Map<string, TurnUsage>;
+    settledKeys: Set<string>;
+}
+
+function accumulateUsage(
+    attributed: Map<string, TurnUsage>,
+    key: string,
+    event: UsageEventDisplay
+): void {
+    const accumulated = attributed.get(key) ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        chargedCents: 0,
+        requestCount: 0,
+        models: [],
+    };
+    const usage = event.tokenUsage ?? {};
+    accumulated.inputTokens += usage.inputTokens ?? 0;
+    accumulated.outputTokens += usage.outputTokens ?? 0;
+    accumulated.cacheReadTokens += usage.cacheReadTokens ?? 0;
+    accumulated.cacheWriteTokens += usage.cacheWriteTokens ?? 0;
+    accumulated.chargedCents += event.chargedCents ?? 0;
+    accumulated.requestCount += 1;
+    if (event.model && !accumulated.models.includes(event.model)) {
+        accumulated.models.push(event.model);
+    }
+    attributed.set(key, accumulated);
+}
+
+export function attributeUsageToTurns(
+    turnStartsMs: number[],
+    events: UsageEventDisplay[]
+): Map<number, TurnUsage> {
+    const byKey = new Map<string, TurnUsage>();
+    const sorted = [...events].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+
+    for (const event of sorted) {
+        const at = Number(event.timestamp) + CLOCK_GRACE_MS;
+        let turn = -1;
+        for (let index = 0; index < turnStartsMs.length; index++) {
+            if (turnStartsMs[index] > at) {
+                break;
+            }
+            turn = index;
+        }
+        if (turn >= 0) {
+            accumulateUsage(byKey, String(turn), event);
+        }
+    }
+
+    return new Map([...byKey].map(([key, usage]) => [Number(key), usage]));
+}
+
+function usageRevision(usageKey: string): number {
+    const parsed = Number(usageKey.split('\u0000').at(-1));
+    return Number.isFinite(parsed) ? parsed : 1;
+}
+
+function completionMarker(item: Pick<PendingUsage, 'turnStartMs' | 'turnEndMs'>): number {
+    return item.turnEndMs !== undefined && Number.isFinite(item.turnEndMs)
+        ? item.turnEndMs
+        : item.turnStartMs;
+}
+
+/**
+ * Partition Cursor usage events across pending revisions without sharing an
+ * event between usage keys. Revision completion times split edits that retain
+ * the original user-bubble timestamp. When Cursor exposes no finer identity,
+ * chronological assignment preserves the exact total cost once.
+ */
+export function attributeUsageToPending(
+    pending: Pick<PendingUsage, 'usageKey' | 'turnStartMs' | 'turnEndMs'>[],
+    turnStartsMs: number[],
+    events: UsageEventDisplay[]
+): PendingUsageAttribution {
+    const starts = [...new Set([
+        ...turnStartsMs,
+        ...pending.map(item => item.turnStartMs),
+    ])].sort((a, b) => a - b);
+    const candidatesByTurn = new Map<number, typeof pending>();
+    for (const item of pending) {
+        const candidates = candidatesByTurn.get(item.turnStartMs) ?? [];
+        candidates.push(item);
+        candidatesByTurn.set(item.turnStartMs, candidates);
+    }
+    for (const candidates of candidatesByTurn.values()) {
+        candidates.sort((left, right) =>
+            completionMarker(left) - completionMarker(right) ||
+            usageRevision(left.usageKey) - usageRevision(right.usageKey) ||
+            left.usageKey.localeCompare(right.usageKey)
+        );
+    }
+
+    const usageByKey = new Map<string, TurnUsage>();
+    const latestAttributedIndexByTurn = new Map<number, number>();
+    const sortedEvents = [...events].sort((a, b) => Number(a.timestamp) - Number(b.timestamp));
+
+    for (const event of sortedEvents) {
+        const at = Number(event.timestamp) + CLOCK_GRACE_MS;
+        let turnStart: number | undefined;
+        for (const start of starts) {
+            if (start > at) {
+                break;
+            }
+            turnStart = start;
+        }
+        if (turnStart === undefined) {
+            continue;
+        }
+
+        const candidates = candidatesByTurn.get(turnStart) ?? [];
+        let targetIndex = -1;
+        for (let index = 0; index < candidates.length; index++) {
+            if (completionMarker(candidates[index]) <= at) {
+                targetIndex = index;
+            }
+        }
+        if (targetIndex < 0) {
+            continue;
+        }
+
+        accumulateUsage(usageByKey, candidates[targetIndex].usageKey, event);
+        latestAttributedIndexByTurn.set(
+            turnStart,
+            Math.max(latestAttributedIndexByTurn.get(turnStart) ?? -1, targetIndex)
+        );
+    }
+
+    const settledKeys = new Set<string>(usageByKey.keys());
+    // If a later revision already has an event, earlier pending revisions with
+    // no separately identifiable event cannot be allowed to consume the same
+    // bucket on a later tick. Settle them without adding cost; the later event
+    // already preserves the exact composer total once.
+    for (const [turnStart, latestIndex] of latestAttributedIndexByTurn) {
+        const candidates = candidatesByTurn.get(turnStart) ?? [];
+        for (let index = 0; index <= latestIndex; index++) {
+            settledKeys.add(candidates[index].usageKey);
+        }
+    }
+
+    return { usageByKey, settledKeys };
+}

--- a/extensions/cursor/src/cursor/usageLedger.ts
+++ b/extensions/cursor/src/cursor/usageLedger.ts
@@ -1,4 +1,4 @@
-import { ForkCopyState, RequestLedgerEntry, TurnUsage } from '../interface';
+import { ForkCopyState, RequestLedger, RequestLedgerEntry, TurnUsage } from '../interface';
 import { aggregateTurnUsage } from './usageAggregation';
 
 export type UsageDelivery = ForkCopyState | RequestLedgerEntry;
@@ -44,10 +44,27 @@ export function hasAppliedUsage(delivery: UsageDelivery, usageKey: string): bool
         delivery.usageByRevision?.[COMPACTED_KEY] !== undefined;
 }
 
+export function recordUsageEventOwnership(
+    delivery: UsageDelivery,
+    usageKey: string,
+    eventKeys: string[]
+): boolean {
+    delivery.appliedUsageEvents ??= {};
+    let changed = false;
+    for (const eventKey of eventKeys) {
+        if (delivery.appliedUsageEvents[eventKey] !== usageKey) {
+            delivery.appliedUsageEvents[eventKey] = usageKey;
+            changed = true;
+        }
+    }
+    return changed;
+}
+
 export function recordAppliedUsage(
     delivery: UsageDelivery,
     usageKey: string,
-    usage: TurnUsage
+    usage: TurnUsage,
+    eventKeys: string[] = []
 ): TurnUsage {
     delivery.usageByRevision ??= {};
     delivery.appliedUsageKeys = [...new Set([
@@ -55,6 +72,34 @@ export function recordAppliedUsage(
         ...exactUsageKeys(delivery),
         usageKey,
     ])];
+    recordUsageEventOwnership(delivery, usageKey, eventKeys);
     delivery.usageByRevision[usageKey] = usage;
     return aggregateUsageByRevision(delivery.usageByRevision);
+}
+
+export function aggregateUsageWithRevision(
+    delivery: UsageDelivery,
+    usageKey: string,
+    usage: TurnUsage
+): TurnUsage {
+    return aggregateUsageByRevision({
+        ...(delivery.usageByRevision ?? {}),
+        [usageKey]: usage,
+    });
+}
+
+export function appliedUsageEventOwners(
+    ledger: RequestLedger,
+    composerId: string
+): Map<string, string> {
+    const owners = new Map<string, string>();
+    for (const entry of Object.values(ledger)) {
+        const delivery = entry.ownerComposerId === composerId
+            ? entry
+            : entry.forkCopies?.[composerId];
+        for (const [eventKey, usageKey] of Object.entries(delivery?.appliedUsageEvents ?? {})) {
+            owners.set(eventKey, usageKey);
+        }
+    }
+    return owners;
 }

--- a/extensions/cursor/src/cursor/usageLedger.ts
+++ b/extensions/cursor/src/cursor/usageLedger.ts
@@ -1,0 +1,60 @@
+import { ForkCopyState, RequestLedgerEntry, TurnUsage } from '../interface';
+import { aggregateTurnUsage } from './usageAggregation';
+
+export type UsageDelivery = ForkCopyState | RequestLedgerEntry;
+
+const COMPACTED_KEY = 'compacted';
+
+function revisionOrder(key: string): number {
+    if (key === COMPACTED_KEY) {
+        return Number.NEGATIVE_INFINITY;
+    }
+    const revision = Number(key.split('\u0000').at(-1));
+    return Number.isFinite(revision) ? revision : 0;
+}
+
+export function aggregateUsageByRevision(
+    usageByRevision: Record<string, TurnUsage>
+): TurnUsage {
+    const ordered = Object.entries(usageByRevision)
+        .sort(([left], [right]) =>
+            revisionOrder(left) - revisionOrder(right) || left.localeCompare(right)
+        )
+        .map(([, usage]) => usage);
+    return aggregateTurnUsage(ordered);
+}
+
+function exactUsageKeys(delivery: UsageDelivery): string[] {
+    return Object.keys(delivery.usageByRevision ?? {}).filter(key => key !== COMPACTED_KEY);
+}
+
+export function hasAppliedUsage(delivery: UsageDelivery, usageKey: string): boolean {
+    if (delivery.appliedUsageKeys?.includes(usageKey)) {
+        return true;
+    }
+    if (delivery.usageByRevision?.[usageKey]) {
+        return true;
+    }
+
+    // Builds briefly shipped during development with a compacted aggregate but
+    // without the exact acknowledgement keys. A completed delivery plus that
+    // aggregate means a surviving queue entry is a removal retry, not new cost.
+    return delivery.usageStatus === 'complete' &&
+        delivery.appliedUsageKeys === undefined &&
+        delivery.usageByRevision?.[COMPACTED_KEY] !== undefined;
+}
+
+export function recordAppliedUsage(
+    delivery: UsageDelivery,
+    usageKey: string,
+    usage: TurnUsage
+): TurnUsage {
+    delivery.usageByRevision ??= {};
+    delivery.appliedUsageKeys = [...new Set([
+        ...(delivery.appliedUsageKeys ?? []),
+        ...exactUsageKeys(delivery),
+        usageKey,
+    ])];
+    delivery.usageByRevision[usageKey] = usage;
+    return aggregateUsageByRevision(delivery.usageByRevision);
+}

--- a/extensions/cursor/src/cursor/usageLedger.ts
+++ b/extensions/cursor/src/cursor/usageLedger.ts
@@ -5,6 +5,15 @@ export type UsageDelivery = ForkCopyState | RequestLedgerEntry;
 
 const COMPACTED_KEY = 'compacted';
 
+export function usageDeliveryForComposer(
+    entry: RequestLedgerEntry,
+    composerId: string
+): UsageDelivery | undefined {
+    return entry.ownerComposerId === composerId
+        ? entry
+        : entry.forkCopies?.[composerId];
+}
+
 function revisionOrder(key: string): number {
     if (key === COMPACTED_KEY) {
         return Number.NEGATIVE_INFINITY;
@@ -94,9 +103,7 @@ export function appliedUsageEventOwners(
 ): Map<string, string> {
     const owners = new Map<string, string>();
     for (const entry of Object.values(ledger)) {
-        const delivery = entry.ownerComposerId === composerId
-            ? entry
-            : entry.forkCopies?.[composerId];
+        const delivery = usageDeliveryForComposer(entry, composerId);
         for (const [eventKey, usageKey] of Object.entries(delivery?.appliedUsageEvents ?? {})) {
             owners.set(eventKey, usageKey);
         }

--- a/extensions/cursor/src/cursor/usageQueue.ts
+++ b/extensions/cursor/src/cursor/usageQueue.ts
@@ -11,7 +11,9 @@ function nonEmptyString(value: unknown): value is string {
 }
 
 function hasDurableUsageKey(value: unknown): value is string {
-    return nonEmptyString(value) && value.split('\u0000').length >= 5;
+    return nonEmptyString(value) &&
+        !value.startsWith('legacy\u0000') &&
+        value.split('\u0000').length >= 5;
 }
 
 function legacyCompatibilityKey(item: Partial<PendingUsage>): string | undefined {
@@ -32,7 +34,8 @@ function legacyCompatibilityKey(item: Partial<PendingUsage>): string | undefined
 }
 
 function isLegacyCompatibilityItem(item: Partial<PendingUsage>): boolean {
-    return !hasDurableUsageKey(item.usageKey) ||
+    return item.usageKey?.startsWith('legacy\u0000') === true ||
+        !hasDurableUsageKey(item.usageKey) ||
         item.requestKey?.startsWith('legacy\u0000') === true;
 }
 

--- a/extensions/cursor/src/cursor/usageQueue.ts
+++ b/extensions/cursor/src/cursor/usageQueue.ts
@@ -1,0 +1,43 @@
+import { PendingUsage } from '../interface';
+
+type UsageTurn = Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>;
+
+function fallbackIdentity(item: Pick<PendingUsage, 'composerId' | 'turnStartMs'>): string {
+    return `${item.composerId}:${item.turnStartMs}`;
+}
+
+/** Merge new work while upgrading legacy records that predate usageKey. */
+export function mergePendingUsage(
+    pending: PendingUsage[],
+    turns: UsageTurn[],
+    now: number
+): PendingUsage[] {
+    const merged = [...pending];
+
+    for (const turn of turns) {
+        const index = merged.findIndex(item =>
+            (item.usageKey && item.usageKey === turn.usageKey) ||
+            ((!item.usageKey || item.usageKey.split('\u0000').length < 5) &&
+                fallbackIdentity(item) === fallbackIdentity(turn))
+        );
+        if (index >= 0) {
+            const previous = merged[index];
+            // Fill the request-ledger fields on upgraded records so usage is
+            // aggregated through the same delivery rather than patched twice.
+            merged[index] = {
+                ...previous,
+                ...turn,
+                attempt: previous.attempt ?? 0,
+                nextAttemptAt: previous.nextAttemptAt ?? now,
+            };
+            continue;
+        }
+        merged.push({
+            ...turn,
+            attempt: 0,
+            nextAttemptAt: now,
+        });
+    }
+
+    return merged;
+}

--- a/extensions/cursor/src/cursor/usageQueue.ts
+++ b/extensions/cursor/src/cursor/usageQueue.ts
@@ -6,6 +6,69 @@ function fallbackIdentity(item: Pick<PendingUsage, 'composerId' | 'turnStartMs'>
     return `${item.composerId}:${item.turnStartMs}`;
 }
 
+function nonEmptyString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0;
+}
+
+function hasDurableUsageKey(value: unknown): value is string {
+    return nonEmptyString(value) && value.split('\u0000').length >= 5;
+}
+
+function legacyCompatibilityKey(item: Partial<PendingUsage>): string | undefined {
+    if (!nonEmptyString(item.composerId) ||
+        !Number.isFinite(item.turnStartMs) ||
+        !nonEmptyString(item.traceId) ||
+        !nonEmptyString(item.spanId)) {
+        return undefined;
+    }
+    return [
+        'legacy',
+        item.projectName ?? 'default',
+        item.composerId,
+        String(item.turnStartMs),
+        item.traceId,
+        item.spanId,
+    ].join('\u0000');
+}
+
+function isLegacyCompatibilityItem(item: Partial<PendingUsage>): boolean {
+    return !hasDurableUsageKey(item.usageKey) ||
+        item.requestKey?.startsWith('legacy\u0000') === true;
+}
+
+function normalizeLegacyPending(item: PendingUsage, now: number): PendingUsage {
+    const compatibilityKey = legacyCompatibilityKey(item);
+    if (!compatibilityKey) {
+        return item;
+    }
+    return {
+        ...item,
+        usageKey: hasDurableUsageKey(item.usageKey)
+            ? item.usageKey
+            : `${compatibilityKey}\u00001`,
+        requestId: nonEmptyString(item.requestId) ? item.requestId : compatibilityKey,
+        requestKey: nonEmptyString(item.requestKey) ? item.requestKey : compatibilityKey,
+        turnStartsMs: Array.isArray(item.turnStartsMs) && item.turnStartsMs.length > 0
+            ? item.turnStartsMs
+            : [item.turnStartMs],
+        attempt: Number.isFinite(item.attempt) ? item.attempt : 0,
+        nextAttemptAt: Number.isFinite(item.nextAttemptAt) ? item.nextAttemptAt : now,
+    };
+}
+
+export function canAttributePendingUsage(
+    item: Partial<PendingUsage>
+): item is PendingUsage {
+    return nonEmptyString(item.usageKey) &&
+        nonEmptyString(item.requestKey) &&
+        nonEmptyString(item.composerId) &&
+        Number.isFinite(item.turnStartMs) &&
+        nonEmptyString(item.traceId) &&
+        nonEmptyString(item.spanId) &&
+        Number.isFinite(item.attempt) &&
+        Number.isFinite(item.nextAttemptAt);
+}
+
 /** Merge new work while upgrading legacy records that predate usageKey. */
 export function mergePendingUsage(
     pending: PendingUsage[],
@@ -17,7 +80,7 @@ export function mergePendingUsage(
     for (const turn of turns) {
         const index = merged.findIndex(item =>
             (item.usageKey && item.usageKey === turn.usageKey) ||
-            ((!item.usageKey || item.usageKey.split('\u0000').length < 5) &&
+            (isLegacyCompatibilityItem(item) &&
                 fallbackIdentity(item) === fallbackIdentity(turn))
         );
         if (index >= 0) {
@@ -39,7 +102,7 @@ export function mergePendingUsage(
         });
     }
 
-    return merged;
+    return merged.map(item => normalizeLegacyPending(item, now));
 }
 
 export function shouldKeepPendingUsage(applyFailed: boolean, settled: boolean): boolean {

--- a/extensions/cursor/src/cursor/usageQueue.ts
+++ b/extensions/cursor/src/cursor/usageQueue.ts
@@ -41,3 +41,7 @@ export function mergePendingUsage(
 
     return merged;
 }
+
+export function shouldKeepPendingUsage(applyFailed: boolean, settled: boolean): boolean {
+    return applyFailed || !settled;
+}

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -46,10 +46,12 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(configChangeListener);
 
     // Register reset command
-    const resetCommand = vscode.commands.registerCommand('opik.resetState', () => {
-      resetExtensionState(context);
-      vscode.window.showInformationMessage('Opik: Extension state has been reset. Recent conversations will be re-synced.');
-      console.log('🔄 Extension state reset - will re-sync recent conversations');
+    const resetCommand = vscode.commands.registerCommand('opik.resetState', async () => {
+      await resetExtensionState(context);
+      vscode.window.showInformationMessage(
+        'Opik: Sync cursor reset. Sent-request and pending-cost tracking were retained to prevent duplicates.'
+      );
+      console.log('🔄 Sync cursor reset; durable request delivery state retained');
     });
     context.subscriptions.push(resetCommand);
 

--- a/extensions/cursor/src/extension.ts
+++ b/extensions/cursor/src/extension.ts
@@ -7,12 +7,14 @@ import { CursorService } from './cursor/cursorService';
 import { initializeSentry, captureException } from './sentry';
 import { MCPService } from './mcp/mcpService';
 import { updateStatusBar, showInitialApiKeyWarning } from './ui';
-import { resetExtensionState } from './state';
+import { getOrCreateAutomaticTraceCutoffAt, resetExtensionState } from './state';
 
-export function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext) {
   // Get or create user UUID for tracking
   const userId = getOrCreateUUID(context);
   const mcpService = new MCPService(context);
+  const cursorService = new CursorService(context);
+  const automaticTraceCutoffAt = await getOrCreateAutomaticTraceCutoffAt(context);
 
   // Initialize Sentry with user context
   initializeSentry(context, userId);
@@ -55,6 +57,29 @@ export function activate(context: vscode.ExtensionContext) {
     });
     context.subscriptions.push(resetCommand);
 
+    const importHistoricalCommand = vscode.commands.registerCommand('opik.importHistoricalTraces', async () => {
+      const apiKey = getOpikApiKey();
+      if (!apiKey) {
+        showInitialApiKeyWarning(context);
+        return;
+      }
+
+      const VSInstallationPath = getDefaultVSCodeUserDataPath(context);
+      const count = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Opik: Importing historical Cursor traces',
+          cancellable: false,
+        },
+        () => cursorService.processCursorTraces(apiKey, VSInstallationPath, {
+          includeHistorical: true,
+          automaticCutoffAt: automaticTraceCutoffAt,
+        })
+      );
+      vscode.window.showInformationMessage(`Opik: Imported ${count} historical Cursor trace(s).`);
+    });
+    context.subscriptions.push(importHistoricalCommand);
+
     const opikConfigPath = path.join(os.homedir(), '.opik.config');
     if (fs.existsSync(opikConfigPath)) {
       const configWatcher = fs.watch(opikConfigPath, async (eventType) => {
@@ -70,8 +95,6 @@ export function activate(context: vscode.ExtensionContext) {
     
     // Main processing loop
     let logAPIKeyBIEvent = true;
-    const cursorService = new CursorService(context);
-
     const interval = setInterval(async () => {
       try {
         const apiKey = getOpikApiKey();
@@ -82,7 +105,11 @@ export function activate(context: vscode.ExtensionContext) {
         }
         
         const VSInstallationPath = getDefaultVSCodeUserDataPath(context);
-        const numberOfCursorTracesLogged = await cursorService.processCursorTraces(apiKey, VSInstallationPath);
+        const numberOfCursorTracesLogged = await cursorService.processCursorTraces(
+          apiKey,
+          VSInstallationPath,
+          { automaticCutoffAt: automaticTraceCutoffAt }
+        );
 
         console.log(`Number of Cursor traces logged: ${numberOfCursorTracesLogged}`);
         console.log('Finished loop');

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -15,6 +15,7 @@ export interface Session {
 }
 
 export interface SpanData {
+    id?: string;
     name: string;
     type: 'llm' | 'tool' | 'general';
     startTime: Date;
@@ -29,11 +30,20 @@ export interface SpanData {
 }
 
 export interface TraceData {
+    id: string;
+    root_span_id: string;
+    request_id: string;
+    request_key: string;
+    upload_kind: 'canonical' | 'fork_copy' | 'edit_revision' | 'fork_edit_revision';
+    revision: number;
+    usage_key: string;
+    cost_owner: boolean;
     name: string;
     project_name?: string;
     start_time: string; // ISO 8601 format
     end_time?: string; // ISO 8601 format
     turn_start_ms: number;
+    turn_starts_ms: number[];
     model?: string;
     input: any;
     output: any;
@@ -54,11 +64,55 @@ export interface TurnUsage {
 }
 
 export interface PendingUsage {
+    usageKey: string;
+    requestId: string;
+    requestKey: string;
     composerId: string;
     turnStartMs: number;
+    turnStartsMs: number[];
     traceId: string;
     spanId: string;
     projectName: string;
     attempt: number;
     nextAttemptAt: number;
 }
+
+export type UploadStatus = 'pending' | 'uploaded';
+export type UsageStatus = 'disabled' | 'pending' | 'complete';
+
+export interface ForkCopyState {
+    traceId: string;
+    rootSpanId: string;
+    status: UploadStatus;
+    fingerprint?: string;
+    latestTurnStartMs?: number;
+    originalTurnStartMs?: number;
+    revision?: number;
+    usageStatus?: UsageStatus;
+    usageByRevision?: Record<string, TurnUsage>;
+}
+
+/**
+ * Durable identity and delivery state for one logical Cursor request.
+ *
+ * The request key includes the Opik project. Cursor's requestId is stable when
+ * a composer is forked, while bubble and composer ids are not.
+ */
+export interface RequestLedgerEntry {
+    requestId: string;
+    projectName: string;
+    ownerComposerId: string;
+    turnStartMs: number;
+    canonicalTraceId: string;
+    canonicalRootSpanId: string;
+    canonicalStatus: UploadStatus;
+    usageStatus: UsageStatus;
+    canonicalFingerprint?: string;
+    latestTurnStartMs?: number;
+    canonicalRevision?: number;
+    usageByRevision?: Record<string, TurnUsage>;
+    forkCopies: Record<string, ForkCopyState>;
+    lastSeenAt: number;
+}
+
+export type RequestLedger = Record<string, RequestLedgerEntry>;

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -44,6 +44,8 @@ export interface TraceData {
     end_time?: string; // ISO 8601 format
     turn_start_ms: number;
     turn_starts_ms: number[];
+    canonical_thread_id?: string;
+    canonical_turn_start_ms?: number;
     model?: string;
     input: any;
     output: any;
@@ -77,7 +79,7 @@ export interface PendingUsage {
     nextAttemptAt: number;
 }
 
-export type UploadStatus = 'pending' | 'uploaded';
+export type UploadStatus = 'pending' | 'uploaded' | 'excluded';
 export type UsageStatus = 'disabled' | 'pending' | 'complete';
 
 export interface ForkCopyState {

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -94,6 +94,7 @@ export interface ForkCopyState {
     usageStatus?: UsageStatus;
     usageByRevision?: Record<string, TurnUsage>;
     appliedUsageKeys?: string[];
+    appliedUsageEvents?: Record<string, string>;
 }
 
 /**
@@ -116,6 +117,7 @@ export interface RequestLedgerEntry {
     canonicalRevision?: number;
     usageByRevision?: Record<string, TurnUsage>;
     appliedUsageKeys?: string[];
+    appliedUsageEvents?: Record<string, string>;
     forkCopies: Record<string, ForkCopyState>;
     lastSeenAt: number;
 }

--- a/extensions/cursor/src/interface.ts
+++ b/extensions/cursor/src/interface.ts
@@ -71,6 +71,7 @@ export interface PendingUsage {
     requestKey: string;
     composerId: string;
     turnStartMs: number;
+    turnEndMs?: number;
     turnStartsMs: number[];
     traceId: string;
     spanId: string;
@@ -92,6 +93,7 @@ export interface ForkCopyState {
     revision?: number;
     usageStatus?: UsageStatus;
     usageByRevision?: Record<string, TurnUsage>;
+    appliedUsageKeys?: string[];
 }
 
 /**
@@ -113,6 +115,7 @@ export interface RequestLedgerEntry {
     latestTurnStartMs?: number;
     canonicalRevision?: number;
     usageByRevision?: Record<string, TurnUsage>;
+    appliedUsageKeys?: string[];
     forkCopies: Record<string, ForkCopyState>;
     lastSeenAt: number;
 }

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -2,8 +2,7 @@ import * as vscode from 'vscode';
 import { PendingUsage, TraceData, TurnUsage } from './interface';
 import { captureException } from './sentry';
 import { latestUsageModel } from './cursor/usageAggregation';
-
-type LoggedTurn = Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>;
+import { deliverTracesWithClient, LoggedTurn } from './cursor/traceDelivery';
 
 async function createClient(apiKey: string) {
     const config = vscode.workspace.getConfiguration();
@@ -16,172 +15,16 @@ async function createClient(apiKey: string) {
     });
 }
 
-function isRevision(trace: TraceData): boolean {
-    return trace.upload_kind === 'edit_revision' || trace.upload_kind === 'fork_edit_revision';
-}
-
-async function updateTraceRevision(
-    client: Awaited<ReturnType<typeof createClient>>,
-    traceData: TraceData,
-    metadata: Record<string, unknown>
-): Promise<void> {
-    const projectName = traceData.project_name ?? 'default';
-
-    // Keep the original trace/root start time and UUIDv7 table position. The
-    // latest edited input/output and end time replace the visible turn data.
-    await client.api.traces.updateTrace(traceData.id, {
-        body: {
-            projectName,
-            name: traceData.name,
-            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-            input: traceData.input,
-            output: traceData.output,
-            metadata,
-            tags: traceData.tags,
-            threadId: traceData.thread_id,
-        },
-    });
-
-    await client.api.spans.updateSpan(traceData.root_span_id, {
-        body: {
-            traceId: traceData.id,
-            projectName,
-            name: 'llm_turn',
-            type: 'llm',
-            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-            model: traceData.model,
-            provider: 'cursor',
-            input: traceData.input,
-            output: traceData.output,
-            metadata: traceData.metadata,
-            tags: traceData.tags,
-        },
-    });
-
-    // Revision children are appended as an audit trail. Their UUIDv7 values
-    // embed the actual edit-event times, while the root remains a single turn.
-    if (traceData.spans && traceData.spans.length > 0) {
-        await client.api.spans.createSpans({
-            spans: traceData.spans.map(child => ({
-                id: child.id,
-                traceId: traceData.id,
-                parentSpanId: traceData.root_span_id,
-                projectName,
-                name: child.name,
-                type: child.type,
-                model: child.model,
-                provider: child.provider,
-                input: child.input,
-                output: child.output,
-                errorInfo: child.errorInfo,
-                startTime: child.startTime,
-                endTime: child.endTime,
-                tags: child.tags,
-                metadata: {
-                    ...(child.metadata ?? {}),
-                    edit_revision: traceData.revision,
-                    revision_turn_start_ms: traceData.turn_start_ms,
-                },
-            })),
-        });
-    }
-}
-
 export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Promise<LoggedTurn[]> {
     if (traces.length === 0) {
         return [];
     }
 
     console.log(`📦 Processing ${traces.length} traces using Opik SDK`);
-    const loggedTurns: LoggedTurn[] = [];
-
     try {
         const client = await createClient(apiKey);
-
-        for (const traceData of traces) {
-            const metadata = {
-                ...(traceData.metadata || {}),
-                created_from: "cursor-extension"
-            };
-
-            if (isRevision(traceData)) {
-                await updateTraceRevision(client, traceData, metadata);
-            } else {
-                const trace = client.trace({
-                    id: traceData.id,
-                    name: traceData.name,
-                    projectName: traceData.project_name,
-                    input: traceData.input,
-                    output: traceData.output,
-                    startTime: new Date(traceData.start_time),
-                    endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-                    tags: traceData.tags,
-                    metadata: metadata,
-                    threadId: traceData.thread_id
-                });
-
-                // The span is created without usage. Cursor only exposes token
-                // counts a few seconds later, so UsageEnricher patches it.
-                // This root carries the whole turn usage because Cursor bills
-                // once per turn rather than once per model-call child span.
-                const span = trace.span({
-                    id: traceData.root_span_id,
-                    name: 'llm_turn',
-                    type: 'llm',
-                    model: traceData.model,
-                    provider: 'cursor',
-                    input: traceData.input,
-                    output: traceData.output,
-                    startTime: new Date(traceData.start_time),
-                    endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-                    tags: traceData.tags,
-                    metadata: traceData.metadata
-                });
-
-                for (const child of traceData.spans ?? []) {
-                    trace.span({
-                        id: child.id,
-                        parentSpanId: traceData.root_span_id,
-                        name: child.name,
-                        type: child.type,
-                        model: child.model,
-                        provider: child.provider,
-                        input: child.input,
-                        output: child.output,
-                        errorInfo: child.errorInfo,
-                        startTime: child.startTime,
-                        endTime: child.endTime,
-                        tags: child.tags,
-                        metadata: child.metadata
-                    });
-                }
-            }
-            // Deliberately not calling span.end()/trace.end(): both overwrite
-            // endTime with the current time, which would replace the real Cursor
-            // turn end with the upload time.
-
-            // Plain fork copies are cost-excluded. Canonical turns and edited
-            // fork revisions own the usage generated in their own composer.
-            if (traceData.thread_id && traceData.cost_owner) {
-                loggedTurns.push({
-                    usageKey: traceData.usage_key,
-                    requestId: traceData.request_id,
-                    requestKey: traceData.request_key,
-                    composerId: traceData.thread_id,
-                    turnStartMs: traceData.turn_start_ms,
-                    turnEndMs: traceData.end_time
-                        ? new Date(traceData.end_time).getTime()
-                        : undefined,
-                    turnStartsMs: traceData.turn_starts_ms,
-                    traceId: traceData.id,
-                    spanId: traceData.root_span_id,
-                    projectName: traceData.project_name ?? 'default',
-                });
-            }
-        }
-
         console.log(`📤 Flushing ${traces.length} traces to Opik`);
-        await client.flush();
+        const loggedTurns = await deliverTracesWithClient(client, traces);
         console.log(`🎉 All ${traces.length} traces processed successfully using Opik SDK!`);
 
         return loggedTurns;

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -15,6 +15,77 @@ async function createClient(apiKey: string) {
     });
 }
 
+function isRevision(trace: TraceData): boolean {
+    return trace.upload_kind === 'edit_revision' || trace.upload_kind === 'fork_edit_revision';
+}
+
+async function updateTraceRevision(
+    client: Awaited<ReturnType<typeof createClient>>,
+    traceData: TraceData,
+    metadata: Record<string, unknown>
+): Promise<void> {
+    const projectName = traceData.project_name ?? 'default';
+
+    // Keep the original trace/root start time and UUIDv7 table position. The
+    // latest edited input/output and end time replace the visible turn data.
+    await client.api.traces.updateTrace(traceData.id, {
+        body: {
+            projectName,
+            name: traceData.name,
+            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+            input: traceData.input,
+            output: traceData.output,
+            metadata,
+            tags: traceData.tags,
+            threadId: traceData.thread_id,
+        },
+    });
+
+    await client.api.spans.updateSpan(traceData.root_span_id, {
+        body: {
+            traceId: traceData.id,
+            projectName,
+            name: 'llm_turn',
+            type: 'llm',
+            endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+            model: traceData.model,
+            provider: 'cursor',
+            input: traceData.input,
+            output: traceData.output,
+            metadata: traceData.metadata,
+            tags: traceData.tags,
+        },
+    });
+
+    // Revision children are appended as an audit trail. Their UUIDv7 values
+    // embed the actual edit-event times, while the root remains a single turn.
+    if (traceData.spans && traceData.spans.length > 0) {
+        await client.api.spans.createSpans({
+            spans: traceData.spans.map(child => ({
+                id: child.id,
+                traceId: traceData.id,
+                parentSpanId: traceData.root_span_id,
+                projectName,
+                name: child.name,
+                type: child.type,
+                model: child.model,
+                provider: child.provider,
+                input: child.input,
+                output: child.output,
+                errorInfo: child.errorInfo,
+                startTime: child.startTime,
+                endTime: child.endTime,
+                tags: child.tags,
+                metadata: {
+                    ...(child.metadata ?? {}),
+                    edit_revision: traceData.revision,
+                    revision_turn_start_ms: traceData.turn_start_ms,
+                },
+            })),
+        });
+    }
+}
+
 export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Promise<LoggedTurn[]> {
     if (traces.length === 0) {
         return [];
@@ -32,65 +103,74 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
                 created_from: "cursor-extension"
             };
 
-            const trace = client.trace({
-                name: traceData.name,
-                projectName: traceData.project_name,
-                input: traceData.input,
-                output: traceData.output,
-                startTime: new Date(traceData.start_time),
-                endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-                tags: traceData.tags,
-                metadata: metadata,
-                threadId: traceData.thread_id
-            });
-
-            // The span is created without usage. Cursor only exposes token counts
-            // a few seconds later over its usage API, so UsageEnricher patches it.
-            //
-            // This one span carries the usage of the whole turn on purpose.
-            // Cursor records tokens once per turn, never per model call: only
-            // 477 of 19691 bubbles in a real database hold a non-zero
-            // tokenCount, always the last bubble of a turn, and the billing API
-            // reports one request per turn too. Splitting that total across the
-            // child llm spans would invent numbers.
-            const span = trace.span({
-                name: 'llm_turn',
-                type: 'llm',
-                model: traceData.model,
-                provider: 'cursor',
-                input: traceData.input,
-                output: traceData.output,
-                startTime: new Date(traceData.start_time),
-                endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
-                tags: traceData.tags,
-                metadata: traceData.metadata
-            });
-
-            for (const child of traceData.spans ?? []) {
-                span.span({
-                    name: child.name,
-                    type: child.type,
-                    model: child.model,
-                    provider: child.provider,
-                    input: child.input,
-                    output: child.output,
-                    errorInfo: child.errorInfo,
-                    startTime: child.startTime,
-                    endTime: child.endTime,
-                    tags: child.tags,
-                    metadata: child.metadata
+            if (isRevision(traceData)) {
+                await updateTraceRevision(client, traceData, metadata);
+            } else {
+                const trace = client.trace({
+                    id: traceData.id,
+                    name: traceData.name,
+                    projectName: traceData.project_name,
+                    input: traceData.input,
+                    output: traceData.output,
+                    startTime: new Date(traceData.start_time),
+                    endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+                    tags: traceData.tags,
+                    metadata: metadata,
+                    threadId: traceData.thread_id
                 });
+
+                // The span is created without usage. Cursor only exposes token
+                // counts a few seconds later, so UsageEnricher patches it.
+                // This root carries the whole turn usage because Cursor bills
+                // once per turn rather than once per model-call child span.
+                const span = trace.span({
+                    id: traceData.root_span_id,
+                    name: 'llm_turn',
+                    type: 'llm',
+                    model: traceData.model,
+                    provider: 'cursor',
+                    input: traceData.input,
+                    output: traceData.output,
+                    startTime: new Date(traceData.start_time),
+                    endTime: traceData.end_time ? new Date(traceData.end_time) : undefined,
+                    tags: traceData.tags,
+                    metadata: traceData.metadata
+                });
+
+                for (const child of traceData.spans ?? []) {
+                    trace.span({
+                        id: child.id,
+                        parentSpanId: traceData.root_span_id,
+                        name: child.name,
+                        type: child.type,
+                        model: child.model,
+                        provider: child.provider,
+                        input: child.input,
+                        output: child.output,
+                        errorInfo: child.errorInfo,
+                        startTime: child.startTime,
+                        endTime: child.endTime,
+                        tags: child.tags,
+                        metadata: child.metadata
+                    });
+                }
             }
             // Deliberately not calling span.end()/trace.end(): both overwrite
             // endTime with the current time, which would replace the real Cursor
             // turn end with the upload time.
 
-            if (traceData.thread_id) {
+            // Plain fork copies are cost-excluded. Canonical turns and edited
+            // fork revisions own the usage generated in their own composer.
+            if (traceData.thread_id && traceData.cost_owner) {
                 loggedTurns.push({
+                    usageKey: traceData.usage_key,
+                    requestId: traceData.request_id,
+                    requestKey: traceData.request_key,
                     composerId: traceData.thread_id,
                     turnStartMs: traceData.turn_start_ms,
-                    traceId: trace.data.id,
-                    spanId: span.data.id,
+                    turnStartsMs: traceData.turn_starts_ms,
+                    traceId: traceData.id,
+                    spanId: traceData.root_span_id,
                     projectName: traceData.project_name ?? 'default',
                 });
             }

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { PendingUsage, TraceData, TurnUsage } from './interface';
 import { captureException } from './sentry';
+import { latestUsageModel } from './cursor/usageAggregation';
 
 type LoggedTurn = Omit<PendingUsage, 'attempt' | 'nextAttemptAt'>;
 
@@ -222,7 +223,7 @@ export async function applyTurnUsage(
         body: {
             traceId: pending.traceId,
             projectName: pending.projectName,
-            model: usage.models[0],
+            model: latestUsageModel(usage),
             provider: 'cursor',
             usage: spanUsage,
             totalEstimatedCost: usage.chargedCents / 100,

--- a/extensions/cursor/src/opik.ts
+++ b/extensions/cursor/src/opik.ts
@@ -169,6 +169,9 @@ export async function logTracesToOpik(apiKey: string, traces: TraceData[]): Prom
                     requestKey: traceData.request_key,
                     composerId: traceData.thread_id,
                     turnStartMs: traceData.turn_start_ms,
+                    turnEndMs: traceData.end_time
+                        ? new Date(traceData.end_time).getTime()
+                        : undefined,
                     turnStartsMs: traceData.turn_starts_ms,
                     traceId: traceData.id,
                     spanId: traceData.root_span_id,

--- a/extensions/cursor/src/state.ts
+++ b/extensions/cursor/src/state.ts
@@ -39,6 +39,28 @@ export function updateLastSyncedAt(context: vscode.ExtensionContext, timestamp: 
   return context.globalState.update('lastSyncedAt', timestamp);
 }
 
+/**
+ * The first turn normal polling is allowed to upload.
+ *
+ * New installations start at activation time, so existing Cursor history is
+ * imported only through the explicit command. Upgrades start at the last
+ * successful poll, preserving turns created while the previous build was
+ * inactive without replaying conversations it already handled.
+ */
+export async function getOrCreateAutomaticTraceCutoffAt(
+  context: vscode.ExtensionContext
+): Promise<number> {
+  const stored = context.globalState.get<number>('automaticTraceCutoffAt');
+  if (stored !== undefined) {
+    return stored;
+  }
+
+  const previousSync = context.globalState.get<number>('lastSyncedAt');
+  const cutoff = previousSync ?? Date.now();
+  await context.globalState.update('automaticTraceCutoffAt', cutoff);
+  return cutoff;
+}
+
 export function getPendingUsage(context: vscode.ExtensionContext): PendingUsage[] {
   return context.globalState.get<PendingUsage[]>('pendingUsage', []);
 }

--- a/extensions/cursor/src/state.ts
+++ b/extensions/cursor/src/state.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { PendingUsage, RequestLedger, SessionInfo } from './interface';
+import { compactRequestLedger } from './cursor/ledgerRetention';
+import { resolveAutomaticTraceCutoff } from './cursor/stateMigration';
 
 export function getSessionInfo(context: vscode.ExtensionContext): Record<string, SessionInfo> {
   return context.globalState.get<Record<string, SessionInfo>>('sessionInfo', {});
@@ -56,7 +58,8 @@ export async function getOrCreateAutomaticTraceCutoffAt(
   }
 
   const previousSync = context.globalState.get<number>('lastSyncedAt');
-  const cutoff = previousSync ?? Date.now();
+  const legacySync = context.globalState.get<number | null>('lastSyncTime', null);
+  const cutoff = resolveAutomaticTraceCutoff(previousSync, legacySync, Date.now());
   await context.globalState.update('automaticTraceCutoffAt', cutoff);
   return cutoff;
 }
@@ -74,7 +77,7 @@ export function getRequestLedger(context: vscode.ExtensionContext): RequestLedge
 }
 
 export function updateRequestLedger(context: vscode.ExtensionContext, ledger: RequestLedger): Thenable<void> {
-  return context.globalState.update('requestLedger', ledger);
+  return context.globalState.update('requestLedger', compactRequestLedger(ledger));
 }
 
 export async function resetExtensionState(context: vscode.ExtensionContext): Promise<void> {

--- a/extensions/cursor/src/state.ts
+++ b/extensions/cursor/src/state.ts
@@ -1,24 +1,24 @@
 import * as vscode from 'vscode';
-import { PendingUsage, SessionInfo } from './interface';
+import { PendingUsage, RequestLedger, SessionInfo } from './interface';
 
 export function getSessionInfo(context: vscode.ExtensionContext): Record<string, SessionInfo> {
   return context.globalState.get<Record<string, SessionInfo>>('sessionInfo', {});
 }
 
-export function resetGlobalState(context: vscode.ExtensionContext) {
-  context.globalState.update('sessionInfo', undefined);
+export function resetGlobalState(context: vscode.ExtensionContext): Thenable<void> {
+  return context.globalState.update('sessionInfo', undefined);
 }
 
-export function updateSessionInfo(context: vscode.ExtensionContext, sessionInfo: Record<string, SessionInfo>) {
-  context.globalState.update('sessionInfo', sessionInfo);
+export function updateSessionInfo(context: vscode.ExtensionContext, sessionInfo: Record<string, SessionInfo>): Thenable<void> {
+  return context.globalState.update('sessionInfo', sessionInfo);
 }
 
 export function getLastSyncTime(context: vscode.ExtensionContext): number | null {
   return context.globalState.get<number | null>('lastSyncTime', null);
 }
 
-export function updateLastSyncTime(context: vscode.ExtensionContext, time: number) {
-  context.globalState.update('lastSyncTime', time);
+export function updateLastSyncTime(context: vscode.ExtensionContext, time: number): Thenable<void> {
+  return context.globalState.update('lastSyncTime', time);
 }
 
 export function getLastSyncedAt(context: vscode.ExtensionContext): number {
@@ -35,21 +35,30 @@ export function getLastSyncedAt(context: vscode.ExtensionContext): number {
   return storedValue;
 }
 
-export function updateLastSyncedAt(context: vscode.ExtensionContext, timestamp: number) {
-  context.globalState.update('lastSyncedAt', timestamp);
+export function updateLastSyncedAt(context: vscode.ExtensionContext, timestamp: number): Thenable<void> {
+  return context.globalState.update('lastSyncedAt', timestamp);
 }
 
 export function getPendingUsage(context: vscode.ExtensionContext): PendingUsage[] {
   return context.globalState.get<PendingUsage[]>('pendingUsage', []);
 }
 
-export function updatePendingUsage(context: vscode.ExtensionContext, pending: PendingUsage[]) {
-  context.globalState.update('pendingUsage', pending);
+export function updatePendingUsage(context: vscode.ExtensionContext, pending: PendingUsage[]): Thenable<void> {
+  return context.globalState.update('pendingUsage', pending);
 }
 
-export function resetExtensionState(context: vscode.ExtensionContext) {
-  context.globalState.update('sessionInfo', undefined);
-  context.globalState.update('lastSyncTime', null);
-  context.globalState.update('lastSyncedAt', undefined);
-  context.globalState.update('pendingUsage', undefined);
+export function getRequestLedger(context: vscode.ExtensionContext): RequestLedger {
+  return context.globalState.get<RequestLedger>('requestLedger', {});
+}
+
+export function updateRequestLedger(context: vscode.ExtensionContext, ledger: RequestLedger): Thenable<void> {
+  return context.globalState.update('requestLedger', ledger);
+}
+
+export async function resetExtensionState(context: vscode.ExtensionContext): Promise<void> {
+  await Promise.all([
+    context.globalState.update('sessionInfo', undefined),
+    context.globalState.update('lastSyncTime', null),
+    context.globalState.update('lastSyncedAt', undefined),
+  ]);
 }

--- a/extensions/cursor/tests/cursor-regressions.test.ts
+++ b/extensions/cursor/tests/cursor-regressions.test.ts
@@ -1,0 +1,197 @@
+import assert = require('node:assert/strict');
+import test = require('node:test');
+
+import { composerIdFromKey, resolveCanonicalBubbleOwners, isCursorComposerId } from '../src/cursor/composerIdentity';
+import { compactRequestLedger, REQUEST_LEDGER_RETENTION_MS } from '../src/cursor/ledgerRetention';
+import {
+    acknowledgeUploadedTraces,
+    prepareTraceForUpload,
+    requestIdForTurn,
+    requestKey,
+    uuidV7Timestamp,
+} from '../src/cursor/requestIdentity';
+import { resolveAutomaticTraceCutoff } from '../src/cursor/stateMigration';
+import { aggregateTurnUsage, latestUsageModel } from '../src/cursor/usageAggregation';
+import { mergePendingUsage } from '../src/cursor/usageQueue';
+import { PendingUsage, RequestLedger, TraceData, TurnUsage } from '../src/interface';
+
+const T0 = Date.parse('2026-01-10T19:57:00.000Z');
+const ORIGINAL = '11111111-1111-4111-8111-111111111111';
+const FORK = '22222222-2222-4222-8222-222222222222';
+
+function trace(requestId: string, composerId: string, startMs = T0): TraceData {
+    return {
+        id: '',
+        root_span_id: '',
+        request_id: requestId,
+        request_key: requestKey('cursor-tests', requestId),
+        upload_kind: 'canonical',
+        revision: 1,
+        usage_key: '',
+        cost_owner: true,
+        name: 'cursor-chat',
+        project_name: 'cursor-tests',
+        start_time: new Date(startMs).toISOString(),
+        end_time: new Date(startMs + 1000).toISOString(),
+        turn_start_ms: startMs,
+        turn_starts_ms: [startMs],
+        input: { input: 'question' },
+        output: { output: 'answer' },
+        thread_id: composerId,
+        metadata: {},
+        spans: [{
+            name: 'model-call',
+            type: 'llm',
+            startTime: new Date(startMs + 100),
+            endTime: new Date(startMs + 200),
+        }],
+    };
+}
+
+function usage(model: string, chargedCents: number): TurnUsage {
+    return {
+        inputTokens: 10,
+        outputTokens: 2,
+        cacheReadTokens: 3,
+        cacheWriteTokens: 0,
+        chargedCents,
+        requestCount: 1,
+        models: [model],
+    };
+}
+
+test('fork-first polling retains the original composer as owner', () => {
+    const owners = resolveCanonicalBubbleOwners([
+        {
+            composerId: FORK,
+            composerCreatedAt: T0 + 10_000,
+            headers: [{ bubbleId: 'shared', type: 1, createdAt: new Date(T0 + 20_000).toISOString() }],
+        },
+        {
+            composerId: ORIGINAL,
+            composerCreatedAt: T0 - 1000,
+            headers: [{ bubbleId: 'shared', type: 1, createdAt: new Date(T0).toISOString() }],
+        },
+    ]);
+    const fork = trace('request', FORK, T0 + 20_000);
+    fork.canonical_thread_id = owners.get('shared')?.composerId;
+    fork.canonical_turn_start_ms = owners.get('shared')?.turnStartMs;
+
+    const ledger: RequestLedger = {};
+    const prepared = prepareTraceForUpload(fork, ledger);
+
+    assert.equal(ledger[fork.request_key].ownerComposerId, ORIGINAL);
+    assert.equal(ledger[fork.request_key].canonicalStatus, 'excluded');
+    assert.equal(prepared?.upload_kind, 'fork_edit_revision');
+    assert.equal(prepared?.cost_owner, true);
+    assert.equal(uuidV7Timestamp(prepared!.id), T0);
+});
+
+test('an unedited inherited fork remains cost-excluded when seen first', () => {
+    const fork = trace('request', FORK, T0);
+    fork.canonical_thread_id = ORIGINAL;
+    fork.canonical_turn_start_ms = T0;
+    const prepared = prepareTraceForUpload(fork, {});
+    assert.equal(prepared?.upload_kind, 'fork_copy');
+    assert.equal(prepared?.cost_owner, false);
+});
+
+test('composer creation order keeps ownership stable after the source is edited', () => {
+    const owners = resolveCanonicalBubbleOwners([
+        {
+            composerId: ORIGINAL,
+            composerCreatedAt: T0,
+            headers: [{ bubbleId: 'shared', type: 1, createdAt: new Date(T0 + 30_000).toISOString() }],
+        },
+        {
+            composerId: FORK,
+            composerCreatedAt: T0 + 10_000,
+            headers: [{ bubbleId: 'shared', type: 1, createdAt: new Date(T0 + 5000).toISOString() }],
+        },
+    ]);
+    assert.equal(owners.get('shared')?.composerId, ORIGINAL);
+    assert.equal(owners.get('shared')?.turnStartMs, T0 + 5000);
+});
+
+test('same-timestamp edits receive distinct revision usage and child identities', () => {
+    const ledger: RequestLedger = {};
+    const original = prepareTraceForUpload(trace('same-time', ORIGINAL), ledger)!;
+    acknowledgeUploadedTraces([original], ledger);
+    const editedInput = trace('same-time', ORIGINAL);
+    editedInput.input = { input: 'edited at the same timestamp' };
+    const edited = prepareTraceForUpload(editedInput, ledger)!;
+    assert.notEqual(edited.usage_key, original.usage_key);
+    assert.notEqual(edited.spans![0].id, original.spans![0].id);
+    assert.equal(edited.revision, 2);
+});
+
+test('independent legacy turns with identical text and timestamps stay distinct', () => {
+    const left = requestIdForTurn({ userMessages: [{ id: 'left', text: 'same', resolvedTimestamp: T0 }] });
+    const right = requestIdForTurn({ userMessages: [{ id: 'right', text: 'same', resolvedTimestamp: T0 }] });
+    assert.notEqual(left, right);
+});
+
+test('legacy pending usage is upgraded instead of duplicated', () => {
+    const legacy = {
+        composerId: ORIGINAL,
+        turnStartMs: T0,
+        traceId: 'trace',
+        spanId: 'span',
+        projectName: 'cursor-tests',
+        attempt: 2,
+        nextAttemptAt: T0,
+    } as PendingUsage;
+    const modern = {
+        usageKey: 'usage-key',
+        requestId: 'request',
+        requestKey: 'request-key',
+        composerId: ORIGINAL,
+        turnStartMs: T0,
+        turnStartsMs: [T0],
+        traceId: 'trace',
+        spanId: 'span',
+        projectName: 'cursor-tests',
+    };
+    const merged = mergePendingUsage([legacy], [modern], T0 + 5000);
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0].usageKey, 'usage-key');
+    assert.equal(merged[0].requestKey, 'request-key');
+    assert.equal(merged[0].attempt, 2);
+});
+
+test('aggregated revisions keep the latest billed model for the root span', () => {
+    const aggregate = aggregateTurnUsage([usage('old-model', 10), usage('new-model', 20)]);
+    assert.equal(latestUsageModel(aggregate), 'new-model');
+    assert.equal(aggregate.chargedCents, 30);
+});
+
+test('legacy cutoff migration prefers lastSyncTime before activation time', () => {
+    assert.equal(resolveAutomaticTraceCutoff(undefined, T0, T0 + 1000), T0);
+    assert.equal(resolveAutomaticTraceCutoff(T0 - 1000, T0, T0 + 1000), T0 - 1000);
+});
+
+test('composer ids are validated before SQL range construction', () => {
+    assert.equal(isCursorComposerId(ORIGINAL), true);
+    assert.equal(isCursorComposerId("x' OR 1=1 --"), false);
+    assert.equal(composerIdFromKey(`composerData:${ORIGINAL}`), ORIGINAL);
+    assert.equal(composerIdFromKey("composerData:x' OR 1=1 --"), undefined);
+});
+
+test('ledger compaction collapses revision costs and prunes expired deliveries', () => {
+    const active = trace('active', ORIGINAL);
+    const ledger: RequestLedger = {};
+    prepareTraceForUpload(active, ledger);
+    const entry = ledger[active.request_key];
+    entry.canonicalStatus = 'uploaded';
+    entry.usageStatus = 'complete';
+    entry.usageByRevision = { first: usage('old-model', 10), edit: usage('new-model', 20) };
+    // Reopening an old thread must not extend retention forever.
+    entry.lastSeenAt = T0 + REQUEST_LEDGER_RETENTION_MS + 1;
+
+    compactRequestLedger(ledger, T0 + REQUEST_LEDGER_RETENTION_MS - 1);
+    assert.equal(Object.keys(entry.usageByRevision!).length, 1);
+    assert.equal(Object.values(entry.usageByRevision!)[0].chargedCents, 30);
+
+    compactRequestLedger(ledger, T0 + REQUEST_LEDGER_RETENTION_MS + 1);
+    assert.equal(ledger[active.request_key], undefined);
+});

--- a/extensions/cursor/tests/cursor-regressions.test.ts
+++ b/extensions/cursor/tests/cursor-regressions.test.ts
@@ -19,8 +19,13 @@ import {
     appliedUsageEventOwners,
     hasAppliedUsage,
     recordAppliedUsage,
+    usageDeliveryForComposer,
 } from '../src/cursor/usageLedger';
-import { mergePendingUsage, shouldKeepPendingUsage } from '../src/cursor/usageQueue';
+import {
+    canAttributePendingUsage,
+    mergePendingUsage,
+    shouldKeepPendingUsage,
+} from '../src/cursor/usageQueue';
 import { ForkCopyState, PendingUsage, RequestLedger, TraceData, TurnUsage } from '../src/interface';
 
 const T0 = Date.parse('2026-01-10T19:57:00.000Z');
@@ -285,6 +290,7 @@ test('independent legacy turns with identical text and timestamps stay distinct'
 });
 
 test('legacy pending usage is upgraded instead of duplicated', () => {
+    const modernUsageKey = `cursor-tests\u0000request\u0000${ORIGINAL}\u0000${T0}\u00001`;
     const legacy = {
         composerId: ORIGINAL,
         turnStartMs: T0,
@@ -295,7 +301,7 @@ test('legacy pending usage is upgraded instead of duplicated', () => {
         nextAttemptAt: T0,
     } as PendingUsage;
     const modern = {
-        usageKey: 'usage-key',
+        usageKey: modernUsageKey,
         requestId: 'request',
         requestKey: 'request-key',
         composerId: ORIGINAL,
@@ -307,9 +313,37 @@ test('legacy pending usage is upgraded instead of duplicated', () => {
     };
     const merged = mergePendingUsage([legacy], [modern], T0 + 5000);
     assert.equal(merged.length, 1);
-    assert.equal(merged[0].usageKey, 'usage-key');
+    assert.equal(merged[0].usageKey, modernUsageKey);
     assert.equal(merged[0].requestKey, 'request-key');
     assert.equal(merged[0].attempt, 2);
+});
+
+test('unmatched legacy pending usage gets a unique compatibility identity', () => {
+    const legacy = (traceId: string) => ({
+        composerId: ORIGINAL,
+        turnStartMs: T0,
+        traceId,
+        spanId: `span-${traceId}`,
+        projectName: 'cursor-tests',
+        attempt: 0,
+        nextAttemptAt: T0,
+    } as PendingUsage);
+    const normalized = mergePendingUsage([legacy('left'), legacy('right')], [], T0);
+
+    assert.equal(normalized.every(canAttributePendingUsage), true);
+    assert.notEqual(normalized[0].usageKey, normalized[1].usageKey);
+    assert.notEqual(normalized[0].requestKey, normalized[1].requestKey);
+});
+
+test('legacy ledger entries tolerate a missing fork-copy map', () => {
+    const ledger: RequestLedger = {};
+    const original = trace('legacy-ledger', ORIGINAL);
+    prepareTraceForUpload(original, ledger);
+    const entry = ledger[original.request_key];
+    (entry as { forkCopies?: Record<string, ForkCopyState> }).forkCopies = undefined;
+
+    assert.equal(usageDeliveryForComposer(entry, FORK), undefined);
+    assert.equal(usageDeliveryForComposer(entry, ORIGINAL), entry);
 });
 
 test('aggregated revisions keep the latest billed model for the root span', () => {

--- a/extensions/cursor/tests/cursor-regressions.test.ts
+++ b/extensions/cursor/tests/cursor-regressions.test.ts
@@ -11,11 +11,17 @@ import {
     uuidV7Timestamp,
 } from '../src/cursor/requestIdentity';
 import { resolveAutomaticTraceCutoff } from '../src/cursor/stateMigration';
+import { deliverTracesWithClient, TraceDeliveryClient } from '../src/cursor/traceDelivery';
 import { aggregateTurnUsage, latestUsageModel } from '../src/cursor/usageAggregation';
 import { attributeUsageToPending } from '../src/cursor/usageAttribution';
-import { hasAppliedUsage, recordAppliedUsage } from '../src/cursor/usageLedger';
-import { mergePendingUsage } from '../src/cursor/usageQueue';
-import { PendingUsage, RequestLedger, TraceData, TurnUsage } from '../src/interface';
+import {
+    aggregateUsageWithRevision,
+    appliedUsageEventOwners,
+    hasAppliedUsage,
+    recordAppliedUsage,
+} from '../src/cursor/usageLedger';
+import { mergePendingUsage, shouldKeepPendingUsage } from '../src/cursor/usageQueue';
+import { ForkCopyState, PendingUsage, RequestLedger, TraceData, TurnUsage } from '../src/interface';
 
 const T0 = Date.parse('2026-01-10T19:57:00.000Z');
 const ORIGINAL = '11111111-1111-4111-8111-111111111111';
@@ -136,12 +142,12 @@ test('same-timestamp edits receive distinct revision usage and child identities'
     assert.equal(edited.revision, 2);
 });
 
-test('same-timestamp revisions partition usage events exactly once', () => {
+test('partitions events across revisions sharing a turn start', () => {
     const originalKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00001`;
     const editKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00002`;
     const attribution = attributeUsageToPending([
-        { usageKey: originalKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
-        { usageKey: editKey, turnStartMs: T0, turnEndMs: T0 + 2000 },
+        { usageKey: originalKey, requestKey: 'request', turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: editKey, requestKey: 'request', turnStartMs: T0, turnEndMs: T0 + 2000 },
     ], [T0], [
         { timestamp: String(T0 + 1100), model: 'old-model', chargedCents: 10 },
         { timestamp: String(T0 + 2100), model: 'new-model', chargedCents: 20 },
@@ -155,12 +161,12 @@ test('same-timestamp revisions partition usage events exactly once', () => {
     );
 });
 
-test('ambiguous same-time events settle revisions without sharing cost', () => {
+test('settles revisions sharing a completion time without duplicating cost', () => {
     const originalKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00001`;
     const editKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00002`;
     const attribution = attributeUsageToPending([
-        { usageKey: originalKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
-        { usageKey: editKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: originalKey, requestKey: 'request', turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: editKey, requestKey: 'request', turnStartMs: T0, turnEndMs: T0 + 1000 },
     ], [T0], [
         { timestamp: String(T0 + 1100), model: 'new-model', chargedCents: 30 },
     ]);
@@ -168,6 +174,108 @@ test('ambiguous same-time events settle revisions without sharing cost', () => {
     assert.equal(attribution.usageByKey.has(originalKey), false);
     assert.equal(attribution.usageByKey.get(editKey)?.chargedCents, 30);
     assert.deepEqual([...attribution.settledKeys].sort(), [editKey, originalKey].sort());
+});
+
+test('same-start independent requests never settle or reuse each other events', () => {
+    const leftKey = `project\u0000left\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const rightKey = `project\u0000right\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const pending = [
+        { usageKey: leftKey, requestKey: 'left', turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: rightKey, requestKey: 'right', turnStartMs: T0, turnEndMs: T0 + 2000 },
+    ];
+    const firstEvent = { timestamp: String(T0 + 1100), model: 'left-model', chargedCents: 10 };
+    const first = attributeUsageToPending(pending, [T0], [firstEvent]);
+
+    assert.equal(first.usageByKey.get(leftKey)?.chargedCents, 10);
+    assert.equal(first.settledKeys.has(rightKey), false);
+
+    const claims = new Map<string, string>();
+    for (const [usageKey, eventKeys] of first.eventKeysByUsageKey) {
+        for (const eventKey of eventKeys) {
+            claims.set(eventKey, usageKey);
+        }
+    }
+    const second = attributeUsageToPending(
+        [pending[1]],
+        [T0],
+        [
+            firstEvent,
+            { timestamp: String(T0 + 2100), model: 'right-model', chargedCents: 20 },
+        ],
+        claims
+    );
+    assert.equal(second.usageByKey.get(rightKey)?.chargedCents, 20);
+});
+
+test('a failed usage patch remains pending even after attribution settles it', () => {
+    assert.equal(shouldKeepPendingUsage(true, true), true);
+    assert.equal(shouldKeepPendingUsage(false, true), false);
+
+    const delivery: ForkCopyState = {
+        traceId: 'trace',
+        rootSpanId: 'span',
+        status: 'pending',
+    };
+    const aggregate = aggregateUsageWithRevision(delivery, 'unacknowledged', usage('model', 10));
+    assert.equal(aggregate.chargedCents, 10);
+    assert.equal(hasAppliedUsage(delivery, 'unacknowledged'), false);
+});
+
+test('delivery awaits canonical and revision writes before flushing', async () => {
+    const canonical = prepareTraceForUpload(trace('canonical-delivery', ORIGINAL), {})!;
+    const revision = prepareTraceForUpload(trace('revision-delivery', ORIGINAL), {})!;
+    revision.upload_kind = 'edit_revision';
+    revision.revision = 2;
+    revision.end_time = undefined;
+
+    const calls = {
+        traces: [] as unknown[],
+        spans: [] as unknown[],
+        traceUpdates: [] as unknown[],
+        spanUpdates: [] as unknown[],
+        spanBatches: [] as unknown[],
+        flushes: 0,
+    };
+    const client: TraceDeliveryClient = {
+        api: {
+            traces: {
+                async updateTrace(_id, request) {
+                    calls.traceUpdates.push(request);
+                },
+            },
+            spans: {
+                async updateSpan(_id, request) {
+                    calls.spanUpdates.push(request);
+                },
+                async createSpans(request) {
+                    calls.spanBatches.push(request);
+                },
+            },
+        },
+        trace(data) {
+            calls.traces.push(data);
+            return {
+                span(spanData) {
+                    calls.spans.push(spanData);
+                },
+            };
+        },
+        async flush() {
+            calls.flushes += 1;
+        },
+    };
+
+    const logged = await deliverTracesWithClient(client, [canonical, revision]);
+
+    assert.equal(calls.traces.length, 1);
+    assert.equal(calls.spans.length, 2);
+    assert.equal(calls.traceUpdates.length, 1);
+    assert.equal(calls.spanUpdates.length, 1);
+    assert.equal(calls.spanBatches.length, 1);
+    assert.equal(calls.flushes, 1);
+    assert.equal(logged.length, 2);
+    assert.equal(logged[0].turnEndMs, new Date(canonical.end_time!).getTime());
+    assert.equal(logged[1].turnEndMs, undefined);
 });
 
 test('independent legacy turns with identical text and timestamps stay distinct', () => {
@@ -249,14 +357,15 @@ test('compacted usage keeps exact acknowledgements across queue-removal retries'
     const firstKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00001`;
     const editKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00002`;
 
-    recordAppliedUsage(entry, firstKey, usage('old-model', 10));
-    recordAppliedUsage(entry, editKey, usage('new-model', 20));
+    recordAppliedUsage(entry, firstKey, usage('old-model', 10), ['event-first']);
+    recordAppliedUsage(entry, editKey, usage('new-model', 20), ['event-edit']);
     entry.usageStatus = 'complete';
     compactRequestLedger(ledger, T0 + 1);
 
     assert.deepEqual(entry.appliedUsageKeys?.sort(), [editKey, firstKey].sort());
     assert.equal(hasAppliedUsage(entry, editKey), true);
     assert.equal(Object.values(entry.usageByRevision!)[0].chargedCents, 30);
+    assert.equal(appliedUsageEventOwners(ledger, ORIGINAL).get('event-edit'), editKey);
 
     const latestKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00003`;
     const aggregate = recordAppliedUsage(entry, latestKey, usage('latest-model', 5));

--- a/extensions/cursor/tests/cursor-regressions.test.ts
+++ b/extensions/cursor/tests/cursor-regressions.test.ts
@@ -335,6 +335,40 @@ test('unmatched legacy pending usage gets a unique compatibility identity', () =
     assert.notEqual(normalized[0].requestKey, normalized[1].requestKey);
 });
 
+test('normalized legacy usage upgrades on a later tracking invocation', () => {
+    const legacy = {
+        usageKey: 'short-legacy-key',
+        requestId: 'old-request',
+        requestKey: 'old-request-key',
+        composerId: ORIGINAL,
+        turnStartMs: T0,
+        traceId: 'trace',
+        spanId: 'span',
+        projectName: 'cursor-tests',
+        attempt: 1,
+        nextAttemptAt: T0,
+    } as PendingUsage;
+    const normalized = mergePendingUsage([legacy], [], T0);
+    assert.equal(normalized[0].usageKey.startsWith('legacy\u0000'), true);
+
+    const modernUsageKey = `cursor-tests\u0000modern\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const upgraded = mergePendingUsage(normalized, [{
+        usageKey: modernUsageKey,
+        requestId: 'modern',
+        requestKey: 'modern-request-key',
+        composerId: ORIGINAL,
+        turnStartMs: T0,
+        turnStartsMs: [T0],
+        traceId: 'trace',
+        spanId: 'span',
+        projectName: 'cursor-tests',
+    }], T0 + 1);
+
+    assert.equal(upgraded.length, 1);
+    assert.equal(upgraded[0].usageKey, modernUsageKey);
+    assert.equal(canAttributePendingUsage(upgraded[0]), true);
+});
+
 test('legacy ledger entries tolerate a missing fork-copy map', () => {
     const ledger: RequestLedger = {};
     const original = trace('legacy-ledger', ORIGINAL);

--- a/extensions/cursor/tests/cursor-regressions.test.ts
+++ b/extensions/cursor/tests/cursor-regressions.test.ts
@@ -12,6 +12,8 @@ import {
 } from '../src/cursor/requestIdentity';
 import { resolveAutomaticTraceCutoff } from '../src/cursor/stateMigration';
 import { aggregateTurnUsage, latestUsageModel } from '../src/cursor/usageAggregation';
+import { attributeUsageToPending } from '../src/cursor/usageAttribution';
+import { hasAppliedUsage, recordAppliedUsage } from '../src/cursor/usageLedger';
 import { mergePendingUsage } from '../src/cursor/usageQueue';
 import { PendingUsage, RequestLedger, TraceData, TurnUsage } from '../src/interface';
 
@@ -113,6 +115,15 @@ test('composer creation order keeps ownership stable after the source is edited'
     assert.equal(owners.get('shared')?.turnStartMs, T0 + 5000);
 });
 
+test('malformed composer headers are skipped without losing valid ownership', () => {
+    const owners = resolveCanonicalBubbleOwners([{
+        composerId: ORIGINAL,
+        composerCreatedAt: T0,
+        headers: [null, 'invalid', 7, { bubbleId: 'shared', type: 1, createdAt: new Date(T0).toISOString() }],
+    }]);
+    assert.equal(owners.get('shared')?.composerId, ORIGINAL);
+});
+
 test('same-timestamp edits receive distinct revision usage and child identities', () => {
     const ledger: RequestLedger = {};
     const original = prepareTraceForUpload(trace('same-time', ORIGINAL), ledger)!;
@@ -123,6 +134,40 @@ test('same-timestamp edits receive distinct revision usage and child identities'
     assert.notEqual(edited.usage_key, original.usage_key);
     assert.notEqual(edited.spans![0].id, original.spans![0].id);
     assert.equal(edited.revision, 2);
+});
+
+test('same-timestamp revisions partition usage events exactly once', () => {
+    const originalKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const editKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00002`;
+    const attribution = attributeUsageToPending([
+        { usageKey: originalKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: editKey, turnStartMs: T0, turnEndMs: T0 + 2000 },
+    ], [T0], [
+        { timestamp: String(T0 + 1100), model: 'old-model', chargedCents: 10 },
+        { timestamp: String(T0 + 2100), model: 'new-model', chargedCents: 20 },
+    ]);
+
+    assert.equal(attribution.usageByKey.get(originalKey)?.chargedCents, 10);
+    assert.equal(attribution.usageByKey.get(editKey)?.chargedCents, 20);
+    assert.equal(
+        [...attribution.usageByKey.values()].reduce((total, item) => total + item.chargedCents, 0),
+        30
+    );
+});
+
+test('ambiguous same-time events settle revisions without sharing cost', () => {
+    const originalKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const editKey = `project\u0000request\u0000${ORIGINAL}\u0000${T0}\u00002`;
+    const attribution = attributeUsageToPending([
+        { usageKey: originalKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
+        { usageKey: editKey, turnStartMs: T0, turnEndMs: T0 + 1000 },
+    ], [T0], [
+        { timestamp: String(T0 + 1100), model: 'new-model', chargedCents: 30 },
+    ]);
+
+    assert.equal(attribution.usageByKey.has(originalKey), false);
+    assert.equal(attribution.usageByKey.get(editKey)?.chargedCents, 30);
+    assert.deepEqual([...attribution.settledKeys].sort(), [editKey, originalKey].sort());
 });
 
 test('independent legacy turns with identical text and timestamps stay distinct', () => {
@@ -194,4 +239,38 @@ test('ledger compaction collapses revision costs and prunes expired deliveries',
 
     compactRequestLedger(ledger, T0 + REQUEST_LEDGER_RETENTION_MS + 1);
     assert.equal(ledger[active.request_key], undefined);
+});
+
+test('compacted usage keeps exact acknowledgements across queue-removal retries', () => {
+    const active = trace('usage-retry', ORIGINAL);
+    const ledger: RequestLedger = {};
+    prepareTraceForUpload(active, ledger);
+    const entry = ledger[active.request_key];
+    const firstKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00001`;
+    const editKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00002`;
+
+    recordAppliedUsage(entry, firstKey, usage('old-model', 10));
+    recordAppliedUsage(entry, editKey, usage('new-model', 20));
+    entry.usageStatus = 'complete';
+    compactRequestLedger(ledger, T0 + 1);
+
+    assert.deepEqual(entry.appliedUsageKeys?.sort(), [editKey, firstKey].sort());
+    assert.equal(hasAppliedUsage(entry, editKey), true);
+    assert.equal(Object.values(entry.usageByRevision!)[0].chargedCents, 30);
+
+    const latestKey = `${active.request_key}\u0000${ORIGINAL}\u0000${T0}\u00003`;
+    const aggregate = recordAppliedUsage(entry, latestKey, usage('latest-model', 5));
+    assert.equal(aggregate.chargedCents, 35);
+    assert.equal(latestUsageModel(aggregate), 'latest-model');
+});
+
+test('retention never deletes an entry with an unknown legacy delivery status', () => {
+    const active = trace('legacy-status', ORIGINAL);
+    const ledger: RequestLedger = {};
+    prepareTraceForUpload(active, ledger);
+    const entry = ledger[active.request_key];
+    (entry as { canonicalStatus?: string }).canonicalStatus = undefined;
+
+    compactRequestLedger(ledger, T0 + REQUEST_LEDGER_RETENTION_MS + 1);
+    assert.equal(ledger[active.request_key], entry);
 });

--- a/extensions/cursor/tsconfig.json
+++ b/extensions/cursor/tsconfig.json
@@ -15,5 +15,7 @@
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	}
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["tests", "out-test"]
 }

--- a/extensions/cursor/tsconfig.tests.json
+++ b/extensions/cursor/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "out-test",
+    "rootDir": ".",
+    "sourceMap": false
+  },
+  "include": ["tests/**/*.test.ts"],
+  "exclude": ["out-test"]
+}


### PR DESCRIPTION
## Details
Keeps Cursor request delivery state durable so reopening or editing a chat does not create duplicate Opik traces, while preserving fork copies as intentional thread history. Edits now update the existing trace/root span in place, append timestamp-correct revision spans, and aggregate every billed revision exactly once.

- Assign deterministic UUIDv7 trace/span IDs from the corresponding Cursor event timestamps.
- Track canonical requests, fork copies, edit revisions, retries, and pending usage in a persistent request ledger.
- Mark inherited fork copies as cost-excluded; make genuine fork edits cost owners.
- Aggregate edit usage idempotently and retain sent-request tracking when sync state is reset.
- Add regression coverage for reopen, retry, fork, same-request edits, fork edits, UUID timestamps, cost aggregation, and automatic historical-trace exclusion.
- Upload only new turns automatically; expose historical Cursor trace import through an explicit command.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- No linked issue.

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Codex, Cursor, Opik TypeScript SDK and REST API
  - Model(s): OpenAI GPT-5
  - Scope: implementation, test coverage, build verification, and live Cursor/Opik regression testing
  - Human verification: Maintainer UI review is pending; the live acceptance chat and trace identifiers were provided separately for inspection.

## Testing

Commands run from `extensions/cursor` after rebasing onto `origin/main`:

- `npm run compile`
- `npm run test-spans` — 44/44 passing
- `npm run lint` — zero errors; nine existing style warnings in `sessionManager.ts`
- `npm run build` — VSIX packaged successfully
- `npm run verify-usage` — Cursor usage attribution reconciled exactly
- `git diff --check`

`make precommit` was attempted but could not run because the `pre-commit` executable is not installed on the development machine.

Live validation on macOS with the rebuilt VSIX installed in Cursor:

- Baseline request produced one trace with one root and one assistant child span.
- Editing the same Cursor request ID updated that exact trace/root ID to revision 2 and appended one revision child span.
- Raw Cursor charges were $0.041506 and $0.012880; the Opik root cost was the exact aggregate, $0.054386.
- Aggregate usage matched at 50,128 prompt tokens, 67 completion tokens, and 50,195 total tokens.
- UUIDv7 timestamps matched the original turn, original child, and edited child event timestamps exactly.
- Closing and reopening the chat left the result unchanged at one trace, three spans, and $0.054386.
- Fork/reopen/cost-exclusion behavior is additionally covered by the automated regression suite.

## Documentation

Updated the Cursor extension README to document automatic new-turn tracking and the explicit historical import command.