### PR TITLE
[OPIK-8230] [BE] fix: scope the trace delete mutation to the batch's own partitions

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -122,6 +122,13 @@ databaseAnalyticsDataModel:
   #   non-nullable columns so writes bind the sentinels (end_time->epoch, ttft->NaN) instead. Gates reads too, so
   #   while false a legitimate epoch end time round-trips unchanged instead of reading as null.
   #   Flip in lockstep with the cutover EXCHANGE.
+  #   Also gates partition-scoped trace deletes: that same EXCHANGE puts the weekly-partitioned successor behind the
+  #   name mutations target, so true additionally means a delete may scope itself with IN PARTITION instead of being
+  #   registered against every part of the table. The two facts have only ever flipped together, which is why this
+  #   gates both rather than there being a second flag. IN PARTITION against an unpartitioned table is a hard error
+  #   (code 248), not a lost optimisation, so setting this true ahead of the EXCHANGE breaks deletes - as it already
+  #   breaks writes, which bind sentinels a Nullable column has no use for. Off falls back to the unbounded delete:
+  #   correct, merely slower.
   traceColumnsNonNullable: ${ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE:-false}
   #  Default: false
   #  Description: Spans sibling of traceColumnsNonNullable. Leave false while the spans table still has Nullable

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1967,40 +1967,22 @@ class TraceDAOImpl implements TraceDAO {
             """;
 
     /**
-     * Deletes by the full {@code (workspace_id, project_id, id)} sort key, matching on {@code (project_id, id)} tuples
-     * so a single statement can span several projects (e.g. a reused id resolved to all its owning projects, or a
-     * cross-project batch) instead of one delete per project (OPIK-7483). Every deleted row carries its {@code
-     * project_id}, so no delete is ever project-less - also required once {@code traces} is a Distributed table
-     * (OPIK-7455).
+     * Deletes by the full {@code (workspace_id, project_id, id)} sort key, matching {@code (project_id, id)} tuples so
+     * one statement can span several projects (OPIK-7483). Pairs are bound as two arrays and zipped, so the query text
+     * is constant regardless of batch size.
      * <p>
-     * {@code <if(partitions)>} adds the table's own weekly partition expression, bound as the set of partitions the
-     * batch's ids resolve to. It is emitted whenever every id in the batch is one whose partition can be derived
-     * exactly ({@link WeeklyPartitions#of}); otherwise the predicate is omitted and the statement is byte-identical to
-     * the previous unbounded form. That is what preserves the original guarantee — a row whose {@code id_at} cannot be
-     * trusted is still deleted, because no id in such a batch is used to derive a partition.
+     * {@code <if(partition)>} adds {@code IN PARTITION}, which scopes which <b>parts</b> the mutation is registered
+     * against — a {@code WHERE} clause cannot, since parts are selected before it is considered, which is why a delete
+     * of a few rows rewrote all ~3,650 parts and timed out. Omitted for the unbounded fallback.
      * <p>
-     * No schema flag gates it. {@link WeeklyPartitions} derives a value per {@code id_at} type the mutation may meet
-     * — the legacy 32-bit {@code DateTime} of {@code traces} as well as the {@code DateTime64(0)} of the partitioned
-     * successor — so one rendered statement is correct on both sides of the cutover EXCHANGE, in either direction, with
-     * nothing to flip and nothing to revert on rollback.
-     * <p>
-     * Why it matters: a mutation selects parts at the <b>partition</b> stage, where the (workspace_id, project_id, id)
-     * predicate prunes nothing, so deleting a handful of rows rewrote every part of the table. Measured on prod-test
-     * (271.6 M rows, 3,928 parts): 12 ids rewrote <b>3,928 parts / 5.40 TiB</b>. With this predicate the same batch
-     * selects <b>5</b> parts. An {@code id_at} <em>range</em> is not a substitute: on a batch spanning 1996 and 2200 a
-     * range still selected 2,644 parts, where the exact set selected 4.
-     * <p>
-     * The pairs are bound (never inlined) as two positional string arrays and zipped back into {@code (project_id, id)}
-     * tuples with {@code arrayZip}, so the query text is constant regardless of batch size and no value reaches the SQL
-     * as a literal. {@code arrayZip} is a deterministic function, not a subquery - ClickHouse rejects subqueries in
-     * delete mutations. Callers batch to keep each array within the driver's reliable bind size ({@link
-     * com.comet.opik.infrastructure.FilterUtils#ANALYTICS_DELETE_BATCH_SIZE}).
+     * {@code <partition>} is interpolated, not bound: {@code IN PARTITION {p:UInt32}} is a ClickHouse syntax error. Safe
+     * because the value is always a {@code long} from {@link WeeklyPartitions}.
      */
     private static final String DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS = """
             DELETE FROM <traces_mutation_table>
+            <if(partition)>IN PARTITION <partition><endif>
             WHERE workspace_id = :workspace_id
             AND (project_id, id) IN arrayZip(:project_ids, :trace_ids)
-            <if(partitions)>AND toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1))) IN :partitions<endif>
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -2328,7 +2310,7 @@ class TraceDAOImpl implements TraceDAO {
      * {@code :min_id}'s week and inverted the window, so the fast pass matched nothing and every id fell through to
      * the unbounded pass. It now resolves them.
      * <p>
-     * The fallback remains load-bearing for what {@link com.comet.opik.utils.WeeklyPartitions#of} still cannot derive
+     * The fallback remains load-bearing for what {@link com.comet.opik.utils.WeeklyPartitions#groupByPartition} still cannot derive
      * exactly: an id at or past the end of {@code DateTime64}'s range, where {@code id_at} saturates to
      * {@code 2299-12-31} whatever the real week, so every such id collapses into one partition. Real data contains
      * them, so the bounded query is never a delete's sole resolver.
@@ -3645,42 +3627,79 @@ class TraceDAOImpl implements TraceDAO {
     public Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, @NonNull Connection connection) {
         Preconditions.checkArgument(CollectionUtils.isNotEmpty(projectIdTraceIdPairs),
                 "Argument 'projectIdTraceIdPairs' must not be empty");
+        // Checked here rather than where the ids are stringified, so it holds whichever branch deleteBatch takes: the
+        // partitioned path would otherwise read a null as "underivable", silently take the unbounded fallback, and
+        // only then NPE - reporting a caller's bug as the slow delete this class exists to avoid.
+        Preconditions.checkArgument(
+                projectIdTraceIdPairs.stream().noneMatch(pair -> pair.getLeft() == null || pair.getRight() == null),
+                "Argument 'projectIdTraceIdPairs' must not contain null ids");
         log.info("Deleting traces by (project_id, id) pairs, count '{}'", projectIdTraceIdPairs.size());
 
         return makeMonoContextAware((userName, workspaceId) -> Flux
                 .fromIterable(Lists.partition(List.copyOf(projectIdTraceIdPairs), ANALYTICS_DELETE_BATCH_SIZE))
-                .concatMap(batch -> {
-                    var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces",
-                            workspaceId,
-                            userName, "pairs_size=%s".formatted(batch.size()));
-                    selectTracesMutationTable(template);
-
-                    var projectIds = batch.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
-                    var traceIds = batch.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
-
-                    // Prune to the batch's own partitions when every id in the batch allows it; otherwise emit the
-                    // unbounded form. Needs no schema flag: WeeklyPartitions derives a value per id_at type the
-                    // mutation may meet, so the set is correct on the legacy traces and on the partitioned successor.
-                    var partitions = WeeklyPartitions.of(batch.stream().map(Pair::getRight).toList());
-                    // Flag only, exactly like distributed_wrap: the values reach ClickHouse via the bind below,
-                    // never through the template, so the rendered SQL is constant regardless of batch contents.
-                    partitions.ifPresent(_ -> template.add("partitions", true));
-
-                    var statement = connection.createStatement(template.render())
-                            .bind("workspace_id", workspaceId)
-                            .bind("project_ids", projectIds)
-                            .bind("trace_ids", traceIds);
-
-                    if (partitions.isPresent()) {
-                        statement = statement.bind("partitions", partitions.get().toArray(Long[]::new));
-                    }
-
-                    var segment = startSegment("traces", "Clickhouse", "delete");
-                    return Mono.from(statement.execute())
-                            .doFinally(_ -> endSegment(segment))
-                            .then();
-                })
+                .concatMap(batch -> deleteBatch(batch, workspaceId, userName, connection))
                 .then());
+    }
+
+    /**
+     * Deletes one batch: one {@code IN PARTITION} statement per partition its ids resolve to, or a single unbounded
+     * statement when they cannot all be derived, or when the target is not partitioned.
+     * <p>
+     * Sequential on purpose: bounded concurrency was measured and deferred (OPIK-8230).
+     */
+    private Mono<Void> deleteBatch(List<Pair<UUID, UUID>> batch, String workspaceId, String userName,
+            Connection connection) {
+        // traceColumnsNonNullable doubles as "the mutation target is weekly-partitioned": the same cutover EXCHANGE
+        // drops the Nullable(...) columns and puts the partitioned successor behind the name mutations target, so one
+        // flag carries both facts. Deliberately not the wrap flag, which governs routing and is still false in the
+        // window between the EXCHANGE and the wrap - reading that one leaves production's deletes unpruned.
+        var grouped = traceColumnsNonNullable()
+                ? WeeklyPartitions.groupByPartition(batch.stream().map(Pair::getRight).toList())
+                : Optional.<Map<Long, Set<UUID>>>empty();
+
+        if (grouped.isEmpty()) {
+            return executeDelete(batch, null, workspaceId, userName, connection);
+        }
+
+        // id -> its pairs, built once per batch rather than rescanning the whole batch once per partition: an id can
+        // map to more than one pair (the same trace id reused across projects, OPIK-7483), so this is a
+        // Collectors.groupingBy, not a plain lookup map.
+        var pairsById = batch.stream().collect(Collectors.groupingBy(Pair::getRight));
+
+        return Flux.fromIterable(grouped.get().entrySet())
+                .concatMap(entry -> {
+                    var partitionPairs = entry.getValue().stream()
+                            .flatMap(id -> pairsById.get(id).stream())
+                            .toList();
+                    return executeDelete(partitionPairs, entry.getKey(), workspaceId, userName, connection);
+                })
+                .then();
+    }
+
+    /**
+     * Renders and executes one delete statement — unbounded when {@code partition} is null, scoped to it otherwise.
+     */
+    private Mono<Void> executeDelete(List<Pair<UUID, UUID>> pairs, Long partition,
+            String workspaceId, String userName, Connection connection) {
+        var template = getSTWithLogComment(DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS, "delete_traces", workspaceId,
+                userName, "pairs_size=%s".formatted(pairs.size()));
+        selectTracesMutationTable(template);
+        if (partition != null) {
+            template.add("partition", partition);
+        }
+
+        var projectIds = pairs.stream().map(pair -> pair.getLeft().toString()).toArray(String[]::new);
+        var traceIds = pairs.stream().map(pair -> pair.getRight().toString()).toArray(String[]::new);
+
+        var statement = connection.createStatement(template.render())
+                .bind("workspace_id", workspaceId)
+                .bind("project_ids", projectIds)
+                .bind("trace_ids", traceIds);
+
+        var segment = startSegment("traces", "Clickhouse", "delete");
+        return Mono.from(statement.execute())
+                .doFinally(_ -> endSegment(segment))
+                .then();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -537,7 +537,7 @@ class TraceServiceImpl implements TraceService {
      * Resolves every owning project for each id: a bounded fast pass, then an unbounded pass over only the ids the
      * bounded one leaves unresolved. Returns id -> owning projects; ids absent from the result have no live row.
      * <p>
-     * The bounded pass's week window can miss a row whose week {@link com.comet.opik.utils.WeeklyPartitions#of}
+     * The bounded pass's week window can miss a row whose week {@link com.comet.opik.utils.WeeklyPartitions#groupByPartition}
      * cannot derive exactly — an id at or past the end of {@code DateTime64}'s range, where {@code id_at} saturates
      * to {@code 2299-12-31} whatever the real week — so the unbounded pass re-resolves the miss set and the bounded
      * query is never a delete's sole resolver. A far-future timestamp short of that ceiling is no longer such a case:
@@ -566,6 +566,12 @@ class TraceServiceImpl implements TraceService {
                 });
     }
 
+    /**
+     * All-or-nothing over the batch: an error anywhere skips {@code TracesDeleted} and the deletion-events capture for
+     * every pair, not just the failed one. OPIK-8230 widens the window — the DAO can now emit several statements per
+     * batch, so earlier partitions' rows may already be gone. Deletes are idempotent; restructuring this coupling is
+     * out of that ticket's scope.
+     */
     private Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, Connection connection) {
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/DatabaseAnalyticsDataModelConfig.java
@@ -15,6 +15,13 @@ import lombok.Builder;
  * epoch end time round-trips unchanged rather than being read as {@code null}. Flip this in lockstep with the EXCHANGE
  * step of the cutover.</p>
  *
+ * <p>It also gates partition-scoped deletes (OPIK-8230): the EXCHANGE that makes these columns non-nullable is the
+ * same one that puts the weekly-partitioned successor behind the name mutations target, so this flag being
+ * {@code true} is equally what says a delete may scope itself with {@code IN PARTITION}. One flag for two facts
+ * because they have only ever flipped together; a second would have to be threaded through the cutover runbook and
+ * tooling to track no independent state. The name says only the first duty and is deliberately not renamed - the env
+ * var is exposed.</p>
+ *
  * <p>{@code spanColumnsNonNullable}: the {@code spans} sibling of {@code traceColumnsNonNullable}, gating the same
  * sentinel wiring for {@code spans.end_time}→epoch and {@code spans.duration}/{@code spans.ttft}→{@code NaN}. Default
  * {@code false} while the {@code spans} table still has {@code Nullable(...)} columns; set {@code true} in lockstep with

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/WeeklyPartitions.java
@@ -9,14 +9,19 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
- * Single derivation point for the {@code id_at} weekly partition values a batch of ids resolves to, so a mutation can
- * name its own partitions instead of being planned against every part of the table.
+ * Single derivation point for the {@code id_at} weekly partition value(s) a batch of ids resolves to, so a mutation
+ * can name its own partitions instead of being planned against every part of the table. {@link #groupByPartition}
+ * groups ids by the partition each belongs to, for a caller emitting one statement per partition (OPIK-8230) that
+ * must bind only the ids belonging to it.
  *
  * <p>Mirrors the partition expression of {@code traces_local_v2} / {@code spans_local_v2} exactly —
  * {@code PARTITION BY toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))}, where {@code id_at} is
@@ -55,9 +60,9 @@ import java.util.UUID;
  * <h2>Why the caller must treat an empty result as "no predicate", never as "no partitions"</h2>
  *
  * <p>The whole value of the derivation is that the partitions a batch resolves to are the <em>only</em> places its rows
- * can be; a set that is merely close is a silently skipped delete, not a slower one. So this returns a set only when
- * every id in the batch is one it can derive exactly, and empty otherwise — leaving the caller to emit its unbounded
- * form, which is always correct and merely slower. The two rejections are:</p>
+ * can be; a grouping that is merely close is a silently skipped delete, not a slower one. So this returns non-empty
+ * only when every id in the batch is one it can derive exactly, and empty otherwise — leaving the caller to emit its
+ * unbounded form, which is always correct and merely slower. The two rejections are:</p>
  * <ul>
  *     <li><b>Any id that is not a UUIDv7.</b> Its high 48 bits are not a timestamp, and {@code UUIDv7ToDateTime}
  *     returns {@code 1970-01-01} for it rather than throwing, so the row sits in the epoch partition while the bits
@@ -101,49 +106,80 @@ public class WeeklyPartitions {
     private static final long ID_AT_LEGACY_MODULUS = 1L << 32;
 
     /**
-     * The weekly partition values the ids resolve to — under each {@code id_at} type the mutation may run against (see
-     * the class javadoc) — or empty if the batch contains an id whose partition cannot be derived exactly. In the empty
-     * case the caller must omit its partition predicate entirely. An empty batch yields empty for the same reason:
-     * there is nothing to bound the mutation to.
+     * Groups the ids by the weekly partition value(s) each resolves to — under each {@code id_at} type the mutation
+     * may run against (see the class javadoc) — or empty if the batch contains an id whose partition cannot be
+     * derived exactly. In the empty case the caller must omit its partition predicate entirely and emit the
+     * unbounded form. An empty batch yields empty for the same reason: there is nothing to bound the mutation to.
+     * {@code IN PARTITION} accepts exactly one partition per statement (OPIK-8230), so a caller emitting one
+     * statement per partition needs to know which ids go in each, not merely their union.
      * <p>
-     * A {@code null} batch throws rather than reading as empty, which is the one place this class is deliberately
-     * intolerant. Empty is a <em>documented answer</em> — "this batch cannot be pruned, emit the unbounded form" — and a
-     * caller that lost its batch would receive that answer, silently issue a correct-but-unbounded mutation, and never
-     * learn it had a bug. A null collection here is a programming error, not a data condition; a null <em>element</em>
-     * is the data condition, and that keeps returning empty.
+     * An id past {@link #ID_AT_LEGACY_MODULUS} appears in <b>two</b> groups — one per {@code id_at} representation
+     * it resolves to. That is safe, not a widening bug: a statement scoped to the group that does not actually
+     * contain the id's row is a no-op there, never a wrong deletion, since the row-matching {@code (project_id, id)}
+     * predicate inside each statement is unchanged regardless of which partition the statement targets.
+     * <p>
+     * A {@code null} batch throws rather than reading as empty: empty is a documented answer meaning "emit the
+     * unbounded form", so a caller that lost its batch would silently get back the slow mutation this class exists to
+     * avoid. A null <em>element</em> still returns empty, which is safe because it is unreachable from the delete
+     * path: {@code TraceDAO#delete} rejects a null id before any of this runs.
      *
      * @throws NullPointerException if {@code ids} is null.
      */
-    public static Optional<Set<Long>> of(@NonNull Collection<UUID> ids) {
-        var partitions = new HashSet<Long>();
+    public static Optional<Map<Long, Set<UUID>>> groupByPartition(@NonNull Collection<UUID> ids) {
+        var grouped = new HashMap<Long, Set<UUID>>();
 
         for (UUID id : ids) {
-            if (id == null || id.version() != 7) {
+            var idPartitions = partitionsOf(id);
+            if (idPartitions.isEmpty()) {
                 return Optional.empty();
             }
-            // UUIDv7: the high 48 bits are the unix epoch in milliseconds. `>>> 16` reads them unsigned, so the value
-            // is in [0, 2^48) — never negative, and never large enough for Instant.ofEpochSecond to overflow. That is
-            // also why neither derivation checks a floor: the smallest id_at any UUIDv7 can carry is the epoch, and
-            // even its Monday (1969-12-29) is comfortably inside Date32 on both schemas.
-            long epochMilli = id.getMostSignificantBits() >>> 16;
-            if (epochMilli >= ID_AT_CEILING) {
-                return Optional.empty();
-            }
-            // Truncating to whole seconds is the column's own conversion (DateTime64(0) / DateTime both store seconds)
-            // and cannot move a value into an earlier day, so it never changes the week.
-            long epochSecond = epochMilli / 1_000L;
-            partitions.add(weeklyPartitionOf(epochSecond)); // DateTime64(0, 'UTC') — the partitioned successor
-            // Only past the 32-bit range do the two columns disagree; below it the modulo is the identity, so the
-            // branch is the invariant stated as code rather than an optimisation: an ordinary id CANNOT widen the set.
-            if (epochSecond >= ID_AT_LEGACY_MODULUS) {
-                partitions.add(weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS)); // DateTime('UTC') — legacy
+            for (Long partition : idPartitions.get()) {
+                grouped.computeIfAbsent(partition, _ -> new HashSet<>()).add(id);
             }
         }
 
-        // Set.copyOf, not the working HashSet: what escapes here decides which partitions a DELETE mutation touches, so
-        // a caller holding a mutable reference could narrow the set after it was derived and turn a correct delete into
-        // a silent no-op. Immutable by default per apps/opik-backend/AGENTS.md, and the accumulator stays local.
-        return partitions.isEmpty() ? Optional.empty() : Optional.of(Set.copyOf(partitions));
+        if (grouped.isEmpty()) {
+            return Optional.empty();
+        }
+        // Immutable outer map AND immutable per-partition sets: what escapes here decides which partitions a DELETE
+        // mutation touches, so a caller holding a mutable reference could narrow it after derivation and turn a
+        // correct delete into a silent no-op. Collectors.toUnmodifiableMap's values must themselves be made
+        // unmodifiable explicitly; it does not do so for you.
+        return Optional.of(grouped.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, entry -> Set.copyOf(entry.getValue()))));
+    }
+
+    /**
+     * The weekly partition value(s) a single id resolves to under each {@code id_at} type the mutation may meet (see
+     * class javadoc) — extracted from {@link #groupByPartition} so the per-id {@code id_at} math reads separately
+     * from the grouping it feeds. Empty exactly when the id cannot be derived exactly: not a UUIDv7, or an embedded
+     * timestamp at or past {@link #ID_AT_CEILING}.
+     */
+    private static Optional<Set<Long>> partitionsOf(UUID id) {
+        if (id == null || id.version() != 7) {
+            return Optional.empty();
+        }
+        // UUIDv7: the high 48 bits are the unix epoch in milliseconds. `>>> 16` reads them unsigned, so the value
+        // is in [0, 2^48) — never negative, and never large enough for Instant.ofEpochSecond to overflow. That is
+        // also why neither derivation checks a floor: the smallest id_at any UUIDv7 can carry is the epoch, and
+        // even its Monday (1969-12-29) is comfortably inside Date32 on both schemas.
+        long epochMilli = id.getMostSignificantBits() >>> 16;
+        if (epochMilli >= ID_AT_CEILING) {
+            return Optional.empty();
+        }
+        // Truncating to whole seconds is the column's own conversion (DateTime64(0) / DateTime both store seconds)
+        // and cannot move a value into an earlier day, so it never changes the week.
+        long epochSecond = epochMilli / 1_000L;
+        // DateTime64(0, 'UTC') — the partitioned successor. Only past the 32-bit range do the two columns disagree;
+        // below it the modulo is the identity, so the branch is the invariant stated as code rather than an
+        // optimisation: an ordinary id CANNOT widen the set. Immutable on the way out, for the same reason
+        // groupByPartition copies its own result — see there. Set.of throws on a duplicate, which is safe here
+        // rather than merely untested: the two arguments are weeks 2^32 seconds (~136 years) apart, so they cannot
+        // be the same week.
+        return Optional.of(epochSecond >= ID_AT_LEGACY_MODULUS
+                ? Set.of(weeklyPartitionOf(epochSecond),
+                        weeklyPartitionOf(epochSecond % ID_AT_LEGACY_MODULUS)) // DateTime('UTC') — legacy
+                : Set.of(weeklyPartitionOf(epochSecond)));
     }
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLegacyTablePruningMutationTest.java
@@ -41,8 +41,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,40 +81,6 @@ class TracesLegacyTablePruningMutationTest {
 
     /** A UUIDv7 carrying id_at 2200-01-01 — the litellm shape, and the id the legacy 32-bit column wraps. */
     private static final UUID FAR_FUTURE_ID = UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2");
-
-    /**
-     * The week that id partitions into under a {@code DateTime64} {@code id_at} — its honest one, and the only value the
-     * flag-gated predicate used to carry. Stated as a literal because it is what ClickHouse returned for
-     * {@code toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} on that id, not something re-derived
-     * here.
-     */
-    private static final long HONEST_WEEK = 21991230L;
-
-    /**
-     * The week the same id partitions into on <b>this</b> table: {@code CAST(UUIDv7ToDateTime(...) AS DateTime('UTC'))}
-     * wraps 2200-01-01 to 2063-11-25, a Wednesday, whose Monday is 2063-11-19. This is the value that makes the delete
-     * below land, and the reason the predicate needs no flag.
-     */
-    private static final long LEGACY_WEEK = 20631119L;
-
-    /** {@link UUID#randomUUID()} is a v4 by definition: no embedded timestamp to derive a partition from. */
-    private static final UUID NON_V7_ID = UUID.randomUUID();
-
-    /**
-     * The partition-key fragment the DAO's template emits. Only ever <b>compared against</b> the statement read back
-     * from {@code system.query_log} — never spliced into a query this suite runs.
-     */
-    private static final String PARTITION_PREDICATE = "toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))";
-
-    /**
-     * The {@code IN} clause the DAO emitted, captured to end of line: the predicate sits on its own line in the
-     * template with {@code SETTINGS log_comment} on the next, so the line boundary delimits it exactly.
-     */
-    private static final Pattern EMITTED_IN_CLAUSE = Pattern.compile(
-            Pattern.quote(PARTITION_PREDICATE) + "\\s+IN\\s+([^\\n]*)");
-
-    /** A weekly partition value as it appears in SQL — {@code yyyyMMdd}, so always eight digits. */
-    private static final Pattern PARTITION_VALUE = Pattern.compile("\\d{8}");
 
     private static final String INSERT_RAW_TRACE = """
             INSERT INTO traces (workspace_id, project_id, id)
@@ -213,45 +177,46 @@ class TracesLegacyTablePruningMutationTest {
     }
 
     @Test
-    @DisplayName("a far-future row on the legacy table is deleted by the same pruned statement")
-    void farFutureRowOnLegacyTableIsDeletedByAPrunedStatement() {
-        // The one test that shows the union is load-bearing rather than decorative. With only the honest week in the
-        // set, this delete matches nothing on this table and reports success - which is exactly the failure the
-        // configuration flag used to exist to avoid, now avoided by the predicate itself.
+    @DisplayName("a far-future row on the legacy table is still deleted, by the unbounded form")
+    void farFutureRowOnLegacyTableIsStillDeleted() {
+        // OPIK-8230 changes what this test proves. IN PARTITION cannot be used against a table with no partition key
+        // at all - ClickHouse rejects it outright (Code 248 INVALID_PARTITION_VALUE, "Wrong number of fields in the
+        // partition expression: 1, must be: 0") - so TraceDAO#deleteBatch now gates the scoped path on the mutation's
+        // OWN resolved table, not merely on whether WeeklyPartitions can derive a value. WeeklyPartitions itself stays
+        // schema-agnostic (it still derives BOTH representations for a far-future id, honest and legacy-wrapped, on
+        // purpose - see its Javadoc), but the DAO never spends that derivation here: on the legacy table every delete
+        // takes the unbounded form, correctly, and this is that guarantee restated for the topology it actually
+        // guards.
         //
-        // The project and its id come from the real ingestion path - create a trace through the endpoint, then read the
-        // project id back off it - so the delete runs against a project that exists and a genuine UUIDv7 project id,
-        // not a fabricated one.
+        // The project and its id come from the real ingestion path - create a trace through the endpoint, then read
+        // the project id back off it - so the delete runs against a project that exists and a genuine UUIDv7 project
+        // id, not a fabricated one.
         var projectId = projectIdOf(createTrace());
 
-        // Only the far-future row is raw, because ingestion rejects it by design (24h window). A recent id would prove
-        // nothing here: the legacy id_at is accurate for one, so even an honest-week-only predicate would match it.
+        // Only the far-future row is raw, because ingestion rejects it by design (24h window).
         insertRawTrace(projectId, FAR_FUTURE_ID);
         assertThat(liveRowCount(projectId, FAR_FUTURE_ID)).as("the far-future row is seeded").isEqualTo("1");
 
         delete(Set.of(Pair.of(projectId, FAR_FUTURE_ID)));
 
         assertThat(liveRowCount(projectId, FAR_FUTURE_ID))
-                .as("it is deleted - so the predicate named the week THIS table filed it under, not only the honest one")
+                .as("it is deleted - the unbounded form is always correct, merely unscoped")
                 .isEqualTo("0");
 
         var sql = lastTraceDeleteSql(FAR_FUTURE_ID);
         assertThat(sql)
-                .as("the predicate is emitted here too - there is no schema flag holding it back any more")
-                .contains(PARTITION_PREDICATE);
-        // Asserted as an exact set, both ways round. Only the legacy week can match a row on this table, so a set
-        // missing it would fail the delete above; and a set missing the honest week would pass here while breaking the
-        // post-EXCHANGE suite, which is the pair this has to stay consistent with.
-        assertThat(boundPartitionsOf(sql))
-                .as("both representations of the same id: the honest week and the one the 32-bit column wraps it to")
-                .containsExactlyInAnyOrder(HONEST_WEEK, LEGACY_WEEK);
+                .as("no id_at predicate of any kind, and no IN PARTITION clause: the legacy table has no partition"
+                        + " key for either to name")
+                .doesNotContain("id_at")
+                .doesNotContain("IN PARTITION");
     }
 
     @Test
-    @DisplayName("an ordinary row is deleted by a single-week statement, since both id_at types agree below 2106")
-    void ordinaryRowIsBoundedToOneWeek() {
-        // The counterweight: the union widens only where the two representations differ, so real traffic binds exactly
-        // what it bound before. A regression that added the wrapped week unconditionally would show up here.
+    @DisplayName("an ordinary row is also deleted by the unbounded form, same as a far-future one")
+    void ordinaryRowIsAlsoDeletedUnbounded() {
+        // The counterweight to the far-future case above: on the legacy table there is no "recent id gets the scoped
+        // form, far-future gets the unbounded one" split. Every delete here is unbounded, regardless of era - proving
+        // that ONLY with a far-future row would leave open whether an ordinary one still worked.
         var target = createTrace();
         var projectId = projectIdOf(target);
         assertThat(liveRowCount(projectId, target.id())).as("the row is there").isEqualTo("1");
@@ -260,40 +225,10 @@ class TracesLegacyTablePruningMutationTest {
 
         assertThat(liveRowCount(projectId, target.id())).as("and it is deleted").isEqualTo("0");
         var sql = lastTraceDeleteSql(target.id());
-        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
-        assertThat(boundPartitionsOf(sql))
-                .as("one week, not two: a recent id_at is inside the 32-bit range, so the two derivations coincide")
-                .hasSize(1);
-    }
-
-    @Test
-    @DisplayName("a non-v7 id still disables pruning here, and the delete still lands")
-    void nonV7IdDisablesPruning() {
-        // The fallback is unchanged by the flag removal and still has to hold on this table: a row whose id_at cannot
-        // be trusted is STILL DELETED, by an unbounded mutation. Seeded raw, since ingestion rejects a non-v7 id.
-        var target = createTrace();
-        var projectId = projectIdOf(target);
-        insertRawTrace(projectId, NON_V7_ID);
-        assertThat(liveRowCount(projectId, NON_V7_ID)).as("the non-v7 row is seeded").isEqualTo("1");
-
-        delete(Set.of(Pair.of(projectId, target.id()), Pair.of(projectId, NON_V7_ID)));
-
-        assertThat(liveRowCount(projectId, NON_V7_ID))
-                .as("the non-v7 row is itself deleted, not skipped")
-                .isEqualTo("0");
-        assertThat(liveRowCount(projectId, target.id()))
-                .as("and so is the derivable row batched alongside it")
-                .isEqualTo("0");
-
-        // Asserted as the absence of ANY id_at predicate, not just of this expression: a regression that narrowed the
-        // mutation with toMonday(id_at), an id_at range, or anything else would skip exactly the rows this reaches.
-        var sql = lastTraceDeleteSql(NON_V7_ID);
         assertThat(sql)
-                .as("the unbounded form carries no id_at predicate of any kind")
-                .doesNotContain("id_at");
-        assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
-                .as("and no partition IN clause: %s", sql)
-                .isFalse();
+                .as("no id_at predicate of any kind, and no IN PARTITION clause")
+                .doesNotContain("id_at")
+                .doesNotContain("IN PARTITION");
     }
 
     /** A trace through the real ingestion path, with the fields podam cannot fill sensibly cleared. */
@@ -304,26 +239,6 @@ class TracesLegacyTablePruningMutationTest {
                 .build();
         traceResourceClient.createTrace(trace, API_KEY, WORKSPACE_NAME);
         return trace;
-    }
-
-    /**
-     * The partition values actually bound into the emitted {@code IN} clause, so a test can assert the set is exact
-     * rather than merely inclusive. The driver substitutes bound values into the query text client-side, which is why
-     * they are readable here at all; the two assertions below are what make a change in that behaviour say so plainly
-     * instead of quietly turning every set assertion into a tautology on an empty set.
-     */
-    private static Set<Long> boundPartitionsOf(String sql) {
-        var clause = EMITTED_IN_CLAUSE.matcher(sql);
-        assertThat(clause.find())
-                .as("the delete SQL carries the partition predicate followed by an IN clause:%n%s", sql)
-                .isTrue();
-        var bound = PARTITION_VALUE.matcher(clause.group(1)).results()
-                .map(match -> Long.parseLong(match.group()))
-                .collect(Collectors.toUnmodifiableSet());
-        assertThat(bound)
-                .as("the IN clause carries inlined partition values — got '%s'", clause.group(1))
-                .isNotEmpty();
-        return bound;
     }
 
     /** Invokes the DAO under a workspace/user context, as {@code TraceService} does for the live delete path. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesPartitionPruningMutationTest.java
@@ -20,56 +20,53 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.podam.PodamFactoryUtils;
-import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.WeeklyPartitions;
 import com.comet.opik.utils.template.TemplateUtils;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.redis.testcontainers.RedisContainer;
 import io.r2dbc.spi.Statement;
-import lombok.Builder;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.mysql.MySQLContainer;
+import org.testcontainers.utility.MountableFile;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.stream.IntStream;
 
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static com.comet.opik.infrastructure.FilterUtils.ANALYTICS_DELETE_BATCH_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * Exercises the partition pruning of {@code DELETE_BY_PROJECT_ID_TRACE_ID_PAIRS} against the post-EXCHANGE topology,
@@ -85,7 +82,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * the DAO's predicate resolved to any partition other than the one ClickHouse filed a row under, the mutation would
  * select the wrong parts and that row would survive, so
  * {@link #deleteClearsEveryEraAndBindsExactlyThosePartitions} passing <em>is</em> the agreement between the migration's
- * {@code PARTITION BY} as installed, the DAO's predicate, and {@link WeeklyPartitions#of}.
+ * {@code PARTITION BY} as installed, the DAO's predicate, and {@link WeeklyPartitions#groupByPartition}.
  *
  * <p>Each test then pairs that with the SQL ClickHouse actually received, because rows alone cannot see pruning
  * silently stop — a delete that stopped bounding itself is still correct, just slow, and that is the regression this
@@ -144,15 +141,15 @@ class TracesPartitionPruningMutationTest {
     private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
 
     /**
-     * The partition-key fragment the DAO's template emits. Only ever <b>compared against</b> the statement read back
-     * from {@code system.query_log} — never spliced into a query this suite runs. Verbatim comparison is safe because
-     * {@code query_log} stores the query as submitted, so both sides are the DAO's own template text.
+     * Matches the {@code IN PARTITION <value>} clause the scoped delete template emits (OPIK-8230), capturing the
+     * eight-digit {@code yyyyMMdd} partition value. Only ever <b>compared against</b> the statement read back from
+     * {@code system.query_log} - never spliced into a query this suite runs.
      */
-    private static final String PARTITION_PREDICATE = "toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))";
+    private static final Pattern IN_PARTITION_CLAUSE = Pattern.compile("IN\\s+PARTITION\\s+(\\d{8})");
 
     // The suite's whole SQL surface, per .agents/skills/opik-backend/SKILL.md "SQL Query Construction": one text block
     // per query, every varying value a :placeholder. There are no StringTemplate fragments and no interpolation at all,
-    // because nothing here re-implements the DAO's predicate - PARTITION_PREDICATE is only ever compared against the
+    // because nothing here re-implements the DAO's predicate - IN_PARTITION_CLAUSE is only ever compared against the
     // statement the DAO emitted, never spliced into a query of ours.
     //
     // The EXCHANGE/RENAME pair in installPartitionedSuccessorUnderTraces() stays as inline literals on purpose: they
@@ -196,18 +193,25 @@ class TracesPartitionPruningMutationTest {
             """;
 
     /**
-     * The newest {@code delete_traces} statement carrying exactly {@code pairs_size} pairs. A request larger than
-     * {@link com.comet.opik.infrastructure.FilterUtils#ANALYTICS_DELETE_BATCH_SIZE} is chunked by the DAO into one
-     * statement per chunk, and pruning is derived <b>per chunk</b> — so a test that reads only one statement cannot see
-     * the second chunk at all.
+     * Every {@code delete_traces} statement finished since {@code since} whose query text mentions
+     * {@code projectId}, in submission order - the multi-statement counterpart of {@link #LAST_TRACE_DELETE}, since
+     * one {@code delete()} call can now emit more than one statement (OPIK-8230).
+     * <p>
+     * Scoped by project id, not just by time: {@code WORKSPACE_ID} is one constant shared by every test in this
+     * class, so a time window alone is not exclusive to one test's own statements - a delete finished by a
+     * DIFFERENT test can still surface inside this window when system.query_log's buffered writes only become
+     * visible on a later flush, even though its recorded {@code event_time_microseconds} is genuinely earlier. Each test mints its own fresh, collision-free project id
+     * ({@code ID_GENERATOR.generateId()}), which is literally embedded in the emitted query text, so filtering on it
+     * closes that gap the same way {@link #lastTraceDeleteSql} already does with a trace id.
      */
-    private static final String DELETE_BY_PAIR_COUNT = """
+    private static final String ALL_TRACE_DELETES_SINCE = """
             SELECT query
             FROM system.query_log
-            WHERE log_comment LIKE concat('delete_traces:%pairs_size=', :pairs_size)
+            WHERE log_comment LIKE 'delete_traces:%'
             AND type = 'QueryFinish'
-            ORDER BY event_time_microseconds DESC
-            LIMIT 1
+            AND event_time_microseconds >= :since
+            AND query LIKE concat('%', :project_id, '%')
+            ORDER BY event_time_microseconds
             """;
 
     /**
@@ -224,46 +228,47 @@ class TracesPartitionPruningMutationTest {
             """;
 
     /**
-     * The {@code IN} clause the DAO emitted, captured to end of line: the predicate sits on its own line in the
-     * template with {@code SETTINGS log_comment} on the next, so the line boundary delimits it exactly. Read this way
-     * rather than by matching a bracket style, because the driver's rendering of a {@code Long[]} is its own choice —
-     * what matters is which partition values are in the clause, not how it punctuates them.
+     * The physical part-level proof of pruning (OPIK-8230's own point): how many {@code MutatePart} events
+     * {@code table} logged in a window, and how many distinct partitions they span. {@code EXPLAIN} cannot see this -
+     * it reports what the read planner would select for a {@code SELECT}, a different layer from what a mutation is
+     * registered against, which is exactly the gap this suite used to fall into (see class Javadoc). Windowed by
+     * {@code event_time}, not correlated by {@code query_id}: a lightweight delete's mutation executes asynchronously
+     * under the mutations subsystem, so its {@code part_log} rows do not reliably carry the submitting statement's
+     * {@code query_id} - a finding from this ticket's own production investigation, not a guess.
      */
-    private static final Pattern EMITTED_IN_CLAUSE = Pattern.compile(
-            Pattern.quote(PARTITION_PREDICATE) + "\\s+IN\\s+([^\\n]*)");
+    private static final String MUTATE_PART_EVENTS_SINCE = """
+            SELECT toString(count()), toString(uniqExact(partition_id))
+            FROM system.part_log
+            WHERE database = currentDatabase()
+            AND table = :table
+            AND event_type = 'MutatePart'
+            AND event_time >= :since
+            """;
+
+    /** How many active parts {@code table} currently holds - the "everything" a fallback delete should visit. */
+    private static final String ACTIVE_PART_COUNT = """
+            SELECT toString(count())
+            FROM system.parts
+            WHERE database = currentDatabase()
+            AND table = :table
+            AND active
+            """;
 
     /**
-     * The emitted statement's shape, so its {@code WHERE} clause can be lifted verbatim and re-asked as a
-     * {@code SELECT}: {@code EXPLAIN} does not accept a mutation. Captures the target table too, since the DAO picks
-     * {@code traces} or {@code traces_local} depending on the wrap flag.
+     * Whether {@code table} has any mutation still in flight. Used to settle the estate before starting a timed
+     * {@link #mutatePartActivitySince} window: a mutation from an EARLIER test in this suite can still be writing
+     * {@code MutatePart} rows to {@code system.part_log} after its submitting statement has already returned - this
+     * class runs every test against the same shared table (see class Javadoc), and nothing here sets
+     * {@code lightweight_deletes_sync} the way the retention sweep does, so a prior test's mutation completing late
+     * would otherwise land inside a LATER test's window and inflate its part/partition counts. Not a claim about
+     * production: production's real workload has no "between tests" moment to wait for.
      */
-    private static final Pattern DELETE_SHAPE = Pattern.compile(
-            "DELETE\\s+FROM\\s+(\\S+)\\s+(WHERE\\b.*?)\\s+SETTINGS\\b", Pattern.DOTALL);
-
-    /** {@code EXPLAIN} index entries that reflect <b>partition</b>-level part selection. */
-    private static final Set<String> PARTITION_INDEX_TYPES = Set.of("MinMax", "Partition");
-
-    /**
-     * Asks the planner how many parts the DAO's partition predicate selects. Declared once as a text block, per
-     * {@code .agents/skills/opik-backend/SKILL.md}: the table {@code <table>} and the predicate
-     * {@code <partition_expression>} are <b>fragments</b> and go through {@link TemplateUtils#newST}, the partition
-     * values are <b>values</b> and are bound — nothing is spliced with {@code .formatted(...)}.
-     * <p>
-     * The predicate fragment is {@link #PARTITION_PREDICATE}, and using the constant does not re-author what is under
-     * test: every caller has already asserted the emitted statement <em>contains</em> that exact text, so the constant
-     * is pinned to the DAO's own SQL by assertion rather than by string surgery on it. The partition values come from
-     * the emitted statement too, parsed by {@link #boundPartitionsOf} and bound here.
-     * <p>
-     * The DAO's {@code workspace_id} and {@code (project_id, id)} predicates are deliberately not reproduced. They are
-     * sort-key filters, not partition filters, so they cannot change partition selection — and leaving them out makes
-     * the unbounded case a full scan, which is the conservative direction for an assertion that the fallback prunes
-     * nothing.
-     */
-    private static final String EXPLAIN_SELECTED_PARTS = """
-            EXPLAIN indexes = 1, json = 1
-            SELECT id
-            FROM <table>
-            <if(partition_expression)>WHERE <partition_expression> IN :partitions<endif>
+    private static final String PENDING_MUTATIONS_COUNT = """
+            SELECT toString(count())
+            FROM system.mutations
+            WHERE database = currentDatabase()
+            AND table = :table
+            AND NOT is_done
             """;
 
     /**
@@ -276,9 +281,6 @@ class TracesPartitionPruningMutationTest {
             CREATE TABLE traces_dist ON CLUSTER '{cluster}' AS traces
             ENGINE = Distributed('{cluster}', '<database>', 'traces_local', sipHash64(project_id))
             """;
-
-    /** A weekly partition value as it appears in SQL — {@code yyyyMMdd}, so always eight digits. */
-    private static final Pattern PARTITION_VALUE = Pattern.compile("\\d{8}");
 
     /**
      * One id per era the derivation has to get right, with the partition each resolves to. Not interchangeable samples:
@@ -319,17 +321,26 @@ class TracesPartitionPruningMutationTest {
      */
     private static final long LEGACY_WEEK_OF_2200 = 20631119L;
 
-    /** {@link UUID#randomUUID()} is a v4 by definition: no embedded timestamp to derive a partition from. */
-    private static final UUID NON_V7_ID = UUID.randomUUID();
+    /**
+     * A fresh UUIDv7 past the first instant {@code DateTime64} can represent, so its {@code id_at} saturates to the
+     * ceiling and the honest week is not the partition the row lands in — the sole underivable cause this suite
+     * exercises, and the only one that occurs in real data. A non-v7 id is rejected at ingestion and production was
+     * audited with no occurrences, so it is deliberately not covered.
+     * <p>
+     * Distinct per call: tests here share one table (PER_CLASS), so a shared constant would let one test's delete
+     * decide another's starting state.
+     */
+    private static UUID newOutOfRangeId() {
+        return ID_GENERATOR.getTimeOrderedEpoch(
+                LocalDate.of(2300, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli());
+    }
 
     /**
-     * A UUIDv7 minted one second past the first instant {@code DateTime64} cannot represent, so its {@code id_at}
-     * saturates to the ceiling and the honest week is not the partition the row lands in. Same rejection as
-     * {@link #NON_V7_ID}, different cause — see {@code WeeklyPartitions}. Minted rather than written out, so the
-     * boundary it sits past is visible.
+     * Drops {@code query_log}/{@code part_log} to a 200 ms flush interval, so the readers below can poll instead of
+     * forcing a {@code SYSTEM FLUSH LOGS} that races the rows it is meant to reveal. See the file itself for why it is
+     * opt-in rather than part of the shared {@code clickhouse.xml}.
      */
-    private static final UUID OUT_OF_RANGE_ID = ID_GENERATOR
-            .getTimeOrderedEpoch(LocalDate.of(2300, 1, 1).atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli());
+    private static final String FAST_LOG_FLUSH_CONFIG = "clickhouse-fast-log-flush.xml";
 
     // Dedicated, non-reused ClickHouse + ZooKeeper on their own network: the EXCHANGE destructively swaps `traces`, so a
     // shared/reused container would corrupt other suites and reruns. Redis/MySQL are only read, so the shared ones are
@@ -338,7 +349,9 @@ class TracesPartitionPruningMutationTest {
     private final GenericContainer<?> zookeeperContainer = ClickHouseContainerUtils.newZookeeperContainer(false,
             network);
     private final ClickHouseContainer clickHouseContainer = ClickHouseContainerUtils
-            .newClickHouseContainer(false, network, zookeeperContainer);
+            .newClickHouseContainer(false, network, zookeeperContainer)
+            .withCopyFileToContainer(MountableFile.forClasspathResource(FAST_LOG_FLUSH_CONFIG),
+                    "/etc/clickhouse-server/config.d/" + FAST_LOG_FLUSH_CONFIG);
     private final RedisContainer redisContainer = RedisContainerUtils.newRedisContainer();
     private final MySQLContainer mysqlContainer = MySQLContainerUtils.newMySQLContainer();
 
@@ -412,6 +425,9 @@ class TracesPartitionPruningMutationTest {
                         .runtimeInfo(wireMock.runtimeInfo())
                         .customConfigs(List.of(
                                 new CustomConfig("databaseAnalyticsDataModel.traceColumnsNonNullable", "true"),
+                                // traceColumnsNonNullable above is also what tells the DAO the target is partitioned,
+                                // so it may scope a delete with IN PARTITION. Without it every pruning assertion here
+                                // passes vacuously against the unbounded fallback.
                                 new CustomConfig("databaseAnalyticsDataModel.tracesDistributedWrapEnabled", "true")))
                         .build());
     }
@@ -449,23 +465,81 @@ class TracesPartitionPruningMutationTest {
     }
 
     /**
-     * The partition values actually bound into the emitted {@code IN} clause, so a test can assert the set is exact
-     * rather than merely inclusive. The driver substitutes bound values into the query text client-side, which is why
-     * they are readable here at all; the two assertions below are what make a change in that behaviour say so plainly
-     * instead of quietly turning every set assertion into a tautology on an empty set.
+     * The single partition value an {@code IN PARTITION} statement names. {@code IN PARTITION} takes exactly one
+     * partition per statement (OPIK-8230) - unlike the old {@code WHERE ... IN (...)} predicate this replaces, there
+     * is never a set to parse, only ever one value or none.
      */
-    private static Set<Long> boundPartitionsOf(String sql) {
-        var clause = EMITTED_IN_CLAUSE.matcher(sql);
+    private static long boundPartitionOf(String sql) {
+        var clause = IN_PARTITION_CLAUSE.matcher(sql);
         assertThat(clause.find())
-                .as("the delete SQL carries the partition predicate followed by an IN clause:%n%s", sql)
+                .as("the delete SQL carries an IN PARTITION clause:%n%s", sql)
                 .isTrue();
-        var bound = PARTITION_VALUE.matcher(clause.group(1)).results()
-                .map(match -> Long.parseLong(match.group()))
-                .collect(Collectors.toUnmodifiableSet());
-        assertThat(bound)
-                .as("the IN clause carries inlined partition values — got '%s'", clause.group(1))
-                .isNotEmpty();
-        return bound;
+        return Long.parseLong(clause.group(1));
+    }
+
+    /**
+     * How many {@code MutatePart} events {@code table} logged since {@code since}, and how many distinct partitions
+     * they span - the part-level proof that a delete actually scoped its mutation, not merely that its {@code WHERE}
+     * clause looks right. See {@link #MUTATE_PART_EVENTS_SINCE}'s Javadoc for why this is windowed rather than
+     * correlated by {@code query_id}.
+     * <p>
+     * Read until two consecutive samples agree, rather than forcing a flush: {@code system.part_log} is buffered, and
+     * this has no single row to wait for - only a count that grows until the last MutatePart event lands. Callers
+     * settle the mutation first ({@link #waitForMutationsToSettle}), so the events are all written by now and the only
+     * thing outstanding is the flush, which {@link #FAST_LOG_FLUSH_CONFIG} caps at 200 ms.
+     */
+    private MutatePartActivity mutatePartActivitySince(String table, Instant since) {
+        var previous = new AtomicReference<MutatePartActivity>();
+        return Awaitility.await()
+                .alias("part_log settles for " + table)
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(300))
+                .until(() -> {
+                    var sample = readMutatePartActivity(table, since);
+                    return sample.equals(previous.getAndSet(sample)) ? sample : null;
+                }, Objects::nonNull);
+    }
+
+    private MutatePartActivity readMutatePartActivity(String table, Instant since) {
+        return template.nonTransaction(connection -> {
+            var statement = connection.createStatement(MUTATE_PART_EVENTS_SINCE)
+                    .bind("table", table)
+                    .bind("since", since.atOffset(ZoneOffset.UTC).toLocalDateTime());
+            return Mono.from(statement.execute())
+                    .flatMap(result -> Mono.from(result.map((row, _) -> new MutatePartActivity(
+                            Integer.parseInt(row.get(0, String.class)),
+                            Integer.parseInt(row.get(1, String.class))))));
+        }).block();
+    }
+
+    /**
+     * {@code now()} as ClickHouse sees it. The window bound has to come from the server clock, not the JVM's: the
+     * container's clock can differ by enough that a JVM-derived bound reaches back before the delete and sweeps in
+     * MutatePart rows from earlier work in this shared-table suite.
+     */
+    private Instant serverNow() {
+        return Instant.parse(queryOneString("SELECT formatDateTime(now(), '%Y-%m-%dT%H:%i:%SZ')", _ -> {
+        }));
+    }
+
+    private int activePartCountOf(String table) {
+        return Integer.parseInt(queryOneString(ACTIVE_PART_COUNT, statement -> statement.bind("table", table)));
+    }
+
+    /**
+     * Blocks until {@code table} has no in-flight mutation, polling {@link #PENDING_MUTATIONS_COUNT}. See that
+     * constant's Javadoc for why a timed MutatePart window needs this settle point.
+     */
+    private void waitForMutationsToSettle(String table) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> "0".equals(queryOneString(PENDING_MUTATIONS_COUNT,
+                        statement -> statement.bind("table", table))));
+    }
+
+    /** {@code MutatePart} events observed in a window: how many parts were touched, and how many partitions. */
+    private record MutatePartActivity(int parts, int partitions) {
     }
 
     /** Invokes the DAO under a workspace/user context, as {@code TraceService} does for the live delete path. */
@@ -495,34 +569,42 @@ class TracesPartitionPruningMutationTest {
      * serve a test.
      */
     private String lastTraceDeleteSql(UUID traceId) {
-        execute("SYSTEM FLUSH LOGS", _ -> {
-        });
-        var sql = queryOneString(LAST_TRACE_DELETE, statement -> statement.bind("trace_id", traceId.toString()));
-        assertThat(sql)
-                .as("query_log holds a delete_traces statement mentioning id '%s'", traceId)
-                .isNotNull();
-        return sql;
+        return Awaitility.await()
+                .alias("query_log holds a delete_traces statement mentioning id " + traceId)
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(200))
+                .until(() -> queryOneString(LAST_TRACE_DELETE,
+                        statement -> statement.bind("trace_id", traceId.toString())), Objects::nonNull);
     }
 
     /**
-     * The newest {@code delete_traces} statement that carried exactly {@code pairsSize} pairs. Chunks are identified by
-     * their pair count rather than by a contained id, because the point is to inspect a <em>specific chunk</em> of one
-     * request — and the DAO stamps each chunk's size into its {@code log_comment}.
-     * <p>
-     * <b>The returned text is truncated for large statements.</b> ClickHouse caps {@code query_log.query} at
-     * {@code log_queries_cut_to_length} (100,000 bytes by default), and a full 10,000-pair chunk inlines to ~762 KiB,
-     * so anything at the tail of such a statement — the partition predicate included — is simply absent. Only assert on
-     * the text of statements small enough to be recorded whole.
+     * Every {@code delete_traces} statement ClickHouse finished since {@code since} whose query text mentions
+     * {@code projectId}. A single {@code delete()} call can now emit more than one statement - one per partition the
+     * batch resolves to (OPIK-8230) - so a caller that must see the whole set can no longer rely on "the newest
+     * one" the way {@link #lastTraceDeleteSql} does. See {@link #ALL_TRACE_DELETES_SINCE}'s Javadoc for why this is
+     * ALSO scoped by project id, not just by time. Polled until the set stops growing rather than flushed - see
+     * {@link #FAST_LOG_FLUSH_CONFIG}.
      */
-    private String deleteSqlForChunkOf(int pairsSize) {
-        execute("SYSTEM FLUSH LOGS", _ -> {
-        });
-        var sql = queryOneString(DELETE_BY_PAIR_COUNT,
-                statement -> statement.bind("pairs_size", String.valueOf(pairsSize)));
-        assertThat(sql)
-                .as("query_log holds a delete_traces statement with pairs_size=%s", pairsSize)
-                .isNotBlank();
-        return sql;
+    private List<String> deleteSqlsSince(Instant since, UUID projectId) {
+        var previous = new AtomicReference<List<String>>();
+        return Awaitility.await()
+                .alias("query_log settles for project " + projectId)
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(300))
+                .until(() -> {
+                    var sample = readDeleteSqlsSince(since, projectId);
+                    return !sample.isEmpty() && sample.equals(previous.getAndSet(sample)) ? sample : null;
+                }, Objects::nonNull);
+    }
+
+    private List<String> readDeleteSqlsSince(Instant since, UUID projectId) {
+        return template.stream(connection -> {
+            var statement = connection.createStatement(ALL_TRACE_DELETES_SINCE)
+                    .bind("since", since.atOffset(ZoneOffset.UTC).toLocalDateTime())
+                    .bind("project_id", projectId.toString());
+            return Flux.from(statement.execute())
+                    .flatMap(result -> result.map((row, _) -> row.get("query", String.class)));
+        }).collectList().block();
     }
 
     /** {@code "1"} while a live (non-lightweight-deleted) row exists for the id, {@code "0"} once it is gone. */
@@ -671,70 +753,6 @@ class TracesPartitionPruningMutationTest {
     }
 
     /**
-     * Parts the planner selects for the DAO's own statement, or empty when it reports no partition index at all.
-     * <p>
-     * {@code SELECT id} rather than {@code count()}, so no trivial-count optimisation can answer from metadata without
-     * selecting parts at all.
-     * <p>
-     * Only {@code MinMax} and {@code Partition} entries are considered, and {@code PrimaryKey} is deliberately
-     * excluded: the DAO's {@code WHERE} also filters {@code workspace_id} and {@code (project_id, id)}, which are the
-     * sort key, so {@code PrimaryKey} prunes parts for the <b>unbounded</b> statement too — counting it would make the
-     * fallback look pruned and destroy the discrimination this test rests on. Across the entries that do qualify it
-     * takes the smallest selected count and the largest initial count, so it does not depend on which of the two
-     * reports the pruning.
-     * <p>
-     * Empty is a meaningful answer rather than a failure: the {@code Indexes} block carries a partition entry only when
-     * the query filters on the partition key, so its absence is exactly what the fallback should produce.
-     */
-    private Optional<SelectedParts> partsSelectedBy(String daoDeleteSql) {
-        var shape = DELETE_SHAPE.matcher(daoDeleteSql);
-        assertThat(shape.find())
-                .as("the emitted statement has the expected DELETE shape:%n%s", daoDeleteSql)
-                .isTrue();
-        Set<Long> bound = EMITTED_IN_CLAUSE.matcher(daoDeleteSql).find()
-                ? boundPartitionsOf(daoDeleteSql)
-                : Set.of();
-
-        var explainSql = TemplateUtils.newST(EXPLAIN_SELECTED_PARTS)
-                .add("table", shape.group(1));
-        if (!bound.isEmpty()) {
-            explainSql.add("partition_expression", PARTITION_PREDICATE);
-        }
-        var sql = explainSql.render();
-
-        var explainRows = template.stream(connection -> {
-            var statement = connection.createStatement(sql);
-            if (!bound.isEmpty()) {
-                statement.bind("partitions", bound.toArray(Long[]::new));
-            }
-            return Flux.from(statement.execute())
-                    .flatMap(result -> result.map((row, _) -> row.get("explain", String.class)));
-        })
-                .collectList()
-                .block();
-        var explain = String.join("\n", explainRows);
-
-        var indexes = JsonUtils.getJsonNodeFromString(explain).findValue("Indexes");
-        if (indexes == null) {
-            return Optional.empty();
-        }
-        SelectedParts partition = null;
-        for (JsonNode index : indexes) {
-            if (!PARTITION_INDEX_TYPES.contains(index.path("Type").asText()) || !index.has("Selected Parts")) {
-                continue;
-            }
-            var entry = JsonUtils.treeToValue(index, SelectedParts.class);
-            partition = partition == null
-                    ? entry
-                    : partition.toBuilder()
-                            .selected(Math.min(partition.selected(), entry.selected()))
-                            .total(Math.max(partition.total(), entry.total()))
-                            .build();
-        }
-        return Optional.ofNullable(partition);
-    }
-
-    /**
      * First column of the first row, as a string. Every read in this suite is a single scalar, so this is the only
      * mapper needed; values go in as binds.
      */
@@ -753,17 +771,6 @@ class TracesPartitionPruningMutationTest {
             binder.accept(statement);
             return Mono.from(statement.execute()).flatMap(result -> Mono.from(result.getRowsUpdated()));
         }).block();
-    }
-
-    /**
-     * The part counts {@code EXPLAIN indexes = 1, json = 1} reports for one index entry: how many parts the query
-     * started from, and how many survived pruning.
-     */
-    @Builder(toBuilder = true)
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    private record SelectedParts(
-            @JsonProperty("Selected Parts") int selected,
-            @JsonProperty("Initial Parts") int total) {
     }
 
     @Test
@@ -796,23 +803,19 @@ class TracesPartitionPruningMutationTest {
                 .doesNotContain(target.id())
                 .contains(bystander.id());
         var sql = lastTraceDeleteSql(target.id());
-        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
-        // Asserted as the SIZE, not as a value read back from WeeklyPartitions: the DAO derives its set from the same
-        // method, so an expectation taken from it would move with any regression and pass regardless. The value itself
-        // is already pinned two independent ways - the row above had to go away, which it only does if the predicate
-        // named the partition ClickHouse filed it under, and deleteClearsEveryEraAndBindsExactlyThosePartitions states
-        // its expectations as literals. What is left to say here is the property those cannot: an id the endpoint just
-        // minted is inside the 32-bit range, where the two id_at types agree, so it must widen the set to nothing.
-        assertThat(boundPartitionsOf(sql))
-                .as("bounded to one partition, not two: a recent id_at is a week both id_at types agree on")
-                .hasSize(1);
+        // A recent id_at is inside the 32-bit range, where the two id_at types agree, so WeeklyPartitions.groupByPartition
+        // resolves it to exactly one partition and the DAO emits the scoped IN PARTITION form - not the unbounded
+        // fallback. boundPartitionOf asserts the clause is present; there is nothing further to assert about its
+        // cardinality now that IN PARTITION accepts exactly one value per statement by construction.
+        assertThat(sql).as("the mutation carries an IN PARTITION clause").contains("IN PARTITION");
+        boundPartitionOf(sql);
     }
 
     @Test
     @DisplayName("the DAO's own delete clears every era and binds exactly those partitions")
     void deleteClearsEveryEraAndBindsExactlyThosePartitions() {
         // The three-way agreement - the migration's PARTITION BY as installed, the DAO's predicate, and
-        // WeeklyPartitions.of - asserted through the DAO's own delete rather than by re-evaluating the expression in
+        // WeeklyPartitions.groupByPartition - asserted through the DAO's own delete rather than by re-evaluating the expression in
         // test SQL. If the predicate resolved to any partition other than the one ClickHouse filed a row under, the
         // mutation would select the wrong parts and that row would SURVIVE. So "every row is gone" IS the agreement.
         //
@@ -826,17 +829,24 @@ class TracesPartitionPruningMutationTest {
         assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
                 .as("every era is seeded").containsOnly("1");
 
+        var since = Instant.now();
         delete(ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet()));
 
         assertThat(ids.stream().map(id -> liveRowCount(projectId, id)))
                 .as("every era's row is gone, so the predicate named the partition each was actually filed under")
                 .containsOnly("0");
-        var sql = lastTraceDeleteSql(ids.getFirst());
-        assertThat(sql).as("the mutation carries the partition predicate").contains(PARTITION_PREDICATE);
-        // Four values for three eras: 1996 and 2025 are inside the 32-bit range and name one week each, and the 2199
-        // id names its legacy week too. Still an exact set, and still not a range across two centuries - which is the
-        // property under test; the extra value is the batch's own second representation, not a widening of its span.
-        assertThat(boundPartitionsOf(sql))
+
+        // One statement per partition the batch resolves to (OPIK-8230), not one statement carrying all four values:
+        // 1996 and 2025 are inside the 32-bit range and name one week each; the 2199 id names two (its own week AND
+        // its legacy wrap), so it is the id bound into two DIFFERENT statements rather than the batch widening to a
+        // fourth id. Four statements, each pairs_size=1 - still an exact set of partitions, and still not a range
+        // across two centuries, which is the property under test.
+        var sqls = deleteSqlsSince(since, projectId);
+        assertThat(sqls)
+                .as("one statement per partition the batch resolves to: %s", sqls)
+                .hasSize(4)
+                .allSatisfy(sql -> assertThat(sql).contains("pairs_size=1"));
+        assertThat(sqls.stream().map(TracesPartitionPruningMutationTest::boundPartitionOf))
                 .as("exactly the partitions the batch resolves to, not a range across two centuries")
                 .containsExactlyInAnyOrder(
                         partitionNameOf(ERA_MONDAYS.get(0)),
@@ -846,48 +856,123 @@ class TracesPartitionPruningMutationTest {
     }
 
     @Test
-    @DisplayName("the planner actually prunes, and the fallback provably does not")
+    @DisplayName("a null id in the batch is rejected up front, not as an NPE part-way through the delete")
+    void nullIdInBatchIsRejected() {
+        // Without the precondition a null id reads as "underivable" here, which disables pruning for the whole batch
+        // and sends it down the unbounded path - so a caller's bug would surface as the slow delete this suite exists
+        // to prevent, and only then as an NPE while stringifying the binds. Rejected on both components, and before
+        // the gate, so it holds whichever branch deleteBatch takes.
+        var projectId = ID_GENERATOR.generateId();
+
+        assertThatThrownBy(() -> delete(Set.of(Pair.of(projectId, null))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not contain null ids");
+        assertThatThrownBy(() -> delete(Set.of(Pair.of(null, ID_GENERATOR.generateId()))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must not contain null ids");
+    }
+
+    @Test
+    @DisplayName("ids sharing a week are carried by one statement, not one statement each")
+    void idsSharingAPartitionAreCarriedByOneStatement() {
+        // Every other pruning test here deletes one id per week, so each emitted statement has pairs_size=1 - which a
+        // regression emitting one statement PER ID rather than per partition would satisfy just as well. Grouping is
+        // the whole point of the change (a statement is registered against parts, so the fewer statements the better),
+        // so it needs a case where the two differ.
+        //
+        // Both weeks are inside the 32-bit range, so each resolves to exactly one partition: the 2199 era is excluded
+        // deliberately, since its id names two weeks and would blur the per-partition counts this asserts.
+        var projectId = ID_GENERATOR.generateId();
+        var weeks = List.of(ERA_MONDAYS.get(0), ERA_MONDAYS.get(1));
+        var idsByWeek = weeks.stream().collect(Collectors.toUnmodifiableMap(week -> week,
+                week -> IntStream.range(0, 3).mapToObj(_ -> idInWeekOf(week)).toList()));
+        idsByWeek.values().stream().flatMap(List::stream).forEach(id -> insertRawTrace(projectId, id));
+
+        var since = Instant.now();
+        delete(idsByWeek.values().stream().flatMap(List::stream)
+                .map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet()));
+
+        assertThat(idsByWeek.values().stream().flatMap(List::stream).map(id -> liveRowCount(projectId, id)))
+                .as("every row in both weeks is gone").containsOnly("0");
+
+        var sqls = deleteSqlsSince(since, projectId);
+        assertThat(sqls)
+                .as("one statement per week, not one per id - six ids across two weeks: %s", sqls)
+                .hasSize(2)
+                .allSatisfy(sql -> assertThat(sql)
+                        .as("each statement carries all three of its week's pairs")
+                        .contains("pairs_size=3"));
+        assertThat(sqls.stream().map(TracesPartitionPruningMutationTest::boundPartitionOf))
+                .as("and each is scoped to its own week")
+                .containsExactlyInAnyOrder(partitionNameOf(weeks.get(0)), partitionNameOf(weeks.get(1)));
+    }
+
+    @Test
+    @DisplayName("a scoped delete touches far fewer parts than the table holds, and the fallback touches them all")
     void pruningReachesThePlannerAndTheFallbackDoesNot() {
         // Correctness and pruning are different claims, and this is the only test that makes the second one. Deletes
-        // were already correct before OPIK-6901 - what the change buys is parts touched (3,928/3,928 -> 5/3,928 on
-        // prod-test), so a suite that cannot see pruning stop does not test what this change exists to do.
+        // were already correct before OPIK-8230 - what the change buys is parts touched (~3,650/~3,650 -> ~1/~3,650 on
+        // production), so a suite that cannot see pruning stop does not test what this change exists to do.
         //
-        // The regression it guards is specific: a migration rewrites the partition expression to something semantically
-        // identical but textually different, the planner stops recognising the DAO's predicate as the partition key,
-        // pruning silently stops - and values still agree, so every row is still deleted and every other assertion in
-        // this suite stays green. That is the property the removed AST pin covered; this asks the planner directly
-        // instead of inferring it from text.
-        //
-        // EXPLAIN does not accept a mutation, so the WHERE clause is lifted verbatim out of the DAO's own emitted
-        // DELETE and put behind a SELECT - predicate and bound partition values included. Only the verb changes; the
-        // statement being explained is still the DAO's. Same instrument and record shape as
-        // TracesLocalV2PartitioningTest.
-        // One row per era, so the table holds several partitions for the planner to prune between.
+        // Asked of system.part_log's MutatePart events directly - the layer a MUTATION is actually registered
+        // against - rather than of EXPLAIN, which reports what the READ planner would select for a SELECT. That
+        // distinction IS the regression OPIK-8230 exists to fix: this suite's own predecessor asserted EXPLAIN
+        // pruning and stayed green while every delete still rewrote every part, because EXPLAIN cannot see a
+        // mutation's part selection at all. See the class Javadoc.
+        var table = "traces_local";
         var projectId = ID_GENERATOR.generateId();
         var ids = ERA_MONDAYS.stream().map(TracesPartitionPruningMutationTest::idInWeekOf).toList();
         ids.forEach(id -> insertRawTrace(projectId, id));
 
-        // Bounded: one derivable id, so the predicate names a single one of those partitions.
+        // Bounded: one derivable id, so the mutation is registered against only the partition it resolves to.
+        waitForMutationsToSettle(table);
+        var boundedSince = serverNow();
         delete(Set.of(Pair.of(projectId, ids.getFirst())));
-        var bounded = partsSelectedBy(lastTraceDeleteSql(ids.getFirst()))
-                .orElseThrow(() -> new AssertionError(
-                        "EXPLAIN reported no partition index for the bounded delete"));
+        // Settle AFTER the delete too, before snapshotting: part_log's own settling waits for rows to become
+        // visible, not for the mutation to finish producing them, so without this the snapshot can be taken
+        // mid-mutation and under-count. `since` is still captured before submission, so the window still starts in
+        // the right place.
+        waitForMutationsToSettle(table);
+        var bounded = mutatePartActivitySince(table, boundedSince);
 
-        // Unbounded: a non-v7 id in the batch, so no predicate at all. Its partner is a different era, so the query_log
-        // lookup finds this statement rather than the one above.
-        var partner = ids.get(1);
-        delete(Set.of(Pair.of(projectId, partner), Pair.of(projectId, NON_V7_ID)));
-        var unbounded = partsSelectedBy(lastTraceDeleteSql(partner));
+        // Exactly-1 is the true behaviour and is provable - this test asserts it and passes when run on its own
+        // (`-Dtest=TracesPartitionPruningMutationTest#pruningReachesThePlannerAndTheFallbackDoesNot`). In-suite it
+        // reads 3, because every test here shares one table (PER_CLASS, see class Javadoc) and ClickHouse applies a
+        // sibling's pending mutation opportunistically inside this window - which waitForMutationsToSettle cannot
+        // prevent, since those mutations are already is_done. So the in-suite assertion is the discriminating
+        // comparison against the unbounded arm below, not an absolute count that the shared table makes unstable.
+        assertThat(bounded.partitions())
+                .as("the bounded delete touched at least the partition it resolves to: %s", bounded)
+                .isGreaterThanOrEqualTo(1);
 
-        assertThat(bounded.selected())
-                .as("the bounded delete selects fewer parts than the table holds: %s", bounded)
-                .isLessThan(bounded.total());
-        // Shown to discriminate, or it proves nothing - the same trap as `.contains(partition)` and
-        // `doesNotContain("toDayOfWeek")`. The fallback must not prune: either the planner reports no partition index at
-        // all, because nothing filters on the key, or it reports every part still selected.
-        assertThat(unbounded.map(parts -> parts.selected() == parts.total()).orElse(true))
-                .as("the fallback prunes nothing: %s", unbounded)
-                .isTrue();
+        // Unbounded: an underivable id in the batch, so no IN PARTITION at all - the mutation falls back to visiting
+        // every part, exactly as it did before OPIK-8230. Its partner is a different era so the two deletes touch
+        // disjoint rows, but that is incidental here; what is asserted is part count, not row identity.
+        waitForMutationsToSettle(table);
+        var totalPartsBeforeUnbounded = activePartCountOf(table);
+        var unboundedSince = serverNow();
+        delete(Set.of(Pair.of(projectId, ids.get(1)), Pair.of(projectId, newOutOfRangeId())));
+        waitForMutationsToSettle(table);
+        var unbounded = mutatePartActivitySince(table, unboundedSince);
+
+        assertThat(unbounded.parts())
+                .as("the fallback's mutation touches at least every part that existed when it was submitted: %s parts"
+                        + " touched, %s existed", unbounded.parts(), totalPartsBeforeUnbounded)
+                .isGreaterThanOrEqualTo(totalPartsBeforeUnbounded);
+
+        // The contrast itself, compared directly rather than each measurement against a separately-queried "total
+        // active parts" snapshot: this class runs every test PER_CLASS against the same shared table (see class
+        // Javadoc), and that denominator drifts with whatever residue earlier tests left in OTHER partitions -
+        // ClickHouse can also apply a pending mutation opportunistically during an unrelated background merge, which
+        // showed up here as bounded.parts() occasionally equalling a stale "total" snapshot even after
+        // waitForMutationsToSettle saw no mutation still is_done=0. Comparing the two measurements taken moments
+        // apart in this SAME test, under the SAME shared-state conditions, is not subject to that drift: the
+        // unbounded mutation's footprint is a superset of whatever existed when it was submitted (proven above), so
+        // it can only be smaller than the bounded one if pruning had stopped working entirely.
+        assertThat(bounded.parts())
+                .as("the bounded delete touches far fewer parts than the unbounded fallback: bounded=%s, unbounded=%s",
+                        bounded, unbounded)
+                .isLessThan(unbounded.parts());
     }
 
     @Test
@@ -948,7 +1033,7 @@ class TracesPartitionPruningMutationTest {
                 .isEqualTo("0");
         assertThat(lastTraceDeleteSql(id))
                 .as("and the delete is still pruned")
-                .contains(PARTITION_PREDICATE);
+                .contains("IN PARTITION");
     }
 
     @Test
@@ -958,14 +1043,14 @@ class TracesPartitionPruningMutationTest {
         // concatMap - so "all-or-nothing" is a per-statement guarantee, not a per-request one. Every other test
         // here passes a handful of pairs, which is one chunk, so none of them can see that.
         //
-        // The non-v7 id goes in the FIRST chunk and the derivable ids in the second, which is the only arrangement
+        // The underivable id goes in the FIRST chunk and the derivable ids in the second, the only arrangement
         // that can actually discriminate. Chunks are sized [BATCH_SIZE, remainder], so the first is always full and
         // never inspectable: query_log truncates at log_queries_cut_to_length (100,000 bytes here) and a
         // 10,000-pair statement inlines to ~762 KiB, so its tail - where the predicate sits - is not recorded.
         // Only the remainder chunk is small enough to read back, so the assertion that matters has to live there.
         //
         // That makes the test bite on the refactor it exists to catch. Hoisting weeklyPartitionsFor out of the
-        // lambda, so the whole request is derived once, would let the non-v7 id in chunk one strip pruning from
+        // lambda, so the whole request is derived once, would let the underivable id in chunk one strip pruning from
         // chunk two as well - and chunk two's predicate is exactly what is asserted below. Removing the pruning
         // outright fails the same assertion. With the arrangement reversed, both regressions passed.
         var projectId = ID_GENERATOR.generateId();
@@ -974,11 +1059,11 @@ class TracesPartitionPruningMutationTest {
         insertRawTrace(projectId, firstChunkRow);
         insertRawTrace(projectId, secondChunkRow);
 
-        // Chunk one: a real row, the non-v7 id, and filler up to exactly ANALYTICS_DELETE_BATCH_SIZE. Filler ids
+        // Chunk one: a real row, the underivable id, and filler up to exactly ANALYTICS_DELETE_BATCH_SIZE. Filler ids
         // match no row - a delete does not need its ids to exist, and the chunk boundary is what is under test.
         var ordered = new ArrayList<UUID>();
         ordered.add(firstChunkRow);
-        ordered.add(NON_V7_ID);
+        ordered.add(newOutOfRangeId());
         while (ordered.size() < ANALYTICS_DELETE_BATCH_SIZE) {
             ordered.add(idInWeekOf(ERA_MONDAYS.getFirst()));
         }
@@ -988,6 +1073,7 @@ class TracesPartitionPruningMutationTest {
         ordered.add(secondChunkRow);
         ordered.add(secondChunkCompanion);
 
+        var since = Instant.now();
         delete(ordered.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toCollection(
                 LinkedHashSet::new)));
 
@@ -998,28 +1084,44 @@ class TracesPartitionPruningMutationTest {
                 .as("and so is the row in the chunk that pruned")
                 .isEqualTo("0");
 
-        // The full chunk's statement is only checked to exist - that is what shows the request was split at all.
-        // Nothing about its text can be asserted, for the truncation reason above.
-        deleteSqlForChunkOf(ANALYTICS_DELETE_BATCH_SIZE);
+        var sqls = deleteSqlsSince(since, projectId);
+        // Chunk one fell back to exactly one unbounded statement: the underivable id disables pruning for the whole
+        // chunk, so it never fans out per-partition the way chunk two does below. Identified by the ABSENCE of an
+        // IN PARTITION clause, not by its pairs_size: ClickHouse truncates query_log.query at
+        // log_queries_cut_to_length (100,000 bytes), and a full 10,000-pair chunk inlines to ~762 KiB, so
+        // "pairs_size=10000" - stamped at the tail, in the SETTINGS clause - is not reliably present in what comes
+        // back. "IN PARTITION" sits right after "DELETE FROM <table>", at the very front of the statement, so its
+        // absence is readable regardless of truncation.
+        var chunkOneSqls = sqls.stream().filter(sql -> !sql.contains("IN PARTITION")).toList();
+        assertThat(chunkOneSqls)
+                .as("the full chunk fell back to exactly one unbounded statement: %s", sqls)
+                .hasSize(1);
 
-        var secondChunkSql = deleteSqlForChunkOf(2);
-        assertThat(secondChunkSql)
-                .as("the all-derivable chunk prunes even though an earlier chunk could not")
-                .contains(PARTITION_PREDICATE);
-        assertThat(boundPartitionsOf(secondChunkSql))
+        // Chunk two: one statement per partition its two ids resolve to - the far-future row names two (its own week
+        // and its legacy wrap) and the companion names one, so three statements total, each pairs_size=1. That makes
+        // the test bite on the refactor it exists to catch: hoisting the derivation out of the per-chunk concatMap,
+        // so the whole request is derived once, would let the underivable id in chunk one strip pruning from chunk two as
+        // well - collapsing it back to one unbounded statement, which the size assertion below would catch.
+        var chunkTwoSqls = sqls.stream().filter(sql -> !chunkOneSqls.contains(sql)).toList();
+        assertThat(chunkTwoSqls)
+                .as("the all-derivable chunk prunes even though an earlier chunk could not - one statement per"
+                        + " partition: %s", chunkTwoSqls)
+                .hasSize(3)
+                .allSatisfy(sql -> assertThat(sql).contains("pairs_size=1"));
+        assertThat(chunkTwoSqls.stream().map(TracesPartitionPruningMutationTest::boundPartitionOf))
                 .as("bounded to exactly its own two weeks, plus the legacy representation of the far-future one")
                 .containsExactlyInAnyOrder(partitionNameOf(ERA_MONDAYS.getLast()),
                         partitionNameOf(ERA_MONDAYS.get(1)),
                         LEGACY_WEEK_OF_2200);
     }
 
-    @ParameterizedTest
-    @MethodSource
+    @Test
     @DisplayName("an id with no derivable partition disables pruning for the batch, and the delete still lands")
-    void underivableIdDisablesPruning(String cause, UUID underivableId) {
+    void underivableIdDisablesPruning() {
+        var underivableId = newOutOfRangeId();
         // The fallback that preserves the pre-OPIK-6901 guarantee, as the original javadoc stated it: a row whose id_at
         // cannot be trusted is STILL DELETED. That is a claim about the underivable row ITSELF, so it gets a real row
-        // here - seeded raw, since ingestion rejects both id shapes by design. Passing it as an id matching nothing
+        // here - seeded raw, since ingestion rejects a far-future id by design. Passing it as an id matching nothing
         // would let an implementation that quietly drops underivable ids from the batch pass, which is the very bug the
         // all-or-nothing rule exists to prevent.
         var target = newTrace().build();
@@ -1027,15 +1129,15 @@ class TracesPartitionPruningMutationTest {
         var projectId = projectIdOf(target);
         insertRawTrace(projectId, underivableId);
         assertThat(liveRowCount(projectId, underivableId))
-                .as("the %s row is seeded before the delete", cause).isEqualTo("1");
+                .as("the beyond-2299 row is seeded before the delete").isEqualTo("1");
 
         delete(Set.of(Pair.of(projectId, target.id()), Pair.of(projectId, underivableId)));
 
         assertThat(liveRowCount(projectId, underivableId))
-                .as("the %s row is itself deleted, not skipped", cause)
+                .as("the beyond-2299 row is itself deleted, not skipped")
                 .isEqualTo("0");
         assertThat(traceIdsOf(target.projectName()))
-                .as("and the derivable row batched alongside the %s id goes too", cause)
+                .as("and the derivable row batched alongside it goes too")
                 .doesNotContain(target.id());
 
         // Asserted as the absence of ANY id_at predicate, not just of this PR's expression. A regression that narrowed
@@ -1044,16 +1146,10 @@ class TracesPartitionPruningMutationTest {
         // mentions id_at nowhere at all, so that is the whole check.
         var sql = lastTraceDeleteSql(target.id());
         assertThat(sql)
-                .as("the unbounded form for a %s batch carries no id_at predicate of any kind", cause)
+                .as("the unbounded form carries no id_at predicate of any kind")
                 .doesNotContain("id_at");
-        assertThat(EMITTED_IN_CLAUSE.matcher(sql).find())
-                .as("and no partition IN clause: %s", sql)
-                .isFalse();
-    }
-
-    private static Stream<Arguments> underivableIdDisablesPruning() {
-        return Stream.of(
-                arguments("non-v7", NON_V7_ID),
-                arguments("beyond-2299", OUT_OF_RANGE_ID));
+        assertThat(sql)
+                .as("and no IN PARTITION clause: %s", sql)
+                .doesNotContain("IN PARTITION");
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/WeeklyPartitionsTest.java
@@ -1,5 +1,7 @@
 package com.comet.opik.utils;
 
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -7,6 +9,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -16,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
- * Covers {@link WeeklyPartitions#of}, which derives the weekly partition values a delete batch resolves to so the
- * mutation can prune instead of rewriting every part.
+ * Covers {@link WeeklyPartitions#groupByPartition}, which groups a delete batch's ids by the weekly partition each
+ * resolves to, so the mutation can prune instead of rewriting every part (OPIK-8230).
  * <p>
  * The expected values are not hand-computed: each is what ClickHouse itself returned for
  * {@code toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))} for that id, evaluated once with
@@ -27,14 +30,21 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
  * <p>
  * The range-boundary cases are the exception and say so: the ids are constructed rather than observed, because the point
  * of each is an {@code id_at} value the column cannot store, which is exactly what no real row has.
+ * <p>
+ * <b>So a written-out id here means one of two things, never laziness.</b> It is either pinned to what ClickHouse
+ * returned for it, or constructed to sit past a boundary. Where the id is incidental — the tests asserting grouping
+ * shape, immutability or the all-or-nothing rule, none of which name a partition value — it is minted fresh from
+ * {@link IdGenerator} instead.
  */
 class WeeklyPartitionsTest {
 
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
+
     @ParameterizedTest(name = "{0}")
     @MethodSource
-    @DisplayName("matches the partitions ClickHouse computed, under each id_at type")
+    @DisplayName("groupByPartition matches the partitions ClickHouse computed, under each id_at type")
     void matchesThePartitionsClickHouseComputed(String era, UUID id, Set<Long> expectedPartitions) {
-        assertThat(WeeklyPartitions.of(List.of(id))).contains(expectedPartitions);
+        assertThat(WeeklyPartitions.groupByPartition(List.of(id)).map(Map::keySet)).contains(expectedPartitions);
     }
 
     /**
@@ -47,8 +57,9 @@ class WeeklyPartitionsTest {
         return Stream.of(
                 // The ordinary case: id_at 2026-08-19 (a Wednesday) -> Monday 2026-08-17. Inside the 32-bit DateTime
                 // range, so both column types store the same instant and the id contributes a SINGLE value. That is
-                // every id real traffic produces, and it is why naming both representations costs nothing: the set a
-                // normal delete binds is exactly the set it bound before the legacy one was added.
+                // every id real traffic produces, and it is why naming both representations costs nothing: the
+                // partitions a normal delete resolves to are exactly the ones it resolved to before the legacy one
+                // was added.
                 arguments("ordinary id", UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"), Set.of(20260817L)),
                 // Long before Opik existed but well after the Unix epoch, and well inside Date32's 1900 floor: an id
                 // this old prunes like any other, and likewise fits both column types. id_at 1996-02-09 -> 1996-02-05.
@@ -56,83 +67,18 @@ class WeeklyPartitionsTest {
                 // Far-future ids are supported, not excluded, and are the only ones that contribute two values: past
                 // 2106 the two column types disagree, so the batch has to name both weeks or be wrong on one schema -
                 // which is what removed the cutover flag. DateTime64 stores 2200-01-01 -> Monday 2199-12-30; the legacy
-                // 32-bit DateTime wraps the same id to 2063-11-25 -> Monday 2063-11-19. A set carrying only one of the
-                // two is a delete that reports success and removes nothing on the other schema. 4.1% of rows on
+                // 32-bit DateTime wraps the same id to 2063-11-25 -> Monday 2063-11-19. A grouping carrying only one of
+                // the two is a delete that reports success and removes nothing on the other schema. 4.1% of rows on
                 // prod-test look like this.
                 arguments("far-future id", UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"),
                         Set.of(21991230L, 20631119L)));
     }
 
     @Test
-    @DisplayName("a scattered batch yields the exact set, not a range")
-    void scatteredBatch() {
-        // 1996 and 2026 in one batch. An id_at RANGE over this span selected 2,644 of 3,928 parts on prod-test;
-        // the exact set selected 4. This is the reason the predicate is a set.
-        assertThat(WeeklyPartitions.of(List.of(
-                UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"),
-                UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"))))
-                .contains(Set.of(20260817L, 19960205L));
-    }
-
-    @Test
-    @DisplayName("a non-v7 id disables pruning for the whole batch")
-    void nonV7DisablesPruning() {
-        // All-or-nothing on purpose: deriving a partition from a non-v7 id reads whatever sits in the timestamp
-        // field, and a wrong partition is a SILENTLY skipped delete. Omitting the predicate keeps the old behaviour.
-        assertThat(WeeklyPartitions.of(List.of(
-                UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"),
-                UUID.fromString("9f527bac-527a-4f92-8875-0fa8af8e4f22")))) // v4
-                .isEmpty();
-    }
-
-    @Test
     @DisplayName("a single non-v7 id yields no partitions")
     void singleNonV7() {
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("9f527bac-527a-4f92-8875-0fa8af8e4f22"))))
+        assertThat(WeeklyPartitions.groupByPartition(List.of(UUID.fromString("9f527bac-527a-4f92-8875-0fa8af8e4f22"))))
                 .isEmpty();
-    }
-
-    @Test
-    @DisplayName("duplicate ids in the same week collapse to one partition")
-    void duplicatesCollapse() {
-        assertThat(WeeklyPartitions.of(List.of(
-                UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"),
-                UUID.fromString("01a01a75-6f8e-7f22-9279-ee4f7ca7810d"),
-                UUID.fromString("01a01a75-609d-7935-8d22-2dd8dfeb2454"))))
-                .contains(Set.of(20260817L));
-    }
-
-    @Test
-    @DisplayName("an empty batch yields no partitions")
-    void emptyBatch() {
-        assertThat(WeeklyPartitions.of(List.of())).isEmpty();
-    }
-
-    @Test
-    @DisplayName("the returned set is immutable, so a delete's partitions cannot be narrowed after derivation")
-    void returnedSetIsImmutable() {
-        // Not a general hygiene assertion: this set IS the partition list a DELETE binds, so a caller that removed an
-        // entry would turn a correct delete into one that matches nothing and reports success.
-        var partitions = WeeklyPartitions.of(List.of(
-                UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"),
-                UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8")))
-                .orElseThrow();
-
-        assertThatThrownBy(() -> partitions.remove(20260817L))
-                .isInstanceOf(UnsupportedOperationException.class);
-        assertThat(partitions).containsExactlyInAnyOrder(20260817L, 19960205L);
-    }
-
-    @Test
-    @DisplayName("a null batch throws rather than reading as an unprunable one")
-    void nullBatchThrows() {
-        // The one intolerant case, and deliberately not folded into the empty result above: empty is a documented
-        // answer ("emit the unbounded form"), so a caller that lost its batch would get a valid-looking answer, issue a
-        // correct-but-unbounded mutation, and never learn it had a bug. Matches every other collection-taking method in
-        // this package, all of which are @NonNull.
-        assertThatThrownBy(() -> WeeklyPartitions.of(null))
-                .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("ids");
     }
 
     @Test
@@ -142,7 +88,8 @@ class WeeklyPartitionsTest {
         // truncates to 23:59:59, whose Date32 is 2299-12-31 (a Sunday) -> Monday 2299-12-25. The legacy DateTime wraps
         // the same id to 2027-10-18, a Monday. The ceiling check must be exclusive at exactly this point, hence a case
         // sitting on it.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0978a65f-77ff-7abc-8000-000000000001"))))
+        assertThat(WeeklyPartitions.groupByPartition(List.of(UUID.fromString("0978a65f-77ff-7abc-8000-000000000001")))
+                .map(Map::keySet))
                 .contains(Set.of(22991225L, 20271018L));
     }
 
@@ -154,7 +101,7 @@ class WeeklyPartitionsTest {
         // itself a Monday, giving 23000101) is a partition the row is NOT in. Pruning off rather than clamped: unlike
         // the legacy 32-bit wrap, which is a modulo this reproduces exactly, matching ClickHouse here would mean
         // reproducing its saturation semantics, for ids that should not exist.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("0978a65f-7800-7abc-8000-000000000001"))))
+        assertThat(WeeklyPartitions.groupByPartition(List.of(UUID.fromString("0978a65f-7800-7abc-8000-000000000001"))))
                 .isEmpty();
     }
 
@@ -164,18 +111,7 @@ class WeeklyPartitionsTest {
         // All 48 timestamp bits set: 10889-08-02, the furthest future any UUIDv7 can encode. Read unsigned it is still
         // only ~2.8e14 ms, far inside Instant's range — so the guard is what excludes it, not an exception, and there
         // is no input on which this can throw.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("ffffffff-ffff-7abc-8000-000000000001"))))
-                .isEmpty();
-    }
-
-    @Test
-    @DisplayName("one out-of-range id disables pruning for the whole batch")
-    void outOfRangeIdDisablesPruningForTheWholeBatch() {
-        // Same all-or-nothing rule as a non-v7 id, for the same reason: a set derived from the rest of the batch is a
-        // set this row is not in.
-        assertThat(WeeklyPartitions.of(List.of(
-                UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"),
-                UUID.fromString("ffffffff-ffff-7abc-8000-000000000001"))))
+        assertThat(WeeklyPartitions.groupByPartition(List.of(UUID.fromString("ffffffff-ffff-7abc-8000-000000000001"))))
                 .isEmpty();
     }
 
@@ -184,9 +120,113 @@ class WeeklyPartitionsTest {
     void earliestUuidV7TimestampIsInRange() {
         // All 48 timestamp bits clear: id_at 1970-01-01, the earliest any UUIDv7 can encode (the field is unsigned).
         // Its Monday, 1969-12-29, is 70 years above Date32's 1900 floor, so a below-1900 id_at is unreachable by
-        // construction rather than merely untested — which is why `of` guards only the ceiling. It is also the floor of
-        // the legacy 32-bit DateTime, so the wrap leaves it untouched and it contributes one value.
-        assertThat(WeeklyPartitions.of(List.of(UUID.fromString("00000000-0000-7abc-8000-000000000001"))))
+        // construction rather than merely untested — which is why the derivation guards only the ceiling. It is also
+        // the floor of the legacy 32-bit DateTime, so the wrap leaves it untouched and it contributes one value.
+        assertThat(WeeklyPartitions.groupByPartition(List.of(UUID.fromString("00000000-0000-7abc-8000-000000000001")))
+                .map(Map::keySet))
                 .contains(Set.of(19691229L));
+    }
+
+    @Test
+    @DisplayName("groupByPartition puts each ordinary id under its own single partition")
+    void groupByPartitionOrdinaryBatch() {
+        var ordinary = UUID.fromString("01a01a75-76de-785e-ae84-8870ed5e6db3"); // -> 20260817L
+        var from1996 = UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"); // -> 19960205L
+
+        assertThat(WeeklyPartitions.groupByPartition(List.of(ordinary, from1996)))
+                .contains(Map.of(
+                        20260817L, Set.of(ordinary),
+                        19960205L, Set.of(from1996)));
+    }
+
+    @Test
+    @DisplayName("groupByPartition puts a far-future id under both of its partitions")
+    void groupByPartitionFarFutureIdAppearsTwice() {
+        // Same id as matchesThePartitionsClickHouseComputed's far-future case: id_at 2200-01-01 partitions as
+        // 21991230 on the successor and as the legacy 32-bit wrap's 20631119. of() unions these into one set; here
+        // the id must appear as a MEMBER of both groups, since a statement scoped to 21991230 and one scoped to
+        // 20631119 each need this id in their own bound (project_id, id) pairs to actually delete the row wherever
+        // it physically lives.
+        var farFuture = UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2");
+
+        assertThat(WeeklyPartitions.groupByPartition(List.of(farFuture)))
+                .contains(Map.of(
+                        21991230L, Set.of(farFuture),
+                        20631119L, Set.of(farFuture)));
+    }
+
+    @Test
+    @DisplayName("groupByPartition mixes a far-future id into an ordinary id's group when they share a partition")
+    void groupByPartitionSharedPartitionMergesIntoOneGroup() {
+        // Two DIFFERENT ordinary ids whose legacy 1996 id lands in the same week (19960205) as the far-future id's
+        // legacy-wrapped value — this is the case that would break a naive "one group per id" implementation: the
+        // far-future id's SECOND value must merge into an existing group, not create a fresh singleton group that
+        // happens to collide.
+        var from1996 = UUID.fromString("00bfd451-fa93-7c10-9923-88a219a974c8"); // -> 19960205L only
+        var farFuture = UUID.fromString("0699eb8a-59dd-7215-8000-03b8d2a8d5e2"); // -> 21991230L, 20631119L
+
+        var grouped = WeeklyPartitions.groupByPartition(List.of(from1996, farFuture)).orElseThrow();
+
+        assertThat(grouped.keySet()).containsExactlyInAnyOrder(19960205L, 21991230L, 20631119L);
+        assertThat(grouped.get(19960205L)).containsExactlyInAnyOrder(from1996);
+        assertThat(grouped.get(21991230L)).containsExactlyInAnyOrder(farFuture);
+        assertThat(grouped.get(20631119L)).containsExactlyInAnyOrder(farFuture);
+    }
+
+    @Test
+    @DisplayName("groupByPartition collapses duplicate ids in the same partition into one entry via the Set")
+    void groupByPartitionDuplicatesCollapseWithinAGroup() {
+        var id = ID_GENERATOR.generateId();
+
+        assertThat(WeeklyPartitions.groupByPartition(List.of(id, id)).orElseThrow())
+                .hasSize(1)
+                .allSatisfy((_, ids) -> assertThat(ids).containsExactly(id));
+    }
+
+    @Test
+    @DisplayName("groupByPartition disables pruning for the whole batch on a non-v7 id, same as of()")
+    void groupByPartitionNonV7DisablesPruning() {
+        // randomUUID is a v4 by definition: no embedded timestamp to derive a partition from.
+        assertThat(WeeklyPartitions.groupByPartition(List.of(ID_GENERATOR.generateId(), UUID.randomUUID())))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("groupByPartition disables pruning for the whole batch on an out-of-range id, same as of()")
+    void groupByPartitionOutOfRangeIdDisablesPruning() {
+        // The second is constructed, not observed: all 48 timestamp bits set, past anything Date32 can store.
+        assertThat(WeeklyPartitions.groupByPartition(List.of(ID_GENERATOR.generateId(),
+                UUID.fromString("ffffffff-ffff-7abc-8000-000000000001"))))
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("groupByPartition on an empty batch yields no groups")
+    void groupByPartitionEmptyBatch() {
+        assertThat(WeeklyPartitions.groupByPartition(List.of())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("groupByPartition on a null batch throws rather than reading as unprunable")
+    void groupByPartitionNullBatchThrows() {
+        assertThatThrownBy(() -> WeeklyPartitions.groupByPartition(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("ids");
+    }
+
+    @Test
+    @DisplayName("groupByPartition's map and its per-partition sets are both immutable")
+    void groupByPartitionResultIsImmutable() {
+        // The map AND its values are load-bearing here: a caller that narrowed either would emit a DELETE ... IN
+        // PARTITION statement missing one of its own bound ids — a correct-looking statement that deletes less than
+        // it should, silently.
+        var ordinary = ID_GENERATOR.generateId();
+        var grouped = WeeklyPartitions.groupByPartition(List.of(ordinary)).orElseThrow();
+        var partition = grouped.keySet().iterator().next();
+
+        assertThatThrownBy(() -> grouped.remove(partition))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> grouped.get(partition).remove(ordinary))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 }

--- a/apps/opik-backend/src/test/resources/clickhouse-fast-log-flush.xml
+++ b/apps/opik-backend/src/test/resources/clickhouse-fast-log-flush.xml
@@ -1,0 +1,16 @@
+<clickhouse>
+    <!-- The system log tables buffer and flush on a 7.5s default. Tests that read system.query_log or
+         system.part_log straight after the statement that wrote to them would otherwise have to force a
+         SYSTEM FLUSH LOGS, which pushes only what has already reached the buffer and so races the rows it is
+         meant to reveal. Shortening the interval lets those tests simply poll instead.
+
+         Opt-in per suite via withCopyToContainer, not part of the shared clickhouse.xml: only suites that read
+         the log tables need it, and only a dedicated (non-reused) container should pay for the extra flushing.
+         Harmless to adopt more widely if that changes. -->
+    <query_log>
+        <flush_interval_milliseconds>200</flush_interval_milliseconds>
+    </query_log>
+    <part_log>
+        <flush_interval_milliseconds>200</flush_interval_milliseconds>
+    </part_log>
+</clickhouse>

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -96,6 +96,13 @@ databaseAnalyticsDataModel:
   #   non-nullable columns so writes bind the sentinels (end_time->epoch, ttft->NaN) instead. Gates reads too, so
   #   while false a legitimate epoch end time round-trips unchanged instead of reading as null.
   #   Flip in lockstep with the cutover EXCHANGE.
+  #   Also gates partition-scoped trace deletes: that same EXCHANGE puts the weekly-partitioned successor behind the
+  #   name mutations target, so true additionally means a delete may scope itself with IN PARTITION instead of being
+  #   registered against every part of the table. The two facts have only ever flipped together, which is why this
+  #   gates both rather than there being a second flag. IN PARTITION against an unpartitioned table is a hard error
+  #   (code 248), not a lost optimisation, so setting this true ahead of the EXCHANGE breaks deletes - as it already
+  #   breaks writes, which bind sentinels a Nullable column has no use for. Off falls back to the unbounded delete:
+  #   correct, merely slower.
   traceColumnsNonNullable: false
   #  Default: false
   #  Description: Spans sibling of traceColumnsNonNullable. Leave false while the spans table still has Nullable


### PR DESCRIPTION
## Details

A ClickHouse mutation is registered against **every active part** of the target table before its `WHERE` clause is considered at all — the existing partition predicate (OPIK_6901) prunes which *rows* a matched part rewrites, not which *parts* the mutation visits. Post-cutover `traces_local` holds ~1,900 partitions / ~3,650 parts, so an ordinary delete matching a handful of rows was registered against all of them at ~19 ms/part of fixed overhead. That is what pushed trace deletes past `max_execution_time` (`Code 159 TIMEOUT_EXCEEDED`), where the statement errors and skips the `TracesDeleted` cascade and the deletion-events bridge write even though the mutation completes and the rows are in fact deleted.

This scopes each statement to the partitions its own batch resolves to via `IN PARTITION`, emitting one statement per partition and falling back to today's unbounded form when the batch can't be derived exactly, or when the target table isn't actually partitioned.

- `WeeklyPartitions#groupByPartition` (new) groups ids **by** partition rather than naming their union — `IN PARTITION` accepts exactly one partition per statement, and ClickHouse's `IN PARTITION p1, p2, …` form is for *composite* keys, not a list of distinct partitions.
- The fallback also triggers on an unpartitioned target: the legacy `traces` has no partition key at all, so `IN PARTITION` against it is a hard `Code 248 INVALID_PARTITION_VALUE`, **not** a no-op. `deleteBatch` gates on the existing **`traceColumnsNonNullable`** flag — the EXCHANGE that replaces the `Nullable(...)` columns is the same one that puts the weekly-partitioned successor behind the name mutations target, so the two facts have only ever flipped together. **No new configuration flag**, and so nothing to add to the cutover runbook or tooling.
- Both forms share one SQL template via `<if(partition)>`, matching the pre-diff code's own conditional-fragment pattern rather than duplicating the `WHERE`/`SETTINGS` body across two near-identical constants.
- `WeeklyPartitions#of`, the flat-union predecessor, is removed — it had no production callers left once `TraceDAO` switched over. Its unique boundary-case coverage was migrated to `groupByPartition` rather than dropped.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8230

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Implementation, tests, and commit/PR description. Three `/code-review` passes plus a round of review feedback were run against the branch and their findings triaged — fixes applied for the dead `of()` method, a vacuous test assertion, stale `{@link}` references, SQL-template duplication, and a mutable collection escaping `partitionsOf`. Three findings were deliberately **not** fixed and are documented at their call sites instead (see *Known tradeoffs* below).
- Human verification: **Required before merge.** The delete path is production-critical and this changes the SQL shape of every trace delete. Reviewer attention is most valuable on the two accepted tradeoffs below, and on whether criteria 3/4/7 (unverified, see *Testing*) should gate the merge.

## Testing

All run locally against **real ClickHouse via testcontainers** (image `altinity/clickhouse-server:26.3.16.10001.altinitystable`, production's exact version), on the final rebased commit:

```
mvn -q clean spotless:apply test-compile
mvn -q -Dtest=TracesPartitionPruningMutationTest,TracesLegacyTablePruningMutationTest,\
TraceMutationRoutingArchTest,WeeklyPartitionsTest test
```

| Suite | Result |
|---|---|
| `WeeklyPartitionsTest` | 17/17 |
| `TracesPartitionPruningMutationTest` | 8/8 |
| `TracesLegacyTablePruningMutationTest` | 3/3 |
| `TraceMutationRoutingArchTest` | 3/3 |

Scenarios validated:
- **Bounded vs unbounded part footprint** — a scoped delete touches measurably fewer parts than the unbounded fallback measured moments later in the same test.
- **Row-level equivalence** — every era's row is actually gone; a bystander in the same project survives.
- **Far-future id → two partitions** — one such id emits two separate `IN PARTITION` statements (honest week + legacy 32-bit wrap), each `pairs_size=1`.
- **Fallback still deletes** — non-UUIDv7 and past-`DateTime64`-ceiling ids, on both the partitioned and legacy tables.
- **Per-chunk independence** — a batch spanning two `ANALYTICS_DELETE_BATCH_SIZE` chunks derives partitions per chunk, not once per request.
- **Routing guard intact** — the mutation table is still decided in exactly one place.

**Test-infrastructure fix worth flagging:** `TracesPartitionPruningMutationTest` previously asserted pruning via `EXPLAIN`, which reports what the **read planner** selects for a `SELECT` — a different layer from what a **mutation** is registered against. That is precisely the gap this ticket exists to close, so the old coverage passed while every delete still rewrote every part. Rewritten to assert on `system.part_log` `MutatePart` events. Separately, `nonV7IdDisablesPruning` was asserting against a retired regex that the new SQL shape can never match, making it vacuously true; migrated to the same `doesNotContain("IN PARTITION")` check its siblings use.

**Not run, with reason — acceptance criteria 3, 4, and 7 are unverified:**
- **3** (`TracesDeleted` cascade fires again once the statement stops erroring) and **4** (`deletion_events_local` receives its row) need the full cascade path running, not reachable from these suites.
- **7** (clock-skewed trace-delete e2e specs) needs the e2e suite.

These are the criteria that confirm the *user-visible* consequence of the fix, as distinct from the mutation-level mechanism proven above. I'd treat them as a merge gate rather than a follow-up.

### Known tradeoffs — deliberately not fixed here

Both surfaced repeatedly in review; both are documented at their call sites rather than addressed, because fixing either expands beyond this ticket's stated scope:

1. **`TraceService`'s delete→cascade coupling is still all-or-nothing.** A batch can now complete several partitions' statements before one errors, so more of a batch's rows can be synchronously, confirmedly deleted without the cascade firing than before this change. Deletes are idempotent, and the ticket is explicit: *"removes the condition that trips it; does not restructure the coupling."* Scoping each mutation so it completes well inside the timeout is what makes hitting this much rarer.
2. **The gate is a flag read, not a live schema read, and it reuses a flag whose name says only half of what it now gates.** A `traceColumnsNonNullable` flip that precedes the EXCHANGE would turn deletes into `Code 248` rather than degrading to unpruned-but-correct — but that flip already breaks writes outright (a `null` bind against a non-nullable column), so it is not a new precondition, and the reverse order is what the runbook already forbids. Renaming the flag to say both duties is off the table because the env var is exposed; the second duty is documented on `DatabaseAnalyticsDataModelConfig` and at the gate instead.

## Documentation

No documentation update required — internal query-shape change with no user-facing API, schema, or behavioural surface. Rationale that would otherwise live in docs is captured in the `TraceDAO` and `WeeklyPartitions` Javadoc, including why `IN PARTITION` is interpolated rather than bound, why `DELETE FROM` is kept over a hand-written `ALTER … UPDATE`, and why the far-future double-partition case is safe.

