### PR TITLE
[OPIK-7862] [BE] fix: accept window_in_seconds for threshold errors

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/AlertTriggerConfig.java
@@ -43,6 +43,7 @@ public record AlertTriggerConfig(
     public static final String PROJECT_IDS_CONFIG_KEY = "project_ids";
     public static final String THRESHOLD_CONFIG_KEY = "threshold";
     public static final String WINDOW_CONFIG_KEY = "window";
+    public static final String WINDOW_IN_SECONDS_CONFIG_KEY = "window_in_seconds";
     public static final String NAME_CONFIG_KEY = "name";
     public static final String OPERATOR_CONFIG_KEY = "operator";
     // Comma-separated GuardrailType names (e.g. "PII,TOPIC"); empty/absent means all types.

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJob.java
@@ -59,6 +59,7 @@ import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.WINDOW_IN_SECONDS_CONFIG_KEY;
 
 /**
  * Scheduled job for processing metrics-based alerts.
@@ -427,9 +428,12 @@ public class MetricsAlertJob extends Job implements InterruptableJob {
 
         var windowString = config.configValue().get(WINDOW_CONFIG_KEY);
         if (windowString == null) {
+            windowString = config.configValue().get(WINDOW_IN_SECONDS_CONFIG_KEY);
+        }
+        if (windowString == null) {
             throw new IllegalArgumentException(
-                    "Missing config value for key '%s' in trigger of type '%s'"
-                            .formatted(WINDOW_CONFIG_KEY, thresholdConfigType));
+                    "Missing config value for key '%s' or '%s' in trigger of type '%s'"
+                            .formatted(WINDOW_CONFIG_KEY, WINDOW_IN_SECONDS_CONFIG_KEY, thresholdConfigType));
         }
         long windowSeconds = Long.parseLong(windowString);
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/jobs/MetricsAlertJobTest.java
@@ -37,6 +37,7 @@ import static com.comet.opik.api.AlertTriggerConfig.NAME_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.OPERATOR_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.THRESHOLD_CONFIG_KEY;
 import static com.comet.opik.api.AlertTriggerConfig.WINDOW_CONFIG_KEY;
+import static com.comet.opik.api.AlertTriggerConfig.WINDOW_IN_SECONDS_CONFIG_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -230,6 +231,29 @@ class MetricsAlertJobTest {
     }
 
     @Test
+    void firesTraceErrorsAlertWhenWindowIsProvidedAsWindowInSeconds() {
+        Alert alert = alertWithErrorThresholdConfig(Map.of(
+                THRESHOLD_CONFIG_KEY, "2",
+                WINDOW_IN_SECONDS_CONFIG_KEY, "60"));
+
+        when(projectMetricsDAO.getTotalTraceErrors(anyList(), any(Instant.class), any(Instant.class)))
+                .thenAnswer(invocation -> {
+                    Instant startTime = invocation.getArgument(1);
+                    Instant endTime = invocation.getArgument(2);
+                    assertThat(java.time.Duration.between(startTime, endTime).getSeconds()).isEqualTo(60);
+                    return Mono.just(new BigDecimal("3"));
+                });
+        when(alertService.findAllByWorkspaceAndEventTypes(null,
+                MetricsAlertJob.SUPPORTED_EVENT_TYPES)).thenReturn(List.of(alert));
+
+        job.doJob(null);
+
+        verify(alertWebhookSender, timeout(ASYNC_TIMEOUT_MS)).createAndSendWebhook(
+                any(), eq(WORKSPACE_ID), anyString(), eq(AlertEventType.TRACE_ERRORS), anyList(), anyList(),
+                anyList());
+    }
+
+    @Test
     void doesNotEvaluateWhenInterrupted() throws org.quartz.UnableToInterruptJobException {
         job.interrupt();
         job.doJob(null);
@@ -284,6 +308,28 @@ class MetricsAlertJobTest {
                         THRESHOLD_CONFIG_KEY, threshold,
                         WINDOW_CONFIG_KEY, "300"))
                 .groupIndex(groupIndex)
+                .build();
+    }
+
+    private static Alert alertWithErrorThresholdConfig(Map<String, String> configValue) {
+        AlertTrigger trigger = AlertTrigger.builder()
+                .id(UUID.randomUUID())
+                .eventType(AlertEventType.TRACE_ERRORS)
+                .triggerConfigs(List.of(AlertTriggerConfig.builder()
+                        .id(UUID.randomUUID())
+                        .type(AlertTriggerConfigType.THRESHOLD_ERRORS)
+                        .configValue(configValue)
+                        .build()))
+                .build();
+
+        return Alert.builder()
+                .id(UUID.randomUUID())
+                .name("test-alert")
+                .enabled(true)
+                .webhook(Webhook.builder().url("http://example/hook").build())
+                .triggers(List.of(trigger))
+                .projectId(PROJECT_ID)
+                .workspaceId(WORKSPACE_ID)
                 .build();
     }
 


### PR DESCRIPTION
## Details
`threshold:errors` alerts accepted `window_in_seconds` when created, but the evaluator only read `window`, so stored alerts never used the intended window. This change lets evaluation accept either key while keeping the canonical `window` path unchanged.

## Issues

- Fixes #7862