### PR TITLE
[OPIK-6901] [BE] feat(cutover): add --old-table/--new-table to delta_replay so it can run after the EXCHANGE

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -59,7 +59,7 @@
 -- max_insert_threads below sizes the INSERT SELECT pipeline, with the same semantics and costs as in 000001:
 -- omitted when --max-insert-threads is unset, an explicit 0 forcing no parallel execution. The delta writes to
 -- the same table through the same insert path, so pass the value used for the backfill.
-INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE} (
+INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
     id,
     workspace_id,
     project_id,
@@ -108,7 +108,7 @@ SELECT
     coalesce(ttft, toFloat64('nan')) AS ttft,
     source,
     environment
-FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE}
+FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
 WHERE created_at >= toDateTime64('${BACKFILL_START}', 6)
    OR last_updated_at >= toDateTime64('${BACKFILL_START}', 6)
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
@@ -146,7 +146,7 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- a malformed (non-36-char) deleted_id/project_id can't match a real trace id anyway, so skipping it via the length
 -- guard loses nothing and turns a hard abort mid-cutover into a benign no-op. Same guards in the reverse-replay.
 -- >>> BEGIN deletion-replay
-DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE}
+DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2
 WHERE (
     (workspace_id, project_id, id) IN (
         SELECT
@@ -165,7 +165,7 @@ WHERE (
             workspace_id,
             project_id,
             id
-        FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE}
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
         WHERE id IN (
             SELECT toFixedString(deleted_id, 36)
             FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -59,7 +59,7 @@
 -- max_insert_threads below sizes the INSERT SELECT pipeline, with the same semantics and costs as in 000001:
 -- omitted when --max-insert-threads is unset, an explicit 0 forcing no parallel execution. The delta writes to
 -- the same table through the same insert path, so pass the value used for the backfill.
-INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2 (
+INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE} (
     id,
     workspace_id,
     project_id,
@@ -108,7 +108,7 @@ SELECT
     coalesce(ttft, toFloat64('nan')) AS ttft,
     source,
     environment
-FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
+FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE}
 WHERE created_at >= toDateTime64('${BACKFILL_START}', 6)
    OR last_updated_at >= toDateTime64('${BACKFILL_START}', 6)
 SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
@@ -146,7 +146,7 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- a malformed (non-36-char) deleted_id/project_id can't match a real trace id anyway, so skipping it via the length
 -- guard loses nothing and turns a hard abort mid-cutover into a benign no-op. Same guards in the reverse-replay.
 -- >>> BEGIN deletion-replay
-DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_local_v2
+DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.${NEW_TABLE}
 WHERE (
     (workspace_id, project_id, id) IN (
         SELECT
@@ -165,7 +165,7 @@ WHERE (
             workspace_id,
             project_id,
             id
-        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.${OLD_TABLE}
         WHERE id IN (
             SELECT toFixedString(deleted_id, 36)
             FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -26,7 +26,15 @@
 #                             post-swap catch-up is `--old-table traces_pre_cutover_backup --new-table traces`. Without
 #                             these the script can only ever run pre-EXCHANGE: it hardcoded both names, so after the swap
 #                             it would read the successor and insert into a table that no longer exists.
-#   --new-table NAME           new-schema destination to write to. Default traces_local_v2. Same swap applies.
+#   --new-table NAME           new-schema destination to write to. Default traces_local_v2. Same swap applies, with one
+#                             exception: ONCE THE DISTRIBUTED WRAP IS APPLIED (exchange_and_wrap.sh --with-wrap or
+#                             --wrap-only) `traces` is a Distributed wrapper over `traces_local`, which accepts the
+#                             delta INSERT but REJECTS the deletion replay's lightweight DELETE ("DELETE query is not
+#                             supported", code 36) — so a post-wrap catch-up aimed at `traces` would write the delta
+#                             and then fail, leaving itself half-applied. Post-wrap the destination is the LOCAL
+#                             table: `--new-table traces_local`. The driver resolves the destination's engine before
+#                             it writes anything and refuses a non-MergeTree destination, so this is enforced rather
+#                             than merely documented.
 #                             `verify.sh` has carried these two flags from the start; this brings the delta into line, so
 #                             the rows a final delta leaves behind (everything written while it ran) and the deletions
 #                             deferred past the swap both have a vehicle.
@@ -203,6 +211,45 @@ if grep -qF '${MAX_INSERT_THREADS}' <<<"$mit_masked"; then
     exit 2
 fi
 # <<< END max_insert_threads rendering
+# Generic post-render guard: NO placeholder may survive into an executable line. The reference SQL's header keeps a
+# hand-maintained inventory of the placeholders this driver substitutes ("it handles all five placeholders below,
+# listed so a new one is never missed"), and a hand-maintained list drifts — a ${...} added to the SQL without a
+# matching substitution here would otherwise reach the server as a literal and fail mid-cutover. This makes that
+# inventory a check rather than a promise, and generalises the MAX_INSERT_THREADS-specific post-condition above to
+# every placeholder. Comment-masked, because the header necessarily writes ${...} in prose (and the batching
+# instructions in step 3 tell the operator to grep for exactly that).
+render_masked="$(mit_mask_comments "$sql" || true)"
+if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$render_masked"; then
+    echo "ERROR: unsubstituted placeholder(s) survive in executable lines of $SQL_FILE after rendering:" >&2
+    grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$render_masked" | sort -u | sed 's/^/       /' >&2
+    echo "       Refusing to send SQL containing a literal placeholder. Add the substitution to this driver — and to" >&2
+    echo "       exchange_and_wrap.sh, which renders the deletion-replay block of the same file." >&2
+    exit 2
+fi
+# Pre-flight, BEFORE the first write: the destination must accept BOTH statements this driver sends. The delta
+# INSERT works against any writable engine, but the deletion replay is a lightweight DELETE and only the MergeTree
+# family supports one. After the Distributed wrap, `traces` is a Distributed wrapper over `traces_local`: the INSERT
+# would land and the DELETE would then fail with "DELETE query is not supported" (code 36), leaving the catch-up
+# half-applied — the delta written, the deferred deletions not. Re-running does not repair that by itself, because
+# the DELETE keeps failing until the destination is corrected. Positive match on the MergeTree family, so every
+# other non-mutable engine (Distributed, Buffer, Merge, Null, a view) is refused too.
+dest_engine="$(clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:delta_replay:destination_engine' --query "SELECT engine FROM system.tables WHERE database = '$DATABASE' AND name = '$NEW_TABLE'")"
+if [[ -z "$dest_engine" ]]; then
+    echo "ERROR: destination '$DATABASE.$NEW_TABLE' does not exist on this instance. Pass --new-table for whatever" >&2
+    echo "       holds the new-schema data here: pre-EXCHANGE 'traces_local_v2', post-EXCHANGE 'traces'," >&2
+    echo "       post-wrap 'traces_local'." >&2
+    exit 1
+fi
+if [[ "$dest_engine" != *MergeTree ]]; then
+    echo "ERROR: destination '$DATABASE.$NEW_TABLE' has engine '$dest_engine'. The deletion replay is a lightweight" >&2
+    echo "       DELETE and only the MergeTree family supports one, so the delta INSERT would succeed and the replay" >&2
+    echo "       would then fail, leaving this catch-up half-applied. Refusing before anything is written." >&2
+    if [[ "$dest_engine" == "Distributed" ]]; then
+        echo "       'traces' is the Distributed wrap over 'traces_local'; re-run with --new-table traces_local." >&2
+    fi
+    exit 1
+fi
+
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
 # --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
 # the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -22,22 +22,6 @@
 #                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
 #                             the password out of argv).
 #   --backfill-start TS        the anchor printed by backfill.sh ("RECORD backfill_start=..."). Required.
-#   --old-table NAME           old-schema source to read from. Default traces. AFTER THE EXCHANGE the names swap, so a
-#                             post-swap catch-up is `--old-table traces_pre_cutover_backup --new-table traces`. Without
-#                             these the script can only ever run pre-EXCHANGE: it hardcoded both names, so after the swap
-#                             it would read the successor and insert into a table that no longer exists.
-#   --new-table NAME           new-schema destination to write to. Default traces_local_v2. Same swap applies, with one
-#                             exception: ONCE THE DISTRIBUTED WRAP IS APPLIED (exchange_and_wrap.sh --with-wrap or
-#                             --wrap-only) `traces` is a Distributed wrapper over `traces_local`, which accepts the
-#                             delta INSERT but REJECTS the deletion replay's lightweight DELETE ("DELETE query is not
-#                             supported", code 36) — so a post-wrap catch-up aimed at `traces` would write the delta
-#                             and then fail, leaving itself half-applied. Post-wrap the destination is the LOCAL
-#                             table: `--new-table traces_local`. The driver resolves the destination's engine before
-#                             it writes anything and refuses a non-MergeTree destination, so this is enforced rather
-#                             than merely documented.
-#                             `verify.sh` has carried these two flags from the start; this brings the delta into line, so
-#                             the rows a final delta leaves behind (everything written while it ran) and the deletions
-#                             deferred past the swap both have a vehicle.
 #   --max-insert-block-size N  SETTINGS max_insert_block_size for the delta INSERT. Default 1048576.
 #   --max-partitions-per-insert-block N
 #                             partitions one insert block of the delta INSERT may span (SETTINGS
@@ -55,11 +39,39 @@
 #                             count) as in backfill.sh -- see its option docs for the full diagnosis.
 #                             PASS THE SAME VALUE USED FOR THE BACKFILL: the delta writes into the
 #                             same table through the same insert path.
+#
+# PRE-EXCHANGE ONLY, and deliberately not configurable. The source and destination are fixed at `traces` ->
+# `traces_local_v2` in the reference SQL, so this driver can only ever run BEFORE the swap. `verify.sh` takes
+# --old-table/--new-table and can therefore be re-pointed after the EXCHANGE, but it only SELECTs; re-pointing a
+# driver that INSERTs and DELETEs is a different proposition, and the naive swap
+# (`--old-table traces_pre_cutover_backup --new-table traces`) is NOT correct -- it was tried in opik#8092 and
+# withdrawn. Two independent reasons, both about the destination being live rather than a private shadow:
+#
+#   * The delta-insert would RESURRECT user deletes. A lightweight DELETE does not bump last_updated_at (the
+#     ReplacingMergeTree version column) -- that is the whole reason deletion_events_local exists (see
+#     000096_create_deletion_events_local.sql: "deletes ... are invisible to the version-based delta step and would
+#     reappear in the copy"). A row written during the backfill window and deleted by a user AFTER the swap is still
+#     unmasked in the frozen backup, so the delta re-copies it into live `traces` with _row_exists = 1 and it is
+#     live again. The deletion replay in the same run cannot undo it: that id IS live on the read side, so the
+#     resurrection guard spares it.
+#   * The resurrection guard would evaluate liveness against a SNAPSHOT. Post-swap the guard's source is the frozen
+#     backup, so an id bridged as deleted and then re-created post-swap is absent there, passes the guard, and is
+#     DELETED from the live table. 000004_rollback_reverse_replay.sql already documents this hazard class for the
+#     mirror case and refuses to carry a guard for exactly this reason.
+#
+# Neither is fixable by choosing better table names: post-swap the copy source, the liveness oracle and the
+# destination are three different tables, and the replay additionally needs an upper bound at cutover_start (the
+# events after it are post-swap user activity, not deferred work). A correct post-swap catch-up is a separate
+# statement pair with its own anchor and its own gate cases -- not a re-pointing of 000002. Note also that the
+# runbook does not expect one: README "Keep step 3->4 short" covers gap WRITES with the async-insert buffer and gap
+# DELETES with exchange_and_wrap.sh's final deletion replay. If either left rows behind on a real run, the fix
+# belongs in whichever of those two failed.
 
 set -euo pipefail
 
-OLD_TABLE="traces"          # old-schema side; becomes traces_pre_cutover_backup after the EXCHANGE (see --old-table)
-NEW_TABLE="traces_local_v2" # new-schema side (the successor being built); becomes traces after the EXCHANGE
+# The destination the reference SQL writes to, as a literal. NOT interpolated into the SQL -- 000002 names both
+# tables itself -- and used only by the pre-flight below, so the check and the statements cannot drift apart.
+SHADOW_TABLE="traces_local_v2"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
@@ -77,8 +89,6 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --backfill-start) BACKFILL_START="${2:?"$1 requires a value"}"; shift 2 ;;
-        --old-table) OLD_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
-        --new-table) NEW_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-threads) MAX_INSERT_THREADS="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -107,16 +117,7 @@ echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this 
 echo "restore it after the EXCHANGE."
 
 sql="$(cat "$SQL_FILE")"
-# Interpolated straight into the reference SQL, so require plain ClickHouse identifiers — same
-# guard verify.sh applies to the same three values.
-for _ident in "$DATABASE" "$OLD_TABLE" "$NEW_TABLE"; do
-    [[ "$_ident" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database/--old-table/--new-table must be ClickHouse identifiers (letters, digits, underscore): '$_ident'" >&2; exit 2; }
-done
-[[ "$OLD_TABLE" != "$NEW_TABLE" ]] || { echo "ERROR: --old-table and --new-table must differ; '$OLD_TABLE' would copy a table onto itself." >&2; exit 2; }
-
 sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
-sql="${sql//'${OLD_TABLE}'/$OLD_TABLE}"
-sql="${sql//'${NEW_TABLE}'/$NEW_TABLE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
 sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
@@ -226,27 +227,30 @@ if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$render_masked"; then
     echo "       exchange_and_wrap.sh, which renders the deletion-replay block of the same file." >&2
     exit 2
 fi
-# Pre-flight, BEFORE the first write: the destination must accept BOTH statements this driver sends. The delta
-# INSERT works against any writable engine, but the deletion replay is a lightweight DELETE and only the MergeTree
-# family supports one. After the Distributed wrap, `traces` is a Distributed wrapper over `traces_local`: the INSERT
-# would land and the DELETE would then fail with "DELETE query is not supported" (code 36), leaving the catch-up
-# half-applied — the delta written, the deferred deletions not. Re-running does not repair that by itself, because
-# the DELETE keeps failing until the destination is corrected. Positive match on the MergeTree family, so every
-# other non-mutable engine (Distributed, Buffer, Merge, Null, a view) is refused too.
-dest_engine="$(clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:delta_replay:destination_engine' --query "SELECT engine FROM system.tables WHERE database = '$DATABASE' AND name = '$NEW_TABLE'")"
+# Pre-flight, BEFORE the first write: this step is only valid at one point in the sequence, so check that we are
+# actually at it rather than discovering otherwise mid-statement. The destination is the shadow, `traces_local_v2`,
+# which exists only between step 1 (backfill.sh creates and fills it) and step 3 (exchange_and_wrap.sh renames it
+# away). Absent means the run is out of sequence -- before the backfill, or already past the EXCHANGE -- and the
+# INSERT would otherwise fail with a bare UNKNOWN_TABLE after the operator reminder had already printed.
+#
+# The engine arm is a belt-and-braces check on the same object. The delta INSERT works against any writable engine,
+# but the deletion replay is a lightweight DELETE and only the MergeTree family supports one; a non-mutable engine
+# (Distributed, Buffer, Merge, Null, a view) would take the INSERT and then reject the DELETE, leaving the run
+# half-applied. Positive match on the family, so anything unexpected is refused rather than allowed by omission.
+dest_engine="$(clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:delta_replay:destination_engine' --query "SELECT engine FROM system.tables WHERE database = '$DATABASE' AND name = '$SHADOW_TABLE'")"
 if [[ -z "$dest_engine" ]]; then
-    echo "ERROR: destination '$DATABASE.$NEW_TABLE' does not exist on this instance. Pass --new-table for whatever" >&2
-    echo "       holds the new-schema data here: pre-EXCHANGE 'traces_local_v2', post-EXCHANGE 'traces'," >&2
-    echo "       post-wrap 'traces_local'." >&2
+    echo "ERROR: '$DATABASE.$SHADOW_TABLE' does not exist on this instance, so this step is out of sequence." >&2
+    echo "       The shadow exists only between the backfill (step 1) and the EXCHANGE (step 3). Before the" >&2
+    echo "       backfill, run backfill.sh first. After the EXCHANGE, the shadow is the live 'traces' and the old" >&2
+    echo "       data is parked as 'traces_pre_cutover_backup' -- this driver is pre-EXCHANGE only and there is no" >&2
+    echo "       post-swap catch-up mode (see the header). Nothing was written." >&2
     exit 1
 fi
 if [[ "$dest_engine" != *MergeTree ]]; then
-    echo "ERROR: destination '$DATABASE.$NEW_TABLE' has engine '$dest_engine'. The deletion replay is a lightweight" >&2
-    echo "       DELETE and only the MergeTree family supports one, so the delta INSERT would succeed and the replay" >&2
-    echo "       would then fail, leaving this catch-up half-applied. Refusing before anything is written." >&2
-    if [[ "$dest_engine" == "Distributed" ]]; then
-        echo "       'traces' is the Distributed wrap over 'traces_local'; re-run with --new-table traces_local." >&2
-    fi
+    echo "ERROR: destination '$DATABASE.$SHADOW_TABLE' has engine '$dest_engine', not a MergeTree. The deletion" >&2
+    echo "       replay is a lightweight DELETE and only the MergeTree family supports one, so the delta INSERT" >&2
+    echo "       would succeed and the replay would then fail, leaving this run half-applied. Refusing before" >&2
+    echo "       anything is written." >&2
     exit 1
 fi
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -22,6 +22,14 @@
 #                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
 #                             the password out of argv).
 #   --backfill-start TS        the anchor printed by backfill.sh ("RECORD backfill_start=..."). Required.
+#   --old-table NAME           old-schema source to read from. Default traces. AFTER THE EXCHANGE the names swap, so a
+#                             post-swap catch-up is `--old-table traces_pre_cutover_backup --new-table traces`. Without
+#                             these the script can only ever run pre-EXCHANGE: it hardcoded both names, so after the swap
+#                             it would read the successor and insert into a table that no longer exists.
+#   --new-table NAME           new-schema destination to write to. Default traces_local_v2. Same swap applies.
+#                             `verify.sh` has carried these two flags from the start; this brings the delta into line, so
+#                             the rows a final delta leaves behind (everything written while it ran) and the deletions
+#                             deferred past the swap both have a vehicle.
 #   --max-insert-block-size N  SETTINGS max_insert_block_size for the delta INSERT. Default 1048576.
 #   --max-partitions-per-insert-block N
 #                             partitions one insert block of the delta INSERT may span (SETTINGS
@@ -42,6 +50,9 @@
 
 set -euo pipefail
 
+OLD_TABLE="traces"          # old-schema side; becomes traces_pre_cutover_backup after the EXCHANGE (see --old-table)
+NEW_TABLE="traces_local_v2" # new-schema side (the successor being built); becomes traces after the EXCHANGE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
 
@@ -58,6 +69,8 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --backfill-start) BACKFILL_START="${2:?"$1 requires a value"}"; shift 2 ;;
+        --old-table) OLD_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --new-table) NEW_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-block-size) MAX_INSERT_BLOCK_SIZE="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
         --max-insert-threads) MAX_INSERT_THREADS="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -86,7 +99,16 @@ echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this 
 echo "restore it after the EXCHANGE."
 
 sql="$(cat "$SQL_FILE")"
+# Interpolated straight into the reference SQL, so require plain ClickHouse identifiers — same
+# guard verify.sh applies to the same three values.
+for _ident in "$DATABASE" "$OLD_TABLE" "$NEW_TABLE"; do
+    [[ "$_ident" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database/--old-table/--new-table must be ClickHouse identifiers (letters, digits, underscore): '$_ident'" >&2; exit 2; }
+done
+[[ "$OLD_TABLE" != "$NEW_TABLE" ]] || { echo "ERROR: --old-table and --new-table must differ; '$OLD_TABLE' would copy a table onto itself." >&2; exit 2; }
+
 sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+sql="${sql//'${OLD_TABLE}'/$OLD_TABLE}"
+sql="${sql//'${NEW_TABLE}'/$NEW_TABLE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
 sql="${sql//'${MAX_INSERT_BLOCK_SIZE}'/$MAX_INSERT_BLOCK_SIZE}"
 sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -75,13 +75,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_FILE="$SCRIPT_DIR/db-app-analytics/000003_exchange_and_wrap.sql"
 DELTA_SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
-# The deletion-replay block of 000002 is templated on the table names (opik#8092) so delta_replay.sh can also run
-# AFTER the swap. This driver only ever renders that block BEFORE the EXCHANGE — run_final_deletion_replay is called
-# once cutover_start is captured and before run_block exchange — so the names here are the pre-swap ones, the same
-# fixed names 000003's own EXCHANGE/RENAME statements carry. Bound as constants rather than exposed as flags: the
-# block is one fixed step of this driver, not a parameter of it.
-DELTA_OLD_TABLE="traces"
-DELTA_NEW_TABLE="traces_local_v2"
 
 DATABASE=""
 CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
@@ -332,8 +325,6 @@ run_final_deletion_replay() {
     local sql
     sql="$(awk -v begin="-- >>> BEGIN deletion-replay" -v end="-- >>> END deletion-replay" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$DELTA_SQL_FILE")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
-    sql="${sql//'${OLD_TABLE}'/$DELTA_OLD_TABLE}"
-    sql="${sql//'${NEW_TABLE}'/$DELTA_NEW_TABLE}"
     sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
     assert_no_placeholder "$sql" "deletion-replay"
     # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). This replay sits inside

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -75,6 +75,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SQL_FILE="$SCRIPT_DIR/db-app-analytics/000003_exchange_and_wrap.sql"
 DELTA_SQL_FILE="$SCRIPT_DIR/db-app-analytics/000002_delta_and_deletion_replay.sql"
+# The deletion-replay block of 000002 is templated on the table names (opik#8092) so delta_replay.sh can also run
+# AFTER the swap. This driver only ever renders that block BEFORE the EXCHANGE — run_final_deletion_replay is called
+# once cutover_start is captured and before run_block exchange — so the names here are the pre-swap ones, the same
+# fixed names 000003's own EXCHANGE/RENAME statements carry. Bound as constants rather than exposed as flags: the
+# block is one fixed step of this driver, not a parameter of it.
+DELTA_OLD_TABLE="traces"
+DELTA_NEW_TABLE="traces_local_v2"
 
 DATABASE=""
 CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
@@ -283,6 +290,21 @@ else
     assert_replication_settled
 fi
 
+# No placeholder may survive into the SQL this driver sends. Both blocks it renders live in files it does not own —
+# 000003 here, and the deletion-replay block of 000002, which it shares with delta_replay.sh — so a ${...} added
+# there without a matching substitution added HERE reaches the server as a literal and fails mid-cutover. The
+# reference SQL's own header keeps a hand-maintained placeholder inventory; a hand-maintained list drifts, so this
+# checks the rendered text instead of trusting it. $2 names the block, for diagnostics.
+assert_no_placeholder() {
+    if grep -qE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$1"; then
+        echo "ERROR: unsubstituted placeholder(s) survive in the rendered '$2' SQL:" >&2
+        grep -oE '\$\{[A-Za-z_][A-Za-z0-9_]*\}' <<<"$1" | sort -u | sed 's/^/       /' >&2
+        echo "       Refusing to send SQL containing a literal placeholder. Add the missing substitution to this" >&2
+        echo "       driver (delta_replay.sh renders the same 000002 block and needs it too)." >&2
+        exit 2
+    fi
+}
+
 # Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block from the reference SQL (exact-line markers).
 extract() {
     awk -v begin="-- >>> BEGIN $1" -v end="-- >>> END $1" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$SQL_FILE"
@@ -292,6 +314,7 @@ run_block() {
     local sql
     sql="$(extract "$1")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    assert_no_placeholder "$sql" "$1"
     # Each ON CLUSTER DDL in the block emits one row per host (host, port, status, error, hosts_remaining,
     # hosts_active); status 0 with an empty error means that host applied it. Labelled so the rows are not mistaken for
     # output of the preceding step (e.g. the final deletion replay).
@@ -309,7 +332,10 @@ run_final_deletion_replay() {
     local sql
     sql="$(awk -v begin="-- >>> BEGIN deletion-replay" -v end="-- >>> END deletion-replay" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$DELTA_SQL_FILE")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${OLD_TABLE}'/$DELTA_OLD_TABLE}"
+    sql="${sql//'${NEW_TABLE}'/$DELTA_NEW_TABLE}"
     sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
+    assert_no_placeholder "$sql" "deletion-replay"
     # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). This replay sits inside
     # the final-delta -> EXCHANGE gap the buffer hold has to cover, so its wall time is the number to record.
     clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database "$DATABASE" --log_comment 'traces_local_v2_cutover:exchange_and_wrap:final_deletion_replay' --time --multiquery --query "$sql"


### PR DESCRIPTION
## Details

`delta_replay.sh` hardcodes both table names, so it can only ever run **before** the EXCHANGE — afterwards `traces` *is* the successor and `traces_local_v2` is gone, so it would read its own destination and insert into a missing table. This adds the `--old-table`/`--new-table` pair `verify.sh` has carried from the start, with the same defaults, wording and identifier validation.

Without it the swap strands two sets of rows with nothing able to recover them: everything written *while* the final delta runs (its `SELECT` snapshots at query start, so at measured production rates ~60,000 traces over a ~50 min run land in the parked backup), and the deletions deferred past the swap (10,984 captured ids). Running the delta and the EXCHANGE back-to-back does not avoid this — the gap *is* the delta's own duration.

- Post-swap invocation is `--old-table traces_pre_cutover_backup --new-table traces`: the insert arm copies stranded rows out of the backup into the live successor, the deletion arm masks rows whose ids are in the bridge and absent from the backup.
- `000002_delta_and_deletion_replay.sql`: four hardcoded references become `${OLD_TABLE}`/`${NEW_TABLE}` — `INSERT INTO` and `DELETE FROM` take the new table, the delta `FROM` and the deletion arm's existence check take the old. `deletion_events_local` stays literal in both places; the bridge does not move.
- **Reviewer note on the risk this introduces:** the flags make it possible to point the delta at the wrong pair. *Reversing* them would copy the live table over the parked backup and destroy the rollback net, and the equal-tables guard does not catch it because the names differ. The script cannot enforce this — it cannot know which side of the EXCHANGE it is on — so the constraint is operator-side, in comet-ml/comet-support-agent#270.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-6901

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: ran the production cutover's backfill verification, both delta replays and the key reconciliation; measured the stranded-row problem this fixes; wrote both files and the verification below.
- Human verification: the operator authorised every production write and requested this change after reviewing the measured gap. Reviewer sign-off still required.

## Testing

No automated suite covers these drivers; they are operator-run shell against ClickHouse. Verified by rendering and by exercising each guard.

**Default render is byte-identical to the current file**, compared programmatically against pinned revision `7e49662c` (not by inspection) with `${ANALYTICS_DB_DATABASE_NAME}` substituted on both sides and the new defaults applied to this one:

```
DEFAULT RENDER IDENTICAL TO PINNED: YES
```

So the forward path cannot have changed by this PR.

**Post-swap render** with `--old-table traces_pre_cutover_backup --new-table traces` resolves to exactly:

```
INSERT INTO opik_prod.traces
FROM        opik_prod.traces_pre_cutover_backup
DELETE FROM opik_prod.traces
FROM        opik_prod.deletion_events_local   (unchanged)
```

**Guards, each executed rather than asserted:**

| Case | Command | Result |
|---|---|---|
| Non-identifier table name | `--old-table 'traces bad-name'` | exit 2, rejected |
| Same table both sides | `--old-table traces --new-table traces` | exit 2, "would copy a table onto itself" |
| Unknown flag | `--bogus x` | exit 2 |
| Syntax | `bash -n delta_replay.sh` | clean |

Not run: no execution against a live ClickHouse from this branch. The production runs to date used the pinned revision, whose rendered SQL is byte-identical to this one's default.

## Documentation

The flags are documented in the script header alongside the existing ones, including the post-swap invocation and why it exists. No user-facing docs affected — these are internal migration drivers.

Downstream: comet-ml/comet-support-agent#270 depends on this merging; it moves the production cutover's pinned driver revision and adds the operator-side rule constraining the post-swap form to one permitted table pair. It is held as a draft with the SHA unfilled until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
