### PR TITLE
[OPIK-7791] [QA] Proposed e2e specs from the 2.2.46 → 2.2.47 release exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -249,10 +249,12 @@ areas:
       - trace-explore/trace-delete.spec.ts
       - trace-explore/trace-filters.spec.ts
       - trace-explore/trace-attachments.spec.ts
+      - trace-explore/far-future-trace-window.spec.ts
+      - trace-explore/trace-stream-cursor.spec.ts
 
     # ---- functional dimension ----
     capabilities:
-      list-traces:            { covered: true,  tier: t1-smoke }
+      list-traces:            { covered: true,  tier: t1-smoke, note: "also the time-windowed reads: which rows a from_time/to_time window is entitled to (incl. a far-future UUIDv7 id), and the traces/search stream paged with last_retrieved_id" }
       trace-ordering:         { covered: true,  tier: t1-smoke }
       open-trace-panel:       { covered: true,  tier: t1-smoke }
       span-tree-expand:       { covered: true,  tier: t2-cuj }
@@ -319,8 +321,9 @@ areas:
       - trace-explore/thread-logging-smoke.spec.ts
       - trace-explore/thread-id-prefilter.spec.ts
       - trace-explore/thread-evaluation.spec.ts
+      - trace-explore/far-future-thread-window.spec.ts
     capabilities:
-      list-threads:            { covered: true,  tier: t1-smoke }
+      list-threads:            { covered: true,  tier: t1-smoke, note: "also the time-windowed read: which threads a from_time/to_time window is entitled to, incl. a thread whose traces carry far-future UUIDv7 ids" }
       thread-message-count:    { covered: true,  tier: t1-smoke }
       open-thread-panel:       { covered: true,  tier: t1-smoke }
       turn-order-io:           { covered: true,  tier: t1-smoke }
@@ -369,6 +372,7 @@ areas:
       - dashboards/workspace-span-metrics.spec.ts
       - dashboards/project-span-metrics.spec.ts
       - dashboards/dashboards-list-filters.spec.ts
+      - dashboards/project-metric-daily-buckets.spec.ts
     capabilities:
       list-dashboards:      { covered: true,  tier: t2-cuj, note: "the list is filtered by the Description column; the other operators and columns are uncovered" }
       create-dashboard:     { covered: true,  tier: t2-cuj, note: "created via the Create dashboard dialog as the UI test's setup; rename/delete/duplicate uncovered" }
@@ -376,7 +380,7 @@ areas:
       edit-dashboard:       { covered: false }
       delete-dashboard:     { covered: false }
       add-widget:           { covered: true,  tier: t2-cuj, note: "Time series widget added through the widget dialog by workspace-span-metrics; other widget types and the config dialog's remaining options are uncovered" }
-      configure-widget:     { covered: true,  tier: t2-cuj, note: "scoping a Time series widget to one project and picking its metric through the widget dialog, plus the data contract of the per-project read it then makes (POST /projects/{id}/metrics across every MetricType and span breakdown); the widget dialog's remaining options — chart type, filters, group by, sub-metric — are uncovered" }
+      configure-widget:     { covered: true,  tier: t2-cuj, note: "scoping a Time series widget to one project and picking its metric through the widget dialog, plus the data contract of the per-project read it then makes (POST /projects/{id}/metrics across every MetricType and span breakdown); the widget dialog's remaining options — chart type, filters, group by, sub-metric — are uncovered. The per-project read's DAILY bucket *values* are pinned too (FEEDBACK_SCORES and TRACE_COUNT over a window crossing a week start, plus /projects/stats over a sub-window); reading those values back off the rendered chart is not possible, so that half stays API-level" }
       widget-filters:       { covered: true,  tier: t2-cuj, note: "data contract (POST /workspaces/metrics/spans against the front end's own filter payload, incl. the 400 path) plus a UI test that builds a workspace-scoped Time series widget and reads its chart" }
       metric-date-range:    { covered: true,  tier: t2-cuj, note: "data contract for the four presets at the interval calculateIntervalType implies, plus the UI date-range control driving a rendered widget" }
 

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -254,7 +254,7 @@ areas:
 
     # ---- functional dimension ----
     capabilities:
-      list-traces:            { covered: true,  tier: t1-smoke, note: "also the time-windowed reads: which rows a from_time/to_time window is entitled to (incl. a far-future UUIDv7 id), and the traces/search stream paged with last_retrieved_id" }
+      list-traces:            { covered: true,  tier: t1-smoke, note: "also the time-windowed reads: which rows a from_time/to_time window includes (incl. a far-future UUIDv7 id), and the traces/search stream paged with last_retrieved_id" }
       trace-ordering:         { covered: true,  tier: t1-smoke }
       open-trace-panel:       { covered: true,  tier: t1-smoke }
       span-tree-expand:       { covered: true,  tier: t2-cuj }
@@ -323,7 +323,7 @@ areas:
       - trace-explore/thread-evaluation.spec.ts
       - trace-explore/far-future-thread-window.spec.ts
     capabilities:
-      list-threads:            { covered: true,  tier: t1-smoke, note: "also the time-windowed read: which threads a from_time/to_time window is entitled to, incl. a thread whose traces carry far-future UUIDv7 ids" }
+      list-threads:            { covered: true,  tier: t1-smoke, note: "also the time-windowed read: which threads a from_time/to_time window includes, incl. a thread whose traces carry far-future UUIDv7 ids" }
       thread-message-count:    { covered: true,  tier: t1-smoke }
       open-thread-panel:       { covered: true,  tier: t1-smoke }
       turn-order-io:           { covered: true,  tier: t1-smoke }
@@ -380,7 +380,7 @@ areas:
       edit-dashboard:       { covered: false }
       delete-dashboard:     { covered: false }
       add-widget:           { covered: true,  tier: t2-cuj, note: "Time series widget added through the widget dialog by workspace-span-metrics; other widget types and the config dialog's remaining options are uncovered" }
-      configure-widget:     { covered: true,  tier: t2-cuj, note: "scoping a Time series widget to one project and picking its metric through the widget dialog, plus the data contract of the per-project read it then makes (POST /projects/{id}/metrics across every MetricType and span breakdown); the widget dialog's remaining options — chart type, filters, group by, sub-metric — are uncovered. The per-project read's DAILY bucket *values* are pinned too (FEEDBACK_SCORES and TRACE_COUNT over a window crossing a week start, plus /projects/stats over a sub-window); reading those values back off the rendered chart is not possible, so that half stays API-level" }
+      configure-widget:     { covered: true,  tier: t2-cuj, note: "scoping a Time series widget to one project and picking its metric through the widget dialog, plus the data contract of the per-project read it then makes (POST /projects/{id}/metrics across every MetricType and span breakdown); the widget dialog's remaining options — chart type, filters, group by, sub-metric — are uncovered. The per-project read's DAILY bucket *values* are pinned too (FEEDBACK_SCORES and TRACE_COUNT over a window crossing a week start); reading those values back off the rendered chart is not possible, so that half stays API-level" }
       widget-filters:       { covered: true,  tier: t2-cuj, note: "data contract (POST /workspaces/metrics/spans against the front end's own filter payload, incl. the 400 path) plus a UI test that builds a workspace-scoped Time series widget and reads its chart" }
       metric-date-range:    { covered: true,  tier: t2-cuj, note: "data contract for the four presets at the interval calculateIntervalType implies, plus the UI date-range control driving a rendered widget" }
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -341,6 +341,22 @@ export const PROJECT_METRIC_TYPES = [
 
 export type ProjectMetricType = (typeof PROJECT_METRIC_TYPES)[number];
 
+/** The entity a Logs metrics-summary (KPI) card counts. */
+export type KpiEntityType = 'traces' | 'spans' | 'threads';
+
+/**
+ * One card of a `POST /v1/private/projects/{id}/kpi-cards` answer.
+ *
+ * `null` is a real answer from this endpoint, not a missing one: a card whose
+ * interval matched nothing reports a null value rather than a zero, and the two
+ * must not be collapsed by a caller asserting on a count.
+ */
+export interface KpiStat {
+  type: string;
+  currentValue: number | null;
+  previousValue: number | null;
+}
+
 /** The `breakdown` block a widget sends when the user picks a "Group by". */
 export interface MetricBreakdown {
   /** `model`, `provider`, `type`, `name`, `tags`, … — the backend's BreakdownField. */
@@ -1000,6 +1016,45 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
     },
 
     /**
+     * `POST /v1/private/projects/{id}/kpi-cards` — the counts the Logs page's
+     * metrics-summary strip renders above the Traces/Threads table.
+     *
+     * Same payload the front end sends (`useProjectKpiCards.ts`): an
+     * `entity_type` plus an explicit `interval_start`/`interval_end`. That
+     * interval is the point — the card read is time-bounded where the table's
+     * own list read leaves the upper bound open, so it exercises a different
+     * branch of the same week-bound predicate.
+     */
+    async projectKpiCards(args: {
+      projectId: string;
+      entityType: KpiEntityType;
+      intervalStart: Date;
+      intervalEnd: Date;
+    }): Promise<RawApiResult & { stats: KpiStat[] }> {
+      const { status, message, json } = await rawFetch(
+        'POST',
+        `/v1/private/projects/${args.projectId}/kpi-cards`,
+        {
+          body: {
+            entity_type: args.entityType,
+            interval_start: args.intervalStart.toISOString(),
+            interval_end: args.intervalEnd.toISOString(),
+          },
+        },
+      );
+      const stats = (json as { stats?: Array<Record<string, unknown>> } | null)?.stats ?? [];
+      return {
+        status,
+        message,
+        stats: stats.map((s) => ({
+          type: String(s.type ?? ''),
+          currentValue: (s.current_value as number | null | undefined) ?? null,
+          previousValue: (s.previous_value as number | null | undefined) ?? null,
+        })),
+      };
+    },
+
+    /**
      * `DELETE /v1/private/dashboards/{id}`.
      *
      * A dashboard does not hang off a project, so no project delete reaches
@@ -1626,6 +1681,60 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
     },
 
     /**
+     * `POST /v1/private/traces/search` — the streaming read the SDK pages a
+     * project with, in stream order (descending id).
+     *
+     * `lastRetrievedId` is the pagination cursor, and driving it is the whole
+     * reason this exists: the endpoint answers `application/octet-stream`
+     * NDJSON, which neither the pinned SDK nor `rawFetch` (which parses one JSON
+     * document) can read, and the paged `GET /traces` has no cursor at all.
+     *
+     * Ids only, like `listTraceIds` — what a cursor test asserts is *which*
+     * rows a page is entitled to and in what order, never their content.
+     */
+    async searchTraceIds(
+      args: { projectId: string; lastRetrievedId?: string; limit?: number } & ReadWindow,
+    ): Promise<RawApiResult & { ids: string[] }> {
+      const headers: Record<string, string> = {
+        ...workspaceHeaders(),
+        Accept: 'application/octet-stream',
+        'Content-Type': 'application/json',
+      };
+      const res = await fetch(`${env.apiBaseUrl}/v1/private/traces/search`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          project_id: args.projectId,
+          truncate: true,
+          ...(args.limit === undefined ? {} : { limit: args.limit }),
+          ...(args.lastRetrievedId ? { last_retrieved_id: args.lastRetrievedId } : {}),
+          ...(args.fromTime ? { from_time: args.fromTime.toISOString() } : {}),
+          ...(args.toTime ? { to_time: args.toTime.toISOString() } : {}),
+        }),
+      });
+      const text = await res.text();
+      if (!res.ok) {
+        return { status: res.status, message: text.slice(0, 300), ids: [], location: null };
+      }
+      // One JSON document per line. The endpoint can also emit an ErrorMessage
+      // object mid-stream, which carries no `id` — surfaced as a thrown error
+      // rather than silently shortening the page, since a caller comparing the
+      // stream to an expected set would otherwise read it as missing rows.
+      const ids: string[] = [];
+      for (const line of text.split('\n')) {
+        if (line.trim() === '') continue;
+        const row = JSON.parse(line) as { id?: unknown; message?: unknown };
+        if (typeof row.id !== 'string') {
+          throw new Error(
+            `searchTraceIds: stream carried a row with no id: ${line.slice(0, 300)}`,
+          );
+        }
+        ids.push(row.id);
+      }
+      return { status: res.status, message: '', ids, location: null };
+    },
+
+    /**
      * Create a trace with an explicit id and `source`. The SDK bridge always
      * emits `source=sdk`; the optimization-trial overlay filters on
      * `source=optimization`, so a trial-log fixture cannot be built through the
@@ -1650,6 +1759,13 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       input?: TraceJsonSection;
       output?: TraceJsonSection;
       metadata?: Record<string, unknown>;
+      /**
+       * Puts the trace in a thread, so the same seed is readable through
+       * `/traces/threads` as well as `/traces`. The bridge's `createNestedTrace`
+       * takes a `thread_id` too, but it mints its own id — a caller that needs
+       * both an explicit id and a thread has only this route.
+       */
+      threadId?: string;
       startTime?: Date;
       /**
        * Set this to make the trace eligible for online scoring.
@@ -1666,6 +1782,7 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
           name: args.name,
           source: args.source,
           start_time: (args.startTime ?? new Date()).toISOString(),
+          ...(args.threadId ? { thread_id: args.threadId } : {}),
           ...(args.endTime ? { end_time: args.endTime.toISOString() } : {}),
           ...(args.input === undefined ? {} : { input: args.input }),
           ...(args.output === undefined ? {} : { output: args.output }),

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1690,7 +1690,7 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
      * document) can read, and the paged `GET /traces` has no cursor at all.
      *
      * Ids only, like `listTraceIds` — what a cursor test asserts is *which*
-     * rows a page is entitled to and in what order, never their content.
+     * rows a page includes and in what order, never their content.
      */
     async searchTraceIds(
       args: { projectId: string; lastRetrievedId?: string; limit?: number } & ReadWindow,

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -14,6 +14,8 @@ export {
   type MetricBreakdown,
   type WorkspaceMetricType,
   type ProjectMetricType,
+  type KpiEntityType,
+  type KpiStat,
   PROJECT_METRIC_TYPES,
   type AttachmentRef,
   type ProjectStatsRef,

--- a/tests_end_to_end/e2e/fixtures/far-future-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/far-future-traces.fixture.ts
@@ -1,0 +1,177 @@
+import { test as baseTest } from './dashboard-cleanup.fixture';
+import { uuid7 } from '../core/backend';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+export interface FarFutureTracesRef {
+  /** The trace whose UUIDv7 id carries a timestamp centuries from now. */
+  farFuture: { id: string; name: string; threadId: string; at: Date };
+  /**
+   * Ordinary traces stamped minutes ago, newest first — the same order the
+   * descending-id reads under test return them in.
+   */
+  present: Array<{ id: string; name: string }>;
+  /** The thread the present-day traces share. */
+  presentThreadId: string;
+  /** Every seeded id, newest first: the far-future row, then `present`. */
+  allIdsNewestFirst: string[];
+  /**
+   * A window that opens a week ago. Its lower bound sits below every seeded id
+   * and its upper bound is the caller's choice — which is the axis under test.
+   */
+  windowStart: Date;
+}
+
+export interface FarFutureTracesFixtures {
+  farFutureTraces: FarFutureTracesRef;
+}
+
+/**
+ * 2200-06-15, the instant the exploration reproduced against. Any date past
+ * 2149 would do — `toMonday` returns a 16-bit Date that wraps beyond it — but a
+ * fixed one keeps the seed identical run to run, and it is far enough past the
+ * wrap that a bucket landing near "now" cannot be a rounding artefact.
+ */
+const FAR_FUTURE_AT = new Date('2200-06-15T12:00:00.000Z');
+
+/** Four ordinary rows: enough that a collapsed page is unmistakably empty. */
+const PRESENT_TRACE_COUNT = 4;
+const MINUTE_MS = 60 * 1000;
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+/** Ingestion budget for the seeded rows to become queryable. */
+const SEED_VISIBLE_TIMEOUT_MS = 120_000;
+
+/**
+ * One project holding four ordinary traces and one whose UUIDv7 id is stamped
+ * centuries in the future (OPIK-7791, PR #8096).
+ *
+ * The far-future id is the entire seed. Opik's time-bounded trace reads window
+ * on the timestamp embedded in the id, and each pairs its id range with a
+ * week-start bound on the partition key; `toMonday` used to wrap for a
+ * far-future value, so the row fell out of every windowed read it belonged in.
+ * A row that vanishes that way raises nothing — no error, no empty state — so
+ * the only way to see it is to seed a row on the far side of the wrap and ask
+ * for it back.
+ *
+ * Ids are minted here rather than left to the backend for two reasons: the
+ * timestamp *is* the fixture (`age_days` on the SDK bridge only reaches
+ * backwards), and `POST /v1/private/traces` answers 201 with no body, so a spec
+ * asserting on exact ids has to know them upfront.
+ *
+ * The present-day rows are the discriminator. Without them, "the far-future row
+ * came back" would also be satisfied by a read that ignored its window
+ * entirely; with them, every assertion can name the whole expected set and a
+ * leak in either direction fails.
+ *
+ * Teardown deletes the traces explicitly: `ProjectService.delete` removes only
+ * the project row, so traces do not cascade with it, and `global-teardown`'s
+ * run-prefix sweep does not know about traces either.
+ */
+export const test = baseTest.extend<FarFutureTracesFixtures>({
+  farFutureTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    const now = Date.now();
+    const presentThreadId = `${testNamespace}-present-thread`;
+    const farFutureThreadId = `${testNamespace}-future-thread`;
+
+    const farFuture = {
+      id: uuid7(FAR_FUTURE_AT),
+      name: `${testNamespace}-far-future`,
+      threadId: farFutureThreadId,
+      at: FAR_FUTURE_AT,
+    };
+    await backendClient.createTraceWithSource({
+      id: farFuture.id,
+      projectName: project.name,
+      name: farFuture.name,
+      source: 'sdk',
+      threadId: farFutureThreadId,
+      input: { question: 'seeded at 2200-06-15' },
+      output: { answer: 'seeded at 2200-06-15' },
+      startTime: FAR_FUTURE_AT,
+      endTime: new Date(FAR_FUTURE_AT.getTime() + 1_000),
+    });
+
+    // Minutes back, not "now": a row stamped against the runner's clock can
+    // land marginally ahead of the backend's and then sit outside a window
+    // ending at now, which reads as a wrong answer rather than a bad seed.
+    // Five-minute spacing also fixes the descending-id order the reads return.
+    const present: Array<{ id: string; name: string }> = [];
+    for (let i = 0; i < PRESENT_TRACE_COUNT; i++) {
+      const at = new Date(now - (i + 1) * 5 * MINUTE_MS);
+      const seed = { id: uuid7(at), name: `${testNamespace}-present-${i + 1}` };
+      await backendClient.createTraceWithSource({
+        id: seed.id,
+        projectName: project.name,
+        name: seed.name,
+        source: 'sdk',
+        threadId: presentThreadId,
+        input: { question: `present-day trace ${i + 1}` },
+        output: { answer: `present-day trace ${i + 1}` },
+        startTime: at,
+        endTime: new Date(at.getTime() + 1_000),
+      });
+      present.push(seed);
+    }
+
+    const allIdsNewestFirst = [farFuture.id, ...present.map((p) => p.id)];
+
+    // Ingestion is asynchronous, so wait for the whole set before any spec
+    // reads. Polling the *unwindowed* list on purpose: it is the one read the
+    // wrap never affected, so a timeout here is a slow write, not the behaviour
+    // under test masquerading as one.
+    const deadline = Date.now() + SEED_VISIBLE_TIMEOUT_MS;
+    let visible: string[] = [];
+    for (;;) {
+      const ids = await backendClient.listTraceIds({ projectId: project.id });
+      visible = allIdsNewestFirst.filter((id) => ids.includes(id));
+      if (visible.length === allIdsNewestFirst.length) break;
+      if (Date.now() > deadline) {
+        throw new Error(
+          `[farFutureTraces fixture] only ${visible.length}/${allIdsNewestFirst.length} seeded traces ` +
+            `became queryable within ${SEED_VISIBLE_TIMEOUT_MS}ms — missing ` +
+            allIdsNewestFirst.filter((id) => !visible.includes(id)).join(', '),
+        );
+      }
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+
+    // The seed only discriminates if the far-future row really is far-future.
+    // A backend that clamped the id or `start_time` on write would leave every
+    // window assertion in these specs trivially true, and nothing else would
+    // notice — the row would still be there, just not where it claims to be.
+    const beforeNow = await backendClient.listTraceIds({
+      projectId: project.id,
+      toTime: new Date(now),
+    });
+    if (beforeNow.includes(farFuture.id)) {
+      throw new Error(
+        `[farFutureTraces fixture] ${farFuture.id} is inside a window ending now — ` +
+          'it was not stored with a far-future timestamp, so the seed proves nothing',
+      );
+    }
+
+    const ref: FarFutureTracesRef = {
+      farFuture,
+      present,
+      presentThreadId,
+      allIdsNewestFirst,
+      windowStart: new Date(now - WEEK_MS),
+    };
+
+    await testInfo.attach('opik.farFutureTraces', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteTraces(allIdsNewestFirst);
+      } catch (err) {
+        console.warn('[farFutureTraces fixture] trace delete warning:', err);
+      }
+    }
+  },
+});
+
+export { expect } from './dashboard-cleanup.fixture';

--- a/tests_end_to_end/e2e/fixtures/far-future-traces.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/far-future-traces.fixture.ts
@@ -64,111 +64,129 @@ const SEED_VISIBLE_TIMEOUT_MS = 120_000;
  *
  * Teardown deletes the traces explicitly: `ProjectService.delete` removes only
  * the project row, so traces do not cascade with it, and `global-teardown`'s
- * run-prefix sweep does not know about traces either.
+ * run-prefix sweep does not know about traces either. Each id is registered for
+ * deletion the moment it is written and the cleanup runs in a `finally`, so a
+ * rejection from a later seed, the readiness poll or the far-future check still
+ * takes the rows already written with it — registering only after the whole
+ * setup succeeded would orphan them.
  */
 export const test = baseTest.extend<FarFutureTracesFixtures>({
   farFutureTraces: async ({ backendClient, project, testNamespace }, use, testInfo) => {
     const now = Date.now();
     const presentThreadId = `${testNamespace}-present-thread`;
     const farFutureThreadId = `${testNamespace}-future-thread`;
+    const seededIds: string[] = [];
 
-    const farFuture = {
-      id: uuid7(FAR_FUTURE_AT),
-      name: `${testNamespace}-far-future`,
-      threadId: farFutureThreadId,
-      at: FAR_FUTURE_AT,
-    };
-    await backendClient.createTraceWithSource({
-      id: farFuture.id,
-      projectName: project.name,
-      name: farFuture.name,
-      source: 'sdk',
-      threadId: farFutureThreadId,
-      input: { question: 'seeded at 2200-06-15' },
-      output: { answer: 'seeded at 2200-06-15' },
-      startTime: FAR_FUTURE_AT,
-      endTime: new Date(FAR_FUTURE_AT.getTime() + 1_000),
-    });
-
-    // Minutes back, not "now": a row stamped against the runner's clock can
-    // land marginally ahead of the backend's and then sit outside a window
-    // ending at now, which reads as a wrong answer rather than a bad seed.
-    // Five-minute spacing also fixes the descending-id order the reads return.
-    const present: Array<{ id: string; name: string }> = [];
-    for (let i = 0; i < PRESENT_TRACE_COUNT; i++) {
-      const at = new Date(now - (i + 1) * 5 * MINUTE_MS);
-      const seed = { id: uuid7(at), name: `${testNamespace}-present-${i + 1}` };
+    try {
+      const farFuture = {
+        id: uuid7(FAR_FUTURE_AT),
+        name: `${testNamespace}-far-future`,
+        threadId: farFutureThreadId,
+        at: FAR_FUTURE_AT,
+      };
       await backendClient.createTraceWithSource({
-        id: seed.id,
+        id: farFuture.id,
         projectName: project.name,
-        name: seed.name,
+        name: farFuture.name,
         source: 'sdk',
-        threadId: presentThreadId,
-        input: { question: `present-day trace ${i + 1}` },
-        output: { answer: `present-day trace ${i + 1}` },
-        startTime: at,
-        endTime: new Date(at.getTime() + 1_000),
+        threadId: farFutureThreadId,
+        input: { question: 'seeded at 2200-06-15' },
+        output: { answer: 'seeded at 2200-06-15' },
+        startTime: FAR_FUTURE_AT,
+        endTime: new Date(FAR_FUTURE_AT.getTime() + 1_000),
       });
-      present.push(seed);
-    }
+      seededIds.push(farFuture.id);
 
-    const allIdsNewestFirst = [farFuture.id, ...present.map((p) => p.id)];
+      // Minutes back, not "now": a row stamped against the runner's clock can
+      // land marginally ahead of the backend's and then sit outside a window
+      // ending at now, which reads as a wrong answer rather than a bad seed.
+      // Five-minute spacing also fixes the descending-id order the reads return.
+      const present: Array<{ id: string; name: string }> = [];
+      for (let i = 0; i < PRESENT_TRACE_COUNT; i++) {
+        const at = new Date(now - (i + 1) * 5 * MINUTE_MS);
+        const seed = { id: uuid7(at), name: `${testNamespace}-present-${i + 1}` };
+        await backendClient.createTraceWithSource({
+          id: seed.id,
+          projectName: project.name,
+          name: seed.name,
+          source: 'sdk',
+          threadId: presentThreadId,
+          input: { question: `present-day trace ${i + 1}` },
+          output: { answer: `present-day trace ${i + 1}` },
+          startTime: at,
+          endTime: new Date(at.getTime() + 1_000),
+        });
+        seededIds.push(seed.id);
+        present.push(seed);
+      }
 
-    // Ingestion is asynchronous, so wait for the whole set before any spec
-    // reads. Polling the *unwindowed* list on purpose: it is the one read the
-    // wrap never affected, so a timeout here is a slow write, not the behaviour
-    // under test masquerading as one.
-    const deadline = Date.now() + SEED_VISIBLE_TIMEOUT_MS;
-    let visible: string[] = [];
-    for (;;) {
-      const ids = await backendClient.listTraceIds({ projectId: project.id });
-      visible = allIdsNewestFirst.filter((id) => ids.includes(id));
-      if (visible.length === allIdsNewestFirst.length) break;
-      if (Date.now() > deadline) {
+      const allIdsNewestFirst = [farFuture.id, ...present.map((p) => p.id)];
+
+      // Ingestion is asynchronous, so wait for the whole set before any spec
+      // reads. Polling the *unwindowed* list on purpose: it is the one read the
+      // wrap never affected, so a timeout here is a slow write, not the behaviour
+      // under test masquerading as one.
+      const deadline = Date.now() + SEED_VISIBLE_TIMEOUT_MS;
+      let visible: string[] = [];
+      for (;;) {
+        const ids = await backendClient.listTraceIds({ projectId: project.id });
+        visible = allIdsNewestFirst.filter((id) => ids.includes(id));
+        if (visible.length === allIdsNewestFirst.length) break;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `[farFutureTraces fixture] only ${visible.length}/${allIdsNewestFirst.length} seeded traces ` +
+              `became queryable within ${SEED_VISIBLE_TIMEOUT_MS}ms — missing ` +
+              allIdsNewestFirst.filter((id) => !visible.includes(id)).join(', '),
+          );
+        }
+        await new Promise((r) => setTimeout(r, 1_000));
+      }
+
+      // The seed only discriminates if the far-future row really is far-future.
+      // A backend that clamped the id or `start_time` on write would leave every
+      // window assertion in these specs trivially true, and nothing else would
+      // notice — the row would still be there, just not where it claims to be.
+      //
+      // Note the limit of this check. A window ending now excludes this id on
+      // the id bound alone, so the check catches a clamped *id* but says
+      // nothing about `traces.id_at` — the column the week bound actually
+      // reads, and a 32-bit `DateTime` that truncates a 2200 instant on write.
+      // Establishing that the far-future instant survived storage needs a probe
+      // this fixture does not have; see the review note on OPIK-7791.
+      const beforeNow = await backendClient.listTraceIds({
+        projectId: project.id,
+        toTime: new Date(now),
+      });
+      if (beforeNow.includes(farFuture.id)) {
         throw new Error(
-          `[farFutureTraces fixture] only ${visible.length}/${allIdsNewestFirst.length} seeded traces ` +
-            `became queryable within ${SEED_VISIBLE_TIMEOUT_MS}ms — missing ` +
-            allIdsNewestFirst.filter((id) => !visible.includes(id)).join(', '),
+          `[farFutureTraces fixture] ${farFuture.id} is inside a window ending now — ` +
+            'it was not stored with a far-future timestamp, so the seed proves nothing',
         );
       }
-      await new Promise((r) => setTimeout(r, 1_000));
-    }
 
-    // The seed only discriminates if the far-future row really is far-future.
-    // A backend that clamped the id or `start_time` on write would leave every
-    // window assertion in these specs trivially true, and nothing else would
-    // notice — the row would still be there, just not where it claims to be.
-    const beforeNow = await backendClient.listTraceIds({
-      projectId: project.id,
-      toTime: new Date(now),
-    });
-    if (beforeNow.includes(farFuture.id)) {
-      throw new Error(
-        `[farFutureTraces fixture] ${farFuture.id} is inside a window ending now — ` +
-          'it was not stored with a far-future timestamp, so the seed proves nothing',
-      );
-    }
+      const ref: FarFutureTracesRef = {
+        farFuture,
+        present,
+        presentThreadId,
+        allIdsNewestFirst,
+        windowStart: new Date(now - WEEK_MS),
+      };
 
-    const ref: FarFutureTracesRef = {
-      farFuture,
-      present,
-      presentThreadId,
-      allIdsNewestFirst,
-      windowStart: new Date(now - WEEK_MS),
-    };
+      await testInfo.attach('opik.farFutureTraces', {
+        body: JSON.stringify(ref, null, 2),
+        contentType: 'application/json',
+      });
 
-    await testInfo.attach('opik.farFutureTraces', {
-      body: JSON.stringify(ref, null, 2),
-      contentType: 'application/json',
-    });
-
-    await use(ref);
-
-    if (!shouldLeaveArtifacts(testInfo)) {
-      try {
-        await backendClient.deleteTraces(allIdsNewestFirst);
-      } catch (err) {
-        console.warn('[farFutureTraces fixture] trace delete warning:', err);
+      await use(ref);
+    } finally {
+      if (!shouldLeaveArtifacts(testInfo) && seededIds.length > 0) {
+        try {
+          await backendClient.deleteTraces(seededIds);
+        } catch (err) {
+          // Never rethrow from cleanup: a delete failure must not replace the
+          // test's own error with a less useful one.
+          console.warn('[farFutureTraces fixture] trace delete warning:', err);
+        }
       }
     }
   },

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './dashboard-cleanup.fixture';
+export { test, expect } from './project-metric-days.fixture';
 export type {
   OauthProviderSeed,
   ProviderKeysFixture,
@@ -105,4 +105,13 @@ export type {
   TraceAttachmentsFixtures,
 } from './trace-attachments.fixture';
 export type { DashboardCleanupFixtures } from './dashboard-cleanup.fixture';
+export type {
+  FarFutureTracesRef,
+  FarFutureTracesFixtures,
+} from './far-future-traces.fixture';
+export type {
+  ProjectMetricDayRef,
+  ProjectMetricDaysRef,
+  ProjectMetricDaysFixtures,
+} from './project-metric-days.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/project-metric-days.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/project-metric-days.fixture.ts
@@ -1,0 +1,184 @@
+import { test as baseTest } from './far-future-traces.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+
+/** One seeded day of the window and the values every bucket for it must carry. */
+export interface ProjectMetricDayRef {
+  /** Whole days before "now". Never 0 — see the note on the seed below. */
+  ageDays: number;
+  /** `YYYY-MM-DD` (UTC) of the DAILY bucket this day's traces fall in. */
+  bucketDate: string;
+  /** The one feedback score seeded on this day; also the day's expected average. */
+  scoreValue: number;
+  /** Traces stamped on this day — 2 on the day that also carries the error. */
+  traceCount: number;
+  traceIds: string[];
+}
+
+export interface ProjectMetricDaysRef {
+  days: ProjectMetricDayRef[];
+  /** The feedback-score name, which is also the metric series name. */
+  scoreName: string;
+  /** Opens on a UTC day boundary two empty days before the oldest seeded day. */
+  windowStart: Date;
+  /**
+   * A sub-window holding only the three most recent seeded days, with the
+   * totals `GET /v1/private/projects/stats` must report for it.
+   */
+  subWindow: { fromTime: Date; toTime: Date; traceCount: number; scoreAverage: number };
+  /** Every seeded trace id. */
+  allTraceIds: string[];
+}
+
+export interface ProjectMetricDaysFixtures {
+  projectMetricDays: ProjectMetricDaysRef;
+}
+
+/** Eleven consecutive days — enough to cross at least one Monday whenever it runs. */
+const SEEDED_DAYS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+/** The day that also carries an errored trace, so its trace count is 2 not 1. */
+const ERROR_DAY = 1;
+const SCORE_NAME = 'bucket-value';
+/** Two empty days sit between the window's start and the oldest seeded day. */
+const WINDOW_DAYS = 13;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const utcDate = (at: Date): string => at.toISOString().slice(0, 10);
+
+/** The Monday (ISO week start) a UTC date belongs to, as `YYYY-MM-DD`. */
+const weekStart = (at: Date): string => {
+  const d = new Date(`${utcDate(at)}T00:00:00.000Z`);
+  // getUTCDay(): 0 = Sunday. ISO weeks start Monday, which is what the read
+  // path's `toDayOfWeek(..., 1)` uses.
+  const offset = (d.getUTCDay() + 6) % 7;
+  return utcDate(new Date(d.getTime() - offset * DAY_MS));
+};
+
+/**
+ * A project carrying one scored trace per day for eleven consecutive days, plus
+ * one errored trace (OPIK-7791, PR #8096).
+ *
+ * `ProjectMetricsDAO`'s `TRACE_FILTERED_PREFIX` — the CTE behind every
+ * trace-based project metric — was rewritten by the far-future window fix, along
+ * with `GET_AVERAGE_DURATION` and `GET_TOTAL_TRACE_ERRORS`. 426 lines of SQL.
+ * The estate's existing guard over that endpoint asserts HTTP 200 across the 20
+ * metric types, which is a binding check, not a correctness one: it would pass
+ * unchanged if every bucket came back at the wrong date or with the wrong value.
+ *
+ * So each day gets a *distinct* score value equal to its own age. A query that
+ * dropped its bucket expression and summed the window, or that shifted buckets
+ * by a day, cannot land on eleven distinct values by accident — whereas eleven
+ * identical days would forgive both. The one errored trace makes the daily trace
+ * counts uneven too, for the same reason.
+ *
+ * Eleven consecutive days always contain at least one Monday, which is the
+ * boundary the rewritten week bound turns on; the fixture asserts that rather
+ * than trusting it.
+ *
+ * `ageDays` is never 0: a trace stamped against the runner's clock is a coin
+ * flip against the backend's, and one landing marginally ahead of it is silently
+ * excluded from any window ending at now — which reads as a wrong aggregate
+ * rather than a bad seed.
+ *
+ * Teardown deletes the traces rather than relying on the project delete: a
+ * project delete does not take its traces with it, and traces left behind would
+ * be counted by a later run reading the same window.
+ */
+export const test = baseTest.extend<ProjectMetricDaysFixtures>({
+  projectMetricDays: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const now = Date.now();
+    const days: ProjectMetricDayRef[] = [];
+
+    for (const ageDays of SEEDED_DAYS) {
+      const traceIds: string[] = [];
+      const scored = await sdkClient.python.createNestedTrace({
+        project_name: project.name,
+        name: `${testNamespace}-d${ageDays}`,
+        input: { question: `seeded day -${ageDays}` },
+        output: { answer: `seeded day -${ageDays}` },
+        age_days: ageDays,
+        feedback_scores: [{ name: SCORE_NAME, value: ageDays }],
+        spans: [],
+      });
+      traceIds.push(scored.id);
+
+      if (ageDays === ERROR_DAY) {
+        const errored = await sdkClient.python.createNestedTrace({
+          project_name: project.name,
+          name: `${testNamespace}-d${ageDays}-error`,
+          input: { question: `seeded day -${ageDays} error` },
+          output: { answer: `seeded day -${ageDays} error` },
+          age_days: ageDays,
+          error_info: {
+            exception_type: 'ValueError',
+            message: `seeded failure on day -${ageDays}`,
+          },
+          spans: [],
+        });
+        traceIds.push(errored.id);
+      }
+
+      days.push({
+        ageDays,
+        bucketDate: utcDate(new Date(now - ageDays * DAY_MS)),
+        scoreValue: ageDays,
+        traceCount: traceIds.length,
+        traceIds,
+      });
+    }
+
+    // Distinct dates are what the per-bucket assertions key on. They can only
+    // collide if SEEDED_DAYS repeated, but the seed is data — say so here
+    // rather than letting two days quietly collapse into one expectation that
+    // then "passes".
+    const dates = new Set(days.map((d) => d.bucketDate));
+    if (dates.size !== days.length) {
+      throw new Error(
+        `[projectMetricDays fixture] seeded days share a UTC bucket: ${days.map((d) => d.bucketDate).join(', ')}`,
+      );
+    }
+
+    // The week boundary is the whole reason this window is eleven days wide. If
+    // it ever stopped crossing one, every assertion below would still pass while
+    // no longer testing the predicate that was rewritten.
+    const weeks = new Set(days.map((d) => weekStart(new Date(`${d.bucketDate}T00:00:00.000Z`))));
+    if (weeks.size < 2) {
+      throw new Error(
+        `[projectMetricDays fixture] the seeded window does not cross a week start: ${[...weeks].join(', ')}`,
+      );
+    }
+
+    // Three most recent days, bounded half a day past the oldest of them so
+    // neither edge lands on a bucket boundary where inclusivity is ambiguous.
+    const subDays = days.filter((d) => d.ageDays <= 3);
+    const ref: ProjectMetricDaysRef = {
+      days,
+      scoreName: SCORE_NAME,
+      windowStart: new Date(`${utcDate(new Date(now - WINDOW_DAYS * DAY_MS))}T00:00:00.000Z`),
+      subWindow: {
+        fromTime: new Date(now - 3.5 * DAY_MS),
+        toTime: new Date(now),
+        traceCount: subDays.reduce((acc, d) => acc + d.traceCount, 0),
+        scoreAverage:
+          subDays.reduce((acc, d) => acc + d.scoreValue, 0) / subDays.length,
+      },
+      allTraceIds: days.flatMap((d) => d.traceIds),
+    };
+
+    await testInfo.attach('opik.projectMetricDays', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+
+    if (!shouldLeaveArtifacts(testInfo)) {
+      try {
+        await backendClient.deleteTraces(ref.allTraceIds);
+      } catch (err) {
+        console.warn('[projectMetricDays fixture] trace delete warning:', err);
+      }
+    }
+  },
+});
+
+export { expect } from './far-future-traces.fixture';

--- a/tests_end_to_end/e2e/fixtures/project-metric-days.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/project-metric-days.fixture.ts
@@ -3,7 +3,7 @@ import { shouldLeaveArtifacts } from '../core/artifacts';
 
 /** One seeded day of the window and the values every bucket for it must carry. */
 export interface ProjectMetricDayRef {
-  /** Whole days before "now". Never 0 — see the note on the seed below. */
+  /** Whole UTC days before today. Never 0 — see the note on the seed below. */
   ageDays: number;
   /** `YYYY-MM-DD` (UTC) of the DAILY bucket this day's traces fall in. */
   bucketDate: string;
@@ -42,7 +42,13 @@ const SCORE_NAME = 'bucket-value';
 const WINDOW_DAYS = 13;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
+/** Noon UTC, so a bucket cannot be moved by any plausible clock difference. */
+const MIDDAY_MS = 12 * 60 * 60 * 1000;
+
 const utcDate = (at: Date): string => at.toISOString().slice(0, 10);
+
+/** Today's 00:00 UTC — every instant and window bound below is relative to it. */
+const utcMidnight = (at: Date): number => Date.parse(`${utcDate(at)}T00:00:00.000Z`);
 
 /** The Monday (ISO week start) a UTC date belongs to, as `YYYY-MM-DD`. */
 const weekStart = (at: Date): string => {
@@ -79,103 +85,131 @@ const weekStart = (at: Date): string => {
  * excluded from any window ending at now — which reads as a wrong aggregate
  * rather than a bad seed.
  *
+ * Every seed is aimed at **noon UTC** of its day rather than at "now minus N
+ * days", and `age_days` is sent as the fraction that lands it there. The bridge
+ * subtracts `age_days` from a clock of its own (`datetime.now(UTC)`, once per
+ * call), so a whole-day offset computed here puts each trace within milliseconds
+ * of a UTC midnight: a run crossing midnight mid-seed, or any skew between the
+ * runner and the driver, would silently move a trace into the neighbouring
+ * bucket and fail every per-day expectation below. Noon gives that a 12-hour
+ * margin in both directions.
+ *
  * Teardown deletes the traces rather than relying on the project delete: a
  * project delete does not take its traces with it, and traces left behind would
- * be counted by a later run reading the same window.
+ * be counted by a later run reading the same window. Each id is registered as
+ * soon as it is written and the delete runs in a `finally`, so a rejection part
+ * way through the seed still takes the earlier rows with it.
  */
 export const test = baseTest.extend<ProjectMetricDaysFixtures>({
   projectMetricDays: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
     const now = Date.now();
+    const midnightToday = utcMidnight(new Date(now));
+    /** Noon UTC of the day `ageDays` before today. */
+    const instantFor = (ageDays: number): number =>
+      midnightToday - ageDays * DAY_MS + MIDDAY_MS;
     const days: ProjectMetricDayRef[] = [];
+    const seededIds: string[] = [];
 
-    for (const ageDays of SEEDED_DAYS) {
-      const traceIds: string[] = [];
-      const scored = await sdkClient.python.createNestedTrace({
-        project_name: project.name,
-        name: `${testNamespace}-d${ageDays}`,
-        input: { question: `seeded day -${ageDays}` },
-        output: { answer: `seeded day -${ageDays}` },
-        age_days: ageDays,
-        feedback_scores: [{ name: SCORE_NAME, value: ageDays }],
-        spans: [],
-      });
-      traceIds.push(scored.id);
-
-      if (ageDays === ERROR_DAY) {
-        const errored = await sdkClient.python.createNestedTrace({
+    try {
+      for (const ageDays of SEEDED_DAYS) {
+        const at = instantFor(ageDays);
+        // Fractional, and derived from the same instant the expectation is:
+        // the bridge only accepts an offset from its own now, so the offset is
+        // how the target instant is expressed.
+        const ageDaysExact = (now - at) / DAY_MS;
+        const traceIds: string[] = [];
+        const scored = await sdkClient.python.createNestedTrace({
           project_name: project.name,
-          name: `${testNamespace}-d${ageDays}-error`,
-          input: { question: `seeded day -${ageDays} error` },
-          output: { answer: `seeded day -${ageDays} error` },
-          age_days: ageDays,
-          error_info: {
-            exception_type: 'ValueError',
-            message: `seeded failure on day -${ageDays}`,
-          },
+          name: `${testNamespace}-d${ageDays}`,
+          input: { question: `seeded day -${ageDays}` },
+          output: { answer: `seeded day -${ageDays}` },
+          age_days: ageDaysExact,
+          feedback_scores: [{ name: SCORE_NAME, value: ageDays }],
           spans: [],
         });
-        traceIds.push(errored.id);
+        seededIds.push(scored.id);
+        traceIds.push(scored.id);
+
+        if (ageDays === ERROR_DAY) {
+          const errored = await sdkClient.python.createNestedTrace({
+            project_name: project.name,
+            name: `${testNamespace}-d${ageDays}-error`,
+            input: { question: `seeded day -${ageDays} error` },
+            output: { answer: `seeded day -${ageDays} error` },
+            age_days: ageDaysExact,
+            error_info: {
+              exception_type: 'ValueError',
+              message: `seeded failure on day -${ageDays}`,
+            },
+            spans: [],
+          });
+          seededIds.push(errored.id);
+          traceIds.push(errored.id);
+        }
+
+        days.push({
+          ageDays,
+          bucketDate: utcDate(new Date(at)),
+          scoreValue: ageDays,
+          traceCount: traceIds.length,
+          traceIds,
+        });
       }
 
-      days.push({
-        ageDays,
-        bucketDate: utcDate(new Date(now - ageDays * DAY_MS)),
-        scoreValue: ageDays,
-        traceCount: traceIds.length,
-        traceIds,
+      // Distinct dates are what the per-bucket assertions key on. They can only
+      // collide if SEEDED_DAYS repeated, but the seed is data — say so here
+      // rather than letting two days quietly collapse into one expectation that
+      // then "passes".
+      const dates = new Set(days.map((d) => d.bucketDate));
+      if (dates.size !== days.length) {
+        throw new Error(
+          `[projectMetricDays fixture] seeded days share a UTC bucket: ${days.map((d) => d.bucketDate).join(', ')}`,
+        );
+      }
+
+      // The week boundary is the whole reason this window is eleven days wide. If
+      // it ever stopped crossing one, every assertion below would still pass while
+      // no longer testing the predicate that was rewritten.
+      const weeks = new Set(days.map((d) => weekStart(new Date(`${d.bucketDate}T00:00:00.000Z`))));
+      if (weeks.size < 2) {
+        throw new Error(
+          `[projectMetricDays fixture] the seeded window does not cross a week start: ${[...weeks].join(', ')}`,
+        );
+      }
+
+      // Three most recent days, opening half a day below the oldest of them so
+      // neither edge lands on a bucket boundary where inclusivity is ambiguous:
+      // day -3 sits at noon, the bound at the preceding midnight-minus-12h.
+      const subDays = days.filter((d) => d.ageDays <= 3);
+      const ref: ProjectMetricDaysRef = {
+        days,
+        scoreName: SCORE_NAME,
+        windowStart: new Date(midnightToday - WINDOW_DAYS * DAY_MS),
+        subWindow: {
+          fromTime: new Date(midnightToday - 3.5 * DAY_MS),
+          toTime: new Date(now),
+          traceCount: subDays.reduce((acc, d) => acc + d.traceCount, 0),
+          scoreAverage:
+            subDays.reduce((acc, d) => acc + d.scoreValue, 0) / subDays.length,
+        },
+        allTraceIds: days.flatMap((d) => d.traceIds),
+      };
+
+      await testInfo.attach('opik.projectMetricDays', {
+        body: JSON.stringify(ref, null, 2),
+        contentType: 'application/json',
       });
-    }
 
-    // Distinct dates are what the per-bucket assertions key on. They can only
-    // collide if SEEDED_DAYS repeated, but the seed is data — say so here
-    // rather than letting two days quietly collapse into one expectation that
-    // then "passes".
-    const dates = new Set(days.map((d) => d.bucketDate));
-    if (dates.size !== days.length) {
-      throw new Error(
-        `[projectMetricDays fixture] seeded days share a UTC bucket: ${days.map((d) => d.bucketDate).join(', ')}`,
-      );
-    }
-
-    // The week boundary is the whole reason this window is eleven days wide. If
-    // it ever stopped crossing one, every assertion below would still pass while
-    // no longer testing the predicate that was rewritten.
-    const weeks = new Set(days.map((d) => weekStart(new Date(`${d.bucketDate}T00:00:00.000Z`))));
-    if (weeks.size < 2) {
-      throw new Error(
-        `[projectMetricDays fixture] the seeded window does not cross a week start: ${[...weeks].join(', ')}`,
-      );
-    }
-
-    // Three most recent days, bounded half a day past the oldest of them so
-    // neither edge lands on a bucket boundary where inclusivity is ambiguous.
-    const subDays = days.filter((d) => d.ageDays <= 3);
-    const ref: ProjectMetricDaysRef = {
-      days,
-      scoreName: SCORE_NAME,
-      windowStart: new Date(`${utcDate(new Date(now - WINDOW_DAYS * DAY_MS))}T00:00:00.000Z`),
-      subWindow: {
-        fromTime: new Date(now - 3.5 * DAY_MS),
-        toTime: new Date(now),
-        traceCount: subDays.reduce((acc, d) => acc + d.traceCount, 0),
-        scoreAverage:
-          subDays.reduce((acc, d) => acc + d.scoreValue, 0) / subDays.length,
-      },
-      allTraceIds: days.flatMap((d) => d.traceIds),
-    };
-
-    await testInfo.attach('opik.projectMetricDays', {
-      body: JSON.stringify(ref, null, 2),
-      contentType: 'application/json',
-    });
-
-    await use(ref);
-
-    if (!shouldLeaveArtifacts(testInfo)) {
-      try {
-        await backendClient.deleteTraces(ref.allTraceIds);
-      } catch (err) {
-        console.warn('[projectMetricDays fixture] trace delete warning:', err);
+      await use(ref);
+    } finally {
+      if (!shouldLeaveArtifacts(testInfo) && seededIds.length > 0) {
+        try {
+          await backendClient.deleteTraces(seededIds);
+        } catch (err) {
+          // Never rethrow from cleanup: a delete failure must not replace the
+          // test's own error with a less useful one.
+          console.warn('[projectMetricDays fixture] trace delete warning:', err);
+        }
       }
     }
   },

--- a/tests_end_to_end/e2e/pom/logs.page.ts
+++ b/tests_end_to_end/e2e/pom/logs.page.ts
@@ -31,6 +31,25 @@ export class LogsPage {
     });
   }
 
+  /**
+   * Open Logs with the Traces tab active for the given project.
+   *
+   * `goto()` above leaves the tab to the page, and the page's default is
+   * data-dependent: `useLogsType` opens on Threads whenever the project has a
+   * thread in the current date range, falling back to Traces only when it has
+   * none. A spec whose subject is the Traces table has to ask for it, or it
+   * silently asserts against whichever table the seed happened to produce.
+   */
+  async gotoTraces(projectId: string): Promise<void> {
+    return test.step(`Open Logs (Traces) for project ${projectId}`, async () => {
+      this.projectId = projectId;
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/projects/${projectId}/logs?logsType=traces`,
+      );
+    });
+  }
+
   /** Open Logs with the Threads tab active for the given project. */
   async gotoThreads(projectId: string): Promise<void> {
     return test.step(`Open Logs (Threads) for project ${projectId}`, async () => {

--- a/tests_end_to_end/e2e/tests/dashboards/project-metric-daily-buckets.spec.ts
+++ b/tests_end_to_end/e2e/tests/dashboards/project-metric-daily-buckets.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@e2e/fixtures';
+import type { MetricSeries } from '@e2e/core/backend';
+
+/**
+ * The values a project Time series widget plots, across a week boundary
+ * (OPIK-7791, PR #8096).
+ *
+ * `ProjectMetricsDAO`'s `TRACE_FILTERED_PREFIX` — the CTE every trace-based
+ * project metric selects through — took the far-future week-bound rewrite, along
+ * with `GET_AVERAGE_DURATION` and `GET_TOTAL_TRACE_ERRORS`. The estate's
+ * existing cover for that endpoint, `project-span-metrics.spec.ts`, asserts HTTP
+ * 200 across the 20 metric types: a binding guard for a 426-line SQL edit, not a
+ * correctness one. It would pass unchanged if every bucket came back a day late
+ * or carrying the whole window's total.
+ *
+ * So this asserts values. The fixture gives each of eleven consecutive days a
+ * distinct feedback score equal to its own age, which makes every bucket exactly
+ * predictable and makes a collapsed or shifted bucketing impossible to satisfy
+ * by accident. The window necessarily crosses a Monday, which is the boundary
+ * the rewritten predicate turns on.
+ *
+ * API-level, and deliberately so. What a chart can be asked is whether it drew
+ * *something* — points are SVG geometry, so a rendered series cannot be compared
+ * to a seeded value, and `project-span-metrics.spec.ts` already drives the
+ * project-scoped widget dialog under this same capability. The numbers are only
+ * checkable here.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** The UTC day a DAILY bucket falls on, as the fixture records its seeds. */
+const bucketDate = (point: { time: string }): string => point.time.slice(0, 10);
+
+/**
+ * One named series' points folded to `bucketDate -> value`.
+ *
+ * The series must be present: an absent one means the aggregation returned
+ * nothing at all, which is a failure and not a window of zeroes. Individual
+ * points may be null — `WITH FILL` pads empty buckets — and those are zero.
+ */
+const byDate = (series: MetricSeries[], name: string): Map<string, number> => {
+  const found = series.find((s) => s.name === name);
+  expect(found, `the answer carries a "${name}" series`).toBeDefined();
+  const out = new Map<string, number>();
+  for (const point of found!.points) {
+    out.set(bucketDate(point), (out.get(bucketDate(point)) ?? 0) + (point.value ?? 0));
+  }
+  return out;
+};
+
+test.describe('Project metric daily buckets — CUJ', { tag: ['@t2-cuj', '@area:dashboards'] }, () => {
+  // The fixture writes twelve traces and blocks on each until it is queryable.
+  test.slow();
+
+  test(
+    'every daily bucket carries the value seeded on its own day, across a week boundary',
+    { tag: ['@cap:dashboards.configure-widget'] },
+    async ({ projectMetricDays, project, backendClient }) => {
+      const { days, scoreName, windowStart } = projectMetricDays;
+      const window = { intervalStart: windowStart, intervalEnd: new Date() };
+      const seededDates = new Set(days.map((d) => d.bucketDate));
+
+      await test.step('Each FEEDBACK_SCORES bucket is the score seeded on that day', async () => {
+        const { status, message, series } = await backendClient.projectMetric({
+          projectId: project.id,
+          metricType: 'FEEDBACK_SCORES',
+          interval: 'DAILY',
+          ...window,
+        });
+        expect(status, `FEEDBACK_SCORES rejected with: ${message}`).toBe(200);
+
+        const values = byDate(series, scoreName);
+        for (const day of days) {
+          expect(
+            values.get(day.bucketDate),
+            `${scoreName} on ${day.bucketDate} (day -${day.ageDays})`,
+          ).toBeCloseTo(day.scoreValue, 6);
+        }
+
+        // The half a per-day comparison alone would miss: nothing landed in a
+        // day that was never seeded. A query that ignored its bucket expression
+        // would put every score in one bucket and still satisfy the loop above
+        // for that one day.
+        const strays = [...values.entries()].filter(
+          ([date, value]) => !seededDates.has(date) && value !== 0,
+        );
+        expect(strays, 'buckets outside the seeded days are empty').toEqual([]);
+      });
+
+      await test.step('Each TRACE_COUNT bucket is the number of traces stamped on that day', async () => {
+        const { status, message, series } = await backendClient.projectMetric({
+          projectId: project.id,
+          metricType: 'TRACE_COUNT',
+          interval: 'DAILY',
+          ...window,
+        });
+        expect(status, `TRACE_COUNT rejected with: ${message}`).toBe(200);
+
+        const counts = byDate(series, 'traces');
+        for (const day of days) {
+          expect(
+            counts.get(day.bucketDate),
+            `traces on ${day.bucketDate} (day -${day.ageDays})`,
+          ).toBe(day.traceCount);
+        }
+        const strays = [...counts.entries()].filter(
+          ([date, value]) => !seededDates.has(date) && value !== 0,
+        );
+        expect(strays, 'buckets outside the seeded days are empty').toEqual([]);
+
+        // The project is fresh, so the window's total is exactly the seed — a
+        // read that leaked another project's rows in would fail here even if
+        // every seeded day happened to be right.
+        const total = [...counts.values()].reduce((a, b) => a + b, 0);
+        expect(total, 'the window holds exactly the seeded traces').toBe(
+          days.reduce((acc, d) => acc + d.traceCount, 0),
+        );
+      });
+
+      await test.step('A window closing before the seed aggregates to nothing', async () => {
+        // Without this, everything above would also hold for an endpoint that
+        // ignored interval_start/interval_end and read all of time.
+        const { status, series } = await backendClient.projectMetric({
+          projectId: project.id,
+          metricType: 'TRACE_COUNT',
+          interval: 'DAILY',
+          intervalStart: windowStart,
+          intervalEnd: new Date(Date.now() - 12 * DAY_MS),
+        });
+        expect(status, 'a window ending before the oldest seeded day').toBe(200);
+        const traces = series.find((s) => s.name === 'traces');
+        // Absent and zero are the same answer for a window that matched
+        // nothing, unlike the seeded windows above where an absent series would
+        // mean the aggregation returned nothing at all.
+        expect(
+          traces?.points.reduce((acc, p) => acc + (p.value ?? 0), 0) ?? 0,
+          'traces before the seed',
+        ).toBe(0);
+      });
+    },
+  );
+
+  test(
+    'project stats over a sub-window report the traces and score average that window holds',
+    { tag: ['@cap:dashboards.configure-widget'] },
+    async ({ projectMetricDays, project, backendClient }) => {
+      const { scoreName, subWindow } = projectMetricDays;
+
+      await test.step('The three most recent days aggregate to their own totals', async () => {
+        // A different read from the metrics endpoint above — `/projects/stats`
+        // windows on the id range without bucketing — and the one the Projects
+        // list renders its columns from. Same predicate underneath.
+        const stats = await backendClient.getProjectStats({
+          name: project.name,
+          fromTime: subWindow.fromTime,
+          toTime: subWindow.toTime,
+        });
+        const row = stats.find((s) => s.projectId === project.id);
+        expect(row, `projects/stats returned a row for ${project.name}`).toBeDefined();
+
+        expect(row!.traceCount, 'traces in the last three seeded days').toBe(subWindow.traceCount);
+        // Required, not conditional: the fixture seeded a score on every one of
+        // those days, so a missing average is a regression in this read and not
+        // a reason to skip the comparison.
+        expect(
+          row!.feedbackScores[scoreName],
+          `projects/stats reports a "${scoreName}" average for the sub-window`,
+        ).not.toBeUndefined();
+        expect(
+          row!.feedbackScores[scoreName],
+          `the "${scoreName}" average over the last three seeded days`,
+        ).toBeCloseTo(subWindow.scoreAverage, 6);
+      });
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/far-future-thread-window.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/far-future-thread-window.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * The thread half of the far-future window fix (OPIK-7791, PR #8096).
+ *
+ * `ThreadDAO` took the identical week-bound rewrite as `TraceDAO`, and it is the
+ * one with no regression test upstream at all — the PR's own guard runs against
+ * traces. A thread is derived from its traces, so a thread whose traces carry
+ * far-future ids inherits the same wrap: it cleared the id bound, folded into a
+ * past Monday and vanished from the Threads view.
+ *
+ * Split from `far-future-trace-window.spec.ts` because a spec belongs to exactly
+ * one `@area:`, and these assertions are threads. Both drive the same fixture.
+ *
+ * Every assertion names the whole expected set of thread ids: a read that
+ * ignored its window would also contain the thread being looked for.
+ */
+
+const FAR_WINDOW_START = new Date('2200-01-01T00:00:00.000Z');
+const FAR_WINDOW_END = new Date('2201-01-01T00:00:00.000Z');
+
+/** The `count` card of a kpi-cards answer, required rather than optional. */
+const countCard = (stats: Array<{ type: string; currentValue: number | null }>): number => {
+  const card = stats.find((s) => s.type === 'count');
+  expect(card, 'the kpi-cards answer carries a "count" card').toBeDefined();
+  expect(card!.currentValue, 'the count card carries a current value').not.toBeNull();
+  return card!.currentValue!;
+};
+
+test.describe('Far-future thread windowing — CUJ', { tag: ['@t2-cuj', '@area:threads'] }, () => {
+  // Seeding writes five traces; thread rollup is then eventually consistent.
+  test.slow();
+
+  test(
+    'a thread built from far-future traces is listed by every window that spans it',
+    { tag: ['@cap:threads.list-threads'] },
+    async ({ farFutureTraces, project, backendClient }) => {
+      const { farFuture, presentThreadId, windowStart } = farFutureTraces;
+      const bothThreads = [farFuture.threadId, presentThreadId].sort();
+
+      await test.step('Wait for both threads to be aggregated', async () => {
+        // Thread rollup lags trace ingestion, so poll for the full set rather
+        // than reading once — a slow deploy is a wait, not a failure. The
+        // unwindowed read is the right one to wait on: it is the only one the
+        // wrap never affected, so a timeout here cannot be the bug under test.
+        await expect
+          .poll(
+            async () => {
+              const { threads } = await backendClient.listThreads({ projectId: project.id });
+              return threads.map((t) => t.id).sort();
+            },
+            { timeout: 120_000, intervals: [1_000, 2_000, 5_000] },
+          )
+          .toEqual(bothThreads);
+      });
+
+      await test.step('A window spanning 2200 lists both threads', async () => {
+        const { total, threads } = await backendClient.listThreads({
+          projectId: project.id,
+          fromTime: windowStart,
+          toTime: FAR_WINDOW_END,
+        });
+        expect(threads.map((t) => t.id).sort(), 'a week ago -> 2201 spans both threads').toEqual(
+          bothThreads,
+        );
+        // `total` drives the pager independently of the page body, so a read
+        // that returned the rows but counted them under the old predicate would
+        // still paginate wrongly.
+        expect(total, 'the reported total agrees with the page').toBe(bothThreads.length);
+      });
+
+      await test.step('A window that closes now lists only the present-day thread', async () => {
+        const { total, threads } = await backendClient.listThreads({
+          projectId: project.id,
+          fromTime: windowStart,
+          toTime: new Date(),
+        });
+        expect(threads.map((t) => t.id), 'a week ago -> now excludes the far-future thread').toEqual(
+          [presentThreadId],
+        );
+        expect(total, 'the reported total agrees with the page').toBe(1);
+      });
+
+      await test.step('A window wholly inside 2200 lists the far-future thread alone', async () => {
+        const { total, threads } = await backendClient.listThreads({
+          projectId: project.id,
+          fromTime: FAR_WINDOW_START,
+          toTime: FAR_WINDOW_END,
+        });
+        expect(threads.map((t) => t.id), '2200 -> 2201 holds exactly the far-future thread').toEqual(
+          [farFuture.threadId],
+        );
+        expect(total, 'the reported total agrees with the page').toBe(1);
+      });
+
+      await test.step('The metrics-summary card counts threads under the same intervals', async () => {
+        // KpiCardDAO's thread branch — a third DAO carrying the same predicate,
+        // and the number the Threads tab's strip renders.
+        const spanning = await backendClient.projectKpiCards({
+          projectId: project.id,
+          entityType: 'threads',
+          intervalStart: windowStart,
+          intervalEnd: FAR_WINDOW_END,
+        });
+        expect(spanning.status, `kpi-cards over a week ago -> 2201: ${spanning.message}`).toBe(200);
+        expect(countCard(spanning.stats), 'threads counted in a week ago -> 2201').toBe(2);
+
+        const recent = await backendClient.projectKpiCards({
+          projectId: project.id,
+          entityType: 'threads',
+          intervalStart: windowStart,
+          intervalEnd: new Date(),
+        });
+        expect(recent.status, `kpi-cards over the past week: ${recent.message}`).toBe(200);
+        expect(countCard(recent.stats), 'threads counted in the past week').toBe(1);
+      });
+    },
+  );
+
+  test(
+    'the Threads tab renders the far-future thread alongside the present-day one',
+    { tag: ['@cap:threads.list-threads'] },
+    async ({ farFutureTraces, project, backendClient, page }) => {
+      const logs = new LogsPage(page);
+      const { farFuture, presentThreadId } = farFutureTraces;
+
+      await test.step('Both threads are aggregated before the browser opens', async () => {
+        // Otherwise a slow rollup renders an empty Threads table and this fails
+        // as a UI defect, which it would not be.
+        await expect
+          .poll(
+            async () => {
+              const { threads } = await backendClient.listThreads({ projectId: project.id });
+              return threads.map((t) => t.id).sort();
+            },
+            { timeout: 120_000, intervals: [1_000, 2_000, 5_000] },
+          )
+          .toEqual([farFuture.threadId, presentThreadId].sort());
+      });
+
+      await test.step('Open the Threads tab and verify both rows', async () => {
+        await logs.gotoThreads(project.id);
+        await logs.waitForThreadsReady(farFuture.threadId);
+
+        await expect(
+          logs.threadRow(farFuture.threadId),
+          'the thread whose traces are dated 2200 is rendered',
+        ).toBeVisible();
+        await expect(logs.threadRow(presentThreadId)).toBeVisible();
+        // The whole table, not just the two rows looked for: the project is
+        // fresh, so a third row would mean the view reached beyond it.
+        await expect(logs.traceRows).toHaveCount(2);
+      });
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/far-future-trace-window.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/far-future-trace-window.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+
+/**
+ * A trace whose UUIDv7 id is stamped centuries from now must still be returned
+ * by the time-bounded reads that span it (OPIK-7791, PR #8096).
+ *
+ * Opik windows a trace read on the timestamp inside the id, and pairs every id
+ * bound with a week-start bound on the partition key "as a strict consequence
+ * of the id range" — a pruning aid that is not supposed to filter. `toMonday`
+ * returns a 16-bit Date that wraps past 2149, so a far-future row cleared the id
+ * bound, folded into a past Monday and failed the week bound. It disappeared
+ * from reads it belonged in, with no error and no empty state: the count simply
+ * came back smaller. The fix measured 12.68M such rows across 39,038 projects on
+ * production.
+ *
+ * The upstream regression test covers `TraceDAO` alone, and the same predicate
+ * landed in `ThreadDAO`, `KpiCardDAO` and `ProjectMetricsDAO`. This drives what
+ * a user can actually reach: the paged list, the metrics-summary cards above it,
+ * and the Logs table that renders both.
+ *
+ * Every assertion names the whole expected set rather than looking for the
+ * far-future row in the answer. A read that ignored its window entirely would
+ * also contain it — the failure this exists to catch is a *set* that is wrong,
+ * in either direction.
+ *
+ * NOTE on tags: the `kpi-cards` read has no capability of its own in
+ * taxonomy.yaml (the metrics-summary strip is listed under neither `traces` nor
+ * `threads`), so it is asserted here without claiming one. `@cap:` names what
+ * this spec covers, not everything it checks.
+ */
+
+/** A window that opens before 2200 and closes after it. */
+const FAR_WINDOW_START = new Date('2200-01-01T00:00:00.000Z');
+const FAR_WINDOW_END = new Date('2201-01-01T00:00:00.000Z');
+
+/** The `count` card of a kpi-cards answer, required rather than optional. */
+const countCard = (stats: Array<{ type: string; currentValue: number | null }>): number => {
+  const card = stats.find((s) => s.type === 'count');
+  expect(card, 'the kpi-cards answer carries a "count" card').toBeDefined();
+  // null is this endpoint's answer for "nothing matched", which is a different
+  // fact from zero — but either way it is not a number, and coercing one to the
+  // other here would let an empty answer satisfy a count assertion.
+  expect(card!.currentValue, 'the count card carries a current value').not.toBeNull();
+  return card!.currentValue!;
+};
+
+test.describe('Far-future trace windowing — CUJ', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  // The fixture writes five traces and blocks until every one is queryable.
+  test.slow();
+
+  test(
+    'every windowed traces read returns exactly the rows its window spans, far-future row included',
+    { tag: ['@cap:traces.list-traces'] },
+    async ({ farFutureTraces, project, backendClient }) => {
+      const { farFuture, present, allIdsNewestFirst, windowStart } = farFutureTraces;
+      const presentIds = present.map((p) => p.id);
+
+      await test.step('The unwindowed list returns every seeded trace', async () => {
+        const ids = await backendClient.listTraceIds({ projectId: project.id });
+        expect(ids.sort(), 'the whole project, no window').toEqual([...allIdsNewestFirst].sort());
+      });
+
+      await test.step('A window spanning 2200 returns the far-future row alongside the ordinary ones', async () => {
+        const ids = await backendClient.listTraceIds({
+          projectId: project.id,
+          fromTime: windowStart,
+          toTime: FAR_WINDOW_END,
+        });
+        // The regression, stated directly: before the fix this answer was
+        // missing the far-future row and nothing said so.
+        expect(ids.sort(), 'a week ago -> 2201 spans every seeded trace').toEqual(
+          [...allIdsNewestFirst].sort(),
+        );
+      });
+
+      await test.step('A window that closes now excludes it, and keeps every ordinary row', async () => {
+        const ids = await backendClient.listTraceIds({
+          projectId: project.id,
+          fromTime: windowStart,
+          toTime: new Date(),
+        });
+        // Both halves matter. Without the far-future row the read is honest
+        // about its upper bound; with all four ordinary rows it is not simply
+        // dropping everything.
+        expect(ids.sort(), 'a week ago -> now excludes only the far-future row').toEqual(
+          [...presentIds].sort(),
+        );
+      });
+
+      await test.step('A window wholly inside 2200 returns the far-future row alone', async () => {
+        const ids = await backendClient.listTraceIds({
+          projectId: project.id,
+          fromTime: FAR_WINDOW_START,
+          toTime: FAR_WINDOW_END,
+        });
+        expect(ids, '2200 -> 2201 holds exactly the far-future trace').toEqual([farFuture.id]);
+      });
+
+      await test.step('The metrics-summary card counts it under the same intervals', async () => {
+        // A separate DAO from the list above (KpiCardDAO), carrying the same
+        // week-bound predicate. It is also the read the Logs strip makes, and
+        // unlike the list it always sends an explicit interval_end — so it is
+        // the upper-bound half of the wrap that the list never exercises.
+        const spanning = await backendClient.projectKpiCards({
+          projectId: project.id,
+          entityType: 'traces',
+          intervalStart: FAR_WINDOW_START,
+          intervalEnd: FAR_WINDOW_END,
+        });
+        expect(spanning.status, `kpi-cards over 2200 -> 2201: ${spanning.message}`).toBe(200);
+        expect(countCard(spanning.stats), 'traces counted in 2200 -> 2201').toBe(1);
+
+        const recent = await backendClient.projectKpiCards({
+          projectId: project.id,
+          entityType: 'traces',
+          intervalStart: windowStart,
+          intervalEnd: new Date(),
+        });
+        expect(recent.status, `kpi-cards over the past week: ${recent.message}`).toBe(200);
+        expect(countCard(recent.stats), 'traces counted in the past week').toBe(present.length);
+      });
+    },
+  );
+
+  test(
+    'the Logs table renders the far-future trace alongside the present-day ones',
+    { tag: ['@cap:traces.list-traces'] },
+    async ({ farFutureTraces, project, page }) => {
+      const logs = new LogsPage(page);
+      const { farFuture, present, allIdsNewestFirst } = farFutureTraces;
+
+      await test.step('Open Logs on the Traces tab for the seeded project', async () => {
+        // Explicitly the Traces tab: every seeded trace carries a thread, and
+        // `useLogsType` opens Logs on Threads for any project that has one.
+        await logs.gotoTraces(project.id);
+        await logs.waitForReady();
+      });
+
+      await test.step('Every seeded trace has a row, and nothing else does', async () => {
+        // The Logs list sends a from_time from its date-range preset and no
+        // to_time, so the upper bound is open and the far-future row belongs on
+        // the page. Asserting the count as well as each row means a read that
+        // silently widened — or a preset that dropped the present-day rows —
+        // fails here rather than passing on a subset.
+        await expect(logs.traceRows).toHaveCount(allIdsNewestFirst.length);
+        await expect(
+          logs.traceRow(farFuture.id),
+          'the 2200-dated trace is rendered in the Traces table',
+        ).toBeVisible();
+        for (const trace of present) {
+          await expect(logs.traceRow(trace.id)).toBeVisible();
+        }
+      });
+
+      // Deliberately NOT asserted here: the number on the metrics-summary strip
+      // (`logs.countTraces()`). On this page the strip and the table answer two
+      // different requests for one range — the list leaves its upper bound open
+      // while kpi-cards sends interval_end — so with a far-future row seeded
+      // they legitimately disagree today. That disagreement is reported
+      // separately; pinning it here would assert a contract that has not been
+      // settled, and asserting it *matches* would ship a red spec.
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-stream-cursor.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-stream-cursor.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@e2e/fixtures';
+
+/**
+ * `POST /v1/private/traces/search` paged with a far-future cursor
+ * (OPIK-7791, PR #8096).
+ *
+ * The commit message singles this out as the failure a lower-bound-only fix
+ * would miss. `last_retrieved_id` is a cursor lifted from a row the stream just
+ * returned, and it is paired with `toMonday(id_at) <= toMonday(:cursor)`. When
+ * the cursor is far-future its Monday wraps into the past, every ordinary row's
+ * honest week is later, and the `<=` excludes all of them: the next page comes
+ * back **empty** and pagination stops silently. Nothing errors — the caller just
+ * believes it has read the whole project.
+ *
+ * The upstream guard for it runs against the legacy pre-cutover table, and
+ * nothing in this estate drives `last_retrieved_id` at all. API-level by design:
+ * this is a cursor on a streaming read that no page in the product exposes, and
+ * a UI proxy for it would be both weaker and slower.
+ *
+ * Assertions compare the whole stream, in order. `id < :last_received_id` is the
+ * cursor predicate, so the stream descends by id and the expected page is exact
+ * — a page that merely *contains* the right rows would hide a leak.
+ */
+test.describe('Traces stream cursor — CUJ', { tag: ['@t2-cuj', '@area:traces'] }, () => {
+  // The fixture writes five traces and blocks until every one is queryable.
+  test.slow();
+
+  test(
+    'a far-future cursor pages on to the ordinary traces instead of collapsing the stream',
+    { tag: ['@cap:traces.list-traces'] },
+    async ({ farFutureTraces, project, backendClient }) => {
+      const { farFuture, present, allIdsNewestFirst } = farFutureTraces;
+      const presentIds = present.map((p) => p.id);
+
+      await test.step('The uncursored stream returns every seeded trace, far-future row first', async () => {
+        const { status, message, ids } = await backendClient.searchTraceIds({
+          projectId: project.id,
+        });
+        expect(status, `traces/search rejected with: ${message}`).toBe(200);
+        // Order is asserted, not just membership: the far-future id is the
+        // largest, so a descending stream must lead with it — and the next step
+        // uses exactly that row as its cursor.
+        expect(ids, 'the whole project streams back in descending id order').toEqual(
+          allIdsNewestFirst,
+        );
+      });
+
+      await test.step('Paging from the far-future row returns the remaining ordinary traces', async () => {
+        const { status, message, ids } = await backendClient.searchTraceIds({
+          projectId: project.id,
+          lastRetrievedId: farFuture.id,
+        });
+        expect(status, `traces/search rejected with: ${message}`).toBe(200);
+        // The regression, stated directly. Before the fix this was `[]`.
+        expect(ids, 'the page after the far-future cursor').toEqual(presentIds);
+        expect(ids.length, 'the page after a far-future cursor is not empty').toBeGreaterThan(0);
+      });
+
+      await test.step('An ordinary cursor still pages normally', async () => {
+        // The control. Without it, "the far-future cursor returned four rows"
+        // would be equally consistent with a stream that had started ignoring
+        // its cursor altogether.
+        const { status, ids } = await backendClient.searchTraceIds({
+          projectId: project.id,
+          lastRetrievedId: presentIds[0],
+        });
+        expect(status).toBe(200);
+        expect(ids, 'the page after the newest ordinary trace').toEqual(presentIds.slice(1));
+      });
+
+      await test.step('The last cursor in the project returns an empty page', async () => {
+        // The other end of the same control: an empty page is the correct
+        // answer here, which is what makes it wrong in the step above.
+        const { status, ids } = await backendClient.searchTraceIds({
+          projectId: project.id,
+          lastRetrievedId: presentIds[presentIds.length - 1],
+        });
+        expect(status).toBe(200);
+        expect(ids, 'nothing follows the oldest seeded trace').toEqual([]);
+      });
+    },
+  );
+});


### PR DESCRIPTION
> **Generated by the release QA side flow, and not reviewed by a human.**
> It is a draft on purpose. Please read every assertion before promoting it —
> a plausible-looking spec that asserts the wrong thing is worse than no spec.

## Where these came from

The 2.2.46 → 2.2.47 release exploration. A human worked the release's
manual-verification list against **staging** (`staging.dev.comet.com/opik`) and
verified each of these flows by hand first; only flows that were reached and
observed became candidates. Four specs are proposed here, from three candidates.

Everything in this train traces back to one change: **PR #8096** replaced 56
week-bound predicates across five DAOs. `toMonday()` returns a 16-bit `Date`
that wraps past 2149, so a trace whose UUIDv7 id carries a far-future timestamp
cleared its id bound, folded into a past Monday and **failed the week bound** —
disappearing from reads it belonged in, with no error and no empty state. The
commit measured 12,680,766 such rows across 39,038 projects on production.

The gap the exploration found: the PR's own regression test covers `TraceDAO`
alone. `ThreadDAO`, `KpiCardDAO` and `ProjectMetricsDAO` took the identical
rewrite with **no far-future row exercised anywhere**, and nothing in this
estate drives `last_retrieved_id` at all.

### Which ref these were written and run against

Written and run against the release ref **`2.2.47`** (`dd87fed`), which is the
build the exploration verified. `main` is only where they have to merge — a
release tag is not a branch, so it cannot be a PR base. `main` will have moved
on; please re-run before merging if anything under `tests_end_to_end/` or the
trace read path has changed since.

## Verification — all four specs pass

Run from `tests_end_to_end/e2e/`, against `$OPIK_BASE_URL =
https://staging.dev.comet.com/opik` (workspace `opik-testing`), i.e. the same
environment and credentials the exploration used:

```bash
npx playwright test \
  tests/trace-explore/far-future-trace-window.spec.ts \
  tests/trace-explore/far-future-thread-window.spec.ts \
  tests/trace-explore/trace-stream-cursor.spec.ts \
  tests/dashboards/project-metric-daily-buckets.spec.ts \
  --reporter=list
```

**6 passed.** Nothing is `.skip`ped, and no spec was dropped for being red.

`tag_lint.py` is green too: `58 specs checked, 1 exempt, 0 problem(s)`.

Because this touches the shared `LogsPage` page object and the fixtures chain,
the whole `tests/trace-explore/` + `tests/dashboards/` directories were run as
well (36 tests, 3 workers, `--retries=1`): **31 passed, 5 flaky, 0 failed.** All
six of the specs proposed here passed on the first attempt.

The five flaky ones are **pre-existing specs, and one honest caveat**. Each
failed identically — `opik-sdk-driver POST /traces aborted after 30000ms` in
`conversation.fixture` / `trace.fixture` / an inline seed — and each passed on
retry. That is the SDK bridge's own client-side timeout being hit while shared
staging rate-limits the workspace (`Rate limited (HTTP 429) for 'search_traces',
continuing in 52 seconds` appears throughout the run). Nothing here calls that
bridge route. But spec 4 does seed twelve traces through the bridge, so running
it alongside the rest of the directory plausibly *contributed* to the contention
that surfaced a pre-existing sensitivity — worth knowing before this lands in a
suite that runs everything at once.

> `npx tsc --noEmit` **cannot run at this ref** and does not run here: the
> pinned `typescript@^7.0.2` rejects `tsconfig.json`'s `baseUrl` (`TS5102:
> Option 'baseUrl' has been removed`), which aborts before any file is checked.
> That is pre-existing on `2.2.47` and unrelated to this change. Every file here
> was typechecked with the same compiler against a temporary config with
> `baseUrl` dropped and `types: ["node"]` added: **clean**, apart from a
> pre-existing `TS2300: Duplicate identifier 'deleteDashboard'` in
> `core/backend/client.ts` (two methods of that name at `HEAD`, untouched here).

## The specs

### 1. `trace-explore/far-future-trace-window.spec.ts` — `@t2-cuj @area:traces`

**Capability:** `@cap:traces.list-traces`

Seeds four ordinary traces and one whose UUIDv7 id is stamped `2200-06-15`, then
asserts the *whole* row set returned by each window, in both directions:

| read | expected |
|---|---|
| `GET /traces`, no window | all five |
| `from_time=now-7d & to_time=2201` | all five ← **the regression** |
| `from_time=now-7d & to_time=now` | the four ordinary rows, and only those |
| `from_time=2200 & to_time=2201` | the far-future row alone |
| `POST /projects/{id}/kpi-cards` (traces) | 1 over 2200→2201, 4 over the past week |

Then a UI test: the Logs **Traces** table renders all five rows.

Every assertion names the whole expected set rather than looking for the
far-future row in the answer — a read that ignored its window entirely would
also contain it, so "it's in there" proves nothing.

### 2. `trace-explore/far-future-thread-window.spec.ts` — `@t2-cuj @area:threads`

**Capability:** `@cap:threads.list-threads`

The `ThreadDAO` half, which has **no upstream regression test at all**. Same
fixture, read through `GET /traces/threads`: a window spanning 2200 lists both
threads, a window closing now lists only the present-day one, a window inside
2200 lists only the far-future one — asserting `total` as well as the page body,
since `total` drives the pager independently. Plus the threads `kpi-cards`
branch, and a UI test over the Threads tab.

Split from spec 1 because a spec belongs to exactly one `@area:` and these
assertions are threads; both drive one fixture.

### 3. `trace-explore/trace-stream-cursor.spec.ts` — `@t2-cuj @area:traces`

**Capability:** `@cap:traces.list-traces`

The failure the commit message singles out as the one a lower-bound-only fix
would miss. `last_retrieved_id` is a cursor lifted from a row the stream just
returned; paired with a wrapped upper bound, a far-future cursor folds into a
past week, every ordinary row fails `<=`, **the page comes back empty and
pagination stops silently**. The only upstream guard runs against the legacy
pre-cutover table.

Four cursors, whole-stream comparisons in order: none, the far-future row (→ the
four ordinary rows — before the fix, `[]`), the newest ordinary row (the
control), and the oldest (→ `[]`, which is what makes an empty page wrong in the
second case).

API-level with no browser: this is a cursor on a streaming read no page exposes.

### 4. `dashboards/project-metric-daily-buckets.spec.ts` — `@t2-cuj @area:dashboards`

**Capability:** `@cap:dashboards.configure-widget`

`ProjectMetricsDAO`'s `TRACE_FILTERED_PREFIX` — the CTE behind every trace-based
project metric — plus `GET_AVERAGE_DURATION` and `GET_TOTAL_TRACE_ERRORS` were
rewritten. 426 lines of SQL. The estate's existing cover,
`project-span-metrics.spec.ts`, asserts HTTP 200 across the 20 metric types:
a **binding** guard, not a correctness one. It would pass unchanged if every
bucket came back a day late or carrying the whole window's total.

So this pins values. One scored trace per day for eleven consecutive days, each
score equal to its own age — distinct values a collapsed or shifted bucketing
cannot satisfy by accident — plus one errored trace, which makes the daily trace
counts uneven for the same reason. Asserts each `FEEDBACK_SCORES` and
`TRACE_COUNT` daily bucket, that **no** bucket outside the seeded days carries
anything, that a window closing before the seed aggregates to zero, and that
`/projects/stats` over a three-day sub-window reports the same numbers. Eleven
consecutive days always contain a Monday; the fixture asserts that rather than
trusting it.

Runtime ~3.1 min per test (twelve SDK seeds, rate-limited on a shared cloud
workspace), inside the `test.slow()` budget the neighbouring spec also uses.

## Things a reviewer should push back on if they disagree

- **Candidate 4 was marked `surface: both`; spec 4 is API-only.** A chart plots
  points as SVG geometry, so a seeded bucket value cannot be read back off it —
  `project-span-metrics.spec.ts` says so in its own comments — and that spec
  already drives the project-scoped Time series widget dialog under this same
  capability. A UI leg here would have added flake and no coverage. Said plainly
  rather than quietly narrowed; happy to add one if you want the widget driven
  again.
- **`kpi-cards` is asserted but claims no `@cap:`.** The Logs metrics-summary
  strip has no capability in `taxonomy.yaml` — it appears under neither `traces`
  nor `threads`. Rather than stretch the nearest key with an explanatory note,
  the reads are asserted and nothing is claimed for them. If a capability is
  added later, these specs already cover it.
- **No capability was flipped `false → true`.** All three were already
  `covered: true`; the taxonomy change adds the four specs to their areas'
  `specs:` lists and extends the notes to say what the new dimension is.

## What was deliberately *not* written

Three candidates the exploration proposed were dropped, and one it had already
excluded is worth repeating here:

1. **Logs KPI strip vs. the table for the same range.** The sharpest finding of
   the run, and **wrong today**: the strip says Traces 12 while the table says
   13 (1 vs 3 on Threads). One range, two requests, two denominators — the list
   sends no `to_time` and gets an open upper bound; `kpi-cards` sends
   `interval_end`. A spec asserting the correct behaviour would land red, and
   there is no capability to tag it with. Spec 1 deliberately does **not**
   assert `countTraces()`, and says why in a comment, so nobody closes the gap
   by pinning an unsettled contract.
2. **A far-future trace is bucketed at its own date in project metrics.** A
   trace at `2200-06-15` lands in a `2064-05-07` daily bucket and a `2021-01-02`
   weekly one — the 2³²-second `DateTime` wrap. A defect, not a coverable flow;
   a spec asserting the honest bucket would fail today. Spec 4's "no bucket
   outside the requested interval" holds for ordinary data and will start
   failing if a far-future row ever leaks into a normal window.
3. **Workspace feedback-score summary / daily endpoints.** Both return nothing
   on staging for every window tried, so no passing test can be written against
   them. Both are `@Deprecated` with no consumer in the 2.2.47 frontend, and
   neither has a taxonomy capability.
4. **Helm chart and npm artifact checks.** Not reachable from an e2e suite.

No candidate was dropped for being red or for failing to run.

## Supporting changes, and why they are here rather than in the tests

- `fixtures/far-future-traces.fixture.ts`, `fixtures/project-metric-days.fixture.ts`
  — seeding and teardown, per `conventions.md`. Both delete their traces
  explicitly (a project delete does not cascade to traces) and honour
  `shouldLeaveArtifacts`. `far-future-traces` also **proves it can
  discriminate** before any spec reads: it waits for every seeded row to be
  queryable, then asserts the far-future row really is outside a window ending
  now — a backend that clamped the id on write would otherwise leave every
  assertion in specs 1–3 trivially true.
- `pom/logs.page.ts` — a `gotoTraces()` counterpart to the existing
  `gotoThreads()`. `goto()` leaves the tab to the page, and `useLogsType`'s
  default is data-dependent: it opens on **Threads** whenever the project has a
  thread in range. Every trace in this fixture carries one, so spec 1's UI test
  landed on the wrong table until it asked for Traces explicitly. Purely
  additive; no existing caller changes.
- `core/backend/client.ts` — `projectKpiCards()` and `searchTraceIds()` (the
  stream answers `application/octet-stream` NDJSON, which neither the pinned SDK
  nor `rawFetch` can read, and the paged `GET /traces` has no cursor), plus an
  optional `threadId` on the existing `createTraceWithSource()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
