### PR TITLE
[OPIK-8242] fix: price models with compact YYYYMMDD date suffixes

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -71,7 +71,12 @@ public class CostService {
     public static final String MODEL_PRICES_FILE = "model_prices_and_context_window.json";
     public static final String MODEL_PRICES_OVERRIDES_FILE = "model_prices_overrides.json";
     private static final String BEDROCK_PROVIDER = "bedrock";
-    private static final String DATE_SUFFIX_PATTERN = "-\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$";
+    // Both hyphen-separated (2025-12-17) and compact (20251217) date suffixes. Anthropic ships
+    // compact dates on every dated model id (claude-haiku-4-5-20251001), so without the optional
+    // separators a compact-dated name only ever prices when it is present verbatim in the price
+    // table -- any name needing normalization (dot form, an `alias_of` entry, or a release the
+    // daily LiteLLM sync has not picked up yet) silently fell through to a zero cost.
+    private static final String DATE_SUFFIX_PATTERN = "-\\d{4}-?(0[1-9]|1[0-2])-?(0[1-9]|[12]\\d|3[01])$";
     private static final String VERSION_SUFFIX_PATTERN = ":\\d+$";
     private static final Map<String, BiFunction<ModelPrice, Map<String, Integer>, BigDecimal>> PROVIDERS_CACHE_COST_CALCULATOR = Map
             .ofEntries(
@@ -276,7 +281,11 @@ public class CostService {
      * This handles cases where providers return dated model names (e.g., "gpt-5.2-2025-12-17")
      * but the pricing database only has the base model name (e.g., "gpt-5.2").
      *
-     * Date patterns recognized: YYYY-MM-DD (e.g., "2025-12-17") at the end of the model name.
+     * Date patterns recognized at the end of the model name: YYYY-MM-DD (e.g., "2025-12-17")
+     * and the compact YYYYMMDD form (e.g., "20251217") that Anthropic uses for every dated
+     * model id. The separators are optional independently, so partially-separated forms are
+     * tolerated too; month and day are still range-checked, so a plain 8-digit build number
+     * such as "-99999999" is left alone.
      *
      * @param modelName The model name
      * @return Lowercase model name with date suffix removed if present, otherwise lowercase original name

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -371,6 +372,68 @@ class CostServiceTest {
                 "completion_tokens", 500);
 
         BigDecimal cost = CostService.calculateCost("unknown-model-2025-12-17", "openai", usage, null);
+
+        assertThat(cost).isEqualTo(BigDecimal.ZERO);
+    }
+
+    /**
+     * A compact-dated name must price at exactly the rate of the base model it normalizes to,
+     * not merely at some non-zero rate -- that is what distinguishes a real price-table hit from
+     * an accidental one. Every case below was observed in production traffic routed through an
+     * enterprise gateway, which emits Anthropic ids in reversed family/version order with a
+     * compact date. Before the fix each of these resolved to DEFAULT_COST and reported $0.00.
+     */
+    @ParameterizedTest
+    @MethodSource("provideCompactDatedModelNamesWithBaseEquivalent")
+    void calculateCost_compactDateSuffixPricesSameAsBaseModel(String datedModelName, String baseModelName,
+            String provider) {
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", 1000,
+                "completion_tokens", 500);
+
+        BigDecimal datedCost = CostService.calculateCost(datedModelName, provider, usage, null);
+        BigDecimal baseCost = CostService.calculateCost(baseModelName, provider, usage, null);
+
+        assertThat(baseCost).isGreaterThan(BigDecimal.ZERO);
+        assertThat(datedCost).isEqualByComparingTo(baseCost);
+    }
+
+    private static Stream<Arguments> provideCompactDatedModelNamesWithBaseEquivalent() {
+        return Stream.of(
+                // Reversed family/version order reaches the price row through an `alias_of` entry,
+                // which is only reachable once the compact date is stripped.
+                Arguments.of("anthropic/claude-4.6-opus-20260205", "claude-opus-4-6", "anthropic"),
+                Arguments.of("anthropic/claude-4.6-sonnet-20260217", "claude-sonnet-4-6", "anthropic"),
+                Arguments.of("anthropic/claude-4.5-haiku-20251001", "claude-haiku-4-5", "anthropic"),
+                // Same path without the provider prefix.
+                Arguments.of("claude-4.6-opus-20260205", "claude-opus-4-6", "anthropic"),
+                // Canonical order, compact date, dot form: reaches the row via dot normalization.
+                Arguments.of("claude-opus-4.6-20260205", "claude-opus-4-6", "anthropic"));
+    }
+
+    @Test
+    void calculateCost_shouldReturnZeroForUnknownModelWithCompactDateSuffix() {
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", 1000,
+                "completion_tokens", 500);
+
+        BigDecimal cost = CostService.calculateCost("unknown-model-20251217", "openai", usage, null);
+
+        assertThat(cost).isEqualTo(BigDecimal.ZERO);
+    }
+
+    /**
+     * The month/day ranges in the pattern keep an arbitrary 8-digit build or revision number from
+     * being mistaken for a date and silently collapsing a distinct model onto another model's row.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"gpt-5.2-99999999", "gpt-5.2-20251345", "gpt-5.2-12345678"})
+    void calculateCost_shouldNotStripNonDateEightDigitSuffix(String modelName) {
+        Map<String, Integer> usage = Map.of(
+                "prompt_tokens", 1000,
+                "completion_tokens", 500);
+
+        BigDecimal cost = CostService.calculateCost(modelName, "openai", usage, null);
 
         assertThat(cost).isEqualTo(BigDecimal.ZERO);
     }
@@ -965,7 +1028,12 @@ class CostServiceTest {
                 Arguments.of("claude-sonnet-4.5", "anthropic"),
                 // 4. Provider prefix + date suffix: prefix stripped first, then date suffix removed
                 Arguments.of("anthropic/claude-sonnet-4.5-2025-12-17", "anthropic"),
-                Arguments.of("openai/gpt-5.2-2025-12-17", "openai"));
+                Arguments.of("openai/gpt-5.2-2025-12-17", "openai"),
+                // 5. Compact YYYYMMDD dates, the form Anthropic actually ships on every dated id.
+                Arguments.of("gpt-5.2-20251217", "openai"),
+                Arguments.of("claude-sonnet-4.5-20251217", "anthropic"),
+                Arguments.of("anthropic/claude-sonnet-4.5-20251217", "anthropic"),
+                Arguments.of("openai/gpt-5.2-20251217", "openai"));
     }
 
     /**


### PR DESCRIPTION
## Details

`CostService.DATE_SUFFIX_PATTERN` only stripped **hyphen-separated** date suffixes (`-2025-12-17`). Anthropic ships **compact** `YYYYMMDD` dates on every dated model ID (`claude-haiku-4-5-20251001`, `claude-sonnet-4-5-20250929`), so the date-suffix fallback in `findModelPrice` never fired for them.

Consequence: **a compact-dated model ID priced correctly only if present verbatim in the price table.** Needing *any* normalization step meant falling through every fallback to `DEFAULT_COST` and returning **$0 — silently**, with token counts still captured. Hyphenated-dated IDs degrade gracefully to the base model row; compact ones did not. Only 13 of 3,176 price rows carry compact dates, so the verbatim hit that masks this is the exception.

Three failure paths, all live in production:

1. **`alias_of` entries were unreachable when dated.** `model_prices_overrides.json` already has `"claude-4-6-opus": {"alias_of": "claude-opus-4-6"}` for reversed family/version ordering. `anthropic/claude-4.6-opus` prices at $5/$25; add the real date — `anthropic/claude-4.6-opus-20260205` — and it silently became $0, because the compact date must be stripped before the alias can match.
2. **New releases before the daily LiteLLM sync** priced at $0 instead of falling back to their base model.
3. **Not Anthropic-specific** — the pattern is provider-agnostic. `gpt-5.4-nano-20260205` missed too.

The fix makes both separators optional. Month/day ranges are retained, so an arbitrary 8-digit build number (`-99999999`, `-20251345`) is still not mistaken for a date and cannot collapse a distinct model onto another model's price row.

```diff
-    private static final String DATE_SUFFIX_PATTERN = "-\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$";
+    private static final String DATE_SUFFIX_PATTERN = "-\\d{4}-?(0[1-9]|1[0-2])-?(0[1-9]|[12]\\d|3[01])$";
```

**The pricing arithmetic itself is unchanged and was verified correct** — across 11,951 correctly-priced production spans (7,504 with cache reads), stored cost matched `input·p + cache_write·1.25p + cache_read·0.1p + output·q` with zero mismatches. This defect was purely model-name resolution.

### Production impact that surfaced it

One project (`internal-ollie-assist-monitoring`): **71,442 of ~131,000 LLM spans (54%) priced at $0**, hiding ~$4,470 of spend. Zero of those spans had a non-zero cost — fully deterministic.

The user-visible symptom was a cost KPI reading **+573,216%** over 60 days while span volume grew only 21%. Re-pricing both windows:

| 60-day window | Reported | Missing | Actual |
|---|---|---|---|
| Current | $2,955.58 | $349.38 | **$3,304.96** |
| Previous | $4.49 | $3,212.80 | **$3,217.29** |
| **Change** | +65,723% | | **+2.7%** |

Actual spend was flat. Totals are *understated*; period-over-period deltas can be wildly *overstated*. Also affects online-evaluation spend budgets (`BudgetGuard`), which under-count against a cap.

Scope: every project, workspace and deployment — `CostService` is shared, provider-agnostic code with no per-tenant config. Present since the date-stripping fallback (#5018).

## Change checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Issues

Resolves [OPIK-8242](https://comet-ml.atlassian.net/browse/OPIK-8242)

## Testing

`CostServiceTest`: **124/124 pass** with the fix; reverting only the production change (keeping the new tests) yields **8 failures**, confirming they are genuine regression tests rather than tests written to pass.

Added:
- `calculateCost_compactDateSuffixPricesSameAsBaseModel` — asserts a compact-dated name prices at **exactly** the base model's rate, not merely non-zero, which is what distinguishes a real price-table hit from an accidental one. All five cases are real model IDs observed in production traffic.
- `calculateCost_shouldNotStripNonDateEightDigitSuffix` — guards the month/day ranges so a build number is never read as a date.
- `calculateCost_shouldReturnZeroForUnknownModelWithCompactDateSuffix` — genuinely unknown models still return $0.
- Four compact-date cases added to the existing `provideModelNamesWithDateSuffixes` provider.

Ran locally on JDK 26 with spotless enabled.

## Follow-ups (deliberately not in this PR)

1. **Historical backfill** — `total_estimated_cost` is written at ingestion, so existing spans do not self-heal. Trend lines stay wrong until affected spans are re-priced.
2. **Stop failing silently** — an unresolved model should be observable (unpriced-span counter/metric, or a UI signal that a cost total is incomplete). This ran ~3 months across 71k spans in one project precisely because $0 is indistinguishable from "genuinely free".

## Documentation

No user-facing docs change — internal pricing-resolution fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-8242]: https://comet-ml.atlassian.net/browse/OPIK-8242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ