### PR TITLE
[NA] [SDK] [DOCS] Update automatically OpenAPI spec and Fern code

### DIFF
--- a/apps/opik-documentation/documentation/fern/openapi/opik.yaml
+++ b/apps/opik-documentation/documentation/fern/openapi/opik.yaml
@@ -9614,6 +9614,8 @@ components:
           type: string
         name:
           type: string
+        is_default:
+          type: boolean
     AuthorizationServerMetadata:
       type: object
       properties:

--- a/sdks/code_generation/fern/openapi/openapi.yaml
+++ b/sdks/code_generation/fern/openapi/openapi.yaml
@@ -9614,6 +9614,8 @@ components:
           type: string
         name:
           type: string
+        is_default:
+          type: boolean
     AuthorizationServerMetadata:
       type: object
       properties:

--- a/sdks/python/src/opik/rest_api/types/workspace_info.py
+++ b/sdks/python/src/opik/rest_api/types/workspace_info.py
@@ -9,6 +9,7 @@ from ..core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 class WorkspaceInfo(UniversalBaseModel):
     id: typing.Optional[str] = None
     name: typing.Optional[str] = None
+    is_default: typing.Optional[bool] = None
 
     if IS_PYDANTIC_V2:
         model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2

--- a/sdks/typescript/src/opik/rest_api/api/types/WorkspaceInfo.ts
+++ b/sdks/typescript/src/opik/rest_api/api/types/WorkspaceInfo.ts
@@ -3,4 +3,5 @@
 export interface WorkspaceInfo {
     id?: string;
     name?: string;
+    isDefault?: boolean;
 }

--- a/sdks/typescript/src/opik/rest_api/serialization/types/WorkspaceInfo.ts
+++ b/sdks/typescript/src/opik/rest_api/serialization/types/WorkspaceInfo.ts
@@ -8,11 +8,13 @@ export const WorkspaceInfo: core.serialization.ObjectSchema<serializers.Workspac
     core.serialization.object({
         id: core.serialization.string().optional(),
         name: core.serialization.string().optional(),
+        isDefault: core.serialization.property("is_default", core.serialization.boolean().optional()),
     });
 
 export declare namespace WorkspaceInfo {
     export interface Raw {
         id?: string | null;
         name?: string | null;
+        is_default?: boolean | null;
     }
 }


### PR DESCRIPTION
## Details
Automated daily update of OpenAPI spec and Fern code after running `./scripts/generate_openapi.sh` and `./sdks/opik_optimizer/scripts/generate_fern_docs.py`.

## Change checklist
- [ ] User facing changes
- [X] Documentation updated

## Issues
N/A

## Testing
- Passed CI

## Documentation
- https://buildwithfern.com/learn/cli-api-reference/cli-reference/commands#fern-generate