### PR TITLE
[NA] [BE] fix: register gmi, gradient_ai and libertai as canonical providers so their model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -56,7 +56,10 @@ public class CostService {
             Map.entry("sambanova", "sambanova"),
             Map.entry("nebius", "nebius"),
             Map.entry("snowflake", "snowflake"),
-            Map.entry("deepinfra", "deepinfra"));
+            Map.entry("deepinfra", "deepinfra"),
+            Map.entry("gmi", "gmi"),
+            Map.entry("gradient_ai", "gradient_ai"),
+            Map.entry("libertai", "libertai"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1062,4 +1062,32 @@ class CostServiceTest {
                                 "original_usage.prompt_tokens_details.cached_tokens", 300),
                         "0.005709"));
     }
+
+    /**
+     * Covers registering {@code gmi}, {@code gradient_ai} and {@code libertai} as canonical providers
+     * so that their token-priced entries in {@code model_prices_and_context_window.json} are no longer
+     * silently dropped at load time. Each case exercises a representative token-priced model routed
+     * through {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("provideGatewayProviderCases")
+    void calculateCostHandlesGatewayProviderModels(String provider, String model, String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, provider,
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideGatewayProviderCases() {
+        return Stream.of(
+                // gmi/anthropic/claude-opus-4.5: input 5e-06, output 2.5e-05
+                // 1000*5e-06 + 200*2.5e-05 = 0.01
+                Arguments.of("gmi", "gmi/anthropic/claude-opus-4.5", "0.01"),
+                // gradient_ai/anthropic-claude-3-opus: input 1.5e-05, output 7.5e-05
+                // 1000*1.5e-05 + 200*7.5e-05 = 0.03
+                Arguments.of("gradient_ai", "gradient_ai/anthropic-claude-3-opus", "0.03"),
+                // libertai/hermes-3-8b-tee: input 1.5e-07, output 6e-07
+                // 1000*1.5e-07 + 200*6e-07 = 0.00027
+                Arguments.of("libertai", "libertai/hermes-3-8b-tee", "0.00027"));
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` did not include `gmi`, `gradient_ai` or `libertai`, so every priced model those providers ship in `model_prices_and_context_window.json` was dropped at load time and their spans fell back to zero cost. This registers all three as canonical providers (identity mapping, same as the existing entries) so their prices load. None of the three publishes cache rates today, so they route through the default `textGenerationCost` calculator.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude
- Scope: full change (mapping entries plus the parameterized regression test)
- Human verification: cost math checked against the exact per-token rates in model_prices_and_context_window.json; provider-key resolution traced through buildRuntimeKey and findModelPrice, matching the already-merged snowflake and deepinfra registrations

## Testing

Added a parameterized regression test in `CostServiceTest` (`calculateCostHandlesTokenPricedProviderModels`) with one case per provider, asserting a real token-priced model from each now returns a non-zero cost equal to prompt and completion tokens billed at the provider's configured rates. The cases fail before the mapping entries are added (cost resolves to zero) and pass after. Run with `mvn test -Dtest=CostServiceTest` in `apps/opik-backend`.

## Documentation
