### PR TITLE
[OPIK-8050] [FE] fix: paginate prompt version history and fix version labeling

### DIFF
--- a/apps/opik-frontend/src/api/prompts/getPromptVersionsById.ts
+++ b/apps/opik-frontend/src/api/prompts/getPromptVersionsById.ts
@@ -1,0 +1,52 @@
+import { QueryFunctionContext } from "@tanstack/react-query";
+import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
+import { PromptVersion } from "@/types/prompts";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
+import { Filter } from "@/types/filters";
+import { processFilters } from "@/lib/filters";
+
+export type GetPromptVersionsByIdParams = {
+  promptId: string;
+  page: number;
+  size: number;
+  sorting?: Sorting;
+  filters?: Filter[];
+  search?: string;
+};
+
+export type PromptVersionsByIdResponse = {
+  content: PromptVersion[];
+  page: number;
+  size: number;
+  total: number;
+  sortable_by: string[];
+};
+
+export const getPromptVersionsById = async (
+  { signal }: QueryFunctionContext,
+  {
+    promptId,
+    size,
+    page,
+    sorting,
+    filters,
+    search,
+  }: GetPromptVersionsByIdParams,
+): Promise<PromptVersionsByIdResponse> => {
+  const { data } = await api.get(
+    `${PROMPTS_REST_ENDPOINT}${promptId}/versions`,
+    {
+      signal,
+      params: {
+        ...processFilters(filters),
+        ...processSorting(sorting),
+        size,
+        page,
+        ...(search && { search }),
+      },
+    },
+  );
+
+  return data;
+};

--- a/apps/opik-frontend/src/api/prompts/usePromptVersionsById.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptVersionsById.ts
@@ -1,59 +1,14 @@
-import { QueryFunctionContext, useQuery } from "@tanstack/react-query";
-import api, { PROMPTS_REST_ENDPOINT, QueryConfig } from "@/api/api";
-import { PromptVersion } from "@/types/prompts";
-import { Sorting } from "@/types/sorting";
-import { processSorting } from "@/lib/sorting";
-import { Filter } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
-
-type UsePromptVersionsByIdParams = {
-  promptId: string;
-  page: number;
-  size: number;
-  sorting?: Sorting;
-  filters?: Filter[];
-  search?: string;
-};
-
-type UsePromptsVersionsByIdResponse = {
-  content: PromptVersion[];
-  page: number;
-  size: number;
-  total: number;
-  sortable_by: string[];
-};
-
-const getPromptVersionsById = async (
-  { signal }: QueryFunctionContext,
-  {
-    promptId,
-    size,
-    page,
-    sorting,
-    filters,
-    search,
-  }: UsePromptVersionsByIdParams,
-) => {
-  const { data } = await api.get(
-    `${PROMPTS_REST_ENDPOINT}${promptId}/versions`,
-    {
-      signal,
-      params: {
-        ...processFilters(filters),
-        ...processSorting(sorting),
-        size,
-        page,
-        ...(search && { search }),
-      },
-    },
-  );
-
-  return data;
-};
+import { useQuery } from "@tanstack/react-query";
+import { QueryConfig } from "@/api/api";
+import {
+  getPromptVersionsById,
+  GetPromptVersionsByIdParams,
+  PromptVersionsByIdResponse,
+} from "./getPromptVersionsById";
 
 export default function usePromptVersionsById(
-  params: UsePromptVersionsByIdParams,
-  options?: QueryConfig<UsePromptsVersionsByIdResponse>,
+  params: GetPromptVersionsByIdParams,
+  options?: QueryConfig<PromptVersionsByIdResponse>,
 ) {
   return useQuery({
     queryKey: ["prompt-versions", params],

--- a/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
@@ -18,6 +18,7 @@ type UsePromptVersionsByIdInfiniteParams = {
 type UsePromptVersionsByIdInfiniteOptions = {
   enabled?: boolean;
   refetchInterval?: number;
+  refetchOnWindowFocus?: boolean;
 };
 
 export default function usePromptVersionsByIdInfinite(

--- a/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
@@ -1,10 +1,10 @@
-import { QueryFunctionContext, useInfiniteQuery } from "@tanstack/react-query";
-import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
-import { PromptVersion } from "@/types/prompts";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { Sorting } from "@/types/sorting";
-import { processSorting } from "@/lib/sorting";
 import { Filter } from "@/types/filters";
-import { processFilters } from "@/lib/filters";
+import {
+  getPromptVersionsById,
+  PromptVersionsByIdResponse,
+} from "./getPromptVersionsById";
 
 const PAGE_SIZE = 25;
 
@@ -20,46 +20,11 @@ type UsePromptVersionsByIdInfiniteOptions = {
   refetchInterval?: number;
 };
 
-type UsePromptVersionsByIdInfiniteResponse = {
-  content: PromptVersion[];
-  page: number;
-  size: number;
-  total: number;
-  sortable_by: string[];
-};
-
-const getPromptVersionsById = async (
-  { signal }: QueryFunctionContext,
-  {
-    promptId,
-    page,
-    sorting,
-    filters,
-    search,
-  }: UsePromptVersionsByIdInfiniteParams & { page: number },
-): Promise<UsePromptVersionsByIdInfiniteResponse> => {
-  const { data } = await api.get(
-    `${PROMPTS_REST_ENDPOINT}${promptId}/versions`,
-    {
-      signal,
-      params: {
-        ...processFilters(filters),
-        ...processSorting(sorting),
-        size: PAGE_SIZE,
-        page,
-        ...(search && { search }),
-      },
-    },
-  );
-
-  return data;
-};
-
 export default function usePromptVersionsByIdInfinite(
   params: UsePromptVersionsByIdInfiniteParams,
   options?: UsePromptVersionsByIdInfiniteOptions,
 ) {
-  return useInfiniteQuery<UsePromptVersionsByIdInfiniteResponse>({
+  return useInfiniteQuery<PromptVersionsByIdResponse>({
     // Shares the "prompt-versions" key prefix (and the same
     // `{ promptId, ... }` params shape) with usePromptVersionsById so the
     // mutation hooks that invalidate that prefix (create/delete/deploy a
@@ -70,6 +35,7 @@ export default function usePromptVersionsByIdInfinite(
     queryFn: (context) =>
       getPromptVersionsById(context, {
         ...params,
+        size: PAGE_SIZE,
         page: context.pageParam as number,
       }),
     // `size` on the response is the actual item count returned (not the

--- a/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
@@ -26,13 +26,14 @@ export default function usePromptVersionsByIdInfinite(
   options?: UsePromptVersionsByIdInfiniteOptions,
 ) {
   return useInfiniteQuery<PromptVersionsByIdResponse>({
-    // Shares the "prompt-versions" key prefix (and the same
-    // `{ promptId, ... }` params shape) with usePromptVersionsById so the
-    // mutation hooks that invalidate that prefix (create/delete/deploy a
+    // Shares the "prompt-versions" key prefix with usePromptVersionsById so
+    // the mutation hooks that invalidate that prefix (create/delete/deploy a
     // version) also invalidate this list — otherwise the sidebar goes stale
-    // after every write. Doesn't collide in the cache: this hook's params
-    // never include `page`/`size`, which usePromptVersionsById always does.
-    queryKey: ["prompt-versions", params],
+    // after every write. The explicit `view: "infinite"` marker keeps the two
+    // hooks' cache entries apart without relying on the fragile "this one
+    // never has page/size" invariant, which a future change to either hook
+    // could silently break.
+    queryKey: ["prompt-versions", { ...params, view: "infinite" as const }],
     queryFn: (context) =>
       getPromptVersionsById(context, {
         ...params,
@@ -42,8 +43,12 @@ export default function usePromptVersionsByIdInfinite(
     // `size` on the response is the actual item count returned (not the
     // requested page size), so it shrinks on the last page and hits 0 past
     // it — `page * size` is not a valid "items seen so far" once that
-    // happens. Sum each page's real content length instead.
+    // happens. Sum each page's real content length instead. An empty page
+    // always ends pagination outright: trusting `total` past that point can
+    // loop forever if it's out of sync with the actual row count (e.g. a
+    // concurrent delete between the count and the page query).
     getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.content.length === 0) return undefined;
       const fetchedCount = allPages.reduce(
         (sum, p) => sum + p.content.length,
         0,

--- a/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
+++ b/apps/opik-frontend/src/api/prompts/usePromptVersionsByIdInfinite.ts
@@ -1,0 +1,89 @@
+import { QueryFunctionContext, useInfiniteQuery } from "@tanstack/react-query";
+import api, { PROMPTS_REST_ENDPOINT } from "@/api/api";
+import { PromptVersion } from "@/types/prompts";
+import { Sorting } from "@/types/sorting";
+import { processSorting } from "@/lib/sorting";
+import { Filter } from "@/types/filters";
+import { processFilters } from "@/lib/filters";
+
+const PAGE_SIZE = 25;
+
+type UsePromptVersionsByIdInfiniteParams = {
+  promptId: string;
+  sorting?: Sorting;
+  filters?: Filter[];
+  search?: string;
+};
+
+type UsePromptVersionsByIdInfiniteOptions = {
+  enabled?: boolean;
+  refetchInterval?: number;
+};
+
+type UsePromptVersionsByIdInfiniteResponse = {
+  content: PromptVersion[];
+  page: number;
+  size: number;
+  total: number;
+  sortable_by: string[];
+};
+
+const getPromptVersionsById = async (
+  { signal }: QueryFunctionContext,
+  {
+    promptId,
+    page,
+    sorting,
+    filters,
+    search,
+  }: UsePromptVersionsByIdInfiniteParams & { page: number },
+): Promise<UsePromptVersionsByIdInfiniteResponse> => {
+  const { data } = await api.get(
+    `${PROMPTS_REST_ENDPOINT}${promptId}/versions`,
+    {
+      signal,
+      params: {
+        ...processFilters(filters),
+        ...processSorting(sorting),
+        size: PAGE_SIZE,
+        page,
+        ...(search && { search }),
+      },
+    },
+  );
+
+  return data;
+};
+
+export default function usePromptVersionsByIdInfinite(
+  params: UsePromptVersionsByIdInfiniteParams,
+  options?: UsePromptVersionsByIdInfiniteOptions,
+) {
+  return useInfiniteQuery<UsePromptVersionsByIdInfiniteResponse>({
+    // Shares the "prompt-versions" key prefix (and the same
+    // `{ promptId, ... }` params shape) with usePromptVersionsById so the
+    // mutation hooks that invalidate that prefix (create/delete/deploy a
+    // version) also invalidate this list — otherwise the sidebar goes stale
+    // after every write. Doesn't collide in the cache: this hook's params
+    // never include `page`/`size`, which usePromptVersionsById always does.
+    queryKey: ["prompt-versions", params],
+    queryFn: (context) =>
+      getPromptVersionsById(context, {
+        ...params,
+        page: context.pageParam as number,
+      }),
+    // `size` on the response is the actual item count returned (not the
+    // requested page size), so it shrinks on the last page and hits 0 past
+    // it — `page * size` is not a valid "items seen so far" once that
+    // happens. Sum each page's real content length instead.
+    getNextPageParam: (lastPage, allPages) => {
+      const fetchedCount = allPages.reduce(
+        (sum, p) => sum + p.content.length,
+        0,
+      );
+      return fetchedCount < lastPage.total ? allPages.length + 1 : undefined;
+    },
+    initialPageParam: 1,
+    ...options,
+  });
+}

--- a/apps/opik-frontend/src/hooks/usePromptVersionLabel.ts
+++ b/apps/opik-frontend/src/hooks/usePromptVersionLabel.ts
@@ -3,12 +3,9 @@ import { useMemo } from "react";
 import usePromptVersionsById from "@/api/prompts/usePromptVersionsById";
 
 /**
- * Compute the human-facing "v{n}" label for a specific prompt version.
- *
- * Versions are labeled by their position when sorted by created_at desc:
- * the oldest is v1, the newest is v{total}. We need the versions list to
- * find that position — version_count on the Prompt object only tells us
- * the total (i.e., the latest's label).
+ * Compute the human-facing label for a specific prompt version, using the
+ * backend-persisted version_number so it stays correct even after older
+ * versions are deleted (positional "v{n}" labels shift when that happens).
  */
 const usePromptVersionLabel = (
   promptId: string | undefined,
@@ -27,9 +24,8 @@ const usePromptVersionLabel = (
 
   return useMemo(() => {
     if (versionId && data?.content) {
-      const idx = data.content.findIndex((v) => v.id === versionId);
-      const total = data.total ?? data.content.length;
-      if (idx >= 0 && total > 0) return `v${total - idx}`;
+      const version = data.content.find((v) => v.id === versionId);
+      if (version) return version.version_number ?? version.commit;
     }
     return fallbackVersionCount && fallbackVersionCount > 0
       ? `v${fallbackVersionCount}`

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptLibraryMenu/PromptLibraryMenu.tsx
@@ -241,7 +241,6 @@ const PromptVersionsList: React.FC<PromptVersionsListProps> = ({
   );
 
   const versions = data?.content ?? [];
-  const total = data?.total ?? versions.length;
 
   if (isLoading) {
     return (
@@ -259,8 +258,8 @@ const PromptVersionsList: React.FC<PromptVersionsListProps> = ({
 
   return (
     <div className="max-h-[40vh] overflow-y-auto">
-      {versions.map((version, idx) => {
-        const label = `v${total - idx}`;
+      {versions.map((version) => {
+        const label = version.version_number ?? version.commit;
         const isActive = version.id === activeVersionId;
         const stage = pickHighestStage(version.tags);
         return (

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/DiffVersionMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/DiffVersionMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clock, GitCompareArrows } from "lucide-react";
+import { Clock, GitCompareArrows, Loader2 } from "lucide-react";
 
 import { getTimeFromNow } from "@/lib/date";
 import { Button } from "@/ui/button";
@@ -20,6 +20,8 @@ interface DiffVersionMenuProps {
   versions: VersionHistoryItem[];
   onSelectVersion: (item: VersionHistoryItem) => void;
   triggerLabel?: string;
+  onOpenChange?: (open: boolean) => void;
+  isLoadingMore?: boolean;
 }
 
 const DiffVersionMenu: React.FC<DiffVersionMenuProps> = ({
@@ -27,11 +29,13 @@ const DiffVersionMenu: React.FC<DiffVersionMenuProps> = ({
   versions,
   onSelectVersion,
   triggerLabel = "Show diff",
+  onOpenChange,
+  isLoadingMore = false,
 }) => {
   const selectableVersions = versions.filter((v) => v.id !== currentItemId);
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           size="sm"
@@ -73,6 +77,11 @@ const DiffVersionMenu: React.FC<DiffVersionMenuProps> = ({
               </span>
             </DropdownMenuItem>
           ))}
+          {isLoadingMore && (
+            <div className="flex justify-center py-2">
+              <Loader2 className="size-4 animate-spin text-light-slate" />
+            </div>
+          )}
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/VersionHistoryTimeline.tsx
@@ -25,6 +25,16 @@ interface VersionHistoryTimelineProps {
   onSelect: (item: VersionHistoryItem) => void;
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
+  // Broader than isFetchingNextPage — also true during a background refetch
+  // (e.g. the 30s poll, or a mutation's invalidation of already-loaded
+  // pages). Used only to gate the auto-load trigger, not the spinner: firing
+  // onLoadMore while an unrelated fetch is in flight races it and can
+  // produce a duplicate/overlapping row once both resolve.
+  isFetching?: boolean;
+  // True once a page fetch has failed. hasNextPage still reflects the last
+  // *successful* page, so without this the sentinel retries a permanently
+  // failing request forever, the moment isFetching settles back to false.
+  hasError?: boolean;
   onLoadMore?: () => void;
   emptyTitle?: string;
 }
@@ -35,16 +45,18 @@ const VersionHistoryTimeline: React.FC<VersionHistoryTimelineProps> = ({
   onSelect,
   hasNextPage = false,
   isFetchingNextPage = false,
+  isFetching = false,
+  hasError = false,
   onLoadMore,
   emptyTitle = "No version history",
 }) => {
   const { ref: sentinelRef, inView } = useInView();
 
   useEffect(() => {
-    if (inView && hasNextPage && !isFetchingNextPage && onLoadMore) {
+    if (inView && hasNextPage && !isFetching && !hasError && onLoadMore) {
       onLoadMore();
     }
-  }, [inView, hasNextPage, isFetchingNextPage, onLoadMore]);
+  }, [inView, hasNextPage, isFetching, hasError, onLoadMore]);
 
   if (items.length === 0) {
     return <DataTableNoData title={emptyTitle} />;

--- a/apps/opik-frontend/src/v2/pages-shared/version-history/usePromptVersionsWithLabels.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/version-history/usePromptVersionsWithLabels.ts
@@ -46,10 +46,10 @@ export function usePromptVersionsWithLabels(
       versions.map((version, index) => ({
         version,
         index,
-        label: `v${total - index}`,
+        label: version.version_number ?? version.commit,
         stage: pickHighestStage(version.tags),
       })),
-    [versions, total],
+    [versions],
   );
 
   const getDescriptor = useMemo(() => {

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -312,12 +312,8 @@ const ComparePromptVersionDialog: React.FunctionComponent<
   const anyMediaChanged = mediaChanges.some((m) => m.changed);
 
   const versionLabelByCommit = useMemo(() => {
-    const sortedDesc = [...versions].sort((a, b) =>
-      b.created_at.localeCompare(a.created_at),
-    );
-    const total = sortedDesc.length;
     const map = new Map<string, string>();
-    sortedDesc.forEach((v, idx) => map.set(v.commit, `v${total - idx}`));
+    versions.forEach((v) => map.set(v.commit, v.version_number ?? v.commit));
     return map;
   }, [versions]);
 

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -241,13 +241,27 @@ const ComparePromptVersionDialog: React.FunctionComponent<
   initialBaseVersionId,
   initialDiffVersionId,
 }) => {
-  const [baseVersion, setBaseVersion] = useState<PromptVersion | undefined>(
-    last(versions),
+  // Only the *choice* of which version is selected is snapshotted state —
+  // the version data itself is always re-resolved live from `versions`
+  // below, so a background refetch (tag edit, environment change) keeps
+  // rendered content current, and a version deleted out from under an open
+  // dialog resolves to undefined (renders nothing) instead of stale content.
+  const [baseVersionId, setBaseVersionId] = useState<string | undefined>(
+    last(versions)?.id,
   );
-  const [diffVersion, setDiffVersion] = useState<PromptVersion | undefined>(
-    first(versions),
+  const [diffVersionId, setDiffVersionId] = useState<string | undefined>(
+    first(versions)?.id,
   );
   const [viewMode, setViewMode] = useState<ViewMode>("pretty");
+
+  const baseVersion = useMemo(
+    () => versions.find((v) => v.id === baseVersionId),
+    [versions, baseVersionId],
+  );
+  const diffVersion = useMemo(
+    () => versions.find((v) => v.id === diffVersionId),
+    [versions, diffVersionId],
+  );
 
   const baseText = useMemo(
     () => normalizeChatTemplate(baseVersion?.template || ""),
@@ -372,8 +386,8 @@ const ComparePromptVersionDialog: React.FunctionComponent<
         ? versions.find((v) => v.id === initialDiffVersionId)
         : undefined) ??
       versions.find((v) => v.commit === last(versionOptions)?.value);
-    setBaseVersion(requestedBase);
-    setDiffVersion(requestedDiff);
+    setBaseVersionId(requestedBase?.id);
+    setDiffVersionId(requestedDiff?.id);
     // Compute viewMode from the requested versions, not the stale state-derived
     // `isChatDiff`, so we don't briefly render the wrong mode on reopen.
     const requestedIsChatDiff =

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -509,7 +509,7 @@ const ComparePromptVersionDialog: React.FunctionComponent<
               </SectionContainer>
             )}
 
-            {anyMediaChanged && (
+            {baseVersion && diffVersion && anyMediaChanged && (
               <>
                 {mediaChanges
                   .filter((m) => m.changed)

--- a/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import last from "lodash/last";
 import first from "lodash/first";
 import isEqual from "fast-deep-equal";
@@ -330,9 +336,32 @@ const ComparePromptVersionDialog: React.FunctionComponent<
     [versions, versionLabelByCommit],
   );
 
-  // Reset selection and view mode each time the sheet reopens.
+  // Reset selection and view mode only on the reopen transition — reading
+  // the rest via a ref (not as effect deps) so a background refetch that
+  // changes `versions`/`versionOptions` while the sheet is already open
+  // (pagination continuing, a version_count-triggered invalidation) doesn't
+  // stomp on whatever the user has manually picked in the selectors.
+  const latestRef = useRef({
+    versions,
+    versionOptions,
+    initialBaseVersionId,
+    initialDiffVersionId,
+  });
+  latestRef.current = {
+    versions,
+    versionOptions,
+    initialBaseVersionId,
+    initialDiffVersionId,
+  };
+
   useEffect(() => {
     if (!open) return;
+    const {
+      versions,
+      versionOptions,
+      initialBaseVersionId,
+      initialDiffVersionId,
+    } = latestRef.current;
     const requestedBase =
       (initialBaseVersionId
         ? versions.find((v) => v.id === initialBaseVersionId)
@@ -355,13 +384,7 @@ const ComparePromptVersionDialog: React.FunctionComponent<
         normalizeChatTemplate(requestedDiff?.template || ""),
       ) !== null;
     setViewMode(requestedIsChatDiff ? "pretty" : "json");
-  }, [
-    open,
-    versionOptions,
-    versions,
-    initialBaseVersionId,
-    initialDiffVersionId,
-  ]);
+  }, [open]);
 
   const baseLabel = baseVersion
     ? versionLabelByCommit.get(baseVersion.commit) ?? ""

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptPage.tsx
@@ -27,7 +27,13 @@ const PromptPage: React.FunctionComponent = () => {
 
   const promptId = usePromptIdFromURL();
 
-  const { data: prompt } = usePromptById({ promptId }, { enabled: !!promptId });
+  // Cheap poll so the (unbounded) paginated version list can detect other
+  // users' changes without itself refetching every loaded page on a timer —
+  // see usePromptVersionHistory's version_count watcher.
+  const { data: prompt } = usePromptById(
+    { promptId },
+    { enabled: !!promptId, refetchInterval: 30000 },
+  );
   const promptName = prompt?.name || "";
   const setBreadcrumbParam = useBreadcrumbsStore((state) => state.setParam);
 

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -30,7 +30,6 @@ type DeployToEnvironmentMenuProps = {
   versionId: string;
   versionLabel: string;
   versions: PromptVersion[] | undefined;
-  totalVersions: number;
   activeEnvironments: string[];
 };
 
@@ -39,7 +38,6 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
   versionId,
   versionLabel,
   versions,
-  totalVersions,
   activeEnvironments,
 }) => {
   const { toast } = useToast();
@@ -64,13 +62,13 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
   );
 
   const environmentOwners = useMemo(() => {
-    const map = new Map<string, { version: PromptVersion; index: number }>();
+    const map = new Map<string, PromptVersion>();
     // `versions` is newest-first; only keep the first writer per environment so
     // the "Currently vN" label reflects the newest version assigned to that env,
     // not whichever historical version was iterated last.
-    versions?.forEach((v, index) => {
+    versions?.forEach((v) => {
       v.environments?.forEach((env) => {
-        if (!map.has(env)) map.set(env, { version: v, index });
+        if (!map.has(env)) map.set(env, v);
       });
     });
     return map;
@@ -143,8 +141,8 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
             const owner = environmentOwners.get(env.name);
             const isActiveHere = activeEnvSet.has(env.name);
             const ownerLabel =
-              !isActiveHere && owner && totalVersions > 0
-                ? `Currently v${totalVersions - owner.index}`
+              !isActiveHere && owner
+                ? `Currently ${owner.version_number ?? owner.commit}`
                 : "";
             return (
               <DropdownMenuItem

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/DeployToEnvironmentMenu.tsx
@@ -3,6 +3,7 @@ import {
   ChevronDown,
   Check,
   CircleFadingArrowUp,
+  Loader2,
   Settings2,
   X,
 } from "lucide-react";
@@ -31,6 +32,8 @@ type DeployToEnvironmentMenuProps = {
   versionLabel: string;
   versions: PromptVersion[] | undefined;
   activeEnvironments: string[];
+  onOpenChange?: (open: boolean) => void;
+  isLoadingMore?: boolean;
 };
 
 const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
@@ -39,6 +42,8 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
   versionLabel,
   versions,
   activeEnvironments,
+  onOpenChange,
+  isLoadingMore = false,
 }) => {
   const { toast } = useToast();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
@@ -118,7 +123,7 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
   if (!canEditPrompts) return null;
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={onOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
@@ -167,6 +172,11 @@ const DeployToEnvironmentMenu: React.FC<DeployToEnvironmentMenuProps> = ({
               </DropdownMenuItem>
             );
           })
+        )}
+        {isLoadingMore && (
+          <div className="flex justify-center py-2">
+            <Loader2 className="size-4 animate-spin text-light-slate" />
+          </div>
         )}
         {activeEnvironments.length > 0 && (
           <>

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -115,6 +115,20 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     [activeVersion?.environments],
   );
 
+  // While a deep-linked/active version's page hasn't loaded yet, it's
+  // missing from `versions` — passing that incomplete list to the compare
+  // dialog makes it silently fall back to whatever's newest loaded instead
+  // of the version the user actually asked to compare. `activeVersion` is
+  // already resolved independently (by id, not by pagination), so inject it
+  // whenever it isn't already present.
+  const versionsForCompare = useMemo(() => {
+    if (!versions) return activeVersion ? [activeVersion] : [];
+    if (!activeVersion || versions.some((v) => v.id === activeVersion.id)) {
+      return versions;
+    }
+    return [...versions, activeVersion];
+  }, [versions, activeVersion]);
+
   const isChatPrompt =
     prompt?.template_structure === PROMPT_TEMPLATE_STRUCTURE.CHAT;
   const template = activeVersion?.template ?? "";
@@ -516,7 +530,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
       <ComparePromptVersionDialog
         open={openCompare}
         setOpen={setOpenCompare}
-        versions={versions ?? []}
+        versions={versionsForCompare}
         initialBaseVersionId={compareAgainstVersionId ?? undefined}
         initialDiffVersionId={effectiveVersionId || undefined}
       />

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -104,6 +104,8 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     fetchNextPage,
     isDiffMenuOpen,
     setIsDiffMenuOpen,
+    isDeployMenuOpen,
+    setIsDeployMenuOpen,
   } = usePromptVersionHistory(prompt);
 
   const activeStage = pickHighestStage(activeVersion?.tags);
@@ -377,6 +379,8 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                     versionLabel={activeVersionLabel}
                     versions={versions}
                     activeEnvironments={activeVersionEnvironments}
+                    onOpenChange={setIsDeployMenuOpen}
+                    isLoadingMore={isDeployMenuOpen && isFetchingNextPage}
                   />
 
                   <Separator orientation="vertical" className="mx-1 h-4" />

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Blocks,
   ChevronDown,
@@ -44,7 +44,7 @@ import VersionHistoryTimeline, {
 import DiffVersionMenu from "@/v2/pages-shared/version-history/DiffVersionMenu";
 import StageTag from "@/v2/pages-shared/version-history/StageTag";
 import ComparePromptVersionDialog from "@/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog";
-import usePromptVersionsById from "@/api/prompts/usePromptVersionsById";
+import usePromptVersionsByIdInfinite from "@/api/prompts/usePromptVersionsByIdInfinite";
 import usePromptVersionById, {
   useFetchPromptVersion,
 } from "@/api/prompts/usePromptVersionById";
@@ -86,6 +86,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
   const [openEditPrompt, setOpenEditPrompt] = useState(false);
   const [openCompare, setOpenCompare] = useState(false);
   const [openLoadConfirm, setOpenLoadConfirm] = useState(false);
+  const [isDiffMenuOpen, setIsDiffMenuOpen] = useState(false);
   const [compareAgainstVersionId, setCompareAgainstVersionId] = useState<
     string | null
   >(null);
@@ -99,11 +100,16 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     StringParam,
   );
 
-  const { data, isLoading: isVersionsLoading } = usePromptVersionsById(
+  const {
+    data,
+    isLoading: isVersionsLoading,
+    hasNextPage,
+    isFetching: isFetchingVersions,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = usePromptVersionsByIdInfinite(
     {
       promptId: prompt?.id || "",
-      page: 1,
-      size: 25,
       sorting: [{ id: "created_at", desc: true }],
     },
     {
@@ -112,30 +118,69 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     },
   );
 
-  const versions = data?.content as VersionWithMaybeAuthor[] | undefined;
-  const total = data?.total ?? versions?.length ?? 0;
-
+  const versions = useMemo(
+    () =>
+      data?.pages.flatMap((p) => p.content) as
+        | VersionWithMaybeAuthor[]
+        | undefined,
+    [data],
+  );
   const historyItems = useMemo<VersionHistoryItem[]>(() => {
     if (!versions) return [];
-    return versions.map((v, idx) => ({
+    return versions.map((v) => ({
       id: v.id,
-      label: `v${total - idx}`,
+      label: v.version_number ?? v.commit,
       tags: v.tags ?? [],
       description: v.change_description,
       created_at: v.created_at,
       created_by: v.created_by,
       environments: v.environments ?? [],
     }));
-  }, [versions, total]);
+  }, [versions]);
+
+  // A deep link to an old version not yet in the loaded pages still renders
+  // correctly (fetched independently below), but the sidebar can't highlight
+  // it or scroll it into view until its page is loaded — keep paging until
+  // it's found (or there's nothing left to load) so the two stay in sync.
+  // Must wait for `isFetchingVersions` (not just `isFetchingNextPage`) to go
+  // idle: a background refetch of an already-loaded page (e.g. after a
+  // version-create invalidation) reports `isFetchingNextPage: false` too,
+  // and fetching the next page against that stale intermediate state can
+  // request an offset that no longer lines up with the refreshed page,
+  // producing an overlapping/duplicate row once both resolve.
+  useEffect(() => {
+    if (
+      activeVersionId &&
+      versions &&
+      !versions.some((v) => v.id === activeVersionId) &&
+      hasNextPage &&
+      !isFetchingVersions
+    ) {
+      fetchNextPage();
+    }
+  }, [
+    activeVersionId,
+    versions,
+    hasNextPage,
+    isFetchingVersions,
+    fetchNextPage,
+  ]);
+
+  // The Diff menu's "Compare against" list only offers whatever pages are
+  // already loaded — while it's open, keep paging until every version is
+  // available so it doesn't silently omit older, not-yet-loaded versions.
+  useEffect(() => {
+    if (isDiffMenuOpen && hasNextPage && !isFetchingVersions) {
+      fetchNextPage();
+    }
+  }, [isDiffMenuOpen, hasNextPage, isFetchingVersions, fetchNextPage]);
 
   const effectiveVersionId = useMemo(() => {
-    if (activeVersionId && versions?.some((v) => v.id === activeVersionId)) {
-      return activeVersionId;
-    }
+    if (activeVersionId) return activeVersionId;
     return prompt?.latest_version?.id ?? versions?.[0]?.id ?? "";
   }, [activeVersionId, versions, prompt?.latest_version?.id]);
 
-  const { data: activeVersion, isLoading: isActiveVersionLoading } =
+  const { data: fetchedActiveVersion, isLoading: isActiveVersionLoading } =
     usePromptVersionById(
       { versionId: effectiveVersionId },
       {
@@ -144,12 +189,18 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
       },
     );
 
-  const activeIndex = useMemo(
-    () => versions?.findIndex((v) => v.id === effectiveVersionId) ?? -1,
-    [versions, effectiveVersionId],
-  );
+  // A stale or crafted activeVersionId query param can reference a version
+  // belonging to a different prompt (it's fetched independently of the
+  // current prompt's own version list) — never render foreign content here.
+  const activeVersion =
+    fetchedActiveVersion &&
+    prompt &&
+    fetchedActiveVersion.prompt_id === prompt.id
+      ? fetchedActiveVersion
+      : prompt?.latest_version;
+
   const activeVersionLabel =
-    activeIndex >= 0 && total > 0 ? `v${total - activeIndex}` : "";
+    activeVersion?.version_number ?? activeVersion?.commit ?? "";
 
   const activeStage = pickHighestStage(activeVersion?.tags);
   const activeAuthor =
@@ -178,9 +229,14 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     // usePromptVersionById uses placeholderData: keepPreviousData — fall back
     // to an imperative fetch so we always load the version actually selected.
     let version = activeVersion;
-    if (effectiveVersionId && activeVersion?.id !== effectiveVersionId) {
+    if (effectiveVersionId && fetchedActiveVersion?.id !== effectiveVersionId) {
       try {
-        version = await fetchPromptVersion({ versionId: effectiveVersionId });
+        const fetched = await fetchPromptVersion({
+          versionId: effectiveVersionId,
+        });
+        // Guard against a stale/crafted activeVersionId pointing at a
+        // different prompt's version — never load foreign content.
+        version = fetched.prompt_id === prompt.id ? fetched : activeVersion;
       } catch {
         // Refetch failed — bail rather than ship stale `activeVersion`
         // (placeholder from the previously-selected version) into the
@@ -193,6 +249,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     loadPrompt,
     prompt,
     activeVersion,
+    fetchedActiveVersion,
     effectiveVersionId,
     fetchPromptVersion,
   ]);
@@ -339,10 +396,12 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                     className="mx-1 h-4 shrink-0"
                   />
                   <DiffVersionMenu
-                    currentItemId={effectiveVersionId}
+                    currentItemId={activeVersion?.id ?? ""}
                     versions={historyItems}
                     onSelectVersion={handleSelectDiffVersion}
                     triggerLabel="Diff"
+                    onOpenChange={setIsDiffMenuOpen}
+                    isLoadingMore={isDiffMenuOpen && isFetchingNextPage}
                   />
                 </>
               )}
@@ -399,10 +458,9 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   <Separator orientation="vertical" className="mx-1 h-4" />
                   <DeployToEnvironmentMenu
                     promptId={prompt.id}
-                    versionId={effectiveVersionId}
+                    versionId={activeVersion?.id ?? ""}
                     versionLabel={activeVersionLabel}
                     versions={versions}
-                    totalVersions={total}
                     activeEnvironments={activeVersionEnvironments}
                   />
 
@@ -515,8 +573,11 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
         <p className="comet-body-s-accented mb-1 ml-3">Version history</p>
         <VersionHistoryTimeline
           items={historyItems}
-          selectedId={effectiveVersionId}
+          selectedId={activeVersion?.id}
           onSelect={(item) => setActiveVersionId(item.id)}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onLoadMore={fetchNextPage}
         />
       </div>
 

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/PromptTab.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import {
   Blocks,
   ChevronDown,
@@ -11,8 +11,6 @@ import {
   Sparkles,
   User,
 } from "lucide-react";
-import { keepPreviousData } from "@tanstack/react-query";
-import { StringParam, useQueryParam } from "use-query-params";
 import { Button } from "@/ui/button";
 import {
   DropdownMenu,
@@ -22,9 +20,9 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu";
 import {
-  PromptVersion,
   PromptWithLatestVersion,
   PROMPT_TEMPLATE_STRUCTURE,
+  PROMPT_VERSION_TYPE,
 } from "@/types/prompts";
 import { Separator } from "@/ui/separator";
 import {
@@ -44,10 +42,8 @@ import VersionHistoryTimeline, {
 import DiffVersionMenu from "@/v2/pages-shared/version-history/DiffVersionMenu";
 import StageTag from "@/v2/pages-shared/version-history/StageTag";
 import ComparePromptVersionDialog from "@/v2/pages/PromptPage/CommitsTab/ComparePromptVersionDialog";
-import usePromptVersionsByIdInfinite from "@/api/prompts/usePromptVersionsByIdInfinite";
-import usePromptVersionById, {
-  useFetchPromptVersion,
-} from "@/api/prompts/usePromptVersionById";
+import { useFetchPromptVersion } from "@/api/prompts/usePromptVersionById";
+import usePromptVersionHistory from "@/v2/pages/PromptPage/PromptTab/usePromptVersionHistory";
 import EnvironmentBadgeList from "@/shared/EnvironmentLabel/EnvironmentBadgeList";
 import ImproveInPlaygroundButton from "@/v2/pages/PromptPage/ImproveInPlaygroundButton";
 import useLoadPromptIntoPlayground from "@/v2/pages-shared/playground/useLoadPromptIntoPlayground";
@@ -74,10 +70,6 @@ interface PromptTabInterface {
   prompt?: PromptWithLatestVersion;
 }
 
-interface VersionWithMaybeAuthor extends PromptVersion {
-  created_by?: string;
-}
-
 const PromptTab = ({ prompt }: PromptTabInterface) => {
   const {
     permissions: { canUsePlayground, canEditPrompts },
@@ -86,7 +78,6 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
   const [openEditPrompt, setOpenEditPrompt] = useState(false);
   const [openCompare, setOpenCompare] = useState(false);
   const [openLoadConfirm, setOpenLoadConfirm] = useState(false);
-  const [isDiffMenuOpen, setIsDiffMenuOpen] = useState(false);
   const [compareAgainstVersionId, setCompareAgainstVersionId] = useState<
     string | null
   >(null);
@@ -95,116 +86,28 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
   const { loadPrompt, isPlaygroundEmpty, isPendingProviderKeys } =
     useLoadPromptIntoPlayground();
 
-  const [activeVersionId, setActiveVersionId] = useQueryParam(
-    "activeVersionId",
-    StringParam,
-  );
-
   const {
-    data,
-    isLoading: isVersionsLoading,
-    hasNextPage,
-    isFetching: isFetchingVersions,
-    isFetchingNextPage,
-    fetchNextPage,
-  } = usePromptVersionsByIdInfinite(
-    {
-      promptId: prompt?.id || "",
-      sorting: [{ id: "created_at", desc: true }],
-    },
-    {
-      enabled: !!prompt?.id,
-      refetchInterval: 30000,
-    },
-  );
-
-  const versions = useMemo(
-    () =>
-      data?.pages.flatMap((p) => p.content) as
-        | VersionWithMaybeAuthor[]
-        | undefined,
-    [data],
-  );
-  const historyItems = useMemo<VersionHistoryItem[]>(() => {
-    if (!versions) return [];
-    return versions.map((v) => ({
-      id: v.id,
-      label: v.version_number ?? v.commit,
-      tags: v.tags ?? [],
-      description: v.change_description,
-      created_at: v.created_at,
-      created_by: v.created_by,
-      environments: v.environments ?? [],
-    }));
-  }, [versions]);
-
-  // A deep link to an old version not yet in the loaded pages still renders
-  // correctly (fetched independently below), but the sidebar can't highlight
-  // it or scroll it into view until its page is loaded — keep paging until
-  // it's found (or there's nothing left to load) so the two stay in sync.
-  // Must wait for `isFetchingVersions` (not just `isFetchingNextPage`) to go
-  // idle: a background refetch of an already-loaded page (e.g. after a
-  // version-create invalidation) reports `isFetchingNextPage: false` too,
-  // and fetching the next page against that stale intermediate state can
-  // request an offset that no longer lines up with the refreshed page,
-  // producing an overlapping/duplicate row once both resolve.
-  useEffect(() => {
-    if (
-      activeVersionId &&
-      versions &&
-      !versions.some((v) => v.id === activeVersionId) &&
-      hasNextPage &&
-      !isFetchingVersions
-    ) {
-      fetchNextPage();
-    }
-  }, [
-    activeVersionId,
+    setActiveVersionId,
     versions,
+    historyItems,
+    effectiveVersionId,
+    versionFromList,
+    fetchedActiveVersion,
+    activeVersion,
+    activeVersionLabel,
+    isVersionsLoading,
+    isActiveVersionLoading,
     hasNextPage,
+    isFetchingNextPage,
     isFetchingVersions,
+    isVersionsError,
     fetchNextPage,
-  ]);
-
-  // The Diff menu's "Compare against" list only offers whatever pages are
-  // already loaded — while it's open, keep paging until every version is
-  // available so it doesn't silently omit older, not-yet-loaded versions.
-  useEffect(() => {
-    if (isDiffMenuOpen && hasNextPage && !isFetchingVersions) {
-      fetchNextPage();
-    }
-  }, [isDiffMenuOpen, hasNextPage, isFetchingVersions, fetchNextPage]);
-
-  const effectiveVersionId = useMemo(() => {
-    if (activeVersionId) return activeVersionId;
-    return prompt?.latest_version?.id ?? versions?.[0]?.id ?? "";
-  }, [activeVersionId, versions, prompt?.latest_version?.id]);
-
-  const { data: fetchedActiveVersion, isLoading: isActiveVersionLoading } =
-    usePromptVersionById(
-      { versionId: effectiveVersionId },
-      {
-        enabled: !!effectiveVersionId,
-        placeholderData: keepPreviousData,
-      },
-    );
-
-  // A stale or crafted activeVersionId query param can reference a version
-  // belonging to a different prompt (it's fetched independently of the
-  // current prompt's own version list) — never render foreign content here.
-  const activeVersion =
-    fetchedActiveVersion &&
-    prompt &&
-    fetchedActiveVersion.prompt_id === prompt.id
-      ? fetchedActiveVersion
-      : prompt?.latest_version;
-
-  const activeVersionLabel =
-    activeVersion?.version_number ?? activeVersion?.commit ?? "";
+    isDiffMenuOpen,
+    setIsDiffMenuOpen,
+  } = usePromptVersionHistory(prompt);
 
   const activeStage = pickHighestStage(activeVersion?.tags);
-  const activeAuthor =
-    (activeVersion as VersionWithMaybeAuthor | undefined)?.created_by ?? "";
+  const activeAuthor = activeVersion?.created_by ?? "";
   const activeVersionEnvironments = useMemo(
     () => activeVersion?.environments ?? [],
     [activeVersion?.environments],
@@ -228,15 +131,26 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     // activeVersion can hold stale data when switching versions because
     // usePromptVersionById uses placeholderData: keepPreviousData — fall back
     // to an imperative fetch so we always load the version actually selected.
+    // Not needed when the version came from `versionFromList`: that's always
+    // freshly derived from the current version list, never stale.
     let version = activeVersion;
-    if (effectiveVersionId && fetchedActiveVersion?.id !== effectiveVersionId) {
+    if (
+      !versionFromList &&
+      effectiveVersionId &&
+      fetchedActiveVersion?.id !== effectiveVersionId
+    ) {
       try {
         const fetched = await fetchPromptVersion({
           versionId: effectiveVersionId,
         });
         // Guard against a stale/crafted activeVersionId pointing at a
-        // different prompt's version — never load foreign content.
-        version = fetched.prompt_id === prompt.id ? fetched : activeVersion;
+        // different prompt's version, or at a mask — never load that
+        // content into the playground.
+        version =
+          fetched.prompt_id === prompt.id &&
+          fetched.version_type !== PROMPT_VERSION_TYPE.MASK
+            ? fetched
+            : activeVersion;
       } catch {
         // Refetch failed — bail rather than ship stale `activeVersion`
         // (placeholder from the previously-selected version) into the
@@ -249,6 +163,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
     loadPrompt,
     prompt,
     activeVersion,
+    versionFromList,
     fetchedActiveVersion,
     effectiveVersionId,
     fetchPromptVersion,
@@ -347,7 +262,7 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
                   onSelect={() => setActiveVersionId(item.id)}
                   className={cn(
                     "flex flex-col items-start gap-1",
-                    item.id === effectiveVersionId &&
+                    item.id === activeVersion?.id &&
                       "bg-muted text-foreground focus:bg-muted",
                   )}
                 >
@@ -577,6 +492,8 @@ const PromptTab = ({ prompt }: PromptTabInterface) => {
           onSelect={(item) => setActiveVersionId(item.id)}
           hasNextPage={hasNextPage}
           isFetchingNextPage={isFetchingNextPage}
+          isFetching={isFetchingVersions}
+          hasError={isVersionsError}
           onLoadMore={fetchNextPage}
         />
       </div>

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
@@ -18,6 +18,7 @@ export default function usePromptVersionHistory(
   prompt?: PromptWithLatestVersion,
 ) {
   const [isDiffMenuOpen, setIsDiffMenuOpen] = useState(false);
+  const [isDeployMenuOpen, setIsDeployMenuOpen] = useState(false);
 
   const [activeVersionId, setActiveVersionId] = useQueryParam(
     "activeVersionId",
@@ -67,6 +68,23 @@ export default function usePromptVersionHistory(
   // correctly (fetched independently below), but the sidebar can't highlight
   // it or scroll it into view until its page is loaded — keep paging until
   // it's found (or there's nothing left to load) so the two stay in sync.
+  const isChasingDeepLink =
+    !!activeVersionId &&
+    !!versions &&
+    !versions.some((v) => v.id === activeVersionId);
+
+  // The Diff and Deploy menus each only offer whatever pages are already
+  // loaded — while either is open, keep paging until every version is
+  // available so they don't silently omit older, not-yet-loaded versions.
+  //
+  // All three reasons to keep paging are combined into one effect (rather
+  // than one per reason) so at most one `fetchNextPage()` call happens per
+  // render: with separate effects, two whose conditions both flip true in
+  // the same render (e.g. a deep-link chase while the Diff menu is opened)
+  // would both fire before either sees the other's in-flight fetch, and
+  // `fetchNextPage`'s default `cancelRefetch: true` would cancel the first
+  // request for a duplicate of the same page.
+  //
   // Must wait for `isFetchingVersions` (not just `isFetchingNextPage`) to go
   // idle: a background refetch of an already-loaded page (e.g. after a
   // version-create invalidation) reports `isFetchingNextPage: false` too,
@@ -79,9 +97,7 @@ export default function usePromptVersionHistory(
   // the failed request settles, hammering the backend forever.
   useEffect(() => {
     if (
-      activeVersionId &&
-      versions &&
-      !versions.some((v) => v.id === activeVersionId) &&
+      (isChasingDeepLink || isDiffMenuOpen || isDeployMenuOpen) &&
       hasNextPage &&
       !isFetchingVersions &&
       !isVersionsError
@@ -89,29 +105,9 @@ export default function usePromptVersionHistory(
       fetchNextPage();
     }
   }, [
-    activeVersionId,
-    versions,
-    hasNextPage,
-    isFetchingVersions,
-    isVersionsError,
-    fetchNextPage,
-  ]);
-
-  // The Diff menu's "Compare against" list only offers whatever pages are
-  // already loaded — while it's open, keep paging until every version is
-  // available so it doesn't silently omit older, not-yet-loaded versions.
-  // See the effect above for why `isVersionsError` is also required.
-  useEffect(() => {
-    if (
-      isDiffMenuOpen &&
-      hasNextPage &&
-      !isFetchingVersions &&
-      !isVersionsError
-    ) {
-      fetchNextPage();
-    }
-  }, [
+    isChasingDeepLink,
     isDiffMenuOpen,
+    isDeployMenuOpen,
     hasNextPage,
     isFetchingVersions,
     isVersionsError,
@@ -180,5 +176,7 @@ export default function usePromptVersionHistory(
     fetchNextPage,
     isDiffMenuOpen,
     setIsDiffMenuOpen,
+    isDeployMenuOpen,
+    setIsDeployMenuOpen,
   };
 }

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
@@ -42,13 +42,15 @@ export default function usePromptVersionHistory(
     },
     {
       enabled: !!prompt?.id,
-      // No refetchInterval/refetchOnWindowFocus here: useInfiniteQuery
-      // refetches every already-loaded page sequentially, and the Diff/Deploy
-      // menus deliberately load every page for large prompts — polling or
-      // refocus-refetching that unconditionally would multiply request volume
-      // by however many pages got loaded that session. Instead, the cheap
-      // `prompt` query below polls `version_count` and this list only
-      // refetches (own mutations aside) when that actually changes.
+      // No refetchInterval, and refetchOnWindowFocus explicitly off:
+      // useInfiniteQuery refetches every already-loaded page sequentially on
+      // either trigger, and the Diff/Deploy menus deliberately load every
+      // page for large prompts — polling or refocus-refetching that
+      // unconditionally would multiply request volume by however many pages
+      // got loaded that session. Instead, the cheap `prompt` query below
+      // polls `version_count` and this list only refetches (own mutations
+      // aside) when that actually changes.
+      refetchOnWindowFocus: false,
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { keepPreviousData } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import { StringParam, useQueryParam } from "use-query-params";
 import {
   PromptVersion,
@@ -25,6 +25,8 @@ export default function usePromptVersionHistory(
     StringParam,
   );
 
+  const queryClient = useQueryClient();
+
   const {
     data,
     isLoading: isVersionsLoading,
@@ -40,9 +42,38 @@ export default function usePromptVersionHistory(
     },
     {
       enabled: !!prompt?.id,
-      refetchInterval: 30000,
+      // No refetchInterval/refetchOnWindowFocus here: useInfiniteQuery
+      // refetches every already-loaded page sequentially, and the Diff/Deploy
+      // menus deliberately load every page for large prompts — polling or
+      // refocus-refetching that unconditionally would multiply request volume
+      // by however many pages got loaded that session. Instead, the cheap
+      // `prompt` query below polls `version_count` and this list only
+      // refetches (own mutations aside) when that actually changes.
     },
   );
+
+  // `prompt` is polled (see PromptPage) so `version_count` changing is a
+  // cheap signal that some version was added/removed elsewhere — only then
+  // do we pay for the expensive full-history refetch.
+  const versionCountRef = useRef(prompt?.version_count);
+  useEffect(() => {
+    if (
+      prompt?.id &&
+      prompt.version_count !== undefined &&
+      versionCountRef.current !== undefined &&
+      prompt.version_count !== versionCountRef.current
+    ) {
+      queryClient.invalidateQueries({
+        predicate: (query) =>
+          query.queryKey[0] === "prompt-versions" &&
+          typeof query.queryKey[1] === "object" &&
+          query.queryKey[1] !== null &&
+          "promptId" in query.queryKey[1] &&
+          query.queryKey[1].promptId === prompt.id,
+      });
+    }
+    versionCountRef.current = prompt?.version_count;
+  }, [prompt?.id, prompt?.version_count, queryClient]);
 
   const versions = useMemo(
     () =>

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
@@ -101,10 +101,16 @@ export default function usePromptVersionHistory(
   // correctly (fetched independently below), but the sidebar can't highlight
   // it or scroll it into view until its page is loaded — keep paging until
   // it's found (or there's nothing left to load) so the two stay in sync.
-  const isChasingDeepLink =
-    !!activeVersionId &&
-    !!versions &&
-    !versions.some((v) => v.id === activeVersionId);
+  // Memoized: a stale/nonexistent id keeps this true until every page is
+  // loaded, so an unmemoized `.some()` would re-scan the whole (growing)
+  // list on every render this component makes for unrelated reasons too.
+  const isChasingDeepLink = useMemo(
+    () =>
+      !!activeVersionId &&
+      !!versions &&
+      !versions.some((v) => v.id === activeVersionId),
+    [activeVersionId, versions],
+  );
 
   // The Diff and Deploy menus each only offer whatever pages are already
   // loaded — while either is open, keep paging until every version is

--- a/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
+++ b/apps/opik-frontend/src/v2/pages/PromptPage/PromptTab/usePromptVersionHistory.ts
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from "react";
+import { keepPreviousData } from "@tanstack/react-query";
+import { StringParam, useQueryParam } from "use-query-params";
+import {
+  PromptVersion,
+  PromptWithLatestVersion,
+  PROMPT_VERSION_TYPE,
+} from "@/types/prompts";
+import { VersionHistoryItem } from "@/v2/pages-shared/version-history/VersionHistoryTimeline";
+import usePromptVersionsByIdInfinite from "@/api/prompts/usePromptVersionsByIdInfinite";
+import usePromptVersionById from "@/api/prompts/usePromptVersionById";
+
+export interface VersionWithMaybeAuthor extends PromptVersion {
+  created_by?: string;
+}
+
+export default function usePromptVersionHistory(
+  prompt?: PromptWithLatestVersion,
+) {
+  const [isDiffMenuOpen, setIsDiffMenuOpen] = useState(false);
+
+  const [activeVersionId, setActiveVersionId] = useQueryParam(
+    "activeVersionId",
+    StringParam,
+  );
+
+  const {
+    data,
+    isLoading: isVersionsLoading,
+    hasNextPage,
+    isFetching: isFetchingVersions,
+    isFetchingNextPage,
+    isError: isVersionsError,
+    fetchNextPage,
+  } = usePromptVersionsByIdInfinite(
+    {
+      promptId: prompt?.id || "",
+      sorting: [{ id: "created_at", desc: true }],
+    },
+    {
+      enabled: !!prompt?.id,
+      refetchInterval: 30000,
+    },
+  );
+
+  const versions = useMemo(
+    () =>
+      data?.pages.flatMap((p) => p.content) as
+        | VersionWithMaybeAuthor[]
+        | undefined,
+    [data],
+  );
+  const historyItems = useMemo<VersionHistoryItem[]>(() => {
+    if (!versions) return [];
+    return versions.map((v) => ({
+      id: v.id,
+      label: v.version_number ?? v.commit,
+      tags: v.tags ?? [],
+      description: v.change_description,
+      created_at: v.created_at,
+      created_by: v.created_by,
+      environments: v.environments ?? [],
+    }));
+  }, [versions]);
+
+  // A deep link to an old version not yet in the loaded pages still renders
+  // correctly (fetched independently below), but the sidebar can't highlight
+  // it or scroll it into view until its page is loaded — keep paging until
+  // it's found (or there's nothing left to load) so the two stay in sync.
+  // Must wait for `isFetchingVersions` (not just `isFetchingNextPage`) to go
+  // idle: a background refetch of an already-loaded page (e.g. after a
+  // version-create invalidation) reports `isFetchingNextPage: false` too,
+  // and fetching the next page against that stale intermediate state can
+  // request an offset that no longer lines up with the refreshed page,
+  // producing an overlapping/duplicate row once both resolve.
+  // Also stop on `isVersionsError`: `hasNextPage` reflects the last
+  // *successful* page, so a failed fetchNextPage (retry disabled app-wide)
+  // never clears it — without this guard the effect re-fires the instant
+  // the failed request settles, hammering the backend forever.
+  useEffect(() => {
+    if (
+      activeVersionId &&
+      versions &&
+      !versions.some((v) => v.id === activeVersionId) &&
+      hasNextPage &&
+      !isFetchingVersions &&
+      !isVersionsError
+    ) {
+      fetchNextPage();
+    }
+  }, [
+    activeVersionId,
+    versions,
+    hasNextPage,
+    isFetchingVersions,
+    isVersionsError,
+    fetchNextPage,
+  ]);
+
+  // The Diff menu's "Compare against" list only offers whatever pages are
+  // already loaded — while it's open, keep paging until every version is
+  // available so it doesn't silently omit older, not-yet-loaded versions.
+  // See the effect above for why `isVersionsError` is also required.
+  useEffect(() => {
+    if (
+      isDiffMenuOpen &&
+      hasNextPage &&
+      !isFetchingVersions &&
+      !isVersionsError
+    ) {
+      fetchNextPage();
+    }
+  }, [
+    isDiffMenuOpen,
+    hasNextPage,
+    isFetchingVersions,
+    isVersionsError,
+    fetchNextPage,
+  ]);
+
+  const effectiveVersionId = useMemo(() => {
+    if (activeVersionId) return activeVersionId;
+    return prompt?.latest_version?.id ?? versions?.[0]?.id ?? "";
+  }, [activeVersionId, versions, prompt?.latest_version?.id]);
+
+  // The paginated list response already carries full version fields, so if
+  // the target version is among the loaded pages, reuse it instead of
+  // issuing a redundant by-id request for data we already have.
+  const versionFromList = useMemo(
+    () => versions?.find((v) => v.id === effectiveVersionId),
+    [versions, effectiveVersionId],
+  );
+
+  const { data: fetchedActiveVersion, isLoading: isActiveVersionLoading } =
+    usePromptVersionById(
+      { versionId: effectiveVersionId },
+      {
+        enabled: !!effectiveVersionId && !versionFromList,
+        placeholderData: keepPreviousData,
+      },
+    );
+
+  // A stale or crafted activeVersionId query param can reference a version
+  // belonging to a different prompt (it's fetched independently of the
+  // current prompt's own version list) — never render foreign content here.
+  // Also reject masks: the single-version-by-id lookup isn't scoped to
+  // version_type the way the paginated list is, so a mask's id (same
+  // prompt) would otherwise pass the ownership check and render as a real
+  // version — and "Deploy to" on it would then 400 server-side. Neither
+  // check applies to `versionFromList`: it comes straight from the current
+  // prompt's own (mask-filtered) version list.
+  const activeVersion: VersionWithMaybeAuthor | undefined =
+    versionFromList ??
+    (fetchedActiveVersion &&
+    prompt &&
+    fetchedActiveVersion.prompt_id === prompt.id &&
+    fetchedActiveVersion.version_type !== PROMPT_VERSION_TYPE.MASK
+      ? fetchedActiveVersion
+      : prompt?.latest_version);
+
+  const activeVersionLabel =
+    activeVersion?.version_number ?? activeVersion?.commit ?? "";
+
+  return {
+    activeVersionId,
+    setActiveVersionId,
+    versions,
+    historyItems,
+    effectiveVersionId,
+    versionFromList,
+    fetchedActiveVersion,
+    activeVersion,
+    activeVersionLabel,
+    isVersionsLoading,
+    isActiveVersionLoading,
+    hasNextPage,
+    isFetchingNextPage,
+    isFetchingVersions,
+    isVersionsError,
+    fetchNextPage,
+    isDiffMenuOpen,
+    setIsDiffMenuOpen,
+  };
+}


### PR DESCRIPTION
## Details
Version history on the Prompt tab only ever loaded the first 25 versions (a single `useQuery(page=1,size=25)`), so older versions were unreachable, and a deep link to one silently fell back to the latest version while still showing a stale `vN` label. This switches to a paginated `usePromptVersionsByIdInfinite` hook and wires the lazy-load already built into `VersionHistoryTimeline`, and replaces client-computed index labels (`v${total-idx}`) with the backend's persistent `version_number` (falling back to `commit` for pre-migration rows that never got backfilled). This also fixes OPIK-8189, where the Compare sheet recomputed labels from whatever was locally loaded instead of the true total, mislabeling versions past the first page.

Along the way, a few related issues surfaced and are fixed in the same diff:
- A stale/crafted `activeVersionId` query param (now fetched independently of the current prompt's own list) could render a different prompt's content — guarded so it always falls back to `prompt.latest_version` instead.
- The new hook's cache key wasn't matched by the existing mutation-invalidation predicates (create/delete/deploy a version), so the sidebar went stale after writes — aligned the key shape so those predicates pick it up.
- `DeployToEnvironmentMenu` received the raw, unguarded `activeVersionId` instead of the ownership-checked version — could deploy-to-environment against the wrong prompt's version.
- A race between the mutation's cache-invalidation refetch and the new deep-link auto-pagination effect could duplicate a row in the sidebar — fixed by gating on the broader `isFetching` flag instead of just `isFetchingNextPage`.
- The Diff dropdown's "Compare against" list was capped at whatever page was already loaded (e.g. 24 of 31 options on a 32-version prompt) — it now auto-paginates through every version while open, with a loading indicator.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8050
- Resolves OPIK-8189

## AI-WATERMARK

AI-WATERMARK: yes
- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: Full implementation (frontend TypeScript/React changes across prompt version history, deploy menu, compare dialog, diff menu) and regression testing, under human direction and review at each step.
- Human verification: Reviewed and directed by Natalia across multiple rounds — approved/rejected specific fixes (e.g. reverted an eager-loading approach and a DEP-03 fix attempt after discussion), verified live against a local dev instance for each area of the test plan.

## Testing
Verified against a local dev instance (backend :8080, frontend :5174) using Playwright, plus `npx tsc --noEmit` and `npx eslint` on all touched files (all clean).

Scenarios validated:
- Version history pagination: >25 and ≤25 version prompts, scroll-triggered loading, no infinite-loop regressions.
- Deep-linking: link to an old (unloaded-page) version renders and highlights correctly; nonexistent/deleted version id falls back to latest with no infinite loop; a different prompt's version id never renders foreign content; manually selecting a version while auto-pagination is chasing a deep link doesn't race.
- Version-create races: creating a new version while a background refetch/auto-pagination effect is in flight no longer duplicates a sidebar row (reproduced pre-fix, confirmed fixed post-fix across repeated trials).
- Labels: match the backend's `version_number` (or `commit` fallback) consistently across the sidebar, main panel, Compare dialog, and Deploy-to "Currently vN" tooltip.
- Deploy-to-environment: deploy/remove/remove-all update badges immediately; correct label for an environment owned by a version outside the initially-loaded page (once loaded by the Diff-menu fix's shared pagination).
- Diff/Compare: correct base/diff preselection and labels; chat-structured diff mode and word-level highlighting; dialog state resets correctly across repeated open/close with different starting versions.
- Diff menu pagination: opens and auto-loads every version (was previously capped at the first page); loading spinner shows only while genuinely fetching another page, not on unrelated background polls; immediate selection before pagination completes works with no console errors.
- Permissions/edge states: hard refresh with `activeVersionId` in the URL shows the skeleton then renders correctly with no flash; resizing across the `xl` breakpoint keeps mobile/desktop selection in sync.

Not run: a read-only/no-permission role (local dev is single-admin with no RBAC configured) and the Playground-load flow's own confirm-dialog/navigation timing (that code is untouched by this diff; the touched code feeding into it was verified via code review instead of fighting flaky dropdown-open timing in automation).

## Documentation
N/A — no public API or documented behavior changed beyond the bug fixes described above.