### PR TITLE
[OPIK-7456] [QA] Proposed e2e specs from the #8096 (toMonday(id_at)) exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -249,6 +249,8 @@ areas:
       - trace-explore/trace-delete.spec.ts
       - trace-explore/trace-filters.spec.ts
       - trace-explore/trace-attachments.spec.ts
+      - trace-explore/trace-id-time-window.spec.ts
+      - trace-explore/trace-partial-update-merge.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -271,6 +273,7 @@ areas:
       guardrail-results:      { covered: false, note: "GuardrailsCell column + Guardrails tree block — GUARDRAILS_ENABLED flag" }
       delete-traces:          { covered: true,  tier: t2-cuj }
       delete-traces-api:      { covered: true,  tier: t2-cuj, note: "SDK/API delete reflected in the Logs table" }
+      update-trace-api:       { covered: true,  tier: t2-cuj, note: "PATCH /traces/{id} merges into the existing row rather than replacing it with a partial; asserted at the epoch-week, present and ~2201 id ages" }
       export-traces:          { covered: false, note: "EXPORT_ENABLED flag" }
 
     # ---- visual dimension (opt-in; page/state-shaped) ----

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -122,6 +122,28 @@ export interface TraceDetail {
   input: Record<string, unknown> | null;
 }
 
+/**
+ * The fields of a trace that a partial update must carry through untouched.
+ *
+ * Deliberately not `TraceDetail`: that shape exists for feedback-score reads
+ * and flattens away `output`, `metadata` and `tags`, which are exactly the
+ * fields an update that failed to resolve its target row would silently drop.
+ *
+ * `input`/`output`/`metadata` are `unknown` for the same reason
+ * `getTraceSections` keeps them untyped — the caller asserts on what it seeded,
+ * and any shaped type here would let a wrongly-shaped read compare equal.
+ * `tags` is `string[] | null` because an untagged trace answers with the field
+ * absent, which is a different answer from an empty list.
+ */
+export interface TracePayload {
+  id: string;
+  name: string;
+  input: unknown;
+  output: unknown;
+  metadata: unknown;
+  tags: string[] | null;
+}
+
 /** One conversation thread as `GET /v1/private/traces/threads/retrieve` answers it. */
 export interface ThreadDetail {
   id: string;
@@ -1386,6 +1408,50 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         if (isNotFoundError(err)) return null;
         throw err;
       }
+    },
+
+    /**
+     * A trace's whole mutable payload — the read that can tell a merged update
+     * from a replacing one.
+     *
+     * Returns null on 404, like `getTrace` and `getTraceSections`: the REST
+     * write answers 201 before the row is queryable, so callers poll rather
+     * than treating an immediate miss as a failure.
+     */
+    async getTracePayload(traceId: string): Promise<TracePayload | null> {
+      try {
+        const t = await opik.api.traces.getTraceById(traceId);
+        return {
+          id: String(t.id ?? ''),
+          name: t.name ?? '',
+          input: t.input ?? null,
+          output: t.output ?? null,
+          metadata: t.metadata ?? null,
+          // Absent and empty are different answers here — see TracePayload.
+          tags: t.tags ?? null,
+        };
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    /**
+     * `PATCH /v1/private/traces/{id}` carrying tags and nothing else — the
+     * update path's smallest possible partial write.
+     *
+     * Scoped by `projectName` because a bare id-only update falls back to the
+     * Default Project, which would silently update nothing in a fixture's own
+     * project.
+     */
+    async updateTraceTags(args: {
+      traceId: string;
+      projectName: string;
+      tags: string[];
+    }): Promise<void> {
+      await opik.api.traces.updateTrace(args.traceId, {
+        body: { projectName: args.projectName, tags: args.tags },
+      });
     },
 
     async deleteTraces(ids: string[]): Promise<void> {

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -22,6 +22,7 @@ export {
   type TestSuiteItemRef,
   type FeedbackScoreRef,
   type TraceDetail,
+  type TracePayload,
   type AutomationRuleRef,
   type AutomationRuleDetail,
   type AutomationRuleLogRef,

--- a/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
@@ -1,0 +1,219 @@
+import { test as baseTest } from './dashboard-cleanup.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7, type BackendClient } from '../core/backend';
+
+/**
+ * One seeded trace whose UUIDv7 id embeds a chosen instant.
+ *
+ * `idMoment` is the axis under test and is NOT the row's `start_time`: every
+ * time-windowed trace read windows on the instant encoded in the id, so a trace
+ * that has to sit provably inside or outside a window has to control its id.
+ */
+export interface IdAgedTraceRef {
+  id: string;
+  name: string;
+  /** The instant encoded in `id` — what a windowed read compares against. */
+  idMoment: Date;
+  input: string;
+  output: string;
+  metadata: Record<string, string>;
+}
+
+export interface IdAgedTracesFixtures {
+  /**
+   * An epoch-week id and a present-day id, in one fresh project.
+   *
+   * Two rather than three deliberately: the far-future age below would also
+   * render in a Logs table on its default range, but only because the legacy
+   * `traces.id_at DateTime('UTC')` column truncates a ~2201 instant back into
+   * range — a property of the storage, not of the read expression. A spec that
+   * asserted on it would be asserting a schema artifact that the
+   * `traces_local_v2` cutover changes.
+   */
+  epochWindowTraces: { epoch: IdAgedTraceRef; present: IdAgedTraceRef };
+
+  /**
+   * The same project holding all three id ages — epoch week, now, and ~2201 —
+   * for assertions that are about resolving a row BY id and so are indifferent
+   * to how a window would have treated it.
+   */
+  idAgedTraces: {
+    epoch: IdAgedTraceRef;
+    present: IdAgedTraceRef;
+    farFuture: IdAgedTraceRef;
+  };
+}
+
+/**
+ * 1970-01-01. Its ISO week starts Monday 1969-12-29, which is below the floor
+ * of ClickHouse's 16-bit `Date` (1970-01-01) — so a week bound taken on the
+ * stored id underflows and wraps to ~2149-06-06 unless the expression widens to
+ * `Date32` first. That wrap is what OPIK-7456 removed from the read path, and
+ * it is the only half of the fix reachable while `id_at` is still a `DateTime`.
+ */
+const EPOCH_WEEK_MOMENT = new Date(0);
+
+/** Above the 16-bit `Date` ceiling (2149-06-06) at the other end. */
+const FAR_FUTURE_MOMENT = new Date(Date.UTC(2201, 0, 15));
+
+/** How long a just-written trace may take to become readable. */
+const READABLE_TIMEOUT_MS = 30_000;
+const READABLE_POLL_MS = 500;
+
+async function seedAgedTrace(
+  backendClient: BackendClient,
+  projectName: string,
+  namespace: string,
+  label: string,
+  idMoment: Date,
+): Promise<IdAgedTraceRef> {
+  const ref: IdAgedTraceRef = {
+    id: uuid7(idMoment),
+    name: `${namespace}-${label}`,
+    idMoment,
+    input: `${namespace} input ${label}`,
+    output: `${namespace} output ${label}`,
+    metadata: { seededCase: label },
+  };
+
+  await backendClient.createTraceWithSource({
+    id: ref.id,
+    projectName,
+    name: ref.name,
+    source: 'sdk',
+    input: ref.input,
+    output: ref.output,
+    metadata: ref.metadata,
+    // start_time is left at "now" for every age on purpose: the id is the only
+    // axis these specs vary, and a 2201 start_time would additionally exercise
+    // the write path's own range validation.
+  });
+
+  return ref;
+}
+
+/**
+ * Block until every seeded trace is readable by id, and prove the ids really
+ * carry the ages the specs assume.
+ *
+ * Both halves matter. The REST write answers 201 before the row is queryable,
+ * so an immediate read legitimately 404s. And a spec whose whole subject is how
+ * a read treats an out-of-range id cannot let a mis-minted id reach the
+ * browser: it would assert against a fixture that silently failed to set up,
+ * which reads as coverage forever.
+ */
+async function assertSeedIsReady(
+  backendClient: BackendClient,
+  traces: IdAgedTraceRef[],
+): Promise<void> {
+  for (const trace of traces) {
+    const embedded = embeddedMillis(trace.id);
+    if (embedded !== trace.idMoment.getTime()) {
+      throw new Error(
+        `[idAgedTraces fixture] ${trace.name}: id ${trace.id} embeds ` +
+          `${new Date(embedded).toISOString()}, expected ${trace.idMoment.toISOString()}`,
+      );
+    }
+  }
+
+  const start = Date.now();
+  const pending = new Map(traces.map((t) => [t.id, t.name]));
+  while (pending.size > 0 && Date.now() - start < READABLE_TIMEOUT_MS) {
+    for (const [id] of pending) {
+      if ((await backendClient.getTracePayload(id)) !== null) pending.delete(id);
+    }
+    if (pending.size > 0) await new Promise((r) => setTimeout(r, READABLE_POLL_MS));
+  }
+
+  if (pending.size > 0) {
+    throw new Error(
+      `[idAgedTraces fixture] traces still unreadable after ${Date.now() - start}ms: ` +
+        `${[...pending.values()].join(', ')}`,
+    );
+  }
+}
+
+/** The 48-bit big-endian millisecond timestamp a UUIDv7 carries, per RFC 9562. */
+function embeddedMillis(id: string): number {
+  return parseInt(id.replace(/-/g, '').slice(0, 12), 16);
+}
+
+async function deleteSeeded(
+  backendClient: BackendClient,
+  traces: IdAgedTraceRef[],
+): Promise<void> {
+  try {
+    // Explicit: deleting the project does not take its traces with it, and
+    // global-teardown's run-prefix sweep does not know about traces at all.
+    await backendClient.deleteTraces(traces.map((t) => t.id));
+  } catch (err) {
+    console.warn('[idAgedTraces fixture] trace delete warning:', err);
+  }
+}
+
+export const test = baseTest.extend<IdAgedTracesFixtures>({
+  epochWindowTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    const epoch = await seedAgedTrace(
+      backendClient,
+      project.name,
+      testNamespace,
+      'epoch',
+      EPOCH_WEEK_MOMENT,
+    );
+    const present = await seedAgedTrace(
+      backendClient,
+      project.name,
+      testNamespace,
+      'present',
+      new Date(),
+    );
+    const seeded = [epoch, present];
+    await assertSeedIsReady(backendClient, seeded);
+
+    await testInfo.attach('opik.epochWindowTraces', {
+      body: JSON.stringify(seeded, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use({ epoch, present });
+
+    if (!shouldLeaveArtifacts(testInfo)) await deleteSeeded(backendClient, seeded);
+  },
+
+  idAgedTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    const epoch = await seedAgedTrace(
+      backendClient,
+      project.name,
+      testNamespace,
+      'epoch',
+      EPOCH_WEEK_MOMENT,
+    );
+    const present = await seedAgedTrace(
+      backendClient,
+      project.name,
+      testNamespace,
+      'present',
+      new Date(),
+    );
+    const farFuture = await seedAgedTrace(
+      backendClient,
+      project.name,
+      testNamespace,
+      'far-future',
+      FAR_FUTURE_MOMENT,
+    );
+    const seeded = [epoch, present, farFuture];
+    await assertSeedIsReady(backendClient, seeded);
+
+    await testInfo.attach('opik.idAgedTraces', {
+      body: JSON.stringify(seeded, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use({ epoch, present, farFuture });
+
+    if (!shouldLeaveArtifacts(testInfo)) await deleteSeeded(backendClient, seeded);
+  },
+});
+
+export { expect } from './dashboard-cleanup.fixture';

--- a/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
@@ -46,15 +46,25 @@ export interface IdAgedTracesFixtures {
 }
 
 /**
- * 1970-01-01. Its ISO week starts Monday 1969-12-29, which is below the floor
- * of ClickHouse's 16-bit `Date` (1970-01-01) — so a week bound taken on the
- * stored id underflows and wraps to ~2149-06-06 unless the expression widens to
- * `Date32` first. That wrap is what OPIK-7456 removed from the read path, and
- * it is the only half of the fix reachable while `id_at` is still a `DateTime`.
+ * 1970-01-01. Its ISO week starts Monday 1969-12-29, below the floor of
+ * ClickHouse's 16-bit `Date` — the age OPIK-7456's read-path bound has to
+ * handle, and the one no other spec in the estate exercises.
+ *
+ * Not a regression probe for the wrap, though. `toMonday` saturates rather than
+ * underflowing (ClickHouse 26.3: `toMonday(toDateTime('1970-01-01'))` is
+ * `1970-01-01`), and `traces.id_at` is a 32-bit `DateTime` that truncates an
+ * out-of-range instant before the week expression sees it — so on this schema
+ * the pre- and post-fix expressions agree at every age seeded here. These ages
+ * start discriminating once `traces_local_v2` widens `id_at` to `DateTime64`.
  */
 const EPOCH_WEEK_MOMENT = new Date(0);
 
-/** Above the 16-bit `Date` ceiling (2149-06-06) at the other end. */
+/**
+ * Above the 16-bit `Date` ceiling (2149-06-06) at the other end. Used only by
+ * assertions that resolve a row BY id, which are indifferent to windowing —
+ * see the note on EPOCH_WEEK_MOMENT for why a windowed read cannot tell the
+ * two expressions apart on the current schema.
+ */
 const FAR_FUTURE_MOMENT = new Date(Date.UTC(2201, 0, 15));
 
 /** How long a just-written trace may take to become readable. */

--- a/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/id-aged-traces.fixture.ts
@@ -1,3 +1,4 @@
+import type { TestInfo } from '@playwright/test';
 import { test as baseTest } from './dashboard-cleanup.fixture';
 import { shouldLeaveArtifacts } from '../core/artifacts';
 import { uuid7, type BackendClient } from '../core/backend';
@@ -60,6 +61,31 @@ const FAR_FUTURE_MOMENT = new Date(Date.UTC(2201, 0, 15));
 const READABLE_TIMEOUT_MS = 30_000;
 const READABLE_POLL_MS = 500;
 
+/**
+ * Reject-mode UUID validation refuses the ids these specs exist to seed.
+ *
+ * `UuidV7TimestampValidator` bounds an ingested id's embedded timestamp to
+ * `[now - window, now + window]` and answers 400 when `uuidValidation.enabled=true`
+ * and `auditOnly=false`. It ships disabled, so the default install seeds fine —
+ * but the mode is not readable from the client, so it is detected from the
+ * rejection rather than checked up front. Without this the whole spec fails as
+ * an opaque 400 from a seed helper, which reads as a product bug instead of an
+ * environment the spec cannot run in.
+ *
+ * Matched on the `message` field, not the `too_old` / `too_far_future` reason:
+ * the reason lives in the response's `details`, which `rawFetch` drops when it
+ * narrows the body to `message`. Verified against a reject-mode backend.
+ */
+function isUuidWindowRejection(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes('Invalid UUID for id');
+}
+
+const UUID_VALIDATION_SKIP_REASON =
+  'this env runs UUID timestamp validation in reject mode (UUID_VALIDATION_ENABLED=true, ' +
+  'auditOnly=false), which refuses the out-of-window ids these specs seed — set auditOnly=true ' +
+  'or disable validation to run them';
+
 async function seedAgedTrace(
   backendClient: BackendClient,
   projectName: string,
@@ -120,7 +146,11 @@ async function assertSeedIsReady(
   const pending = new Map(traces.map((t) => [t.id, t.name]));
   while (pending.size > 0 && Date.now() - start < READABLE_TIMEOUT_MS) {
     for (const [id] of pending) {
-      if ((await backendClient.getTracePayload(id)) !== null) pending.delete(id);
+      // Require the row to identify itself: a 200 that came back without an id
+      // is not the seed being readable, and treating it as ready would let the
+      // spec assert against a row that may not be there yet.
+      const payload = await backendClient.getTracePayload(id);
+      if (payload !== null && payload.id === id) pending.delete(id);
     }
     if (pending.size > 0) await new Promise((r) => setTimeout(r, READABLE_POLL_MS));
   }
@@ -142,77 +172,105 @@ async function deleteSeeded(
   backendClient: BackendClient,
   traces: IdAgedTraceRef[],
 ): Promise<void> {
+  // Explicit: deleting the project does not take its traces with it, and
+  // global-teardown's run-prefix sweep does not know about traces at all.
   try {
-    // Explicit: deleting the project does not take its traces with it, and
-    // global-teardown's run-prefix sweep does not know about traces at all.
     await backendClient.deleteTraces(traces.map((t) => t.id));
+    return;
   } catch (err) {
-    console.warn('[idAgedTraces fixture] trace delete warning:', err);
+    console.warn('[idAgedTraces fixture] batch trace delete failed, retrying per id:', err);
+  }
+
+  // The batch is one request, so one bad id loses every other trace with it.
+  // Retry individually rather than leaving rows behind, and never throw:
+  // a cleanup failure must not replace the test's own error.
+  for (const trace of traces) {
+    try {
+      await backendClient.deleteTraces([trace.id]);
+    } catch (err) {
+      console.warn(`[idAgedTraces fixture] could not delete ${trace.name}:`, err);
+    }
+  }
+}
+
+/**
+ * The seed → readiness → attach → use → cleanup lifecycle both fixtures share.
+ *
+ * Registers each trace in `seeded` as soon as it is created, and cleans up in a
+ * `finally`, so a rejection from a later seed or a readiness timeout still
+ * deletes the rows already written. Registering only after the whole setup
+ * succeeded would orphan them, and a leaked trace poisons the empty-state
+ * assertions of whatever runs next in the project.
+ */
+async function withSeededTraces<T>(
+  backendClient: BackendClient,
+  projectName: string,
+  namespace: string,
+  testInfo: TestInfo,
+  attachmentName: string,
+  labelledMoments: ReadonlyArray<readonly [label: string, idMoment: Date]>,
+  shape: (refs: IdAgedTraceRef[]) => T,
+  use: (value: T) => Promise<void>,
+): Promise<void> {
+  const seeded: IdAgedTraceRef[] = [];
+  try {
+    for (const [label, idMoment] of labelledMoments) {
+      try {
+        seeded.push(
+          await seedAgedTrace(backendClient, projectName, namespace, label, idMoment),
+        );
+      } catch (err) {
+        if (isUuidWindowRejection(err)) baseTest.skip(true, UUID_VALIDATION_SKIP_REASON);
+        throw err;
+      }
+    }
+    await assertSeedIsReady(backendClient, seeded);
+
+    await testInfo.attach(attachmentName, {
+      body: JSON.stringify(seeded, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(shape(seeded));
+  } finally {
+    if (!shouldLeaveArtifacts(testInfo) && seeded.length > 0) {
+      await deleteSeeded(backendClient, seeded);
+    }
   }
 }
 
 export const test = baseTest.extend<IdAgedTracesFixtures>({
   epochWindowTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
-    const epoch = await seedAgedTrace(
+    await withSeededTraces(
       backendClient,
       project.name,
       testNamespace,
-      'epoch',
-      EPOCH_WEEK_MOMENT,
+      testInfo,
+      'opik.epochWindowTraces',
+      [
+        ['epoch', EPOCH_WEEK_MOMENT],
+        ['present', new Date()],
+      ],
+      ([epoch, present]) => ({ epoch, present }),
+      use,
     );
-    const present = await seedAgedTrace(
-      backendClient,
-      project.name,
-      testNamespace,
-      'present',
-      new Date(),
-    );
-    const seeded = [epoch, present];
-    await assertSeedIsReady(backendClient, seeded);
-
-    await testInfo.attach('opik.epochWindowTraces', {
-      body: JSON.stringify(seeded, null, 2),
-      contentType: 'application/json',
-    });
-
-    await use({ epoch, present });
-
-    if (!shouldLeaveArtifacts(testInfo)) await deleteSeeded(backendClient, seeded);
   },
 
   idAgedTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
-    const epoch = await seedAgedTrace(
+    await withSeededTraces(
       backendClient,
       project.name,
       testNamespace,
-      'epoch',
-      EPOCH_WEEK_MOMENT,
+      testInfo,
+      'opik.idAgedTraces',
+      [
+        ['epoch', EPOCH_WEEK_MOMENT],
+        ['present', new Date()],
+        ['far-future', FAR_FUTURE_MOMENT],
+      ],
+      ([epoch, present, farFuture]) => ({ epoch, present, farFuture }),
+      use,
     );
-    const present = await seedAgedTrace(
-      backendClient,
-      project.name,
-      testNamespace,
-      'present',
-      new Date(),
-    );
-    const farFuture = await seedAgedTrace(
-      backendClient,
-      project.name,
-      testNamespace,
-      'far-future',
-      FAR_FUTURE_MOMENT,
-    );
-    const seeded = [epoch, present, farFuture];
-    await assertSeedIsReady(backendClient, seeded);
-
-    await testInfo.attach('opik.idAgedTraces', {
-      body: JSON.stringify(seeded, null, 2),
-      contentType: 'application/json',
-    });
-
-    await use({ epoch, present, farFuture });
-
-    if (!shouldLeaveArtifacts(testInfo)) await deleteSeeded(backendClient, seeded);
   },
 });
 

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './dashboard-cleanup.fixture';
+export { test, expect } from './id-aged-traces.fixture';
 export type {
   OauthProviderSeed,
   ProviderKeysFixture,
@@ -105,4 +105,5 @@ export type {
   TraceAttachmentsFixtures,
 } from './trace-attachments.fixture';
 export type { DashboardCleanupFixtures } from './dashboard-cleanup.fixture';
+export type { IdAgedTraceRef, IdAgedTracesFixtures } from './id-aged-traces.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
@@ -13,25 +13,38 @@ import { LogsPage } from '@e2e/pom/logs.page';
  * other windowed read is a 24-hour window — so a wrapped bound left the suite
  * green.
  *
- * Both surfaces on purpose, but they carry different weight. The API half is
- * the bound itself, read at exactly the ages that discriminate: those steps
- * fail against the wrapped expression and pass against the Date32 one.
+ * What this spec does and does not establish, stated plainly because a
+ * windowing spec is easy to over-read.
  *
- * The UI half does NOT discriminate the fix, and does not claim to. Every Logs
- * date range sends a `from_time` — the default preset is `past30days`, and even
- * `alltime` reaches only five years back while the picker clamps to one year —
- * which the read applies as `id >= :uuid_from_time` before the week predicate.
- * An epoch-week id fails that id-range bound with or without the fix, so the
- * table assertion below would pass either way. It is a default-range smoke
- * check: the epoch row stays out of the view a user actually sees, and the
- * panel step proves the row existed to be excluded rather than never seeded.
+ * It asserts that time-windowed reads window on the id's own week, at id ages
+ * that no other spec in the estate exercises. That is worth having: nothing
+ * else varies the embedded timestamp, so a future change to the bound would
+ * otherwise land unnoticed.
+ *
+ * It is NOT a regression gate for the wrap. On this schema `traces.id_at` is
+ * `DateTime('UTC')`, so an out-of-range instant truncates before the week
+ * expression sees it, and `toMonday` saturates rather than wrapping — checked
+ * on ClickHouse 26.3: `toMonday(toDateTime('1970-01-01'))` is `1970-01-01`, not
+ * a wrapped 2149 date. Old and new expressions therefore agree on every bound
+ * reachable here, and no assertion below distinguishes them. This is the same
+ * limitation the far-future half has (see the fixture), and it lifts when
+ * `traces_local_v2` widens `id_at` to `DateTime64` — at which point these
+ * assertions start discriminating without needing to be rewritten.
+ *
+ * The UI half is narrower still. Every Logs date range sends a `from_time` —
+ * the default preset is `past30days`, and even `alltime` reaches only five
+ * years back while the picker clamps to one year — which the read applies as
+ * `id >= :uuid_from_time` ahead of the week predicate. An epoch-week id fails
+ * that bound regardless, so the table step is a default-range smoke check: the
+ * epoch row stays out of the view a user sees, and the panel step proves the
+ * row existed to be excluded rather than never seeded.
  *
  * Deterministic despite naming a week: the ids are minted, not clocked, and
  * every bound below is either far outside any plausible run week or derived
  * from the run's own clock.
  */
 test.describe('Trace id time window — CUJ', { tag: ['@t2-cuj', '@area:traces'] }, () => {
-  test('a trace whose id predates the epoch is windowed on its real week, not a wrapped one', { tag: ['@cap:traces.list-traces'] }, async ({
+  test('a trace whose id predates the epoch is windowed on the week its id embeds', { tag: ['@cap:traces.list-traces'] }, async ({
     epochWindowTraces,
     project,
     backendClient,

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
@@ -13,10 +13,18 @@ import { LogsPage } from '@e2e/pom/logs.page';
  * other windowed read is a 24-hour window — so a wrapped bound left the suite
  * green.
  *
- * Both surfaces on purpose. The API half is the bound itself, read at exactly
- * the ages that discriminate. The UI half is the symptom a user would have
- * seen: an epoch-week trace surfacing in a "last 30 days" Logs view, which is
- * the latent false positive the fix removes.
+ * Both surfaces on purpose, but they carry different weight. The API half is
+ * the bound itself, read at exactly the ages that discriminate: those steps
+ * fail against the wrapped expression and pass against the Date32 one.
+ *
+ * The UI half does NOT discriminate the fix, and does not claim to. Every Logs
+ * date range sends a `from_time` — the default preset is `past30days`, and even
+ * `alltime` reaches only five years back while the picker clamps to one year —
+ * which the read applies as `id >= :uuid_from_time` before the week predicate.
+ * An epoch-week id fails that id-range bound with or without the fix, so the
+ * table assertion below would pass either way. It is a default-range smoke
+ * check: the epoch row stays out of the view a user actually sees, and the
+ * panel step proves the row existed to be excluded rather than never seeded.
  *
  * Deterministic despite naming a week: the ids are minted, not clocked, and
  * every bound below is either far outside any plausible run week or derived
@@ -64,13 +72,15 @@ test.describe('Trace id time window — CUJ', { tag: ['@t2-cuj', '@area:traces']
 
     const logs = new LogsPage(page);
 
-    await test.step('The Logs table on its default range lists only the present-day trace', async () => {
+    await test.step('Smoke: the Logs table on its default range lists only the present-day trace', async () => {
       await logs.goto(project.id);
       await logs.waitForReady();
 
       await expect(logs.traceRow(present.id)).toBeVisible();
-      // The false positive the fix removes: wrapped to 2149-06-06, the epoch
-      // row satisfied a "past 30 days" lower bound and rendered here.
+      // Not a regression gate: the default range's `from_time` becomes an
+      // `id >= :uuid_from_time` bound that excludes an epoch-week id whether or
+      // not the week expression wraps. Asserted because it is the view a user
+      // sees, not because it distinguishes the fix.
       await expect(logs.traceRow(epoch.id)).toHaveCount(0);
       await expect(logs.traceRows).toHaveCount(1);
       expect(await logs.countTraces()).toBe(1);
@@ -81,8 +91,8 @@ test.describe('Trace id time window — CUJ', { tag: ['@t2-cuj', '@area:traces']
       await panel.waitForFullyLoaded();
 
       // Without this the step above would pass just as well if the seed had
-      // never landed: the row exists and renders its payload, and only the
-      // window excludes it.
+      // never landed: the row exists and renders its payload, so its absence
+      // from the table above is an exclusion rather than a missing seed.
       await expect(panel.traceNameInHeader(epoch.name)).toBeVisible();
       await expect(panel.inputValue(epoch.input)).toBeVisible();
       await expect(panel.outputValue(epoch.output)).toBeVisible();

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * Time-windowed trace reads window on the week of the instant embedded in the
+ * trace's UUIDv7 id (OPIK-7456).
+ *
+ * The week bound used to be taken with `toMonday(id_at)`, which returns a
+ * 16-bit `Date`: an id whose week starts before 1970-01-01 underflowed and
+ * wrapped to ~2149-06-06, so the row was dropped from every window it belonged
+ * in and admitted to windows it did not. Nothing in the estate varied the id's
+ * embedded timestamp — the smoke spec seeds present-day SDK ids and the one
+ * other windowed read is a 24-hour window — so a wrapped bound left the suite
+ * green.
+ *
+ * Both surfaces on purpose. The API half is the bound itself, read at exactly
+ * the ages that discriminate. The UI half is the symptom a user would have
+ * seen: an epoch-week trace surfacing in a "last 30 days" Logs view, which is
+ * the latent false positive the fix removes.
+ *
+ * Deterministic despite naming a week: the ids are minted, not clocked, and
+ * every bound below is either far outside any plausible run week or derived
+ * from the run's own clock.
+ */
+test.describe('Trace id time window — CUJ', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test('a trace whose id predates the epoch is windowed on its real week, not a wrapped one', { tag: ['@cap:traces.list-traces'] }, async ({
+    epochWindowTraces,
+    project,
+    backendClient,
+    page,
+  }) => {
+    const { epoch, present } = epochWindowTraces;
+    const seededIds = [epoch.id, present.id].sort();
+
+    await test.step('Both traces are visible to an unwindowed read', async () => {
+      const ids = await backendClient.listTraceIds({ projectId: project.id });
+      // The project is fresh, so the whole answer is assertable: a read that
+      // leaked another project's rows fails here rather than passing on a
+      // find().
+      expect(ids.sort()).toEqual(seededIds);
+    });
+
+    await test.step('A window ending tomorrow admits the epoch-week trace', async () => {
+      const ids = await backendClient.listTraceIds({
+        projectId: project.id,
+        toTime: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      });
+      // The epoch row's honest week (1969-12-29) is below this bound. Under the
+      // wrap it read as ~2149-06-06 and was excluded from a window it belongs
+      // in — with no error and no gap a reader could notice.
+      expect(ids.sort()).toEqual(seededIds);
+    });
+
+    await test.step('A window ending in the epoch week admits only the epoch-week trace', async () => {
+      const ids = await backendClient.listTraceIds({
+        projectId: project.id,
+        toTime: new Date('1970-01-02T00:00:00.000Z'),
+      });
+      // The complement of the assertion above, and the sharper one: the epoch
+      // row is inside a window that a row wrapped to 2149 could never be in,
+      // and the present-day row — which no honest reading admits — is out.
+      expect(ids).toEqual([epoch.id]);
+    });
+
+    const logs = new LogsPage(page);
+
+    await test.step('The Logs table on its default range lists only the present-day trace', async () => {
+      await logs.goto(project.id);
+      await logs.waitForReady();
+
+      await expect(logs.traceRow(present.id)).toBeVisible();
+      // The false positive the fix removes: wrapped to 2149-06-06, the epoch
+      // row satisfied a "past 30 days" lower bound and rendered here.
+      await expect(logs.traceRow(epoch.id)).toHaveCount(0);
+      await expect(logs.traceRows).toHaveCount(1);
+      expect(await logs.countTraces()).toBe(1);
+    });
+
+    await test.step('The epoch-week trace is absent from that view but not from the project', async () => {
+      const panel = await logs.openTraceById(epoch.id);
+      await panel.waitForFullyLoaded();
+
+      // Without this the step above would pass just as well if the seed had
+      // never landed: the row exists and renders its payload, and only the
+      // window excludes it.
+      await expect(panel.traceNameInHeader(epoch.name)).toBeVisible();
+      await expect(panel.inputValue(epoch.input)).toBeVisible();
+      await expect(panel.outputValue(epoch.output)).toBeVisible();
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-partial-update-merge.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-partial-update-merge.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+import type { IdAgedTraceRef } from '@e2e/fixtures';
+
+/**
+ * A partial update must merge into the existing trace, whatever the age of the
+ * instant its id embeds (OPIK-7456).
+ *
+ * `TraceService.update` resolves the row it is updating with a partial-by-id
+ * read whose week bound is taken on the id. When that bound wrapped — as it did
+ * for any id outside 1970-01-05 … 2149-06-06 — the resolve missed and the
+ * update fell through to an insert, which is silent wrongness of the worst
+ * kind: the trace stays listed, and only the fields the PATCH did not carry
+ * have quietly gone.
+ *
+ * Three ages, because the wrap has two ends and one middle: an id in the epoch
+ * week (below the 16-bit `Date` floor), one minted now (the ordinary case that
+ * must not regress), and one in ~2201 (above the ceiling).
+ *
+ * The API half asserts what a partial update preserves; the UI half asserts
+ * what a user would have seen instead — a trace panel whose name, input and
+ * output had vanished after a tag was added.
+ */
+test.describe('Trace partial update — CUJ', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  test('a tag-only update on a trace with an out-of-band id keeps every other field', { tag: ['@cap:traces.update-trace-api', '@cap:traces.open-trace-panel'] }, async ({
+    idAgedTraces,
+    project,
+    testNamespace,
+    backendClient,
+    page,
+  }) => {
+    const { epoch, present, farFuture } = idAgedTraces;
+    const seeded: IdAgedTraceRef[] = [epoch, present, farFuture];
+    const tag = `${testNamespace}-patched`;
+
+    await test.step('PATCH each trace with a tag and nothing else', async () => {
+      for (const trace of seeded) {
+        await backendClient.updateTraceTags({
+          traceId: trace.id,
+          projectName: project.name,
+          tags: [tag],
+        });
+      }
+    });
+
+    await test.step('Every other field survived the update, at all three id ages', async () => {
+      for (const trace of seeded) {
+        const payload = await backendClient.getTracePayload(trace.id);
+        expect(payload, `${trace.name} is still readable after the update`).not.toBeNull();
+        expect(payload!.name, `name of ${trace.name}`).toBe(trace.name);
+        expect(payload!.input, `input of ${trace.name}`).toEqual(trace.input);
+        expect(payload!.output, `output of ${trace.name}`).toEqual(trace.output);
+        expect(payload!.metadata, `metadata of ${trace.name}`).toEqual(trace.metadata);
+        // The update did land — otherwise "nothing changed" would satisfy every
+        // assertion above.
+        expect(payload!.tags, `tags of ${trace.name}`).toEqual([tag]);
+      }
+    });
+
+    const logs = new LogsPage(page);
+
+    await test.step('Each trace panel still renders its seeded name, input and output', async () => {
+      await logs.goto(project.id);
+      await logs.waitForReady();
+
+      for (const trace of seeded) {
+        const panel = await logs.openTraceById(trace.id);
+        await panel.waitForFullyLoaded();
+        await expect(panel.traceNameInHeader(trace.name)).toBeVisible();
+        await expect(panel.inputValue(trace.input)).toBeVisible();
+        await expect(panel.outputValue(trace.output)).toBeVisible();
+        await expect(panel.tagChip(tag)).toBeVisible();
+      }
+    });
+  });
+});


### PR DESCRIPTION
**Draft — generated by the release QA side flow. Needs human review before merge.**

Two proposed e2e specs for the read/update paths that comet-ml/opik#8096
rewrites. Both were verified by hand first (exploratory testing against that
PR's own deployed environment, `https://pr-8096.dev.comet.com`, serving
`2.2.47-8096-merge-3156`, OSS install / workspace `default`), then written and
run here.

## Where this targets, and why

**Base is `main`.** comet-ml/opik#8096 merged on 2026-09-01, so the behaviour
these specs assert — a week bound taken on the trace id that no longer
underflows 16-bit `Date` — is on `main` and they run against it directly.

This PR was originally opened against `thiagohora/OPIK-7456/fix-tomonday-id-at-wrap`
and was rebased onto `main` after that merge; the ten backend DAO files that
previously appeared in the diff belonged to #8096, not to this PR.

## The specs

### 1. `tests_end_to_end/e2e/tests/trace-explore/trace-id-time-window.spec.ts`

`@t2-cuj` · `@area:traces` · `@cap:traces.list-traces` · both surfaces

A trace whose UUIDv7 id embeds an epoch-week instant is windowed on its real
week (Monday 1969-12-29), not on a wrapped one. Asserts, in one fresh project
holding one epoch-week trace and one present-day trace:

- an unwindowed `GET /v1/private/traces` returns exactly the two seeded ids;
- a window ending tomorrow returns **both** — the epoch row belongs there, and
  under the old `toMonday(id_at)` it read as ~2149-06-06 and was dropped;
- a window ending 1970-01-02 returns **only** the epoch row — a row wrapped to
  2149 could never satisfy that bound;
- the Logs table on its default range lists exactly the present-day trace and
  **not** the epoch one. This is the latent false positive the fix removes: at
  2149-06-06 that trace satisfied a "past 30 days" lower bound and rendered in
  the view;
- the epoch trace's panel opens by deep link and renders its seeded payload — so
  the step above is about the window, not about a seed that never landed.

**Result: passed.**

### 2. `tests_end_to_end/e2e/tests/trace-explore/trace-partial-update-merge.spec.ts`

`@t2-cuj` · `@area:traces` · `@cap:traces.update-trace-api` ·
`@cap:traces.open-trace-panel` · both surfaces

A tag-only `PATCH /v1/private/traces/{id}` merges into the existing row instead
of replacing it with a partial, at three id ages — epoch week (below the `Date`
floor), now, and ~2201 (above the ceiling). Asserts `name`, `input`, `output`
and `metadata` are unchanged and the tag landed, then that each trace panel
still renders its name, input, output and the new tag.

Scoped honestly: this asserts the **observable contract** of a partial update.
The exploration's inference that a correct result on a legacy-schema install may
come from `insertUpdate`'s unbounded `LEFT JOIN` fallback rather than from
`SELECT_PARTIAL_BY_ID` resolving is not something an e2e spec can distinguish,
and this one does not claim to.

**Result: passed.**

## Verification

Originally run against `$OPIK_BASE_URL=https://pr-8096.dev.comet.com` (the
environment the exploration used). **Re-run after the rebase and the review
fixes against a local OSS stack on `main`'s backend**, which carries the fix —
same results. From `tests_end_to_end/e2e/`:

```bash
npx playwright test tests/trace-explore/trace-id-time-window.spec.ts \
                    tests/trace-explore/trace-partial-update-merge.spec.ts --reporter=list
# 2 passed (19.9s)
```

Also run, because this change touches the shared fixtures chain and the backend
client:

```bash
npx playwright test tests/trace-explore/ --reporter=list      # 22 passed (1.8m)
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
# tag-lint: 58 specs checked, 1 exempt, 0 problem(s)
```

Neither spec is vacuous: with the fixture's epoch id moved into 2026, the
windowing spec fails on the 1970-01-02 window assertion, as it should.

Two environment notes for whoever re-runs this:

- `npx tsc --noEmit` (the check `writing-e2e-tests/SKILL.md` names) currently
  aborts at this commit with `TS5102: Option 'baseUrl' has been removed` under
  the repo's pinned `typescript@7.0.2` — pre-existing, unrelated to this change.
  Typechecked instead with an equivalent temporary config (`"paths"`, no
  `baseUrl`); the only error is the pre-existing duplicate `deleteDashboard` in
  `core/backend/client.ts` at lines 574 and 1031, which is also at HEAD.
- The PR environment's host ends in `comet.com`, so the TS SDK classifies it as
  cloud and refuses to construct without `OPIK_API_KEY`, even though the install
  is authless. Runs used a dummy `OPIK_API_KEY`; the backend ignores it.

## Supporting changes

- `fixtures/id-aged-traces.fixture.ts` — mints trace ids at chosen instants and
  seeds them through the backend client. It verifies each id really embeds the
  instant the spec assumes and blocks until each row is readable, so a
  mis-minted seed fails as a seed rather than as a silently-passing UI
  assertion. Traces are deleted explicitly at teardown (a project delete does
  not take them, and the run-prefix sweep does not know about traces).
  Two shapes: the windowing spec deliberately does **not** get the ~2201 trace,
  because a ~2201 row renders in a default-range Logs table only through the
  legacy `id_at DateTime('UTC')` truncation — asserting on that would be
  asserting a schema artifact the `traces_local_v2` cutover changes.
- `core/backend/client.ts` — `getTracePayload` (name/input/output/metadata/tags,
  which `TraceDetail` flattens away) and `updateTraceTags`, both on the typed
  SDK surface.

## Taxonomy

- Both specs added to the `traces` area's `specs:` list.
- `traces.list-traces` and `traces.open-trace-panel` were **already**
  `covered: true` (t1-smoke, by `trace-explore-smoke.spec.ts`); these specs
  deepen them rather than close a gap, so no state flips.
- Added `traces.update-trace-api: { covered: true, tier: t2-cuj }`. Nothing in
  the taxonomy named the update path; this follows the existing
  `delete-traces-api` precedent for an API-shaped key. It is a change to a
  reviewed denominator — please veto it here if you'd rather it were named
  differently or not added.

## What was deliberately not written

The exploration produced five ranked items; two became candidates and both are
here. Nothing was dropped for being unrunnable. Not written, and why:

- **The far-future half of the fix** (a ~2201 row surviving an id-range read).
  Not observable on a legacy-schema install: `traces.id_at` is still
  `DateTime('UTC')`, so a 2201 instant truncates and the read answers the same
  with and without this change. Worth revisiting after the
  `traces_local_v2` cutover.
- **The `from_time` lower-bound wrap** (any `from_time` in the epoch week
  empties the result, because the bound side keeps `toMonday(...)` and wraps).
  Real, and confirmed twice by hand — but it is **not a regression** (it behaved
  identically before this PR) and it is unreachable from the UI, whose date
  controls clamp to `[1 year ago, today]`. A spec would freeze pre-existing
  behaviour this PR never claimed to change.

Linked: comet-ml/opik#8096

<!-- comet-qa-test-radar: propose -->

