### PR TITLE
[NA] [SDK] fix: address review comments on dataset insert deduplication

### DIFF
--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -805,6 +805,10 @@ class Dataset(DatasetExportOperations):
                 batches that already succeeded stay persisted. Older Opik
                 backends do not support parallel upload and fall back to a
                 sequential one.
+
+        Raises:
+            ValueError: If ``num_threads`` is not a positive integer, or
+                ``deduplication`` is not a bool.
         """
         if isinstance(num_threads, bool) or not isinstance(num_threads, int):
             raise ValueError("num_threads must be a positive integer")

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -741,9 +741,15 @@ class Dataset(DatasetExportOperations):
     ) -> None:
         # Validated here rather than in each public entry point: every insert
         # path funnels through this method. A truthy string or None would
-        # otherwise silently pick the wrong duplicate-checking behaviour.
+        # otherwise silently pick the wrong duplicate-checking behaviour, and
+        # a non-integer worker count would fail on the comparison below with a
+        # TypeError instead of naming the offending argument.
         if not isinstance(deduplication, bool):
             raise ValueError("deduplication must be a bool")
+        if isinstance(num_threads, bool) or not isinstance(num_threads, int):
+            raise ValueError("num_threads must be a positive integer")
+        if num_threads < 1:
+            raise ValueError("num_threads must be a positive integer")
 
         # Gated here rather than in `insert` so every caller of this funnel is
         # covered: older backends race on concurrent batches that share a

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -353,6 +353,11 @@ class Dataset(DatasetExportOperations):
         # one-shot sync on the first `insert()` instead of paying an N+1
         # sync at list time.
         self._hashes_synced: bool = True
+        # None until the backend version has actually been determined. Only a
+        # conclusive answer is stored, so a probe that failed to reach the
+        # backend is retried instead of pinning this dataset to sequential
+        # uploads for the rest of the session.
+        self._parallel_insert_supported_cache: Optional[bool] = None
 
     @classmethod
     def from_public(
@@ -611,44 +616,60 @@ class Dataset(DatasetExportOperations):
         )
         LOGGER.debug("Successfully sent dataset items batch of size %d", len(batch))
 
-    @functools.cached_property
+    @property
     def _parallel_insert_supported(self) -> bool:
         """Whether the backend tolerates concurrent batches sharing a batch_group_id.
 
         Older backends race on them, so parallelism is only safe from
         ``constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT`` onwards. When the
-        version cannot be determined at all — unreachable endpoint, non-semver
-        build string — we report unsupported rather than risk the race.
+        version cannot be determined we report unsupported rather than risk the
+        race.
 
-        Cached because the backend cannot change version mid-session, and
-        parallel upload is the default: probing per ``insert`` would add a
-        round trip to every call in a loop.
+        The answer is cached because the backend cannot change version
+        mid-session and parallel upload is the default: probing per ``insert``
+        would add a round trip to every call in a loop. Only a conclusive
+        answer is cached — an unreachable backend is re-probed on the next
+        insert so parallel upload resumes once it recovers.
         """
+        if self._parallel_insert_supported_cache is not None:
+            return self._parallel_insert_supported_cache
+
         try:
             backend_version = self._rest_client.version()["version"]
+        except Exception:
+            LOGGER.warning(
+                "Could not reach the Opik backend to determine its version, "
+                "falling back to a sequential dataset upload for this insert.",
+                exc_info=True,
+            )
+            return False
+
+        try:
             supported = (
                 semantic_version.SemanticVersion.parse(backend_version)
                 >= constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT
             )
         except Exception:
             LOGGER.warning(
-                "Could not determine the Opik backend version, falling back to a "
+                "Could not parse the Opik backend version %s, falling back to a "
                 "sequential dataset upload. Parallel upload requires backend %s "
                 "or newer.",
+                backend_version,
                 constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
                 exc_info=True,
             )
-            return False
+            supported = False
+        else:
+            if not supported:
+                LOGGER.warning(
+                    "Opik backend %s does not support parallel dataset upload, "
+                    "falling back to a sequential upload. Upgrade to backend %s or "
+                    "newer to use num_threads.",
+                    backend_version,
+                    constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
+                )
 
-        if not supported:
-            LOGGER.warning(
-                "Opik backend %s does not support parallel dataset upload, falling "
-                "back to a sequential upload. Upgrade to backend %s or newer to use "
-                "num_threads.",
-                backend_version,
-                constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT,
-            )
-
+        self._parallel_insert_supported_cache = supported
         return supported
 
     def _send_batches(
@@ -718,6 +739,12 @@ class Dataset(DatasetExportOperations):
         num_threads: int = 1,
         deduplication: bool = True,
     ) -> None:
+        # Validated here rather than in each public entry point: every insert
+        # path funnels through this method. A truthy string or None would
+        # otherwise silently pick the wrong duplicate-checking behaviour.
+        if not isinstance(deduplication, bool):
+            raise ValueError("deduplication must be a bool")
+
         if deduplication:
             items_to_send = self._deduplicate(items)
         else:
@@ -756,7 +783,8 @@ class Dataset(DatasetExportOperations):
             deduplication: Whether to skip items whose content already exists
                 in the dataset. Pass ``False`` to insert every item as-is
                 without any duplicate checking, which is significantly faster
-                on large datasets.
+                on large datasets. The next insert that does deduplicate has to
+                re-read the dataset's items to account for what was skipped.
             num_threads: Number of worker threads used to upload the item
                 batches. Must be a positive integer, defaults to ``4``; pass
                 ``1`` to upload sequentially. All batches land in a single
@@ -769,6 +797,9 @@ class Dataset(DatasetExportOperations):
             raise ValueError("num_threads must be a positive integer")
         if num_threads < 1:
             raise ValueError("num_threads must be a positive integer")
+        # Checked before the version probe below so bad input costs no request.
+        if not isinstance(deduplication, bool):
+            raise ValueError("deduplication must be a bool")
 
         if num_threads > 1 and not self._parallel_insert_supported:
             num_threads = 1

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -745,6 +745,13 @@ class Dataset(DatasetExportOperations):
         if not isinstance(deduplication, bool):
             raise ValueError("deduplication must be a bool")
 
+        # Gated here rather than in `insert` so every caller of this funnel is
+        # covered: older backends race on concurrent batches that share a
+        # batch_group_id, and a direct caller asking for workers must not be
+        # able to skip that check.
+        if num_threads > 1 and not self._parallel_insert_supported:
+            num_threads = 1
+
         if deduplication:
             items_to_send = self._deduplicate(items)
         else:
@@ -797,12 +804,9 @@ class Dataset(DatasetExportOperations):
             raise ValueError("num_threads must be a positive integer")
         if num_threads < 1:
             raise ValueError("num_threads must be a positive integer")
-        # Checked before the version probe below so bad input costs no request.
+        # Checked here too so bad input raises before any item is converted.
         if not isinstance(deduplication, bool):
             raise ValueError("deduplication must be a bool")
-
-        if num_threads > 1 and not self._parallel_insert_supported:
-            num_threads = 1
 
         dataset_items: List[dataset_item.DatasetItem] = [  # type: ignore
             (dataset_item.DatasetItem(**item) if isinstance(item, dict) else item)

--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -284,6 +284,10 @@ def get_test_suites(
                 dataset_items_count=dataset_fern.dataset_items_count,
                 client=client,
             )
+            # This suite already holds items on the backend that we have not
+            # hashed locally, so the first insert must sync before it can tell
+            # a duplicate from a new item.
+            suite_dataset.__internal_api__hashes_synced__ = False
 
             suites.append(
                 test_suite_module.TestSuite(

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from opik.api_objects import constants
+from opik.api_objects.dataset import dataset_item
 from opik.api_objects.dataset.dataset import Dataset
 
 
@@ -566,14 +567,29 @@ def test_insert__version_probe_recovers__parallel_upload_resumes(monkeypatch):
         rest_client=mock_rest_client,
     )
 
+    # Spying on the upload layer keeps the assertion on the worker count that
+    # actually reached it, so a gate that stops honouring the probe still fails
+    # this test.
+    workers_per_insert = []
+    original_send = Dataset._send_batches
+
+    def spy_send_batches(self, batches, batch_group_id, num_threads):
+        workers_per_insert.append(num_threads)
+        return original_send(self, batches, batch_group_id, num_threads)
+
+    monkeypatch.setattr(Dataset, "_send_batches", spy_send_batches)
+
     dataset.insert(_make_items(4), deduplication=False)
     dataset.insert(_make_items(4), deduplication=False)
 
     assert mock_rest_client.version.call_count == 2, (
         "The failed probe must be retried rather than cached as unsupported"
     )
-    assert dataset._parallel_insert_supported, (
-        "Once the backend answers, parallel upload must be available again"
+    assert workers_per_insert[0] == 1, (
+        "While the backend is unreachable the upload must stay sequential"
+    )
+    assert workers_per_insert[1] > 1, (
+        "Once the backend answers, the upload must go back to using workers"
     )
 
 
@@ -593,6 +609,37 @@ def test_insert__unparseable_version__probed_once(monkeypatch):
 
     assert mock_rest_client.version.call_count == 1, (
         "A version the SDK cannot parse will not change, so it must not be re-probed"
+    )
+
+
+def test_internal_insert__old_backend__worker_count_still_gated(monkeypatch):
+    """The gate lives in the funnel, so a direct caller cannot skip it."""
+    _small_batches(monkeypatch, size=_GATE_BATCH_SIZE)
+    mock_rest_client = _mock_rest_client("2.2.7")
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    used_workers = []
+    monkeypatch.setattr(
+        Dataset,
+        "_send_batches",
+        lambda self, batches, batch_group_id, num_threads: used_workers.append(
+            num_threads
+        ),
+    )
+
+    dataset.__internal_api__insert_items_as_dataclasses__(
+        [dataset_item.DatasetItem(**item) for item in _make_items(4)],
+        num_threads=4,
+    )
+
+    assert used_workers == [1], (
+        "A backend that predates parallel insert must force a sequential upload "
+        "even when the internal API is called directly"
     )
 
 

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -623,14 +623,17 @@ def test_internal_insert__old_backend__worker_count_still_gated(monkeypatch):
         rest_client=mock_rest_client,
     )
 
+    # The spy calls through, so the upload still happens and the assertions
+    # below cover the items actually reaching the backend, not just the
+    # argument the gate computed.
     used_workers = []
-    monkeypatch.setattr(
-        Dataset,
-        "_send_batches",
-        lambda self, batches, batch_group_id, num_threads: used_workers.append(
-            num_threads
-        ),
-    )
+    original_send = Dataset._send_batches
+
+    def spy_send_batches(self, batches, batch_group_id, num_threads):
+        used_workers.append(num_threads)
+        return original_send(self, batches, batch_group_id, num_threads)
+
+    monkeypatch.setattr(Dataset, "_send_batches", spy_send_batches)
 
     dataset.__internal_api__insert_items_as_dataclasses__(
         [dataset_item.DatasetItem(**item) for item in _make_items(4)],
@@ -641,6 +644,36 @@ def test_internal_insert__old_backend__worker_count_still_gated(monkeypatch):
         "A backend that predates parallel insert must force a sequential upload "
         "even when the internal API is called directly"
     )
+
+    create_or_update = mock_rest_client.datasets.create_or_update_dataset_items
+    submitted = sorted(
+        item.data["input"]["i"]
+        for call in create_or_update.call_args_list
+        for item in call.kwargs["items"]
+    )
+    assert submitted == [0, 1, 2, 3], (
+        "Forcing a sequential upload must still deliver every item exactly once"
+    )
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, 1.5, "2", True, None])
+def test_internal_insert__invalid_num_threads__raises_value_error(bad_value):
+    """Direct callers get the named ValueError, not a TypeError from the gate."""
+    mock_rest_client = Mock()
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(ValueError, match="num_threads must be a positive integer"):
+        dataset.__internal_api__insert_items_as_dataclasses__(
+            [dataset_item.DatasetItem(**item) for item in _make_items(2)],
+            num_threads=bad_value,
+        )
+
+    mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()
 
 
 @pytest.mark.parametrize("bad_value", ["false", 0, 1, None, "", []])

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -551,6 +551,68 @@ def test_insert__version_endpoint_unreachable__uploads_sequentially(monkeypatch)
     ), "A failing version probe must not break insert; it falls back to sequential"
 
 
+def test_insert__version_probe_recovers__parallel_upload_resumes(monkeypatch):
+    """A transient probe failure must not pin the dataset to sequential uploads."""
+    _small_batches(monkeypatch, size=_GATE_BATCH_SIZE)
+    mock_rest_client = Mock()
+    mock_rest_client.version.side_effect = [
+        ConnectionError("backend unreachable"),
+        {"version": constants.MIN_BACKEND_VERSION_FOR_PARALLEL_INSERT},
+    ]
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    dataset.insert(_make_items(4), deduplication=False)
+    dataset.insert(_make_items(4), deduplication=False)
+
+    assert mock_rest_client.version.call_count == 2, (
+        "The failed probe must be retried rather than cached as unsupported"
+    )
+    assert dataset._parallel_insert_supported, (
+        "Once the backend answers, parallel upload must be available again"
+    )
+
+
+def test_insert__unparseable_version__probed_once(monkeypatch):
+    """An unparseable version is a conclusive answer, so it must still cache."""
+    _small_batches(monkeypatch, size=_GATE_BATCH_SIZE)
+    mock_rest_client = _mock_rest_client("dev-local")
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    for _ in range(3):
+        dataset.insert(_make_items(4), deduplication=False)
+
+    assert mock_rest_client.version.call_count == 1, (
+        "A version the SDK cannot parse will not change, so it must not be re-probed"
+    )
+
+
+@pytest.mark.parametrize("bad_value", ["false", 0, 1, None, "", []])
+def test_insert__non_bool_deduplication__raises_before_any_request(bad_value):
+    mock_rest_client = Mock()
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(ValueError, match="deduplication must be a bool"):
+        dataset.insert(_make_items(3), deduplication=bad_value)
+
+    mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()
+    mock_rest_client.version.assert_not_called()
+
+
 def test_insert__sequential__uploads_sequentially_without_probing_version(monkeypatch):
     mock_rest_client = _mock_rest_client()
 

--- a/sdks/python/tests/unit/api_objects/dataset/test_rest_operations.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_rest_operations.py
@@ -1,6 +1,7 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from opik.api_objects.dataset import rest_operations
+from opik.rest_api.types import dataset_item as rest_dataset_item
 
 
 def _find_datasets_returning(*pages) -> Mock:
@@ -27,25 +28,47 @@ def _backend_dataset(name: str, type_: str, items_total: int) -> Mock:
     return dataset_fern
 
 
-def test_get_test_suites__suite_holds_backend_items__first_insert_syncs_hashes():
-    """A listed suite must not treat its empty local hash set as authoritative.
+def test_get_test_suites__insert_duplicates_existing_item__duplicate_not_submitted():
+    """A listed suite must re-read its backend items before deduplicating.
 
-    Otherwise the first deduplicated insert compares against nothing, decides
-    every item is new, and resubmits items the suite already holds.
+    Otherwise the first insert compares against an empty local hash set,
+    decides every item is new, and resubmits items the suite already holds.
     """
+    existing_content = {"question": "already in the suite"}
     mock_rest_client = _find_datasets_returning(
-        [_backend_dataset("my-suite", "evaluation_suite", items_total=25)]
+        [_backend_dataset("my-suite", "evaluation_suite", items_total=1)]
     )
 
     suites = rest_operations.get_test_suites(
         project_name="Test project",
         rest_client=mock_rest_client,
     )
-
     assert len(suites) == 1
-    assert not suites[0]._dataset.__internal_api__hashes_synced__, (
-        "A suite listed from the backend has items we have not hashed locally, "
-        "so the first insert must sync before deduplicating"
+
+    backend_item = rest_dataset_item.DatasetItem(
+        id="existing-item-id", source="sdk", data=existing_content
+    )
+    with patch(
+        "opik.api_objects.dataset.rest_operations.rest_stream_parser.read_and_parse_stream",
+        side_effect=[[backend_item], []],
+    ):
+        suites[0].insert(
+            [
+                {"data": existing_content},
+                {"data": {"question": "brand new"}},
+            ]
+        )
+
+    create_or_update = mock_rest_client.datasets.create_or_update_dataset_items
+    submitted = [
+        item
+        for call in create_or_update.call_args_list
+        for item in call.kwargs["items"]
+    ]
+
+    assert [item.data for item in submitted] == [{"question": "brand new"}], (
+        "The item the suite already holds must be recognised as a duplicate and "
+        "left out of the batch"
     )
 
 

--- a/sdks/python/tests/unit/api_objects/dataset/test_rest_operations.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_rest_operations.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+from opik.api_objects.dataset import rest_operations
+
+
+def _find_datasets_returning(*pages) -> Mock:
+    """A rest client whose find_datasets yields the given pages, then an empty one.
+
+    The pagination loop only stops on an empty page, so the trailing empty page
+    is what keeps these tests from spinning forever.
+    """
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.find_datasets.side_effect = [
+        Mock(content=list(page)) for page in (*pages, ())
+    ]
+    return mock_rest_client
+
+
+def _backend_dataset(name: str, type_: str, items_total: int) -> Mock:
+    dataset_fern = Mock()
+    dataset_fern.configure_mock(
+        name=name,
+        description="",
+        type=type_,
+        dataset_items_count=items_total,
+    )
+    return dataset_fern
+
+
+def test_get_test_suites__suite_holds_backend_items__first_insert_syncs_hashes():
+    """A listed suite must not treat its empty local hash set as authoritative.
+
+    Otherwise the first deduplicated insert compares against nothing, decides
+    every item is new, and resubmits items the suite already holds.
+    """
+    mock_rest_client = _find_datasets_returning(
+        [_backend_dataset("my-suite", "evaluation_suite", items_total=25)]
+    )
+
+    suites = rest_operations.get_test_suites(
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    assert len(suites) == 1
+    assert not suites[0]._dataset.__internal_api__hashes_synced__, (
+        "A suite listed from the backend has items we have not hashed locally, "
+        "so the first insert must sync before deduplicating"
+    )
+
+
+def test_get_test_suites__non_suite_datasets__are_skipped():
+    mock_rest_client = _find_datasets_returning(
+        [
+            _backend_dataset("plain-dataset", "dataset", items_total=3),
+            _backend_dataset("my-suite", "evaluation_suite", items_total=3),
+        ]
+    )
+
+    suites = rest_operations.get_test_suites(
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    assert [suite.name for suite in suites] == ["my-suite"]


### PR DESCRIPTION
## Details

Follow-up to #8113, addressing the Baz review comments left on it. Three behavioural fixes plus a docstring note; one comment declined with reasoning below.

- **Sticky failed version probe.** `_parallel_insert_supported` was a `cached_property`, so a probe that could not reach the backend cached `False` and pinned that `Dataset` to sequential uploads for the rest of the session. This was a regression from #8113 — before it, the probe ran per insert. Now only a conclusive answer is cached: an unreachable backend returns `False` without caching and is re-probed on the next insert, while a version string the SDK cannot parse still caches, since it will not change.
- **Listed test suites bypassed deduplication.** `rest_operations.get_test_suites` constructed its `Dataset` directly and left `_hashes_synced=True` with an empty hash set, so the first deduplicated insert compared against nothing, judged every item new, and resubmitted items the suite already held. It now starts unsynced, matching `get_datasets` and `get_test_suite`. This one predates #8113 — the lazy-sync design it depends on landed earlier — but it lives in the deduplication path that PR touched.
- **Non-bool `deduplication`.** `deduplication="false"` silently enabled deduplication and `None`/`0` silently disabled it. Rejected with a `ValueError` now, validated both in `insert` (before the version probe, so bad input costs no request) and in `__internal_api__insert_items_as_dataclasses__`, which is the funnel every path including `TestSuite.insert` goes through.
- **Docstring.** One sentence noting that `deduplication=False` makes the next deduplicating insert re-read the dataset's items.

### Declined: per-Dataset locking around the bypass write

Baz asked for synchronization so a `deduplication=False` insert cannot race a concurrent deduplicating insert on the same `Dataset`. Not taken: `Dataset` has never been thread-safe — `_hashes`, `_id_to_hash` and `_dataset_items_count` are all unsynchronized today — so this would be a new concurrency contract rather than a fix, and a lock spanning the REST upload would serialize the parallel-batch upload the same class just gained. The existing ordering is also the safe one: `_hashes_synced` is cleared *before* the upload, so a failed or partial upload leaves the cache invalidated rather than falsely marked fresh. Worth a separate discussion if we want to declare `Dataset` thread-safe.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Implementation and tests for this change.
- Human verification: Reviewed by the author.

## Testing

Commands run:
- `pytest tests/unit` in `sdks/python` — 5135 passed, 2 skipped.
- `pre-commit run --files <changed files>` — ruff, ruff-format and mypy pass.

New unit tests:
- A transient probe failure is retried on the next insert and parallel upload resumes once the backend answers.
- An unparseable version is probed only once across repeated inserts.
- Non-bool `deduplication` values (`"false"`, `0`, `1`, `None`, `""`, `[]`) raise before any request is made.
- `get_test_suites` returns suites whose first insert will sync hashes, and still skips non-suite datasets.

The `get_test_suites` test was mutation-checked by removing the fix — it fails, confirming it covers the reported defect.

## Documentation

No documentation changes. The public behaviour documented in `manage_datasets.mdx` by #8113 is unchanged; this PR only adds a one-sentence note to the `Dataset.insert` docstring about the resync cost of `deduplication=False`.