### PR TITLE
[OPIK-7532] [QA] Proposed taxonomy changes from app surface

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -265,6 +265,7 @@ areas:
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
       agent-graph-tab:        { covered: false }
+      prompts-tab:            { covered: false, note: "PromptsTab — conditional on opik_prompts metadata + canViewPrompts, like agent-graph-tab" }
       attachments-media:      { covered: true,  tier: t2-cuj, note: "presigned multipart upload with mime_type omitted, asserting the type tika derives from each file name (incl. the octet-stream fallback), plus every attachment rendering as a thumbnail in the trace panel" }
       set-guardrail:          { covered: false, note: "SetGuardrailDialog — GUARDRAILS_ENABLED flag" }
       guardrail-results:      { covered: false, note: "GuardrailsCell column + Guardrails tree block — GUARDRAILS_ENABLED flag" }


### PR DESCRIPTION
## Proposed by nightly taxonomy discovery

Read the app's route/nav/tab surface and compared it against `taxonomy.yaml`.
Baseline before this change: **19 areas, 201 functional capabilities**.

# Taxonomy discovery — proposal (2026-09-02)

**Target:** `opik/tests_end_to_end/coverage/taxonomy.yaml`
**Result:** one addition. `traces.prompts-tab`.

## Measured against

```
opik @ 77345212a7  "Update versions to 2.2.47 and bump base version to 2.2.48"
git -C opik status --porcelain  ->  (empty; clean tree)
```

`surface.json` was supplied by the caller and not regenerated. It reports 60
routes, 20 nav items, 8 tab groups, and **1** `unmatched_surfaces` entry —
identical to the baseline the skill records for 2026-08-03, so no new route has
landed in the window.

---

## 1. What changed

One capability added, to the `traces` area:

```yaml
      prompts-tab:            { covered: false, note: "PromptsTab — conditional on opik_prompts metadata + canViewPrompts, like agent-graph-tab" }
```

Inserted directly after `agent-graph-tab` (its sibling in the same component), as
a single-line `Edit`. `covered: false`, no `tier:` — reconcile.py owns those.

### Evidence

The trace details panel renders five tabs from one `TabsList`
(`src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx:270-306`):

| Tab value | Label | Rendered by | Functional capability today |
|---|---|---|---|
| `messages` | Messages | `MessagesTab.tsx` (281 lines) | `open-trace-panel` (default landing tab) |
| `details` | Details | `DetailsTab.tsx` (84 lines) | `open-trace-panel` (fallback landing tab) |
| `feedback_scores` | Feedback scores | `ConfigurableFeedbackScoreTable` | `manual-feedback-score` |
| `prompts` | Prompts | `PromptsTab.tsx` (50 lines) | **none** ← the gap |
| `graph` | Agent graph | `AgentGraphTab.tsx` | `agent-graph-tab` |

Three things make `prompts` a capability rather than over-splitting:

1. **House precedent, same component.** `agent-graph-tab` is already its own
   functional capability. `prompts` and `graph` are the panel's two
   *conditionally rendered* tabs — `{hasPrompts && <TabsTrigger …>}` at line 293
   and `{hasSpanAgentGraph && <TabsTrigger …>}` at line 302, structurally
   identical. Naming one and not the other is an inconsistency, not a decision.
2. **Not incidentally reachable.** `hasPrompts = Boolean(getRawPrompts(data)) &&
   canViewPrompts` (line 78). `getRawPrompts` reads `metadata.opik_prompts` and
   returns null for an empty/absent array (`PromptsTab.tsx:14-24`). So the tab
   only appears for a trace deliberately logged with prompt-library metadata, by
   a user holding `canViewPrompts`. A test has to set that up; it cannot be
   swept up by `open-trace-panel`.
3. **The visual dimension already names it.** `traces.visual.trace-sidebar-prompts`
   is `covered: true` (`trace-sidebar.spec.ts S04`), and the file's own footer
   comment maps S04 to "traces (tab-level)". The functional dimension was the
   one missing an entry for a tab the taxonomy otherwise acknowledges.

Not `cloud_only`: gated by a workspace permission and by trace data, not by
`usePluginsStore`. Per the skill's rule, a permission/data gate is not a
cloud gate, and `cloud_only` is omitted rather than written `false`.

**Verified after editing:** `yaml.safe_load` passes; `git diff --stat` is
`1 file changed, 1 insertion(+)`; `tag_lint.py --taxonomy coverage/taxonomy.yaml
--estate .` reports `54 specs checked, 1 exempt, 0 problem(s)`.

---

## 2. Coverage arithmetic

Recounted from the file, before and after, per dimension — never blended.

**Functional (whole taxonomy):** 109/201 (54.2%) → **109/202 (54.0%)**
**Functional (`traces` area):** 11/19 (57.9%) → **11/20 (55.0%)**
**Visual:** 30/54 (55.6%) → **30/54 (55.6%)** — unchanged, nothing added.
**Load:** `status: planned`; denominator untouched.

The 0.2pp drop is the intended effect: a tab that ships and has no test now
shows as a gap instead of being absent from the denominator.

---

## 2b. Rejected surfaces

Everything considered and ruled out, with the evidence that ruled it out.

### Routes

**`/$workspaceName/home` — the sole `unmatched_surfaces` entry. Rejected.**

The skill records this as a "genuine borderline… left for a human on purpose."
Reading the component settles it, and not as a borderline:

```tsx
// src/v2/pages/HomePage/HomePage.tsx — the whole file is 21 lines
const HomePage = () => {
  const workspaceName = useActiveWorkspaceName();
  const navigate = useNavigate();
  useEffect(() => {
    navigate({ to: "/$workspaceName/projects", params: { workspaceName }, replace: true });
  }, [workspaceName, navigate]);
  return <Loader />;
};
```

It renders a spinner and immediately redirects to `/$workspaceName/projects`
with `replace: true`. It is navigational plumbing — semantically `kind:
redirect`, the class the skill excludes; `surface.py` classified it as `surface`
only because it has a real component file rather than a `<Navigate>`-style
marker. There is no behaviour here a test could assert beyond "it redirects,"
and the destination is already owned by `projects.list-projects`. It is *not* a
workspace-level analogue of `projects.project-home`, which is what the
borderline framing assumed.

Its nav flag `showHomePage` is gated by `PROJECT_HOMEPAGE_ENABLED`
(`SideBarMenuItems.tsx:50`) — a FeatureToggleKey, so not cloud-only either. Moot
given the rejection, recorded so the next run does not re-derive it.

The other 59 routes all matched an owning area. The `redirect` / `index` /
`shell` entries (`TracesTabRedirect`, `OptimizationsNewRedirect`,
`TrialsRedirect`, the `/$workspaceName/redirect/*` family, the `<Outlet/>`
shells) are excluded by kind, per the skill's table.

### Nav labels

All 20 `nav_items` resolve to an existing area: Home → (redirect, above),
Opik Connect → `ollie`, Logs → `traces`/`threads`, Diagnostics → `diagnostics`,
Dashboards → `dashboards`, Prompt library → `prompts`, Agent playground →
`agent-playground`, Prompt playground → `playground`, Optimization runs →
`optimization-studio`, Test suites → `test-suites`, Datasets → `datasets`,
Experiments → `experiments`, Annotation queues → `annotation-queues`, Online
evaluation → `online-evaluation`, Alerts → `alerts`, Workspace/Projects →
`projects`, Configuration → `configuration`. No unowned label.

### Tabs

| Component | Tab values | Verdict |
|---|---|---|
| `AgentRunnerEmptyState.tsx` | `python` / `typescript` | **Format toggle**, not a capability — one code snippet, two renderings. The skill's own example. |
| `CreateDatasetSidebar.tsx` | `python` / `typescript` | Same. Rejected. |
| `AnnotationQueuePage.tsx` | `items` / `configuration` | Owned: `annotation-queues.queue-configuration-tab`, and `score-queue-item` / `skip-item` for the items tab. |
| `TrialSidebarContent.tsx` | `results` / `prompt` | Owned: `optimization-studio.trial-detail` and `best-trial-prompt`. |
| `PromptPage.tsx` | `prompt` / `experiments` | Owned: `prompts.experiments-tab`, plus `version-history` / `compare-versions`. |
| `DatasetItemsPage.tsx` | `items` / `version-history` | Owned: `datasets.view-items`, `version-history-view`. |
| `ThreadDetailsPanel.tsx` | `messages` / `feedback_scores` | Owned: `threads.turn-order-io`, `thread-feedback-score`. |
| `TraceDataViewer.tsx` | 5 values | Four owned; `prompts` proposed above. |

**Trace panel `details` and `messages` tabs — considered, rejected.** Unlike
`prompts` and `graph` these are rendered unconditionally, and one of them is
always the landing tab: `defaultTab = canShowMessagesTab ? "messages" :
"details"` (line 97). Opening the panel *is* landing on one of them, so
`open-trace-panel` (covered) already asserts them; separate keys would be
altitude-splitting a single behaviour. That line — conditional tab gets a key,
default landing tab does not — is the same one `agent-graph-tab` already sits on.

---

## 3. Removals

**None.** Every area's declared `routes:` still resolves against the router,
including the ones easiest to suspect: `annotation-queues`' `/$workspaceName/sme`,
`online-evaluation`'s `/$workspaceName/automation-logs`, `ollie`'s `/pair/v1`,
`diagnostics`' `/diagnostics/resolved`, and `onboarding`'s `/quickstart` +
`/get-started` are all present in `surface.json`. Nothing has left the app, so
nothing shrinks the denominator this run.

## 4. Rename notes for a human

**No renames made** — none are proposed as edits, per the never-rename rule.
One inconsistency worth a human's eye, deliberately left alone:

* `taxonomy.yaml` now holds **19** areas, but two comments in `rules.release_surface`
  still say 18 (`"all 18 areas join to at least one component"`, line ~170, and
  `"it covers 18 UI areas"`, line ~188). `workspace-roles` looks like the area
  added after those comments were written. This is stale prose, not a stale key —
  no tag is affected — but it is the kind of drift that makes a reader distrust
  the rest of the header. A one-word fix for whoever next touches that block; I
  left it out to keep this diff to the single line under review.

---

## 5. The blind spot

> This sweep reads only what is in the opik repo.
> `PluginsStore.collectRoutes()` and `PluginsStore.sidebarSections` let the
> out-of-tree `comet` plugin inject routes and nav entries that are invisible
> here, so surfaces that exist only in the commercial build are not covered by
> this diff.

`surface.json` carries this as its single caveat, and `nav_gating.plugin_components`
names the three injection points seen from in-tree: `AssistantSidebar`,
`SidebarWorkspaceSelectorComponent`, `sidebarSections`. Two nav flags
(`showOlliePage`, `showDiagnostics`) are plugin-gated through `AssistantSidebar`
and are already marked `cloud_only: true` on their areas — but that is only the
gating this repo can *see*. Any surface the plugin adds outright leaves no trace
in this tree at all, and this proposal cannot speak to it.

Two further limits specific to this run:

* `surface.json` was taken as given, not regenerated. It matches the recorded
  baseline exactly, which is corroboration, not proof, that it was built from
  `77345212a7`.
* Tab discovery is Radix `<TabsTrigger>`-shaped. A surface using another
  in-component switching mechanism would not appear in the `tabs` map and was
  not swept.

---

### Why this is a draft

The denominator is a reviewed file — adding a capability lowers coverage
until a test exists, and removing one raises it. Both need a human.
New capabilities land `covered: false` with no `tier:`; `reconcile.py`
fills those in once a tagged spec exists.

Run: https://github.com/comet-ml/comet-automation-tests/actions/runs/33594208539
