### PR TITLE
[NA] [DEV] fix: point EM backend S3 at the published MinIO API port

### DIFF
--- a/scripts/dev-runner-platform.sh
+++ b/scripts/dev-runner-platform.sh
@@ -276,9 +276,13 @@ SQL
 }
 
 # Patch the module's test-config.yml into a runtime config that works against
-# Opik's infra. Only redisConfig.redisPass isn't ${..}-overridable: it is
-# hardcoded 'NA' and Opik's Redis needs 'opik'.
-# Everything else is env-substituted from start_platform_backend_local.
+# Opik's infra:
+#   - redisConfig.redisPass is hardcoded 'NA'; Opik's Redis needs 'opik'
+#   - templates older than comet-backend 6cb013b662 hardcode the MinIO port as
+#     ':9000' instead of '${MINIO_PORT:-9000}'; Opik's MinIO API is published on
+#     ${MINIO_API_PORT} because ClickHouse holds 9000
+# Newer templates carry the ${MINIO_PORT} placeholder and are covered by the
+# env-substitution from start_platform_backend_local instead.
 generate_platform_backend_config() {
     local src="$COMET_BACKEND_PATH/comet-ml-react-webapp/src/test/resources/test-config.yml"
     if [ ! -f "$src" ]; then
@@ -287,6 +291,7 @@ generate_platform_backend_config() {
     fi
     sed -E \
         -e 's/redisPass: NA/redisPass: opik/g' \
+        -e "/MINIO_HOST/ s/:9000/:${MINIO_API_PORT}/g" \
         "$src" > "$PLATFORM_BACKEND_CONFIG_FILE"
     log_debug "Generated EM backend config: $PLATFORM_BACKEND_CONFIG_FILE"
 }

--- a/scripts/dev-runner-platform.sh
+++ b/scripts/dev-runner-platform.sh
@@ -276,10 +276,8 @@ SQL
 }
 
 # Patch the module's test-config.yml into a runtime config that works against
-# Opik's infra. Only two values aren't ${..}-overridable and need rewriting:
-#   - redisConfig.redisPass is hardcoded 'NA'; Opik's Redis needs 'opik'
-#   - the S3 endpoint port is hardcoded ':9000'; Opik's MinIO API is on
-#     ${MINIO_API_PORT} (the :9000 rewrite is scoped to MINIO_HOST lines)
+# Opik's infra. Only redisConfig.redisPass isn't ${..}-overridable: it is
+# hardcoded 'NA' and Opik's Redis needs 'opik'.
 # Everything else is env-substituted from start_platform_backend_local.
 generate_platform_backend_config() {
     local src="$COMET_BACKEND_PATH/comet-ml-react-webapp/src/test/resources/test-config.yml"
@@ -289,7 +287,6 @@ generate_platform_backend_config() {
     fi
     sed -E \
         -e 's/redisPass: NA/redisPass: opik/g' \
-        -e "/MINIO_HOST/ s/:9000/:${MINIO_API_PORT}/g" \
         "$src" > "$PLATFORM_BACKEND_CONFIG_FILE"
     log_debug "Generated EM backend config: $PLATFORM_BACKEND_CONFIG_FILE"
 }
@@ -340,7 +337,7 @@ start_platform_backend_local() {
         MYSQL_HOST=localhost MYSQL_PORT="$MYSQL_PORT" MYSQL_DB=logger \
         MYSQL_RW_USER=user MYSQL_RO_USER=user-ro MYSQL_PASSWORD=pass \
         REDIS_HOST=localhost REDIS_PORT="$REDIS_PORT" REDIS_USER=default REDIS_TOKEN=opik \
-        MINIO_HOST=localhost MINIO_HOST_VIEW=localhost \
+        MINIO_HOST=localhost MINIO_HOST_VIEW=localhost MINIO_PORT="$MINIO_API_PORT" \
         CASSANDRA_ENABLED=false MPM_ENABLED=false \
         FORCE_FAIL_ON_TIMEZONE_MISMATCH=False \
         MYSQL_MIN_MAX_ALLOWED_PACKET_MB=3 \


### PR DESCRIPTION
## Details

The EM backend resolved its S3 endpoint to `localhost:9000`, where ClickHouse listens on its native TCP port — MinIO's API is published on `MINIO_API_PORT` (9001 at offset 0) precisely because ClickHouse claims 9000 first. The S3 client connected, spoke HTTP at a binary protocol, and failed with `SdkClientException: Unable to execute HTTP request: null`. Since `AuthEndpoint.auth` calls `UserService.getIsImageInS3Cached` to look up a profile picture, every login in platform mode died on that error.

The EM config template exists in two shapes, and both are now handled:

- **comet-backend `6cb013b662` (2026-07-31) onward** — the template reads `${MINIO_PORT:-9000}`, but only `MINIO_HOST`/`MINIO_HOST_VIEW` were exported, so the `9000` default applied. Now `MINIO_PORT="$MINIO_API_PORT"` is exported and Dropwizard substitutes it at load time, which also keeps the port correct in worktrees carrying a `PORT_OFFSET`.
- **Older checkouts** — the template hardcodes a literal `:9000`, which the `MINIO_HOST`-scoped `sed` in `generate_platform_backend_config` rewrites. `COMET_BACKEND_PATH` accepts these, so the rewrite is retained.

The two don't collide: `${MINIO_PORT:-9000}` contains no `:9000` substring (it's `:-9000`, with a hyphen), so the `sed` passes the modern template through untouched.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation
- Human verification: manual testing against the local platform stack

## Testing

Local platform stack (`./scripts/dev-runner.sh --platform-enabled --restart`), macOS, process mode.

Before the fix, the EM backend log showed the login failing on every attempt:

```
ERROR com.comet.utils.monitoring.ErrorReporter: failed to auth test the user: <user>. got error: Unable to execute HTTP request: null
! Causing: com.amazonaws.SdkClientException: Unable to execute HTTP request: null
!   at com.comet.s3.upload.CometS3.doesExistInPublicS3(CometS3.java:238)
!   at com.comet.services.em.UserService.getIsImageInS3Cached(UserService.java:167)
!   at com.comet.site.webapp.endpoint.AuthEndpoint.auth(AuthEndpoint.java:1185)
```

After restarting with the fix:

- `MINIO_PORT=9001` present in the EM backend process environment (`ps eww`)
- MinIO reachable: `GET localhost:9001/minio/health/live` → 200, `public` bucket → 200
- Login through the EM proxy: `GET localhost:9100/login?from=llm&from_workspace_name=...` → **200**
- Zero occurrences of `failed to auth test the user` / `doesExistInPublicS3` in the EM backend log after the login
- Stack healthy end to end: Opik BE 8080, Opik FE 5174, EM BE 8200, EM FE 8300, proxy 9100

Root cause confirmed directly — `curl localhost:9000` returns `HTTP/1.0 400 Bad Request`, ClickHouse rejecting HTTP on its native port.

Both template shapes exercised with `MINIO_API_PORT=9001`: the literal `:9000` form is rewritten to `:9001`, and the `${MINIO_PORT:-9000}` form passes through for env substitution.

Checks run: `bash -n scripts/dev-runner-platform.sh` (passes). No Maven/npm/SDK checks — the change touches only a dev-runner shell script, no application code. `pre-commit` and `shellcheck` are not installed in this environment, so neither was run.

## Documentation

N/A — no user-facing or documented behavior changes; the comment above `generate_platform_backend_config` documents both template shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)