### PR TITLE
[OPIK-8196] [SDK] BI events improvements

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
@@ -485,7 +485,7 @@ left on the default workspace are attributed to a one-way hash of the hostname a
 username instead.
 
 The two configuration commands — `opik configure` and `opik mcp configure` — report
-three additional things, so that setting Opik up can be tied to how the MCP server is
+four additional things, so that setting Opik up can be tied to how the MCP server is
 used afterwards and we can see where the onboarding flow loses people:
 
 - the **Comet username** of the account being configured, when you are on Opik Cloud.
@@ -493,8 +493,9 @@ used afterwards and we can see where the onboarding flow loses people:
 - a **one-way SHA-256 digest of your API key** — never the key itself, and it cannot be
   turned back into one. It exists so that two setup steps performed with the same
   credential can be recognised as the same setup.
-- the **workspace** that was configured, and the MCP server's machine id if that server
-  is already installed on this machine.
+- the **workspace** that was configured.
+- the **MCP server's machine id**, if that server is already installed on this machine.
+  It is read, never created.
 
 No other event reports any of these.
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
@@ -484,9 +484,23 @@ reporting, so that an error and the usage around it describe the same user. Inst
 left on the default workspace are attributed to a one-way hash of the hostname and
 username instead.
 
+The two configuration commands — `opik configure` and `opik mcp configure` — report
+three additional things, so that setting Opik up can be tied to how the MCP server is
+used afterwards and we can see where the onboarding flow loses people:
+
+- the **Comet username** of the account being configured, when you are on Opik Cloud.
+  Self-hosted and local installations report no username at all.
+- a **one-way SHA-256 digest of your API key** — never the key itself, and it cannot be
+  turned back into one. It exists so that two setup steps performed with the same
+  credential can be recognised as the same setup.
+- the **workspace** that was configured, and the MCP server's machine id if that server
+  is already installed on this machine.
+
+No other event reports any of these.
+
 **Never sent:** the contents of your traces, spans, prompts, datasets or evaluation
-results, your API key, or your project names. Reporting always happens on a background
-thread and never affects your application.
+results, your API key itself, or your project names. Reporting always happens on a
+background thread and never affects your application.
 
 Events are sent to Comet's usage-reporting endpoint, the same pipeline the Opik UI and
 backend already report through.

--- a/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/tracing/advanced/sdk_configuration.mdx
@@ -484,24 +484,9 @@ reporting, so that an error and the usage around it describe the same user. Inst
 left on the default workspace are attributed to a one-way hash of the hostname and
 username instead.
 
-The two configuration commands — `opik configure` and `opik mcp configure` — report
-four additional things, so that setting Opik up can be tied to how the MCP server is
-used afterwards and we can see where the onboarding flow loses people:
-
-- the **Comet username** of the account being configured, when you are on Opik Cloud.
-  Self-hosted and local installations report no username at all.
-- a **one-way SHA-256 digest of your API key** — never the key itself, and it cannot be
-  turned back into one. It exists so that two setup steps performed with the same
-  credential can be recognised as the same setup.
-- the **workspace** that was configured.
-- the **MCP server's machine id**, if that server is already installed on this machine.
-  It is read, never created.
-
-No other event reports any of these.
-
 **Never sent:** the contents of your traces, spans, prompts, datasets or evaluation
-results, your API key itself, or your project names. Reporting always happens on a
-background thread and never affects your application.
+results, your API key, or your project names. Reporting always happens on a background
+thread and never affects your application.
 
 Events are sent to Comet's usage-reporting endpoint, the same pipeline the Opik UI and
 backend already report through.

--- a/sdks/python/src/opik/analytics/__init__.py
+++ b/sdks/python/src/opik/analytics/__init__.py
@@ -7,11 +7,27 @@ Only what a call site passes explicitly is ever sent, alongside the environment
 name, the same identifier used for error reports. Trace, span, prompt and dataset
 contents are never sent, nor is the API key.
 
+One exception, and it is deliberate: the two `configuration` events - `opik configure`
+and `opik mcp configure` - also report the Comet login of the account being
+configured, when there is one to resolve. It is the value the MCP server reports as
+its own `user_id`, and the warehouse's own user key, so it is what ties a
+configuration run to what that person went on to do; hashing it would make it
+unjoinable, which is the whole point of reporting it. See
+`opik.cli.account_identity`. No other event carries it, and no other personal data
+goes with it.
+
 Reporting happens on a background thread, is switched off by
 `OPIK_ANALYTICS_ENABLE=false`, and never raises into calling code.
 """
 
-from .api import Component, flush, internal, shutdown, track_event
+from .api import (
+    Component,
+    flush,
+    internal,
+    reporting_allowed,
+    shutdown,
+    track_event,
+)
 from .rules import register_rule
 from .worker import PropertyValue
 
@@ -21,6 +37,7 @@ __all__ = [
     "flush",
     "internal",
     "register_rule",
+    "reporting_allowed",
     "shutdown",
     "track_event",
 ]

--- a/sdks/python/src/opik/analytics/api.py
+++ b/sdks/python/src/opik/analytics/api.py
@@ -200,6 +200,25 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reset_after_fork)
 
 
+def reporting_allowed() -> bool:
+    """
+    Whether an event reported from this process would be sent anywhere.
+
+    For a call site that has to do work to enrich an event - a lookup, a round-trip
+    - and must not do that work when nothing will be reported. Asking here keeps
+    `OPIK_ANALYTICS_ENABLE` the single switch that governs analytics, the work done
+    to produce it included.
+    """
+    if _DISABLED:
+        return False
+
+    try:
+        return rules.reporting_allowed(config.OpikConfig())
+    except Exception:
+        LOGGER.debug("Failed to decide whether analytics may report", exc_info=True)
+        return False
+
+
 def _disable_after_rejection() -> None:
     """
     Called from the worker thread when the destination has told us to stop. Turning

--- a/sdks/python/src/opik/analytics/api.py
+++ b/sdks/python/src/opik/analytics/api.py
@@ -208,12 +208,17 @@ def reporting_allowed() -> bool:
     - and must not do that work when nothing will be reported. Asking here keeps
     `OPIK_ANALYTICS_ENABLE` the single switch that governs analytics, the work done
     to produce it included.
+
+    Every reason `_start_worker` refuses to report has to be a reason here too, or
+    an enrichment pays for an event that is then dropped - which is why a missing
+    destination counts, not just the opt-out.
     """
     if _DISABLED:
         return False
 
     try:
-        return rules.reporting_allowed(config.OpikConfig())
+        config_ = config.OpikConfig()
+        return rules.reporting_allowed(config_) and bool(config_.analytics_url)
     except Exception:
         LOGGER.debug("Failed to decide whether analytics may report", exc_info=True)
         return False

--- a/sdks/python/src/opik/cli/account_identity.py
+++ b/sdks/python/src/opik/cli/account_identity.py
@@ -1,0 +1,254 @@
+"""Who ran a configuration command, for the `configuration` analytics events.
+
+`opik configure` and `opik mcp configure` are where MCP adoption starts, and their
+events carried nothing the MCP funnels key on - so a configure run could not be tied
+to the person who went on to use the MCP server, or to drop it. One runner in twenty
+was attributable.
+
+Three keys are reported, because no single one covers the population. Measured over
+30 days against the local stdio funnel's own grain, 761 installs:
+
+- `api_key_sha256` - **628 installs (83%)**. The MCP server reports the digest of the
+  same key this command configures, so two runs of the same credential meet here even
+  when nobody's name could be resolved on either side. The widest bridge by far, and
+  the only one available on the first run of a brand-new install.
+- `user_id` - the Comet login, **72 installs (9%)**, a strict subset of the above. Thin
+  on its own, and worth reporting anyway: it is the warehouse's own user key and the
+  only key that names a person rather than a credential.
+- `install_id` - the MCP server's own per-machine id, read from `~/.opik-mcp/install-id`
+  when it is already there. Exact, and the only bridge for the 133 installs (17%) with
+  no credential at all - a local or open source Opik, which has no accounts. Read,
+  never written: the server reports `install_id_freshly_generated` on the run that
+  creates that file, and creating it here would report every onboarding as a returning
+  install.
+
+The login is a plaintext personal identifier, which is a narrow, deliberate amendment
+to the analytics privacy contract in `opik.analytics`: hashing it would make it
+unjoinable, which is the only reason to report it. The key digest is one-way and the
+raw key never leaves the process. These two commands are the only place either is
+reported, and nothing else personal goes with them.
+
+Three rules, so that none of this is ever something a user feels:
+
+- **Nothing is looked up when nothing would be reported.** This is work done for
+  analytics, so `OPIK_ANALYTICS_ENABLE=false` switches it off too.
+- **Cloud only, and bounded.** `account-details` does not exist on a self-hosted or
+  local Opik, and no configure run should spend a timeout on an answer that cannot
+  exist there.
+- **Failure is silent, and countable.** Every path reports `identity_lookup`, so an
+  unattributed run says which reason it was rather than being an absence someone has
+  to guess at.
+
+`identity_lookup`, `workspace` and `workspace_kind` deliberately reuse the MCP
+server's own property names and values - `resolved` / `miss` / `none_expected`, and
+`configured` / `resolved` / `placeholder` / `unknown` - so one BI query reads both
+products. `no_credential` is the one value the MCP has no analogue for: it is a run
+that has not reached its credential yet, rather than one that will never have it.
+
+Note what this does NOT change: the identity an event is *attributed* to. Every SDK
+event, these included, is still keyed on the workspace-derived `anonymous_id`, while
+the MCP server keys its events on the login. So the login reported here joins the two
+by value - which is what the warehouse joins on - and not as one PostHog person.
+"""
+
+import dataclasses
+import functools
+import hashlib
+import logging
+import pathlib
+import uuid
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+import opik.config as opik_config
+import opik.url_helpers as url_helpers
+from opik import analytics
+
+LOGGER = logging.getLogger(__name__)
+
+# Where the MCP server keeps its per-machine id. Matches
+# `opik_mcp.analytics.identity._install_id_path`; a different path here would report
+# an id nothing else has ever seen.
+_MCP_INSTALL_ID_PATH = pathlib.Path.home() / ".opik-mcp" / "install-id"
+
+# Tight on purpose: this runs inside a command someone is waiting on. The answer is
+# worth a moment and never a hang, and it is cached below, so a command pays for it
+# at most once however many events it reports.
+_TIMEOUT_SECONDS = 3.0
+
+
+@dataclasses.dataclass(frozen=True)
+class _Account:
+    """What `account-details` says about the holder of an API key."""
+
+    user_name: Optional[str]
+    default_workspace_name: Optional[str]
+
+
+def event_properties() -> Dict[str, analytics.PropertyValue]:
+    """The identity properties to report with a `configuration` event.
+
+    `identity_lookup` and `workspace_kind` are always present: they say where the
+    other two values came from, which is what makes a missing one countable instead
+    of indistinguishable from a version that never reported it.
+
+    Never raises, and returns nothing at all when analytics is switched off.
+    """
+    try:
+        if not analytics.reporting_allowed():
+            return {}
+
+        return _properties(opik_config.OpikConfig())
+    except Exception:
+        LOGGER.debug("Failed to resolve the account to report", exc_info=True)
+        return {"identity_lookup": "miss", "workspace_kind": "unknown"}
+
+
+def _properties(
+    config_: opik_config.OpikConfig,
+) -> Dict[str, analytics.PropertyValue]:
+    account, lookup = _resolve(config_)
+    workspace, workspace_kind = _workspace(config_, account)
+
+    properties: Dict[str, analytics.PropertyValue] = {
+        "identity_lookup": lookup,
+        "workspace_kind": workspace_kind,
+    }
+    if account is not None and account.user_name:
+        properties["user_id"] = account.user_name
+    if workspace is not None:
+        properties["workspace"] = workspace
+    if config_.api_key:
+        # Reported whatever the deployment: a self-hosted install resolves no login,
+        # but its key still meets the MCP server's digest of the same key.
+        properties["api_key_sha256"] = _digest(config_.api_key)
+
+    install_id = _mcp_install_id()
+    if install_id is not None:
+        properties["install_id"] = install_id
+
+    return properties
+
+
+def _resolve(config_: opik_config.OpikConfig) -> Tuple[Optional[_Account], str]:
+    """The account behind this run, and why it came out that way."""
+    # Asked before the credential, because the two answers mean opposite things: a
+    # missing key is a run that has not got there yet, while a deployment with no
+    # accounts is one that can never be attributed at all.
+    if not config_.is_cloud_installation:
+        # No account-details endpoint on a self-hosted Opik, and no accounts at all
+        # on the open source one. Unattributable by construction, not a gap to close
+        # - which is what the MCP server means by this value too.
+        return None, "none_expected"
+
+    if not config_.api_key:
+        # `opik configure` reports its first event before it has asked for a key, so
+        # this is the ordinary state of a first-ever run rather than a failure.
+        return None, "no_credential"
+
+    account = _fetch(config_.api_key, url_helpers.get_base_url(config_.url_override))
+    if account is None or not account.user_name:
+        return account, "miss"
+
+    return account, "resolved"
+
+
+def _workspace(
+    config_: opik_config.OpikConfig, account: Optional[_Account]
+) -> Tuple[Optional[str], str]:
+    """The workspace to report, and where its name came from.
+
+    Reported explicitly even though every event is already attributed to a
+    workspace: that attribution is read once per process, and `opik configure`
+    changes the workspace while it runs - so on the run that matters most it names
+    the workspace the user had before this command, or the shared `default`
+    sentinel. This is the one the command actually configured.
+    """
+    configured = (config_.workspace or "").strip()
+
+    if configured and configured != opik_config.OPIK_WORKSPACE_DEFAULT_NAME:
+        # Someone named this workspace deliberately, and they may be working outside
+        # their account default - so it outranks the resolved name.
+        return configured, "configured"
+
+    resolved = account.default_workspace_name if account is not None else None
+    if resolved:
+        return resolved, "resolved"
+
+    if configured:
+        # The literal `default`: one name shared by every install that never set
+        # one, so it is reported but must never be joined on as a workspace.
+        return configured, "placeholder"
+
+    return None, "unknown"
+
+
+@functools.lru_cache(maxsize=None)
+def _fetch(api_key: str, base_url: str) -> Optional[_Account]:
+    """Ask Comet who holds this key. `None` on any failure whatsoever.
+
+    Cached for the process: a command reports an entry event and a result event, and
+    the second must not cost a second round-trip.
+
+    TLS is always verified, matching the analytics sender: `check_tls_certificate`
+    exists for a self-hosted deployment's own certificate, and this only ever calls
+    Comet's cloud host.
+    """
+    try:
+        with httpx.Client(timeout=_TIMEOUT_SECONDS, verify=True) as client:
+            response = client.get(
+                url_helpers.get_account_details_url(base_url),
+                headers={"Authorization": api_key},
+            )
+
+        if response.status_code != 200:
+            LOGGER.debug("account-details returned %s", response.status_code)
+            return None
+
+        body = response.json()
+    except Exception:
+        LOGGER.debug("account-details lookup failed", exc_info=True)
+        return None
+
+    if not isinstance(body, dict):
+        return None
+
+    return _Account(
+        user_name=_text(body.get("userName")),
+        default_workspace_name=_text(body.get("defaultWorkspaceName")),
+    )
+
+
+def _digest(api_key: str) -> str:
+    """SHA-256 hex of the key, the transform `opik_mcp.credential_identity` uses.
+
+    Lowercase hex of the UTF-8 bytes, because BI joins on the exact string: a
+    different encoding or casing here would produce a digest that matches nothing.
+    """
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
+def _mcp_install_id() -> Optional[str]:
+    """The MCP server's per-machine id if it has already written one.
+
+    Deliberately read-only, and deliberately not created. The server reports
+    `install_id_freshly_generated` on whichever run writes that file, and the install
+    funnel counts new installs with it - so writing it from here would file every
+    person who onboards through this command as a returning install instead.
+
+    Normalised through `UUID` exactly as the server does, so a hand-edited or
+    truncated file reports nothing rather than an id that joins to nothing.
+    """
+    try:
+        return str(uuid.UUID(_MCP_INSTALL_ID_PATH.read_text().strip()))
+    except Exception:
+        LOGGER.debug("No MCP install id to report", exc_info=True)
+        return None
+
+
+def _text(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    return value.strip()

--- a/sdks/python/src/opik/cli/account_identity.py
+++ b/sdks/python/src/opik/cli/account_identity.py
@@ -225,6 +225,23 @@ def _digest(api_key: str) -> str:
 
     Lowercase hex of the UTF-8 bytes, because BI joins on the exact string: a
     different encoding or casing here would produce a digest that matches nothing.
+
+    A plain fast hash is the right primitive, and CodeQL's
+    `py/weak-sensitive-data-hashing` will disagree because the input is named like
+    a credential. That rule is about *storing a password for verification*, where
+    a fast hash lets whoever steals the store brute-force human-chosen secrets.
+    Neither half holds here:
+
+    - This is a label, not a verifier. Nothing compares it to anything to grant
+      access; it exists so two reports of the same credential can be recognised as
+      one setup. The raw key never leaves the process.
+    - A password KDF cannot do the job. bcrypt / scrypt / PBKDF2 are salted, so the
+      same key would digest differently on every machine and join to nothing - and
+      an unsalted slow hash would still have to match what the MCP server emits,
+      which is this.
+
+    An Opik API key is also a high-entropy generated value rather than something a
+    person chose, so the guessing attack the rule guards against does not apply.
     """
     return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
 

--- a/sdks/python/src/opik/cli/account_identity.py
+++ b/sdks/python/src/opik/cli/account_identity.py
@@ -24,9 +24,10 @@ Three keys are reported, because no single one covers the population. Measured o
 
 The login is a plaintext personal identifier, which is a narrow, deliberate amendment
 to the analytics privacy contract in `opik.analytics`: hashing it would make it
-unjoinable, which is the only reason to report it. The key digest is one-way and the
-raw key never leaves the process. These two commands are the only place either is
-reported, and nothing else personal goes with them.
+unjoinable, which is the only reason to report it. The key is reported only as a
+one-way digest; the key itself is never sent anywhere but the Opik deployment it
+authenticates against. These two commands are the only place either is reported, and
+nothing else personal goes with them.
 
 Three rules, so that none of this is ever something a user feels:
 
@@ -52,7 +53,6 @@ by value - which is what the warehouse joins on - and not as one PostHog person.
 """
 
 import dataclasses
-import functools
 import hashlib
 import logging
 import pathlib
@@ -77,6 +77,11 @@ _MCP_INSTALL_ID_PATH = pathlib.Path.home() / ".opik-mcp" / "install-id"
 # at most once however many events it reports.
 _TIMEOUT_SECONDS = 3.0
 
+# A CLI run configures one account, so this exists to serve the second event of a
+# pair rather than to hold a directory. Bounded so nothing accumulates in a process
+# that calls `opik.configure()` in a loop.
+_MAX_CACHED_ACCOUNTS = 4
+
 
 @dataclasses.dataclass(frozen=True)
 class _Account:
@@ -84,6 +89,11 @@ class _Account:
 
     user_name: Optional[str]
     default_workspace_name: Optional[str]
+
+
+# Keyed by `(key digest, base url)`: recognising a key we already resolved needs no
+# more than its digest, so the process never holds a credential to do it.
+_RESOLVED: Dict[Tuple[str, str], Optional[_Account]] = {}
 
 
 def event_properties() -> Dict[str, analytics.PropertyValue]:
@@ -184,17 +194,36 @@ def _workspace(
     return None, "unknown"
 
 
-@functools.lru_cache(maxsize=None)
 def _fetch(api_key: str, base_url: str) -> Optional[_Account]:
     """Ask Comet who holds this key. `None` on any failure whatsoever.
 
     Cached for the process: a command reports an entry event and a result event, and
-    the second must not cost a second round-trip.
+    the second must not cost a second round-trip. The cache is keyed by a digest of
+    the key rather than the key itself, and bounded, so a long-lived process that
+    configures several accounts never accumulates credentials in memory - it holds
+    only what it needs to recognise a key it has already resolved.
 
     TLS is always verified, matching the analytics sender: `check_tls_certificate`
     exists for a self-hosted deployment's own certificate, and this only ever calls
     Comet's cloud host.
     """
+    cache_key = (_digest(api_key), base_url)
+    if cache_key in _RESOLVED:
+        return _RESOLVED[cache_key]
+
+    account = _request(api_key, base_url)
+
+    # A plain dict with a bound rather than an LRU: one CLI run resolves one
+    # account, so eviction order cannot matter, and dropping the oldest keeps the
+    # common case (one entry) allocation-free.
+    if len(_RESOLVED) >= _MAX_CACHED_ACCOUNTS:
+        _RESOLVED.pop(next(iter(_RESOLVED)))
+    _RESOLVED[cache_key] = account
+
+    return account
+
+
+def _request(api_key: str, base_url: str) -> Optional[_Account]:
     try:
         with httpx.Client(timeout=_TIMEOUT_SECONDS, verify=True) as client:
             response = client.get(
@@ -234,7 +263,9 @@ def _digest(api_key: str) -> str:
 
     - This is a label, not a verifier. Nothing compares it to anything to grant
       access; it exists so two reports of the same credential can be recognised as
-      one setup. The raw key never leaves the process.
+      one setup. Only the digest is ever reported - the key itself goes nowhere
+      except the Opik deployment it authenticates against, which is where the
+      configure flow already sends it.
     - A password KDF cannot do the job. bcrypt / scrypt / PBKDF2 are salted, so the
       same key would digest differently on every machine and join to nothing - and
       an unsalted slow hash would still have to match what the MCP server emits,

--- a/sdks/python/src/opik/cli/configure.py
+++ b/sdks/python/src/opik/cli/configure.py
@@ -8,6 +8,7 @@ import click
 
 import opik.config as opik_config
 from opik import analytics
+from opik.cli import account_identity
 from opik.cli import assistants
 from opik.cli import install_view
 from opik.cli import status_view
@@ -333,6 +334,9 @@ def configure(
         # "never asked" — the flag is also how an agent drives this.
         install_mcp=str(install_mcp),
         install_skills=str(install_skills),
+        # Whoever is already configured, if anyone: a first-ever run has no
+        # credential yet at this point, and says so.
+        **account_identity.event_properties(),
     )
 
     # With no terminal there is nobody to ask, and every question here has a sane
@@ -356,6 +360,10 @@ def configure(
         "result",
         clients_written=outcome.clients,
         skills_installed=outcome.skills,
+        # Resolved again rather than reused from the entry event: this is the run
+        # that just wrote ~/.opik.config, so it is the first point at which a
+        # first-ever configure has an account to name at all.
+        **account_identity.event_properties(),
     )
 
 

--- a/sdks/python/src/opik/cli/mcp.py
+++ b/sdks/python/src/opik/cli/mcp.py
@@ -8,6 +8,7 @@ import click
 import opik.config as opik_config
 import opik.url_helpers as url_helpers
 from opik import analytics
+from opik.cli import account_identity
 from opik.cli import configure as configure_cli
 from opik.cli import assistants
 from opik.cli import install_view
@@ -153,6 +154,9 @@ def configure(
         # must not carry a string on one event and a bool on another.
         skills_requested=str(skills_flag),
         local_server=local_server,
+        # This command reuses an existing Opik configuration, so the account is
+        # normally known from the start — this is the MCP funnel's entry point.
+        **account_identity.event_properties(),
     )
 
     host_keys = _resolve_host_keys(hosts)
@@ -227,6 +231,10 @@ def configure(
         "result",
         clients_written=outcome.clients,
         skills_installed=outcome.skills,
+        # Resolved again, not reused: this command can run `opik configure` on the
+        # way through, which is what turns an unconfigured run into an attributed
+        # one.
+        **account_identity.event_properties(),
     )
 
 

--- a/sdks/python/tests/unit/analytics/test_api.py
+++ b/sdks/python/tests/unit/analytics/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 
 from opik import analytics
+from opik import config
 from opik.analytics import api
 
 
@@ -305,3 +306,17 @@ class TestReportingAllowed:
         monkeypatch.setattr(api.config, "OpikConfig", broken)
 
         assert analytics.reporting_allowed() is False
+
+
+def test_reporting_allowed__no_analytics_url__is_false(monkeypatch):
+    """A missing destination has to refuse enrichment, not just sending.
+
+    `_start_worker` already gives up without a URL, so a call site that pays for
+    a lookup before reporting would be doing it for an event that is dropped.
+    """
+    monkeypatch.setattr(api.rules.environment, "in_pytest", lambda: False)
+    monkeypatch.setattr(
+        api.config, "OpikConfig", lambda: config.OpikConfig(analytics_url="")
+    )
+
+    assert analytics.reporting_allowed() is False

--- a/sdks/python/tests/unit/analytics/test_api.py
+++ b/sdks/python/tests/unit/analytics/test_api.py
@@ -267,3 +267,37 @@ def test_track_event__action_is_not_a_string__does_not_raise(action, recording_w
     api.track_event("client", action)
 
     assert recording_worker.names == []
+
+
+class TestReportingAllowed:
+    """The question a call site asks before doing work to enrich an event.
+
+    Enrichment can cost a round-trip, so `OPIK_ANALYTICS_ENABLE=false` has to
+    switch that off too, not just the sending.
+    """
+
+    def test_reporting_allowed__happyflow(self, monkeypatch):
+        monkeypatch.setattr(api.rules.environment, "in_pytest", lambda: False)
+        # Switched off for good is process-wide state, and an earlier test asking
+        # for a worker under pytest is enough to have set it.
+        monkeypatch.setattr(api, "_DISABLED", False)
+
+        assert analytics.reporting_allowed() is True
+
+    def test_reporting_allowed__rules_say_no__is_false(self):
+        """Running under pytest is one of those rules."""
+        assert analytics.reporting_allowed() is False
+
+    def test_reporting_allowed__already_disabled__is_false(self, monkeypatch):
+        monkeypatch.setattr(api.rules.environment, "in_pytest", lambda: False)
+        monkeypatch.setattr(api, "_DISABLED", True)
+
+        assert analytics.reporting_allowed() is False
+
+    def test_reporting_allowed__config_unreadable__is_false(self, monkeypatch):
+        def broken():
+            raise ValueError("boom")
+
+        monkeypatch.setattr(api.config, "OpikConfig", broken)
+
+        assert analytics.reporting_allowed() is False

--- a/sdks/python/tests/unit/analytics/test_api.py
+++ b/sdks/python/tests/unit/analytics/test_api.py
@@ -277,9 +277,13 @@ class TestReportingAllowed:
     """
 
     def test_reporting_allowed__happyflow(self, monkeypatch):
+        # Every "yes" this can answer has to be arranged explicitly, because the
+        # answer is read from the environment the suite itself runs in: CI sets
+        # OPIK_ANALYTICS_ENABLE=false, pytest is a rule of its own, and being
+        # switched off for good is process-wide state that an earlier test asking
+        # for a worker is enough to have set.
+        monkeypatch.setenv("OPIK_ANALYTICS_ENABLE", "true")
         monkeypatch.setattr(api.rules.environment, "in_pytest", lambda: False)
-        # Switched off for good is process-wide state, and an earlier test asking
-        # for a worker under pytest is enough to have set it.
         monkeypatch.setattr(api, "_DISABLED", False)
 
         assert analytics.reporting_allowed() is True

--- a/sdks/python/tests/unit/cli/test_account_identity.py
+++ b/sdks/python/tests/unit/cli/test_account_identity.py
@@ -5,6 +5,8 @@ import hashlib
 import pytest
 from unittest import mock
 
+from opik.analytics import api as analytics_api
+from opik.analytics import rules as analytics_rules
 from opik.cli import account_identity
 
 
@@ -17,7 +19,7 @@ def reporting_on(monkeypatch, tmp_path):
     """
     monkeypatch.setattr(account_identity.analytics, "reporting_allowed", lambda: True)
     # Resolution is cached for the process, which outlives a single test.
-    account_identity._fetch.cache_clear()
+    account_identity._RESOLVED.clear()
     # Away from the developer's own home directory: whoever runs these has the MCP
     # server installed, and the tests would then assert against their machine's id.
     monkeypatch.setattr(
@@ -25,12 +27,20 @@ def reporting_on(monkeypatch, tmp_path):
     )
 
 
-def _config(api_key="key", workspace="my-ws", cloud=True):
+def _config(
+    api_key="key",
+    workspace="my-ws",
+    cloud=True,
+    analytics_url="https://stats.invalid/notify/event/",
+    analytics_enable=True,
+):
     return mock.Mock(
         api_key=api_key,
         workspace=workspace,
         is_cloud_installation=cloud,
         url_override="https://www.comet.com/opik/api",
+        analytics_url=analytics_url,
+        analytics_enable=analytics_enable,
     )
 
 
@@ -265,3 +275,67 @@ class TestNeverFeltByTheUser:
             "identity_lookup": "miss",
             "workspace_kind": "unknown",
         }
+
+
+class TestThePublicEntryPoint:
+    """`event_properties()` is what the CLI calls, so the gate and the config
+    loading it does have to be exercised through it rather than around it.
+
+    The tests above call `_properties` with a config they built, which says
+    nothing about whether the real entry point reads the configuration, honours
+    the analytics switch, or assembles the same payload.
+    """
+
+    def test_configured_cloud_account__properties_assembled_end_to_end(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(
+            account_identity.analytics, "reporting_allowed", lambda: True
+        )
+        monkeypatch.setattr(
+            account_identity.opik_config,
+            "OpikConfig",
+            lambda: _config(api_key="secret-key", workspace="their-ws"),
+        )
+
+        with mock.patch.object(
+            account_identity.httpx,
+            "Client",
+            return_value=_responding(
+                body={"userName": "someone", "defaultWorkspaceName": "their-ws"}
+            ),
+        ):
+            properties = account_identity.event_properties()
+
+        assert properties == {
+            "identity_lookup": "resolved",
+            "workspace_kind": "configured",
+            "user_id": "someone",
+            "workspace": "their-ws",
+            "api_key_sha256": hashlib.sha256(b"secret-key").hexdigest(),
+        }
+
+    def test_analytics_url_empty__nothing_reported_and_nothing_asked(self, monkeypatch):
+        """No destination means the event would be dropped, so the lookup is waste.
+
+        `_start_worker` already refuses to report without an analytics URL; the
+        gate has to refuse the enrichment for the same reason, or a configure run
+        pays for a round trip whose event goes nowhere.
+        """
+        # The autouse fixture stubs the gate out; this test is about the real one.
+        monkeypatch.setattr(
+            account_identity.analytics,
+            "reporting_allowed",
+            analytics_api.reporting_allowed,
+        )
+        monkeypatch.setattr(
+            account_identity.opik_config,
+            "OpikConfig",
+            lambda: _config(analytics_url="", analytics_enable=True),
+        )
+        monkeypatch.setattr(analytics_rules.environment, "in_pytest", lambda: False)
+
+        with mock.patch.object(account_identity.httpx, "Client") as client:
+            assert account_identity.event_properties() == {}
+
+        client.assert_not_called()

--- a/sdks/python/tests/unit/cli/test_account_identity.py
+++ b/sdks/python/tests/unit/cli/test_account_identity.py
@@ -1,0 +1,267 @@
+"""Tests for the account identity reported with the `configuration` events."""
+
+import hashlib
+
+import pytest
+from unittest import mock
+
+from opik.cli import account_identity
+
+
+@pytest.fixture(autouse=True)
+def reporting_on(monkeypatch, tmp_path):
+    """Analytics is off under pytest, and off means nothing is looked up at all.
+
+    Every test here is about what gets reported when it is on, so the switch is
+    flipped for all of them; the one test that needs it off flips it back.
+    """
+    monkeypatch.setattr(account_identity.analytics, "reporting_allowed", lambda: True)
+    # Resolution is cached for the process, which outlives a single test.
+    account_identity._fetch.cache_clear()
+    # Away from the developer's own home directory: whoever runs these has the MCP
+    # server installed, and the tests would then assert against their machine's id.
+    monkeypatch.setattr(
+        account_identity, "_MCP_INSTALL_ID_PATH", tmp_path / "absent" / "install-id"
+    )
+
+
+def _config(api_key="key", workspace="my-ws", cloud=True):
+    return mock.Mock(
+        api_key=api_key,
+        workspace=workspace,
+        is_cloud_installation=cloud,
+        url_override="https://www.comet.com/opik/api",
+    )
+
+
+def _responding(status=200, body=None, error=None):
+    """A stand-in httpx client, so the transport is not what is under test."""
+    client = mock.MagicMock()
+    client.__enter__.return_value = client
+    if error is not None:
+        client.get.side_effect = error
+    else:
+        response = mock.Mock(status_code=status)
+        response.json.return_value = body if body is not None else {}
+        client.get.return_value = response
+    return client
+
+
+class TestResolvedAccount:
+    def test_cloud_key__login_is_reported(self):
+        with mock.patch.object(
+            account_identity.httpx,
+            "Client",
+            return_value=_responding(
+                body={"userName": "someone", "defaultWorkspaceName": "their-ws"}
+            ),
+        ):
+            properties = account_identity._properties(_config())
+
+        assert properties["user_id"] == "someone"
+        assert properties["identity_lookup"] == "resolved"
+
+    def test_two_events__cost_one_round_trip(self):
+        """A command reports an entry and a result event, not two lookups."""
+        client = _responding(body={"userName": "someone"})
+
+        with mock.patch.object(account_identity.httpx, "Client", return_value=client):
+            account_identity._properties(_config())
+            account_identity._properties(_config())
+
+        assert client.get.call_count == 1
+
+    def test_key_is_sent_as_authorization__and_never_as_a_property(self):
+        client = _responding(body={"userName": "someone"})
+
+        with mock.patch.object(account_identity.httpx, "Client", return_value=client):
+            properties = account_identity._properties(_config(api_key="secret-key"))
+
+        assert client.get.call_args.kwargs["headers"] == {"Authorization": "secret-key"}
+        assert "secret-key" not in properties.values()
+
+
+class TestUnresolvedAccount:
+    """An unattributed run has to say which reason it was.
+
+    Coverage that ramps with upgrades is only readable if "nobody to ask about
+    yet", "nobody to ask, ever" and "asked and got nothing" are separable.
+    """
+
+    def test_no_api_key__reports_no_credential_without_asking(self):
+        with mock.patch.object(account_identity.httpx, "Client") as client:
+            properties = account_identity._properties(_config(api_key=None))
+
+        assert properties["identity_lookup"] == "no_credential"
+        assert "user_id" not in properties
+        client.assert_not_called()
+
+    def test_self_hosted__reports_none_expected_without_asking(self):
+        """There is no account-details endpoint to spend a timeout on."""
+        with mock.patch.object(account_identity.httpx, "Client") as client:
+            properties = account_identity._properties(_config(cloud=False))
+
+        assert properties["identity_lookup"] == "none_expected"
+        client.assert_not_called()
+
+    def test_local_install_without_a_key__is_none_expected_rather_than_no_credential(
+        self,
+    ):
+        """A local Opik has no accounts at all, so it is not a run to wait on."""
+        properties = account_identity._properties(_config(api_key=None, cloud=False))
+
+        assert properties["identity_lookup"] == "none_expected"
+
+    @pytest.mark.parametrize(
+        "answer",
+        [
+            {"status": 401},
+            {"status": 200, "body": {"defaultWorkspaceName": "their-ws"}},
+            {"error": Exception("no route to host")},
+        ],
+    )
+    def test_lookup_produced_no_login__reports_a_miss(self, answer):
+        with mock.patch.object(
+            account_identity.httpx, "Client", return_value=_responding(**answer)
+        ):
+            properties = account_identity._properties(_config())
+
+        assert properties["identity_lookup"] == "miss"
+        assert "user_id" not in properties
+
+    def test_answer_is_not_json__does_not_raise(self):
+        with mock.patch.object(
+            account_identity.httpx, "Client", return_value=_responding(body=["nope"])
+        ):
+            properties = account_identity._properties(_config())
+
+        assert properties["identity_lookup"] == "miss"
+
+
+class TestCredentialBridge:
+    """The key digest is the widest bridge to the MCP funnels, so it is unconditional.
+
+    Measured on the local stdio funnel: 83% of installs carry a key digest against 9%
+    that resolve a login, and the login set is a subset of the digest set.
+    """
+
+    def test_api_key__reported_as_the_same_digest_the_mcp_server_emits(self):
+        # sha256("secret-key"), the transform in opik_mcp.credential_identity.
+        expected = hashlib.sha256(b"secret-key").hexdigest()
+
+        properties = account_identity._properties(
+            _config(api_key="secret-key", cloud=False)
+        )
+
+        assert properties["api_key_sha256"] == expected
+        # The bridge has to survive a deployment that can resolve no name at all.
+        assert properties["identity_lookup"] == "none_expected"
+
+    def test_no_api_key__no_digest_property(self):
+        properties = account_identity._properties(_config(api_key=None))
+
+        assert "api_key_sha256" not in properties
+
+
+class TestMcpInstallId:
+    """The only bridge for an install with no credential at all."""
+
+    def test_install_id_file__is_read_and_reported(self, tmp_path, monkeypatch):
+        path = tmp_path / "install-id"
+        path.write_text("0a597378-b4c9-4eff-a4b7-62e50a03279d\n")
+        monkeypatch.setattr(account_identity, "_MCP_INSTALL_ID_PATH", path)
+
+        properties = account_identity._properties(_config(api_key=None))
+
+        assert properties["install_id"] == "0a597378-b4c9-4eff-a4b7-62e50a03279d"
+
+    def test_no_install_id_file__is_never_created(self, tmp_path, monkeypatch):
+        """Writing it would report every onboarding as a returning install."""
+        path = tmp_path / "install-id"
+        monkeypatch.setattr(account_identity, "_MCP_INSTALL_ID_PATH", path)
+
+        properties = account_identity._properties(_config(api_key=None))
+
+        assert "install_id" not in properties
+        assert not path.exists()
+
+    @pytest.mark.parametrize("content", ["", "not-a-uuid", "0a597378-b4c9"])
+    def test_unusable_install_id__reports_nothing(self, content, tmp_path, monkeypatch):
+        """An id that joins to nothing is worse than no id."""
+        path = tmp_path / "install-id"
+        path.write_text(content)
+        monkeypatch.setattr(account_identity, "_MCP_INSTALL_ID_PATH", path)
+
+        assert "install_id" not in account_identity._properties(_config(api_key=None))
+
+
+class TestWorkspace:
+    """The workspace someone is configuring, and how much a join can trust it."""
+
+    def test_configured_workspace__outranks_the_account_default(self):
+        """They may be working outside their own default, deliberately."""
+        with mock.patch.object(
+            account_identity.httpx,
+            "Client",
+            return_value=_responding(
+                body={"userName": "someone", "defaultWorkspaceName": "their-ws"}
+            ),
+        ):
+            properties = account_identity._properties(_config(workspace="other-ws"))
+
+        assert properties["workspace"] == "other-ws"
+        assert properties["workspace_kind"] == "configured"
+
+    def test_default_sentinel__falls_back_to_the_resolved_name(self):
+        with mock.patch.object(
+            account_identity.httpx,
+            "Client",
+            return_value=_responding(
+                body={"userName": "someone", "defaultWorkspaceName": "their-ws"}
+            ),
+        ):
+            properties = account_identity._properties(_config(workspace="default"))
+
+        assert properties["workspace"] == "their-ws"
+        assert properties["workspace_kind"] == "resolved"
+
+    def test_default_sentinel__nothing_resolved__is_marked_a_placeholder(self):
+        """One name shared by every install that never set one: never a join key."""
+        properties = account_identity._properties(
+            _config(api_key=None, workspace="default")
+        )
+
+        assert properties["workspace"] == "default"
+        assert properties["workspace_kind"] == "placeholder"
+
+    def test_no_workspace_at_all__is_unknown_and_names_nothing(self):
+        properties = account_identity._properties(_config(api_key=None, workspace=""))
+
+        assert properties["workspace_kind"] == "unknown"
+        assert "workspace" not in properties
+
+
+class TestNeverFeltByTheUser:
+    def test_analytics_switched_off__nothing_reported_and_nothing_asked(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            account_identity.analytics, "reporting_allowed", lambda: False
+        )
+
+        with mock.patch.object(account_identity.httpx, "Client") as client:
+            assert account_identity.event_properties() == {}
+
+        client.assert_not_called()
+
+    def test_config_unreadable__still_returns_countable_properties(self, monkeypatch):
+        monkeypatch.setattr(
+            account_identity.opik_config,
+            "OpikConfig",
+            mock.Mock(side_effect=Exception("no config")),
+        )
+
+        assert account_identity.event_properties() == {
+            "identity_lookup": "miss",
+            "workspace_kind": "unknown",
+        }

--- a/sdks/python/tests/unit/cli/test_configure_cli.py
+++ b/sdks/python/tests/unit/cli/test_configure_cli.py
@@ -384,6 +384,42 @@ class TestCometCloudHostMatch:
         assert configure_cli._is_comet_cloud_host("not a url at all") is False
 
 
+class TestIdentityIsReportedWithBothEvents:
+    """`opik configure` reports before and after it writes the configuration.
+
+    The account is resolved separately for each, because a first-ever run has no
+    credential to resolve until the flow has written one — and that run is exactly
+    the one the funnel starts from.
+    """
+
+    def test_entry_and_result__each_resolve_the_account(self):
+        runner = CliRunner()
+        answers = [
+            {"identity_lookup": "no_credential"},
+            {"user_id": "someone", "identity_lookup": "resolved"},
+        ]
+
+        with (
+            mock.patch.object(
+                configure_cli.interactive_helpers, "is_interactive", return_value=True
+            ),
+            mock.patch.object(configure_cli, "run_interactive_configure"),
+            mock.patch.object(
+                configure_cli.account_identity,
+                "event_properties",
+                side_effect=answers,
+            ),
+            mock.patch.object(configure_cli.analytics, "track_event") as track,
+        ):
+            result = runner.invoke(cli, ["configure", "--use-local"])
+
+        assert result.exit_code == 0
+        entry, outcome = track.call_args_list
+        assert entry.kwargs["identity_lookup"] == "no_credential"
+        assert "user_id" not in entry.kwargs
+        assert outcome.kwargs["user_id"] == "someone"
+
+
 class TestAssistantOutcomeReachesTheCaller:
     """The assistant step's result has to travel back up to the click command.
 

--- a/sdks/python/tests/unit/cli/test_configure_cli.py
+++ b/sdks/python/tests/unit/cli/test_configure_cli.py
@@ -418,6 +418,9 @@ class TestIdentityIsReportedWithBothEvents:
         assert entry.kwargs["identity_lookup"] == "no_credential"
         assert "user_id" not in entry.kwargs
         assert outcome.kwargs["user_id"] == "someone"
+        # Asserted alongside the login: without it the pair still passes when the
+        # metadata that says how to read the login goes missing or changes value.
+        assert outcome.kwargs["identity_lookup"] == "resolved"
 
 
 class TestAssistantOutcomeReachesTheCaller:

--- a/sdks/python/tests/unit/cli/test_mcp.py
+++ b/sdks/python/tests/unit/cli/test_mcp.py
@@ -210,6 +210,40 @@ class TestInstallCommand:
         assert setup_spy.call_args.args[0]["use_local"] is True
 
 
+class TestIdentityIsReportedWithBothEvents:
+    """Both events of the pair have to name the account, or neither joins.
+
+    The entry event is what a drop-off is counted from, so identity only on the
+    result event would attribute the runs that finished and none of the ones worth
+    acting on.
+    """
+
+    def test_configure__entry_and_result__both_carry_the_account(self):
+        runner = CliRunner()
+        identity = {"user_id": "someone", "identity_lookup": "resolved"}
+
+        with (
+            patch.object(
+                mcp_cli.opik_config, "OpikConfig", return_value=_config(api_key="key")
+            ),
+            patch.object(
+                mcp_cli.interactive_helpers, "is_interactive", return_value=True
+            ),
+            patch.object(mcp_cli.assistants, "setup"),
+            patch.object(
+                mcp_cli.account_identity, "event_properties", return_value=identity
+            ),
+            patch.object(mcp_cli.analytics, "track_event") as track,
+        ):
+            result = runner.invoke(cli, ["mcp", "configure"])
+
+        assert result.exit_code == 0
+        assert len(track.call_args_list) == 2
+        for call in track.call_args_list:
+            assert call.kwargs["user_id"] == "someone"
+            assert call.kwargs["identity_lookup"] == "resolved"
+
+
 class TestHostFlag:
     """`--host` is what lets an agent, a Dockerfile, or CI run this at all."""
 


### PR DESCRIPTION
## Details

`opik configure` and `opik mcp configure` are where MCP adoption starts, but their BI events carried nothing the MCP funnels key on, so a configure run could not be tied to what the person did next. One runner in twenty was attributable, by the accident of a workspace named after its owner.

Those four events now carry the keys the MCP server already reports, so the two join: the Comet login (`user_id`), a one-way digest of the API key (`api_key_sha256`), and the MCP install id when the server has already written one. Three rather than one because no single key covers the population — measured on the local stdio funnel, the digest reaches 83% of installs, the login 9%, and the install id is the only bridge for the 17% with no credential at all. `workspace`, `workspace_kind` and `identity_lookup` come along, reusing the MCP server's own names and values so one query reads both products.

Nothing here is felt by a user: no lookup happens when nothing would be reported, it is cloud-only, bounded at three seconds, cached per process, and every failure is silent but countable. The install-id file is read and never created — writing it would file every onboarding as a returning install.

The login is a plaintext personal identifier, so the privacy contract in `opik.analytics` is amended explicitly rather than quietly: hashing it would make it unjoinable, which is the only reason to report it. These two commands are the only place any of this is reported.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8196

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation, including the measurements that chose the keys
- Human verification: code review + author-run verification against the live analytics pipeline

## Testing

- `pytest tests/unit` — 5154 passed
- `make precommit` — ruff, ruff-format, mypy on the changed files

Unit tests cover each key and each way it can be absent: a resolved login; a lookup that 401s, answers without a name, or cannot connect; self-hosted, local, and not-yet-credentialed runs; workspace precedence including the shared `default` sentinel; the digest matching the one the MCP server emits; an install-id file read, malformed, and absent-and-not-created. Three pin the guarantees rather than the values — analytics off performs no lookup, an empty analytics URL performs no lookup, and both events of a pair carry the identity for one round trip.

Verified against the live pipeline, since CI cannot exercise it: the id and digest computed on a real machine match real MCP events at every funnel stage, and a new property on a configure event was seen arriving in the warehouse. Writing the join query surfaced one defect, now fixed — absent properties read as NULL, not empty, so a naive guard let unkeyable runs on both sides match each other and inflate every stage.

## Documentation

None in this PR — the docs change was dropped at review request.

**This leaves a gap worth tracking.** The published SDK docs still say usage analytics are attributed to the workspace name, and the "Never sent" list does not mention the API-key digest. Once this merges, both statements are incomplete: the two configure commands report a plaintext Comet login and a one-way digest of the key. The disclosure needs to ship somewhere before or alongside the release that carries this.
