### PR TITLE
[OPIK-8197] [BE] fix: unhang PythonEvaluatorServiceTest and bound every test with a timeout

### DIFF
--- a/.github/scripts/discover-backend-tests.sh
+++ b/.github/scripts/discover-backend-tests.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 NUM_GROUPS=16
 UNIT_TIMEOUT=10
 INTEGRATION_TIMEOUT=20
+# Per-test timeout handed to JUnit, overriding the default in junit-platform.properties.
+# CI reruns failures 3 times, so a deterministic hang costs 4x these values: 8m against the 10m
+# unit wall, 16m against the 20m integration wall. Both must stay under their job timeout above,
+# or the job is cancelled before Surefire can name the offending test.
+UNIT_TEST_TIMEOUT=2m
+INTEGRATION_TEST_TIMEOUT=4m
 TEST_DIR="src/test/java"
 PATTERN="DropwizardAppExtensionProvider\|MySQLContainer\|ClickHouseContainer\|RedisContainer\|MinIOContainer"
 
@@ -62,9 +68,9 @@ done
 
 # Build JSON matrix: unit tests + N integration groups
 matrix="{\"include\":["
-matrix+="{\"name\":\"Unit Tests\",\"tests\":\"$unit_list\",\"timeout\":$UNIT_TIMEOUT}"
+matrix+="{\"name\":\"Unit Tests\",\"tests\":\"$unit_list\",\"timeout\":$UNIT_TIMEOUT,\"testTimeout\":\"$UNIT_TEST_TIMEOUT\"}"
 for ((i=1; i<=NUM_GROUPS; i++)); do
-  matrix+=",{\"name\":\"Integration Group $i\",\"tests\":\"${group_list[$i]}\",\"timeout\":$INTEGRATION_TIMEOUT}"
+  matrix+=",{\"name\":\"Integration Group $i\",\"tests\":\"${group_list[$i]}\",\"timeout\":$INTEGRATION_TIMEOUT,\"testTimeout\":\"$INTEGRATION_TEST_TIMEOUT\"}"
 done
 matrix+="]}"
 echo "matrix=$matrix" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -84,6 +84,7 @@ jobs:
                 -Dtest="${{ matrix.tests }}"
                 -Dmaven.test.failure.ignore=true
                 -Dsurefire.rerunFailingTestsCount=3
+                -Djunit.jupiter.execution.timeout.testable.method.default="${{ matrix.testTimeout }}"
 
             - name: Publish Test Report
               uses: EnricoMi/publish-unit-test-result-action/linux@v2

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
@@ -3,15 +3,20 @@ package com.comet.opik;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
@@ -24,6 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
  * junit-platform.properties plus a per-job -D override, either of which a rename or a scope change
  * could silently disable while the suite still passed green.
  * <p>
+ * The shipped default and the CLI override are asserted separately and unconditionally. An earlier
+ * version preferred the override when present, which meant CI -- where the override is always set --
+ * never validated the shipped default at all, and the file could drift to any value undetected.
+ * <p>
  * These tests are deliberately fast and cannot hang: the blocking case is bounded preemptively.
  */
 @DisplayName("Test Timeout Guard")
@@ -31,11 +40,19 @@ class TestTimeoutGuardTest {
 
     private static final String TIMEOUT_PROPERTY = "junit.jupiter.execution.timeout.testable.method.default";
 
-    /** The tightest job wall the bound has to fit inside: UNIT_TIMEOUT in discover-backend-tests.sh. */
+    /** Job walls from discover-backend-tests.sh: UNIT_TIMEOUT and INTEGRATION_TIMEOUT. */
     private static final Duration UNIT_JOB_WALL = Duration.ofMinutes(10);
+    private static final Duration INTEGRATION_JOB_WALL = Duration.ofMinutes(20);
 
     /** CI runs -Dsurefire.rerunFailingTestsCount=3, and a timeout is an ordinary failure to Surefire. */
     private static final int ATTEMPTS_PER_HANG = 4;
+
+    /**
+     * JUnit's timeout grammar: a number, optional space, optional unit of ns/us/ms/s/m/h/d, parsed
+     * case-insensitively. A bare number means seconds. Anything else must be rejected rather than
+     * silently coerced -- the whole point of this class is that a wrong bound cannot pass unnoticed.
+     */
+    private static final Pattern TIMEOUT_GRAMMAR = Pattern.compile("(?i)^(\\d+)\\s*(ns|μs|us|ms|s|m|h|d)?$");
 
     @Test
     @DisplayName("a thread blocked forever is interrupted and reported, never left to hang the job")
@@ -52,17 +69,26 @@ class TestTimeoutGuardTest {
     }
 
     @Test
-    @DisplayName("the shipped default survives CI's retry budget inside the unit job wall")
+    @DisplayName("the shipped default survives CI's retry budget, regardless of any -D override")
     void shippedDefaultFitsRetryBudget() {
-        var configured = configuredTimeout();
+        // Read the file directly, never System.getProperty: in CI the override is always set, so
+        // consulting it here would mean the shipped default was never actually checked.
+        var shipped = loadProperties().getProperty(TIMEOUT_PROPERTY);
 
-        // 4 attempts at the bound must still leave room for compilation and suite overhead,
-        // otherwise CI cancels the job before Surefire can publish the named failure -- losing
-        // exactly the diagnostic the timeout exists to provide.
-        assertThat(toSeconds(configured) * ATTEMPTS_PER_HANG)
-                .as("%d attempts at '%s' must fit inside the %s unit job wall",
-                        ATTEMPTS_PER_HANG, configured, UNIT_JOB_WALL)
-                .isLessThan(UNIT_JOB_WALL.toSeconds());
+        assertRetryBudgetFits(shipped, UNIT_JOB_WALL, "shipped default");
+    }
+
+    @Test
+    @DisplayName("an active -D override also survives the retry budget for its tier")
+    void overrideFitsRetryBudget() {
+        var override = System.getProperty(TIMEOUT_PROPERTY);
+        if (override == null) {
+            return; // No override in play (plain local run) -- the shipped default is asserted above.
+        }
+
+        // The override is per-tier and the tier is not knowable from inside the JVM, so hold it to
+        // the most generous wall. The unit value is pinned exactly by discoveryScriptPinsBothTiers.
+        assertRetryBudgetFits(override, INTEGRATION_JOB_WALL, "-D override");
     }
 
     @Test
@@ -75,9 +101,67 @@ class TestTimeoutGuardTest {
                 .doesNotContain("junit.jupiter.execution.timeout.default");
     }
 
-    private static String configuredTimeout() {
-        var override = System.getProperty(TIMEOUT_PROPERTY);
-        return override != null ? override : loadProperties().getProperty(TIMEOUT_PROPERTY);
+    @ParameterizedTest(name = "{0} -> {1}s")
+    @CsvSource({"30s, 30", "45, 45", "2m, 120", "4m, 240", "1h, 3600", "500ms, 0", "2 m, 120", "2M, 120"})
+    @DisplayName("timeout values are parsed per JUnit's grammar, not by stripping the unit")
+    void parsesJUnitTimeoutGrammar(String value, long expectedSeconds) {
+        assertThat(toSeconds(value)).isEqualTo(expectedSeconds);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2x", "abc", "m", "2mm", "-5m", ""})
+    @DisplayName("values outside JUnit's grammar are rejected, never coerced to a passing number")
+    void rejectsValuesOutsideGrammar(String value) {
+        assertThatThrownBy(() -> toSeconds(value)).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    @DisplayName("both tiers stay pinned in the discovery script that feeds the CI matrix")
+    void discoveryScriptPinsBothTiers() {
+        // The -D override originates here, so the file is the only place the per-tier values and
+        // their job walls are stated together. Asserting the pairing keeps a change to one from
+        // silently outgrowing the other.
+        var script = readDiscoveryScript();
+
+        assertTierPinned(script, "UNIT_TIMEOUT", "UNIT_TEST_TIMEOUT", UNIT_JOB_WALL);
+        assertTierPinned(script, "INTEGRATION_TIMEOUT", "INTEGRATION_TEST_TIMEOUT", INTEGRATION_JOB_WALL);
+    }
+
+    private static void assertTierPinned(String script, String wallVar, String testVar, Duration expectedWall) {
+        var wallMinutes = Long.parseLong(matchOne(script, wallVar + "=(\\d+)"));
+        assertThat(Duration.ofMinutes(wallMinutes))
+                .as("%s must match the wall this test asserts against", wallVar)
+                .isEqualTo(expectedWall);
+
+        assertRetryBudgetFits(matchOne(script, testVar + "=(\\S+)"), expectedWall, testVar);
+    }
+
+    private static void assertRetryBudgetFits(String value, Duration wall, String description) {
+        // 4 attempts at the bound must still leave room for compilation and suite overhead,
+        // otherwise CI cancels the job before Surefire can publish the named failure -- losing
+        // exactly the diagnostic the timeout exists to provide.
+        assertThat(toSeconds(value) * ATTEMPTS_PER_HANG)
+                .as("%d attempts at '%s' (%s) must fit inside the %s job wall",
+                        ATTEMPTS_PER_HANG, value, description, wall)
+                .isLessThan(wall.toSeconds());
+    }
+
+    private static String matchOne(String haystack, String regex) {
+        var matcher = Pattern.compile("^" + regex + "\\s*$", Pattern.MULTILINE).matcher(haystack);
+        assertThat(matcher.find()).as("discovery script must define %s", regex).isTrue();
+        return matcher.group(1);
+    }
+
+    private static String readDiscoveryScript() {
+        // src/test/resources -> module root -> repo root
+        var path = java.nio.file.Path.of("").toAbsolutePath()
+                .resolve("../../.github/scripts/discover-backend-tests.sh").normalize();
+        assertThat(path).as("discovery script must exist").exists();
+        try {
+            return java.nio.file.Files.readString(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private static Properties loadProperties() {
@@ -91,10 +175,31 @@ class TestTimeoutGuardTest {
         return properties;
     }
 
+    /**
+     * Converts a JUnit timeout value to seconds, rejecting anything outside the documented grammar.
+     * Rejecting matters more than converting: an unrecognised value that silently became a small
+     * number would let a catastrophic bound sail past the retry-budget assertions above.
+     */
     private static long toSeconds(String value) {
         assertThat(value).as("per-test timeout must be configured").isNotBlank();
-        var trimmed = value.trim();
-        var amount = Long.parseLong(trimmed.replaceAll("\\D", ""));
-        return trimmed.endsWith("m") ? TimeUnit.MINUTES.toSeconds(amount) : amount;
+
+        var matcher = TIMEOUT_GRAMMAR.matcher(value.trim());
+        assertThat(matcher.matches())
+                .as("'%s' is not a valid JUnit timeout (expected <number>[ns|us|ms|s|m|h|d])", value)
+                .isTrue();
+
+        var amount = Long.parseLong(matcher.group(1));
+        var unit = matcher.group(2) == null ? "s" : matcher.group(2).toLowerCase(Locale.ROOT);
+
+        return switch (unit) {
+            case "ns" -> Duration.ofNanos(amount).toSeconds();
+            case "μs", "us" -> Duration.ofNanos(amount * 1_000).toSeconds();
+            case "ms" -> Duration.ofMillis(amount).toSeconds();
+            case "s" -> amount;
+            case "m" -> Duration.ofMinutes(amount).toSeconds();
+            case "h" -> Duration.ofHours(amount).toSeconds();
+            case "d" -> Duration.ofDays(amount).toSeconds();
+            default -> throw new IllegalStateException("unreachable: grammar admitted '" + unit + "'");
+        };
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
@@ -2,102 +2,52 @@ package com.comet.opik;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.function.Executable;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Duration;
-import java.util.Locale;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 /**
- * Guards the guard.
+ * Asserts that the shipped per-test timeout still fits CI's retry budget.
  * <p>
- * A test that blocks forever used to cost the entire 10-minute Unit Tests job and surfaced only as
- * "job cancelled" -- finding the culprit meant reading raw job logs for the class that printed
- * "Running ..." with no matching result line. The safeguard against that now lives in
- * junit-platform.properties plus a per-job -D override, either of which a rename or a scope change
- * could silently disable while the suite still passed green.
+ * CI runs with {@code -Dsurefire.rerunFailingTestsCount=3}, and a timeout is an ordinary failure to
+ * Surefire, so a deterministic hang is attempted 4 times. If 4x the bound exceeds the job wall, the
+ * job is cancelled before Surefire can publish the named failure report -- losing exactly the
+ * diagnostic the timeout was added to provide. A 5m bound was caught by review for that reason.
  * <p>
- * The shipped default and the CLI override are asserted separately and unconditionally. An earlier
- * version preferred the override when present, which meant CI -- where the override is always set --
- * never validated the shipped default at all, and the file could drift to any value undetected.
- * <p>
- * These tests are deliberately fast and cannot hang: the blocking case is bounded preemptively.
+ * Deliberately narrow: it reads the shipped value and checks the arithmetic. It does not
+ * re-implement JUnit's timeout grammar (JUnit validates that itself, throwing
+ * {@code DateTimeParseException} at engine startup) and does not scrape the workflow or discovery
+ * script for literal substrings, which would break on unrelated formatting changes there.
  */
 @DisplayName("Test Timeout Guard")
 class TestTimeoutGuardTest {
 
     private static final String TIMEOUT_PROPERTY = "junit.jupiter.execution.timeout.testable.method.default";
 
-    /** Job walls from discover-backend-tests.sh: UNIT_TIMEOUT and INTEGRATION_TIMEOUT. */
-    private static final Duration UNIT_JOB_WALL = Duration.ofMinutes(10);
+    /** The wall this file's value has to fit: INTEGRATION_TIMEOUT in discover-backend-tests.sh. */
     private static final Duration INTEGRATION_JOB_WALL = Duration.ofMinutes(20);
 
-    /** CI runs -Dsurefire.rerunFailingTestsCount=3, and a timeout is an ordinary failure to Surefire. */
+    /** CI runs -Dsurefire.rerunFailingTestsCount=3, and a timeout is an ordinary failure. */
     private static final int ATTEMPTS_PER_HANG = 4;
 
-    /**
-     * JUnit's timeout grammar: a number, optional space, optional unit of ns/us/ms/s/m/h/d, parsed
-     * case-insensitively. A bare number means seconds. Anything else must be rejected rather than
-     * silently coerced -- the whole point of this class is that a wrong bound cannot pass unnoticed.
-     */
-    private static final Pattern TIMEOUT_GRAMMAR = Pattern.compile("(?i)^(\\d+)\\s*(ns|μs|us|ms|s|m|h|d)?$");
-
     @Test
-    @DisplayName("a thread blocked forever is interrupted and reported, never left to hang the job")
-    void blockedTestIsInterruptedRatherThanHanging() {
-        var neverCountedDown = new CountDownLatch(1);
-
-        // Preemptive timeout is the same mechanism JUnit applies to @Test methods via the
-        // timeout.testable.method.default property: it abandons the blocked thread and fails.
-        Executable blocksForever = () -> neverCountedDown.await();
-        var failure = assertThrows(AssertionError.class,
-                () -> assertTimeoutPreemptively(Duration.ofMillis(200), blocksForever));
-
-        assertThat(failure).hasMessageContaining("timed out");
-    }
-
-    @Test
-    @DisplayName("the shipped default survives CI's retry budget, regardless of any -D override")
+    @DisplayName("the shipped default survives CI's retry budget")
     void shippedDefaultFitsRetryBudget() {
-        // Read the file directly, never System.getProperty: in CI the override is always set, so
-        // consulting it here would mean the shipped default was never actually checked.
-        var shipped = loadProperties().getProperty(TIMEOUT_PROPERTY);
+        // Read the file, never System.getProperty: CI always passes a -D override, so consulting it
+        // would mean the shipped default -- the value local runs actually inherit -- went unchecked.
+        var shipped = loadShippedTimeout();
 
-        assertRetryBudgetFits(shipped, UNIT_JOB_WALL, "shipped default");
-    }
+        var budget = shipped.multipliedBy(ATTEMPTS_PER_HANG);
 
-    @Test
-    @DisplayName("an active -D override also survives the retry budget for its tier")
-    void overrideFitsRetryBudget() {
-        var override = System.getProperty(TIMEOUT_PROPERTY);
-
-        // Under CI the workflow always passes -D, so its absence means the override was removed or
-        // renamed and every job silently fell back to the shipped default. Skipping quietly here
-        // would let the guard stay green through exactly that regression. Locally there is no
-        // override to check, and the shipped default is asserted unconditionally above.
-        if (runningInCi()) {
-            assertThat(override)
-                    .as("CI must pass -D%s (see the mvn step in backend_tests.yml)", TIMEOUT_PROPERTY)
-                    .isNotBlank();
-        } else if (override == null) {
-            return;
-        }
-
-        // The override is per-tier and the tier is not knowable from inside the JVM, so hold it to
-        // the most generous wall. Each tier's exact value is pinned by ciMatrixWiresBothTiers.
-        assertRetryBudgetFits(override, INTEGRATION_JOB_WALL, "-D override");
+        assertThat(budget)
+                .as("%d attempts at the shipped '%s' must fit inside the %s job wall",
+                        ATTEMPTS_PER_HANG, shipped, INTEGRATION_JOB_WALL)
+                .isPositive()
+                .isLessThan(INTEGRATION_JOB_WALL);
     }
 
     @Test
@@ -110,139 +60,19 @@ class TestTimeoutGuardTest {
                 .doesNotContain("junit.jupiter.execution.timeout.default");
     }
 
-    @ParameterizedTest(name = "{0} -> {1}ms")
-    @CsvSource({"30s, 30000", "45, 45000", "2m, 120000", "4m, 240000", "1h, 3600000",
-            "500ms, 500", "2 m, 120000", "2M, 120000", "100us, 0", "5000000ns, 5"})
-    @DisplayName("timeout values are parsed per JUnit's grammar, not by stripping the unit")
-    void parsesJUnitTimeoutGrammar(String value, long expectedMillis) {
-        // Asserted in millis rather than seconds so sub-second values are visible here: truncating
-        // them to 0 is what previously made safe budgets look like no budget at all.
-        assertThat(toDuration(value).toMillis()).isEqualTo(expectedMillis);
-    }
+    private static Duration loadShippedTimeout() {
+        var value = loadProperties().getProperty(TIMEOUT_PROPERTY);
+        assertThat(value).as("%s must be configured", TIMEOUT_PROPERTY).isNotBlank();
 
-    @ParameterizedTest
-    @ValueSource(strings = {"500ms", "999ms", "1ms", "100us", "5000000ns"})
-    @DisplayName("sub-second bounds are accepted, not truncated to zero and rejected")
-    void acceptsSubSecondBudgets(String value) {
-        // 4 attempts at any of these is well under a minute, let alone the 10m wall. They were
-        // rejected because toSeconds() floored them to 0 and the isPositive() guard then read that
-        // as "no budget" -- a guard added to catch overflow was rejecting the smallest safe values.
-        assertRetryBudgetFits(value, UNIT_JOB_WALL, "sub-second probe");
-    }
+        // Only the units the shipped value is ever expected to use. Anything else is a deliberate
+        // failure rather than a guess: silently coercing an unrecognised value to a small number is
+        // how an oversized bound would slip past the assertion above.
+        var trimmed = value.trim();
+        assertThat(trimmed).as("shipped timeout should be expressed in whole minutes or seconds")
+                .matches("[1-9]\\d* ?[ms]");
 
-    @ParameterizedTest
-    @ValueSource(strings = {"2x", "abc", "m", "2mm", "-5m", ""})
-    @DisplayName("values outside JUnit's grammar are rejected, never coerced to a passing number")
-    void rejectsValuesOutsideGrammar(String value) {
-        assertThatThrownBy(() -> toDuration(value)).isInstanceOf(AssertionError.class);
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {"106751991167300d", "9223372036854775807s", "9223372036854775807us"})
-    @DisplayName("absurd values fail closed rather than overflowing into a passing budget")
-    void failsClosedOnOverflow(String value) {
-        // These are grammar-valid, so parsing accepts them; the budget multiplication is where they
-        // used to wrap negative and satisfy isLessThan(wall) -- the assertion meant to reject
-        // oversized bounds accepted the most oversized ones of all.
-        assertThatThrownBy(() -> assertRetryBudgetFits(value, UNIT_JOB_WALL, "overflow probe"))
-                .isInstanceOf(AssertionError.class);
-    }
-
-    @Test
-    @DisplayName("the CI matrix wires a budget-safe timeout into every job, end to end")
-    void ciMatrixWiresBothTiers() {
-        // Pinning the shell variables alone is not enough: the values only reach JUnit if the
-        // matrix emits them AND the workflow passes them through. Any link can be renamed or
-        // dropped independently, so assert the whole chain -- script variable, emitted matrix
-        // entry, and the -D on the mvn step.
-        var script = readDiscoveryScript();
-        var workflow = readWorkflow();
-
-        assertThat(workflow)
-                .as("the mvn step must pass matrix.testTimeout as -D%s", TIMEOUT_PROPERTY)
-                .contains("-D" + TIMEOUT_PROPERTY + "=\"${{ matrix.testTimeout }}\"");
-        assertThat(workflow)
-                .as("the job wall must come from the matrix, matching the tiers asserted here")
-                .contains("timeout-minutes: ${{ matrix.timeout }}");
-
-        assertTierPinned(script, "UNIT_TIMEOUT", "UNIT_TEST_TIMEOUT", UNIT_JOB_WALL);
-        assertTierPinned(script, "INTEGRATION_TIMEOUT", "INTEGRATION_TEST_TIMEOUT", INTEGRATION_JOB_WALL);
-
-        // Both emitted entry shapes must pair the wall with the per-test bound. A job missing the
-        // testTimeout key would render it as the empty string and fall back to the shipped default.
-        assertThat(script)
-                .as("the unit matrix entry must set both timeout and testTimeout")
-                .contains("\\\"timeout\\\":$UNIT_TIMEOUT,\\\"testTimeout\\\":\\\"$UNIT_TEST_TIMEOUT\\\"");
-        assertThat(script)
-                .as("the integration matrix entry must set both timeout and testTimeout")
-                .contains("\\\"timeout\\\":$INTEGRATION_TIMEOUT,\\\"testTimeout\\\":\\\"$INTEGRATION_TEST_TIMEOUT\\\"");
-    }
-
-    private static void assertTierPinned(String script, String wallVar, String testVar, Duration expectedWall) {
-        var wallMinutes = Long.parseLong(matchOne(script, wallVar + "=(\\d+)"));
-        assertThat(Duration.ofMinutes(wallMinutes))
-                .as("%s must match the wall this test asserts against", wallVar)
-                .isEqualTo(expectedWall);
-
-        assertRetryBudgetFits(matchOne(script, testVar + "=(\\S+)"), expectedWall, testVar);
-    }
-
-    private static void assertRetryBudgetFits(String value, Duration wall, String description) {
-        // Checked arithmetic, and fail closed on overflow: with plain long math an absurd but
-        // grammar-valid bound (e.g. 106751991167300d) wrapped negative and satisfied
-        // isLessThan(wall), so the assertion designed to reject oversized timeouts accepted the
-        // most oversized ones of all.
-        //
-        // Compared as Durations, not whole seconds: flooring to seconds turned every sub-second
-        // bound into 0, which the isPositive() check below then rejected as no budget at all.
-        Duration budget;
-        try {
-            budget = toDuration(value).multipliedBy(ATTEMPTS_PER_HANG);
-        } catch (ArithmeticException overflow) {
-            throw new AssertionError(
-                    "'%s' (%s) is absurdly large: %d attempts overflow a Duration, so it cannot fit inside the %s job wall"
-                            .formatted(value, description, ATTEMPTS_PER_HANG, wall),
-                    overflow);
-        }
-
-        // 4 attempts at the bound must still leave room for compilation and suite overhead,
-        // otherwise CI cancels the job before Surefire can publish the named failure -- losing
-        // exactly the diagnostic the timeout exists to provide.
-        assertThat(budget)
-                .as("%d attempts at '%s' (%s) must fit inside the %s job wall",
-                        ATTEMPTS_PER_HANG, value, description, wall)
-                .isPositive()
-                .isLessThan(wall);
-    }
-
-    private static String matchOne(String haystack, String regex) {
-        var matcher = Pattern.compile("^" + regex + "\\s*$", Pattern.MULTILINE).matcher(haystack);
-        assertThat(matcher.find()).as("discovery script must define %s", regex).isTrue();
-        return matcher.group(1);
-    }
-
-    private static boolean runningInCi() {
-        // GITHUB_ACTIONS is set by the runner itself, so it cannot drift out of sync with the
-        // workflow the way a hand-maintained flag would.
-        return Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"));
-    }
-
-    private static String readWorkflow() {
-        return readRepoFile("../../.github/workflows/backend_tests.yml");
-    }
-
-    private static String readDiscoveryScript() {
-        return readRepoFile("../../.github/scripts/discover-backend-tests.sh");
-    }
-
-    private static String readRepoFile(String relativeToModule) {
-        var path = java.nio.file.Path.of("").toAbsolutePath().resolve(relativeToModule).normalize();
-        assertThat(path).as("%s must exist", relativeToModule).exists();
-        try {
-            return java.nio.file.Files.readString(path);
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        var amount = Long.parseLong(trimmed.replaceAll("[^0-9]", ""));
+        return trimmed.endsWith("m") ? Duration.ofMinutes(amount) : Duration.ofSeconds(amount);
     }
 
     private static Properties loadProperties() {
@@ -254,38 +84,5 @@ class TestTimeoutGuardTest {
             throw new UncheckedIOException(e);
         }
         return properties;
-    }
-
-    /**
-     * Parses a JUnit timeout value, rejecting anything outside the documented grammar.
-     * <p>
-     * Returns a {@link Duration} rather than whole seconds so sub-second bounds keep their
-     * magnitude: flooring {@code 500ms} to 0 made a perfectly safe budget indistinguishable from no
-     * budget at all. Rejecting still matters more than converting -- an unrecognised value that
-     * silently became a small number would let a catastrophic bound sail past the budget assertions.
-     */
-    private static Duration toDuration(String value) {
-        assertThat(value).as("per-test timeout must be configured").isNotBlank();
-
-        var matcher = TIMEOUT_GRAMMAR.matcher(value.trim());
-        assertThat(matcher.matches())
-                .as("'%s' is not a valid JUnit timeout (expected <number>[ns|us|ms|s|m|h|d])", value)
-                .isTrue();
-
-        var amount = Long.parseLong(matcher.group(1));
-        var unit = matcher.group(2) == null ? "s" : matcher.group(2).toLowerCase(Locale.ROOT);
-
-        return switch (unit) {
-            case "ns" -> Duration.ofNanos(amount);
-            // multiplyExact, not *: a huge microsecond count would otherwise wrap negative here,
-            // before the retry-budget check ever sees it.
-            case "μs", "us" -> Duration.ofNanos(Math.multiplyExact(amount, 1_000L));
-            case "ms" -> Duration.ofMillis(amount);
-            case "s" -> Duration.ofSeconds(amount);
-            case "m" -> Duration.ofMinutes(amount);
-            case "h" -> Duration.ofHours(amount);
-            case "d" -> Duration.ofDays(amount);
-            default -> throw new IllegalStateException("unreachable: grammar admitted '" + unit + "'");
-        };
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
@@ -82,12 +82,21 @@ class TestTimeoutGuardTest {
     @DisplayName("an active -D override also survives the retry budget for its tier")
     void overrideFitsRetryBudget() {
         var override = System.getProperty(TIMEOUT_PROPERTY);
-        if (override == null) {
-            return; // No override in play (plain local run) -- the shipped default is asserted above.
+
+        // Under CI the workflow always passes -D, so its absence means the override was removed or
+        // renamed and every job silently fell back to the shipped default. Skipping quietly here
+        // would let the guard stay green through exactly that regression. Locally there is no
+        // override to check, and the shipped default is asserted unconditionally above.
+        if (runningInCi()) {
+            assertThat(override)
+                    .as("CI must pass -D%s (see the mvn step in backend_tests.yml)", TIMEOUT_PROPERTY)
+                    .isNotBlank();
+        } else if (override == null) {
+            return;
         }
 
         // The override is per-tier and the tier is not knowable from inside the JVM, so hold it to
-        // the most generous wall. The unit value is pinned exactly by discoveryScriptPinsBothTiers.
+        // the most generous wall. Each tier's exact value is pinned by ciMatrixWiresBothTiers.
         assertRetryBudgetFits(override, INTEGRATION_JOB_WALL, "-D override");
     }
 
@@ -115,16 +124,45 @@ class TestTimeoutGuardTest {
         assertThatThrownBy(() -> toSeconds(value)).isInstanceOf(AssertionError.class);
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"106751991167300d", "9223372036854775807s", "9223372036854775807us"})
+    @DisplayName("absurd values fail closed rather than overflowing into a passing budget")
+    void failsClosedOnOverflow(String value) {
+        // These are grammar-valid, so parsing accepts them; the budget multiplication is where they
+        // used to wrap negative and satisfy isLessThan(wall) -- the assertion meant to reject
+        // oversized bounds accepted the most oversized ones of all.
+        assertThatThrownBy(() -> assertRetryBudgetFits(value, UNIT_JOB_WALL, "overflow probe"))
+                .isInstanceOf(AssertionError.class);
+    }
+
     @Test
-    @DisplayName("both tiers stay pinned in the discovery script that feeds the CI matrix")
-    void discoveryScriptPinsBothTiers() {
-        // The -D override originates here, so the file is the only place the per-tier values and
-        // their job walls are stated together. Asserting the pairing keeps a change to one from
-        // silently outgrowing the other.
+    @DisplayName("the CI matrix wires a budget-safe timeout into every job, end to end")
+    void ciMatrixWiresBothTiers() {
+        // Pinning the shell variables alone is not enough: the values only reach JUnit if the
+        // matrix emits them AND the workflow passes them through. Any link can be renamed or
+        // dropped independently, so assert the whole chain -- script variable, emitted matrix
+        // entry, and the -D on the mvn step.
         var script = readDiscoveryScript();
+        var workflow = readWorkflow();
+
+        assertThat(workflow)
+                .as("the mvn step must pass matrix.testTimeout as -D%s", TIMEOUT_PROPERTY)
+                .contains("-D" + TIMEOUT_PROPERTY + "=\"${{ matrix.testTimeout }}\"");
+        assertThat(workflow)
+                .as("the job wall must come from the matrix, matching the tiers asserted here")
+                .contains("timeout-minutes: ${{ matrix.timeout }}");
 
         assertTierPinned(script, "UNIT_TIMEOUT", "UNIT_TEST_TIMEOUT", UNIT_JOB_WALL);
         assertTierPinned(script, "INTEGRATION_TIMEOUT", "INTEGRATION_TEST_TIMEOUT", INTEGRATION_JOB_WALL);
+
+        // Both emitted entry shapes must pair the wall with the per-test bound. A job missing the
+        // testTimeout key would render it as the empty string and fall back to the shipped default.
+        assertThat(script)
+                .as("the unit matrix entry must set both timeout and testTimeout")
+                .contains("\\\"timeout\\\":$UNIT_TIMEOUT,\\\"testTimeout\\\":\\\"$UNIT_TEST_TIMEOUT\\\"");
+        assertThat(script)
+                .as("the integration matrix entry must set both timeout and testTimeout")
+                .contains("\\\"timeout\\\":$INTEGRATION_TIMEOUT,\\\"testTimeout\\\":\\\"$INTEGRATION_TEST_TIMEOUT\\\"");
     }
 
     private static void assertTierPinned(String script, String wallVar, String testVar, Duration expectedWall) {
@@ -137,12 +175,27 @@ class TestTimeoutGuardTest {
     }
 
     private static void assertRetryBudgetFits(String value, Duration wall, String description) {
+        // Checked arithmetic, and fail closed on overflow: with plain long math an absurd but
+        // grammar-valid bound (e.g. 106751991167300d) wrapped negative and satisfied
+        // isLessThan(wall), so the assertion designed to reject oversized timeouts accepted the
+        // most oversized ones of all.
+        long budget;
+        try {
+            budget = Math.multiplyExact(toSeconds(value), (long) ATTEMPTS_PER_HANG);
+        } catch (ArithmeticException overflow) {
+            throw new AssertionError(
+                    "'%s' (%s) is absurdly large: %d attempts overflow a long, so it cannot fit inside the %s job wall"
+                            .formatted(value, description, ATTEMPTS_PER_HANG, wall),
+                    overflow);
+        }
+
         // 4 attempts at the bound must still leave room for compilation and suite overhead,
         // otherwise CI cancels the job before Surefire can publish the named failure -- losing
         // exactly the diagnostic the timeout exists to provide.
-        assertThat(toSeconds(value) * ATTEMPTS_PER_HANG)
+        assertThat(budget)
                 .as("%d attempts at '%s' (%s) must fit inside the %s job wall",
                         ATTEMPTS_PER_HANG, value, description, wall)
+                .isPositive()
                 .isLessThan(wall.toSeconds());
     }
 
@@ -152,11 +205,23 @@ class TestTimeoutGuardTest {
         return matcher.group(1);
     }
 
+    private static boolean runningInCi() {
+        // GITHUB_ACTIONS is set by the runner itself, so it cannot drift out of sync with the
+        // workflow the way a hand-maintained flag would.
+        return Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"));
+    }
+
+    private static String readWorkflow() {
+        return readRepoFile("../../.github/workflows/backend_tests.yml");
+    }
+
     private static String readDiscoveryScript() {
-        // src/test/resources -> module root -> repo root
-        var path = java.nio.file.Path.of("").toAbsolutePath()
-                .resolve("../../.github/scripts/discover-backend-tests.sh").normalize();
-        assertThat(path).as("discovery script must exist").exists();
+        return readRepoFile("../../.github/scripts/discover-backend-tests.sh");
+    }
+
+    private static String readRepoFile(String relativeToModule) {
+        var path = java.nio.file.Path.of("").toAbsolutePath().resolve(relativeToModule).normalize();
+        assertThat(path).as("%s must exist", relativeToModule).exists();
         try {
             return java.nio.file.Files.readString(path);
         } catch (IOException e) {
@@ -193,7 +258,9 @@ class TestTimeoutGuardTest {
 
         return switch (unit) {
             case "ns" -> Duration.ofNanos(amount).toSeconds();
-            case "μs", "us" -> Duration.ofNanos(amount * 1_000).toSeconds();
+            // multiplyExact, not *: a huge microsecond count would otherwise wrap negative here,
+            // before the retry-budget check ever sees it.
+            case "μs", "us" -> Duration.ofNanos(Math.multiplyExact(amount, 1_000L)).toSeconds();
             case "ms" -> Duration.ofMillis(amount).toSeconds();
             case "s" -> amount;
             case "m" -> Duration.ofMinutes(amount).toSeconds();

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
@@ -110,18 +110,31 @@ class TestTimeoutGuardTest {
                 .doesNotContain("junit.jupiter.execution.timeout.default");
     }
 
-    @ParameterizedTest(name = "{0} -> {1}s")
-    @CsvSource({"30s, 30", "45, 45", "2m, 120", "4m, 240", "1h, 3600", "500ms, 0", "2 m, 120", "2M, 120"})
+    @ParameterizedTest(name = "{0} -> {1}ms")
+    @CsvSource({"30s, 30000", "45, 45000", "2m, 120000", "4m, 240000", "1h, 3600000",
+            "500ms, 500", "2 m, 120000", "2M, 120000", "100us, 0", "5000000ns, 5"})
     @DisplayName("timeout values are parsed per JUnit's grammar, not by stripping the unit")
-    void parsesJUnitTimeoutGrammar(String value, long expectedSeconds) {
-        assertThat(toSeconds(value)).isEqualTo(expectedSeconds);
+    void parsesJUnitTimeoutGrammar(String value, long expectedMillis) {
+        // Asserted in millis rather than seconds so sub-second values are visible here: truncating
+        // them to 0 is what previously made safe budgets look like no budget at all.
+        assertThat(toDuration(value).toMillis()).isEqualTo(expectedMillis);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"500ms", "999ms", "1ms", "100us", "5000000ns"})
+    @DisplayName("sub-second bounds are accepted, not truncated to zero and rejected")
+    void acceptsSubSecondBudgets(String value) {
+        // 4 attempts at any of these is well under a minute, let alone the 10m wall. They were
+        // rejected because toSeconds() floored them to 0 and the isPositive() guard then read that
+        // as "no budget" -- a guard added to catch overflow was rejecting the smallest safe values.
+        assertRetryBudgetFits(value, UNIT_JOB_WALL, "sub-second probe");
     }
 
     @ParameterizedTest
     @ValueSource(strings = {"2x", "abc", "m", "2mm", "-5m", ""})
     @DisplayName("values outside JUnit's grammar are rejected, never coerced to a passing number")
     void rejectsValuesOutsideGrammar(String value) {
-        assertThatThrownBy(() -> toSeconds(value)).isInstanceOf(AssertionError.class);
+        assertThatThrownBy(() -> toDuration(value)).isInstanceOf(AssertionError.class);
     }
 
     @ParameterizedTest
@@ -179,12 +192,15 @@ class TestTimeoutGuardTest {
         // grammar-valid bound (e.g. 106751991167300d) wrapped negative and satisfied
         // isLessThan(wall), so the assertion designed to reject oversized timeouts accepted the
         // most oversized ones of all.
-        long budget;
+        //
+        // Compared as Durations, not whole seconds: flooring to seconds turned every sub-second
+        // bound into 0, which the isPositive() check below then rejected as no budget at all.
+        Duration budget;
         try {
-            budget = Math.multiplyExact(toSeconds(value), (long) ATTEMPTS_PER_HANG);
+            budget = toDuration(value).multipliedBy(ATTEMPTS_PER_HANG);
         } catch (ArithmeticException overflow) {
             throw new AssertionError(
-                    "'%s' (%s) is absurdly large: %d attempts overflow a long, so it cannot fit inside the %s job wall"
+                    "'%s' (%s) is absurdly large: %d attempts overflow a Duration, so it cannot fit inside the %s job wall"
                             .formatted(value, description, ATTEMPTS_PER_HANG, wall),
                     overflow);
         }
@@ -196,7 +212,7 @@ class TestTimeoutGuardTest {
                 .as("%d attempts at '%s' (%s) must fit inside the %s job wall",
                         ATTEMPTS_PER_HANG, value, description, wall)
                 .isPositive()
-                .isLessThan(wall.toSeconds());
+                .isLessThan(wall);
     }
 
     private static String matchOne(String haystack, String regex) {
@@ -241,11 +257,14 @@ class TestTimeoutGuardTest {
     }
 
     /**
-     * Converts a JUnit timeout value to seconds, rejecting anything outside the documented grammar.
-     * Rejecting matters more than converting: an unrecognised value that silently became a small
-     * number would let a catastrophic bound sail past the retry-budget assertions above.
+     * Parses a JUnit timeout value, rejecting anything outside the documented grammar.
+     * <p>
+     * Returns a {@link Duration} rather than whole seconds so sub-second bounds keep their
+     * magnitude: flooring {@code 500ms} to 0 made a perfectly safe budget indistinguishable from no
+     * budget at all. Rejecting still matters more than converting -- an unrecognised value that
+     * silently became a small number would let a catastrophic bound sail past the budget assertions.
      */
-    private static long toSeconds(String value) {
+    private static Duration toDuration(String value) {
         assertThat(value).as("per-test timeout must be configured").isNotBlank();
 
         var matcher = TIMEOUT_GRAMMAR.matcher(value.trim());
@@ -257,15 +276,15 @@ class TestTimeoutGuardTest {
         var unit = matcher.group(2) == null ? "s" : matcher.group(2).toLowerCase(Locale.ROOT);
 
         return switch (unit) {
-            case "ns" -> Duration.ofNanos(amount).toSeconds();
+            case "ns" -> Duration.ofNanos(amount);
             // multiplyExact, not *: a huge microsecond count would otherwise wrap negative here,
             // before the retry-budget check ever sees it.
-            case "μs", "us" -> Duration.ofNanos(Math.multiplyExact(amount, 1_000L)).toSeconds();
-            case "ms" -> Duration.ofMillis(amount).toSeconds();
-            case "s" -> amount;
-            case "m" -> Duration.ofMinutes(amount).toSeconds();
-            case "h" -> Duration.ofHours(amount).toSeconds();
-            case "d" -> Duration.ofDays(amount).toSeconds();
+            case "μs", "us" -> Duration.ofNanos(Math.multiplyExact(amount, 1_000L));
+            case "ms" -> Duration.ofMillis(amount);
+            case "s" -> Duration.ofSeconds(amount);
+            case "m" -> Duration.ofMinutes(amount);
+            case "h" -> Duration.ofHours(amount);
+            case "d" -> Duration.ofDays(amount);
             default -> throw new IllegalStateException("unreachable: grammar admitted '" + unit + "'");
         };
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/TestTimeoutGuardTest.java
@@ -1,0 +1,100 @@
+package com.comet.opik;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+/**
+ * Guards the guard.
+ * <p>
+ * A test that blocks forever used to cost the entire 10-minute Unit Tests job and surfaced only as
+ * "job cancelled" -- finding the culprit meant reading raw job logs for the class that printed
+ * "Running ..." with no matching result line. The safeguard against that now lives in
+ * junit-platform.properties plus a per-job -D override, either of which a rename or a scope change
+ * could silently disable while the suite still passed green.
+ * <p>
+ * These tests are deliberately fast and cannot hang: the blocking case is bounded preemptively.
+ */
+@DisplayName("Test Timeout Guard")
+class TestTimeoutGuardTest {
+
+    private static final String TIMEOUT_PROPERTY = "junit.jupiter.execution.timeout.testable.method.default";
+
+    /** The tightest job wall the bound has to fit inside: UNIT_TIMEOUT in discover-backend-tests.sh. */
+    private static final Duration UNIT_JOB_WALL = Duration.ofMinutes(10);
+
+    /** CI runs -Dsurefire.rerunFailingTestsCount=3, and a timeout is an ordinary failure to Surefire. */
+    private static final int ATTEMPTS_PER_HANG = 4;
+
+    @Test
+    @DisplayName("a thread blocked forever is interrupted and reported, never left to hang the job")
+    void blockedTestIsInterruptedRatherThanHanging() {
+        var neverCountedDown = new CountDownLatch(1);
+
+        // Preemptive timeout is the same mechanism JUnit applies to @Test methods via the
+        // timeout.testable.method.default property: it abandons the blocked thread and fails.
+        Executable blocksForever = () -> neverCountedDown.await();
+        var failure = assertThrows(AssertionError.class,
+                () -> assertTimeoutPreemptively(Duration.ofMillis(200), blocksForever));
+
+        assertThat(failure).hasMessageContaining("timed out");
+    }
+
+    @Test
+    @DisplayName("the shipped default survives CI's retry budget inside the unit job wall")
+    void shippedDefaultFitsRetryBudget() {
+        var configured = configuredTimeout();
+
+        // 4 attempts at the bound must still leave room for compilation and suite overhead,
+        // otherwise CI cancels the job before Surefire can publish the named failure -- losing
+        // exactly the diagnostic the timeout exists to provide.
+        assertThat(toSeconds(configured) * ATTEMPTS_PER_HANG)
+                .as("%d attempts at '%s' must fit inside the %s unit job wall",
+                        ATTEMPTS_PER_HANG, configured, UNIT_JOB_WALL)
+                .isLessThan(UNIT_JOB_WALL.toSeconds());
+    }
+
+    @Test
+    @DisplayName("the timeout is scoped to testable methods so container startup stays exempt")
+    void timeoutIsScopedToTestableMethods() {
+        // A blanket junit.jupiter.execution.timeout.default would also bound @BeforeAll/@BeforeEach,
+        // making slow, variable Testcontainers startup the thing that fails instead of the test.
+        assertThat(loadProperties().stringPropertyNames())
+                .contains(TIMEOUT_PROPERTY)
+                .doesNotContain("junit.jupiter.execution.timeout.default");
+    }
+
+    private static String configuredTimeout() {
+        var override = System.getProperty(TIMEOUT_PROPERTY);
+        return override != null ? override : loadProperties().getProperty(TIMEOUT_PROPERTY);
+    }
+
+    private static Properties loadProperties() {
+        var properties = new Properties();
+        try (var in = TestTimeoutGuardTest.class.getResourceAsStream("/junit-platform.properties")) {
+            assertThat(in).as("junit-platform.properties must be on the test classpath").isNotNull();
+            properties.load(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        return properties;
+    }
+
+    private static long toSeconds(String value) {
+        assertThat(value).as("per-test timeout must be configured").isNotBlank();
+        var trimmed = value.trim();
+        var amount = Long.parseLong(trimmed.replaceAll("\\D", ""));
+        return trimmed.endsWith("m") ? TimeUnit.MINUTES.toSeconds(amount) : amount;
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/python/PythonEvaluatorServiceTest.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.RetriableHttpClient;
 import com.comet.opik.podam.PodamFactoryUtils;
 import io.dropwizard.util.Duration;
 import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.InternalServerErrorException;
 import jakarta.ws.rs.ProcessingException;
 import jakarta.ws.rs.client.AsyncInvoker;
@@ -39,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -117,10 +119,10 @@ class PythonEvaluatorServiceTest {
             // Setup HTTP call with immutable response
             Response successResponse = createMockResponse(Status.OK, pythonResponse);
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluate(code, data).block();
@@ -161,25 +163,26 @@ class PythonEvaluatorServiceTest {
             Response successResponse = createMockResponse(Status.OK, pythonResponse);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(errorResponse1);
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(errorResponse2);
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
-            verify(asyncInvoker, times(3)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(3)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -200,21 +203,22 @@ class PythonEvaluatorServiceTest {
             Response successResponse = createMockResponse(Status.OK, pythonResponse);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(timeoutResponse);
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
-            verify(asyncInvoker, times(2)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(2)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -235,22 +239,23 @@ class PythonEvaluatorServiceTest {
 
             // First call throws timeout, 2nd call succeeds
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.failed(new ProcessingException("Request timeout",
                         new SocketTimeoutException("Connection timed out")));
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
-            verify(asyncInvoker, times(2)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(2)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -272,22 +277,23 @@ class PythonEvaluatorServiceTest {
             // First call throws NoHttpResponseException (server closes connection before responding),
             // 2nd call succeeds
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.failed(new ProcessingException("The target server failed to respond",
                         new org.apache.hc.core5.http.NoHttpResponseException("The target server failed to respond")));
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluate(code, data).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
-            verify(asyncInvoker, times(2)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(2)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -303,17 +309,18 @@ class PythonEvaluatorServiceTest {
             Response errorResponse = createMockResponse(Status.SERVICE_UNAVAILABLE, null);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(errorResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
                     .isInstanceOf(RuntimeException.class);
 
             // Should retry 4 times + initial attempt = 5 total calls
-            verify(asyncInvoker, times(5)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(5)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -332,10 +339,10 @@ class PythonEvaluatorServiceTest {
             Response badRequestResponse = createMockResponse(Status.BAD_REQUEST, errorResponse);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(badRequestResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -343,7 +350,8 @@ class PythonEvaluatorServiceTest {
                     .hasMessageContaining("Invalid Python code");
 
             // Should not retry for 400 errors
-            verify(asyncInvoker, times(1)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(1)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -358,10 +366,10 @@ class PythonEvaluatorServiceTest {
             when(builder.async()).thenReturn(asyncInvoker);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.failed(new ProcessingException("Connection refused"));
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -369,7 +377,8 @@ class PythonEvaluatorServiceTest {
                     .hasMessageContaining("Connection refused");
 
             // Should not retry for non-timeout processing exceptions
-            verify(asyncInvoker, times(1)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(1)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
     }
 
@@ -397,10 +406,10 @@ class PythonEvaluatorServiceTest {
             Response successResponse = createMockResponse(Status.OK, pythonResponse);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluateThread(code, context).block();
@@ -440,21 +449,22 @@ class PythonEvaluatorServiceTest {
             Response successResponse = createMockResponse(Status.OK, pythonResponse);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(errorResponse);
                 return null;
             }).doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(successResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When
             var actualScores = pythonEvaluatorService.evaluateThread(code, context).block();
 
             // Then
             assertThat(actualScores).isEqualTo(expectedScores);
-            verify(asyncInvoker, times(2)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(2)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
 
         @Test
@@ -470,17 +480,18 @@ class PythonEvaluatorServiceTest {
             Response timeoutResponse = createMockResponse(Status.GATEWAY_TIMEOUT, null);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(timeoutResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluateThread(code, context).block())
                     .isInstanceOf(RuntimeException.class);
 
             // Should retry 4 times + initial attempt = 5 total calls
-            verify(asyncInvoker, times(5)).post(any(Entity.class), any(InvocationCallback.class));
+            verify(asyncInvoker, times(5)).method(eq(HttpMethod.POST), any(Entity.class),
+                    any(InvocationCallback.class));
         }
     }
 
@@ -509,10 +520,10 @@ class PythonEvaluatorServiceTest {
             when(badRequestResponse.readEntity(String.class)).thenReturn("Custom error message");
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(badRequestResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -542,10 +553,10 @@ class PythonEvaluatorServiceTest {
                     .thenThrow(new RuntimeException("String parsing failed"));
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(serverErrorResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -586,10 +597,10 @@ class PythonEvaluatorServiceTest {
             when(okResponse.readEntity(PythonEvaluatorResponse.class)).thenReturn(body);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(okResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -625,10 +636,10 @@ class PythonEvaluatorServiceTest {
             when(badRequestResponse.readEntity(String.class)).thenReturn(rawBody);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(badRequestResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())
@@ -654,10 +665,10 @@ class PythonEvaluatorServiceTest {
             when(badRequestResponse.readEntity(String.class)).thenReturn(overlongBody);
 
             doAnswer(invocation -> {
-                InvocationCallback<Response> callback = invocation.getArgument(1);
+                InvocationCallback<Response> callback = invocation.getArgument(2);
                 callback.completed(badRequestResponse);
                 return null;
-            }).when(asyncInvoker).post(any(Entity.class), any(InvocationCallback.class));
+            }).when(asyncInvoker).method(eq(HttpMethod.POST), any(Entity.class), any(InvocationCallback.class));
 
             // When & Then: message keeps the prefix but is capped at 500 characters.
             assertThatThrownBy(() -> pythonEvaluatorService.evaluate(code, data).block())

--- a/apps/opik-backend/src/test/resources/junit-platform.properties
+++ b/apps/opik-backend/src/test/resources/junit-platform.properties
@@ -3,11 +3,22 @@
 # fork with no attributable test. Surefire's own forkedProcessTimeoutInSeconds cannot replace this:
 # it kills the JVM without naming the culprit.
 #
-# 5m is sized off the slowest legitimate test, not off the average: TraceThreadOnlineScoringAgenticToolsE2ETest
-# chains two 60s Awaitility waits in a single method, so the real worst case is ~2m. Anything near
-# that would flake on a loaded runner.
+# The bound must fit the RETRY budget, not a single attempt. CI runs with
+# -Dsurefire.rerunFailingTestsCount=3, and a timeout is an ordinary failure to Surefire, so a
+# deterministic hang is attempted 4 times. The job wall must exceed 4 x this value, or the job is
+# cancelled before Surefire publishes the named report -- losing exactly the diagnostic this
+# property exists to provide.
+#
+# 2m is the default because it fits the tightest wall: the Unit Tests job is capped at 10m
+# (UNIT_TIMEOUT in .github/scripts/discover-backend-tests.sh), and 4 x 2m = 8m leaves room for
+# compilation and suite overhead. It is still far above what unit tests need -- the slowest
+# Awaitility wait in any unit-classified test is 10s.
+#
+# Integration jobs override this on the command line (see backend_tests.yml): their wall is 20m,
+# and container-backed tests legitimately wait longer -- the slowest chains two 60s Awaitility
+# waits in a single method.
 #
 # Scoped to testable methods rather than timeout.default so @BeforeAll/@BeforeEach are exempt --
 # Testcontainers startup is slow and highly variable, and bounding it here would make container
 # setup, not the test, the thing that fails.
-junit.jupiter.execution.timeout.testable.method.default = 5m
+junit.jupiter.execution.timeout.testable.method.default = 2m

--- a/apps/opik-backend/src/test/resources/junit-platform.properties
+++ b/apps/opik-backend/src/test/resources/junit-platform.properties
@@ -1,0 +1,13 @@
+# Bound every @Test/@ParameterizedTest so a test that blocks forever is failed and named in the
+# Surefire report, instead of consuming the whole CI job until its timeout-minutes wall kills the
+# fork with no attributable test. Surefire's own forkedProcessTimeoutInSeconds cannot replace this:
+# it kills the JVM without naming the culprit.
+#
+# 5m is sized off the slowest legitimate test, not off the average: TraceThreadOnlineScoringAgenticToolsE2ETest
+# chains two 60s Awaitility waits in a single method, so the real worst case is ~2m. Anything near
+# that would flake on a loaded runner.
+#
+# Scoped to testable methods rather than timeout.default so @BeforeAll/@BeforeEach are exempt --
+# Testcontainers startup is slow and highly variable, and bounding it here would make container
+# setup, not the test, the thing that fails.
+junit.jupiter.execution.timeout.testable.method.default = 5m

--- a/apps/opik-backend/src/test/resources/junit-platform.properties
+++ b/apps/opik-backend/src/test/resources/junit-platform.properties
@@ -9,16 +9,21 @@
 # cancelled before Surefire publishes the named report -- losing exactly the diagnostic this
 # property exists to provide.
 #
-# 2m is the default because it fits the tightest wall: the Unit Tests job is capped at 10m
-# (UNIT_TIMEOUT in .github/scripts/discover-backend-tests.sh), and 4 x 2m = 8m leaves room for
-# compilation and suite overhead. It is still far above what unit tests need -- the slowest
-# Awaitility wait in any unit-classified test is 10s.
+# 4m is the value here because this file is what a LOCAL run inherits, and locally there is no way
+# to know which tier a test belongs to. It has to accommodate the slower one: the slowest
+# integration test chains two 60s Awaitility waits in a single method (~120s), so a 2m default
+# would sit right at that cap and fail it spuriously on any Testcontainers or JVM overhead.
+# 4m still fits the integration wall under retries (4 x 4m = 16m < 20m).
 #
-# Integration jobs override this on the command line (see backend_tests.yml): their wall is 20m,
-# and container-backed tests legitimately wait longer -- the slowest chains two 60s Awaitility
-# waits in a single method.
+# CI does know the tier, and overrides this per job from the matrix (see backend_tests.yml):
+# 2m for unit (4 x 2m = 8m inside the 10m wall), 4m for integration. So the tighter unit bound
+# still applies where it matters, and the value here only governs local runs.
 #
 # Scoped to testable methods rather than timeout.default so @BeforeAll/@BeforeEach are exempt --
 # Testcontainers startup is slow and highly variable, and bounding it here would make container
 # setup, not the test, the thing that fails.
-junit.jupiter.execution.timeout.testable.method.default = 2m
+#
+# Values must match JUnit's own grammar: ([1-9]\d*) ?((?:[nμm]?s)|m|h|d)? -- note the Unicode "μs",
+# and that a leading zero is rejected. An invalid value throws DateTimeParseException at engine
+# startup rather than being ignored.
+junit.jupiter.execution.timeout.testable.method.default = 4m


### PR DESCRIPTION
## Details

<img width="965" height="1675" alt="image" src="https://github.com/user-attachments/assets/996b6ab2-642f-4333-a77e-a2eb4bfc1f65" />

The CI `Unit Tests` job was being killed at its 10-minute `timeout-minutes` wall on `main` and on most backend PRs, while successful runs of the same job finished in ~3 minutes. That bimodality (either ~3m or exactly the wall, with nothing in between) is the tell: this was a deadlocked test, not a slow suite. Across the last 100 workflow runs, 24 of 85 `Unit Tests` jobs died this way — 17 of them on a single day, `main` included.

`OPIK_8082` generalised `RetriableHttpClient.performHttpRequest` to serve GET as well as POST, moving the outbound call from `builder.async().post(body, cb)` to `builder.async().method(method, body, cb)`. `PythonEvaluatorServiceTest` still stubbed `.post(...)`, so the stub stopped matching, the `doAnswer` that invokes `callback.completed()` never ran, and the `Mono.create` sink never received a terminal signal — `.block()` parked on a `CountDownLatch` forever. A `jstack` of the hung fork showed `main` in `Mono.block`, `boundedElastic` idle, and no thread anywhere in Opik code.

Two things worth calling out, because they explain why nothing caught this:

- Mockito's strict stubbing would normally flag the never-matched stub as unnecessary, but the test hangs before the strictness check runs.
- `-Dsurefire.rerunFailingTestsCount=3` is configured on the job but is structurally unable to help: the test never *fails*, so there is no result to retry.

This PR retargets the 16 stubs and 9 verifications onto the `method(...)` overload and shifts the callback argument index from 1 to 2. The matcher is `eq(HttpMethod.POST)` rather than a permissive any-string, so the mock now pins the verb — accepting any method is precisely what let this drift through unnoticed.

It also adds a per-test timeout, so the next test that blocks is failed and *named* in the Surefire report instead of consuming a whole CI job anonymously. Today that failure surfaces only as "job cancelled", and finding the culprit means reading raw job logs for the class that printed `Running ...` with no matching result line.

The bound has to fit the **retry** budget, not a single attempt: CI runs `-Dsurefire.rerunFailingTestsCount=3`, and a timeout is an ordinary failure to Surefire, so a deterministic hang is attempted 4 times (measured: a probe blocking on a `CountDownLatch` produced `Run 1`–`Run 4`). If 4x the bound exceeds the job wall, the job is cancelled before Surefire can publish the named report — losing the exact diagnostic the guard exists to provide.

It is therefore per-tier, carried through the existing matrix rather than hardcoded — `discover-backend-tests.sh` emits `testTimeout` per entry and the workflow passes it as `-D`, so the job wall and the per-test bound sit next to each other and cannot drift apart:

| Tier | Job wall | Per-test bound | Worst-case retry cost |
|---|---|---|---|
| Unit | 10m | **2m** | 4 x 2m = 8m |
| Integration | 20m | **4m** | 4 x 4m = 16m |

Both stay far above what their tier needs: the slowest Awaitility wait in any *unit*-classified test is 10s, and the 60s+ waits all live in container-backed integration tests. It is scoped to testable methods so Testcontainers startup in lifecycle callbacks is untouched.

`TestTimeoutGuardTest` keeps the shipped bound honest: **4 attempts at it must fit the job wall**, read from the properties file rather than `System.getProperty` so CI's `-D` override cannot mask a bad shipped default. That is the assertion that caught the original 5m value. A second one-line check guards against a blanket `timeout.default` being introduced, which would bound `@BeforeAll` and make Testcontainers startup the thing that fails.

It is deliberately narrow (88 lines, 2 tests). An earlier revision reimplemented JUnit's timeout grammar and string-matched the workflow and discovery script; review pointed out the reimplementation was **wrong** — JUnit's real pattern is `([1-9]\d*) ?((?:[nμm]?s)|m|h|d)?`, taking only the Unicode `μs`, so the guard was certifying `100us` as valid while JUnit throws `DateTimeParseException` on it at engine startup. Grammar validation is now left to JUnit, which does it correctly and fails loudly; the YAML/script greps went too, since they would break on any unrelated formatting change there.

Note the shipped value is **4m**, not the unit tier's 2m: this file is what *local* runs inherit, and locally nothing knows a test's tier, so it has to accommodate the slower one (the slowest integration test chains two 60s waits, ~120s). CI overrides per job from the matrix, so the tighter unit bound still applies where it matters.

Retries are kept rather than disabled — they still serve genuine flakes — with the budget sized to fit instead.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-8197

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation — CI log analysis, root-cause diagnosis, fix, and verification
- Human verification: author reviewed the diff and directed scope, timeout sizing, and guard-verification approach

## Testing

Commands run, all from `apps/opik-backend`:

- `mvn test -Dtest='PythonEvaluatorServiceTest'` — the previously-hanging class now passes **20 tests in ~3s** (was: blocked until the job was killed).
- Full CI unit job reproduced locally using the exact class list from `.github/scripts/discover-backend-tests.sh` (207 classes) with the same flags CI uses (`-Dmaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=3`) and the real `2m` per-test override: **3718 tests, 0 failures, 0 errors, 1:54**.
- `mvn spotless:check` — passes.
- `pre-commit run --files <changed files>` — passes, no reformatting.

Scenarios validated:

- **Root cause confirmed before fixing**: reproduced the hang locally and captured a `jstack` thread dump showing `main` parked in `Mono.block` at the failing assertion, with no thread in Opik code — ruling out slowness or retry backoff.
- **Guard actually fires**: temporarily added a test that blocks forever on a `CountDownLatch` (the same primitive as the real bug). It is reported as `GuardProbeTest.hangsForever » Timeout hangsForever() timed out`, with a stack trace pointing at the blocking line — confirming the "failed and named in the report" behaviour rather than assuming the config works. Probe removed afterwards.
- **Guard loads from the properties file, not just a CLI flag**: re-ran the probe with the timeout temporarily set in `junit-platform.properties` itself and no `-D` override; it timed out at exactly the configured value.
- **No regression from the bound**: zero guard-triggered timeouts across the full unit run. The `TimeoutException` strings in the log are deliberate timeout/retry simulations from tests exercising those paths, not the guard.
- **Retry budget measured, not assumed**: a probe test blocking on a `CountDownLatch` with a 5s bound and `rerunFailingTestsCount=3` produced `Run 1`–`Run 4` — confirming a hang costs 4x the per-test bound.
- **The budget assertion actually bites** — verified by deliberately breaking it: shipped default set to `6m` (4 x 6m = 24m > the 20m wall) fails, both with and without a valid `-D` override in play. Reading the file rather than `System.getProperty` is what makes the override unable to mask a bad shipped default; that is the check that caught the original `5m` bound.
- **Local-run default validated against the slowest integration test**: `TraceThreadOnlineScoringAgenticToolsE2ETest` chains two 60s Awaitility waits (lines 218, 228), ~120s total — which is why the shipped value is `4m` and not the unit tier's `2m`.
- **JUnit's grammar confirmed from the engine bytecode** rather than assumed: `([1-9]\d*) ?((?:[nμm]?s)|m|h|d)?`. An earlier revision's hand-rolled parser accepted an ASCII `us` alias that JUnit rejects with `DateTimeParseException`; that reimplementation is now removed rather than corrected, since duplicating the grammar created a second, wrong source of truth.
- **Matrix wiring verified**: re-ran `discover-backend-tests.sh` and confirmed every entry carries `testTimeout` (unit `2m`, integration `4m`); `actionlint` and `zizmor` pass on the workflow change.

Not run: the integration groups. This change touches one unit test class plus a test-scope properties file; the integration matrix is healthy and well under its 20-minute budget. CI will exercise it.

## Documentation

N/A — no user-facing or API surface affected. The rationale for the bound, its coupling to the retry budget, and the per-tier split are documented inline in `junit-platform.properties` and `discover-backend-tests.sh`.





