### PR TITLE
[NA] [BE] fix: recalculate the estimated cost on bulk span update

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1768,8 +1768,10 @@ public class SpanDAO {
                 <if(metadata)> :metadata <else> s.metadata <endif> as metadata,
                 <if(model)> :model <else> s.model <endif> as model,
                 <if(provider)> :provider <else> s.provider <endif> as provider,
-                <if(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> s.total_estimated_cost <endif> as total_estimated_cost,
-                <if(total_estimated_cost_version)> :total_estimated_cost_version <else> s.total_estimated_cost_version <endif> as total_estimated_cost_version,
+                <if(recalculated_cost)> if(s.total_estimated_cost > 0 AND s.total_estimated_cost_version = '', s.total_estimated_cost, toDecimal128(:total_estimated_cost, 12))
+                <elseif(total_estimated_cost)> toDecimal128(:total_estimated_cost, 12) <else> s.total_estimated_cost <endif> as total_estimated_cost,
+                <if(recalculated_cost)> if(s.total_estimated_cost > 0 AND s.total_estimated_cost_version = '', s.total_estimated_cost_version, :total_estimated_cost_version)
+                <elseif(total_estimated_cost_version)> :total_estimated_cost_version <else> s.total_estimated_cost_version <endif> as total_estimated_cost_version,
                 """
             + TagOperations.tagUpdateFragment("s.tags")
             + """
@@ -3218,9 +3220,16 @@ public class SpanDAO {
         Optional.ofNullable(spanUpdate.errorInfo())
                 .ifPresent(errorInfo -> template.add("error_info", JsonUtils.readTree(errorInfo).toString()));
 
-        if (spanUpdate.totalEstimatedCost() != null) {
+        boolean shouldRecalculateEstimatedCost = spanUpdate.totalEstimatedCost() == null
+                && isUpdateCostRecalculationAvailable(spanUpdate);
+        if (spanUpdate.totalEstimatedCost() != null || shouldRecalculateEstimatedCost) {
             template.add("total_estimated_cost", "total_estimated_cost");
             template.add("total_estimated_cost_version", "total_estimated_cost_version");
+        }
+        if (shouldRecalculateEstimatedCost) {
+            // Bulk doesn't load the rows it updates, so a cost the user set manually is kept by the
+            // query itself, the way isManualCost keeps it on the single span path.
+            template.add("recalculated_cost", "recalculated_cost");
         }
         Optional.ofNullable(spanUpdate.ttft())
                 .ifPresent(ttft -> template.add("ttft", ttft));
@@ -3268,6 +3277,11 @@ public class SpanDAO {
         if (spanUpdate.totalEstimatedCost() != null) {
             statement.bind("total_estimated_cost", spanUpdate.totalEstimatedCost().toString());
             statement.bind("total_estimated_cost_version", "");
+        } else if (isUpdateCostRecalculationAvailable(spanUpdate)) {
+            BigDecimal estimatedCost = CostService.calculateCost(spanUpdate.model(), spanUpdate.provider(),
+                    spanUpdate.usage(), spanUpdate.metadata());
+            statement.bind("total_estimated_cost", estimatedCost.toString());
+            statement.bind("total_estimated_cost_version", ESTIMATED_COST_VERSION);
         }
         Optional.ofNullable(spanUpdate.ttft())
                 .ifPresent(ttft -> statement.bind("ttft", ttft));

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansBatchUpdateResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/SpansBatchUpdateResourceTest.java
@@ -20,6 +20,7 @@ import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.domain.SpanType;
+import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -387,6 +388,113 @@ class SpansBatchUpdateResourceTest {
             assertThat(span.errorInfo().exceptionType()).isEqualTo("ValidationError");
             assertThat(span.errorInfo().message()).isEqualTo("Invalid input");
             assertThat(span.ttft()).isEqualTo(123.45);
+        }
+    }
+
+    @Nested
+    @DisplayName("Batch Update Cost:")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class BatchUpdateCost {
+
+        private static final String MODEL = "gpt-4o-2024-05-13";
+        private static final String PROVIDER = "openai";
+        private static final Map<String, Integer> USAGE = Map.of("prompt_tokens", 1000, "completion_tokens", 500);
+
+        private UUID traceId;
+
+        @BeforeEach
+        void setUp() {
+            var trace = podamFactory.manufacturePojo(Trace.class).toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .feedbackScores(null)
+                    .build();
+            traceId = traceResourceClient.createTrace(trace, API_KEY, TEST_WORKSPACE);
+        }
+
+        @Test
+        @DisplayName("Success: batch update recalculates the cost when the model becomes priceable")
+        void batchUpdate__whenModelBecomesPriceable__thenRecalculateCost() {
+            var id = createUnpricedSpan(null);
+
+            batchUpdate(id, SpanUpdate.builder()
+                    .projectName(DEFAULT_PROJECT)
+                    .traceId(traceId)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .usage(USAGE)
+                    .build());
+
+            var updatedSpan = spanResourceClient.getById(id, TEST_WORKSPACE, API_KEY);
+            assertThat(updatedSpan.totalEstimatedCost())
+                    .isEqualByComparingTo(CostService.calculateCost(MODEL, PROVIDER, USAGE, null));
+            assertThat(updatedSpan.totalEstimatedCostVersion()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("Success: batch update keeps a manually set cost")
+        void batchUpdate__whenSpanHasManualCost__thenKeepManualCost() {
+            var manualCost = new BigDecimal("0.5");
+            var id = createUnpricedSpan(manualCost);
+
+            batchUpdate(id, SpanUpdate.builder()
+                    .projectName(DEFAULT_PROJECT)
+                    .traceId(traceId)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .usage(USAGE)
+                    .build());
+
+            var updatedSpan = spanResourceClient.getById(id, TEST_WORKSPACE, API_KEY);
+            assertThat(updatedSpan.totalEstimatedCost()).isEqualByComparingTo(manualCost);
+            assertThat(updatedSpan.totalEstimatedCostVersion()).isNull();
+        }
+
+        @Test
+        @DisplayName("Success: batch update without a priceable model keeps the stored cost")
+        void batchUpdate__whenUpdateIsNotPriceable__thenKeepStoredCost() {
+            var span = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .traceId(traceId)
+                    .parentSpanId(null)
+                    .model(MODEL)
+                    .provider(PROVIDER)
+                    .usage(USAGE)
+                    .totalEstimatedCost(null)
+                    .feedbackScores(null)
+                    .build();
+            var id = spanResourceClient.createSpan(span, API_KEY, TEST_WORKSPACE);
+            var storedCost = spanResourceClient.getById(id, TEST_WORKSPACE, API_KEY).totalEstimatedCost();
+
+            batchUpdate(id, SpanUpdate.builder()
+                    .projectName(DEFAULT_PROJECT)
+                    .traceId(traceId)
+                    .name("updated-name")
+                    .build());
+
+            var updatedSpan = spanResourceClient.getById(id, TEST_WORKSPACE, API_KEY);
+            assertThat(updatedSpan.totalEstimatedCost()).isEqualByComparingTo(storedCost);
+        }
+
+        private UUID createUnpricedSpan(BigDecimal manualCost) {
+            var span = podamFactory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(DEFAULT_PROJECT)
+                    .traceId(traceId)
+                    .parentSpanId(null)
+                    .model(null)
+                    .provider(null)
+                    .usage(null)
+                    .totalEstimatedCost(manualCost)
+                    .feedbackScores(null)
+                    .build();
+            return spanResourceClient.createSpan(span, API_KEY, TEST_WORKSPACE);
+        }
+
+        private void batchUpdate(UUID id, SpanUpdate update) {
+            spanResourceClient.batchUpdateSpans(SpanBatchUpdate.builder()
+                    .ids(Set.of(id))
+                    .update(update)
+                    .mergeTags(false)
+                    .build(), API_KEY, TEST_WORKSPACE);
         }
     }
 }


### PR DESCRIPTION
## Details
`PATCH /v1/private/spans/batch` only wrote the cost columns when the client sent `total_estimated_cost`. The single-span update recomputes it through `CostService` when `model`, `provider` or `usage` change and no manual cost is given, so a span first written without a priceable model kept a zero or stale cost after a batch correction and under-reported project and experiment spend. This mirrors that branch into `newBulkUpdateTemplate` / `bindBulkUpdateParams`.

- Bulk does not read the rows it updates, so the query itself keeps a manually set cost (`total_estimated_cost > 0 AND total_estimated_cost_version = ''`) rather than going through `isManualCost`.
- An explicit `total_estimated_cost` in the batch payload still wins and is still stored as manual (blank version).

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8098
- OPIK-

## AI-WATERMARK

AI-WATERMARK: [no]

- If yes:
  - Tools:
  - Model(s):
  - Scope:
  - Human verification:

## Testing
Run from `apps/opik-backend` on JDK 25, local Docker Testcontainers.

- `mvn -B test -Dtest=SpansBatchUpdateResourceTest` -> 9 tests, 0 failures.
- `mvn -B test -Dtest="SpansResourceTest,SpansBatchUpdateResourceTest,SpanServiceImplTest,FindSpansResourceTest,SpansLocalV2TableTest"` -> 1878 tests, 0 failures.
- `mvn spotless:check` -> clean.

Scenarios, all in a new `BatchUpdateCost` nested class:

- Batch update with a priceable model + usage and no cost -> cost recalculated and stored with the estimated version. Fails on `main` with `Expecting actual not to be null`.
- Span with a manually set cost, same batch update -> manual cost kept, version stays blank.
- Batch update with no priceable model -> stored cost untouched.

The existing `batchUpdate__updateAllFields__success` covers an explicit `total_estimated_cost` in the batch payload and still passes.

Not run: the full backend suite. CI splits it into 16 jobs; I ran every span test class instead. No screen recording.

## Documentation
None needed. No API shape change.
