### PR TITLE
[issue-7686] [BE][FE] feat: add OpenInference pretty formatting

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -335,6 +335,22 @@ public class OpenTelemetryMapper {
         model = resolved.model();
         provider = resolved.provider();
 
+        if (openInference != null && usage.containsKey("prompt_tokens")) {
+            // OpenInference prompt totals include cache reads/writes. Preserve those totals for
+            // display, but provide the exclusive input count expected by these providers' pricing.
+            String exclusiveInputKey = switch (provider) {
+                case "anthropic", "anthropic_vertexai" -> "original_usage.input_tokens";
+                case "bedrock", "bedrock_converse" -> "original_usage.inputTokens";
+                case null, default -> null;
+            };
+            if (exclusiveInputKey != null) {
+                long uncachedTokens = (long) usage.get("prompt_tokens")
+                        - usage.getOrDefault("cache_read_input_tokens", 0)
+                        - usage.getOrDefault("cache_creation_input_tokens", 0);
+                usage.put(exclusiveInputKey, (int) Math.max(0, uncachedTokens));
+            }
+        }
+
         // Agent-run spans (gen_ai.operation.name=invoke_agent) are not LLM calls. Other attributes
         // on them (e.g. gen_ai.system_instructions) would otherwise type them as llm; force general.
         if ("invoke_agent".equals(metadata.path("gen_ai.operation.name").asText(null))) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -6,9 +6,11 @@ import com.comet.opik.api.Span.SpanBuilder;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.domain.mapping.otel.GenAIMappingRules;
 import com.comet.opik.domain.mapping.otel.GeneralMappingRules;
+import com.comet.opik.domain.mapping.otel.OpenInferenceSpanNormalizer;
 import com.comet.opik.domain.mapping.otel.ProviderResolvers;
 import com.comet.opik.domain.retention.RetentionUtils;
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.KeyValue;
@@ -153,6 +155,7 @@ public class OpenTelemetryMapper {
         ObjectNode output = JsonUtils.createObjectNode();
         ObjectNode metadata = JsonUtils.createObjectNode();
         Set<String> tags = new HashSet<>();
+        var openInference = OpenInferenceSpanNormalizer.normalize(attributes).orElse(null);
         // Claude Code spans carry a lot of session/config attributes that aren't input. For that
         // integration the default bucket for unmapped attributes is metadata (not input), so only
         // the explicitly promoted content attributes land in input/output/usage.
@@ -160,7 +163,7 @@ public class OpenTelemetryMapper {
         // batch can mix scopes from more than one integration, so gating this on the batch-wide
         // value could misroute a non-Claude span or skip routing for a real Claude Code span.
         boolean isClaudeCode = OpenTelemetryMappingRuleFactory.isClaudeCodeSpan(spanName);
-        ObjectNode defaultBucket = isClaudeCode ? metadata : input;
+        ObjectNode defaultBucket = isClaudeCode || openInference != null ? metadata : input;
 
         // Hold model and provider until the attribute loop completes so we can apply
         // post-processing (e.g. Elastic Inference Service routing) that needs both values.
@@ -179,6 +182,12 @@ public class OpenTelemetryMapper {
         for (KeyValue attribute : attributes) {
             var key = attribute.getKey();
             var value = attribute.getValue();
+
+            // OpenInference semantic attributes have already been normalized as one coherent shape.
+            // Skipping them here prevents generic prefix rules from processing the same key again.
+            if (openInference != null && openInference.consumes(key)) {
+                continue;
+            }
 
             // Claude Code's `new_context` is the latest message fed to the model on llm_request
             // spans (the real LLM input); on interaction/tool spans it just repeats the prompt /
@@ -278,6 +287,37 @@ public class OpenTelemetryMapper {
             extractToolOutputEvent(events, output);
         }
 
+        if (openInference != null) {
+            // User-supplied OpenInference metadata is already filtered by the normalizer. Apply
+            // exact semantic metadata after common rules so marker/MIME/identity fields remain
+            // authoritative and unknown OpenInference fields retain their original dotted key.
+            metadata.setAll(openInference.metadata());
+
+            // An explicit Opik thread_id wins regardless of OTLP attribute order. Otherwise use
+            // the OpenInference session identifier as the trace-grouping thread id.
+            var explicitThreadId = attributes.stream()
+                    .filter(attribute -> "thread_id".equals(attribute.getKey()))
+                    .map(KeyValue::getValue)
+                    .findFirst();
+            if (explicitThreadId.isPresent()) {
+                extractToJsonColumn(metadata, "thread_id", explicitThreadId.get());
+            } else if (StringUtils.isNotBlank(openInference.sessionId())) {
+                metadata.put("thread_id", openInference.sessionId());
+            }
+
+            usage.putAll(openInference.usage());
+            tags.addAll(openInference.tags());
+            if (StringUtils.isNotBlank(openInference.model())) {
+                model = openInference.model();
+            }
+            if (StringUtils.isNotBlank(openInference.provider())) {
+                provider = openInference.provider();
+            }
+            if (openInference.totalEstimatedCost() != null) {
+                spanBuilder.totalEstimatedCost(openInference.totalEstimatedCost());
+            }
+        }
+
         // Fall back to the current `gen_ai.provider.name` only when the deprecated `gen_ai.system`
         // did not report a provider.
         // Both sides must be non-blank: a non-string or empty `gen_ai.provider.name` yields ""
@@ -300,6 +340,9 @@ public class OpenTelemetryMapper {
         if ("invoke_agent".equals(metadata.path("gen_ai.operation.name").asText(null))) {
             spanBuilder.type(SpanType.general);
         }
+        if (openInference != null) {
+            spanBuilder.type(openInference.spanType());
+        }
 
         if (model != null) {
             spanBuilder.model(model);
@@ -311,11 +354,17 @@ public class OpenTelemetryMapper {
         if (!metadata.isEmpty()) {
             spanBuilder.metadata(metadata);
         }
-        if (!output.isEmpty()) {
-            spanBuilder.output(output);
+        JsonNode finalOutput = openInference == null
+                ? (output.isEmpty() ? null : output)
+                : openInference.composeOutput(output);
+        JsonNode finalInput = openInference == null
+                ? (input.isEmpty() ? null : input)
+                : openInference.composeInput(input);
+        if (finalOutput != null) {
+            spanBuilder.output(finalOutput);
         }
-        if (!input.isEmpty()) {
-            spanBuilder.input(input);
+        if (finalInput != null) {
+            spanBuilder.input(finalInput);
         }
         if (!usage.isEmpty()) {
             // Some integrations (e.g. PydanticAI) send prompt_tokens and completion_tokens

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -344,10 +344,10 @@ public class OpenTelemetryMapper {
                 case null, default -> null;
             };
             if (exclusiveInputKey != null) {
-                long uncachedTokens = (long) usage.get("prompt_tokens")
-                        - usage.getOrDefault("cache_read_input_tokens", 0)
-                        - usage.getOrDefault("cache_creation_input_tokens", 0);
-                usage.put(exclusiveInputKey, (int) Math.max(0, uncachedTokens));
+                long uncachedTokens = Math.max(0L, usage.get("prompt_tokens"))
+                        - Math.max(0L, usage.getOrDefault("cache_read_input_tokens", 0))
+                        - Math.max(0L, usage.getOrDefault("cache_creation_input_tokens", 0));
+                usage.put(exclusiveInputKey, Math.clamp(uncachedTokens, 0, Integer.MAX_VALUE));
             }
         }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -266,6 +266,10 @@ public class OpenTelemetryMapper {
                     break;
 
                 case THREAD_ID :
+                    // Empty IDs must not suppress a valid conversation/session fallback.
+                    if (value.hasStringValue() && StringUtils.isBlank(value.getStringValue())) {
+                        break;
+                    }
                     // On OpenInference spans: explicit Opik ID > GenAI conversation > session.
                     // Repeated attributes of the same priority retain the first value.
                     boolean explicit = THREAD_ID.equals(key);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/OpenTelemetryMapper.java
@@ -136,10 +136,11 @@ public class OpenTelemetryMapper {
     }
 
     private static final String CLAUDE_CODE_LLM_SPAN = "claude_code.llm_request";
+    private static final String THREAD_ID = "thread_id";
     private static final String NEW_CONTEXT_ATTR = "new_context";
 
     // Reserved metadata keys that must not be overwritten by user-supplied JSON merged from opik.metadata.
-    private static final Set<String> RESERVED_METADATA_KEYS = Set.of("thread_id", "integration", "server.address");
+    private static final Set<String> RESERVED_METADATA_KEYS = Set.of(THREAD_ID, "integration", "server.address");
 
     /**
      * Same as {@link #enrichSpanWithAttributes(SpanBuilder, List, String, List)} but with the OTEL
@@ -173,6 +174,7 @@ public class OpenTelemetryMapper {
         // Provider reported via the current `gen_ai.provider.name`, held separately so the
         // deprecated `gen_ai.system` stays authoritative. See the PROVIDER case below.
         String providerName = null;
+        boolean hasExplicitThreadId = false;
 
         if (StringUtils.isNotBlank(integrationName)) {
             metadata.put("integration", integrationName);
@@ -264,11 +266,13 @@ public class OpenTelemetryMapper {
                     break;
 
                 case THREAD_ID :
-                    // Store as 'thread_id' in metadata for trace grouping
-                    // First value wins if multiple attributes map to THREAD_ID
-                    if (!metadata.has("thread_id")) {
-                        extractToJsonColumn(metadata, "thread_id", value);
+                    // On OpenInference spans: explicit Opik ID > GenAI conversation > session.
+                    // Repeated attributes of the same priority retain the first value.
+                    boolean explicit = THREAD_ID.equals(key);
+                    if (!metadata.has(THREAD_ID) || (openInference != null && explicit && !hasExplicitThreadId)) {
+                        extractToJsonColumn(metadata, THREAD_ID, value);
                     }
+                    hasExplicitThreadId |= explicit;
                     break;
 
                 case DROP :
@@ -293,16 +297,8 @@ public class OpenTelemetryMapper {
             // authoritative and unknown OpenInference fields retain their original dotted key.
             metadata.setAll(openInference.metadata());
 
-            // An explicit Opik thread_id wins regardless of OTLP attribute order. Otherwise use
-            // the OpenInference session identifier as the trace-grouping thread id.
-            var explicitThreadId = attributes.stream()
-                    .filter(attribute -> "thread_id".equals(attribute.getKey()))
-                    .map(KeyValue::getValue)
-                    .findFirst();
-            if (explicitThreadId.isPresent()) {
-                extractToJsonColumn(metadata, "thread_id", explicitThreadId.get());
-            } else if (StringUtils.isNotBlank(openInference.sessionId())) {
-                metadata.put("thread_id", openInference.sessionId());
+            if (!metadata.has(THREAD_ID) && StringUtils.isNotBlank(openInference.sessionId())) {
+                metadata.put(THREAD_ID, openInference.sessionId());
             }
 
             usage.putAll(openInference.usage());
@@ -335,18 +331,19 @@ public class OpenTelemetryMapper {
         model = resolved.model();
         provider = resolved.provider();
 
-        if (openInference != null && usage.containsKey("prompt_tokens")) {
+        if (openInference != null && openInference.usage().containsKey("prompt_tokens")) {
             // OpenInference prompt totals include cache reads/writes. Preserve those totals for
             // display, but provide the exclusive input count expected by these providers' pricing.
+            // Only OpenInference-sourced totals carry this contract; do not reinterpret generic usage.
             String exclusiveInputKey = switch (provider) {
                 case "anthropic", "anthropic_vertexai" -> "original_usage.input_tokens";
-                case "bedrock", "bedrock_converse" -> "original_usage.inputTokens";
+                case "bedrock" -> "original_usage.inputTokens";
                 case null, default -> null;
             };
             if (exclusiveInputKey != null) {
-                long uncachedTokens = Math.max(0L, usage.get("prompt_tokens"))
-                        - Math.max(0L, usage.getOrDefault("cache_read_input_tokens", 0))
-                        - Math.max(0L, usage.getOrDefault("cache_creation_input_tokens", 0));
+                long uncachedTokens = Math.max(0L, openInference.usage().get("prompt_tokens"))
+                        - Math.max(0L, openInference.usage().getOrDefault("cache_read_input_tokens", 0))
+                        - Math.max(0L, openInference.usage().getOrDefault("cache_creation_input_tokens", 0));
                 usage.put(exclusiveInputKey, Math.clamp(uncachedTokens, 0, Integer.MAX_VALUE));
             }
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -67,7 +67,8 @@ public class CostService {
     // Vertex for online evaluation. Canonical names (and any not listed) pass through unchanged.
     private static final Map<String, String> RUNTIME_PROVIDER_MAPPING = Map.of(
             "gemini", "google_ai",
-            "vertex-ai", "google_vertexai");
+            "vertex-ai", "google_vertexai",
+            "bedrock_converse", "bedrock");
     public static final String MODEL_PRICES_FILE = "model_prices_and_context_window.json";
     public static final String MODEL_PRICES_OVERRIDES_FILE = "model_prices_overrides.json";
     private static final String BEDROCK_PROVIDER = "bedrock";
@@ -140,7 +141,7 @@ public class CostService {
             return DEFAULT_COST;
         }
 
-        // Normalize runtime provider names ("gemini", "vertex-ai") to the canonical price-table provider
+        // Normalize runtime provider names to the canonical price-table provider
         // so callers holding an LlmProvider value hit the same rows as callers passing the canonical name.
         provider = RUNTIME_PROVIDER_MAPPING.getOrDefault(provider, provider);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -66,9 +66,9 @@ public class CostService {
     // public pricing to map to. Vertex is unambiguous here because only Gemini models are offered on
     // Vertex for online evaluation. Canonical names (and any not listed) pass through unchanged.
     private static final Map<String, String> RUNTIME_PROVIDER_MAPPING = Map.of(
-            "gemini", "google_ai",
+            "gemini", PROVIDERS_MAPPING.get("gemini"),
             "vertex-ai", "google_vertexai",
-            "bedrock_converse", "bedrock");
+            "bedrock_converse", PROVIDERS_MAPPING.get("bedrock_converse"));
     public static final String MODEL_PRICES_FILE = "model_prices_and_context_window.json";
     public static final String MODEL_PRICES_OVERRIDES_FILE = "model_prices_overrides.json";
     private static final String BEDROCK_PROVIDER = "bedrock";

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAiProviderAliasResolver.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/GenAiProviderAliasResolver.java
@@ -50,6 +50,7 @@ public class GenAiProviderAliasResolver implements ProviderResolver {
             Map.entry("gcp.vertex_ai", GoogleProviderResolver.GOOGLE_VERTEX_AI),
             Map.entry("gcp.gemini", GoogleProviderResolver.GOOGLE_AI),
             Map.entry("aws.bedrock", "bedrock"),
+            Map.entry("bedrock_converse", "bedrock"),
             Map.entry("azure.ai.openai", "azure"),
             Map.entry("mistral_ai", "mistral"),
             Map.entry("x_ai", "xai"));

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceMappingRules.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceMappingRules.java
@@ -16,7 +16,9 @@ public final class OpenInferenceMappingRules {
 
     private static final List<OpenTelemetryMappingRule> RULES = List.of(
             OpenTelemetryMappingRule.builder()
-                    .rule("llm.invocation_parameters.*").isPrefix(true).source(SOURCE)
+                    // Keep the legacy unmarked-span fallback, but match the real semantic key.
+                    // Marked OpenInference spans are handled atomically by OpenInferenceSpanNormalizer.
+                    .rule("llm.invocation_parameters").source(SOURCE)
                     .outcome(OpenTelemetryMappingRule.Outcome.INPUT).spanType(SpanType.llm).build(),
             OpenTelemetryMappingRule.builder()
                     .rule("llm.model_name").source(SOURCE).outcome(OpenTelemetryMappingRule.Outcome.MODEL)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
@@ -405,13 +405,13 @@ public final class OpenInferenceSpanNormalizer {
                 resolvedProvider = "bedrock";
             }
             if (!inputMessages.isEmpty()) {
-                ArrayNode messages = buildMessages(inputMessages, false);
+                ArrayNode messages = buildMessages(inputMessages);
                 if (!messages.isEmpty()) {
                     input.set("messages", messages);
                 }
             }
             if (!outputMessages.isEmpty()) {
-                ArrayNode messages = buildMessages(outputMessages, true);
+                ArrayNode messages = buildMessages(outputMessages);
                 if (!messages.isEmpty()) {
                     output.set("messages", messages);
                 }
@@ -459,16 +459,10 @@ public final class OpenInferenceSpanNormalizer {
                     sessionId);
         }
 
-        private ArrayNode buildMessages(TreeMap<Integer, MessageBuilder> messages, boolean outputSide) {
+        private ArrayNode buildMessages(TreeMap<Integer, MessageBuilder> messages) {
             ArrayNode result = JsonUtils.createArrayNode();
             messages.values().forEach(messageBuilder -> {
                 ObjectNode message = messageBuilder.build();
-                JsonNode legacyFunctionCall = message.remove("function_call");
-                if (outputSide && functionCall == null && legacyFunctionCall != null) {
-                    functionCall = legacyFunctionCall;
-                } else if (legacyFunctionCall != null) {
-                    message.set("function_call", legacyFunctionCall);
-                }
                 if (!message.isEmpty()) {
                     result.add(message);
                 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
@@ -3,6 +3,8 @@ package com.comet.opik.domain.mapping.otel;
 import com.comet.opik.domain.SpanType;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingUtils;
 import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
@@ -13,7 +15,6 @@ import io.opentelemetry.proto.common.v1.KeyValue;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.List;
@@ -270,6 +271,13 @@ public final class OpenInferenceSpanNormalizer {
                     putPromptTemplateField("version", key, value, false);
                     yield true;
                 }
+                case "tool.json_schema" -> {
+                    JsonNode parsed = parseJsonStringOrMetadata(key, value);
+                    if (parsed != null) {
+                        metadata.set(key, parsed);
+                    }
+                    yield true;
+                }
                 case "llm.cost.total" -> {
                     totalEstimatedCost = OpenTelemetryMappingUtils.extractCost(value).orElse(null);
                     if (totalEstimatedCost == null) {
@@ -493,21 +501,20 @@ public final class OpenInferenceSpanNormalizer {
                 metadata.set("metadata", toJsonNode(value));
                 return;
             }
-            try {
-                JsonNode parsed = JsonUtils.getJsonNodeFromString(value.getStringValue());
-                if (!parsed.isObject()) {
-                    metadata.set("metadata", parsed);
-                    return;
-                }
-                parsed.fields().forEachRemaining(entry -> {
-                    if (!RESERVED_METADATA_KEYS.contains(entry.getKey())) {
-                        metadata.set(entry.getKey(), entry.getValue());
-                    }
-                });
-            } catch (UncheckedIOException exception) {
-                log.debug("Failed to parse OpenInference metadata as JSON", exception);
+            JsonNode parsed = parseJsonString(value.getStringValue());
+            if (parsed == null) {
                 metadata.put("metadata", value.getStringValue());
+                return;
             }
+            if (!parsed.isObject()) {
+                metadata.set("metadata", parsed);
+                return;
+            }
+            parsed.fields().forEachRemaining(entry -> {
+                if (!RESERVED_METADATA_KEYS.contains(entry.getKey())) {
+                    metadata.set(entry.getKey(), entry.getValue());
+                }
+            });
         }
 
         private String stringValueOrMetadata(String key, AnyValue value) {
@@ -531,7 +538,11 @@ public final class OpenInferenceSpanNormalizer {
                 metadata.set(originalKey, toJsonNode(value));
                 return null;
             }
-            return parseJsonString(value.getStringValue());
+            JsonNode parsed = parseJsonString(value.getStringValue());
+            if (parsed == null) {
+                metadata.put(originalKey, value.getStringValue());
+            }
+            return parsed;
         }
     }
 
@@ -561,7 +572,11 @@ public final class OpenInferenceSpanNormalizer {
                 if (!value.hasStringValue()) {
                     return false;
                 }
-                functionCall.set("arguments", parseJsonString(value.getStringValue()));
+                JsonNode arguments = parseJsonString(value.getStringValue());
+                if (arguments == null) {
+                    return false;
+                }
+                functionCall.set("arguments", arguments);
                 return true;
             }
 
@@ -744,12 +759,12 @@ public final class OpenInferenceSpanNormalizer {
         if (!JSON_MIME_TYPE.equals(normalizeMimeType(mimeType))) {
             return JsonUtils.valueToTree(value.getStringValue());
         }
-        try {
-            return JsonUtils.getJsonNodeFromString(value.getStringValue());
-        } catch (UncheckedIOException exception) {
-            log.debug("Failed to parse OpenInference {} as JSON; preserving the original value", key, exception);
-            return JsonUtils.valueToTree(value.getStringValue());
+        JsonNode parsed = parseJsonString(value.getStringValue());
+        if (parsed != null) {
+            return parsed;
         }
+        log.debug("Failed to parse OpenInference {} as JSON; preserving the original value", key);
+        return JsonUtils.valueToTree(value.getStringValue());
     }
 
     private static String normalizeMimeType(String mimeType) {
@@ -762,7 +777,15 @@ public final class OpenInferenceSpanNormalizer {
     }
 
     private static JsonNode parseJsonString(String value) {
-        return JsonUtils.getJsonNodeFromStringWithFallback(value);
+        try {
+            JsonNode parsed = JsonUtils.getMapper()
+                    .reader()
+                    .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+                    .readTree(value);
+            return parsed == null || parsed.isMissingNode() ? null : parsed;
+        } catch (JsonProcessingException exception) {
+            return null;
+        }
     }
 
     private static SpanType toSpanType(String kind) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
@@ -1,0 +1,810 @@
+package com.comet.opik.domain.mapping.otel;
+
+import com.comet.opik.domain.SpanType;
+import com.comet.opik.domain.mapping.OpenTelemetryMappingUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Normalizes the flattened OpenInference semantic conventions into Opik's input, output and span fields.
+ *
+ * <p>The normalizer is intentionally gated by the required per-span {@code openinference.span.kind}
+ * attribute. Instrumentation scope names are batch-level in OTLP and cannot safely identify a span when
+ * one request contains several integrations.</p>
+ */
+@Slf4j
+public final class OpenInferenceSpanNormalizer {
+
+    public static final String SPAN_KIND = "openinference.span.kind";
+
+    private static final String INPUT_VALUE = "input.value";
+    private static final String INPUT_MIME_TYPE = "input.mime_type";
+    private static final String OUTPUT_VALUE = "output.value";
+    private static final String OUTPUT_MIME_TYPE = "output.mime_type";
+    private static final String JSON_MIME_TYPE = "application/json";
+
+    private static final Pattern MESSAGE_ATTRIBUTE = Pattern.compile(
+            "^llm\\.(input|output)_messages\\.([^.]+)\\.message\\.(.+)$");
+    private static final Pattern MESSAGE_CONTENT_ATTRIBUTE = Pattern.compile(
+            "^contents\\.([^.]+)\\.(.+)$");
+    private static final Pattern MESSAGE_TOOL_CALL_ATTRIBUTE = Pattern.compile(
+            "^tool_calls\\.([^.]+)\\.tool_call\\.(.+)$");
+    private static final Pattern TOOL_ATTRIBUTE = Pattern.compile(
+            "^llm\\.tools\\.([^.]+)\\.tool\\.(name|description|json_schema)$");
+    private static final Pattern PROMPT_ATTRIBUTE = Pattern.compile(
+            "^llm\\.prompts\\.([^.]+)\\.prompt\\.text$");
+    private static final Pattern CHOICE_ATTRIBUTE = Pattern.compile(
+            "^llm\\.choices\\.([^.]+)\\.completion\\.text$");
+
+    private static final Map<String, String> USAGE_KEYS = Map.of(
+            "llm.token_count.prompt", "prompt_tokens",
+            "llm.token_count.completion", "completion_tokens",
+            "llm.token_count.total", "total_tokens",
+            "llm.token_count.prompt_details.cache_read", "cache_read_input_tokens",
+            "llm.token_count.prompt_details.cache_write", "cache_creation_input_tokens",
+            "llm.token_count.prompt_details.audio", "input_audio_tokens",
+            "llm.token_count.completion_details.reasoning", "reasoning_tokens",
+            "llm.token_count.completion_details.audio", "output_audio_tokens");
+
+    private static final Set<String> RESERVED_METADATA_KEYS = Set.of(
+            "thread_id", "integration", "server.address", SPAN_KIND, INPUT_MIME_TYPE, OUTPUT_MIME_TYPE,
+            "user.id");
+
+    private static final Set<String> OPENINFERENCE_PREFIXES = Set.of(
+            "openinference.", "input.", "output.", "llm.", "session.", "user.", "tag.", "tool.",
+            "embedding.", "retrieval.", "reranker.", "prompt.", "agent.", "graph.");
+
+    private OpenInferenceSpanNormalizer() {
+    }
+
+    /**
+     * Returns a normalization result only when the exact required marker is present on this span.
+     */
+    public static Optional<Result> normalize(List<KeyValue> attributes) {
+        if (attributes == null || attributes.stream().noneMatch(attribute -> SPAN_KIND.equals(attribute.getKey()))) {
+            return Optional.empty();
+        }
+
+        var state = new State();
+        attributes.forEach(state::accept);
+        return Optional.of(state.finish());
+    }
+
+    /**
+     * OpenInference values that are applied after the common OTEL rules, so semantic attributes win
+     * deterministic collisions with raw input/output objects and generic attributes.
+     */
+    public record Result(
+            Set<String> consumedKeys,
+            JsonNode rawInput,
+            boolean hasRawInput,
+            JsonNode rawOutput,
+            boolean hasRawOutput,
+            ObjectNode structuredInput,
+            ObjectNode structuredOutput,
+            ObjectNode metadata,
+            Map<String, Integer> usage,
+            Set<String> tags,
+            String model,
+            String provider,
+            SpanType spanType,
+            BigDecimal totalEstimatedCost,
+            String sessionId) {
+
+        public boolean consumes(String key) {
+            return consumedKeys.contains(key);
+        }
+
+        public JsonNode composeInput(ObjectNode commonInput) {
+            return compose(rawInput, hasRawInput, commonInput, structuredInput);
+        }
+
+        public JsonNode composeOutput(ObjectNode commonOutput) {
+            return compose(rawOutput, hasRawOutput, commonOutput, structuredOutput);
+        }
+
+        private static JsonNode compose(JsonNode raw, boolean hasRaw, ObjectNode common, ObjectNode semantic) {
+            boolean hasCommon = common != null && !common.isEmpty();
+            boolean hasSemantic = semantic != null && !semantic.isEmpty();
+
+            if (hasRaw && !raw.isObject() && !hasCommon && !hasSemantic) {
+                return raw.deepCopy();
+            }
+            if (!hasRaw && !hasCommon && !hasSemantic) {
+                return null;
+            }
+
+            ObjectNode result = JsonUtils.createObjectNode();
+            if (hasRaw) {
+                if (raw.isObject()) {
+                    result.setAll((ObjectNode) raw);
+                } else {
+                    result.set("value", raw.deepCopy());
+                }
+            }
+            if (hasCommon) {
+                result.setAll(common);
+            }
+            if (hasSemantic) {
+                result.setAll(semantic);
+            }
+            return result;
+        }
+    }
+
+    private static final class State {
+
+        private final Set<String> consumedKeys = new HashSet<>();
+        private final ObjectNode input = JsonUtils.createObjectNode();
+        private final ObjectNode output = JsonUtils.createObjectNode();
+        private final ObjectNode metadata = JsonUtils.createObjectNode();
+        private final Map<String, Integer> usage = new TreeMap<>();
+        private final Set<String> tags = new HashSet<>();
+        private final TreeMap<Integer, MessageBuilder> inputMessages = new TreeMap<>();
+        private final TreeMap<Integer, MessageBuilder> outputMessages = new TreeMap<>();
+        private final TreeMap<Integer, ObjectNode> tools = new TreeMap<>();
+        private final TreeMap<Integer, ObjectNode> prompts = new TreeMap<>();
+        private final TreeMap<Integer, ObjectNode> choices = new TreeMap<>();
+
+        private AnyValue rawInput;
+        private AnyValue rawOutput;
+        private String inputMimeType;
+        private String outputMimeType;
+        private String responseModel;
+        private String model;
+        private String requestModel;
+        private String provider;
+        private String system;
+        private String spanKind;
+        private String sessionId;
+        private BigDecimal totalEstimatedCost;
+        private JsonNode functionCall;
+
+        private void accept(KeyValue attribute) {
+            String key = attribute.getKey();
+            AnyValue value = attribute.getValue();
+
+            if (acceptExact(key, value)
+                    || acceptMessage(key, value)
+                    || acceptIndexedObject(key, value)
+                    || acceptUsage(key, value)) {
+                consumedKeys.add(key);
+                return;
+            }
+
+            if (isOpenInferenceAttribute(key)) {
+                metadata.set(key, toJsonNode(value));
+                consumedKeys.add(key);
+            }
+        }
+
+        private boolean acceptExact(String key, AnyValue value) {
+            return switch (key) {
+                case SPAN_KIND -> {
+                    spanKind = stringValueOrMetadata(key, value);
+                    metadata.set(key, toJsonNode(value));
+                    yield true;
+                }
+                case INPUT_VALUE -> {
+                    rawInput = value;
+                    yield true;
+                }
+                case OUTPUT_VALUE -> {
+                    rawOutput = value;
+                    yield true;
+                }
+                case INPUT_MIME_TYPE -> {
+                    inputMimeType = stringValueOrMetadata(key, value);
+                    metadata.set(key, toJsonNode(value));
+                    yield true;
+                }
+                case OUTPUT_MIME_TYPE -> {
+                    outputMimeType = stringValueOrMetadata(key, value);
+                    metadata.set(key, toJsonNode(value));
+                    yield true;
+                }
+                case "llm.response.model_name" -> {
+                    responseModel = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.model_name" -> {
+                    model = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.request.model_name" -> {
+                    requestModel = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.provider" -> {
+                    provider = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.system" -> {
+                    system = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.invocation_parameters" -> {
+                    JsonNode parsed = parseJsonStringOrMetadata(key, value);
+                    if (parsed != null) {
+                        input.set("invocation_parameters", parsed);
+                    }
+                    yield true;
+                }
+                case "llm.function_call" -> {
+                    functionCall = parseJsonStringOrMetadata(key, value);
+                    yield true;
+                }
+                case "llm.finish_reason" -> {
+                    putStringOrMetadata(output, "finish_reason", key, value);
+                    yield true;
+                }
+                case "llm.prompt_template.template" -> {
+                    putPromptTemplateField("template", key, value, false);
+                    yield true;
+                }
+                case "llm.prompt_template.variables" -> {
+                    putPromptTemplateField("variables", key, value, true);
+                    yield true;
+                }
+                case "llm.prompt_template.version" -> {
+                    putPromptTemplateField("version", key, value, false);
+                    yield true;
+                }
+                case "llm.cost.total" -> {
+                    totalEstimatedCost = OpenTelemetryMappingUtils.extractCost(value).orElse(null);
+                    if (totalEstimatedCost == null) {
+                        metadata.set(key, toJsonNode(value));
+                    }
+                    yield true;
+                }
+                case "session.id" -> {
+                    sessionId = stringValueOrMetadata(key, value);
+                    yield true;
+                }
+                case "user.id" -> {
+                    metadata.set(key, toJsonNode(value));
+                    yield true;
+                }
+                case "tag.tags" -> {
+                    var extractedTags = OpenTelemetryMappingUtils.extractTags(value);
+                    boolean validTagsValue = value.hasStringValue()
+                            || (value.hasArrayValue()
+                                    && value.getArrayValue().getValuesList().stream()
+                                            .allMatch(AnyValue::hasStringValue));
+                    if (!validTagsValue) {
+                        metadata.set(key, toJsonNode(value));
+                    } else {
+                        tags.addAll(extractedTags);
+                    }
+                    yield true;
+                }
+                case "metadata" -> {
+                    mergeMetadata(value);
+                    yield true;
+                }
+                default -> false;
+            };
+        }
+
+        private boolean acceptMessage(String key, AnyValue value) {
+            Matcher matcher = MESSAGE_ATTRIBUTE.matcher(key);
+            if (!matcher.matches()) {
+                return false;
+            }
+
+            Integer messageIndex = parseIndex(matcher.group(2));
+            if (messageIndex == null) {
+                metadata.set(key, toJsonNode(value));
+                return true;
+            }
+
+            TreeMap<Integer, MessageBuilder> messages = "input".equals(matcher.group(1))
+                    ? inputMessages
+                    : outputMessages;
+            MessageBuilder message = messages.computeIfAbsent(messageIndex, ignored -> new MessageBuilder());
+            if (!message.accept(matcher.group(3), value)) {
+                metadata.set(key, toJsonNode(value));
+            }
+            return true;
+        }
+
+        private boolean acceptIndexedObject(String key, AnyValue value) {
+            Matcher toolMatcher = TOOL_ATTRIBUTE.matcher(key);
+            if (toolMatcher.matches()) {
+                Integer index = parseIndex(toolMatcher.group(1));
+                if (index == null) {
+                    metadata.set(key, toJsonNode(value));
+                    return true;
+                }
+                String field = toolMatcher.group(2);
+                ObjectNode tool = tools.computeIfAbsent(index, ignored -> JsonUtils.createObjectNode());
+                if ("json_schema".equals(field)) {
+                    JsonNode parsed = parseJsonStringOrMetadata(key, value);
+                    if (parsed != null) {
+                        tool.set(field, parsed);
+                    }
+                } else {
+                    putStringOrMetadata(tool, field, key, value);
+                }
+                return true;
+            }
+
+            Matcher promptMatcher = PROMPT_ATTRIBUTE.matcher(key);
+            if (promptMatcher.matches()) {
+                Integer index = parseIndex(promptMatcher.group(1));
+                if (index == null) {
+                    metadata.set(key, toJsonNode(value));
+                    return true;
+                }
+                ObjectNode prompt = prompts.computeIfAbsent(index, ignored -> JsonUtils.createObjectNode());
+                putStringOrMetadata(prompt, "text", key, value);
+                return true;
+            }
+
+            Matcher choiceMatcher = CHOICE_ATTRIBUTE.matcher(key);
+            if (choiceMatcher.matches()) {
+                Integer index = parseIndex(choiceMatcher.group(1));
+                if (index == null) {
+                    metadata.set(key, toJsonNode(value));
+                    return true;
+                }
+                ObjectNode choice = choices.computeIfAbsent(index, ignored -> JsonUtils.createObjectNode());
+                putStringOrMetadata(choice, "text", key, value);
+                return true;
+            }
+            return false;
+        }
+
+        private boolean acceptUsage(String key, AnyValue value) {
+            String usageKey = USAGE_KEYS.get(key);
+            if (usageKey == null) {
+                return false;
+            }
+
+            Integer tokenCount = nonNegativeInt(value);
+            if (tokenCount == null) {
+                metadata.set(key, toJsonNode(value));
+            } else {
+                usage.put(usageKey, tokenCount);
+            }
+            return true;
+        }
+
+        private Result finish() {
+            if (!inputMessages.isEmpty()) {
+                ArrayNode messages = buildMessages(inputMessages, false);
+                if (!messages.isEmpty()) {
+                    input.set("messages", messages);
+                }
+            }
+            if (!outputMessages.isEmpty()) {
+                ArrayNode messages = buildMessages(outputMessages, true);
+                if (!messages.isEmpty()) {
+                    output.set("messages", messages);
+                }
+            }
+            if (!tools.isEmpty()) {
+                ArrayNode normalizedTools = buildArray(tools);
+                if (!normalizedTools.isEmpty()) {
+                    input.set("tools", normalizedTools);
+                }
+            }
+            if (!prompts.isEmpty()) {
+                ArrayNode normalizedPrompts = buildArray(prompts);
+                if (!normalizedPrompts.isEmpty()) {
+                    input.set("prompts", normalizedPrompts);
+                }
+            }
+            if (!choices.isEmpty()) {
+                ArrayNode normalizedChoices = buildArray(choices);
+                if (!normalizedChoices.isEmpty()) {
+                    output.set("choices", normalizedChoices);
+                }
+            }
+            if (functionCall != null) {
+                output.set("function_call", functionCall);
+            }
+
+            JsonNode parsedInput = rawInput == null ? null : parseRawValue(rawInput, inputMimeType, INPUT_VALUE);
+            JsonNode parsedOutput = rawOutput == null ? null : parseRawValue(rawOutput, outputMimeType, OUTPUT_VALUE);
+
+            return new Result(
+                    Set.copyOf(consumedKeys),
+                    parsedInput,
+                    rawInput != null,
+                    parsedOutput,
+                    rawOutput != null,
+                    input,
+                    output,
+                    metadata,
+                    Map.copyOf(usage),
+                    Set.copyOf(tags),
+                    StringUtils.firstNonBlank(responseModel, model, requestModel),
+                    StringUtils.firstNonBlank(provider, system),
+                    toSpanType(spanKind),
+                    totalEstimatedCost,
+                    sessionId);
+        }
+
+        private ArrayNode buildMessages(TreeMap<Integer, MessageBuilder> messages, boolean outputSide) {
+            ArrayNode result = JsonUtils.createArrayNode();
+            messages.values().forEach(messageBuilder -> {
+                ObjectNode message = messageBuilder.build();
+                JsonNode legacyFunctionCall = message.remove("function_call");
+                if (outputSide && functionCall == null && legacyFunctionCall != null) {
+                    functionCall = legacyFunctionCall;
+                } else if (legacyFunctionCall != null) {
+                    message.set("function_call", legacyFunctionCall);
+                }
+                if (!message.isEmpty()) {
+                    result.add(message);
+                }
+            });
+            return result;
+        }
+
+        private void putPromptTemplateField(String field, String originalKey, AnyValue value, boolean parseJson) {
+            if (parseJson) {
+                JsonNode parsed = parseJsonStringOrMetadata(originalKey, value);
+                if (parsed != null) {
+                    promptTemplate().set(field, parsed);
+                }
+                return;
+            }
+            if (!value.hasStringValue()) {
+                metadata.set(originalKey, toJsonNode(value));
+                return;
+            }
+            promptTemplate().put(field, value.getStringValue());
+        }
+
+        private ObjectNode promptTemplate() {
+            JsonNode existing = input.get("prompt_template");
+            if (existing instanceof ObjectNode object) {
+                return object;
+            }
+            ObjectNode template = JsonUtils.createObjectNode();
+            input.set("prompt_template", template);
+            return template;
+        }
+
+        private void mergeMetadata(AnyValue value) {
+            if (!value.hasStringValue()) {
+                metadata.set("metadata", toJsonNode(value));
+                return;
+            }
+            try {
+                JsonNode parsed = JsonUtils.getJsonNodeFromString(value.getStringValue());
+                if (!parsed.isObject()) {
+                    metadata.set("metadata", parsed);
+                    return;
+                }
+                parsed.fields().forEachRemaining(entry -> {
+                    if (!RESERVED_METADATA_KEYS.contains(entry.getKey())) {
+                        metadata.set(entry.getKey(), entry.getValue());
+                    }
+                });
+            } catch (UncheckedIOException exception) {
+                log.debug("Failed to parse OpenInference metadata as JSON", exception);
+                metadata.put("metadata", value.getStringValue());
+            }
+        }
+
+        private String stringValueOrMetadata(String key, AnyValue value) {
+            if (value.hasStringValue()) {
+                return StringUtils.trimToNull(value.getStringValue());
+            }
+            metadata.set(key, toJsonNode(value));
+            return null;
+        }
+
+        private void putStringOrMetadata(ObjectNode target, String field, String originalKey, AnyValue value) {
+            if (value.hasStringValue()) {
+                target.put(field, value.getStringValue());
+            } else {
+                metadata.set(originalKey, toJsonNode(value));
+            }
+        }
+
+        private JsonNode parseJsonStringOrMetadata(String originalKey, AnyValue value) {
+            if (!value.hasStringValue()) {
+                metadata.set(originalKey, toJsonNode(value));
+                return null;
+            }
+            return parseJsonString(value.getStringValue());
+        }
+    }
+
+    private static final class MessageBuilder {
+
+        private final ObjectNode message = JsonUtils.createObjectNode();
+        private final TreeMap<Integer, ContentBuilder> contents = new TreeMap<>();
+        private final TreeMap<Integer, ToolCallBuilder> toolCalls = new TreeMap<>();
+        private final ObjectNode functionCall = JsonUtils.createObjectNode();
+
+        private boolean accept(String path, AnyValue value) {
+            if (Set.of("role", "content", "name", "tool_call_id").contains(path)) {
+                if (!value.hasStringValue()) {
+                    return false;
+                }
+                message.put(path, value.getStringValue());
+                return true;
+            }
+            if ("function_call_name".equals(path)) {
+                if (!value.hasStringValue()) {
+                    return false;
+                }
+                functionCall.put("name", value.getStringValue());
+                return true;
+            }
+            if ("function_call_arguments_json".equals(path)) {
+                if (!value.hasStringValue()) {
+                    return false;
+                }
+                functionCall.set("arguments", parseJsonString(value.getStringValue()));
+                return true;
+            }
+
+            Matcher contentMatcher = MESSAGE_CONTENT_ATTRIBUTE.matcher(path);
+            if (contentMatcher.matches()) {
+                Integer index = parseIndex(contentMatcher.group(1));
+                if (index == null) {
+                    return false;
+                }
+                return contents.computeIfAbsent(index, ignored -> new ContentBuilder())
+                        .accept(contentMatcher.group(2), value);
+            }
+
+            Matcher toolCallMatcher = MESSAGE_TOOL_CALL_ATTRIBUTE.matcher(path);
+            if (toolCallMatcher.matches()) {
+                Integer index = parseIndex(toolCallMatcher.group(1));
+                if (index == null) {
+                    return false;
+                }
+                return toolCalls.computeIfAbsent(index, ignored -> new ToolCallBuilder())
+                        .accept(toolCallMatcher.group(2), value);
+            }
+            return false;
+        }
+
+        private ObjectNode build() {
+            if (!contents.isEmpty()) {
+                ArrayNode array = JsonUtils.createArrayNode();
+                contents.values().stream().map(ContentBuilder::build).filter(node -> !node.isEmpty())
+                        .forEach(array::add);
+                if (!array.isEmpty()) {
+                    message.set("contents", array);
+                }
+            }
+            if (!toolCalls.isEmpty()) {
+                ArrayNode array = JsonUtils.createArrayNode();
+                toolCalls.values().stream().map(ToolCallBuilder::build).filter(node -> !node.isEmpty())
+                        .forEach(array::add);
+                if (!array.isEmpty()) {
+                    message.set("tool_calls", array);
+                }
+            }
+            if (!functionCall.isEmpty()) {
+                message.set("function_call", functionCall);
+            }
+            return message;
+        }
+    }
+
+    private static final class ContentBuilder {
+
+        private final ObjectNode content = JsonUtils.createObjectNode();
+        private final ObjectNode image = JsonUtils.createObjectNode();
+        private final ObjectNode audio = JsonUtils.createObjectNode();
+        private final ToolCallBuilder toolCall = new ToolCallBuilder();
+
+        private boolean accept(String path, AnyValue value) {
+            if (Set.of("message_content.type", "message_content.text", "message_content.id",
+                    "message_content.signature", "message_content.data", "message_content.encrypted_content")
+                    .contains(path)) {
+                if (!value.hasStringValue()) {
+                    return false;
+                }
+                content.put(path.substring("message_content.".length()), value.getStringValue());
+                return true;
+            }
+            if ("message_content.image.image.url".equals(path)) {
+                if (!value.hasStringValue()) {
+                    return false;
+                }
+                image.put("url", value.getStringValue());
+                return true;
+            }
+            if (path.startsWith("message_content.audio.audio.")) {
+                String field = path.substring("message_content.audio.audio.".length());
+                if (!Set.of("url", "mime_type", "transcript").contains(field) || !value.hasStringValue()) {
+                    return false;
+                }
+                audio.put(field, value.getStringValue());
+                return true;
+            }
+            if (path.startsWith("tool_call.")) {
+                return toolCall.accept(path.substring("tool_call.".length()), value);
+            }
+            return false;
+        }
+
+        private ObjectNode build() {
+            if (!image.isEmpty()) {
+                content.set("image", image);
+            }
+            if (!audio.isEmpty()) {
+                content.set("audio", audio);
+            }
+            ObjectNode builtToolCall = toolCall.build();
+            if (!builtToolCall.isEmpty()) {
+                content.set("tool_call", builtToolCall);
+            }
+            return content;
+        }
+    }
+
+    private static final class ToolCallBuilder {
+
+        private final ObjectNode toolCall = JsonUtils.createObjectNode();
+        private final ObjectNode function = JsonUtils.createObjectNode();
+
+        private boolean accept(String path, AnyValue value) {
+            if (!value.hasStringValue()) {
+                return false;
+            }
+            return switch (path) {
+                case "id" -> {
+                    toolCall.put("id", value.getStringValue());
+                    yield true;
+                }
+                case "function.name" -> {
+                    function.put("name", value.getStringValue());
+                    yield true;
+                }
+                case "function.arguments" -> {
+                    // OpenInference defines tool arguments as an opaque JSON string. Preserve it verbatim.
+                    function.put("arguments", value.getStringValue());
+                    yield true;
+                }
+                case "reasoning_signature" -> {
+                    toolCall.put("reasoning_signature", value.getStringValue());
+                    yield true;
+                }
+                default -> false;
+            };
+        }
+
+        private ObjectNode build() {
+            if (!function.isEmpty()) {
+                toolCall.set("function", function);
+            }
+            return toolCall;
+        }
+    }
+
+    private static ArrayNode buildArray(TreeMap<Integer, ObjectNode> values) {
+        ArrayNode result = JsonUtils.createArrayNode();
+        values.values().stream().filter(node -> !node.isEmpty()).forEach(result::add);
+        return result;
+    }
+
+    private static Integer parseIndex(String rawIndex) {
+        try {
+            int index = Integer.parseInt(rawIndex);
+            return index >= 0 ? index : null;
+        } catch (NumberFormatException exception) {
+            return null;
+        }
+    }
+
+    private static Integer nonNegativeInt(AnyValue value) {
+        long parsed;
+        if (value.hasIntValue()) {
+            parsed = value.getIntValue();
+        } else if (value.hasStringValue()) {
+            try {
+                parsed = Long.parseLong(value.getStringValue());
+            } catch (NumberFormatException exception) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+        if (parsed < 0 || parsed > Integer.MAX_VALUE) {
+            return null;
+        }
+        return (int) parsed;
+    }
+
+    private static JsonNode parseRawValue(AnyValue value, String mimeType, String key) {
+        if (!value.hasStringValue()) {
+            return toJsonNode(value);
+        }
+        if (!JSON_MIME_TYPE.equals(normalizeMimeType(mimeType))) {
+            return JsonUtils.valueToTree(value.getStringValue());
+        }
+        try {
+            return JsonUtils.getJsonNodeFromString(value.getStringValue());
+        } catch (UncheckedIOException exception) {
+            log.debug("Failed to parse OpenInference {} as JSON; preserving the original value", key, exception);
+            return JsonUtils.valueToTree(value.getStringValue());
+        }
+    }
+
+    private static String normalizeMimeType(String mimeType) {
+        if (mimeType == null) {
+            return null;
+        }
+        int parameters = mimeType.indexOf(';');
+        String type = parameters >= 0 ? mimeType.substring(0, parameters) : mimeType;
+        return type.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static JsonNode parseJsonString(String value) {
+        return JsonUtils.getJsonNodeFromStringWithFallback(value);
+    }
+
+    private static SpanType toSpanType(String kind) {
+        if (kind == null) {
+            return SpanType.general;
+        }
+        return switch (kind.toUpperCase(Locale.ROOT)) {
+            case "LLM" -> SpanType.llm;
+            case "TOOL" -> SpanType.tool;
+            case "GUARDRAIL" -> SpanType.guardrail;
+            default -> SpanType.general;
+        };
+    }
+
+    private static boolean isOpenInferenceAttribute(String key) {
+        if ("metadata".equals(key)) {
+            return true;
+        }
+        return OPENINFERENCE_PREFIXES.stream().anyMatch(key::startsWith);
+    }
+
+    private static JsonNode toJsonNode(AnyValue value) {
+        return switch (value.getValueCase()) {
+            case STRING_VALUE -> JsonUtils.valueToTree(value.getStringValue());
+            case BOOL_VALUE -> JsonUtils.valueToTree(value.getBoolValue());
+            case INT_VALUE -> JsonUtils.valueToTree(value.getIntValue());
+            case DOUBLE_VALUE -> JsonUtils.valueToTree(value.getDoubleValue());
+            case BYTES_VALUE -> BinaryNode.valueOf(value.getBytesValue().toByteArray());
+            case ARRAY_VALUE -> {
+                ArrayNode array = JsonUtils.createArrayNode();
+                value.getArrayValue().getValuesList().stream().map(OpenInferenceSpanNormalizer::toJsonNode)
+                        .forEach(array::add);
+                yield array;
+            }
+            case KVLIST_VALUE -> {
+                ObjectNode object = JsonUtils.createObjectNode();
+                value.getKvlistValue().getValuesList()
+                        .forEach(entry -> object.set(entry.getKey(), toJsonNode(entry.getValue())));
+                yield object;
+            }
+            case VALUE_NOT_SET -> NullNode.getInstance();
+            default -> NullNode.getInstance();
+        };
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
@@ -63,9 +63,9 @@ public final class OpenInferenceSpanNormalizer {
             "llm.token_count.total", "total_tokens",
             "llm.token_count.prompt_details.cache_read", "cache_read_input_tokens",
             "llm.token_count.prompt_details.cache_write", "cache_creation_input_tokens",
-            "llm.token_count.prompt_details.audio", "input_audio_tokens",
+            "llm.token_count.prompt_details.audio", "prompt_tokens_details.audio_tokens",
             "llm.token_count.completion_details.reasoning", "reasoning_tokens",
-            "llm.token_count.completion_details.audio", "output_audio_tokens");
+            "llm.token_count.completion_details.audio", "completion_tokens_details.audio_tokens");
 
     private static final Set<String> RESERVED_METADATA_KEYS = Set.of(
             "thread_id", "integration", "server.address", SPAN_KIND, INPUT_MIME_TYPE, OUTPUT_MIME_TYPE,
@@ -399,6 +399,11 @@ public final class OpenInferenceSpanNormalizer {
         }
 
         private Result finish() {
+            String resolvedProvider = StringUtils.firstNonBlank(provider, system);
+            // OpenInference names the hosting provider "aws"; Opik prices it as Bedrock.
+            if ("aws".equals(resolvedProvider)) {
+                resolvedProvider = "bedrock";
+            }
             if (!inputMessages.isEmpty()) {
                 ArrayNode messages = buildMessages(inputMessages, false);
                 if (!messages.isEmpty()) {
@@ -448,7 +453,7 @@ public final class OpenInferenceSpanNormalizer {
                     Map.copyOf(usage),
                     Set.copyOf(tags),
                     StringUtils.firstNonBlank(responseModel, model, requestModel),
-                    StringUtils.firstNonBlank(provider, system),
+                    resolvedProvider,
                     toSpanType(spanKind),
                     totalEstimatedCost,
                     sessionId);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mapping/otel/OpenInferenceSpanNormalizer.java
@@ -6,6 +6,7 @@ import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
 import com.fasterxml.jackson.databind.node.NullNode;
@@ -43,6 +44,8 @@ public final class OpenInferenceSpanNormalizer {
     private static final String OUTPUT_VALUE = "output.value";
     private static final String OUTPUT_MIME_TYPE = "output.mime_type";
     private static final String JSON_MIME_TYPE = "application/json";
+    private static final ObjectReader JSON_READER = JsonUtils.getMapper().reader()
+            .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
 
     private static final Pattern MESSAGE_ATTRIBUTE = Pattern.compile(
             "^llm\\.(input|output)_messages\\.([^.]+)\\.message\\.(.+)$");
@@ -332,6 +335,10 @@ public final class OpenInferenceSpanNormalizer {
             MessageBuilder message = messages.computeIfAbsent(messageIndex, ignored -> new MessageBuilder());
             if (!message.accept(matcher.group(3), value)) {
                 metadata.set(key, toJsonNode(value));
+            } else {
+                // Existing scoring rules address the original flattened input keys, including
+                // sparse indices. Keep those aliases alongside the canonical message arrays.
+                input.set(key, toLegacyMessageValue(value));
             }
             return true;
         }
@@ -401,7 +408,7 @@ public final class OpenInferenceSpanNormalizer {
         private Result finish() {
             String resolvedProvider = StringUtils.firstNonBlank(provider, system);
             // OpenInference names the hosting provider "aws"; Opik prices it as Bedrock.
-            if ("aws".equals(resolvedProvider)) {
+            if ("aws".equalsIgnoreCase(resolvedProvider)) {
                 resolvedProvider = "bedrock";
             }
             if (!inputMessages.isEmpty()) {
@@ -762,7 +769,7 @@ public final class OpenInferenceSpanNormalizer {
         if (parsed != null) {
             return parsed;
         }
-        log.debug("Failed to parse OpenInference {} as JSON; preserving the original value", key);
+        log.debug("Failed to parse OpenInference value as JSON; preserving the original value, key='{}'", key);
         return JsonUtils.valueToTree(value.getStringValue());
     }
 
@@ -777,10 +784,7 @@ public final class OpenInferenceSpanNormalizer {
 
     private static JsonNode parseJsonString(String value) {
         try {
-            JsonNode parsed = JsonUtils.getMapper()
-                    .reader()
-                    .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
-                    .readTree(value);
+            JsonNode parsed = JSON_READER.readTree(value);
             return parsed == null || parsed.isMissingNode() ? null : parsed;
         } catch (JsonProcessingException exception) {
             return null;
@@ -797,6 +801,25 @@ public final class OpenInferenceSpanNormalizer {
             case "GUARDRAIL" -> SpanType.guardrail;
             default -> SpanType.general;
         };
+    }
+
+    private static JsonNode toLegacyMessageValue(AnyValue value) {
+        if (value.hasStringValue()) {
+            String text = value.getStringValue();
+            // Match the historical JSON decoding of flattened message attributes, without
+            // logging payloads when parsing fails.
+            if (text.startsWith("{") || text.startsWith("[") || text.startsWith("\"")) {
+                JsonNode parsed = parseJsonString(text);
+                if (parsed != null) {
+                    if (parsed.isTextual()) {
+                        JsonNode nested = parseJsonString(parsed.asText());
+                        return nested == null ? parsed : nested;
+                    }
+                    return parsed;
+                }
+            }
+        }
+        return toJsonNode(value);
     }
 
     private static boolean isOpenInferenceAttribute(String key) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -512,6 +512,88 @@ class OpenTelemetryResourceTest {
         }
 
         @Test
+        @DisplayName("normalizes OpenInference spans through the OTLP protobuf endpoint")
+        void testOpenInferenceSpanNormalization() {
+            String workspaceName = UUID.randomUUID().toString();
+            String projectName = "OpenInference Test";
+            mockTargetWorkspace(okApikey, workspaceName);
+
+            var otelTraceId = UUID.randomUUID().toString().getBytes();
+            long startTimeUnixNano = (System.currentTimeMillis() - 1_000) * 1_000_000L;
+            long endTimeUnixNano = System.currentTimeMillis() * 1_000_000L;
+
+            var openInferenceSpan = Span.newBuilder()
+                    .setName("openinference llm call")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(UUID.randomUUID().toString().getBytes()))
+                    .setStartTimeUnixNano(startTimeUnixNano)
+                    .setEndTimeUnixNano(endTimeUnixNano)
+                    .addAttributes(stringAttribute("llm.output_messages.4.message.content", "Hello from Opik"))
+                    .addAttributes(intAttribute("llm.token_count.completion", 4))
+                    .addAttributes(stringAttribute("input.value", "{\"request_id\":\"request-7\"}"))
+                    .addAttributes(stringAttribute("llm.input_messages.2.message.content", "Hello"))
+                    .addAttributes(stringAttribute("llm.response.model_name", "gpt-4o-mini"))
+                    .addAttributes(stringAttribute("output.mime_type", "application/json"))
+                    .addAttributes(intAttribute("llm.token_count.prompt", 3))
+                    .addAttributes(stringAttribute("llm.output_messages.4.message.role", "assistant"))
+                    .addAttributes(stringAttribute("llm.provider", "openai"))
+                    .addAttributes(stringAttribute("input.mime_type", "application/json"))
+                    .addAttributes(intAttribute("llm.token_count.total", 7))
+                    .addAttributes(stringAttribute("output.value", "{\"response_id\":\"response-7\"}"))
+                    .addAttributes(stringAttribute("llm.input_messages.2.message.role", "user"))
+                    .addAttributes(stringAttribute("openinference.span.kind", "LLM"))
+                    .build();
+
+            // A neighboring span in the same protobuf batch must keep the legacy generic mapping.
+            var unmarkedSpan = Span.newBuilder()
+                    .setName("unmarked call")
+                    .setTraceId(ByteString.copyFrom(otelTraceId))
+                    .setSpanId(ByteString.copyFrom(UUID.randomUUID().toString().getBytes()))
+                    .setStartTimeUnixNano(startTimeUnixNano + 1)
+                    .setEndTimeUnixNano(endTimeUnixNano)
+                    .addAttributes(stringAttribute("llm.output_messages.0.message.content", "leave me unchanged"))
+                    .build();
+
+            var expectedTraceId = OpenTelemetryMapper.convertOtelIdToUUIDv7(
+                    otelTraceId, Duration.ofNanos(startTimeUnixNano).toMillis());
+
+            sendProtobufTraces(List.of(openInferenceSpan, unmarkedSpan), projectName, workspaceName, okApikey, true,
+                    null);
+
+            var persistedSpans = spanResourceClient.getByTraceIdAndProject(
+                    expectedTraceId, projectName, workspaceName, okApikey).content();
+            assertThat(persistedSpans).hasSize(2);
+
+            var persistedOpenInferenceSpan = persistedSpans.stream()
+                    .filter(span -> "openinference llm call".equals(span.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(persistedOpenInferenceSpan.type()).isEqualTo(SpanType.llm);
+            assertThat(persistedOpenInferenceSpan.model()).isEqualTo("gpt-4o-mini");
+            assertThat(persistedOpenInferenceSpan.provider()).isEqualTo("openai");
+            assertThat(persistedOpenInferenceSpan.usage())
+                    .containsEntry("prompt_tokens", 3)
+                    .containsEntry("completion_tokens", 4)
+                    .containsEntry("total_tokens", 7);
+            assertThat(persistedOpenInferenceSpan.input().path("request_id").asText()).isEqualTo("request-7");
+            assertThat(persistedOpenInferenceSpan.input().path("messages").get(0).path("role").asText())
+                    .isEqualTo("user");
+            assertThat(persistedOpenInferenceSpan.output().path("response_id").asText()).isEqualTo("response-7");
+            assertThat(persistedOpenInferenceSpan.output().path("messages").get(0).path("content").asText())
+                    .isEqualTo("Hello from Opik");
+            assertThat(persistedOpenInferenceSpan.metadata().path("openinference.span.kind").asText())
+                    .isEqualTo("LLM");
+
+            var persistedUnmarkedSpan = persistedSpans.stream()
+                    .filter(span -> "unmarked call".equals(span.name()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(persistedUnmarkedSpan.input().path("llm.output_messages.0.message.content").asText())
+                    .isEqualTo("leave me unchanged");
+            assertThat(persistedUnmarkedSpan.output()).isNull();
+        }
+
+        @Test
         @DisplayName("test thread_id support in OpenTelemetry")
         void testThreadIdSupport() {
             String workspaceName = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -578,6 +578,10 @@ class OpenTelemetryResourceTest {
             assertThat(persistedOpenInferenceSpan.input().path("request_id").asText()).isEqualTo("request-7");
             assertThat(persistedOpenInferenceSpan.input().path("messages").get(0).path("role").asText())
                     .isEqualTo("user");
+            assertThat(persistedOpenInferenceSpan.input().path("llm.input_messages.2.message.content").asText())
+                    .isEqualTo("Hello");
+            assertThat(persistedOpenInferenceSpan.input().path("llm.output_messages.4.message.content").asText())
+                    .isEqualTo("Hello from Opik");
             assertThat(persistedOpenInferenceSpan.output().path("response_id").asText()).isEqualTo("response-7");
             assertThat(persistedOpenInferenceSpan.output().path("messages").get(0).path("content").asText())
                     .isEqualTo("Hello from Opik");

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/OpenTelemetryResourceTest.java
@@ -71,6 +71,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -572,9 +573,8 @@ class OpenTelemetryResourceTest {
             assertThat(persistedOpenInferenceSpan.model()).isEqualTo("gpt-4o-mini");
             assertThat(persistedOpenInferenceSpan.provider()).isEqualTo("openai");
             assertThat(persistedOpenInferenceSpan.usage())
-                    .containsEntry("prompt_tokens", 3)
-                    .containsEntry("completion_tokens", 4)
-                    .containsEntry("total_tokens", 7);
+                    .containsExactlyInAnyOrderEntriesOf(
+                            Map.of("prompt_tokens", 3, "completion_tokens", 4, "total_tokens", 7));
             assertThat(persistedOpenInferenceSpan.input().path("request_id").asText()).isEqualTo("request-7");
             assertThat(persistedOpenInferenceSpan.input().path("messages").get(0).path("role").asText())
                     .isEqualTo("user");

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Span;
+import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.fasterxml.uuid.Generators;
@@ -2585,9 +2586,9 @@ class OpenTelemetryMapperTest {
                         .containsEntry("total_tokens", 28)
                         .containsEntry("cache_read_input_tokens", 4)
                         .containsEntry("cache_creation_input_tokens", 2)
-                        .containsEntry("input_audio_tokens", 3)
+                        .containsEntry("prompt_tokens_details.audio_tokens", 3)
                         .containsEntry("reasoning_tokens", 5)
-                        .containsEntry("output_audio_tokens", 1);
+                        .containsEntry("completion_tokens_details.audio_tokens", 1);
                 assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.0125");
                 assertThat(span.metadata().path("thread_id").asText()).isEqualTo("explicit-thread");
                 assertThat(span.metadata().path("custom").asText()).isEqualTo("kept");
@@ -2609,6 +2610,46 @@ class OpenTelemetryMapperTest {
                     str("llm.system", "mistral_ai"),
                     str("llm.model_name", "mistral-small")));
             assertThat(aliasedProvider.provider()).isEqualTo("mistral");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "anthropic, claude-haiku-4-5, original_usage.input_tokens, 0.000405",
+                "aws, anthropic.claude-3-5-haiku-20241022-v1:0, original_usage.inputTokens, 0.000324",
+                "anthropic_vertexai, vertex_ai/claude-haiku-4-5, original_usage.input_tokens, 0.000405"
+        })
+        void calculatesCacheCostWithoutCountingCachedPromptTokensTwice(
+                String provider, String model, String exclusiveInputKey, String expectedCost) {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.provider", provider),
+                    str("llm.model_name", model),
+                    integer("llm.token_count.prompt", 1000),
+                    integer("llm.token_count.completion", 20),
+                    integer("llm.token_count.prompt_details.cache_read", 800),
+                    integer("llm.token_count.prompt_details.cache_write", 100)));
+
+            assertThat(span.usage()).containsEntry("prompt_tokens", 1000)
+                    .containsEntry("total_tokens", 1020)
+                    .containsEntry(exclusiveInputKey, 100);
+            assertThat(CostService.calculateCost(span.model(), span.provider(), span.usage(), span.metadata()))
+                    .isEqualByComparingTo(expectedCost);
+        }
+
+        @Test
+        void calculatesAudioCostAtAudioRates() {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.provider", "openai"),
+                    str("llm.model_name", "gpt-4o-audio-preview"),
+                    integer("llm.token_count.prompt", 1000),
+                    integer("llm.token_count.completion", 500),
+                    integer("llm.token_count.prompt_details.audio", 300),
+                    integer("llm.token_count.completion_details.audio", 200)));
+
+            // 700 text input + 300 audio input + 300 text output + 200 audio output.
+            assertThat(CostService.calculateCost(span.model(), span.provider(), span.usage(), span.metadata()))
+                    .isEqualByComparingTo("0.03275");
         }
 
         @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.Span;
 import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.uuid.Generators;
 import com.fasterxml.uuid.impl.TimeBasedEpochGenerator;
 import com.google.protobuf.ByteString;
@@ -2545,6 +2546,34 @@ class OpenTelemetryMapperTest {
             assertThat(span.output().path("function_call").path("arguments").path("city").asText())
                     .isEqualTo("Paris");
             assertThat(span.output().path("finish_reason").asText()).isEqualTo("stop");
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void preservesIndexedFunctionCallsOnTheirMessages(boolean hasStandaloneCall) throws Exception {
+            var attributes = new ArrayList<>(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.output_messages.1.message.function_call_name", "search"),
+                    str("llm.output_messages.1.message.function_call_arguments_json", "{\"query\":\"weather\"}"),
+                    str("llm.output_messages.0.message.function_call_name", "weather"),
+                    str("llm.output_messages.0.message.function_call_arguments_json", "{\"city\":\"Paris\"}")));
+            if (hasStandaloneCall) {
+                attributes.add(str("llm.function_call", "{\"name\":\"standalone\"}"));
+            }
+
+            var span = enrich(attributes);
+
+            assertThat(span.output().path("messages")).isEqualTo(JsonUtils.getMapper().readTree("""
+                    [
+                      {"function_call": {"name": "weather", "arguments": {"city": "Paris"}}},
+                      {"function_call": {"name": "search", "arguments": {"query": "weather"}}}
+                    ]
+                    """));
+            assertThat(span.output().has("function_call")).isEqualTo(hasStandaloneCall);
+            if (hasStandaloneCall) {
+                assertThat(span.output().path("function_call"))
+                        .isEqualTo(JsonUtils.getMapper().readTree("{\"name\":\"standalone\"}"));
+            }
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -20,6 +20,8 @@ import uk.co.jemos.podam.api.PodamFactory;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -2308,6 +2310,368 @@ class OpenTelemetryMapperTest {
 
             assertThat(span.metadata().has(reservedKey)).isFalse();
             assertThat(span.metadata().get("custom").asText()).isEqualTo("ok");
+        }
+    }
+
+    @Nested
+    class OpenInferenceNormalization {
+
+        private Span enrich(List<KeyValue> attributes) {
+            var spanBuilder = Span.builder()
+                    .id(UUID.randomUUID())
+                    .traceId(UUID.randomUUID())
+                    .projectId(UUID.randomUUID())
+                    .startTime(Instant.now());
+            OpenTelemetryMapper.enrichSpanWithAttributes(spanBuilder, attributes, "mixed-batch-scope", null);
+            return spanBuilder.build();
+        }
+
+        private KeyValue str(String key, String value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setStringValue(value))
+                    .build();
+        }
+
+        private KeyValue integer(String key, long value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setIntValue(value))
+                    .build();
+        }
+
+        private KeyValue decimal(String key, double value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setDoubleValue(value))
+                    .build();
+        }
+
+        private KeyValue bool(String key, boolean value) {
+            return KeyValue.newBuilder()
+                    .setKey(key)
+                    .setValue(AnyValue.newBuilder().setBoolValue(value))
+                    .build();
+        }
+
+        private KeyValue array(String key, AnyValue... values) {
+            var value = AnyValue.newBuilder();
+            for (AnyValue item : values) {
+                value.getArrayValueBuilder().addValues(item);
+            }
+            return KeyValue.newBuilder().setKey(key).setValue(value).build();
+        }
+
+        private KeyValue object(String key, KeyValue... fields) {
+            var value = AnyValue.newBuilder();
+            for (KeyValue field : fields) {
+                value.getKvlistValueBuilder().addValues(field);
+            }
+            return KeyValue.newBuilder().setKey(key).setValue(value).build();
+        }
+
+        @Test
+        void normalizesSparseOutOfOrderChatToolsAndMultimodalContent() {
+            var attributes = List.of(
+                    str("llm.output_messages.7.message.contents.8.tool_call.function.arguments",
+                            "{\"city\":\"Paris\"}"),
+                    str("llm.input_messages.10.message.content", "{\"temperature\":21}"),
+                    str("llm.output_messages.7.message.contents.4.message_content.image.image.url",
+                            "data:image/png;base64,AAAA"),
+                    str("llm.output_messages.7.message.tool_calls.4.tool_call.function.name", "weather"),
+                    str("llm.input_messages.2.message.role", "human"),
+                    str("llm.output_messages.7.message.contents.1.message_content.signature", "opaque-signature"),
+                    str("llm.output_messages.7.message.contents.6.message_content.audio.audio.transcript", "hello"),
+                    str("llm.output_messages.7.message.contents.8.message_content.type", "tool_use"),
+                    str("llm.output_messages.7.message.contents.6.message_content.audio.audio.mime_type", "audio/wav"),
+                    str("llm.output_messages.7.message.contents.3.message_content.text", "Visible answer"),
+                    str("llm.output_messages.7.message.contents.1.message_content.text", "Visible reasoning"),
+                    str("llm.output_messages.7.message.contents.1.message_content.id", "reasoning-1"),
+                    str("llm.output_messages.7.message.contents.1.message_content.data", "opaque-data"),
+                    str("llm.output_messages.7.message.contents.1.message_content.encrypted_content",
+                            "opaque-encrypted-content"),
+                    str("llm.output_messages.7.message.contents.6.message_content.audio.audio.url",
+                            "https://example.test/audio.wav"),
+                    str("llm.output_messages.7.message.contents.4.message_content.type", "image"),
+                    str("llm.output_messages.7.message.tool_calls.4.tool_call.id", "call-7"),
+                    str("llm.input_messages.10.message.name", "weather"),
+                    str("llm.output_messages.7.message.contents.8.tool_call.id", "call-7"),
+                    str("llm.output_messages.7.message.contents.6.message_content.type", "audio"),
+                    str("llm.output_messages.7.message.contents.8.tool_call.function.name", "weather"),
+                    str("llm.input_messages.2.message.content", "What is the weather?"),
+                    str("llm.output_messages.7.message.tool_calls.4.tool_call.reasoning_signature", "tool-signature"),
+                    str("llm.output_messages.7.message.role", "model"),
+                    str("llm.input_messages.10.message.tool_call_id", "call-7"),
+                    str("llm.output_messages.7.message.contents.3.message_content.type", "text"),
+                    str("llm.output_messages.7.message.tool_calls.4.tool_call.function.arguments",
+                            "{\"city\":\"Paris\"}"),
+                    str("llm.output_messages.7.message.contents.1.message_content.type", "reasoning"),
+                    str("llm.input_messages.10.message.role", "tool"),
+                    str("openinference.span.kind", "LLM"));
+
+            var span = enrich(attributes);
+
+            assertThat(span.input().path("messages").size()).isEqualTo(2);
+            assertThat(span.input().path("messages").get(0).path("content").asText())
+                    .isEqualTo("What is the weather?");
+            assertThat(span.input().path("messages").get(1).path("tool_call_id").asText()).isEqualTo("call-7");
+
+            var outputMessage = span.output().path("messages").get(0);
+            assertThat(outputMessage.path("role").asText()).isEqualTo("model");
+            assertThat(outputMessage.path("contents").size()).isEqualTo(5);
+            assertThat(outputMessage.path("contents").get(0).path("type").asText()).isEqualTo("reasoning");
+            assertThat(outputMessage.path("contents").get(0).path("signature").asText())
+                    .isEqualTo("opaque-signature");
+            assertThat(outputMessage.path("contents").get(0).path("id").asText()).isEqualTo("reasoning-1");
+            assertThat(outputMessage.path("contents").get(0).path("data").asText()).isEqualTo("opaque-data");
+            assertThat(outputMessage.path("contents").get(0).path("encrypted_content").asText())
+                    .isEqualTo("opaque-encrypted-content");
+            assertThat(outputMessage.path("contents").get(2).path("image").path("url").asText())
+                    .isEqualTo("data:image/png;base64,AAAA");
+            assertThat(outputMessage.path("contents").get(3).path("audio").path("mime_type").asText())
+                    .isEqualTo("audio/wav");
+            assertThat(outputMessage.path("contents").get(4).path("tool_call").path("function")
+                    .path("arguments").asText()).isEqualTo("{\"city\":\"Paris\"}");
+            assertThat(outputMessage.path("tool_calls").get(0).path("reasoning_signature").asText())
+                    .isEqualTo("tool-signature");
+            assertThat(span.input().fieldNames()).toIterable()
+                    .noneMatch(name -> name.startsWith("llm."));
+            assertThat(span.output().fieldNames()).toIterable()
+                    .noneMatch(name -> name.startsWith("llm."));
+        }
+
+        @Test
+        void usesMimeTypeForRawValuesAndMergesSemanticFieldsLast() {
+            var jsonObject = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("input.mime_type", "application/json; charset=utf-8"),
+                    str("input.value", "{\"messages\":\"raw\",\"question\":\"hello\"}"),
+                    str("llm.input_messages.0.message.role", "user"),
+                    str("llm.input_messages.0.message.content", "semantic")));
+            assertThat(jsonObject.input().path("question").asText()).isEqualTo("hello");
+            assertThat(jsonObject.input().path("messages").isArray()).isTrue();
+            assertThat(jsonObject.input().path("messages").get(0).path("content").asText()).isEqualTo("semantic");
+
+            var plainText = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("input.value", "{\"kept\":\"as text\"}")));
+            assertThat(plainText.input().isTextual()).isTrue();
+            assertThat(plainText.input().asText()).isEqualTo("{\"kept\":\"as text\"}");
+
+            var malformedJson = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("output.mime_type", "application/json"),
+                    str("output.value", "{invalid")));
+            assertThat(malformedJson.output().isTextual()).isTrue();
+            assertThat(malformedJson.output().asText()).isEqualTo("{invalid");
+
+            var scalarWithStructure = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("output.mime_type", "application/json"),
+                    str("output.value", "[1,2,3]"),
+                    str("llm.output_messages.0.message.role", "assistant"),
+                    str("llm.output_messages.0.message.content", "done")));
+            assertThat(scalarWithStructure.output().path("value").isArray()).isTrue();
+            assertThat(scalarWithStructure.output().path("messages").get(0).path("content").asText())
+                    .isEqualTo("done");
+
+            var textPlain = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("output.mime_type", "text/plain"),
+                    str("output.value", "plain output")));
+            assertThat(textPlain.output().asText()).isEqualTo("plain output");
+
+            var unsupportedMime = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("input.mime_type", "application/xml"),
+                    str("input.value", "<request />")));
+            assertThat(unsupportedMime.input().asText()).isEqualTo("<request />");
+
+            var nativeObject = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    object("input.value", str("question", "native object"), str("messages", "raw collision")),
+                    str("llm.input_messages.0.message.role", "user"),
+                    str("llm.input_messages.0.message.content", "semantic wins")));
+            assertThat(nativeObject.input().path("question").asText()).isEqualTo("native object");
+            assertThat(nativeObject.input().path("messages").get(0).path("content").asText())
+                    .isEqualTo("semantic wins");
+
+            var nativeArray = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    array("input.value",
+                            AnyValue.newBuilder().setIntValue(1).build(),
+                            AnyValue.newBuilder().setStringValue("two").build())));
+            assertThat(nativeArray.input().isArray()).isTrue();
+            assertThat(nativeArray.input().get(0).asInt()).isEqualTo(1);
+            assertThat(nativeArray.input().get(1).asText()).isEqualTo("two");
+        }
+
+        @Test
+        void normalizesCompletionParametersToolsAndLegacyFunctionCalls() {
+            var span = enrich(List.of(
+                    str("llm.tools.8.tool.description", "Look up weather"),
+                    str("llm.prompts.4.prompt.text", "Complete this sentence"),
+                    str("llm.prompt_template.variables", "{\"city\":\"Paris\"}"),
+                    str("llm.tools.8.tool.json_schema", "{\"type\":\"object\"}"),
+                    str("llm.function_call", "{\"name\":\"weather\",\"arguments\":{\"city\":\"Paris\"}}"),
+                    str("llm.invocation_parameters", "{\"temperature\":0.2}"),
+                    str("llm.choices.2.completion.text", "It is sunny."),
+                    str("llm.prompt_template.template", "Weather for {city}"),
+                    str("llm.prompt_template.version", "v2"),
+                    str("llm.tools.8.tool.name", "weather"),
+                    str("llm.finish_reason", "stop"),
+                    str("openinference.span.kind", "LLM")));
+
+            assertThat(span.input().path("tools").get(0).path("json_schema").path("type").asText())
+                    .isEqualTo("object");
+            assertThat(span.input().path("prompts").get(0).path("text").asText())
+                    .isEqualTo("Complete this sentence");
+            assertThat(span.input().path("invocation_parameters").path("temperature").asDouble()).isEqualTo(0.2);
+            assertThat(span.input().path("prompt_template").path("variables").path("city").asText())
+                    .isEqualTo("Paris");
+            assertThat(span.output().path("choices").get(0).path("text").asText()).isEqualTo("It is sunny.");
+            assertThat(span.output().path("function_call").path("arguments").path("city").asText())
+                    .isEqualTo("Paris");
+            assertThat(span.output().path("finish_reason").asText()).isEqualTo("stop");
+        }
+
+        @Test
+        void mapsSpanFieldsWithStablePriorityAndPreservesUnknownAttributesInMetadata() {
+            var attributes = new ArrayList<>(List.of(
+                    str("llm.request.model_name", "requested-model"),
+                    str("llm.model_name", "generic-model"),
+                    str("llm.response.model_name", "actual-model"),
+                    str("llm.system", "anthropic"),
+                    str("llm.provider", "openai"),
+                    integer("llm.token_count.prompt", 20),
+                    integer("llm.token_count.completion", 8),
+                    integer("llm.token_count.total", 28),
+                    integer("llm.token_count.prompt_details.cache_read", 4),
+                    integer("llm.token_count.prompt_details.cache_write", 2),
+                    integer("llm.token_count.prompt_details.audio", 3),
+                    integer("llm.token_count.completion_details.reasoning", 5),
+                    integer("llm.token_count.completion_details.audio", 1),
+                    decimal("llm.cost.total", 0.0125),
+                    str("session.id", "session-fallback"),
+                    str("thread_id", "explicit-thread"),
+                    str("tag.tags", "[\"alpha\",\"beta\"]"),
+                    str("opik.tags", "opik,beta"),
+                    str("metadata", "{\"custom\":\"kept\",\"thread_id\":\"spoofed\",\"integration\":\"spoofed\"}"),
+                    str("user.id", "user-7"),
+                    str("llm.future.attribute", "future-value"),
+                    str("openinference.span.kind", "LLM")));
+
+            var forward = enrich(attributes);
+            Collections.reverse(attributes);
+            var reverse = enrich(attributes);
+
+            for (var span : List.of(forward, reverse)) {
+                assertThat(span.model()).isEqualTo("actual-model");
+                assertThat(span.provider()).isEqualTo("openai");
+                assertThat(span.type()).isEqualTo(SpanType.llm);
+                assertThat(span.usage()).containsEntry("prompt_tokens", 20)
+                        .containsEntry("completion_tokens", 8)
+                        .containsEntry("total_tokens", 28)
+                        .containsEntry("cache_read_input_tokens", 4)
+                        .containsEntry("cache_creation_input_tokens", 2)
+                        .containsEntry("input_audio_tokens", 3)
+                        .containsEntry("reasoning_tokens", 5)
+                        .containsEntry("output_audio_tokens", 1);
+                assertThat(span.totalEstimatedCost()).isEqualByComparingTo("0.0125");
+                assertThat(span.metadata().path("thread_id").asText()).isEqualTo("explicit-thread");
+                assertThat(span.metadata().path("custom").asText()).isEqualTo("kept");
+                assertThat(span.metadata().path("integration").asText()).isEqualTo("mixed-batch-scope");
+                assertThat(span.metadata().path("user.id").asText()).isEqualTo("user-7");
+                assertThat(span.metadata().path("openinference.span.kind").asText()).isEqualTo("LLM");
+                assertThat(span.metadata().path("llm.future.attribute").asText()).isEqualTo("future-value");
+                assertThat(span.tags()).containsExactlyInAnyOrder("alpha", "beta", "opik");
+                assertThat(span.input()).isNull();
+            }
+
+            var sessionFallback = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("session.id", "session-only")));
+            assertThat(sessionFallback.metadata().path("thread_id").asText()).isEqualTo("session-only");
+
+            var aliasedProvider = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.system", "mistral_ai"),
+                    str("llm.model_name", "mistral-small")));
+            assertThat(aliasedProvider.provider()).isEqualTo("mistral");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "LLM, llm",
+                "TOOL, tool",
+                "GUARDRAIL, guardrail",
+                "CHAIN, general",
+                "something-new, general"
+        })
+        void mapsOpenInferenceKinds(String kind, SpanType expected) {
+            assertThat(enrich(List.of(str("openinference.span.kind", kind))).type()).isEqualTo(expected);
+        }
+
+        @Test
+        void malformedIndicesAndValuesDoNotAbortIngestion() {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.input_messages.-1.message.content", "negative"),
+                    str("llm.output_messages.not-a-number.message.content", "invalid"),
+                    integer("llm.input_messages.0.message.role", 7),
+                    integer("llm.output_messages.0.message.function_call_arguments_json", 8),
+                    integer("llm.invocation_parameters", 9),
+                    integer("llm.function_call", 10),
+                    integer("llm.prompt_template.variables", 11),
+                    integer("llm.tools.0.tool.json_schema", 12),
+                    integer("llm.token_count.prompt", -1),
+                    bool("tag.tags", true),
+                    str("llm.tools.999999999999999999999.tool.name", "overflow")));
+
+            assertThat(span.input()).isNull();
+            assertThat(span.output()).isNull();
+            assertThat(span.metadata().fieldNames()).toIterable().contains(
+                    "llm.input_messages.-1.message.content",
+                    "llm.output_messages.not-a-number.message.content",
+                    "llm.input_messages.0.message.role",
+                    "llm.output_messages.0.message.function_call_arguments_json",
+                    "llm.invocation_parameters",
+                    "llm.function_call",
+                    "llm.prompt_template.variables",
+                    "llm.tools.0.tool.json_schema",
+                    "llm.token_count.prompt",
+                    "tag.tags",
+                    "llm.tools.999999999999999999999.tool.name");
+
+            var malformedJsonStrings = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.invocation_parameters", "{broken"),
+                    str("llm.function_call", "{also-broken"),
+                    str("llm.prompt_template.variables", "{still-broken"),
+                    str("llm.tools.0.tool.json_schema", "{schema-broken")));
+            assertThat(malformedJsonStrings.input().path("invocation_parameters").asText()).isEqualTo("{broken");
+            assertThat(malformedJsonStrings.input().path("prompt_template").path("variables").asText())
+                    .isEqualTo("{still-broken");
+            assertThat(malformedJsonStrings.input().path("tools").get(0).path("json_schema").asText())
+                    .isEqualTo("{schema-broken");
+            assertThat(malformedJsonStrings.output().path("function_call").asText()).isEqualTo("{also-broken");
+        }
+
+        @Test
+        void markerIsPerSpanAndUnmarkedFallbackRemainsCompatible() {
+            var flattenedMessage = str("llm.output_messages.0.message.content", "hello");
+
+            var marked = enrich(List.of(str("openinference.span.kind", "LLM"), flattenedMessage));
+            var unmarked = enrich(List.of(flattenedMessage));
+            var unmarkedInvocation = enrich(List.of(str("llm.invocation_parameters", "{\"temperature\":0.5}")));
+
+            assertThat(marked.output().path("messages").get(0).path("content").asText()).isEqualTo("hello");
+            assertThat(marked.input()).isNull();
+            assertThat(unmarked.input().path("llm.output_messages.0.message.content").asText()).isEqualTo("hello");
+            assertThat(unmarked.output()).isNull();
+            assertThat(unmarkedInvocation.input().path("llm.invocation_parameters").path("temperature").asDouble())
+                    .isEqualTo(0.5);
+            assertThat(unmarkedInvocation.type()).isEqualTo(SpanType.llm);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -2465,6 +2465,17 @@ class OpenTelemetryMapperTest {
             assertThat(malformedJson.output().isTextual()).isTrue();
             assertThat(malformedJson.output().asText()).isEqualTo("{invalid");
 
+            var blankJson = enrich(List.of(
+                    str("openinference.span.kind", "CHAIN"),
+                    str("input.mime_type", "application/json"),
+                    str("input.value", ""),
+                    str("output.mime_type", "application/json"),
+                    str("output.value", "   ")));
+            assertThat(blankJson.input().isTextual()).isTrue();
+            assertThat(blankJson.input().asText()).isEmpty();
+            assertThat(blankJson.output().isTextual()).isTrue();
+            assertThat(blankJson.output().asText()).isEqualTo("   ");
+
             var scalarWithStructure = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     str("output.mime_type", "application/json"),
@@ -2648,13 +2659,67 @@ class OpenTelemetryMapperTest {
                     str("llm.invocation_parameters", "{broken"),
                     str("llm.function_call", "{also-broken"),
                     str("llm.prompt_template.variables", "{still-broken"),
-                    str("llm.tools.0.tool.json_schema", "{schema-broken")));
-            assertThat(malformedJsonStrings.input().path("invocation_parameters").asText()).isEqualTo("{broken");
-            assertThat(malformedJsonStrings.input().path("prompt_template").path("variables").asText())
+                    str("llm.tools.0.tool.json_schema", "{schema-broken"),
+                    str("llm.output_messages.0.message.function_call_arguments_json", "{arguments-broken")));
+            assertThat(malformedJsonStrings.input()).isNull();
+            assertThat(malformedJsonStrings.output()).isNull();
+            assertThat(malformedJsonStrings.metadata().path("llm.invocation_parameters").asText())
+                    .isEqualTo("{broken");
+            assertThat(malformedJsonStrings.metadata().path("llm.function_call").asText())
+                    .isEqualTo("{also-broken");
+            assertThat(malformedJsonStrings.metadata().path("llm.prompt_template.variables").asText())
                     .isEqualTo("{still-broken");
-            assertThat(malformedJsonStrings.input().path("tools").get(0).path("json_schema").asText())
+            assertThat(malformedJsonStrings.metadata().path("llm.tools.0.tool.json_schema").asText())
                     .isEqualTo("{schema-broken");
-            assertThat(malformedJsonStrings.output().path("function_call").asText()).isEqualTo("{also-broken");
+            assertThat(malformedJsonStrings.metadata()
+                    .path("llm.output_messages.0.message.function_call_arguments_json").asText())
+                    .isEqualTo("{arguments-broken");
+
+            var trailingJsonTokens = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("input.mime_type", "application/json"),
+                    str("input.value", "{\"request\":true} {}"),
+                    str("output.mime_type", "application/json"),
+                    str("output.value", "[1,2] false"),
+                    str("llm.invocation_parameters", "{\"temperature\":0.2} {}"),
+                    str("llm.function_call", "{\"name\":\"weather\"} []"),
+                    str("llm.prompt_template.variables", "{\"city\":\"Paris\"} true"),
+                    str("llm.tools.0.tool.json_schema", "{\"type\":\"object\"} null"),
+                    str("llm.output_messages.0.message.function_call_arguments_json", "{\"city\":\"Paris\"} 7")));
+            assertThat(trailingJsonTokens.input().asText()).isEqualTo("{\"request\":true} {}");
+            assertThat(trailingJsonTokens.output().asText()).isEqualTo("[1,2] false");
+            assertThat(trailingJsonTokens.metadata().path("llm.invocation_parameters").asText())
+                    .isEqualTo("{\"temperature\":0.2} {}");
+            assertThat(trailingJsonTokens.metadata().path("llm.function_call").asText())
+                    .isEqualTo("{\"name\":\"weather\"} []");
+            assertThat(trailingJsonTokens.metadata().path("llm.prompt_template.variables").asText())
+                    .isEqualTo("{\"city\":\"Paris\"} true");
+            assertThat(trailingJsonTokens.metadata().path("llm.tools.0.tool.json_schema").asText())
+                    .isEqualTo("{\"type\":\"object\"} null");
+            assertThat(trailingJsonTokens.metadata()
+                    .path("llm.output_messages.0.message.function_call_arguments_json").asText())
+                    .isEqualTo("{\"city\":\"Paris\"} 7");
+        }
+
+        @Test
+        void parsesToolSpanSchemaAndPreservesInvalidJsonAttributesInMetadata() {
+            var valid = enrich(List.of(
+                    str("openinference.span.kind", "TOOL"),
+                    str("tool.json_schema", "{\"type\":\"object\",\"required\":[\"question\"]}")));
+
+            assertThat(valid.input()).isNull();
+            assertThat(valid.metadata().path("tool.json_schema").path("type").asText()).isEqualTo("object");
+            assertThat(valid.metadata().path("tool.json_schema").path("required").get(0).asText())
+                    .isEqualTo("question");
+
+            var invalid = enrich(List.of(
+                    str("openinference.span.kind", "TOOL"),
+                    str("tool.json_schema", "{broken"),
+                    str("metadata", "   ")));
+
+            assertThat(invalid.input()).isNull();
+            assertThat(invalid.metadata().path("tool.json_schema").asText()).isEqualTo("{broken");
+            assertThat(invalid.metadata().path("metadata").asText()).isEqualTo("   ");
         }
 
         @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -2382,6 +2382,37 @@ class OpenTelemetryMapperTest {
         }
 
         @ParameterizedTest
+        @ValueSource(strings = {"", "   ", "\t\n"})
+        void ignoresBlankThreadIdsWhenSelectingFallbacks(String blank) {
+            var attributes = new ArrayList<>(List.of(str("openinference.span.kind", "LLM"),
+                    str("thread_id", blank), str("gen_ai.conversation.id", blank), str("session.id", "session")));
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("session");
+            attributes.add(str("gen_ai.conversation.id", "conversation"));
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("conversation");
+            Collections.reverse(attributes);
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("conversation");
+            attributes.add(str("thread_id", "explicit"));
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("explicit");
+            Collections.reverse(attributes);
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("explicit");
+        }
+
+        @Test
+        void preservesNumericExplicitThreadIdOverSession() {
+            var span = enrich(List.of(str("openinference.span.kind", "LLM"),
+                    integer("thread_id", 0), str("session.id", "session")));
+            assertThat(span.metadata().path("thread_id").asInt()).isZero();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "   "})
+        void skipsBlankThreadIdsOnUnmarkedSpans(String blank) {
+            var attributes = List.of(str("thread_id", blank), str("gen_ai.conversation.id", "conversation"));
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("conversation");
+            assertThat(enrich(List.of(str("thread_id", blank))).metadata().has("thread_id")).isFalse();
+        }
+
+        @ParameterizedTest
         @CsvSource({"100,80,50,0", "100,20,10,70", "2147483647,0,0,2147483647"})
         void boundsExclusiveOpenInferenceUsage(int prompt, int read, int write, int expected) {
             var span = enrich(List.of(str("openinference.span.kind", "LLM"), str("llm.provider", "anthropic"),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.comet.opik.api.Span;
+import com.comet.opik.api.resources.v1.events.OnlineScoringEngine;
 import com.comet.opik.domain.cost.CostService;
 import com.comet.opik.domain.mapping.OpenTelemetryMappingRuleFactory;
 import com.comet.opik.podam.PodamFactoryUtils;
@@ -25,6 +26,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -2318,6 +2320,60 @@ class OpenTelemetryMapperTest {
     @Nested
     class OpenInferenceNormalization {
 
+        @Test
+        void preservesLegacyScoringPathsWithOriginalMessageIndices() {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.input_messages.2.message.content", "Question"),
+                    str("llm.output_messages.7.message.content", "Answer"),
+                    str("llm.output_messages.7.message.function_call_arguments_json", "{\"city\":\"Paris\"}")));
+
+            assertThat(OnlineScoringEngine.toReplacements(Map.of(
+                    "old_input", "input.llm.input_messages.2.message.content",
+                    "old_output", "input.llm.output_messages.7.message.content",
+                    "new_input", "input.messages[0].content",
+                    "new_output", "output.messages[0].content"), span))
+                    .isEqualTo(Map.of("old_input", "Question", "old_output", "Answer",
+                            "new_input", "Question", "new_output", "Answer"));
+            assertThat(span.input().path("llm.output_messages.7.message.function_call_arguments_json")
+                    .path("city").asText()).isEqualTo("Paris");
+        }
+
+        @ParameterizedTest
+        @CsvSource({"llm.provider,AWS", "llm.system,AWS", "llm.provider,AwS"})
+        void resolvesAwsProviderWithoutDependingOnCase(String attribute, String provider) {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str(attribute, provider),
+                    str("llm.model_name", "anthropic.claude-3-5-haiku-20241022-v1:0"),
+                    integer("llm.token_count.prompt", 1000),
+                    integer("llm.token_count.completion", 20),
+                    integer("llm.token_count.prompt_details.cache_read", 800),
+                    integer("llm.token_count.prompt_details.cache_write", 100)));
+
+            assertThat(span.provider()).isEqualTo("bedrock");
+            assertThat(CostService.calculateCost(span.model(), span.provider(), span.usage(), span.metadata()))
+                    .isEqualByComparingTo("0.000324");
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "2147483647,-2147483648,-1,2147483647",
+                "100,-5,20,80",
+                "100,80,50,0",
+                "-1,0,0,0"
+        })
+        void boundsUncachedTokensFromMixedUsageAttributes(int prompt, int cacheRead, int cacheWrite, int expected) {
+            var span = enrich(List.of(
+                    str("openinference.span.kind", "LLM"),
+                    str("llm.provider", "anthropic"),
+                    integer("gen_ai.usage.prompt_tokens", prompt),
+                    integer("gen_ai.usage.cache_read_input_tokens", cacheRead),
+                    integer("gen_ai.usage.cache_creation_input_tokens", cacheWrite)));
+
+            assertThat(span.usage()).containsEntry("original_usage.input_tokens", expected);
+        }
+
         private Span enrich(List<KeyValue> attributes) {
             var spanBuilder = Span.builder()
                     .id(UUID.randomUUID())
@@ -2436,8 +2492,10 @@ class OpenTelemetryMapperTest {
                     .path("arguments").asText()).isEqualTo("{\"city\":\"Paris\"}");
             assertThat(outputMessage.path("tool_calls").get(0).path("reasoning_signature").asText())
                     .isEqualTo("tool-signature");
-            assertThat(span.input().fieldNames()).toIterable()
-                    .noneMatch(name -> name.startsWith("llm."));
+            assertThat(span.input().path("llm.input_messages.2.message.content").asText())
+                    .isEqualTo("What is the weather?");
+            assertThat(span.input().path("llm.output_messages.7.message.role").asText())
+                    .isEqualTo("model");
             assertThat(span.output().fieldNames()).toIterable()
                     .noneMatch(name -> name.startsWith("llm."));
         }
@@ -2645,6 +2703,7 @@ class OpenTelemetryMapperTest {
         @CsvSource({
                 "anthropic, claude-haiku-4-5, original_usage.input_tokens, 0.000405",
                 "aws, anthropic.claude-3-5-haiku-20241022-v1:0, original_usage.inputTokens, 0.000324",
+                "bedrock_converse, anthropic.claude-haiku-4-5-20251001-v1:0, original_usage.inputTokens, 0.000405",
                 "anthropic_vertexai, vertex_ai/claude-haiku-4-5, original_usage.input_tokens, 0.000405"
         })
         void calculatesCacheCostWithoutCountingCachedPromptTokensTwice(
@@ -2665,20 +2724,22 @@ class OpenTelemetryMapperTest {
                     .isEqualByComparingTo(expectedCost);
         }
 
-        @Test
-        void calculatesAudioCostAtAudioRates() {
+        @ParameterizedTest
+        @CsvSource({"300,200,0.03275", "300,0,0.01875", "0,200,0.0215"})
+        void calculatesAudioCostAtAudioRates(int inputAudio, int outputAudio, String expectedCost) {
             var span = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     str("llm.provider", "openai"),
                     str("llm.model_name", "gpt-4o-audio-preview"),
                     integer("llm.token_count.prompt", 1000),
                     integer("llm.token_count.completion", 500),
-                    integer("llm.token_count.prompt_details.audio", 300),
-                    integer("llm.token_count.completion_details.audio", 200)));
+                    integer("llm.token_count.prompt_details.audio", inputAudio),
+                    integer("llm.token_count.completion_details.audio", outputAudio)));
 
-            // 700 text input + 300 audio input + 300 text output + 200 audio output.
+            assertThat(span.usage()).containsEntry("prompt_tokens_details.audio_tokens", inputAudio)
+                    .containsEntry("completion_tokens_details.audio_tokens", outputAudio);
             assertThat(CostService.calculateCost(span.model(), span.provider(), span.usage(), span.metadata()))
-                    .isEqualByComparingTo("0.03275");
+                    .isEqualByComparingTo(expectedCost);
         }
 
         @ParameterizedTest
@@ -2801,7 +2862,7 @@ class OpenTelemetryMapperTest {
             var unmarkedInvocation = enrich(List.of(str("llm.invocation_parameters", "{\"temperature\":0.5}")));
 
             assertThat(marked.output().path("messages").get(0).path("content").asText()).isEqualTo("hello");
-            assertThat(marked.input()).isNull();
+            assertThat(marked.input().path("llm.output_messages.0.message.content").asText()).isEqualTo("hello");
             assertThat(unmarked.input().path("llm.output_messages.0.message.content").asText()).isEqualTo("hello");
             assertThat(unmarked.output()).isNull();
             assertThat(unmarkedInvocation.input().path("llm.invocation_parameters").path("temperature").asDouble())

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/OpenTelemetryMapperTest.java
@@ -2357,20 +2357,38 @@ class OpenTelemetryMapperTest {
         }
 
         @ParameterizedTest
-        @CsvSource({
-                "2147483647,-2147483648,-1,2147483647",
-                "100,-5,20,80",
-                "100,80,50,0",
-                "-1,0,0,0"
-        })
-        void boundsUncachedTokensFromMixedUsageAttributes(int prompt, int cacheRead, int cacheWrite, int expected) {
-            var span = enrich(List.of(
-                    str("openinference.span.kind", "LLM"),
-                    str("llm.provider", "anthropic"),
+        @CsvSource({"100,80,50", "100,20,10", "2147483647,0,0"})
+        void doesNotReinterpretGenericUsageOnMarkedSpans(int prompt, int cacheRead, int cacheWrite) {
+            var span = enrich(List.of(str("openinference.span.kind", "LLM"), str("llm.provider", "anthropic"),
                     integer("gen_ai.usage.prompt_tokens", prompt),
                     integer("gen_ai.usage.cache_read_input_tokens", cacheRead),
                     integer("gen_ai.usage.cache_creation_input_tokens", cacheWrite)));
+            assertThat(span.usage()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                    "prompt_tokens", prompt, "cache_read_input_tokens", cacheRead, "cache_creation_input_tokens",
+                    cacheWrite));
+        }
 
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void preservesThreadIdPriorityAcrossAttributeOrder(boolean reverse) {
+            var attributes = new ArrayList<>(List.of(str("openinference.span.kind", "LLM"),
+                    str("session.id", "session"), str("gen_ai.conversation.id", "conversation")));
+            if (reverse) Collections.reverse(attributes);
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("conversation");
+            attributes.add(str("thread_id", "explicit"));
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("explicit");
+            Collections.reverse(attributes);
+            assertThat(enrich(attributes).metadata().path("thread_id").asText()).isEqualTo("explicit");
+        }
+
+        @ParameterizedTest
+        @CsvSource({"100,80,50,0", "100,20,10,70", "2147483647,0,0,2147483647"})
+        void boundsExclusiveOpenInferenceUsage(int prompt, int read, int write, int expected) {
+            var span = enrich(List.of(str("openinference.span.kind", "LLM"), str("llm.provider", "anthropic"),
+                    integer("llm.token_count.prompt", prompt),
+                    integer("llm.token_count.prompt_details.cache_read", read),
+                    integer("llm.token_count.prompt_details.cache_write", write),
+                    integer("gen_ai.usage.cache_read_input_tokens", 999)));
             assertThat(span.usage()).containsEntry("original_usage.input_tokens", expected);
         }
 
@@ -2512,30 +2530,27 @@ class OpenTelemetryMapperTest {
             assertThat(jsonObject.input().path("messages").isArray()).isTrue();
             assertThat(jsonObject.input().path("messages").get(0).path("content").asText()).isEqualTo("semantic");
 
-            var plainText = enrich(List.of(
-                    str("openinference.span.kind", "CHAIN"),
-                    str("input.value", "{\"kept\":\"as text\"}")));
-            assertThat(plainText.input().isTextual()).isTrue();
-            assertThat(plainText.input().asText()).isEqualTo("{\"kept\":\"as text\"}");
+        }
 
-            var malformedJson = enrich(List.of(
-                    str("openinference.span.kind", "CHAIN"),
-                    str("output.mime_type", "application/json"),
-                    str("output.value", "{invalid")));
-            assertThat(malformedJson.output().isTextual()).isTrue();
-            assertThat(malformedJson.output().asText()).isEqualTo("{invalid");
+        @ParameterizedTest
+        @CsvSource(value = {"|{\"kept\":\"as text\"}", "application/json|{invalid", "application/json|''",
+                "text/plain|plain output", "application/xml|<request />"}, delimiter = '|')
+        void preservesRawTextByMimeType(String mime, String value) {
+            var attributes = new ArrayList<>(
+                    List.of(str("openinference.span.kind", "CHAIN"), str("input.value", value)));
+            if (mime != null) attributes.add(str("input.mime_type", mime));
+            assertThat(enrich(attributes).input()).isEqualTo(JsonUtils.valueToTree(value));
+        }
 
-            var blankJson = enrich(List.of(
-                    str("openinference.span.kind", "CHAIN"),
-                    str("input.mime_type", "application/json"),
-                    str("input.value", ""),
-                    str("output.mime_type", "application/json"),
-                    str("output.value", "   ")));
-            assertThat(blankJson.input().isTextual()).isTrue();
-            assertThat(blankJson.input().asText()).isEmpty();
-            assertThat(blankJson.output().isTextual()).isTrue();
-            assertThat(blankJson.output().asText()).isEqualTo("   ");
+        @Test
+        void preservesWhitespaceRawJson() {
+            var span = enrich(List.of(str("openinference.span.kind", "CHAIN"),
+                    str("output.mime_type", "application/json"), str("output.value", "   ")));
+            assertThat(span.output()).isEqualTo(JsonUtils.valueToTree("   "));
+        }
 
+        @Test
+        void keepsRawArrayAlongsideStructuredMessages() {
             var scalarWithStructure = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     str("output.mime_type", "application/json"),
@@ -2546,18 +2561,10 @@ class OpenTelemetryMapperTest {
             assertThat(scalarWithStructure.output().path("messages").get(0).path("content").asText())
                     .isEqualTo("done");
 
-            var textPlain = enrich(List.of(
-                    str("openinference.span.kind", "CHAIN"),
-                    str("output.mime_type", "text/plain"),
-                    str("output.value", "plain output")));
-            assertThat(textPlain.output().asText()).isEqualTo("plain output");
+        }
 
-            var unsupportedMime = enrich(List.of(
-                    str("openinference.span.kind", "CHAIN"),
-                    str("input.mime_type", "application/xml"),
-                    str("input.value", "<request />")));
-            assertThat(unsupportedMime.input().asText()).isEqualTo("<request />");
-
+        @Test
+        void mergesNativeObjectsWithSemanticMessages() {
             var nativeObject = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     object("input.value", str("question", "native object"), str("messages", "raw collision")),
@@ -2567,6 +2574,10 @@ class OpenTelemetryMapperTest {
             assertThat(nativeObject.input().path("messages").get(0).path("content").asText())
                     .isEqualTo("semantic wins");
 
+        }
+
+        @Test
+        void preservesNativeArrays() {
             var nativeArray = enrich(List.of(
                     str("openinference.span.kind", "CHAIN"),
                     array("input.value",
@@ -2772,19 +2783,22 @@ class OpenTelemetryMapperTest {
 
             assertThat(span.input()).isNull();
             assertThat(span.output()).isNull();
-            assertThat(span.metadata().fieldNames()).toIterable().contains(
-                    "llm.input_messages.-1.message.content",
-                    "llm.output_messages.not-a-number.message.content",
-                    "llm.input_messages.0.message.role",
-                    "llm.output_messages.0.message.function_call_arguments_json",
-                    "llm.invocation_parameters",
-                    "llm.function_call",
-                    "llm.prompt_template.variables",
-                    "llm.tools.0.tool.json_schema",
-                    "llm.token_count.prompt",
-                    "tag.tags",
-                    "llm.tools.999999999999999999999.tool.name");
+            assertThat(span.metadata()).isEqualTo(JsonUtils.valueToTree(Map.ofEntries(
+                    Map.entry("openinference.span.kind", "LLM"), Map.entry("integration", "mixed-batch-scope"),
+                    Map.entry("llm.input_messages.-1.message.content", "negative"),
+                    Map.entry("llm.output_messages.not-a-number.message.content", "invalid"),
+                    Map.entry("llm.input_messages.0.message.role", 7L),
+                    Map.entry("llm.output_messages.0.message.function_call_arguments_json", 8L),
+                    Map.entry("llm.invocation_parameters", 9L), Map.entry("llm.function_call", 10L),
+                    Map.entry("llm.prompt_template.variables", 11L), Map.entry("llm.tools.0.tool.json_schema", 12L),
+                    Map.entry("llm.token_count.prompt", -1L), Map.entry("tag.tags", true),
+                    Map.entry("llm.tools.999999999999999999999.tool.name", "overflow"))));
+            assertThat(span.usage()).isNullOrEmpty();
+            assertThat(span.tags()).isNullOrEmpty();
+        }
 
+        @Test
+        void preservesMalformedJsonMetadata() {
             var malformedJsonStrings = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     str("llm.invocation_parameters", "{broken"),
@@ -2806,6 +2820,10 @@ class OpenTelemetryMapperTest {
                     .path("llm.output_messages.0.message.function_call_arguments_json").asText())
                     .isEqualTo("{arguments-broken");
 
+        }
+
+        @Test
+        void preservesTrailingJsonTokens() {
             var trailingJsonTokens = enrich(List.of(
                     str("openinference.span.kind", "LLM"),
                     str("input.mime_type", "application/json"),

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
@@ -1,6 +1,7 @@
 ---
 headline: OpenTelemetry
-og:description: Integrate OpenTelemetry SDKs with Opik to enhance your ML/AI apps
+og:description:
+  Integrate OpenTelemetry SDKs with Opik to enhance your ML/AI apps
   with distributed tracing and streamline monitoring.
 og:site_name: Opik Documentation
 og:title: Get Started with OpenTelemetry - Opik
@@ -16,8 +17,8 @@ your ML/AI applications with distributed tracing. This guide will show you how
 to directly integrate OpenTelemetry SDKs with Opik.
 
 <Note>
-  OpenTelemetry integration in Opik currently supports HTTP transport. We're actively working on expanding the feature
-  set - stay tuned for updates!
+  OpenTelemetry integration in Opik currently supports HTTP transport. We're
+  actively working on expanding the feature set - stay tuned for updates!
 </Note>
 
 ## OpenTelemetry Endpoint Configuration
@@ -61,6 +62,31 @@ metrics, logs) need to be sent to different endpoints:
 ```bash wordWrap
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://<YOUR-OPIK-INSTANCE>/api/v1/private/otel/v1/traces"
 ```
+
+## OpenInference messages
+
+Spans with the `openinference.span.kind` attribute support the **Messages** tab and
+**Pretty** input/output previews. Newly ingested spans store chat messages in
+`input.messages` and `output.messages`, including tool calls and multimodal content.
+Previously stored spans with flattened OpenInference attributes remain readable in
+the UI; their stored data is not rewritten.
+
+<Warning>
+  If your online evaluation rules or custom consumers reference flattened
+  OpenInference fields, update their variable mappings for newly ingested spans.
+  Historical records retain their original paths.
+</Warning>
+
+| Historical variable mapping                   | Mapping for newly ingested spans |
+| --------------------------------------------- | -------------------------------- |
+| `input.llm.input_messages.0.message.content`  | `input.messages[0].content`      |
+| `input.llm.output_messages.0.message.content` | `output.messages[0].content`     |
+
+Message, content, and tool-call arrays are ordered by their original numeric indices
+and compacted, so inspect a new span before updating mappings that use sparse indices.
+Raw `input.value` and `output.value` are parsed according to their MIME type. When a
+raw scalar or array is the only content, it becomes the entire input or output;
+when combined with structured fields, it remains under `value`.
 
 ## Custom via OpenTelemetry SDKs
 
@@ -121,6 +147,7 @@ OpenAIInstrumentor().instrument()
 </Tip>
 
 <Warning>
-  Make sure to import the `http` trace exporter (`opentelemetry.exporter.otlp.proto.http.trace_exporter`), if you use
-  the GRPC exporter you will face errors.
+  Make sure to import the `http` trace exporter
+  (`opentelemetry.exporter.otlp.proto.http.trace_exporter`), if you use the GRPC
+  exporter you will face errors.
 </Warning>

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
@@ -10,8 +10,6 @@ title: OpenTelemetry
 toc_max_heading_level: 4
 ---
 
-# Get Started with OpenTelemetry
-
 Opik provides native support for OpenTelemetry (OTel), allowing you to instrument
 your ML/AI applications with distributed tracing. This guide will show you how
 to directly integrate OpenTelemetry SDKs with Opik.
@@ -65,33 +63,77 @@ export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://<YOUR-OPIK-INSTANCE>/api/v1/pr
 
 ## OpenInference messages
 
-Spans with the `openinference.span.kind` attribute support the **Messages** tab and
-**Pretty** input/output previews. Newly ingested spans store chat messages in
-`input.messages` and `output.messages`, including tool calls and multimodal content.
-Previously stored spans with flattened OpenInference attributes remain readable in
-the UI; their stored data is not rewritten.
+Spans with OpenInference chat messages support the **Messages** tab and **Pretty**
+input/output previews. Newly ingested spans store chat messages in `input.messages`
+and `output.messages`, including tool calls and multimodal content. Previously
+stored spans with flattened OpenInference attributes remain readable in the UI;
+their stored data is not rewritten.
 
-<Note>
-  Existing online evaluation rules can keep using supported
-  `input.llm.input_messages.*` and `input.llm.output_messages.*` paths. Newly
-  ingested spans retain these original message attributes in `input` alongside
-  the structured messages, with their original indices. For new rules, use the
-  structured paths below. Historical records retain their original paths.
-</Note>
+A span marked `openinference.span.kind=LLM` can also show a non-empty raw input or
+output as a message. Other kinds, such as `CHAIN`, `AGENT`, `TOOL`, and `RETRIEVER`,
+need actual message content; their raw payloads remain available in **Details**.
+An OpenInference marker does not override an explicit framework message schema,
+such as LangChain messages with `type: "human"` or `type: "ai"`.
 
-| Compatible historical variable mapping        | Structured variable mapping      |
-| --------------------------------------------- | -------------------------------- |
-| `input.llm.input_messages.0.message.content`  | `input.messages[0].content`      |
-| `input.llm.output_messages.0.message.content` | `output.messages[0].content`     |
+### Evaluation paths and compatibility
+
+<Warning>
+  Compatibility aliases cover only successfully normalized message fields under
+  `llm.input_messages.*.message.*` and `llm.output_messages.*.message.*`. They are
+  retained in `input` with their original indices. Unknown fields, invalid indices,
+  and values with an unsupported type are preserved under their original keys in
+  `metadata`, not as evaluation aliases in `input`. Prompts, choices, tools outside
+  messages, and invocation parameters use their new structured paths.
+</Warning>
+
+The supported message fields are `role`, `content`, `name`, `tool_call_id`,
+`function_call_name`, and `function_call_arguments_json`, plus the nested fields
+listed below. These attributes must be strings; `function_call_arguments_json`
+must also contain valid JSON. Compatibility aliases retain the existing ingestion
+behavior: strings containing valid JSON can be stored as parsed JSON values.
+Structured text and opaque tool-call arguments retain their string form.
+
+For new evaluation rules, use structured paths:
+
+| Historical variable mapping | Structured variable mapping |
+| --- | --- |
+| `input.llm.input_messages.0.message.content` | `input.messages[0].content` |
+| `input.llm.output_messages.0.message.content` | `output.messages[0].content` |
+| `input.llm.input_messages.0.message.contents.0.message_content.text` | `input.messages[0].contents[0].text` |
+| `input.llm.input_messages.0.message.contents.0.message_content.image.image.url` | `input.messages[0].contents[0].image.url` |
+| `input.llm.input_messages.0.message.contents.0.message_content.audio.audio.url` | `input.messages[0].contents[0].audio.url` |
+| `input.llm.output_messages.0.message.tool_calls.0.tool_call.function.arguments` | `output.messages[0].tool_calls[0].function.arguments` |
+| `input.llm.output_messages.0.message.contents.0.tool_call.function.name` | `output.messages[0].contents[0].tool_call.function.name` |
+
+Within `contents`, Opik accepts `message_content.type`, `text`, `id`, `signature`,
+`data`, and `encrypted_content` (each with the `message_content.` prefix),
+`message_content.image.image.url`, and `message_content.audio.audio.url`,
+`mime_type`, and `transcript` (each with the `message_content.audio.audio.` prefix).
+Both message-level and content-level `tool_call` fields support `id`,
+`function.name`, `function.arguments`, and `reasoning_signature`.
 
 Structured message, content, and tool-call arrays are ordered by their original
 numeric indices and compacted. For example, an original message index of `7` can
 become `messages[0]`, while its compatibility attribute keeps index `7`. Inspect a
-new span when switching a rule to structured paths. Other normalized OpenInference
-fields, such as prompts, choices, and invocation parameters, require their new paths.
-Raw `input.value` and `output.value` are parsed according to their MIME type. When a
-raw scalar or array is the only content, it becomes the entire input or output;
-when combined with structured fields, it remains under `value`.
+new span when switching a rule to structured paths.
+
+### Raw input and output
+
+Opik parses `input.value` and `output.value` according to their MIME type. JSON
+objects merge at the top level with the normalized fields, with normalized fields
+winning on collisions. For example, raw `{"question":"Hi","messages":["raw"]}`
+plus a semantic user message becomes
+`{"question":"Hi","messages":[{"role":"user","content":"Hello"}]}`.
+Compatibility aliases may also be present in `input`.
+
+| Raw value | No structured fields | With structured fields |
+| --- | --- | --- |
+| JSON object | The object itself | Top-level merge; normalized fields take precedence |
+| Scalar or array | The scalar or array itself | Stored under `value` alongside structured fields |
+| Text or invalid JSON | The original text | Original text under `value` alongside structured fields |
+
+The Messages view displays only the remaining raw content alongside structured
+prompts or tools, so those structured fields are not repeated in a raw JSON block.
 
 ## Custom via OpenTelemetry SDKs
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
@@ -71,19 +71,24 @@ Spans with the `openinference.span.kind` attribute support the **Messages** tab 
 Previously stored spans with flattened OpenInference attributes remain readable in
 the UI; their stored data is not rewritten.
 
-<Warning>
-  If your online evaluation rules or custom consumers reference flattened
-  OpenInference fields, update their variable mappings for newly ingested spans.
-  Historical records retain their original paths.
-</Warning>
+<Note>
+  Existing online evaluation rules can keep using supported
+  `input.llm.input_messages.*` and `input.llm.output_messages.*` paths. Newly
+  ingested spans retain these original message attributes in `input` alongside
+  the structured messages, with their original indices. For new rules, use the
+  structured paths below. Historical records retain their original paths.
+</Note>
 
-| Historical variable mapping                   | Mapping for newly ingested spans |
+| Compatible historical variable mapping        | Structured variable mapping      |
 | --------------------------------------------- | -------------------------------- |
 | `input.llm.input_messages.0.message.content`  | `input.messages[0].content`      |
 | `input.llm.output_messages.0.message.content` | `output.messages[0].content`     |
 
-Message, content, and tool-call arrays are ordered by their original numeric indices
-and compacted, so inspect a new span before updating mappings that use sparse indices.
+Structured message, content, and tool-call arrays are ordered by their original
+numeric indices and compacted. For example, an original message index of `7` can
+become `messages[0]`, while its compatibility attribute keeps index `7`. Inspect a
+new span when switching a rule to structured paths. Other normalized OpenInference
+fields, such as prompts, choices, and invocation parameters, require their new paths.
 Raw `input.value` and `output.value` are parsed according to their MIME type. When a
 raw scalar or array is the only content, it becomes the entire input or output;
 when combined with structured fields, it remains under `value`.

--- a/apps/opik-frontend/src/lib/openinference.test.ts
+++ b/apps/opik-frontend/src/lib/openinference.test.ts
@@ -116,3 +116,41 @@ describe("isSafeOpenInferenceMediaUrl", () => {
     },
   );
 });
+
+describe("historical nested JSON values", () => {
+  it.each(["text", "data", "signature", "encrypted_content"])(
+    "matches decoded %s without duplicating repeated turns",
+    (field) => {
+      const message = {
+        role: "user",
+        content: "Summary",
+        contents: [{ type: "text", [field]: '{"a":1}' }],
+      };
+      const input = {
+        messages: [message, message],
+        ...Object.fromEntries(
+          [0, 1].flatMap((i) => [
+            [`llm.input_messages.${i}.message.role`, "user"],
+            [`llm.input_messages.${i}.message.content`, "Summary"],
+            [
+              `llm.input_messages.${i}.message.contents.0.message_content.type`,
+              "text",
+            ],
+            [
+              `llm.input_messages.${i}.message.contents.0.message_content.${field}`,
+              { a: 1 },
+            ],
+          ]),
+        ),
+      };
+      expect(parseOpenInferenceFields(input, undefined).inputMessages).toEqual([
+        message,
+        message,
+      ]);
+      expect(
+        parseOpenInferenceFields({ ...input, messages: undefined }, undefined)
+          .inputMessages,
+      ).toHaveLength(2);
+    },
+  );
+});

--- a/apps/opik-frontend/src/lib/openinference.test.ts
+++ b/apps/opik-frontend/src/lib/openinference.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSafeOpenInferenceMediaUrl,
+  parseOpenInferenceFields,
+} from "./openinference";
+
+describe("parseOpenInferenceFields", () => {
+  it("retains semantic output attributes stored alongside canonical messages", () => {
+    const messages = [{ role: "assistant", content: "Answer" }];
+    const parsed = parseOpenInferenceFields(
+      { "llm.function_call": '{"name":"stale"}' },
+      {
+        messages,
+        "llm.function_call": '{"name":"current"}',
+        "llm.finish_reason": "function_call",
+      },
+    );
+
+    expect(parsed.outputMessages).toEqual(messages);
+    expect(parsed.functionCall).toEqual({ name: "current" });
+    expect(parsed.finishReason).toBe("function_call");
+  });
+
+  it("matches reordered message properties without removing repeated turns", () => {
+    const messages = [
+      { role: "user", content: "Again" },
+      { role: "assistant", content: "Answer" },
+      { role: "user", content: "Again" },
+    ];
+    const input = {
+      messages,
+      ...Object.fromEntries(
+        messages.flatMap((message, index) => [
+          [`llm.input_messages.${index * 3}.message.content`, message.content],
+          [`llm.input_messages.${index * 3}.message.role`, message.role],
+        ]),
+      ),
+    };
+
+    expect(parseOpenInferenceFields(input, undefined).inputMessages).toEqual(
+      messages,
+    );
+  });
+
+  it("matches reordered nested tool properties and keeps distinct tools", () => {
+    const tools = [
+      {
+        name: "search",
+        json_schema: { type: "object", required: ["query", "limit"] },
+      },
+      { name: "other" },
+    ];
+    const input = {
+      tools,
+      "llm.tools.0.tool.json_schema":
+        '{"required":["query","limit"],"type":"object"}',
+      "llm.tools.0.tool.name": "search",
+    };
+
+    expect(parseOpenInferenceFields(input, undefined).tools).toEqual(tools);
+  });
+
+  it("keeps array order significant when comparing tools", () => {
+    const tools = [{ name: "search", json_schema: { enum: ["a", "b"] } }];
+    const input = {
+      tools,
+      "llm.tools.0.tool.name": "search",
+      "llm.tools.0.tool.json_schema": '{"enum":["b","a"]}',
+    };
+
+    expect(parseOpenInferenceFields(input, undefined).tools).toEqual([
+      ...tools,
+      { name: "search", json_schema: { enum: ["b", "a"] } },
+    ]);
+  });
+
+  it("matches JSON message content decoded by historical storage", () => {
+    const message = {
+      role: "tool",
+      content: '{"city":"Paris","temperature":21}',
+    };
+    const input = {
+      messages: [message],
+      "llm.input_messages.10.message.role": "tool",
+      "llm.input_messages.10.message.content": {
+        temperature: 21,
+        city: "Paris",
+      },
+    };
+
+    expect(parseOpenInferenceFields(input, undefined).inputMessages).toEqual([
+      message,
+    ]);
+  });
+});
+
+describe("isSafeOpenInferenceMediaUrl", () => {
+  it.each(["image/svg+xml", "image/x-unknown", "text/html"])(
+    "rejects inline %s images",
+    (mimeType) => {
+      expect(
+        isSafeOpenInferenceMediaUrl(`data:${mimeType};base64,AA==`, "image"),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["png", "jpeg", "gif", "webp", "avif", "bmp"])(
+    "accepts inline %s images",
+    (subtype) => {
+      expect(
+        isSafeOpenInferenceMediaUrl(
+          `data:image/${subtype};base64,AA==`,
+          "image",
+        ),
+      ).toBe(true);
+    },
+  );
+});

--- a/apps/opik-frontend/src/lib/openinference.test.ts
+++ b/apps/opik-frontend/src/lib/openinference.test.ts
@@ -1,10 +1,45 @@
 import { describe, expect, it } from "vitest";
 import {
   isSafeOpenInferenceMediaUrl,
+  isOpenInferenceField,
   parseOpenInferenceFields,
 } from "./openinference";
 
 describe("parseOpenInferenceFields", () => {
+  it.each([0, 2147483647])("accepts backend-compatible index %s", (index) => {
+    const parsed = parseOpenInferenceFields(
+      {
+        [`llm.input_messages.${index}.message.content`]: "Question",
+        [`llm.tools.${index}.tool.name`]: "search",
+        [`llm.prompts.${index}.prompt.text`]: "Prompt",
+      },
+      { [`llm.choices.${index}.completion.text`]: "Answer" },
+    );
+    expect(parsed.inputMessages).toEqual([{ content: "Question" }]);
+    expect(parsed.tools).toEqual([{ name: "search" }]);
+    expect(parsed.prompts).toEqual(["Prompt"]);
+    expect(parsed.choices).toEqual(["Answer"]);
+  });
+
+  it.each([2147483648, Number.MAX_SAFE_INTEGER])(
+    "does not render out-of-range index %s",
+    (index) => {
+      const input = {
+        [`llm.input_messages.${index}.message.content`]: "Question",
+        [`llm.tools.${index}.tool.name`]: "search",
+        [`llm.prompts.${index}.prompt.text`]: "Prompt",
+      };
+      const output = { [`llm.choices.${index}.completion.text`]: "Answer" };
+      const parsed = parseOpenInferenceFields(input, output);
+      expect(parsed.inputMessages).toEqual([]);
+      expect(parsed.tools).toEqual([]);
+      expect(parsed.prompts).toEqual([]);
+      expect(parsed.choices).toEqual([]);
+      expect(isOpenInferenceField(input, "input", true, false)).toBe(false);
+      expect(isOpenInferenceField(output, "output", true, false)).toBe(false);
+    },
+  );
+
   it("retains semantic output attributes stored alongside canonical messages", () => {
     const messages = [{ role: "assistant", content: "Answer" }];
     const parsed = parseOpenInferenceFields(

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -1,3 +1,5 @@
+import { isBackendAttachmentPlaceholder } from "@/lib/images";
+
 export const OPENINFERENCE_SPAN_KIND = "openinference.span.kind";
 
 export type OpenInferenceFieldType = "input" | "output";
@@ -52,6 +54,7 @@ export const isSafeOpenInferenceMediaUrl = (
   url: string,
   type: "image" | "audio",
 ): boolean => {
+  if (isBackendAttachmentPlaceholder(url)) return true;
   const placeholderMatch = MEDIA_PLACEHOLDER_RE.exec(url);
   if (placeholderMatch?.[1] === type) return true;
   const dataUriMatch = MEDIA_DATA_URI_RE.exec(url);
@@ -95,6 +98,8 @@ const STRUCTURED_OPENINFERENCE_KEYS = new Set([
   "prompts",
   "choices",
   "tools",
+  "invocation_parameters",
+  "prompt_template",
   "finish_reason",
   "function_call",
   "mime_type",
@@ -455,7 +460,7 @@ const parseCanonicalMessage = (
       .filter((item): item is OpenInferenceToolCall => Boolean(item));
     if (toolCalls.length > 0) message.tool_calls = toolCalls;
   }
-  if (hasOwn(value, "function_call")) {
+  if (value.function_call != null) {
     message.function_call = value.function_call;
   }
   return Object.keys(message).length > 0 ? message : undefined;
@@ -548,6 +553,26 @@ const dedupe = <T>(values: T[]): T[] => {
   });
 };
 
+// Match each legacy occurrence at most once against the canonical representation.
+// Identical turns within one conversation are still separate messages.
+const mergeRepresentations = <T>(canonical: T[], legacy: T[]): T[] => {
+  const remaining = new Map<string | undefined, number>();
+  canonical.forEach((value) => {
+    const fingerprint = JSON.stringify(value);
+    remaining.set(fingerprint, (remaining.get(fingerprint) ?? 0) + 1);
+  });
+  return [
+    ...canonical,
+    ...legacy.filter((value) => {
+      const fingerprint = JSON.stringify(value);
+      const count = remaining.get(fingerprint) ?? 0;
+      if (count === 0) return true;
+      remaining.set(fingerprint, count - 1);
+      return false;
+    }),
+  ];
+};
+
 export const hasLegacyOpenInferenceAttributes = (data: unknown): boolean => {
   if (!isRecord(data)) return false;
   return Object.keys(data).some(
@@ -624,14 +649,14 @@ export const parseOpenInferenceFields = (
 
   const inputRecord = isRecord(input) ? input : undefined;
   const outputRecord = isRecord(output) ? output : undefined;
-  const prompts = dedupe([
-    ...extractTexts(input, "prompts"),
-    ...sortedValues(legacy.prompts),
-  ]);
-  const choices = dedupe([
-    ...extractTexts(output, "choices"),
-    ...sortedValues(legacy.choices),
-  ]);
+  const prompts = mergeRepresentations(
+    extractTexts(input, "prompts"),
+    sortedValues(legacy.prompts),
+  );
+  const choices = mergeRepresentations(
+    extractTexts(output, "choices"),
+    sortedValues(legacy.choices),
+  );
   const canonicalTools =
     inputRecord && Array.isArray(inputRecord.tools) ? inputRecord.tools : [];
   const tools = dedupe([...canonicalTools, ...sortedValues(legacy.tools)]);
@@ -642,11 +667,14 @@ export const parseOpenInferenceFields = (
     (outputRecord && outputRecord.function_call) ?? legacy.functionCall;
 
   return {
-    inputMessages: dedupe([...canonicalInputMessages, ...legacyInputMessages]),
-    outputMessages: dedupe([
-      ...canonicalOutputMessages,
-      ...legacyOutputMessages,
-    ]),
+    inputMessages: mergeRepresentations(
+      canonicalInputMessages,
+      legacyInputMessages,
+    ),
+    outputMessages: mergeRepresentations(
+      canonicalOutputMessages,
+      legacyOutputMessages,
+    ),
     prompts,
     choices,
     tools,
@@ -742,18 +770,13 @@ export const extractOpenInferencePrettyText = (
   data: unknown,
   fieldType: OpenInferenceFieldType,
 ): string | undefined => {
-  const hasRoleBasedMessages =
-    isRecord(data) &&
-    Array.isArray(data.messages) &&
-    data.messages.some(
-      (message) => isRecord(message) && typeof message.role === "string",
-    );
+  const hasMessages = parseCanonicalMessages(data).some(hasRenderableMessage);
   const hasCompletionData =
     isRecord(data) &&
     (extractTexts(data, "prompts").length > 0 ||
       extractTexts(data, "choices").length > 0);
   if (
-    !hasRoleBasedMessages &&
+    !hasMessages &&
     !hasCompletionData &&
     !hasLegacyOpenInferenceAttributes(data)
   ) {

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -1,0 +1,691 @@
+export const OPENINFERENCE_SPAN_KIND = "openinference.span.kind";
+
+export type OpenInferenceFieldType = "input" | "output";
+
+export type OpenInferenceToolCall = {
+  id?: string;
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+  reasoning_signature?: string;
+};
+
+export type OpenInferenceContent = {
+  type?: string;
+  text?: string;
+  id?: string;
+  signature?: string;
+  data?: string;
+  encrypted_content?: string;
+  image?: { url?: string };
+  audio?: { url?: string; mime_type?: string; transcript?: string };
+  tool_call?: OpenInferenceToolCall;
+};
+
+export type OpenInferenceMessage = {
+  role?: string;
+  content?: unknown;
+  contents?: OpenInferenceContent[];
+  tool_calls?: OpenInferenceToolCall[];
+  name?: string;
+  tool_call_id?: string;
+  function_call?: unknown;
+};
+
+export type ParsedOpenInferenceFields = {
+  inputMessages: OpenInferenceMessage[];
+  outputMessages: OpenInferenceMessage[];
+  prompts: string[];
+  choices: string[];
+  tools: unknown[];
+  finishReason?: string;
+  functionCall?: unknown;
+  inputFallback?: unknown;
+  outputFallback?: unknown;
+  hasOpenInferenceData: boolean;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+const MESSAGE_ATTRIBUTE_RE =
+  /^llm\.(input|output)_messages\.([^.]+)\.message\.(.+)$/;
+const CONTENT_ATTRIBUTE_RE = /^contents\.([^.]+)\.(.+)$/;
+const TOOL_CALL_ATTRIBUTE_RE = /^tool_calls\.([^.]+)\.tool_call\.(.+)$/;
+const TOOL_ATTRIBUTE_RE =
+  /^llm\.tools\.([^.]+)\.tool\.(name|description|json_schema)$/;
+const PROMPT_ATTRIBUTE_RE = /^llm\.prompts\.([^.]+)\.prompt\.text$/;
+const CHOICE_ATTRIBUTE_RE = /^llm\.choices\.([^.]+)\.completion\.text$/;
+
+const DISPLAYABLE_LEGACY_PREFIXES = [
+  "llm.input_messages.",
+  "llm.output_messages.",
+  "llm.prompts.",
+  "llm.choices.",
+  "llm.tools.",
+];
+
+const DISPLAYABLE_LEGACY_KEYS = new Set([
+  OPENINFERENCE_SPAN_KIND,
+  "llm.finish_reason",
+  "llm.function_call",
+]);
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const hasOwn = (value: UnknownRecord, key: string) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const parseIndex = (value: string): number | undefined => {
+  if (!/^\d+$/.test(value)) return undefined;
+  const index = Number(value);
+  return Number.isSafeInteger(index) ? index : undefined;
+};
+
+const sortedValues = <T>(values: Map<number, T>): T[] =>
+  [...values.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([, value]) => value);
+
+const toStringValue = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined;
+
+const toArguments = (value: unknown): string | undefined => {
+  if (typeof value === "string") return value;
+  if (value === undefined) return undefined;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return undefined;
+  }
+};
+
+const parseMaybeJson = (value: unknown): unknown => {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+class ToolCallBuilder {
+  private readonly value: OpenInferenceToolCall = {};
+
+  accept(path: string, rawValue: unknown): boolean {
+    if (path === "id") {
+      const id = toStringValue(rawValue);
+      if (id === undefined) return false;
+      this.value.id = id;
+      return true;
+    }
+    if (path === "reasoning_signature") {
+      const signature = toStringValue(rawValue);
+      if (signature === undefined) return false;
+      this.value.reasoning_signature = signature;
+      return true;
+    }
+    if (path === "function.name") {
+      const name = toStringValue(rawValue);
+      if (name === undefined) return false;
+      this.value.function ??= {};
+      this.value.function.name = name;
+      return true;
+    }
+    if (path === "function.arguments") {
+      const args = toArguments(rawValue);
+      if (args === undefined) return false;
+      this.value.function ??= {};
+      this.value.function.arguments = args;
+      return true;
+    }
+    return false;
+  }
+
+  build(): OpenInferenceToolCall | undefined {
+    return Object.keys(this.value).length > 0 ? this.value : undefined;
+  }
+}
+
+class ContentBuilder {
+  private readonly value: OpenInferenceContent = {};
+  private readonly toolCall = new ToolCallBuilder();
+
+  accept(path: string, rawValue: unknown): boolean {
+    const scalarFields: Record<string, keyof OpenInferenceContent> = {
+      "message_content.type": "type",
+      "message_content.text": "text",
+      "message_content.id": "id",
+      "message_content.signature": "signature",
+      "message_content.data": "data",
+      "message_content.encrypted_content": "encrypted_content",
+    };
+    const scalarField = scalarFields[path];
+    if (scalarField) {
+      const value = toStringValue(rawValue);
+      if (value === undefined) return false;
+      Object.assign(this.value, { [scalarField]: value });
+      return true;
+    }
+
+    if (path === "message_content.image.image.url") {
+      const url = toStringValue(rawValue);
+      if (url === undefined) return false;
+      this.value.image = { url };
+      return true;
+    }
+
+    const audioPrefix = "message_content.audio.audio.";
+    if (path.startsWith(audioPrefix)) {
+      const field = path.slice(audioPrefix.length);
+      if (!(["url", "mime_type", "transcript"] as string[]).includes(field))
+        return false;
+      const value = toStringValue(rawValue);
+      if (value === undefined) return false;
+      this.value.audio ??= {};
+      Object.assign(this.value.audio, { [field]: value });
+      return true;
+    }
+
+    if (path.startsWith("tool_call.")) {
+      return this.toolCall.accept(path.slice("tool_call.".length), rawValue);
+    }
+    return false;
+  }
+
+  build(): OpenInferenceContent | undefined {
+    const toolCall = this.toolCall.build();
+    if (toolCall) this.value.tool_call = toolCall;
+    return Object.keys(this.value).length > 0 ? this.value : undefined;
+  }
+}
+
+class MessageBuilder {
+  private readonly value: OpenInferenceMessage = {};
+  private readonly contents = new Map<number, ContentBuilder>();
+  private readonly toolCalls = new Map<number, ToolCallBuilder>();
+  private readonly functionCall: UnknownRecord = {};
+
+  accept(path: string, rawValue: unknown): boolean {
+    if (["role", "name", "tool_call_id"].includes(path)) {
+      const value = toStringValue(rawValue);
+      if (value === undefined) return false;
+      Object.assign(this.value, { [path]: value });
+      return true;
+    }
+    if (path === "content") {
+      this.value.content = rawValue;
+      return true;
+    }
+    if (path === "function_call_name") {
+      const value = toStringValue(rawValue);
+      if (value === undefined) return false;
+      this.functionCall.name = value;
+      return true;
+    }
+    if (path === "function_call_arguments_json") {
+      this.functionCall.arguments = parseMaybeJson(rawValue);
+      return true;
+    }
+
+    const contentMatch = path.match(CONTENT_ATTRIBUTE_RE);
+    if (contentMatch) {
+      const index = parseIndex(contentMatch[1]);
+      if (index === undefined) return false;
+      let content = this.contents.get(index);
+      if (!content) {
+        content = new ContentBuilder();
+        this.contents.set(index, content);
+      }
+      return content.accept(contentMatch[2], rawValue);
+    }
+
+    const toolCallMatch = path.match(TOOL_CALL_ATTRIBUTE_RE);
+    if (toolCallMatch) {
+      const index = parseIndex(toolCallMatch[1]);
+      if (index === undefined) return false;
+      let toolCall = this.toolCalls.get(index);
+      if (!toolCall) {
+        toolCall = new ToolCallBuilder();
+        this.toolCalls.set(index, toolCall);
+      }
+      return toolCall.accept(toolCallMatch[2], rawValue);
+    }
+    return false;
+  }
+
+  build(): OpenInferenceMessage | undefined {
+    const contents = sortedValues(this.contents)
+      .map((content) => content.build())
+      .filter((content): content is OpenInferenceContent => Boolean(content));
+    const toolCalls = sortedValues(this.toolCalls)
+      .map((toolCall) => toolCall.build())
+      .filter((toolCall): toolCall is OpenInferenceToolCall =>
+        Boolean(toolCall),
+      );
+    if (contents.length > 0) this.value.contents = contents;
+    if (toolCalls.length > 0) this.value.tool_calls = toolCalls;
+    if (Object.keys(this.functionCall).length > 0) {
+      this.value.function_call = this.functionCall;
+    }
+    return Object.keys(this.value).length > 0 ? this.value : undefined;
+  }
+}
+
+type LegacyAccumulator = {
+  inputMessages: Map<number, MessageBuilder>;
+  outputMessages: Map<number, MessageBuilder>;
+  prompts: Map<number, string>;
+  choices: Map<number, string>;
+  tools: Map<number, UnknownRecord>;
+  finishReason?: string;
+  functionCall?: unknown;
+  found: boolean;
+};
+
+const createLegacyAccumulator = (): LegacyAccumulator => ({
+  inputMessages: new Map(),
+  outputMessages: new Map(),
+  prompts: new Map(),
+  choices: new Map(),
+  tools: new Map(),
+  found: false,
+});
+
+const acceptLegacyAttribute = (
+  accumulator: LegacyAccumulator,
+  key: string,
+  value: unknown,
+) => {
+  const messageMatch = key.match(MESSAGE_ATTRIBUTE_RE);
+  if (messageMatch) {
+    accumulator.found = true;
+    const index = parseIndex(messageMatch[2]);
+    if (index === undefined) return;
+    const messages =
+      messageMatch[1] === "input"
+        ? accumulator.inputMessages
+        : accumulator.outputMessages;
+    let message = messages.get(index);
+    if (!message) {
+      message = new MessageBuilder();
+      messages.set(index, message);
+    }
+    message.accept(messageMatch[3], value);
+    return;
+  }
+
+  const toolMatch = key.match(TOOL_ATTRIBUTE_RE);
+  if (toolMatch) {
+    accumulator.found = true;
+    const index = parseIndex(toolMatch[1]);
+    if (index === undefined) return;
+    const tool = accumulator.tools.get(index) ?? {};
+    tool[toolMatch[2]] =
+      toolMatch[2] === "json_schema" ? parseMaybeJson(value) : value;
+    accumulator.tools.set(index, tool);
+    return;
+  }
+
+  const promptMatch = key.match(PROMPT_ATTRIBUTE_RE);
+  if (promptMatch) {
+    accumulator.found = true;
+    const index = parseIndex(promptMatch[1]);
+    const text = toStringValue(value);
+    if (index !== undefined && text !== undefined)
+      accumulator.prompts.set(index, text);
+    return;
+  }
+
+  const choiceMatch = key.match(CHOICE_ATTRIBUTE_RE);
+  if (choiceMatch) {
+    accumulator.found = true;
+    const index = parseIndex(choiceMatch[1]);
+    const text = toStringValue(value);
+    if (index !== undefined && text !== undefined)
+      accumulator.choices.set(index, text);
+    return;
+  }
+
+  if (key === "llm.finish_reason") {
+    accumulator.found = true;
+    accumulator.finishReason = toStringValue(value);
+  } else if (key === "llm.function_call") {
+    accumulator.found = true;
+    accumulator.functionCall = parseMaybeJson(value);
+  }
+};
+
+const collectLegacy = (accumulator: LegacyAccumulator, data: unknown): void => {
+  if (!isRecord(data)) return;
+  Object.entries(data).forEach(([key, value]) =>
+    acceptLegacyAttribute(accumulator, key, value),
+  );
+};
+
+const parseCanonicalToolCall = (
+  value: unknown,
+): OpenInferenceToolCall | undefined => {
+  if (!isRecord(value)) return undefined;
+  const toolCall: OpenInferenceToolCall = {};
+  if (typeof value.id === "string") toolCall.id = value.id;
+  if (typeof value.reasoning_signature === "string") {
+    toolCall.reasoning_signature = value.reasoning_signature;
+  }
+  if (isRecord(value.function)) {
+    const fn: NonNullable<OpenInferenceToolCall["function"]> = {};
+    if (typeof value.function.name === "string") fn.name = value.function.name;
+    const args = toArguments(value.function.arguments);
+    if (args !== undefined) fn.arguments = args;
+    if (Object.keys(fn).length > 0) toolCall.function = fn;
+  }
+  return Object.keys(toolCall).length > 0 ? toolCall : undefined;
+};
+
+const parseCanonicalContent = (
+  value: unknown,
+): OpenInferenceContent | undefined => {
+  if (!isRecord(value)) return undefined;
+  const content: OpenInferenceContent = {};
+  (
+    ["type", "text", "id", "signature", "data", "encrypted_content"] as const
+  ).forEach((key) => {
+    const fieldValue = value[key];
+    if (typeof fieldValue === "string") content[key] = fieldValue;
+  });
+  if (isRecord(value.image) && typeof value.image.url === "string") {
+    content.image = { url: value.image.url };
+  }
+  if (isRecord(value.audio)) {
+    const audioValue = value.audio;
+    const audio: NonNullable<OpenInferenceContent["audio"]> = {};
+    (["url", "mime_type", "transcript"] as const).forEach((key) => {
+      const fieldValue = audioValue[key];
+      if (typeof fieldValue === "string") audio[key] = fieldValue;
+    });
+    if (Object.keys(audio).length > 0) content.audio = audio;
+  }
+  const toolCall = parseCanonicalToolCall(value.tool_call);
+  if (toolCall) content.tool_call = toolCall;
+  return Object.keys(content).length > 0 ? content : undefined;
+};
+
+const parseCanonicalMessage = (
+  value: unknown,
+): OpenInferenceMessage | undefined => {
+  if (!isRecord(value)) return undefined;
+  const message: OpenInferenceMessage = {};
+  if (typeof value.role === "string") message.role = value.role;
+  if (hasOwn(value, "content")) message.content = value.content;
+  if (typeof value.name === "string") message.name = value.name;
+  if (typeof value.tool_call_id === "string") {
+    message.tool_call_id = value.tool_call_id;
+  }
+  if (Array.isArray(value.contents)) {
+    const contents = value.contents
+      .map(parseCanonicalContent)
+      .filter((item): item is OpenInferenceContent => Boolean(item));
+    if (contents.length > 0) message.contents = contents;
+  }
+  if (Array.isArray(value.tool_calls)) {
+    const toolCalls = value.tool_calls
+      .map(parseCanonicalToolCall)
+      .filter((item): item is OpenInferenceToolCall => Boolean(item));
+    if (toolCalls.length > 0) message.tool_calls = toolCalls;
+  }
+  if (hasOwn(value, "function_call")) {
+    message.function_call = value.function_call;
+  }
+  return Object.keys(message).length > 0 ? message : undefined;
+};
+
+const parseCanonicalMessages = (data: unknown): OpenInferenceMessage[] => {
+  if (!isRecord(data) || !Array.isArray(data.messages)) return [];
+  return data.messages
+    .map(parseCanonicalMessage)
+    .filter((message): message is OpenInferenceMessage => Boolean(message));
+};
+
+const extractTexts = (data: unknown, key: "prompts" | "choices"): string[] => {
+  if (!isRecord(data) || !Array.isArray(data[key])) return [];
+  const items = data[key] as unknown[];
+  const legacyKey = key === "prompts" ? "prompt.text" : "completion.text";
+  return items
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (!isRecord(item)) return undefined;
+      return toStringValue(item.text) ?? toStringValue(item[legacyKey]);
+    })
+    .filter((item): item is string => item !== undefined);
+};
+
+const extractFallback = (data: unknown): unknown => {
+  if (!isRecord(data)) return data;
+  return hasOwn(data, "value") ? data.value : undefined;
+};
+
+const dedupe = <T>(values: T[]): T[] => {
+  const fingerprints = new Set<string>();
+  return values.filter((value) => {
+    let fingerprint: string;
+    try {
+      fingerprint = JSON.stringify(value) ?? String(value);
+    } catch {
+      return true;
+    }
+    if (fingerprints.has(fingerprint)) return false;
+    fingerprints.add(fingerprint);
+    return true;
+  });
+};
+
+export const hasLegacyOpenInferenceAttributes = (data: unknown): boolean => {
+  if (!isRecord(data)) return false;
+  return Object.keys(data).some(
+    (key) =>
+      DISPLAYABLE_LEGACY_KEYS.has(key) ||
+      DISPLAYABLE_LEGACY_PREFIXES.some((prefix) => key.startsWith(prefix)),
+  );
+};
+
+export const hasLegacyOpenInferenceOutputAttributes = (
+  data: unknown,
+): boolean => {
+  if (!isRecord(data)) return false;
+  return Object.keys(data).some(
+    (key) =>
+      key.startsWith("llm.output_messages.") ||
+      key.startsWith("llm.choices.") ||
+      key === "llm.finish_reason" ||
+      key === "llm.function_call",
+  );
+};
+
+const hasCanonicalDisplayData = (
+  data: unknown,
+  fieldType: OpenInferenceFieldType,
+): boolean => {
+  if (!isRecord(data)) return false;
+  if (Array.isArray(data.messages) && data.messages.some(parseCanonicalMessage))
+    return true;
+  if (fieldType === "input") {
+    return (
+      extractTexts(data, "prompts").length > 0 ||
+      (Array.isArray(data.tools) && data.tools.length > 0)
+    );
+  }
+  return (
+    extractTexts(data, "choices").length > 0 || hasOwn(data, "function_call")
+  );
+};
+
+/**
+ * A hint selects OpenInference ahead of generic OpenAI detection, but does not make a raw
+ * {@code {value: ...}} object displayable on its own.
+ */
+export const isOpenInferenceField = (
+  data: unknown,
+  fieldType: OpenInferenceFieldType,
+  hinted: boolean,
+): boolean =>
+  hasLegacyOpenInferenceAttributes(data) ||
+  (hinted && hasCanonicalDisplayData(data, fieldType));
+
+export const hasOpenInferenceHint = (
+  metadata: unknown,
+  input: unknown,
+  output?: unknown,
+): boolean => {
+  const metadataMarker =
+    isRecord(metadata) && hasOwn(metadata, OPENINFERENCE_SPAN_KIND);
+  return (
+    metadataMarker ||
+    hasLegacyOpenInferenceAttributes(input) ||
+    hasLegacyOpenInferenceAttributes(output)
+  );
+};
+
+export const parseOpenInferenceFields = (
+  input: unknown,
+  output: unknown,
+): ParsedOpenInferenceFields => {
+  const legacy = createLegacyAccumulator();
+  collectLegacy(legacy, input);
+  collectLegacy(legacy, output);
+
+  const canonicalInputMessages = parseCanonicalMessages(input);
+  const canonicalOutputMessages = parseCanonicalMessages(output);
+  const legacyInputMessages = sortedValues(legacy.inputMessages)
+    .map((message) => message.build())
+    .filter((message): message is OpenInferenceMessage => Boolean(message));
+  const legacyOutputMessages = sortedValues(legacy.outputMessages)
+    .map((message) => message.build())
+    .filter((message): message is OpenInferenceMessage => Boolean(message));
+
+  const inputRecord = isRecord(input) ? input : undefined;
+  const outputRecord = isRecord(output) ? output : undefined;
+  const prompts = dedupe([
+    ...extractTexts(input, "prompts"),
+    ...sortedValues(legacy.prompts),
+  ]);
+  const choices = dedupe([
+    ...extractTexts(output, "choices"),
+    ...sortedValues(legacy.choices),
+  ]);
+  const canonicalTools =
+    inputRecord && Array.isArray(inputRecord.tools) ? inputRecord.tools : [];
+  const tools = dedupe([...canonicalTools, ...sortedValues(legacy.tools)]);
+  const finishReason =
+    (outputRecord && toStringValue(outputRecord.finish_reason)) ??
+    legacy.finishReason;
+  const functionCall =
+    (outputRecord && outputRecord.function_call) ?? legacy.functionCall;
+
+  return {
+    inputMessages: dedupe([...canonicalInputMessages, ...legacyInputMessages]),
+    outputMessages: dedupe([
+      ...canonicalOutputMessages,
+      ...legacyOutputMessages,
+    ]),
+    prompts,
+    choices,
+    tools,
+    finishReason,
+    functionCall,
+    inputFallback: extractFallback(input),
+    outputFallback: extractFallback(output),
+    hasOpenInferenceData:
+      legacy.found ||
+      hasLegacyOpenInferenceAttributes(input) ||
+      hasLegacyOpenInferenceAttributes(output) ||
+      hasCanonicalDisplayData(input, "input") ||
+      hasCanonicalDisplayData(output, "output"),
+  };
+};
+
+const messageText = (
+  message: OpenInferenceMessage | undefined,
+): string | undefined => {
+  if (!message) return undefined;
+  if (typeof message.content === "string" && message.content.length > 0) {
+    return message.content;
+  }
+  if (message.contents) {
+    const visible = message.contents
+      .map((content) => content.text ?? content.audio?.transcript)
+      .filter((value): value is string => Boolean(value));
+    if (visible.length > 0) return visible.join("\n\n");
+  }
+  return undefined;
+};
+
+const extractParsedPrettyText = (
+  parsed: ParsedOpenInferenceFields,
+  fieldType: OpenInferenceFieldType,
+): string | undefined => {
+  const messages =
+    fieldType === "input" ? parsed.inputMessages : parsed.outputMessages;
+  const preferredRoles =
+    fieldType === "input"
+      ? new Set(["user", "human"])
+      : new Set(["assistant", "model", "ai", "agent"]);
+  const preferred = [...messages]
+    .reverse()
+    .find(
+      (message) =>
+        message.role && preferredRoles.has(message.role.toLowerCase()),
+    );
+  const text = messageText(preferred ?? messages[messages.length - 1]);
+  if (text) return text;
+
+  const completions = fieldType === "input" ? parsed.prompts : parsed.choices;
+  if (completions.length > 0) return completions[completions.length - 1];
+
+  const fallback =
+    fieldType === "input" ? parsed.inputFallback : parsed.outputFallback;
+  return typeof fallback === "string" ? fallback : undefined;
+};
+
+/** Pure short-text extraction shared by table/annotation/export Pretty ✨ views. */
+export const extractOpenInferencePrettyText = (
+  data: unknown,
+  fieldType: OpenInferenceFieldType,
+): string | undefined => {
+  const hasRoleBasedMessages =
+    isRecord(data) &&
+    Array.isArray(data.messages) &&
+    data.messages.some(
+      (message) => isRecord(message) && typeof message.role === "string",
+    );
+  const hasCompletionData =
+    isRecord(data) &&
+    (extractTexts(data, "prompts").length > 0 ||
+      extractTexts(data, "choices").length > 0);
+  if (
+    !hasRoleBasedMessages &&
+    !hasCompletionData &&
+    !hasLegacyOpenInferenceAttributes(data)
+  ) {
+    return undefined;
+  }
+
+  return extractParsedPrettyText(
+    parseOpenInferenceFields(
+      fieldType === "input" ? data : undefined,
+      fieldType === "output" ? data : undefined,
+    ),
+    fieldType,
+  );
+};
+
+/** Recovers output attributes that older ingestion stored alongside the input raw value. */
+export const extractLegacyOpenInferenceOutputText = (
+  storedInput: unknown,
+): string | undefined => {
+  if (!hasLegacyOpenInferenceOutputAttributes(storedInput)) return undefined;
+  return extractParsedPrettyText(
+    parseOpenInferenceFields(storedInput, undefined),
+    "output",
+  );
+};

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -43,7 +43,25 @@ export type ParsedOpenInferenceFields = {
   functionCall?: unknown;
   inputFallback?: unknown;
   outputFallback?: unknown;
-  hasOpenInferenceData: boolean;
+};
+
+const MEDIA_PLACEHOLDER_RE = /^\[(image|audio)_\d+\]$/;
+const MEDIA_DATA_URI_RE = /^data:(image|audio)\/[a-z0-9.+-]+(?:;[^,]*)?,/i;
+
+export const isSafeOpenInferenceMediaUrl = (
+  url: string,
+  type: "image" | "audio",
+): boolean => {
+  const placeholderMatch = MEDIA_PLACEHOLDER_RE.exec(url);
+  if (placeholderMatch?.[1] === type) return true;
+  const dataUriMatch = MEDIA_DATA_URI_RE.exec(url);
+  if (dataUriMatch?.[1].toLowerCase() === type) return true;
+  try {
+    const protocol = new URL(url).protocol.toLowerCase();
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
 };
 
 type UnknownRecord = Record<string, unknown>;
@@ -57,7 +75,7 @@ const TOOL_ATTRIBUTE_RE =
 const PROMPT_ATTRIBUTE_RE = /^llm\.prompts\.([^.]+)\.prompt\.text$/;
 const CHOICE_ATTRIBUTE_RE = /^llm\.choices\.([^.]+)\.completion\.text$/;
 
-const DISPLAYABLE_LEGACY_PREFIXES = [
+const LEGACY_OPENINFERENCE_PREFIXES = [
   "llm.input_messages.",
   "llm.output_messages.",
   "llm.prompts.",
@@ -65,10 +83,21 @@ const DISPLAYABLE_LEGACY_PREFIXES = [
   "llm.tools.",
 ];
 
-const DISPLAYABLE_LEGACY_KEYS = new Set([
+const LEGACY_OPENINFERENCE_KEYS = new Set([
   OPENINFERENCE_SPAN_KIND,
   "llm.finish_reason",
   "llm.function_call",
+]);
+
+const STRUCTURED_OPENINFERENCE_KEYS = new Set([
+  OPENINFERENCE_SPAN_KIND,
+  "messages",
+  "prompts",
+  "choices",
+  "tools",
+  "finish_reason",
+  "function_call",
+  "mime_type",
 ]);
 
 const isRecord = (value: unknown): value is UnknownRecord =>
@@ -281,7 +310,6 @@ type LegacyAccumulator = {
   tools: Map<number, UnknownRecord>;
   finishReason?: string;
   functionCall?: unknown;
-  found: boolean;
 };
 
 const createLegacyAccumulator = (): LegacyAccumulator => ({
@@ -290,7 +318,6 @@ const createLegacyAccumulator = (): LegacyAccumulator => ({
   prompts: new Map(),
   choices: new Map(),
   tools: new Map(),
-  found: false,
 });
 
 const acceptLegacyAttribute = (
@@ -300,7 +327,6 @@ const acceptLegacyAttribute = (
 ) => {
   const messageMatch = key.match(MESSAGE_ATTRIBUTE_RE);
   if (messageMatch) {
-    accumulator.found = true;
     const index = parseIndex(messageMatch[2]);
     if (index === undefined) return;
     const messages =
@@ -318,7 +344,6 @@ const acceptLegacyAttribute = (
 
   const toolMatch = key.match(TOOL_ATTRIBUTE_RE);
   if (toolMatch) {
-    accumulator.found = true;
     const index = parseIndex(toolMatch[1]);
     if (index === undefined) return;
     const tool = accumulator.tools.get(index) ?? {};
@@ -330,7 +355,6 @@ const acceptLegacyAttribute = (
 
   const promptMatch = key.match(PROMPT_ATTRIBUTE_RE);
   if (promptMatch) {
-    accumulator.found = true;
     const index = parseIndex(promptMatch[1]);
     const text = toStringValue(value);
     if (index !== undefined && text !== undefined)
@@ -340,7 +364,6 @@ const acceptLegacyAttribute = (
 
   const choiceMatch = key.match(CHOICE_ATTRIBUTE_RE);
   if (choiceMatch) {
-    accumulator.found = true;
     const index = parseIndex(choiceMatch[1]);
     const text = toStringValue(value);
     if (index !== undefined && text !== undefined)
@@ -349,10 +372,8 @@ const acceptLegacyAttribute = (
   }
 
   if (key === "llm.finish_reason") {
-    accumulator.found = true;
     accumulator.finishReason = toStringValue(value);
   } else if (key === "llm.function_call") {
-    accumulator.found = true;
     accumulator.functionCall = parseMaybeJson(value);
   }
 };
@@ -447,6 +468,42 @@ const parseCanonicalMessages = (data: unknown): OpenInferenceMessage[] => {
     .filter((message): message is OpenInferenceMessage => Boolean(message));
 };
 
+export const isRenderableOpenInferenceToolCall = (
+  toolCall: OpenInferenceToolCall,
+): boolean => Boolean(toolCall.function?.name || toolCall.function?.arguments);
+
+const hasRenderableMessage = (message: OpenInferenceMessage): boolean => {
+  if (
+    message.content !== undefined &&
+    message.content !== null &&
+    message.content !== ""
+  ) {
+    return true;
+  }
+  if (message.function_call !== undefined && message.function_call !== null) {
+    return true;
+  }
+  if (message.tool_calls?.some(isRenderableOpenInferenceToolCall)) return true;
+  return Boolean(
+    message.contents?.some(
+      (content) =>
+        Boolean(content.text || content.audio?.transcript) ||
+        Boolean(
+          content.image?.url &&
+            isSafeOpenInferenceMediaUrl(content.image.url, "image"),
+        ) ||
+        Boolean(
+          content.audio?.url &&
+            isSafeOpenInferenceMediaUrl(content.audio.url, "audio"),
+        ) ||
+        Boolean(
+          content.tool_call &&
+            isRenderableOpenInferenceToolCall(content.tool_call),
+        ),
+    ),
+  );
+};
+
 const extractTexts = (data: unknown, key: "prompts" | "choices"): string[] => {
   if (!isRecord(data) || !Array.isArray(data[key])) return [];
   const items = data[key] as unknown[];
@@ -460,9 +517,20 @@ const extractTexts = (data: unknown, key: "prompts" | "choices"): string[] => {
     .filter((item): item is string => item !== undefined);
 };
 
+const hasUnwrappedRawObject = (data: unknown): boolean => {
+  if (!isRecord(data)) return false;
+  return Object.keys(data).some(
+    (key) =>
+      !STRUCTURED_OPENINFERENCE_KEYS.has(key) &&
+      !LEGACY_OPENINFERENCE_KEYS.has(key) &&
+      !LEGACY_OPENINFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix)),
+  );
+};
+
 const extractFallback = (data: unknown): unknown => {
   if (!isRecord(data)) return data;
-  return hasOwn(data, "value") ? data.value : undefined;
+  if (hasOwn(data, "value")) return data.value;
+  return hasUnwrappedRawObject(data) ? data : undefined;
 };
 
 const dedupe = <T>(values: T[]): T[] => {
@@ -484,8 +552,8 @@ export const hasLegacyOpenInferenceAttributes = (data: unknown): boolean => {
   if (!isRecord(data)) return false;
   return Object.keys(data).some(
     (key) =>
-      DISPLAYABLE_LEGACY_KEYS.has(key) ||
-      DISPLAYABLE_LEGACY_PREFIXES.some((prefix) => key.startsWith(prefix)),
+      LEGACY_OPENINFERENCE_KEYS.has(key) ||
+      LEGACY_OPENINFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix)),
   );
 };
 
@@ -502,49 +570,40 @@ export const hasLegacyOpenInferenceOutputAttributes = (
   );
 };
 
-const hasCanonicalDisplayData = (
-  data: unknown,
-  fieldType: OpenInferenceFieldType,
-): boolean => {
-  if (!isRecord(data)) return false;
-  if (Array.isArray(data.messages) && data.messages.some(parseCanonicalMessage))
-    return true;
-  if (fieldType === "input") {
-    return (
-      extractTexts(data, "prompts").length > 0 ||
-      (Array.isArray(data.tools) && data.tools.length > 0)
-    );
-  }
-  return (
-    extractTexts(data, "choices").length > 0 || hasOwn(data, "function_call")
+export const hasOpenInferenceMarker = (
+  metadata: unknown,
+  input: unknown,
+  output?: unknown,
+): boolean =>
+  [metadata, input, output].some(
+    (value) => isRecord(value) && hasOwn(value, OPENINFERENCE_SPAN_KIND),
   );
+
+export type OpenInferenceHint = {
+  detected: boolean;
+  authoritative: boolean;
 };
 
-/**
- * A hint selects OpenInference ahead of generic OpenAI detection, but does not make a raw
- * {@code {value: ...}} object displayable on its own.
- */
-export const isOpenInferenceField = (
-  data: unknown,
-  fieldType: OpenInferenceFieldType,
-  hinted: boolean,
-): boolean =>
-  hasLegacyOpenInferenceAttributes(data) ||
-  (hinted && hasCanonicalDisplayData(data, fieldType));
+export const resolveOpenInferenceHint = (
+  metadata: unknown,
+  input: unknown,
+  output?: unknown,
+): OpenInferenceHint => {
+  const authoritative = hasOpenInferenceMarker(metadata, input, output);
+  return {
+    authoritative,
+    detected:
+      authoritative ||
+      hasLegacyOpenInferenceAttributes(input) ||
+      hasLegacyOpenInferenceAttributes(output),
+  };
+};
 
 export const hasOpenInferenceHint = (
   metadata: unknown,
   input: unknown,
   output?: unknown,
-): boolean => {
-  const metadataMarker =
-    isRecord(metadata) && hasOwn(metadata, OPENINFERENCE_SPAN_KIND);
-  return (
-    metadataMarker ||
-    hasLegacyOpenInferenceAttributes(input) ||
-    hasLegacyOpenInferenceAttributes(output)
-  );
-};
+): boolean => resolveOpenInferenceHint(metadata, input, output).detected;
 
 export const parseOpenInferenceFields = (
   input: unknown,
@@ -595,13 +654,44 @@ export const parseOpenInferenceFields = (
     functionCall,
     inputFallback: extractFallback(input),
     outputFallback: extractFallback(output),
-    hasOpenInferenceData:
-      legacy.found ||
-      hasLegacyOpenInferenceAttributes(input) ||
-      hasLegacyOpenInferenceAttributes(output) ||
-      hasCanonicalDisplayData(input, "input") ||
-      hasCanonicalDisplayData(output, "output"),
   };
+};
+
+const hasRenderableParsedField = (
+  parsed: ParsedOpenInferenceFields,
+  fieldType: OpenInferenceFieldType,
+): boolean => {
+  const messages =
+    fieldType === "input" ? parsed.inputMessages : parsed.outputMessages;
+  if (messages.some(hasRenderableMessage)) return true;
+  if (fieldType === "input") {
+    return parsed.prompts.length > 0 || parsed.tools.length > 0;
+  }
+  return parsed.choices.length > 0 || parsed.functionCall !== undefined;
+};
+
+/** A format hint only unlocks raw fallback when it came from an exact span marker. */
+export const isOpenInferenceField = (
+  data: unknown,
+  fieldType: OpenInferenceFieldType,
+  hinted: boolean,
+  authoritativeHint: boolean = false,
+): boolean => {
+  const hasLegacyAttributes = hasLegacyOpenInferenceAttributes(data);
+  if (!hinted && !hasLegacyAttributes) return false;
+
+  const parsed = parseOpenInferenceFields(
+    fieldType === "input" ? data : undefined,
+    fieldType === "output" ? data : undefined,
+  );
+  if (hasRenderableParsedField(parsed, fieldType)) return true;
+
+  const fallback =
+    fieldType === "input" ? parsed.inputFallback : parsed.outputFallback;
+  if (fallback !== undefined && (authoritativeHint || hasLegacyAttributes)) {
+    return true;
+  }
+  return false;
 };
 
 const messageText = (

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -123,7 +123,8 @@ const hasOwn = (value: UnknownRecord, key: string) =>
 const parseIndex = (value: string): number | undefined => {
   if (!/^\d+$/.test(value)) return undefined;
   const index = Number(value);
-  return Number.isSafeInteger(index) ? index : undefined;
+  // Match the ingestion normalizer's signed 32-bit index range.
+  return Number.isSafeInteger(index) && index <= 2147483647 ? index : undefined;
 };
 
 const sortedValues = <T>(values: Map<number, T>): T[] =>
@@ -568,7 +569,7 @@ const extractFallback = (data: unknown): unknown => {
 };
 
 // A span-level instrumentation hint must not override an explicit message schema.
-const hasTypedMessages = (data: unknown): boolean =>
+const hasRolelessTypedMessages = (data: unknown): boolean =>
   isRecord(data) &&
   Array.isArray(data.messages) &&
   data.messages.some(
@@ -816,7 +817,7 @@ export const isOpenInferenceField = (
 ): boolean => {
   const hasLegacyAttributes = hasLegacyOpenInferenceAttributes(data);
   if (!hinted && !hasLegacyAttributes) return false;
-  if (hasTypedMessages(data)) return false;
+  if (hasRolelessTypedMessages(data)) return false;
 
   const parsed = parseOpenInferenceFields(
     fieldType === "input" ? data : undefined,
@@ -897,7 +898,7 @@ export const extractOpenInferencePrettyText = (
   data: unknown,
   fieldType: OpenInferenceFieldType,
 ): string | undefined => {
-  if (hasTypedMessages(data)) return undefined;
+  if (hasRolelessTypedMessages(data)) return undefined;
   const hasMessages = parseCanonicalMessages(data).some(hasRenderableMessage);
   const hasCompletionData =
     isRecord(data) &&

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -49,7 +49,7 @@ export type ParsedOpenInferenceFields = {
 
 const MEDIA_PLACEHOLDER_RE = /^\[(image|audio)_\d+\]$/;
 const MEDIA_DATA_URI_RE = /^data:(image|audio)\/([a-z0-9.+-]+)(?:;[^,]*)?,/i;
-const INLINE_IMAGE_TYPES = new Set([
+const INLINE_IMAGE_SUBTYPES = new Set([
   "png",
   "jpeg",
   "gif",
@@ -68,7 +68,8 @@ export const isSafeOpenInferenceMediaUrl = (
   const dataUriMatch = MEDIA_DATA_URI_RE.exec(url);
   if (dataUriMatch?.[1].toLowerCase() === type) {
     return (
-      type === "audio" || INLINE_IMAGE_TYPES.has(dataUriMatch[2].toLowerCase())
+      type === "audio" ||
+      INLINE_IMAGE_SUBTYPES.has(dataUriMatch[2].toLowerCase())
     );
   }
   try {

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -1,4 +1,5 @@
 import { isBackendAttachmentPlaceholder } from "@/lib/images";
+import { isHttpUrl } from "@/lib/media";
 
 export const OPENINFERENCE_SPAN_KIND = "openinference.span.kind";
 
@@ -72,12 +73,7 @@ export const isSafeOpenInferenceMediaUrl = (
       INLINE_IMAGE_SUBTYPES.has(dataUriMatch[2].toLowerCase())
     );
   }
-  try {
-    const protocol = new URL(url).protocol.toLowerCase();
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
+  return isHttpUrl(url);
 };
 
 type UnknownRecord = Record<string, unknown>;
@@ -138,7 +134,9 @@ const sortedValues = <T>(values: Map<number, T>): T[] =>
 const toStringValue = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined;
 
-const toArguments = (value: unknown): string | undefined => {
+// Historical ingestion JSON-decodes valid strings in compatibility aliases.
+// Restore their text representation without changing the stored aliases.
+const toStringOrJson = (value: unknown): string | undefined => {
   if (typeof value === "string") return value;
   if (value === undefined) return undefined;
   try {
@@ -162,26 +160,26 @@ class ToolCallBuilder {
 
   accept(path: string, rawValue: unknown): boolean {
     if (path === "id") {
-      const id = toStringValue(rawValue);
+      const id = toStringOrJson(rawValue);
       if (id === undefined) return false;
       this.value.id = id;
       return true;
     }
     if (path === "reasoning_signature") {
-      const signature = toStringValue(rawValue);
+      const signature = toStringOrJson(rawValue);
       if (signature === undefined) return false;
       this.value.reasoning_signature = signature;
       return true;
     }
     if (path === "function.name") {
-      const name = toStringValue(rawValue);
+      const name = toStringOrJson(rawValue);
       if (name === undefined) return false;
       this.value.function ??= {};
       this.value.function.name = name;
       return true;
     }
     if (path === "function.arguments") {
-      const args = toArguments(rawValue);
+      const args = toStringOrJson(rawValue);
       if (args === undefined) return false;
       this.value.function ??= {};
       this.value.function.arguments = args;
@@ -210,14 +208,14 @@ class ContentBuilder {
     };
     const scalarField = scalarFields[path];
     if (scalarField) {
-      const value = toStringValue(rawValue);
+      const value = toStringOrJson(rawValue);
       if (value === undefined) return false;
       Object.assign(this.value, { [scalarField]: value });
       return true;
     }
 
     if (path === "message_content.image.image.url") {
-      const url = toStringValue(rawValue);
+      const url = toStringOrJson(rawValue);
       if (url === undefined) return false;
       this.value.image = { url };
       return true;
@@ -228,7 +226,7 @@ class ContentBuilder {
       const field = path.slice(audioPrefix.length);
       if (!(["url", "mime_type", "transcript"] as string[]).includes(field))
         return false;
-      const value = toStringValue(rawValue);
+      const value = toStringOrJson(rawValue);
       if (value === undefined) return false;
       this.value.audio ??= {};
       Object.assign(this.value.audio, { [field]: value });
@@ -256,7 +254,7 @@ class MessageBuilder {
 
   accept(path: string, rawValue: unknown): boolean {
     if (["role", "name", "tool_call_id"].includes(path)) {
-      const value = toStringValue(rawValue);
+      const value = toStringOrJson(rawValue);
       if (value === undefined) return false;
       Object.assign(this.value, { [path]: value });
       return true;
@@ -266,7 +264,7 @@ class MessageBuilder {
       return true;
     }
     if (path === "function_call_name") {
-      const value = toStringValue(rawValue);
+      const value = toStringOrJson(rawValue);
       if (value === undefined) return false;
       this.functionCall.name = value;
       return true;
@@ -421,7 +419,7 @@ const parseCanonicalToolCall = (
   if (isRecord(value.function)) {
     const fn: NonNullable<OpenInferenceToolCall["function"]> = {};
     if (typeof value.function.name === "string") fn.name = value.function.name;
-    const args = toArguments(value.function.arguments);
+    const args = toStringOrJson(value.function.arguments);
     if (args !== undefined) fn.arguments = args;
     if (Object.keys(fn).length > 0) toolCall.function = fn;
   }
@@ -541,30 +539,71 @@ const extractTexts = (data: unknown, key: "prompts" | "choices"): string[] => {
     .filter((item): item is string => item !== undefined);
 };
 
-const hasUnwrappedRawObject = (data: unknown): boolean => {
-  if (!isRecord(data)) return false;
-  return Object.keys(data).some(
-    (key) =>
-      !STRUCTURED_OPENINFERENCE_KEYS.has(key) &&
-      !LEGACY_OPENINFERENCE_KEYS.has(key) &&
-      !LEGACY_OPENINFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix)),
+export const isRenderableOpenInferenceFallback = (value: unknown): boolean => {
+  if (value == null) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return (
+    typeof value === "boolean" ||
+    (typeof value === "number" && Number.isFinite(value))
   );
 };
 
 const extractFallback = (data: unknown): unknown => {
-  if (!isRecord(data)) return data;
-  if (hasOwn(data, "value")) return data.value;
-  return hasUnwrappedRawObject(data) ? data : undefined;
+  if (!isRecord(data))
+    return isRenderableOpenInferenceFallback(data) ? data : undefined;
+  if (hasOwn(data, "value"))
+    return isRenderableOpenInferenceFallback(data.value)
+      ? data.value
+      : undefined;
+  const raw = Object.fromEntries(
+    Object.entries(data).filter(
+      ([key]) =>
+        !STRUCTURED_OPENINFERENCE_KEYS.has(key) &&
+        !LEGACY_OPENINFERENCE_KEYS.has(key) &&
+        !LEGACY_OPENINFERENCE_PREFIXES.some((prefix) => key.startsWith(prefix)),
+    ),
+  );
+  return Object.keys(raw).length > 0 ? raw : undefined;
 };
+
+// A span-level instrumentation hint must not override an explicit message schema.
+const hasTypedMessages = (data: unknown): boolean =>
+  isRecord(data) &&
+  Array.isArray(data.messages) &&
+  data.messages.some(
+    (message) =>
+      isRecord(message) && typeof message.type === "string" && !message.role,
+  );
+
+export const OPENINFERENCE_USER_ROLES = new Set(["user", "human"]);
+export const OPENINFERENCE_ASSISTANT_ROLES = new Set([
+  "assistant",
+  "model",
+  "ai",
+  "agent",
+]);
 
 const semanticFingerprint = (value: unknown): string | undefined => {
   try {
     return JSON.stringify(value, (key, nestedValue: unknown) => {
       // Historical storage parsed JSON message content and arguments into objects.
-      const semanticValue =
-        key === "content" || key === "arguments"
-          ? parseMaybeJson(nestedValue)
-          : nestedValue;
+      const semanticValue = [
+        "content",
+        "arguments",
+        "text",
+        "transcript",
+        "data",
+        "signature",
+        "encrypted_content",
+        "name",
+        "id",
+        "role",
+        "tool_call_id",
+        "reasoning_signature",
+      ].includes(key)
+        ? parseMaybeJson(nestedValue)
+        : nestedValue;
       return isRecord(semanticValue)
         ? Object.fromEntries(
             Object.keys(semanticValue)
@@ -579,6 +618,7 @@ const semanticFingerprint = (value: unknown): string | undefined => {
 };
 
 const dedupe = <T>(values: T[]): T[] => {
+  if (values.length < 2) return [...values];
   const fingerprints = new Set<string>();
   return values.filter((value) => {
     const fingerprint = semanticFingerprint(value);
@@ -592,6 +632,8 @@ const dedupe = <T>(values: T[]): T[] => {
 // Match each legacy occurrence at most once against the canonical representation.
 // Identical turns within one conversation are still separate messages.
 const mergeRepresentations = <T>(canonical: T[], legacy: T[]): T[] => {
+  if (legacy.length === 0) return [...canonical];
+  if (canonical.length === 0) return [...legacy];
   const remaining = new Map<string, number>();
   canonical.forEach((value) => {
     const fingerprint = semanticFingerprint(value);
@@ -644,7 +686,7 @@ export const hasOpenInferenceMarker = (
 
 export type OpenInferenceHint = {
   detected: boolean;
-  authoritative: boolean;
+  authoritative: boolean | undefined;
 };
 
 export const resolveOpenInferenceHint = (
@@ -652,11 +694,18 @@ export const resolveOpenInferenceHint = (
   input: unknown,
   output?: unknown,
 ): OpenInferenceHint => {
-  const authoritative = hasOpenInferenceMarker(metadata, input, output);
+  const marker = [metadata, input, output].find(
+    (value) => isRecord(value) && hasOwn(value, OPENINFERENCE_SPAN_KIND),
+  );
+  // Only LLM raw payloads may be displayed as a synthetic chat. Other span kinds
+  // still support real structured messages and short previews.
+  const authoritative = isRecord(marker)
+    ? String(marker[OPENINFERENCE_SPAN_KIND]).toUpperCase() === "LLM"
+    : undefined;
   return {
     authoritative,
     detected:
-      authoritative ||
+      marker !== undefined ||
       hasLegacyOpenInferenceAttributes(input) ||
       hasLegacyOpenInferenceAttributes(output),
   };
@@ -763,10 +812,11 @@ export const isOpenInferenceField = (
   data: unknown,
   fieldType: OpenInferenceFieldType,
   hinted: boolean,
-  authoritativeHint: boolean = false,
+  authoritativeHint?: boolean,
 ): boolean => {
   const hasLegacyAttributes = hasLegacyOpenInferenceAttributes(data);
   if (!hinted && !hasLegacyAttributes) return false;
+  if (hasTypedMessages(data)) return false;
 
   const parsed = parseOpenInferenceFields(
     fieldType === "input" ? data : undefined,
@@ -776,7 +826,22 @@ export const isOpenInferenceField = (
 
   const fallback =
     fieldType === "input" ? parsed.inputFallback : parsed.outputFallback;
-  if (fallback !== undefined && (authoritativeHint || hasLegacyAttributes)) {
+  const marker = isRecord(data) ? data[OPENINFERENCE_SPAN_KIND] : undefined;
+  // An explicit non-LLM marker disallows synthetic messages, even if legacy
+  // attributes are also present. Unmarked historical {value, mime_type} envelopes
+  // remain readable once the sibling field establishes OpenInference provenance.
+  const legacyEnvelope =
+    hinted &&
+    isRecord(data) &&
+    hasOwn(data, "value") &&
+    typeof data.mime_type === "string" &&
+    Object.keys(data).every((key) => key === "value" || key === "mime_type");
+  const allowsRawFallback =
+    authoritativeHint ??
+    (marker !== undefined
+      ? String(marker).toUpperCase() === "LLM"
+      : hasLegacyAttributes || legacyEnvelope);
+  if (fallback !== undefined && allowsRawFallback) {
     return true;
   }
   return false;
@@ -806,15 +871,17 @@ const extractParsedPrettyText = (
     fieldType === "input" ? parsed.inputMessages : parsed.outputMessages;
   const preferredRoles =
     fieldType === "input"
-      ? new Set(["user", "human"])
-      : new Set(["assistant", "model", "ai", "agent"]);
-  const preferred = [...messages]
-    .reverse()
-    .find(
-      (message) =>
-        message.role && preferredRoles.has(message.role.toLowerCase()),
-    );
-  const text = messageText(preferred ?? messages[messages.length - 1]);
+      ? OPENINFERENCE_USER_ROLES
+      : OPENINFERENCE_ASSISTANT_ROLES;
+  const reversed = [...messages].reverse();
+  const text =
+    reversed
+      .filter(
+        (message) =>
+          message.role && preferredRoles.has(message.role.toLowerCase()),
+      )
+      .map(messageText)
+      .find(Boolean) ?? reversed.map(messageText).find(Boolean);
   if (text) return text;
 
   const completions = fieldType === "input" ? parsed.prompts : parsed.choices;
@@ -830,6 +897,7 @@ export const extractOpenInferencePrettyText = (
   data: unknown,
   fieldType: OpenInferenceFieldType,
 ): string | undefined => {
+  if (hasTypedMessages(data)) return undefined;
   const hasMessages = parseCanonicalMessages(data).some(hasRenderableMessage);
   const hasCompletionData =
     isRecord(data) &&

--- a/apps/opik-frontend/src/lib/openinference.ts
+++ b/apps/opik-frontend/src/lib/openinference.ts
@@ -48,7 +48,15 @@ export type ParsedOpenInferenceFields = {
 };
 
 const MEDIA_PLACEHOLDER_RE = /^\[(image|audio)_\d+\]$/;
-const MEDIA_DATA_URI_RE = /^data:(image|audio)\/[a-z0-9.+-]+(?:;[^,]*)?,/i;
+const MEDIA_DATA_URI_RE = /^data:(image|audio)\/([a-z0-9.+-]+)(?:;[^,]*)?,/i;
+const INLINE_IMAGE_TYPES = new Set([
+  "png",
+  "jpeg",
+  "gif",
+  "webp",
+  "avif",
+  "bmp",
+]);
 
 export const isSafeOpenInferenceMediaUrl = (
   url: string,
@@ -58,7 +66,11 @@ export const isSafeOpenInferenceMediaUrl = (
   const placeholderMatch = MEDIA_PLACEHOLDER_RE.exec(url);
   if (placeholderMatch?.[1] === type) return true;
   const dataUriMatch = MEDIA_DATA_URI_RE.exec(url);
-  if (dataUriMatch?.[1].toLowerCase() === type) return true;
+  if (dataUriMatch?.[1].toLowerCase() === type) {
+    return (
+      type === "audio" || INLINE_IMAGE_TYPES.has(dataUriMatch[2].toLowerCase())
+    );
+  }
   try {
     const protocol = new URL(url).protocol.toLowerCase();
     return protocol === "http:" || protocol === "https:";
@@ -383,11 +395,17 @@ const acceptLegacyAttribute = (
   }
 };
 
-const collectLegacy = (accumulator: LegacyAccumulator, data: unknown): void => {
+const collectLegacy = (
+  accumulator: LegacyAccumulator,
+  data: unknown,
+  includeOutput: boolean = true,
+): void => {
   if (!isRecord(data)) return;
-  Object.entries(data).forEach(([key, value]) =>
-    acceptLegacyAttribute(accumulator, key, value),
-  );
+  Object.entries(data).forEach(([key, value]) => {
+    if (includeOutput || !isLegacyOutputKey(key)) {
+      acceptLegacyAttribute(accumulator, key, value);
+    }
+  });
 };
 
 const parseCanonicalToolCall = (
@@ -538,15 +556,32 @@ const extractFallback = (data: unknown): unknown => {
   return hasUnwrappedRawObject(data) ? data : undefined;
 };
 
+const semanticFingerprint = (value: unknown): string | undefined => {
+  try {
+    return JSON.stringify(value, (key, nestedValue: unknown) => {
+      // Historical storage parsed JSON message content and arguments into objects.
+      const semanticValue =
+        key === "content" || key === "arguments"
+          ? parseMaybeJson(nestedValue)
+          : nestedValue;
+      return isRecord(semanticValue)
+        ? Object.fromEntries(
+            Object.keys(semanticValue)
+              .sort()
+              .map((key) => [key, semanticValue[key]]),
+          )
+        : semanticValue;
+    });
+  } catch {
+    return undefined;
+  }
+};
+
 const dedupe = <T>(values: T[]): T[] => {
   const fingerprints = new Set<string>();
   return values.filter((value) => {
-    let fingerprint: string;
-    try {
-      fingerprint = JSON.stringify(value) ?? String(value);
-    } catch {
-      return true;
-    }
+    const fingerprint = semanticFingerprint(value);
+    if (fingerprint === undefined) return true;
     if (fingerprints.has(fingerprint)) return false;
     fingerprints.add(fingerprint);
     return true;
@@ -556,15 +591,17 @@ const dedupe = <T>(values: T[]): T[] => {
 // Match each legacy occurrence at most once against the canonical representation.
 // Identical turns within one conversation are still separate messages.
 const mergeRepresentations = <T>(canonical: T[], legacy: T[]): T[] => {
-  const remaining = new Map<string | undefined, number>();
+  const remaining = new Map<string, number>();
   canonical.forEach((value) => {
-    const fingerprint = JSON.stringify(value);
+    const fingerprint = semanticFingerprint(value);
+    if (fingerprint === undefined) return;
     remaining.set(fingerprint, (remaining.get(fingerprint) ?? 0) + 1);
   });
   return [
     ...canonical,
     ...legacy.filter((value) => {
-      const fingerprint = JSON.stringify(value);
+      const fingerprint = semanticFingerprint(value);
+      if (fingerprint === undefined) return true;
       const count = remaining.get(fingerprint) ?? 0;
       if (count === 0) return true;
       remaining.set(fingerprint, count - 1);
@@ -582,17 +619,17 @@ export const hasLegacyOpenInferenceAttributes = (data: unknown): boolean => {
   );
 };
 
+const isLegacyOutputKey = (key: string): boolean =>
+  key.startsWith("llm.output_messages.") ||
+  key.startsWith("llm.choices.") ||
+  key === "llm.finish_reason" ||
+  key === "llm.function_call";
+
 export const hasLegacyOpenInferenceOutputAttributes = (
   data: unknown,
 ): boolean => {
   if (!isRecord(data)) return false;
-  return Object.keys(data).some(
-    (key) =>
-      key.startsWith("llm.output_messages.") ||
-      key.startsWith("llm.choices.") ||
-      key === "llm.finish_reason" ||
-      key === "llm.function_call",
-  );
+  return Object.keys(data).some(isLegacyOutputKey);
 };
 
 export const hasOpenInferenceMarker = (
@@ -630,51 +667,73 @@ export const hasOpenInferenceHint = (
   output?: unknown,
 ): boolean => resolveOpenInferenceHint(metadata, input, output).detected;
 
+const buildLegacyMessages = (
+  messages: Map<number, MessageBuilder>,
+): OpenInferenceMessage[] =>
+  sortedValues(messages)
+    .map((message) => message.build())
+    .filter((message): message is OpenInferenceMessage => Boolean(message));
+
 export const parseOpenInferenceFields = (
   input: unknown,
   output: unknown,
 ): ParsedOpenInferenceFields => {
   const legacy = createLegacyAccumulator();
-  collectLegacy(legacy, input);
   collectLegacy(legacy, output);
 
   const canonicalInputMessages = parseCanonicalMessages(input);
   const canonicalOutputMessages = parseCanonicalMessages(output);
-  const legacyInputMessages = sortedValues(legacy.inputMessages)
-    .map((message) => message.build())
-    .filter((message): message is OpenInferenceMessage => Boolean(message));
-  const legacyOutputMessages = sortedValues(legacy.outputMessages)
-    .map((message) => message.build())
-    .filter((message): message is OpenInferenceMessage => Boolean(message));
-
   const inputRecord = isRecord(input) ? input : undefined;
   const outputRecord = isRecord(output) ? output : undefined;
+  const canonicalChoices = extractTexts(output, "choices");
+  const currentMessages = mergeRepresentations(
+    canonicalOutputMessages,
+    buildLegacyMessages(legacy.outputMessages),
+  );
+  const currentChoices = mergeRepresentations(
+    canonicalChoices,
+    sortedValues(legacy.choices),
+  );
+  const currentFunctionCall =
+    outputRecord?.function_call ?? legacy.functionCall ?? undefined;
+  const currentFinishReason =
+    toStringValue(outputRecord?.finish_reason) ?? legacy.finishReason;
+  const hasCurrentOutput =
+    currentMessages.some(hasRenderableMessage) ||
+    currentChoices.length > 0 ||
+    currentFunctionCall != null;
+
+  // Actual semantic output wins over output attributes stored in historical input.
+  collectLegacy(legacy, input, !hasCurrentOutput);
+
   const prompts = mergeRepresentations(
     extractTexts(input, "prompts"),
     sortedValues(legacy.prompts),
   );
-  const choices = mergeRepresentations(
-    extractTexts(output, "choices"),
-    sortedValues(legacy.choices),
-  );
+  const choices = hasCurrentOutput
+    ? currentChoices
+    : mergeRepresentations(canonicalChoices, sortedValues(legacy.choices));
   const canonicalTools =
     inputRecord && Array.isArray(inputRecord.tools) ? inputRecord.tools : [];
   const tools = dedupe([...canonicalTools, ...sortedValues(legacy.tools)]);
-  const finishReason =
-    (outputRecord && toStringValue(outputRecord.finish_reason)) ??
-    legacy.finishReason;
-  const functionCall =
-    (outputRecord && outputRecord.function_call) ?? legacy.functionCall;
+  const finishReason = hasCurrentOutput
+    ? currentFinishReason
+    : currentFinishReason ?? legacy.finishReason;
+  const functionCall = hasCurrentOutput
+    ? currentFunctionCall
+    : legacy.functionCall ?? undefined;
 
   return {
     inputMessages: mergeRepresentations(
       canonicalInputMessages,
-      legacyInputMessages,
+      buildLegacyMessages(legacy.inputMessages),
     ),
-    outputMessages: mergeRepresentations(
-      canonicalOutputMessages,
-      legacyOutputMessages,
-    ),
+    outputMessages: hasCurrentOutput
+      ? currentMessages
+      : mergeRepresentations(
+          canonicalOutputMessages,
+          buildLegacyMessages(legacy.outputMessages),
+        ),
     prompts,
     choices,
     tools,

--- a/apps/opik-frontend/src/lib/trace-previews.test.ts
+++ b/apps/opik-frontend/src/lib/trace-previews.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { getPrettifyConfig, prettifyTraceField } from "./traces";
+import {
+  getPrettifyConfig,
+  getThreadPrettifyConfig,
+  prettifyThreadField,
+  prettifyTraceField,
+} from "./traces";
 describe("trace preview context", () => {
   it("recovers output with legacy attributes only in input", () => {
     const trace = {
@@ -25,5 +30,58 @@ describe("trace preview context", () => {
   });
   it("leaves an ordinary empty trace empty", () => {
     expect(prettifyTraceField({}, "output").message).toBeUndefined();
+  });
+});
+
+describe("thread preview and export context", () => {
+  it("extracts canonical messages without source metadata", () => {
+    const thread = {
+      first_message: { messages: [{ role: "human", content: "Question" }] },
+      last_message: {
+        messages: [
+          { role: "assistant", content: "Answer" },
+          { role: "assistant", tool_calls: [{ function: { name: "search" } }] },
+        ],
+      },
+    };
+    expect(prettifyThreadField(thread, "input").message).toBe("Question");
+    expect(prettifyThreadField(thread, "output").message).toBe("Answer");
+  });
+
+  it("extracts role-less multimodal content", () => {
+    const thread = {
+      last_message: { messages: [{ contents: [{ text: "Nested answer" }] }] },
+    };
+    expect(prettifyThreadField(thread, "output").message).toBe("Nested answer");
+  });
+
+  it.each([
+    {
+      choices: [{ message: { role: "assistant", content: "Provider answer" } }],
+    },
+    { messages: [{ type: "ai", content: "Provider answer" }] },
+    { answer: "Provider answer" },
+  ])(
+    "preserves existing provider and generic formatting: %j",
+    (last_message) => {
+      expect(prettifyThreadField({ last_message }, "output").message).toBe(
+        "Provider answer",
+      );
+    },
+  );
+
+  it("does not infer output from a different trace's first message", () => {
+    const thread = {
+      first_message: { "llm.output_messages.0.message.content": "Old answer" },
+    };
+    expect(prettifyThreadField(thread, "output").message).toBeUndefined();
+  });
+
+  it("does not infer a format from arbitrary raw thread data", () => {
+    const thread = { last_message: { request_id: "raw", status: "done" } };
+    expect(getThreadPrettifyConfig(thread, "output").openInferenceHint).toBe(
+      false,
+    );
+    expect(prettifyThreadField(thread, "output").prettified).toBe(false);
   });
 });

--- a/apps/opik-frontend/src/lib/trace-previews.test.ts
+++ b/apps/opik-frontend/src/lib/trace-previews.test.ts
@@ -33,7 +33,29 @@ describe("trace preview context", () => {
   });
 });
 
-describe("thread preview and export context", () => {
+describe("thread preview context", () => {
+  it.each([0, false, true, "Plain answer", null, ["First", "Second"]])(
+    "accepts the JSON wire domain without casting: %j",
+    (value) => {
+      const thread = { first_message: value, last_message: value };
+      const input = prettifyThreadField(thread, "input");
+      const output = prettifyThreadField(thread, "output");
+      if (
+        typeof value === "number" ||
+        typeof value === "boolean" ||
+        typeof value === "string"
+      ) {
+        expect(input.message).toBe(String(value));
+        expect(output.message).toBe(String(value));
+      } else if (value === null) {
+        expect(input.message).toBeUndefined();
+        expect(output.message).toBeUndefined();
+      } else {
+        expect(input.message).toEqual(value);
+        expect(output.message).toEqual(value);
+      }
+    },
+  );
   it("extracts canonical messages without source metadata", () => {
     const thread = {
       first_message: { messages: [{ role: "human", content: "Question" }] },

--- a/apps/opik-frontend/src/lib/trace-previews.test.ts
+++ b/apps/opik-frontend/src/lib/trace-previews.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getPrettifyConfig, prettifyTraceField } from "./traces";
+describe("trace preview context", () => {
+  it("recovers output with legacy attributes only in input", () => {
+    const trace = {
+      input: { "llm.output_messages.0.message.content": "Recovered" },
+    };
+    expect(prettifyTraceField(trace, "output").message).toBe("Recovered");
+    expect(
+      getPrettifyConfig(trace, "input").openInferenceInput,
+    ).toBeUndefined();
+  });
+  it("uses a metadata-only marker and preserves role-less messages", () => {
+    const trace = {
+      metadata: { "openinference.span.kind": "LLM" },
+      output: { messages: [{ content: "Answer" }] },
+    };
+    expect(prettifyTraceField(trace, "output").message).toBe("Answer");
+  });
+  it("reads format evidence from output too", () => {
+    const trace = {
+      output: { "llm.output_messages.0.message.content": "Answer" },
+    };
+    expect(getPrettifyConfig(trace, "input").openInferenceHint).toBe(true);
+  });
+  it("leaves an ordinary empty trace empty", () => {
+    expect(prettifyTraceField({}, "output").message).toBeUndefined();
+  });
+});

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -538,4 +538,110 @@ describe("prettifyMessage", () => {
       prettified: true,
     });
   });
+
+  it("prettifies canonical OpenInference output messages", () => {
+    const result = prettifyMessage(
+      {
+        messages: [
+          {
+            role: "model",
+            contents: [
+              { type: "reasoning", text: "Check the facts" },
+              { type: "text", text: "The answer is 42" },
+            ],
+          },
+        ],
+      },
+      { type: "output" },
+    );
+
+    expect(result).toEqual({
+      message: "Check the facts\n\nThe answer is 42",
+      prettified: true,
+    });
+  });
+
+  it("prettifies OpenInference completion prompts and choices", () => {
+    expect(
+      prettifyMessage(
+        { prompts: [{ text: "First" }, { text: "Latest prompt" }] },
+        { type: "input" },
+      ),
+    ).toEqual({ message: "Latest prompt", prettified: true });
+    expect(
+      prettifyMessage(
+        { choices: [{ text: "One" }, { text: "Final completion" }] },
+        { type: "output" },
+      ),
+    ).toEqual({ message: "Final completion", prettified: true });
+  });
+
+  it("prettifies historical flattened OpenInference output stored in input", () => {
+    const storedInput = {
+      "openinference.span.kind": "LLM",
+      "llm.input_messages.0.message.role": "user",
+      "llm.input_messages.0.message.content": "Question",
+      "llm.output_messages.4.message.role": "assistant",
+      "llm.output_messages.4.message.content": "Recovered answer",
+    };
+
+    expect(prettifyMessage(storedInput, { type: "output" })).toEqual({
+      message: "Recovered answer",
+      prettified: true,
+    });
+
+    expect(
+      prettifyMessage(undefined, {
+        type: "output",
+        openInferenceInput: storedInput,
+      }),
+    ).toEqual({
+      message: "Recovered answer",
+      prettified: true,
+    });
+
+    expect(
+      prettifyMessage(
+        { value: { choices: [{ text: "Less precise raw answer" }] } },
+        { type: "output", openInferenceInput: storedInput },
+      ),
+    ).toEqual({
+      message: "Recovered answer",
+      prettified: true,
+    });
+  });
+
+  it("does not replace canonical output with canonical input messages", () => {
+    expect(
+      prettifyMessage(
+        {
+          messages: [{ role: "assistant", content: "Canonical answer" }],
+        },
+        {
+          type: "output",
+          openInferenceInput: {
+            messages: [{ role: "tool", content: "Tool result" }],
+          },
+        },
+      ),
+    ).toEqual({
+      message: "Canonical answer",
+      prettified: true,
+    });
+  });
+
+  it("does not treat the legacy input raw value as recovered output", () => {
+    expect(
+      prettifyMessage("Actual answer", {
+        type: "output",
+        openInferenceInput: {
+          value: "Question",
+          "llm.finish_reason": "stop",
+        },
+      }),
+    ).toEqual({
+      message: "Actual answer",
+      prettified: true,
+    });
+  });
 });

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -539,6 +539,24 @@ describe("prettifyMessage", () => {
     });
   });
 
+  it.each([0, false])("preserves raw OpenInference scalar %j", (message) => {
+    expect(
+      prettifyMessage(message, { type: "output", openInferenceHint: true }),
+    ).toEqual({ message: String(message), prettified: true });
+  });
+
+  it("prettifies marked messages without a role", () => {
+    expect(
+      prettifyMessage(
+        { messages: [{ content: "Role-less answer" }] },
+        {
+          type: "output",
+          openInferenceHint: true,
+        },
+      ),
+    ).toEqual({ message: "Role-less answer", prettified: true });
+  });
+
   it("prettifies canonical OpenInference output messages", () => {
     const result = prettifyMessage(
       {

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -552,7 +552,7 @@ describe("prettifyMessage", () => {
           },
         ],
       },
-      { type: "output" },
+      { type: "output", openInferenceHint: true },
     );
 
     expect(result).toEqual({
@@ -565,13 +565,13 @@ describe("prettifyMessage", () => {
     expect(
       prettifyMessage(
         { prompts: [{ text: "First" }, { text: "Latest prompt" }] },
-        { type: "input" },
+        { type: "input", openInferenceHint: true },
       ),
     ).toEqual({ message: "Latest prompt", prettified: true });
     expect(
       prettifyMessage(
         { choices: [{ text: "One" }, { text: "Final completion" }] },
-        { type: "output" },
+        { type: "output", openInferenceHint: true },
       ),
     ).toEqual({ message: "Final completion", prettified: true });
   });
@@ -619,6 +619,7 @@ describe("prettifyMessage", () => {
         },
         {
           type: "output",
+          openInferenceHint: true,
           openInferenceInput: {
             messages: [{ role: "tool", content: "Tool result" }],
           },
@@ -641,6 +642,26 @@ describe("prettifyMessage", () => {
       }),
     ).toEqual({
       message: "Actual answer",
+      prettified: true,
+    });
+  });
+
+  it("does not apply OpenInference extraction to unmarked role messages", () => {
+    const message = {
+      messages: [{ role: "assistant", content: "Keep the existing shape" }],
+    };
+
+    expect(prettifyMessage(message, { type: "input" })).toEqual({
+      message,
+      prettified: false,
+    });
+    expect(
+      prettifyMessage(message, {
+        type: "input",
+        openInferenceHint: true,
+      }),
+    ).toEqual({
+      message: "Keep the existing shape",
       prettified: true,
     });
   });

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -748,3 +748,54 @@ describe("prettifyMessage", () => {
     });
   });
 });
+
+describe("OpenInference review regressions", () => {
+  it.each(["answer", "response", "reply", "final_output"])(
+    "prefers current %s over legacy output",
+    (key) => {
+      expect(
+        prettifyMessage(
+          { [key]: "Current" },
+          {
+            type: "output",
+            openInferenceInput: {
+              "llm.output_messages.0.message.content": "Stale",
+            },
+          },
+        ).message,
+      ).toBe("Current");
+    },
+  );
+  it.each([true, false])(
+    "keeps type-based input direction with hint %s",
+    (openInferenceHint) => {
+      expect(
+        prettifyMessage(
+          {
+            messages: [
+              { type: "human", content: "Question" },
+              { type: "ai", content: "Answer" },
+            ],
+          },
+          { type: "input", openInferenceHint },
+        ).message,
+      ).toBe("Question");
+    },
+  );
+  it("finds text before a trailing tool-only assistant message", () => {
+    expect(
+      prettifyMessage(
+        {
+          messages: [
+            { role: "assistant", content: "Answer" },
+            {
+              role: "assistant",
+              tool_calls: [{ function: { name: "finish" } }],
+            },
+          ],
+        },
+        { type: "output", openInferenceHint: true },
+      ).message,
+    ).toBe("Answer");
+  });
+});

--- a/apps/opik-frontend/src/lib/traces.test.ts
+++ b/apps/opik-frontend/src/lib/traces.test.ts
@@ -664,6 +664,70 @@ describe("prettifyMessage", () => {
     });
   });
 
+  it.each([
+    [{ messages: [{ role: "assistant", content: "Current" }] }, "Current"],
+    [{ messages: [{ content: "Current" }] }, "Current"],
+    [{ choices: [{ text: "Current" }] }, "Current"],
+    [
+      { choices: [{ message: { role: "assistant", content: "Current" } }] },
+      "Current",
+    ],
+    ["Current", "Current"],
+    [0, "0"],
+    [false, "false"],
+  ])(
+    "prefers current output over stale legacy output: %j",
+    (output, expected) => {
+      const result = prettifyMessage(output, {
+        type: "output",
+        openInferenceHint: true,
+        openInferenceInput: {
+          "llm.output_messages.0.message.role": "assistant",
+          "llm.output_messages.0.message.content": "Stale",
+        },
+      });
+
+      expect(result).toEqual({ message: expected, prettified: true });
+    },
+  );
+
+  it("does not replace a current image-only message with stale text", () => {
+    const output = {
+      messages: [
+        {
+          role: "assistant",
+          contents: [
+            { type: "image", image: { url: "https://example.test/a.png" } },
+          ],
+        },
+      ],
+    };
+
+    expect(
+      prettifyMessage(output, {
+        type: "output",
+        openInferenceHint: true,
+        openInferenceInput: {
+          "llm.output_messages.0.message.content": "Stale",
+        },
+      }).message,
+    ).not.toBe("Stale");
+  });
+
+  it.each([undefined, {}, { messages: [{ role: "assistant" }] }])(
+    "recovers legacy output when current output has no content: %j",
+    (output) => {
+      expect(
+        prettifyMessage(output, {
+          type: "output",
+          openInferenceInput: {
+            "llm.output_messages.0.message.content": "Recovered",
+          },
+        }),
+      ).toEqual({ message: "Recovered", prettified: true });
+    },
+  );
+
   it("does not apply OpenInference extraction to unmarked role messages", () => {
     const message = {
       messages: [{ role: "assistant", content: "Keep the existing shape" }],

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -11,6 +11,10 @@ import { ExperimentItem } from "@/types/datasets";
 import { Thread, TRACE_VISIBILITY_MODE } from "@/types/traces";
 import { safelyParseJSON } from "@/lib/utils";
 import isEmpty from "lodash/isEmpty";
+import {
+  extractLegacyOpenInferenceOutputText,
+  extractOpenInferencePrettyText,
+} from "@/lib/openinference";
 
 const MESSAGES_DIVIDER = `\n\n  ----------------- \n\n`;
 
@@ -41,6 +45,7 @@ export const traceVisible = (item: ExperimentItem) =>
 
 type PrettifyMessageConfig = {
   type: "input" | "output";
+  openInferenceInput?: object | string;
 };
 
 type PrettifyMessageResponse = {
@@ -613,6 +618,17 @@ export const prettifyMessage = (
     type: "input",
   },
 ): PrettifyMessageResponse => {
+  const recoveredOpenInferenceOutput =
+    config.type === "output"
+      ? extractLegacyOpenInferenceOutputText(config.openInferenceInput)
+      : undefined;
+  if (isString(recoveredOpenInferenceOutput)) {
+    return {
+      message: recoveredOpenInferenceOutput,
+      prettified: true,
+    };
+  }
+
   if (isString(message)) {
     const extracted = extractTextFieldFromTruncatedJson(message, config);
     return {
@@ -621,7 +637,11 @@ export const prettifyMessage = (
     } as PrettifyMessageResponse;
   }
   try {
-    let processedMessage = prettifyOpenAIMessageLogic(message, config);
+    let processedMessage = extractOpenInferencePrettyText(message, config.type);
+
+    if (!isString(processedMessage)) {
+      processedMessage = prettifyOpenAIMessageLogic(message, config);
+    }
 
     if (!isString(processedMessage)) {
       processedMessage = prettifyOpenAIAgentsMessageLogic(message, config);

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -14,6 +14,7 @@ import isEmpty from "lodash/isEmpty";
 import {
   extractLegacyOpenInferenceOutputText,
   extractOpenInferencePrettyText,
+  hasLegacyOpenInferenceAttributes,
 } from "@/lib/openinference";
 
 const MESSAGES_DIVIDER = `\n\n  ----------------- \n\n`;
@@ -46,6 +47,7 @@ export const traceVisible = (item: ExperimentItem) =>
 type PrettifyMessageConfig = {
   type: "input" | "output";
   openInferenceInput?: object | string;
+  openInferenceHint?: boolean;
 };
 
 type PrettifyMessageResponse = {
@@ -637,7 +639,13 @@ export const prettifyMessage = (
     } as PrettifyMessageResponse;
   }
   try {
-    let processedMessage = extractOpenInferencePrettyText(message, config.type);
+    const shouldExtractOpenInference =
+      config.openInferenceHint ||
+      hasLegacyOpenInferenceAttributes(message) ||
+      hasLegacyOpenInferenceAttributes(config.openInferenceInput);
+    let processedMessage = shouldExtractOpenInference
+      ? extractOpenInferencePrettyText(message, config.type)
+      : undefined;
 
     if (!isString(processedMessage)) {
       processedMessage = prettifyOpenAIMessageLogic(message, config);

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -615,7 +615,7 @@ const extractTextFieldFromTruncatedJson = (
 };
 
 export const prettifyMessage = (
-  message: object | string | undefined,
+  message: object | string | number | boolean | undefined,
   config: PrettifyMessageConfig = {
     type: "input",
   },
@@ -629,6 +629,10 @@ export const prettifyMessage = (
       message: recoveredOpenInferenceOutput,
       prettified: true,
     };
+  }
+
+  if (typeof message === "number" || typeof message === "boolean") {
+    return { message: String(message), prettified: true };
   }
 
   if (isString(message)) {

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -759,6 +759,7 @@ export const prettifyThreadField = (
   type: "input" | "output",
 ) =>
   prettifyMessage(
-    type === "input" ? source.first_message : source.last_message,
+    (type === "input" ? source.first_message : source.last_message) ??
+      undefined,
     getThreadPrettifyConfig(source, type),
   );

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -15,6 +15,8 @@ import {
   extractLegacyOpenInferenceOutputText,
   extractOpenInferencePrettyText,
   hasLegacyOpenInferenceAttributes,
+  hasLegacyOpenInferenceOutputAttributes,
+  hasOpenInferenceHint,
   isOpenInferenceField,
 } from "@/lib/openinference";
 
@@ -45,7 +47,7 @@ export const traceExist = (item: ExperimentItem) =>
 export const traceVisible = (item: ExperimentItem) =>
   item.trace_visibility_mode === TRACE_VISIBILITY_MODE.default;
 
-type PrettifyMessageConfig = {
+export type PrettifyMessageConfig = {
   type: "input" | "output";
   openInferenceInput?: object | string;
   openInferenceHint?: boolean;
@@ -625,7 +627,7 @@ export const prettifyMessage = (
     return { message: String(message), prettified: true };
   }
 
-  if (isString(message)) {
+  if (isString(message) && message.trim().length > 0) {
     const extracted = extractTextFieldFromTruncatedJson(message, config);
     return {
       message: extracted || message,
@@ -673,18 +675,19 @@ export const prettifyMessage = (
       processedMessage = prettifyCustomMessagingLogic(message, config);
     }
 
+    if (!isString(processedMessage)) {
+      processedMessage = prettifyGenericLogic(message, config);
+    }
+
     if (
-      !isString(processedMessage) &&
+      (!isString(processedMessage) || processedMessage.trim().length === 0) &&
       config.type === "output" &&
+      hasLegacyOpenInferenceOutputAttributes(config.openInferenceInput) &&
       !isOpenInferenceField(message, "output", true)
     ) {
       processedMessage = extractLegacyOpenInferenceOutputText(
         config.openInferenceInput,
       );
-    }
-
-    if (!isString(processedMessage)) {
-      processedMessage = prettifyGenericLogic(message, config);
     }
 
     // attempt to improve JSON string if the message is serialised JSON string
@@ -707,3 +710,27 @@ export const prettifyMessage = (
     } as PrettifyMessageResponse;
   }
 };
+
+export type PrettifySource = {
+  input?: object | string;
+  output?: object | string;
+  metadata?: unknown;
+};
+
+export const getPrettifyConfig = (
+  source: PrettifySource,
+  type: "input" | "output",
+): PrettifyMessageConfig => ({
+  type,
+  openInferenceHint: hasOpenInferenceHint(
+    source.metadata,
+    source.input,
+    source.output,
+  ),
+  openInferenceInput: type === "output" ? source.input : undefined,
+});
+
+export const prettifyTraceField = (
+  source: PrettifySource,
+  type: "input" | "output",
+) => prettifyMessage(source[type], getPrettifyConfig(source, type));

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -734,3 +734,31 @@ export const prettifyTraceField = (
   source: PrettifySource,
   type: "input" | "output",
 ) => prettifyMessage(source[type], getPrettifyConfig(source, type));
+
+type ThreadPrettifySource = Partial<
+  Pick<Thread, "first_message" | "last_message">
+>;
+
+export const getThreadPrettifyConfig = (
+  source: ThreadPrettifySource,
+  type: "input" | "output",
+): PrettifyMessageConfig => ({
+  type,
+  // Thread aggregates omit the source trace's metadata. Recognize structured
+  // messages from the field itself without enabling synthetic raw fallbacks.
+  openInferenceHint: isOpenInferenceField(
+    type === "input" ? source.first_message : source.last_message,
+    type,
+    true,
+    false,
+  ),
+});
+
+export const prettifyThreadField = (
+  source: ThreadPrettifySource,
+  type: "input" | "output",
+) =>
+  prettifyMessage(
+    type === "input" ? source.first_message : source.last_message,
+    getThreadPrettifyConfig(source, type),
+  );

--- a/apps/opik-frontend/src/lib/traces.ts
+++ b/apps/opik-frontend/src/lib/traces.ts
@@ -15,6 +15,7 @@ import {
   extractLegacyOpenInferenceOutputText,
   extractOpenInferencePrettyText,
   hasLegacyOpenInferenceAttributes,
+  isOpenInferenceField,
 } from "@/lib/openinference";
 
 const MESSAGES_DIVIDER = `\n\n  ----------------- \n\n`;
@@ -620,17 +621,6 @@ export const prettifyMessage = (
     type: "input",
   },
 ): PrettifyMessageResponse => {
-  const recoveredOpenInferenceOutput =
-    config.type === "output"
-      ? extractLegacyOpenInferenceOutputText(config.openInferenceInput)
-      : undefined;
-  if (isString(recoveredOpenInferenceOutput)) {
-    return {
-      message: recoveredOpenInferenceOutput,
-      prettified: true,
-    };
-  }
-
   if (typeof message === "number" || typeof message === "boolean") {
     return { message: String(message), prettified: true };
   }
@@ -681,6 +671,16 @@ export const prettifyMessage = (
 
     if (!isString(processedMessage)) {
       processedMessage = prettifyCustomMessagingLogic(message, config);
+    }
+
+    if (
+      !isString(processedMessage) &&
+      config.type === "output" &&
+      !isOpenInferenceField(message, "output", true)
+    ) {
+      processedMessage = extractLegacyOpenInferenceOutputText(
+        config.openInferenceInput,
+      );
     }
 
     if (!isString(processedMessage)) {

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
@@ -13,7 +13,7 @@ import {
   PrettifyMessageConfig,
   PrettifySource,
 } from "@/lib/traces";
-import { ROW_HEIGHT } from "@/types/shared";
+import { JsonNode, ROW_HEIGHT } from "@/types/shared";
 import PrettyCell from "./PrettyCell";
 
 function TestTable<TData>({
@@ -22,10 +22,10 @@ function TestTable<TData>({
   config,
 }: {
   row: TData;
-  value: (row: TData) => string | object;
+  value: (row: TData) => JsonNode;
   config?: (row: TData, field: "input" | "output") => PrettifyMessageConfig;
 }) {
-  const columns: ColumnDef<TData, string | object>[] = [
+  const columns: ColumnDef<TData, JsonNode>[] = [
     {
       id: "output",
       accessorFn: value,
@@ -44,6 +44,16 @@ function TestTable<TData>({
 }
 
 describe("PrettyCell", () => {
+  it.each([0, false])("preserves scalar thread output %s", (last_message) => {
+    const html = renderToStaticMarkup(
+      <TestTable
+        row={{ last_message }}
+        value={(thread) => thread.last_message ?? null}
+        config={getThreadPrettifyConfig}
+      />,
+    );
+    expect(html).toContain(`>${last_message}</`);
+  });
   it("recovers an empty trace output using the column's trace context", () => {
     const row: PrettifySource = {
       input: { "llm.output_messages.0.message.content": "Recovered answer" },

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import {
+  getPrettifyConfig,
+  PrettifyMessageConfig,
+  PrettifySource,
+} from "@/lib/traces";
+import { ROW_HEIGHT } from "@/types/shared";
+import PrettyCell from "./PrettyCell";
+
+function TestTable<TData>({
+  row,
+  value,
+  config,
+}: {
+  row: TData;
+  value: (row: TData) => string | object;
+  config?: (row: TData, field: "input" | "output") => PrettifyMessageConfig;
+}) {
+  const columns: ColumnDef<TData, string | object>[] = [
+    {
+      id: "output",
+      accessorFn: value,
+      cell: PrettyCell,
+      meta: { custom: { fieldType: "output", getPrettifyConfig: config } },
+    },
+  ];
+  const table = useReactTable({
+    data: [row],
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    meta: { rowHeight: ROW_HEIGHT.large, rowHeightStyle: {} },
+  });
+  const cell = table.getRowModel().rows[0].getVisibleCells()[0];
+  return <>{flexRender(cell.column.columnDef.cell, cell.getContext())}</>;
+}
+
+describe("PrettyCell", () => {
+  it("recovers an empty trace output using the column's trace context", () => {
+    const row: PrettifySource = {
+      input: { "llm.output_messages.0.message.content": "Recovered answer" },
+    };
+    const html = renderToStaticMarkup(
+      <TestTable
+        row={row}
+        value={(trace) => trace.output ?? ""}
+        config={getPrettifyConfig}
+      />,
+    );
+    expect(html).toContain("Recovered answer");
+  });
+  it("uses a metadata-only hint for role-less output", () => {
+    const row: PrettifySource = {
+      metadata: { "openinference.span.kind": "LLM" },
+      output: { messages: [{ content: "Role-less answer" }] },
+    };
+    expect(
+      renderToStaticMarkup(
+        <TestTable
+          row={row}
+          value={(trace) => trace.output ?? ""}
+          config={getPrettifyConfig}
+        />,
+      ),
+    ).toContain("Role-less answer");
+  });
+  it("renders an ordinary empty cell without inventing output", () => {
+    expect(
+      renderToStaticMarkup(
+        <TestTable row={{}} value={() => ""} config={getPrettifyConfig} />,
+      ),
+    ).toContain(">-</");
+  });
+  it("supports a thread-shaped row without trace-specific metadata", () => {
+    const row = { last_message: { answer: "Thread answer" } };
+    expect(
+      renderToStaticMarkup(
+        <TestTable row={row} value={(thread) => thread.last_message} />,
+      ),
+    ).toContain("Thread answer");
+  });
+});

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-table";
 import {
   getPrettifyConfig,
+  getThreadPrettifyConfig,
   PrettifyMessageConfig,
   PrettifySource,
 } from "@/lib/traces";
@@ -85,5 +86,23 @@ describe("PrettyCell", () => {
         <TestTable row={row} value={(thread) => thread.last_message} />,
       ),
     ).toContain("Thread answer");
+  });
+
+  it("renders canonical thread output as text through the thread column config", () => {
+    const row = {
+      last_message: {
+        messages: [{ role: "assistant", content: "Thread answer" }],
+      },
+    };
+    const html = renderToStaticMarkup(
+      <TestTable
+        row={row}
+        value={(thread) => thread.last_message ?? ""}
+        config={getThreadPrettifyConfig}
+      />,
+    );
+    expect(html).toContain("Thread answer");
+    expect(html).not.toContain("&quot;messages&quot;");
+    expect(html).not.toContain("&quot;role&quot;");
   });
 });

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
@@ -26,11 +26,15 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
   const { fieldType = "input", colorIndicator = false } = (custom ??
     {}) as CustomMeta;
   const value = context.getValue() as string | object | undefined | null;
+  const rowInput = (context.row.original as { input?: object | string })?.input;
 
   const displayMessage = useMemo(() => {
-    if (!value) return "-";
+    const pretty = prettifyMessage(value ?? undefined, {
+      type: fieldType,
+      openInferenceInput: fieldType === "output" ? rowInput : undefined,
+    });
 
-    const pretty = prettifyMessage(value, { type: fieldType });
+    if (!pretty.message) return "-";
 
     let message: string;
     if (isObject(pretty.message)) {
@@ -44,7 +48,7 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
     }
 
     return message;
-  }, [value, fieldType, truncationEnabled, maxDataLength]);
+  }, [value, fieldType, rowInput, truncationEnabled, maxDataLength]);
 
   const rowHeight =
     context.column.columnDef.meta?.overrideRowHeight ??

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
@@ -8,6 +8,7 @@ import LinkifyText from "@/shared/LinkifyText/LinkifyText";
 import { prettifyMessage } from "@/lib/traces";
 import useLocalStorageState from "use-local-storage-state";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 type CustomMeta = {
   fieldType: "input" | "output";
@@ -26,12 +27,23 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
   const { fieldType = "input", colorIndicator = false } = (custom ??
     {}) as CustomMeta;
   const value = context.getValue() as string | object | undefined | null;
-  const rowInput = (context.row.original as { input?: object | string })?.input;
+  const row = context.row.original as {
+    input?: object | string;
+    output?: object | string;
+    metadata?: object;
+  };
+  const rowInput = row.input;
+  const openInferenceHint = hasOpenInferenceHint(
+    row.metadata,
+    row.input,
+    row.output,
+  );
 
   const displayMessage = useMemo(() => {
     const pretty = prettifyMessage(value ?? undefined, {
       type: fieldType,
       openInferenceInput: fieldType === "output" ? rowInput : undefined,
+      openInferenceHint,
     });
 
     if (!pretty.message) return "-";
@@ -48,7 +60,14 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
     }
 
     return message;
-  }, [value, fieldType, rowInput, truncationEnabled, maxDataLength]);
+  }, [
+    value,
+    fieldType,
+    rowInput,
+    openInferenceHint,
+    truncationEnabled,
+    maxDataLength,
+  ]);
 
   const rowHeight =
     context.column.columnDef.meta?.overrideRowHeight ??

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import isObject from "lodash/isObject";
 import { CellContext } from "@tanstack/react-table";
-import { ROW_HEIGHT } from "@/types/shared";
+import { JsonNode, ROW_HEIGHT } from "@/types/shared";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import CellTooltipWrapper from "@/shared/DataTableCells/CellTooltipWrapper";
 import LinkifyText from "@/shared/LinkifyText/LinkifyText";
@@ -21,7 +21,7 @@ type CustomMeta<TData> = {
 const MAX_DATA_LENGTH_KEY = "pretty-cell-data-length-limit";
 const MAX_DATA_LENGTH = 10000;
 
-const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
+const PrettyCell = <TData,>(context: CellContext<TData, JsonNode>) => {
   const truncationEnabled = useTruncationEnabled();
   const [maxDataLength] = useLocalStorageState(MAX_DATA_LENGTH_KEY, {
     defaultValue: MAX_DATA_LENGTH,
@@ -32,7 +32,7 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
     colorIndicator = false,
     getPrettifyConfig,
   } = (custom ?? {}) as CustomMeta<TData>;
-  const value = context.getValue() as string | object | undefined | null;
+  const value = context.getValue();
   const prettifyConfig = getPrettifyConfig?.(context.row.original, fieldType);
   const rowInput = prettifyConfig?.openInferenceInput;
   const openInferenceHint = prettifyConfig?.openInferenceHint;

--- a/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
+++ b/apps/opik-frontend/src/shared/DataTableCells/PrettyCell.tsx
@@ -5,12 +5,15 @@ import { ROW_HEIGHT } from "@/types/shared";
 import CellWrapper from "@/shared/DataTableCells/CellWrapper";
 import CellTooltipWrapper from "@/shared/DataTableCells/CellTooltipWrapper";
 import LinkifyText from "@/shared/LinkifyText/LinkifyText";
-import { prettifyMessage } from "@/lib/traces";
+import { prettifyMessage, PrettifyMessageConfig } from "@/lib/traces";
 import useLocalStorageState from "use-local-storage-state";
 import { useTruncationEnabled } from "@/contexts/server-sync-provider";
-import { hasOpenInferenceHint } from "@/lib/openinference";
 
-type CustomMeta = {
+type CustomMeta<TData> = {
+  getPrettifyConfig?: (
+    row: TData,
+    field: "input" | "output",
+  ) => PrettifyMessageConfig;
   fieldType: "input" | "output";
   colorIndicator?: boolean;
 };
@@ -24,20 +27,15 @@ const PrettyCell = <TData,>(context: CellContext<TData, string | object>) => {
     defaultValue: MAX_DATA_LENGTH,
   });
   const { custom } = context.column.columnDef.meta ?? {};
-  const { fieldType = "input", colorIndicator = false } = (custom ??
-    {}) as CustomMeta;
+  const {
+    fieldType = "input",
+    colorIndicator = false,
+    getPrettifyConfig,
+  } = (custom ?? {}) as CustomMeta<TData>;
   const value = context.getValue() as string | object | undefined | null;
-  const row = context.row.original as {
-    input?: object | string;
-    output?: object | string;
-    metadata?: object;
-  };
-  const rowInput = row.input;
-  const openInferenceHint = hasOpenInferenceHint(
-    row.metadata,
-    row.input,
-    row.output,
-  );
+  const prettifyConfig = getPrettifyConfig?.(context.row.original, fieldType);
+  const rowInput = prettifyConfig?.openInferenceInput;
+  const openInferenceHint = prettifyConfig?.openInferenceHint;
 
   const displayMessage = useMemo(() => {
     const pretty = prettifyMessage(value ?? undefined, {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.test.tsx
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import PrettyLLMMessageUsage from "./PrettyLLMMessageUsage";
+
+describe("PrettyLLMMessageUsage", () => {
+  it.each([
+    undefined,
+    {},
+    { completion_tokens: undefined },
+    { completion_tokens: NaN },
+  ])("does not render missing or invalid usage: %j", (usage) => {
+    expect(renderToStaticMarkup(<PrettyLLMMessageUsage usage={usage} />)).toBe(
+      "",
+    );
+  });
+
+  it.each([
+    ["cache_read_input_tokens", "Cache Read Input Tokens"],
+    [
+      "prompt_tokens_details.audio_tokens",
+      "Prompt Tokens Details Audio Tokens",
+    ],
+    [
+      "completion_tokens_details.audio_tokens",
+      "Completion Tokens Details Audio Tokens",
+    ],
+    ["reasoning_tokens", "Reasoning Tokens"],
+    ["provider_specific_tokens", "Provider Specific Tokens"],
+  ])("renders reported %s even without completion tokens", (key, label) => {
+    const usage = { completion_tokens: undefined, [key]: 7 };
+    const html = renderToStaticMarkup(<PrettyLLMMessageUsage usage={usage} />);
+
+    expect(html).toContain(label);
+    expect(html).toContain(">7<");
+    expect(html).not.toContain("Completion tokens");
+  });
+
+  it("preserves a reported zero", () => {
+    const html = renderToStaticMarkup(
+      <PrettyLLMMessageUsage usage={{ completion_tokens: 0 }} />,
+    );
+    expect(html).toContain("Completion tokens");
+    expect(html).toContain(">0<");
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.test.tsx
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.test.tsx
@@ -16,31 +16,51 @@ describe("PrettyLLMMessageUsage", () => {
   });
 
   it.each([
-    ["cache_read_input_tokens", "Cache Read Input Tokens"],
-    [
-      "prompt_tokens_details.audio_tokens",
-      "Prompt Tokens Details Audio Tokens",
-    ],
-    [
-      "completion_tokens_details.audio_tokens",
-      "Completion Tokens Details Audio Tokens",
-    ],
-    ["reasoning_tokens", "Reasoning Tokens"],
-    ["provider_specific_tokens", "Provider Specific Tokens"],
+    ["cache_read_input_tokens", "Cache read tokens"],
+    ["prompt_tokens_details.audio_tokens", "Input audio tokens"],
+    ["completion_tokens_details.audio_tokens", "Output audio tokens"],
+    ["reasoning_tokens", "Reasoning tokens"],
+    ["provider_specific_tokens", "Provider specific tokens"],
   ])("renders reported %s even without completion tokens", (key, label) => {
     const usage = { completion_tokens: undefined, [key]: 7 };
     const html = renderToStaticMarkup(<PrettyLLMMessageUsage usage={usage} />);
 
     expect(html).toContain(label);
     expect(html).toContain(">7<");
-    expect(html).not.toContain("Completion tokens");
+    expect(html).not.toContain("Output tokens");
   });
 
   it("preserves a reported zero", () => {
     const html = renderToStaticMarkup(
       <PrettyLLMMessageUsage usage={{ completion_tokens: 0 }} />,
     );
-    expect(html).toContain("Completion tokens");
+    expect(html).toContain("Output tokens");
     expect(html).toContain(">0<");
   });
+});
+
+it("renders display metrics without internal duplicates", () => {
+  const html = renderToStaticMarkup(
+    <PrettyLLMMessageUsage
+      usage={{
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+        "original_usage.input_tokens": 8,
+        "original_usage.prompt_tokens": 10,
+        "original_usage.cache_read_input_tokens": 2,
+        invalid: NaN,
+      }}
+    />,
+  );
+  for (const [label, value] of [
+    ["Input tokens", 10],
+    ["Output tokens", 5],
+    ["Total tokens", 15],
+    ["Cache read tokens", 2],
+  ]) {
+    expect(html).toContain(`${label}</span><span>${value}</span>`);
+  }
+  expect(html).not.toContain("Original");
+  expect(html).not.toContain("Invalid");
 });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.tsx
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import startCase from "lodash/startCase";
 import { cn } from "@/lib/utils";
 import { PrettyLLMMessageUsageProps } from "./types";
 
@@ -6,23 +7,28 @@ const PrettyLLMMessageUsage: React.FC<PrettyLLMMessageUsageProps> = ({
   usage,
   className,
 }) => {
-  if (!usage) {
+  const entries = Object.entries(usage ?? {}).filter(
+    ([, value]) => typeof value === "number" && Number.isFinite(value),
+  );
+  if (entries.length === 0) {
     return null;
   }
 
   return (
     <div
       className={cn(
-        "flex items-center gap-4 text-xs text-muted-foreground",
+        "flex flex-wrap items-center gap-4 text-xs text-muted-foreground",
         className,
       )}
     >
-      {usage.completion_tokens !== undefined && (
-        <>
-          <span className="font-medium">Completion tokens</span>
-          <span>{usage.completion_tokens}</span>
-        </>
-      )}
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex items-center gap-2">
+          <span className="font-medium">
+            {key === "completion_tokens" ? "Completion tokens" : startCase(key)}
+          </span>
+          <span>{value}</span>
+        </div>
+      ))}
     </div>
   );
 };

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.tsx
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/PrettyLLMMessageUsage.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import startCase from "lodash/startCase";
+import { getDisplayUsage } from "./usage";
 import { cn } from "@/lib/utils";
 import { PrettyLLMMessageUsageProps } from "./types";
 
@@ -7,9 +7,7 @@ const PrettyLLMMessageUsage: React.FC<PrettyLLMMessageUsageProps> = ({
   usage,
   className,
 }) => {
-  const entries = Object.entries(usage ?? {}).filter(
-    ([, value]) => typeof value === "number" && Number.isFinite(value),
-  );
+  const entries = getDisplayUsage(usage);
   if (entries.length === 0) {
     return null;
   }
@@ -21,11 +19,9 @@ const PrettyLLMMessageUsage: React.FC<PrettyLLMMessageUsageProps> = ({
         className,
       )}
     >
-      {entries.map(([key, value]) => (
+      {entries.map(({ key, value, label }) => (
         <div key={key} className="flex items-center gap-2">
-          <span className="font-medium">
-            {key === "completion_tokens" ? "Completion tokens" : startCase(key)}
-          </span>
+          <span className="font-medium">{label}</span>
           <span>{value}</span>
         </div>
       ))}

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
@@ -1,4 +1,8 @@
-import { LLMMessageFormatDetectionResult, LLMMessageFormat } from "./types";
+import {
+  LLMMessageFormatDetectionResult,
+  LLMMessageFormat,
+  LLMMessagePrettifyConfig,
+} from "./types";
 import { getFormat, getAllFormats } from "./providers/registry";
 
 /**
@@ -15,7 +19,7 @@ import { getFormat, getAllFormats } from "./providers/registry";
  */
 export const detectLLMMessages = (
   data: unknown,
-  prettifyConfig?: { fieldType?: "input" | "output" },
+  prettifyConfig?: LLMMessagePrettifyConfig,
   formatHint?: LLMMessageFormat,
 ): LLMMessageFormatDetectionResult => {
   const isEmpty =
@@ -30,6 +34,35 @@ export const detectLLMMessages = (
   if (formatHint) {
     const format = getFormat(formatHint);
     if (format && format.detector(data, { ...prettifyConfig, formatHint })) {
+      const reliesOnAuthoritativeFallback =
+        prettifyConfig?.formatHintIsAuthoritative === true &&
+        !format.detector(data, {
+          ...prettifyConfig,
+          formatHint,
+          formatHintIsAuthoritative: false,
+        });
+
+      // An exact OpenInference marker permits raw fallbacks. Prefer a provider mapper when
+      // the field also has a provider-specific shape, since it can render richer messages.
+      if (reliesOnAuthoritativeFallback) {
+        const detectedFormat = getAllFormats().find(
+          (candidate) =>
+            candidate.name !== formatHint &&
+            candidate.detector(data, {
+              ...prettifyConfig,
+              formatHint: undefined,
+              formatHintIsAuthoritative: false,
+            }),
+        );
+        if (detectedFormat) {
+          return {
+            supported: true,
+            format: detectedFormat.name,
+            confidence: "medium",
+          };
+        }
+      }
+
       return {
         supported: true,
         format: format.name,
@@ -51,6 +84,19 @@ export const detectLLMMessages = (
   }
 
   return { supported: false };
+};
+
+export const canShowLLMMessages = (
+  input: LLMMessageFormatDetectionResult,
+  output: LLMMessageFormatDetectionResult,
+  allowPartialFields: boolean = false,
+): boolean => {
+  const hasSupportedField = input.supported || output.supported;
+  if (allowPartialFields) return hasSupportedField;
+
+  const hasUnsupportedField =
+    (!input.supported && !input.empty) || (!output.supported && !output.empty);
+  return hasSupportedField && !hasUnsupportedField;
 };
 
 export default detectLLMMessages;

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
@@ -16,7 +16,7 @@ import { getFormat, getAllFormats } from "./providers/registry";
 export const detectLLMMessages = (
   data: unknown,
   prettifyConfig?: { fieldType?: "input" | "output" },
-  formatHint?: string,
+  formatHint?: LLMMessageFormat,
 ): LLMMessageFormatDetectionResult => {
   const isEmpty =
     data == null ||
@@ -28,8 +28,8 @@ export const detectLLMMessages = (
 
   // If format hint provided, try that first
   if (formatHint) {
-    const format = getFormat(formatHint as LLMMessageFormat);
-    if (format && format.detector(data, prettifyConfig)) {
+    const format = getFormat(formatHint);
+    if (format && format.detector(data, { ...prettifyConfig, formatHint })) {
       return {
         supported: true,
         format: format.name,
@@ -41,7 +41,7 @@ export const detectLLMMessages = (
   // Auto-detect by trying all formats
   const formats = getAllFormats();
   for (const format of formats) {
-    if (format.detector(data, prettifyConfig)) {
+    if (format.detector(data, { ...prettifyConfig, formatHint })) {
       return {
         supported: true,
         format: format.name,

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/detectLLMMessages.ts
@@ -1,6 +1,5 @@
 import {
   LLMMessageFormatDetectionResult,
-  LLMMessageFormat,
   LLMMessagePrettifyConfig,
 } from "./types";
 import { getFormat, getAllFormats } from "./providers/registry";
@@ -10,18 +9,18 @@ import { getFormat, getAllFormats } from "./providers/registry";
  *
  * Detection strategy:
  * 1. If format hint is provided, try that format first
- * 2. Fall back to trying all registered formats
+ * 2. If only an authoritative raw fallback matched, prefer a recognized provider schema
+ * 3. Fall back to trying all registered formats
  *
  * @param data - The raw trace/span input or output data
- * @param prettifyConfig - Configuration indicating if this is input or output
- * @param formatHint - Optional format string hint from the span
+ * @param prettifyConfig - Field direction, optional format hint and permission for LLM raw fallback
  * @returns Detection result with supported flag and detected format
  */
 export const detectLLMMessages = (
   data: unknown,
   prettifyConfig?: LLMMessagePrettifyConfig,
-  formatHint?: LLMMessageFormat,
 ): LLMMessageFormatDetectionResult => {
+  const formatHint = prettifyConfig?.formatHint;
   const isEmpty =
     data == null ||
     (typeof data === "object" && Object.keys(data as object).length === 0);

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
@@ -9,6 +9,7 @@ export type {
   LLMMapperResult,
   FormatDetector,
   FormatMapper,
+  LLMMessagePrettifyConfig,
   LLMMessageFormatImplementation,
 } from "./types";
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/index.ts
@@ -1,4 +1,4 @@
-export { detectLLMMessages } from "./detectLLMMessages";
+export { canShowLLMMessages, detectLLMMessages } from "./detectLLMMessages";
 export { mapAndCombineMessages } from "./mapAndCombineMessages";
 
 export type {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { mapAndCombineMessages } from "./mapAndCombineMessages";
+import { detectLLMMessages, canShowLLMMessages } from "./detectLLMMessages";
+import { resolveOpenInferenceHint } from "@/lib/openinference";
+
+const config = {
+  formatHint: "openinference" as const,
+  formatHintIsAuthoritative: true,
+};
+describe("message detection and combining", () => {
+  it.each([{}, { completion_tokens: 5 }])(
+    "retains provider usage when span usage is incomplete: %j",
+    (spanUsage) => {
+      const result = mapAndCombineMessages(
+        { messages: [{ role: "user", content: "Question" }] },
+        {
+          choices: [{ message: { role: "assistant", content: "Answer" } }],
+          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        },
+        { spanUsage },
+      );
+
+      expect(result.usage).toEqual({
+        prompt_tokens: 3,
+        completion_tokens: 4,
+        total_tokens: 7,
+        ...spanUsage,
+      });
+    },
+  );
+
+  it.each([
+    [{ supported: true }, { supported: false, empty: true }, true],
+    [{ supported: true }, { supported: false }, false],
+    [{ supported: false }, { supported: false }, false],
+    [{ supported: false, empty: true }, { supported: true }, true],
+  ] as const)(
+    "gates ordinary message pairs: %j / %j",
+    (input, output, expected) => {
+      expect(canShowLLMMessages(input, output)).toBe(expected);
+    },
+  );
+  it.each(["", "   ", { value: "" }, { value: null }, null, []])(
+    "rejects blank LLM fallback %j",
+    (input) => {
+      expect(
+        detectLLMMessages(input, { ...config, fieldType: "input" }).supported,
+      ).toBe(false);
+    },
+  );
+  it.each([0, false])("keeps scalar %j", (input) => {
+    expect(
+      mapAndCombineMessages(input, undefined, config).messages,
+    ).toHaveLength(1);
+  });
+  it("keeps LangChain message roles under an OpenInference hint", () => {
+    const input = {
+      messages: [
+        { type: "human", content: "Question" },
+        { type: "ai", content: "Answer" },
+      ],
+    };
+    expect(
+      mapAndCombineMessages(input, undefined, config).messages.map(
+        (m) => m.role,
+      ),
+    ).toEqual(["human", "ai"]);
+  });
+  it("does not promote an unrecognized sibling to a raw message", () => {
+    const result = mapAndCombineMessages(
+      { prompt_id: "p1" },
+      { "llm.output_messages.0.message.content": "Answer" },
+      { formatHint: "openinference" },
+    );
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0].blocks[0].props).toMatchObject({
+      children: "Answer",
+    });
+  });
+  it.each(["answer", "response", "reply", "final_output"])(
+    "uses current %s before historical output in Messages",
+    (key) => {
+      for (const settings of [{}, config]) {
+        const result = mapAndCombineMessages(
+          {
+            "llm.input_messages.0.message.content": "Question",
+            "llm.output_messages.0.message.content": "Stale answer",
+          },
+          { [key]: "Current answer" },
+          settings,
+        );
+        expect(
+          result.messages.map((message) => message.blocks[0].props),
+        ).toMatchObject([
+          { children: "Question" },
+          { children: "Current answer" },
+        ]);
+        expect(result.messages).toHaveLength(2);
+      }
+    },
+  );
+  it("retains unmarked legacy output recovery", () => {
+    const result = mapAndCombineMessages(
+      {
+        "llm.input_messages.0.message.content": "Question",
+        "llm.output_messages.0.message.content": "Answer",
+      },
+      undefined,
+    );
+    expect(result.messages.map((m) => m.blocks[0].props)).toMatchObject([
+      { children: "Question" },
+      { children: "Answer" },
+    ]);
+  });
+  it("preserves the raw envelope of an unmarked historical span", () => {
+    const result = mapAndCombineMessages(
+      { "llm.input_messages.0.message.content": "Question" },
+      { value: "Legacy raw answer", mime_type: "text/plain" },
+    );
+    expect(
+      result.messages.map((message) => message.blocks[0].props),
+    ).toMatchObject([
+      { children: "Question" },
+      { children: "Legacy raw answer" },
+    ]);
+  });
+  it("does not use legacy configuration to invent messages on a non-LLM span", () => {
+    const result = mapAndCombineMessages(
+      { query: "weather", "llm.invocation_parameters": { temperature: 0.5 } },
+      { value: "tool result", mime_type: "text/plain" },
+      { formatHint: "openinference", formatHintIsAuthoritative: false },
+    );
+    expect(result.messages).toEqual([]);
+  });
+  it.each(["CHAIN", "AGENT", "TOOL", "RETRIEVER"])(
+    "does not invent chat for raw %s spans",
+    (kind) => {
+      const hint = resolveOpenInferenceHint(
+        { "openinference.span.kind": kind },
+        { query: "weather" },
+      );
+      const settings = {
+        ...config,
+        formatHintIsAuthoritative: hint.authoritative,
+      };
+      expect(hint.detected).toBe(true);
+      expect(
+        mapAndCombineMessages({ query: "weather" }, undefined, settings)
+          .messages,
+      ).toEqual([]);
+      expect(
+        mapAndCombineMessages(
+          { messages: [{ role: "user", content: "Question" }] },
+          undefined,
+          settings,
+        ).messages,
+      ).toHaveLength(1);
+    },
+  );
+  it.each([undefined, "unknown", "image"])(
+    "renders media when type is %j",
+    (type) => {
+      const output = {
+        messages: [
+          {
+            role: "assistant",
+            contents: [
+              { type, image: { url: "https://example.test/image.png" } },
+            ],
+          },
+        ],
+      };
+      const result = mapAndCombineMessages(undefined, output, config);
+      expect(result.messages[0].blocks[0]).toMatchObject({
+        blockType: "image",
+      });
+    },
+  );
+  it("shows only raw remainder alongside structured prompts", () => {
+    const result = mapAndCombineMessages(
+      { query: "weather", prompts: [{ text: "weather" }] },
+      undefined,
+      config,
+    );
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0].blocks[0].props).toMatchObject({
+      code: JSON.stringify({ query: "weather" }, null, 2),
+    });
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -4,17 +4,68 @@ import {
   LLMMessageDescriptor,
   LLMMapperResult,
   LLMMessageFormatDetectionResult,
+  LLMMessageFormat,
 } from "./types";
+import { PrettyLLMMessageUsageProps } from "../types";
 
 export function mapAndCombineMessages(
   input: unknown,
   output: unknown,
+  formatHint?: LLMMessageFormat,
+  spanUsage?: PrettyLLMMessageUsageProps["usage"],
 ): LLMMapperResult {
-  const inputDetection = detectLLMMessages(input, { fieldType: "input" });
-  const outputDetection = detectLLMMessages(output, { fieldType: "output" });
+  const inputDetection = detectLLMMessages(
+    input,
+    { fieldType: "input" },
+    formatHint,
+  );
+  const outputDetection = detectLLMMessages(
+    output,
+    { fieldType: "output" },
+    formatHint,
+  );
 
-  const inputResult = mapForDetection(input, inputDetection, "input");
-  const outputResult = mapForDetection(output, outputDetection, "output");
+  // Historical OpenInference spans can have every flattened output attribute in input,
+  // while output contains only a raw {value, mime_type} fallback. Once either side proves
+  // the format, let its pair-aware combiner inspect both raw fields.
+  if (
+    inputDetection.format === "openinference" ||
+    outputDetection.format === "openinference"
+  ) {
+    const format = getFormat("openinference");
+    if (format?.combiner) {
+      const mapped = format.combiner(
+        {
+          raw: input,
+          mapped: format.mapper(input, {
+            fieldType: "input",
+            formatHint,
+          }),
+        },
+        {
+          raw: output,
+          mapped: format.mapper(output, {
+            fieldType: "output",
+            formatHint,
+          }),
+        },
+      );
+      return { ...mapped, usage: spanUsage ?? mapped.usage };
+    }
+  }
+
+  const inputResult = mapForDetection(
+    input,
+    inputDetection,
+    "input",
+    formatHint,
+  );
+  const outputResult = mapForDetection(
+    output,
+    outputDetection,
+    "output",
+    formatHint,
+  );
 
   if (
     inputDetection.supported &&
@@ -41,9 +92,10 @@ function mapForDetection(
   data: unknown,
   detection: LLMMessageFormatDetectionResult,
   fieldType: "input" | "output",
+  formatHint?: LLMMessageFormat,
 ): LLMMapperResult | null {
   if (!detection.supported || !detection.format) return null;
   const format = getFormat(detection.format);
   if (!format) return null;
-  return format.mapper(data, { fieldType });
+  return format.mapper(data, { fieldType, formatHint });
 }

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -20,6 +20,16 @@ export function mapAndCombineMessages(
   config: MapAndCombineMessagesConfig = {},
 ): LLMMapperResult {
   const { formatHint, formatHintIsAuthoritative = false, spanUsage } = config;
+  const withSpanUsage = (result: LLMMapperResult): LLMMapperResult => {
+    if (!spanUsage) return result;
+    const populatedSpanUsage = Object.fromEntries(
+      Object.entries(spanUsage).filter(([, value]) => value != null),
+    );
+    return {
+      ...result,
+      usage: { ...result.usage, ...populatedSpanUsage },
+    };
+  };
   const inputDetection = detectLLMMessages(
     input,
     { fieldType: "input", formatHintIsAuthoritative },
@@ -65,7 +75,7 @@ export function mapAndCombineMessages(
           }),
         },
       );
-      return { ...mapped, usage: spanUsage ?? mapped.usage };
+      return withSpanUsage(mapped);
     }
   }
 
@@ -92,9 +102,11 @@ export function mapAndCombineMessages(
   ) {
     const format = getFormat(inputDetection.format);
     if (format?.combiner && inputResult && outputResult) {
-      return format.combiner(
-        { raw: input, mapped: inputResult },
-        { raw: output, mapped: outputResult },
+      return withSpanUsage(
+        format.combiner(
+          { raw: input, mapped: inputResult },
+          { raw: output, mapped: outputResult },
+        ),
       );
     }
   }
@@ -102,7 +114,7 @@ export function mapAndCombineMessages(
   const messages: LLMMessageDescriptor[] = [];
   if (inputResult) messages.push(...inputResult.messages);
   if (outputResult) messages.push(...outputResult.messages);
-  return { messages, usage: spanUsage ?? outputResult?.usage };
+  return withSpanUsage({ messages, usage: outputResult?.usage });
 }
 
 function mapForDetection(

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -8,29 +8,42 @@ import {
 } from "./types";
 import { PrettyLLMMessageUsageProps } from "../types";
 
+type MapAndCombineMessagesConfig = {
+  formatHint?: LLMMessageFormat;
+  formatHintIsAuthoritative?: boolean;
+  spanUsage?: PrettyLLMMessageUsageProps["usage"];
+};
+
 export function mapAndCombineMessages(
   input: unknown,
   output: unknown,
-  formatHint?: LLMMessageFormat,
-  spanUsage?: PrettyLLMMessageUsageProps["usage"],
+  config: MapAndCombineMessagesConfig = {},
 ): LLMMapperResult {
+  const { formatHint, formatHintIsAuthoritative = false, spanUsage } = config;
   const inputDetection = detectLLMMessages(
     input,
-    { fieldType: "input" },
+    { fieldType: "input", formatHintIsAuthoritative },
     formatHint,
   );
   const outputDetection = detectLLMMessages(
     output,
-    { fieldType: "output" },
+    { fieldType: "output", formatHintIsAuthoritative },
     formatHint,
   );
 
   // Historical OpenInference spans can have every flattened output attribute in input,
   // while output contains only a raw {value, mime_type} fallback. Once either side proves
   // the format, let its pair-aware combiner inspect both raw fields.
+  const hasConflictingFormat = [inputDetection, outputDetection].some(
+    (detection) =>
+      detection.supported &&
+      detection.format !== undefined &&
+      detection.format !== "openinference",
+  );
   if (
-    inputDetection.format === "openinference" ||
-    outputDetection.format === "openinference"
+    !hasConflictingFormat &&
+    (inputDetection.format === "openinference" ||
+      outputDetection.format === "openinference")
   ) {
     const format = getFormat("openinference");
     if (format?.combiner) {
@@ -40,6 +53,7 @@ export function mapAndCombineMessages(
           mapped: format.mapper(input, {
             fieldType: "input",
             formatHint,
+            formatHintIsAuthoritative,
           }),
         },
         {
@@ -47,6 +61,7 @@ export function mapAndCombineMessages(
           mapped: format.mapper(output, {
             fieldType: "output",
             formatHint,
+            formatHintIsAuthoritative,
           }),
         },
       );
@@ -59,12 +74,14 @@ export function mapAndCombineMessages(
     inputDetection,
     "input",
     formatHint,
+    formatHintIsAuthoritative,
   );
   const outputResult = mapForDetection(
     output,
     outputDetection,
     "output",
     formatHint,
+    formatHintIsAuthoritative,
   );
 
   if (
@@ -85,7 +102,7 @@ export function mapAndCombineMessages(
   const messages: LLMMessageDescriptor[] = [];
   if (inputResult) messages.push(...inputResult.messages);
   if (outputResult) messages.push(...outputResult.messages);
-  return { messages, usage: outputResult?.usage };
+  return { messages, usage: spanUsage ?? outputResult?.usage };
 }
 
 function mapForDetection(
@@ -93,9 +110,14 @@ function mapForDetection(
   detection: LLMMessageFormatDetectionResult,
   fieldType: "input" | "output",
   formatHint?: LLMMessageFormat,
+  formatHintIsAuthoritative: boolean = false,
 ): LLMMapperResult | null {
   if (!detection.supported || !detection.format) return null;
   const format = getFormat(detection.format);
   if (!format) return null;
-  return format.mapper(data, { fieldType, formatHint });
+  return format.mapper(data, {
+    fieldType,
+    formatHint,
+    formatHintIsAuthoritative,
+  });
 }

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -1,3 +1,9 @@
+import {
+  hasLegacyOpenInferenceOutputAttributes,
+  isOpenInferenceField,
+  resolveOpenInferenceHint,
+} from "@/lib/openinference";
+import { prettifyMessage } from "@/lib/traces";
 import { detectLLMMessages } from "./detectLLMMessages";
 import { getFormat } from "./providers/registry";
 import {
@@ -6,12 +12,17 @@ import {
   LLMMessageFormatDetectionResult,
   LLMMessageFormat,
 } from "./types";
-import { PrettyLLMMessageUsageProps } from "../types";
+import { MessageUsage, numericUsage } from "../usage";
+import { mapOpenInferencePair } from "./providers/openinference/mapper";
 
 type MapAndCombineMessagesConfig = {
   formatHint?: LLMMessageFormat;
   formatHintIsAuthoritative?: boolean;
-  spanUsage?: PrettyLLMMessageUsageProps["usage"];
+  spanUsage?: MessageUsage;
+  detections?: {
+    input: LLMMessageFormatDetectionResult;
+    output: LLMMessageFormatDetectionResult;
+  };
 };
 
 export function mapAndCombineMessages(
@@ -19,70 +30,82 @@ export function mapAndCombineMessages(
   output: unknown,
   config: MapAndCombineMessagesConfig = {},
 ): LLMMapperResult {
-  const { formatHint, formatHintIsAuthoritative = false, spanUsage } = config;
+  const pairHint = resolveOpenInferenceHint(undefined, input, output);
+  const {
+    formatHint = pairHint.detected ? "openinference" : undefined,
+    spanUsage,
+  } = config;
+  const formatHintIsAuthoritative =
+    config.formatHintIsAuthoritative ?? pairHint.authoritative;
   const withSpanUsage = (result: LLMMapperResult): LLMMapperResult => {
-    const populatedSpanUsage = Object.fromEntries(
-      Object.entries(spanUsage ?? {}).filter(
-        ([, value]) => typeof value === "number" && Number.isFinite(value),
-      ),
-    );
-    const usage = Object.fromEntries(
-      Object.entries({ ...result.usage, ...populatedSpanUsage }).filter(
-        ([, value]) => typeof value === "number" && Number.isFinite(value),
-      ),
-    );
+    const usage = numericUsage({ ...result.usage, ...numericUsage(spanUsage) });
     return {
       ...result,
       usage: Object.keys(usage).length > 0 ? usage : undefined,
     };
   };
-  const inputDetection = detectLLMMessages(
-    input,
-    { fieldType: "input", formatHintIsAuthoritative },
-    formatHint,
-  );
-  const outputDetection = detectLLMMessages(
-    output,
-    { fieldType: "output", formatHintIsAuthoritative },
-    formatHint,
-  );
+  const inputDetection =
+    config.detections?.input ??
+    detectLLMMessages(input, {
+      fieldType: "input",
+      formatHintIsAuthoritative,
+      formatHint,
+    });
+  const outputDetection =
+    config.detections?.output ??
+    detectLLMMessages(output, {
+      fieldType: "output",
+      formatHintIsAuthoritative,
+      formatHint,
+    });
 
   // Historical OpenInference spans can have every flattened output attribute in input,
   // while output contains only a raw {value, mime_type} fallback. Once either side proves
   // the format, let its pair-aware combiner inspect both raw fields.
-  const hasConflictingFormat = [inputDetection, outputDetection].some(
+  const hasNonOpenInferenceFormat = [inputDetection, outputDetection].some(
     (detection) =>
       detection.supported &&
       detection.format !== undefined &&
       detection.format !== "openinference",
   );
   if (
-    !hasConflictingFormat &&
+    !hasNonOpenInferenceFormat &&
     (inputDetection.format === "openinference" ||
       outputDetection.format === "openinference")
   ) {
-    const format = getFormat("openinference");
-    if (format?.combiner) {
-      const mapped = format.combiner(
-        {
-          raw: input,
-          mapped: format.mapper(input, {
-            fieldType: "input",
-            formatHint,
-            formatHintIsAuthoritative,
-          }),
-        },
-        {
-          raw: output,
-          mapped: format.mapper(output, {
-            fieldType: "output",
-            formatHint,
-            formatHintIsAuthoritative,
-          }),
-        },
-      );
-      return withSpanUsage(mapped);
+    let currentOutput = output;
+    // Use the same current-answer precedence as previews before recovering output
+    // from historical input. Old {value, mime_type} envelopes remain fallbacks.
+    if (
+      formatHintIsAuthoritative !== false &&
+      hasLegacyOpenInferenceOutputAttributes(input) &&
+      output != null &&
+      (typeof output === "object" ||
+        typeof output === "string" ||
+        typeof output === "number" ||
+        typeof output === "boolean") &&
+      !(typeof output === "object" && "value" in output) &&
+      !isOpenInferenceField(output, "output", true, false)
+    ) {
+      const pretty = prettifyMessage(output, { type: "output" });
+      if (
+        pretty.prettified &&
+        typeof pretty.message === "string" &&
+        pretty.message.trim()
+      ) {
+        currentOutput = {
+          messages: [{ role: "assistant", content: pretty.message }],
+        };
+      }
     }
+    return withSpanUsage(
+      mapOpenInferencePair(
+        input,
+        currentOutput,
+        inputDetection.supported,
+        outputDetection.supported,
+      ),
+    );
   }
 
   const inputResult = mapForDetection(
@@ -128,7 +151,7 @@ function mapForDetection(
   detection: LLMMessageFormatDetectionResult,
   fieldType: "input" | "output",
   formatHint?: LLMMessageFormat,
-  formatHintIsAuthoritative: boolean = false,
+  formatHintIsAuthoritative?: boolean,
 ): LLMMapperResult | null {
   if (!detection.supported || !detection.format) return null;
   const format = getFormat(detection.format);

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/mapAndCombineMessages.ts
@@ -21,13 +21,19 @@ export function mapAndCombineMessages(
 ): LLMMapperResult {
   const { formatHint, formatHintIsAuthoritative = false, spanUsage } = config;
   const withSpanUsage = (result: LLMMapperResult): LLMMapperResult => {
-    if (!spanUsage) return result;
     const populatedSpanUsage = Object.fromEntries(
-      Object.entries(spanUsage).filter(([, value]) => value != null),
+      Object.entries(spanUsage ?? {}).filter(
+        ([, value]) => typeof value === "number" && Number.isFinite(value),
+      ),
+    );
+    const usage = Object.fromEntries(
+      Object.entries({ ...result.usage, ...populatedSpanUsage }).filter(
+        ([, value]) => typeof value === "number" && Number.isFinite(value),
+      ),
     );
     return {
       ...result,
-      usage: { ...result.usage, ...populatedSpanUsage },
+      usage: Object.keys(usage).length > 0 ? usage : undefined,
     };
   };
   const inputDetection = detectLLMMessages(

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/index.ts
@@ -1,2 +1,8 @@
 export { openaiFormat, detectOpenAIFormat, mapOpenAIMessages } from "./openai";
+export {
+  openinferenceFormat,
+  detectOpenInferenceFormat,
+  mapOpenInferenceMessages,
+  combineOpenInferenceMessages,
+} from "./openinference";
 export { getFormat, getAllFormats } from "./registry";

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/index.ts
@@ -1,8 +1,0 @@
-export { openaiFormat, detectOpenAIFormat, mapOpenAIMessages } from "./openai";
-export {
-  openinferenceFormat,
-  detectOpenInferenceFormat,
-  mapOpenInferenceMessages,
-  combineOpenInferenceMessages,
-} from "./openinference";
-export { getFormat, getAllFormats } from "./registry";

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openai/mapper.ts
@@ -1,3 +1,4 @@
+import { MessageUsage } from "../../../usage";
 import PrettyLLMMessage from "@/shared/PrettyLLMMessage";
 import {
   FormatMapper,
@@ -84,11 +85,7 @@ interface OpenAIInputData {
 
 interface OpenAIOutputData {
   choices: OpenAIChoice[];
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
+  usage?: MessageUsage;
 }
 
 interface OpenAICustomInputFormat {
@@ -97,11 +94,7 @@ interface OpenAICustomInputFormat {
 
 interface OpenAICustomOutputFormat {
   text: string;
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
+  usage?: MessageUsage;
   finish_reason?: string;
 }
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { detectLLMMessages } from "../../detectLLMMessages";
+import { detectOpenInferenceFormat } from "./detector";
+
+describe("detectOpenInferenceFormat", () => {
+  it("detects historical flattened attributes without a hint", () => {
+    expect(
+      detectOpenInferenceFormat(
+        {
+          "openinference.span.kind": "LLM",
+          "llm.input_messages.0.message.role": "user",
+        },
+        { fieldType: "input" },
+      ),
+    ).toBe(true);
+  });
+
+  it("detects a historical legacy function call without a marker", () => {
+    expect(
+      detectOpenInferenceFormat(
+        { "llm.function_call": '{"name":"weather"}' },
+        { fieldType: "output" },
+      ),
+    ).toBe(true);
+  });
+
+  it("uses a marker-derived hint for the canonical shape", () => {
+    expect(
+      detectLLMMessages(
+        { messages: [{ role: "human", content: "hello" }] },
+        { fieldType: "input" },
+        "openinference",
+      ),
+    ).toMatchObject({
+      supported: true,
+      format: "openinference",
+      confidence: "high",
+    });
+  });
+
+  it("does not accept an arbitrary raw value just because it is hinted", () => {
+    expect(
+      detectOpenInferenceFormat(
+        { value: "not enough to identify OpenInference" },
+        { fieldType: "input", formatHint: "openinference" },
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects canonical-looking data without a marker-derived hint", () => {
+    expect(
+      detectOpenInferenceFormat(
+        { messages: [{ role: "user", content: "hello" }] },
+        { fieldType: "input" },
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectLLMMessages } from "../../detectLLMMessages";
+import { canShowLLMMessages, detectLLMMessages } from "../../detectLLMMessages";
 import { detectOpenInferenceFormat } from "./detector";
 
 describe("detectOpenInferenceFormat", () => {
@@ -9,6 +9,7 @@ describe("detectOpenInferenceFormat", () => {
         {
           "openinference.span.kind": "LLM",
           "llm.input_messages.0.message.role": "user",
+          "llm.input_messages.0.message.content": "Hello",
         },
         { fieldType: "input" },
       ),
@@ -45,6 +46,73 @@ describe("detectOpenInferenceFormat", () => {
         { fieldType: "input", formatHint: "openinference" },
       ),
     ).toBe(false);
+  });
+
+  it("accepts raw-only data when the hint comes from an exact marker", () => {
+    expect(
+      detectOpenInferenceFormat("raw OpenInference input", {
+        fieldType: "input",
+        formatHint: "openinference",
+        formatHintIsAuthoritative: true,
+      }),
+    ).toBe(true);
+    expect(
+      detectOpenInferenceFormat(
+        { value: "raw OpenInference output" },
+        {
+          fieldType: "output",
+          formatHint: "openinference",
+          formatHintIsAuthoritative: true,
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("prefers a provider-specific shape over an authoritative raw fallback", () => {
+    const output = detectLLMMessages(
+      {
+        id: "chatcmpl-1",
+        model: "provider-model",
+        choices: [
+          { message: { role: "assistant", content: "Provider answer" } },
+        ],
+        usage: { total_tokens: 7 },
+      },
+      { fieldType: "output", formatHintIsAuthoritative: true },
+      "openinference",
+    );
+
+    expect(output).toMatchObject({
+      supported: true,
+      format: "openai",
+      confidence: "medium",
+    });
+    expect(
+      canShowLLMMessages({ supported: false, empty: true }, output, true),
+    ).toBe(true);
+  });
+
+  it("does not expose Messages for an authoritative marker without renderable fields", () => {
+    expect(
+      canShowLLMMessages(
+        { supported: false, empty: true },
+        { supported: false, empty: true },
+        true,
+      ),
+    ).toBe(false);
+  });
+
+  it.each([
+    { "openinference.span.kind": "LLM" },
+    { "llm.finish_reason": "stop" },
+    { "llm.output_messages.bad.message.role": "assistant" },
+    {
+      "llm.output_messages.0.message.tool_calls.0.tool_call.id": "only-id",
+    },
+  ])("does not expose Messages for non-renderable legacy data", (value) => {
+    expect(detectOpenInferenceFormat(value, { fieldType: "output" })).toBe(
+      false,
+    );
   });
 
   it("rejects canonical-looking data without a marker-derived hint", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
@@ -102,6 +102,25 @@ describe("detectOpenInferenceFormat", () => {
     ).toBe(false);
   });
 
+  it("does not treat canonical configuration fields as raw messages", () => {
+    expect(
+      detectOpenInferenceFormat(
+        {
+          invocation_parameters: { temperature: 0.2 },
+          prompt_template: {
+            template: "Answer {{question}}",
+            variables: { question: "Why?" },
+          },
+        },
+        {
+          fieldType: "input",
+          formatHint: "openinference",
+          formatHintIsAuthoritative: true,
+        },
+      ),
+    ).toBe(false);
+  });
+
   it.each([
     { "openinference.span.kind": "LLM" },
     { "llm.finish_reason": "stop" },

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.test.ts
@@ -29,8 +29,7 @@ describe("detectOpenInferenceFormat", () => {
     expect(
       detectLLMMessages(
         { messages: [{ role: "human", content: "hello" }] },
-        { fieldType: "input" },
-        "openinference",
+        { fieldType: "input", formatHint: "openinference" },
       ),
     ).toMatchObject({
       supported: true,
@@ -78,8 +77,11 @@ describe("detectOpenInferenceFormat", () => {
         ],
         usage: { total_tokens: 7 },
       },
-      { fieldType: "output", formatHintIsAuthoritative: true },
-      "openinference",
+      {
+        fieldType: "output",
+        formatHintIsAuthoritative: true,
+        formatHint: "openinference",
+      },
     );
 
     expect(output).toMatchObject({
@@ -95,8 +97,22 @@ describe("detectOpenInferenceFormat", () => {
   it("does not expose Messages for an authoritative marker without renderable fields", () => {
     expect(
       canShowLLMMessages(
-        { supported: false, empty: true },
-        { supported: false, empty: true },
+        detectLLMMessages(
+          { "openinference.span.kind": "LLM" },
+          {
+            fieldType: "input",
+            formatHint: "openinference",
+            formatHintIsAuthoritative: true,
+          },
+        ),
+        detectLLMMessages(
+          { "openinference.span.kind": "LLM" },
+          {
+            fieldType: "output",
+            formatHint: "openinference",
+            formatHintIsAuthoritative: true,
+          },
+        ),
         true,
       ),
     ).toBe(false);

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.ts
@@ -12,5 +12,6 @@ export const detectOpenInferenceFormat: FormatDetector = (
     data,
     fieldType,
     prettifyConfig?.formatHint === "openinference",
+    prettifyConfig?.formatHintIsAuthoritative,
   );
 };

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/detector.ts
@@ -1,0 +1,16 @@
+import { isOpenInferenceField } from "@/lib/openinference";
+import { FormatDetector } from "../../types";
+
+export const detectOpenInferenceFormat: FormatDetector = (
+  data,
+  prettifyConfig,
+) => {
+  const fieldType = prettifyConfig?.fieldType;
+  if (!fieldType) return false;
+
+  return isOpenInferenceField(
+    data,
+    fieldType,
+    prettifyConfig?.formatHint === "openinference",
+  );
+};

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/index.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/index.ts
@@ -1,0 +1,19 @@
+import { LLMMessageFormatImplementation } from "../../types";
+import { detectOpenInferenceFormat } from "./detector";
+import {
+  combineOpenInferenceMessages,
+  mapOpenInferenceMessages,
+} from "./mapper";
+
+export const openinferenceFormat: LLMMessageFormatImplementation = {
+  name: "openinference",
+  detector: detectOpenInferenceFormat,
+  mapper: mapOpenInferenceMessages,
+  combiner: combineOpenInferenceMessages,
+};
+
+export {
+  combineOpenInferenceMessages,
+  detectOpenInferenceFormat,
+  mapOpenInferenceMessages,
+};

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
@@ -54,10 +54,13 @@ describe("OpenInference message mapping", () => {
       finish_reason: "tool_calls",
     };
 
-    const result = mapAndCombineMessages(input, output, "openinference", {
-      prompt_tokens: 12,
-      completion_tokens: 4,
-      total_tokens: 16,
+    const result = mapAndCombineMessages(input, output, {
+      formatHint: "openinference",
+      spanUsage: {
+        prompt_tokens: 12,
+        completion_tokens: 4,
+        total_tokens: 16,
+      },
     });
 
     expect(result.messages.map((message) => message.role)).toEqual([
@@ -151,11 +154,9 @@ describe("OpenInference message mapping", () => {
       mime_type: "application/json",
     };
 
-    const result = mapAndCombineMessages(
-      legacyInput,
-      legacyOutput,
-      "openinference",
-    );
+    const result = mapAndCombineMessages(legacyInput, legacyOutput, {
+      formatHint: "openinference",
+    });
 
     expect(result.messages).toHaveLength(2);
     expect(result.messages[0]).toMatchObject({
@@ -187,13 +188,36 @@ describe("OpenInference message mapping", () => {
         "llm.input_messages.0.message.content": "Hello",
       },
       { value: "Raw answer", mime_type: "text/plain" },
-      "openinference",
+      { formatHint: "openinference" },
     );
 
     expect(result.messages).toHaveLength(2);
     expect(result.messages[1].id).toBe("openinference-output-fallback-0");
     expect(result.messages[1].blocks[0].props).toMatchObject({
       children: "Raw answer",
+    });
+  });
+
+  it("renders unwrapped raw objects when an exact span marker supplied the hint", () => {
+    const result = mapAndCombineMessages(
+      { request_id: "request-7" },
+      { response_id: "response-7" },
+      {
+        formatHint: "openinference",
+        formatHintIsAuthoritative: true,
+      },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({
+      id: "openinference-input-fallback-0",
+      role: "user",
+      blocks: [{ blockType: "code", props: { label: "Input" } }],
+    });
+    expect(result.messages[1]).toMatchObject({
+      id: "openinference-output-fallback-0",
+      role: "assistant",
+      blocks: [{ blockType: "code", props: { label: "Output" } }],
     });
   });
 
@@ -215,5 +239,212 @@ describe("OpenInference message mapping", () => {
       { fieldType: "output", formatHint: "openinference" },
     );
     expect(result.messages[0].role).toBe("assistant");
+  });
+
+  it("uses raw fallback when partial semantic messages have no renderable blocks", () => {
+    const result = combineOpenInferenceMessages(
+      {
+        raw: { messages: [{ role: "user" }], value: "Raw question" },
+        mapped: { messages: [] },
+      },
+      {
+        raw: { messages: [{ role: "assistant" }], value: "Raw answer" },
+        mapped: { messages: [] },
+      },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({
+      id: "openinference-input-fallback-0",
+      role: "user",
+    });
+    expect(result.messages[0].blocks[0].props).toMatchObject({
+      children: "Raw question",
+    });
+    expect(result.messages[1]).toMatchObject({
+      id: "openinference-output-fallback-0",
+      role: "assistant",
+    });
+    expect(result.messages[1].blocks[0].props).toMatchObject({
+      children: "Raw answer",
+    });
+  });
+
+  it("keeps distinct tool calls that share a function and arguments", () => {
+    const result = mapOpenInferenceMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            contents: [
+              {
+                type: "tool_use",
+                tool_call: {
+                  id: "ordered-call",
+                  function: { name: "weather", arguments: '{"city":"Paris"}' },
+                },
+              },
+            ],
+            tool_calls: [
+              {
+                id: "separate-call",
+                function: { name: "weather", arguments: '{"city":"Paris"}' },
+              },
+            ],
+          },
+        ],
+      },
+      { fieldType: "output", formatHint: "openinference" },
+    );
+
+    expect(
+      result.messages[0].blocks.filter((block) => block.blockType === "code"),
+    ).toHaveLength(2);
+  });
+
+  it("matches each ordered tool use to at most one message-level tool call", () => {
+    const result = mapOpenInferenceMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            contents: [
+              {
+                type: "tool_use",
+                tool_call: {
+                  function: {
+                    name: "weather",
+                    arguments: '{"city":"Paris"}',
+                  },
+                },
+              },
+            ],
+            tool_calls: [
+              {
+                id: "call-1",
+                function: {
+                  name: "weather",
+                  arguments: '{"city":"Paris"}',
+                },
+              },
+              {
+                id: "call-2",
+                function: {
+                  name: "weather",
+                  arguments: '{"city":"Paris"}',
+                },
+              },
+            ],
+          },
+        ],
+      },
+      { fieldType: "output", formatHint: "openinference" },
+    );
+
+    expect(
+      result.messages[0].blocks.filter((block) => block.blockType === "code"),
+    ).toHaveLength(2);
+  });
+
+  it("uses raw fallback instead of rendering an id-only tool call", () => {
+    const result = mapOpenInferenceMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            tool_calls: [{ id: "only-id" }],
+          },
+        ],
+        value: "Raw answer",
+      },
+      { fieldType: "output", formatHint: "openinference" },
+    );
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]).toMatchObject({
+      id: "openinference-output-fallback-0",
+      blocks: [{ blockType: "text", props: { children: "Raw answer" } }],
+    });
+  });
+
+  it("rejects unsafe media URLs while preserving safe media and transcripts", () => {
+    const result = mapOpenInferenceMessages(
+      {
+        messages: [
+          {
+            role: "assistant",
+            contents: [
+              { type: "image", image: { url: "javascript:alert(1)" } },
+              {
+                type: "image",
+                image: { url: "https://example.test/image.png" },
+              },
+              { type: "image", image: { url: "data:text/html,<script />" } },
+              { type: "image", image: { url: "data:image/png;base64,AA==" } },
+              {
+                type: "audio",
+                audio: {
+                  url: "custom:unsafe",
+                  transcript: "Transcript remains visible",
+                },
+              },
+              {
+                type: "audio",
+                audio: { url: "data:audio/wav;base64,AA==" },
+              },
+            ],
+          },
+        ],
+      },
+      { fieldType: "output", formatHint: "openinference" },
+    );
+
+    expect(result.messages[0].blocks.map((block) => block.blockType)).toEqual([
+      "image",
+      "image",
+      "text",
+      "audio",
+    ]);
+    expect(result.messages[0].blocks).toMatchObject([
+      {
+        blockType: "image",
+        props: { images: [{ url: "https://example.test/image.png" }] },
+      },
+      {
+        blockType: "image",
+        props: { images: [{ url: "data:image/png;base64,AA==" }] },
+      },
+      { blockType: "text" },
+      {
+        blockType: "audio",
+        props: { audios: [{ url: "data:audio/wav;base64,AA==" }] },
+      },
+    ]);
+  });
+
+  it("preserves a separately detected OpenAI output", () => {
+    const result = mapAndCombineMessages(
+      {
+        "openinference.span.kind": "LLM",
+        "llm.input_messages.0.message.role": "user",
+        "llm.input_messages.0.message.content": "Question",
+      },
+      {
+        id: "chatcmpl-1",
+        model: "provider-model",
+        choices: [{ message: { role: "assistant", content: "OpenAI answer" } }],
+        usage: { total_tokens: 7 },
+      },
+      {
+        formatHint: "openinference",
+        formatHintIsAuthoritative: true,
+      },
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1]).toMatchObject({ role: "assistant" });
+    expect(result.messages[1].blocks[0].props).toMatchObject({
+      children: "OpenAI answer",
+    });
   });
 });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
@@ -6,6 +6,119 @@ import {
 } from "./mapper";
 
 describe("OpenInference message mapping", () => {
+  it.each(["canonical", "legacy", "both"])(
+    "preserves repeated turns in %s messages",
+    (representation) => {
+      const messages = [
+        { role: "user", content: "Continue" },
+        { role: "assistant", content: "First answer" },
+        { role: "user", content: "Continue" },
+      ];
+      const legacy = Object.fromEntries(
+        messages.flatMap((message, index) => [
+          [`llm.input_messages.${index}.message.role`, message.role],
+          [`llm.input_messages.${index}.message.content`, message.content],
+        ]),
+      );
+      const input = {
+        ...(representation !== "legacy" && { messages }),
+        ...(representation !== "canonical" && legacy),
+      };
+
+      const result = mapAndCombineMessages(input, undefined, {
+        formatHint: "openinference",
+      });
+
+      expect(result.messages).toMatchObject(
+        messages.map(({ role, content }) => ({
+          role,
+          blocks: [{ blockType: "text", props: { children: content } }],
+        })),
+      );
+    },
+  );
+
+  it("preserves repeated completion choices", () => {
+    const result = mapAndCombineMessages(
+      undefined,
+      {
+        choices: [{ text: "Same answer" }, { text: "Same answer" }],
+      },
+      { formatHint: "openinference" },
+    );
+
+    expect(result.messages).toMatchObject([
+      { blocks: [{ blockType: "text", props: { children: "Same answer" } }] },
+      { blocks: [{ blockType: "text", props: { children: "Same answer" } }] },
+    ]);
+  });
+
+  it.each([
+    ["image", "png", "images"],
+    ["audio", "wav", "audios"],
+  ])(
+    "passes backend %s placeholders to the media resolver",
+    (type, extension, prop) => {
+      const url = `[output-attachment-1-1768916401606.${extension}]`;
+      const result = mapAndCombineMessages(
+        undefined,
+        {
+          messages: [
+            {
+              role: "assistant",
+              contents: [{ type, [type]: { url } }],
+            },
+          ],
+        },
+        { formatHint: "openinference", formatHintIsAuthoritative: true },
+      );
+
+      expect(result.messages).toMatchObject([
+        {
+          role: "assistant",
+          blocks: [{ blockType: type, props: { [prop]: [{ url }] } }],
+        },
+      ]);
+    },
+  );
+
+  it("does not render a null function call", () => {
+    const result = mapAndCombineMessages(
+      undefined,
+      {
+        messages: [
+          { role: "assistant", content: "Answer", function_call: null },
+        ],
+      },
+      { formatHint: "openinference" },
+    );
+
+    expect(result.messages[0].blocks).toMatchObject([
+      { blockType: "text", props: { children: "Answer" } },
+    ]);
+  });
+
+  it.each([{}, { completion_tokens: 5 }])(
+    "retains provider usage when span usage is incomplete: %j",
+    (spanUsage) => {
+      const result = mapAndCombineMessages(
+        { messages: [{ role: "user", content: "Question" }] },
+        {
+          choices: [{ message: { role: "assistant", content: "Answer" } }],
+          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
+        },
+        { spanUsage },
+      );
+
+      expect(result.usage).toEqual({
+        prompt_tokens: 3,
+        completion_tokens: 4,
+        total_tokens: 7,
+        ...spanUsage,
+      });
+    },
+  );
+
   it("maps canonical chat, roles, tools, usage and ordered multimodal content", () => {
     const toolCall = {
       id: "call-1",
@@ -270,7 +383,15 @@ describe("OpenInference message mapping", () => {
     });
   });
 
-  it("keeps distinct tool calls that share a function and arguments", () => {
+  it.each([
+    { name: "distinct ids", orderedId: "ordered-call", ids: ["separate-call"] },
+    {
+      name: "one match per ordered call",
+      orderedId: undefined,
+      ids: ["call-1", "call-2"],
+    },
+  ])("preserves distinct tool calls: $name", ({ orderedId, ids }) => {
+    const fn = { name: "weather", arguments: '{"city":"Paris"}' };
     const result = mapOpenInferenceMessages(
       {
         messages: [
@@ -280,61 +401,12 @@ describe("OpenInference message mapping", () => {
               {
                 type: "tool_use",
                 tool_call: {
-                  id: "ordered-call",
-                  function: { name: "weather", arguments: '{"city":"Paris"}' },
+                  id: orderedId,
+                  function: fn,
                 },
               },
             ],
-            tool_calls: [
-              {
-                id: "separate-call",
-                function: { name: "weather", arguments: '{"city":"Paris"}' },
-              },
-            ],
-          },
-        ],
-      },
-      { fieldType: "output", formatHint: "openinference" },
-    );
-
-    expect(
-      result.messages[0].blocks.filter((block) => block.blockType === "code"),
-    ).toHaveLength(2);
-  });
-
-  it("matches each ordered tool use to at most one message-level tool call", () => {
-    const result = mapOpenInferenceMessages(
-      {
-        messages: [
-          {
-            role: "assistant",
-            contents: [
-              {
-                type: "tool_use",
-                tool_call: {
-                  function: {
-                    name: "weather",
-                    arguments: '{"city":"Paris"}',
-                  },
-                },
-              },
-            ],
-            tool_calls: [
-              {
-                id: "call-1",
-                function: {
-                  name: "weather",
-                  arguments: '{"city":"Paris"}',
-                },
-              },
-              {
-                id: "call-2",
-                function: {
-                  name: "weather",
-                  arguments: '{"city":"Paris"}',
-                },
-              },
-            ],
+            tool_calls: ids.map((id) => ({ id, function: fn })),
           },
         ],
       },
@@ -365,6 +437,25 @@ describe("OpenInference message mapping", () => {
       id: "openinference-output-fallback-0",
       blocks: [{ blockType: "text", props: { children: "Raw answer" } }],
     });
+  });
+
+  it("does not synthesize a user message from canonical configuration", () => {
+    const result = mapOpenInferenceMessages(
+      {
+        invocation_parameters: { temperature: 0.2 },
+        prompt_template: {
+          template: "Answer {{question}}",
+          variables: { question: "Why?" },
+        },
+      },
+      {
+        fieldType: "input",
+        formatHint: "openinference",
+        formatHintIsAuthoritative: true,
+      },
+    );
+
+    expect(result.messages).toEqual([]);
   });
 
   it("rejects unsafe media URLs while preserving safe media and transcripts", () => {

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+import { mapAndCombineMessages } from "../../mapAndCombineMessages";
+import {
+  combineOpenInferenceMessages,
+  mapOpenInferenceMessages,
+} from "./mapper";
+
+describe("OpenInference message mapping", () => {
+  it("maps canonical chat, roles, tools, usage and ordered multimodal content", () => {
+    const toolCall = {
+      id: "call-1",
+      function: { name: "weather", arguments: '{"city":"Paris"}' },
+      reasoning_signature: "opaque-tool-signature",
+    };
+    const input = {
+      messages: [
+        { role: "developer", content: "Be concise" },
+        { role: "human", content: "What is the weather?" },
+      ],
+      prompts: [{ text: "Weather for Paris" }],
+      tools: [{ name: "weather", json_schema: { type: "object" } }],
+    };
+    const output = {
+      messages: [
+        {
+          role: "model",
+          contents: [
+            {
+              type: "reasoning",
+              text: "I should call the tool",
+              encrypted_content: "kept-in-details",
+            },
+            { type: "text", text: "Checking now." },
+            { type: "image", image: { url: "[image_0]" } },
+            {
+              type: "audio",
+              audio: {
+                url: "https://example.test/answer.wav",
+                mime_type: "audio/wav",
+                transcript: "Checking now",
+              },
+            },
+            {
+              type: "tool_use",
+              tool_call: {
+                function: toolCall.function,
+                reasoning_signature: toolCall.reasoning_signature,
+              },
+            },
+          ],
+          tool_calls: [toolCall],
+        },
+      ],
+      finish_reason: "tool_calls",
+    };
+
+    const result = mapAndCombineMessages(input, output, "openinference", {
+      prompt_tokens: 12,
+      completion_tokens: 4,
+      total_tokens: 16,
+    });
+
+    expect(result.messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+      "user",
+      "system",
+      "assistant",
+    ]);
+    const outputMessage = result.messages.at(-1)!;
+    expect(outputMessage.blocks.map((block) => block.blockType)).toEqual([
+      "text",
+      "text",
+      "image",
+      "audio",
+      "text",
+      "code",
+    ]);
+    expect(
+      outputMessage.blocks.filter((block) => block.blockType === "code"),
+    ).toHaveLength(1);
+    expect(outputMessage.finishReason).toBe("tool_calls");
+    expect(result.usage).toEqual({
+      prompt_tokens: 12,
+      completion_tokens: 4,
+      total_tokens: 16,
+    });
+  });
+
+  it("maps completion prompts, choices and a legacy function call", () => {
+    const result = combineOpenInferenceMessages(
+      {
+        raw: {
+          prompts: [{ text: "Complete me" }],
+          tools: [
+            {
+              json_schema: {
+                type: "function",
+                function: { name: "calculator", description: "Calculate" },
+              },
+            },
+          ],
+        },
+        mapped: { messages: [] },
+      },
+      {
+        raw: {
+          choices: [{ text: "Completed" }],
+          function_call: { name: "calculator", arguments: { x: 2 } },
+          finish_reason: "stop",
+        },
+        mapped: { messages: [] },
+      },
+    );
+
+    expect(result.messages.map((message) => message.label)).toEqual([
+      "Prompt",
+      "Available tools",
+      "Completion",
+    ]);
+    expect(result.messages[1].blocks[0].props).toMatchObject({
+      label: "calculator",
+    });
+    expect(result.messages.at(-1)?.finishReason).toBe("stop");
+  });
+
+  it("restores the exact historical storage shape and removes raw output duplication", () => {
+    const legacyInput = {
+      "openinference.span.kind": "LLM",
+      value: { prompt: "raw request" },
+      mime_type: "application/json",
+      "llm.input_messages.3.message.role": "human",
+      "llm.input_messages.3.message.content": "Hello",
+      "llm.output_messages.8.message.role": "model",
+      "llm.output_messages.8.message.content": "Semantic answer",
+      "llm.output_messages.8.message.tool_calls.4.tool_call.id": "call-4",
+      "llm.output_messages.8.message.tool_calls.4.tool_call.function.name":
+        "search",
+      "llm.output_messages.8.message.tool_calls.4.tool_call.function.arguments":
+        {
+          query: "Opik",
+        },
+      "llm.finish_reason": "stop",
+    };
+    const legacyOutput = {
+      value: {
+        choices: [
+          { message: { role: "assistant", content: "Semantic answer" } },
+        ],
+      },
+      mime_type: "application/json",
+    };
+
+    const result = mapAndCombineMessages(
+      legacyInput,
+      legacyOutput,
+      "openinference",
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[0]).toMatchObject({
+      id: "openinference-input-0",
+      role: "user",
+    });
+    expect(result.messages[1]).toMatchObject({
+      id: "openinference-output-0",
+      role: "assistant",
+      finishReason: "stop",
+    });
+    expect(
+      result.messages.some((message) => message.id.includes("fallback")),
+    ).toBe(false);
+    const code = result.messages[1].blocks.find(
+      (block) => block.blockType === "code",
+    );
+    expect(code?.props).toMatchObject({
+      label: "search",
+      code: '{\n  "query": "Opik"\n}',
+    });
+  });
+
+  it("uses old value/mime_type as raw fallback when no semantic output exists", () => {
+    const result = mapAndCombineMessages(
+      {
+        "openinference.span.kind": "LLM",
+        "llm.input_messages.0.message.role": "user",
+        "llm.input_messages.0.message.content": "Hello",
+      },
+      { value: "Raw answer", mime_type: "text/plain" },
+      "openinference",
+    );
+
+    expect(result.messages).toHaveLength(2);
+    expect(result.messages[1].id).toBe("openinference-output-fallback-0");
+    expect(result.messages[1].blocks[0].props).toMatchObject({
+      children: "Raw answer",
+    });
+  });
+
+  it("handles malformed and partial messages without throwing", () => {
+    expect(() =>
+      mapOpenInferenceMessages(
+        {
+          messages: [
+            { role: 42, contents: [{ type: "image", image: {} }] },
+            { role: "unknown-role", contents: [null, { type: "text" }] },
+          ],
+        },
+        { fieldType: "output", formatHint: "openinference" },
+      ),
+    ).not.toThrow();
+
+    const result = mapOpenInferenceMessages(
+      { messages: [{ role: "unknown-role", content: "safe" }] },
+      { fieldType: "output", formatHint: "openinference" },
+    );
+    expect(result.messages[0].role).toBe("assistant");
+  });
+});

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
@@ -6,6 +6,76 @@ import {
 } from "./mapper";
 
 describe("OpenInference message mapping", () => {
+  it.each([
+    { messages: [{ role: "assistant", content: "Current" }] },
+    { choices: [{ text: "Current" }] },
+  ])("prefers current semantic output over historical output: %j", (output) => {
+    const result = mapAndCombineMessages(
+      {
+        "llm.output_messages.0.message.content": "Stale",
+        "llm.choices.0.completion.text": "Stale completion",
+        "llm.function_call": '{"name":"stale_call"}',
+        "llm.finish_reason": "length",
+      },
+      output,
+      { formatHint: "openinference" },
+    );
+
+    expect(result.messages).toMatchObject([
+      { blocks: [{ blockType: "text", props: { children: "Current" } }] },
+    ]);
+    expect(result.messages[0].blocks).toHaveLength(1);
+    expect(result.messages[0].finishReason).toBeUndefined();
+  });
+
+  it("keeps scalar content alongside ordered content and tool calls", () => {
+    const result = mapAndCombineMessages(
+      undefined,
+      {
+        messages: [
+          {
+            role: "assistant",
+            content: "Scalar",
+            contents: [
+              { type: "text", text: "Block" },
+              {
+                type: "tool_use",
+                tool_call: {
+                  id: "call-1",
+                  function: { name: "search", arguments: "{}" },
+                },
+              },
+            ],
+            tool_calls: [
+              { id: "call-1", function: { name: "search", arguments: "{}" } },
+            ],
+          },
+        ],
+      },
+      { formatHint: "openinference" },
+    );
+
+    expect(result.messages[0].blocks).toMatchObject([
+      { blockType: "text", props: { children: "Scalar" } },
+      { blockType: "text", props: { children: "Block" } },
+      { blockType: "code", props: { label: "search" } },
+    ]);
+  });
+
+  it.each([{}, { completion_tokens: undefined }, { completion_tokens: NaN }])(
+    "does not create usage from absent or invalid values: %j",
+    (spanUsage) => {
+      const result = mapAndCombineMessages(
+        undefined,
+        {
+          messages: [{ role: "assistant", content: "Answer" }],
+        },
+        { formatHint: "openinference", spanUsage },
+      );
+      expect(result.usage).toBeUndefined();
+    },
+  );
+
   it.each(["canonical", "legacy", "both"])(
     "preserves repeated turns in %s messages",
     (representation) => {
@@ -519,6 +589,9 @@ describe("OpenInference message mapping", () => {
         "openinference.span.kind": "LLM",
         "llm.input_messages.0.message.role": "user",
         "llm.input_messages.0.message.content": "Question",
+        "llm.output_messages.0.message.content": "Stale answer",
+        "llm.function_call": '{"name":"stale_call"}',
+        "llm.finish_reason": "length",
       },
       {
         id: "chatcmpl-1",
@@ -537,5 +610,7 @@ describe("OpenInference message mapping", () => {
     expect(result.messages[1].blocks[0].props).toMatchObject({
       children: "OpenAI answer",
     });
+    expect(result.messages[1].blocks).toHaveLength(1);
+    expect(result.messages[1].finishReason).toBeUndefined();
   });
 });

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.test.ts
@@ -168,27 +168,6 @@ describe("OpenInference message mapping", () => {
     ]);
   });
 
-  it.each([{}, { completion_tokens: 5 }])(
-    "retains provider usage when span usage is incomplete: %j",
-    (spanUsage) => {
-      const result = mapAndCombineMessages(
-        { messages: [{ role: "user", content: "Question" }] },
-        {
-          choices: [{ message: { role: "assistant", content: "Answer" } }],
-          usage: { prompt_tokens: 3, completion_tokens: 4, total_tokens: 7 },
-        },
-        { spanUsage },
-      );
-
-      expect(result.usage).toEqual({
-        prompt_tokens: 3,
-        completion_tokens: 4,
-        total_tokens: 7,
-        ...spanUsage,
-      });
-    },
-  );
-
   it("maps canonical chat, roles, tools, usage and ordered multimodal content", () => {
     const toolCall = {
       id: "call-1",
@@ -405,7 +384,7 @@ describe("OpenInference message mapping", () => {
   });
 
   it("handles malformed and partial messages without throwing", () => {
-    expect(() =>
+    expect(
       mapOpenInferenceMessages(
         {
           messages: [
@@ -413,13 +392,13 @@ describe("OpenInference message mapping", () => {
             { role: "unknown-role", contents: [null, { type: "text" }] },
           ],
         },
-        { fieldType: "output", formatHint: "openinference" },
-      ),
-    ).not.toThrow();
+        { fieldType: "output" },
+      ).messages,
+    ).toEqual([]);
 
     const result = mapOpenInferenceMessages(
       { messages: [{ role: "unknown-role", content: "safe" }] },
-      { fieldType: "output", formatHint: "openinference" },
+      { fieldType: "output" },
     );
     expect(result.messages[0].role).toBe("assistant");
   });
@@ -480,7 +459,7 @@ describe("OpenInference message mapping", () => {
           },
         ],
       },
-      { fieldType: "output", formatHint: "openinference" },
+      { fieldType: "output" },
     );
 
     expect(
@@ -499,7 +478,7 @@ describe("OpenInference message mapping", () => {
         ],
         value: "Raw answer",
       },
-      { fieldType: "output", formatHint: "openinference" },
+      { fieldType: "output" },
     );
 
     expect(result.messages).toHaveLength(1);
@@ -520,8 +499,6 @@ describe("OpenInference message mapping", () => {
       },
       {
         fieldType: "input",
-        formatHint: "openinference",
-        formatHintIsAuthoritative: true,
       },
     );
 
@@ -557,7 +534,7 @@ describe("OpenInference message mapping", () => {
           },
         ],
       },
-      { fieldType: "output", formatHint: "openinference" },
+      { fieldType: "output" },
     );
 
     expect(result.messages[0].blocks.map((block) => block.blockType)).toEqual([

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
@@ -1,0 +1,342 @@
+import {
+  OpenInferenceContent,
+  OpenInferenceMessage,
+  OpenInferenceToolCall,
+  parseOpenInferenceFields,
+  ParsedOpenInferenceFields,
+} from "@/lib/openinference";
+import PrettyLLMMessage from "@/shared/PrettyLLMMessage";
+import { MessageRole } from "@/shared/PrettyLLMMessage/types";
+import {
+  FormatCombiner,
+  FormatMapper,
+  LLMBlockDescriptor,
+  LLMMessageDescriptor,
+  LLMMapperResult,
+} from "../../types";
+import { isPlaceholder } from "../../utils";
+
+const normalizeRole = (
+  role: string | undefined,
+  fieldType: "input" | "output",
+): MessageRole => {
+  switch (role?.toLowerCase()) {
+    case "assistant":
+    case "model":
+    case "ai":
+    case "agent":
+      return "assistant";
+    case "system":
+    case "developer":
+      return "system";
+    case "tool":
+    case "function":
+      return "tool";
+    case "user":
+    case "human":
+      return "user";
+    default:
+      return fieldType === "output" ? "assistant" : "user";
+  }
+};
+
+const formatCode = (value: unknown): string => {
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+};
+
+const mediaName = (
+  url: string,
+  type: "Image" | "Audio",
+  index: number,
+): string => {
+  if (isPlaceholder(url) || url.startsWith("data:")) {
+    return isPlaceholder(url) ? url : `${type} ${index + 1}`;
+  }
+  try {
+    return new URL(url).pathname.split("/").pop() || `${type} ${index + 1}`;
+  } catch {
+    return `${type} ${index + 1}`;
+  }
+};
+
+const textBlock = (text: string, role: MessageRole): LLMBlockDescriptor => ({
+  blockType: "text",
+  component: PrettyLLMMessage.TextBlock,
+  props: { children: text, role, showMoreButton: true },
+});
+
+const codeBlock = (value: unknown, label: string): LLMBlockDescriptor => ({
+  blockType: "code",
+  component: PrettyLLMMessage.CodeBlock,
+  props: { code: formatCode(value), label },
+});
+
+const toolCallFingerprints = (toolCall: OpenInferenceToolCall): string[] => {
+  const fingerprints: string[] = [];
+  if (toolCall.id) fingerprints.push(`id:${toolCall.id}`);
+  if (toolCall.function?.name || toolCall.function?.arguments) {
+    fingerprints.push(
+      `function:${toolCall.function?.name ?? ""}:${
+        toolCall.function?.arguments ?? ""
+      }`,
+    );
+  }
+  if (toolCall.reasoning_signature) {
+    fingerprints.push(`reasoning:${toolCall.reasoning_signature}`);
+  }
+  return fingerprints;
+};
+
+const toolCallBlock = (toolCall: OpenInferenceToolCall): LLMBlockDescriptor =>
+  codeBlock(
+    toolCall.function?.arguments ?? "",
+    toolCall.function?.name ?? "Tool call",
+  );
+
+const contentBlocks = (
+  contents: OpenInferenceContent[],
+  role: MessageRole,
+): { blocks: LLMBlockDescriptor[]; orderedToolCalls: Set<string> } => {
+  const blocks: LLMBlockDescriptor[] = [];
+  const orderedToolCalls = new Set<string>();
+
+  contents.forEach((content, index) => {
+    switch (content.type) {
+      case "image": {
+        const url = content.image?.url;
+        if (url) {
+          blocks.push({
+            blockType: "image",
+            component: PrettyLLMMessage.ImageBlock,
+            props: { images: [{ url, name: mediaName(url, "Image", index) }] },
+          });
+        }
+        break;
+      }
+      case "audio": {
+        const url = content.audio?.url;
+        if (url) {
+          blocks.push({
+            blockType: "audio",
+            component: PrettyLLMMessage.AudioPlayerBlock,
+            props: { audios: [{ url, name: mediaName(url, "Audio", index) }] },
+          });
+        }
+        if (content.audio?.transcript) {
+          blocks.push(textBlock(content.audio.transcript, role));
+        }
+        break;
+      }
+      case "tool_use": {
+        if (content.tool_call) {
+          toolCallFingerprints(content.tool_call).forEach((fingerprint) =>
+            orderedToolCalls.add(fingerprint),
+          );
+          blocks.push(toolCallBlock(content.tool_call));
+        }
+        break;
+      }
+      case "reasoning":
+      case "text":
+      default:
+        if (content.text) blocks.push(textBlock(content.text, role));
+    }
+  });
+
+  return { blocks, orderedToolCalls };
+};
+
+const mapMessage = (
+  message: OpenInferenceMessage,
+  index: number,
+  fieldType: "input" | "output",
+): LLMMessageDescriptor => {
+  const role = normalizeRole(message.role, fieldType);
+  const blocks: LLMBlockDescriptor[] = [];
+
+  if (message.contents) {
+    const mappedContents = contentBlocks(message.contents, role);
+    blocks.push(...mappedContents.blocks);
+    message.tool_calls
+      ?.filter(
+        (toolCall) =>
+          !toolCallFingerprints(toolCall).some((fingerprint) =>
+            mappedContents.orderedToolCalls.has(fingerprint),
+          ),
+      )
+      .forEach((toolCall) => blocks.push(toolCallBlock(toolCall)));
+  } else {
+    if (message.content !== undefined && message.content !== null) {
+      blocks.push(
+        role === "tool"
+          ? codeBlock(message.content, message.name ?? "Tool result")
+          : typeof message.content === "string"
+            ? textBlock(message.content, role)
+            : codeBlock(message.content, "Content"),
+      );
+    }
+    message.tool_calls?.forEach((toolCall) =>
+      blocks.push(toolCallBlock(toolCall)),
+    );
+  }
+
+  if (message.function_call !== undefined) {
+    blocks.push(codeBlock(message.function_call, "Function call"));
+  }
+
+  return {
+    id: `openinference-${fieldType}-${index}`,
+    role,
+    label: role === "tool" ? message.name ?? message.tool_call_id : undefined,
+    blocks,
+  };
+};
+
+const fallbackMessage = (
+  value: unknown,
+  fieldType: "input" | "output",
+  index: number,
+): LLMMessageDescriptor => {
+  const role: MessageRole = fieldType === "output" ? "assistant" : "user";
+  return {
+    id: `openinference-${fieldType}-fallback-${index}`,
+    role,
+    blocks: [
+      typeof value === "string"
+        ? textBlock(value, role)
+        : codeBlock(value, fieldType === "output" ? "Output" : "Input"),
+    ],
+  };
+};
+
+const toolLabel = (tool: unknown, index: number): string => {
+  if (typeof tool !== "object" || tool === null) return `Tool ${index + 1}`;
+  if ("name" in tool && typeof tool.name === "string") return tool.name;
+  if (!("json_schema" in tool)) return `Tool ${index + 1}`;
+
+  let schema: unknown = tool.json_schema;
+  if (typeof schema === "string") {
+    try {
+      schema = JSON.parse(schema);
+    } catch {
+      return `Tool ${index + 1}`;
+    }
+  }
+  if (typeof schema !== "object" || schema === null) return `Tool ${index + 1}`;
+  if ("name" in schema && typeof schema.name === "string") return schema.name;
+  if (
+    "function" in schema &&
+    typeof schema.function === "object" &&
+    schema.function !== null &&
+    "name" in schema.function &&
+    typeof schema.function.name === "string"
+  ) {
+    return schema.function.name;
+  }
+  return `Tool ${index + 1}`;
+};
+
+const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
+  const messages: LLMMessageDescriptor[] = parsed.inputMessages.map(
+    (message, index) => mapMessage(message, index, "input"),
+  );
+
+  if (parsed.inputMessages.length === 0 && parsed.inputFallback !== undefined) {
+    messages.push(fallbackMessage(parsed.inputFallback, "input", 0));
+  }
+
+  parsed.prompts.forEach((prompt, index) => {
+    messages.push({
+      id: `openinference-prompt-${index}`,
+      role: "user",
+      label: "Prompt",
+      blocks: [textBlock(prompt, "user")],
+    });
+  });
+
+  if (parsed.tools.length > 0) {
+    messages.push({
+      id: "openinference-tools",
+      role: "system",
+      label: "Available tools",
+      blocks: parsed.tools.map((tool, index) =>
+        codeBlock(tool, toolLabel(tool, index)),
+      ),
+    });
+  }
+
+  const outputStart = messages.length;
+  messages.push(
+    ...parsed.outputMessages.map((message, index) =>
+      mapMessage(message, index, "output"),
+    ),
+  );
+
+  parsed.choices.forEach((choice, index) => {
+    messages.push({
+      id: `openinference-choice-${index}`,
+      role: "assistant",
+      label: "Completion",
+      blocks: [textBlock(choice, "assistant")],
+    });
+  });
+
+  if (parsed.functionCall !== undefined) {
+    if (messages.length > outputStart) {
+      messages[messages.length - 1].blocks.push(
+        codeBlock(parsed.functionCall, "Function call"),
+      );
+    } else {
+      messages.push({
+        id: "openinference-function-call",
+        role: "assistant",
+        blocks: [codeBlock(parsed.functionCall, "Function call")],
+      });
+    }
+  }
+
+  // A historical output.value often duplicates the richer llm.output_messages.*
+  // attributes that were incorrectly stored in input. Use raw output only as fallback.
+  if (
+    parsed.outputMessages.length === 0 &&
+    parsed.choices.length === 0 &&
+    parsed.functionCall === undefined &&
+    parsed.outputFallback !== undefined
+  ) {
+    messages.push(fallbackMessage(parsed.outputFallback, "output", 0));
+  }
+
+  if (parsed.finishReason && messages.length > outputStart) {
+    messages[messages.length - 1].finishReason = parsed.finishReason;
+  }
+
+  return { messages };
+};
+
+export const mapOpenInferenceMessages: FormatMapper = (
+  data,
+  prettifyConfig,
+) => {
+  const fieldType = prettifyConfig?.fieldType;
+  if (!fieldType) return { messages: [] };
+  return mapParsed(
+    parseOpenInferenceFields(
+      fieldType === "input" ? data : undefined,
+      fieldType === "output" ? data : undefined,
+    ),
+  );
+};
+
+export const combineOpenInferenceMessages: FormatCombiner = (input, output) =>
+  mapParsed(parseOpenInferenceFields(input.raw, output.raw));

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
@@ -2,6 +2,8 @@ import {
   OpenInferenceContent,
   OpenInferenceMessage,
   OpenInferenceToolCall,
+  isRenderableOpenInferenceToolCall,
+  isSafeOpenInferenceMediaUrl,
   parseOpenInferenceFields,
   ParsedOpenInferenceFields,
 } from "@/lib/openinference";
@@ -82,20 +84,22 @@ const codeBlock = (value: unknown, label: string): LLMBlockDescriptor => ({
   props: { code: formatCode(value), label },
 });
 
-const toolCallFingerprints = (toolCall: OpenInferenceToolCall): string[] => {
-  const fingerprints: string[] = [];
-  if (toolCall.id) fingerprints.push(`id:${toolCall.id}`);
-  if (toolCall.function?.name || toolCall.function?.arguments) {
-    fingerprints.push(
-      `function:${toolCall.function?.name ?? ""}:${
-        toolCall.function?.arguments ?? ""
-      }`,
-    );
+const isSameToolCall = (
+  left: OpenInferenceToolCall,
+  right: OpenInferenceToolCall,
+): boolean => {
+  if (left.id && right.id) return left.id === right.id;
+  if (left.reasoning_signature && right.reasoning_signature) {
+    return left.reasoning_signature === right.reasoning_signature;
   }
-  if (toolCall.reasoning_signature) {
-    fingerprints.push(`reasoning:${toolCall.reasoning_signature}`);
-  }
-  return fingerprints;
+  const leftFunction = left.function;
+  const rightFunction = right.function;
+  if (!leftFunction || !rightFunction) return false;
+  if (!leftFunction.name && !leftFunction.arguments) return false;
+  return (
+    leftFunction.name === rightFunction.name &&
+    leftFunction.arguments === rightFunction.arguments
+  );
 };
 
 const toolCallBlock = (toolCall: OpenInferenceToolCall): LLMBlockDescriptor =>
@@ -107,15 +111,18 @@ const toolCallBlock = (toolCall: OpenInferenceToolCall): LLMBlockDescriptor =>
 const contentBlocks = (
   contents: OpenInferenceContent[],
   role: MessageRole,
-): { blocks: LLMBlockDescriptor[]; orderedToolCalls: Set<string> } => {
+): {
+  blocks: LLMBlockDescriptor[];
+  orderedToolCalls: OpenInferenceToolCall[];
+} => {
   const blocks: LLMBlockDescriptor[] = [];
-  const orderedToolCalls = new Set<string>();
+  const orderedToolCalls: OpenInferenceToolCall[] = [];
 
   contents.forEach((content, index) => {
     switch (content.type) {
       case "image": {
         const url = content.image?.url;
-        if (url) {
+        if (url && isSafeOpenInferenceMediaUrl(url, "image")) {
           blocks.push({
             blockType: "image",
             component: PrettyLLMMessage.ImageBlock,
@@ -126,7 +133,7 @@ const contentBlocks = (
       }
       case "audio": {
         const url = content.audio?.url;
-        if (url) {
+        if (url && isSafeOpenInferenceMediaUrl(url, "audio")) {
           blocks.push({
             blockType: "audio",
             component: PrettyLLMMessage.AudioPlayerBlock,
@@ -139,10 +146,11 @@ const contentBlocks = (
         break;
       }
       case "tool_use": {
-        if (content.tool_call) {
-          toolCallFingerprints(content.tool_call).forEach((fingerprint) =>
-            orderedToolCalls.add(fingerprint),
-          );
+        if (
+          content.tool_call &&
+          isRenderableOpenInferenceToolCall(content.tool_call)
+        ) {
+          orderedToolCalls.push(content.tool_call);
           blocks.push(toolCallBlock(content.tool_call));
         }
         break;
@@ -168,16 +176,25 @@ const mapMessage = (
   if (message.contents) {
     const mappedContents = contentBlocks(message.contents, role);
     blocks.push(...mappedContents.blocks);
+    const unmatchedOrderedToolCalls = [...mappedContents.orderedToolCalls];
     message.tool_calls
-      ?.filter(
-        (toolCall) =>
-          !toolCallFingerprints(toolCall).some((fingerprint) =>
-            mappedContents.orderedToolCalls.has(fingerprint),
-          ),
-      )
-      .forEach((toolCall) => blocks.push(toolCallBlock(toolCall)));
+      ?.filter(isRenderableOpenInferenceToolCall)
+      .forEach((toolCall) => {
+        const matchIndex = unmatchedOrderedToolCalls.findIndex(
+          (orderedToolCall) => isSameToolCall(toolCall, orderedToolCall),
+        );
+        if (matchIndex >= 0) {
+          unmatchedOrderedToolCalls.splice(matchIndex, 1);
+        } else {
+          blocks.push(toolCallBlock(toolCall));
+        }
+      });
   } else {
-    if (message.content !== undefined && message.content !== null) {
+    if (
+      message.content !== undefined &&
+      message.content !== null &&
+      message.content !== ""
+    ) {
       blocks.push(
         role === "tool"
           ? codeBlock(message.content, message.name ?? "Tool result")
@@ -186,9 +203,9 @@ const mapMessage = (
             : codeBlock(message.content, "Content"),
       );
     }
-    message.tool_calls?.forEach((toolCall) =>
-      blocks.push(toolCallBlock(toolCall)),
-    );
+    message.tool_calls
+      ?.filter(isRenderableOpenInferenceToolCall)
+      .forEach((toolCall) => blocks.push(toolCallBlock(toolCall)));
   }
 
   if (message.function_call !== undefined) {
@@ -248,11 +265,12 @@ const toolLabel = (tool: unknown, index: number): string => {
 };
 
 const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
-  const messages: LLMMessageDescriptor[] = parsed.inputMessages.map(
-    (message, index) => mapMessage(message, index, "input"),
-  );
+  const mappedInputMessages = parsed.inputMessages
+    .map((message, index) => mapMessage(message, index, "input"))
+    .filter((message) => message.blocks.length > 0);
+  const messages: LLMMessageDescriptor[] = [...mappedInputMessages];
 
-  if (parsed.inputMessages.length === 0 && parsed.inputFallback !== undefined) {
+  if (mappedInputMessages.length === 0 && parsed.inputFallback !== undefined) {
     messages.push(fallbackMessage(parsed.inputFallback, "input", 0));
   }
 
@@ -277,11 +295,10 @@ const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
   }
 
   const outputStart = messages.length;
-  messages.push(
-    ...parsed.outputMessages.map((message, index) =>
-      mapMessage(message, index, "output"),
-    ),
-  );
+  const mappedOutputMessages = parsed.outputMessages
+    .map((message, index) => mapMessage(message, index, "output"))
+    .filter((message) => message.blocks.length > 0);
+  messages.push(...mappedOutputMessages);
 
   parsed.choices.forEach((choice, index) => {
     messages.push({
@@ -309,7 +326,7 @@ const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
   // A historical output.value often duplicates the richer llm.output_messages.*
   // attributes that were incorrectly stored in input. Use raw output only as fallback.
   if (
-    parsed.outputMessages.length === 0 &&
+    mappedOutputMessages.length === 0 &&
     parsed.choices.length === 0 &&
     parsed.functionCall === undefined &&
     parsed.outputFallback !== undefined

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
@@ -1,4 +1,6 @@
 import {
+  OPENINFERENCE_USER_ROLES,
+  OPENINFERENCE_ASSISTANT_ROLES,
   OpenInferenceContent,
   OpenInferenceMessage,
   OpenInferenceToolCall,
@@ -22,21 +24,16 @@ const normalizeRole = (
   role: string | undefined,
   fieldType: "input" | "output",
 ): MessageRole => {
-  switch (role?.toLowerCase()) {
-    case "assistant":
-    case "model":
-    case "ai":
-    case "agent":
-      return "assistant";
+  const normalized = role?.toLowerCase() ?? "";
+  if (OPENINFERENCE_USER_ROLES.has(normalized)) return "user";
+  if (OPENINFERENCE_ASSISTANT_ROLES.has(normalized)) return "assistant";
+  switch (normalized) {
     case "system":
     case "developer":
       return "system";
     case "tool":
     case "function":
       return "tool";
-    case "user":
-    case "human":
-      return "user";
     default:
       return fieldType === "output" ? "assistant" : "user";
   }
@@ -119,46 +116,39 @@ const contentBlocks = (
   const orderedToolCalls: OpenInferenceToolCall[] = [];
 
   contents.forEach((content, index) => {
-    switch (content.type) {
-      case "image": {
-        const url = content.image?.url;
-        if (url && isSafeOpenInferenceMediaUrl(url, "image")) {
-          blocks.push({
-            blockType: "image",
-            component: PrettyLLMMessage.ImageBlock,
-            props: { images: [{ url, name: mediaName(url, "Image", index) }] },
-          });
-        }
-        break;
-      }
-      case "audio": {
-        const url = content.audio?.url;
-        if (url && isSafeOpenInferenceMediaUrl(url, "audio")) {
-          blocks.push({
-            blockType: "audio",
-            component: PrettyLLMMessage.AudioPlayerBlock,
-            props: { audios: [{ url, name: mediaName(url, "Audio", index) }] },
-          });
-        }
-        if (content.audio?.transcript) {
-          blocks.push(textBlock(content.audio.transcript, role));
-        }
-        break;
-      }
-      case "tool_use": {
-        if (
-          content.tool_call &&
-          isRenderableOpenInferenceToolCall(content.tool_call)
-        ) {
-          orderedToolCalls.push(content.tool_call);
-          blocks.push(toolCallBlock(content.tool_call));
-        }
-        break;
-      }
-      case "reasoning":
-      case "text":
-      default:
-        if (content.text) blocks.push(textBlock(content.text, role));
+    if (content.text) blocks.push(textBlock(content.text, role));
+    const imageUrl = content.image?.url;
+    if (imageUrl && isSafeOpenInferenceMediaUrl(imageUrl, "image")) {
+      blocks.push({
+        blockType: "image",
+        component: PrettyLLMMessage.ImageBlock,
+        props: {
+          images: [
+            { url: imageUrl, name: mediaName(imageUrl, "Image", index) },
+          ],
+        },
+      });
+    }
+    const audioUrl = content.audio?.url;
+    if (audioUrl && isSafeOpenInferenceMediaUrl(audioUrl, "audio")) {
+      blocks.push({
+        blockType: "audio",
+        component: PrettyLLMMessage.AudioPlayerBlock,
+        props: {
+          audios: [
+            { url: audioUrl, name: mediaName(audioUrl, "Audio", index) },
+          ],
+        },
+      });
+    }
+    if (content.audio?.transcript)
+      blocks.push(textBlock(content.audio.transcript, role));
+    if (
+      content.tool_call &&
+      isRenderableOpenInferenceToolCall(content.tool_call)
+    ) {
+      orderedToolCalls.push(content.tool_call);
+      blocks.push(toolCallBlock(content.tool_call));
     }
   });
 
@@ -366,3 +356,17 @@ export const mapOpenInferenceMessages: FormatMapper = (
 
 export const combineOpenInferenceMessages: FormatCombiner = (input, output) =>
   mapParsed(parseOpenInferenceFields(input.raw, output.raw));
+
+// The orchestrator already knows which side permits raw fallback. Keep recovery of
+// structured historical output independent from permission to render an unknown sibling.
+export const mapOpenInferencePair = (
+  input: unknown,
+  output: unknown,
+  allowInputFallback: boolean,
+  allowOutputFallback: boolean,
+): LLMMapperResult => {
+  const parsed = parseOpenInferenceFields(input, output);
+  if (!allowInputFallback) parsed.inputFallback = undefined;
+  if (!allowOutputFallback) parsed.outputFallback = undefined;
+  return mapParsed(parsed);
+};

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/openinference/mapper.ts
@@ -173,6 +173,20 @@ const mapMessage = (
   const role = normalizeRole(message.role, fieldType);
   const blocks: LLMBlockDescriptor[] = [];
 
+  if (
+    message.content !== undefined &&
+    message.content !== null &&
+    message.content !== ""
+  ) {
+    blocks.push(
+      role === "tool"
+        ? codeBlock(message.content, message.name ?? "Tool result")
+        : typeof message.content === "string"
+          ? textBlock(message.content, role)
+          : codeBlock(message.content, "Content"),
+    );
+  }
+
   if (message.contents) {
     const mappedContents = contentBlocks(message.contents, role);
     blocks.push(...mappedContents.blocks);
@@ -190,19 +204,6 @@ const mapMessage = (
         }
       });
   } else {
-    if (
-      message.content !== undefined &&
-      message.content !== null &&
-      message.content !== ""
-    ) {
-      blocks.push(
-        role === "tool"
-          ? codeBlock(message.content, message.name ?? "Tool result")
-          : typeof message.content === "string"
-            ? textBlock(message.content, role)
-            : codeBlock(message.content, "Content"),
-      );
-    }
     message.tool_calls
       ?.filter(isRenderableOpenInferenceToolCall)
       .forEach((toolCall) => blocks.push(toolCallBlock(toolCall)));
@@ -264,7 +265,10 @@ const toolLabel = (tool: unknown, index: number): string => {
   return `Tool ${index + 1}`;
 };
 
-const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
+const mapParsed = (
+  parsed: ParsedOpenInferenceFields,
+  fieldType?: "input" | "output",
+): LLMMapperResult => {
   const mappedInputMessages = parsed.inputMessages
     .map((message, index) => mapMessage(message, index, "input"))
     .filter((message) => message.blocks.length > 0);
@@ -293,6 +297,10 @@ const mapParsed = (parsed: ParsedOpenInferenceFields): LLMMapperResult => {
       ),
     });
   }
+
+  // The pair-aware combiner recovers historical output from input. A standalone input
+  // mapper must not append it beside an output handled by another provider's mapper.
+  if (fieldType === "input") return { messages };
 
   const outputStart = messages.length;
   const mappedOutputMessages = parsed.outputMessages
@@ -352,6 +360,7 @@ export const mapOpenInferenceMessages: FormatMapper = (
       fieldType === "input" ? data : undefined,
       fieldType === "output" ? data : undefined,
     ),
+    fieldType,
   );
 };
 

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/registry.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/providers/registry.ts
@@ -1,6 +1,7 @@
 import { LLMMessageFormat, LLMMessageFormatImplementation } from "../types";
 import { openaiFormat } from "./openai";
 import { langchainFormat } from "./langchain";
+import { openinferenceFormat } from "./openinference";
 
 const FORMAT_REGISTRY: Record<
   LLMMessageFormat,
@@ -10,6 +11,7 @@ const FORMAT_REGISTRY: Record<
   langchain: langchainFormat,
   anthropic: null,
   google: null,
+  openinference: openinferenceFormat,
 };
 
 export const getFormat = (

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
@@ -20,6 +20,7 @@ export type LLMMessageFormat =
 export type LLMMessagePrettifyConfig = {
   fieldType?: "input" | "output";
   formatHint?: LLMMessageFormat;
+  formatHintIsAuthoritative?: boolean;
 };
 
 // Detection result

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
@@ -10,7 +10,17 @@ import {
 } from "@/shared/PrettyLLMMessage/types";
 
 // Format types
-export type LLMMessageFormat = "openai" | "langchain" | "anthropic" | "google";
+export type LLMMessageFormat =
+  | "openai"
+  | "langchain"
+  | "anthropic"
+  | "google"
+  | "openinference";
+
+export type LLMMessagePrettifyConfig = {
+  fieldType?: "input" | "output";
+  formatHint?: LLMMessageFormat;
+};
 
 // Detection result
 export interface LLMMessageFormatDetectionResult {
@@ -67,13 +77,13 @@ export interface LLMMapperResult {
 // Format detector contract
 export type FormatDetector = (
   data: unknown,
-  prettifyConfig?: { fieldType?: "input" | "output" },
+  prettifyConfig?: LLMMessagePrettifyConfig,
 ) => boolean;
 
 // Format mapper contract
 export type FormatMapper = (
   data: unknown,
-  prettifyConfig?: { fieldType?: "input" | "output" },
+  prettifyConfig?: LLMMessagePrettifyConfig,
 ) => LLMMapperResult;
 
 // Format combiner contract

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/llmMessages/types.ts
@@ -1,3 +1,4 @@
+import { MessageUsage } from "../usage";
 import { ComponentType } from "react";
 import {
   PrettyLLMMessageTextBlockProps,
@@ -5,7 +6,6 @@ import {
   PrettyLLMMessageVideoBlockProps,
   PrettyLLMMessageAudioPlayerBlockProps,
   PrettyLLMMessageCodeBlockProps,
-  PrettyLLMMessageUsageProps,
   MessageRole,
 } from "@/shared/PrettyLLMMessage/types";
 
@@ -72,7 +72,7 @@ export interface LLMMessageDescriptor {
 // Mapper result with messages and shared usage
 export interface LLMMapperResult {
   messages: LLMMessageDescriptor[];
-  usage?: PrettyLLMMessageUsageProps["usage"];
+  usage?: MessageUsage;
 }
 
 // Format detector contract

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/types.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/types.ts
@@ -1,3 +1,4 @@
+import { MessageUsage } from "./usage";
 import { ReactNode, ComponentPropsWithoutRef } from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
 
@@ -60,11 +61,7 @@ export interface PrettyLLMMessageAudioPlayerBlockProps {
 }
 
 export interface PrettyLLMMessageFooterProps {
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
+  usage?: MessageUsage;
   finishReason?: string;
   className?: string;
 }
@@ -75,12 +72,6 @@ export interface PrettyLLMMessageFinishReasonProps {
 }
 
 export interface PrettyLLMMessageUsageProps {
-  usage?:
-    | {
-        prompt_tokens?: number;
-        completion_tokens?: number;
-        total_tokens?: number;
-      }
-    | Record<string, number | undefined>;
+  usage?: MessageUsage;
   className?: string;
 }

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/types.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/types.ts
@@ -75,10 +75,12 @@ export interface PrettyLLMMessageFinishReasonProps {
 }
 
 export interface PrettyLLMMessageUsageProps {
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
+  usage?:
+    | {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
+      }
+    | Record<string, number | undefined>;
   className?: string;
 }

--- a/apps/opik-frontend/src/shared/PrettyLLMMessage/usage.ts
+++ b/apps/opik-frontend/src/shared/PrettyLLMMessage/usage.ts
@@ -1,0 +1,59 @@
+import startCase from "lodash/startCase";
+import { UsageData } from "@/types/shared";
+
+export type MessageUsage =
+  | Partial<UsageData>
+  | Record<string, number | undefined>;
+
+export const numericUsage = (usage?: MessageUsage): Record<string, number> =>
+  Object.fromEntries(
+    Object.entries(usage ?? {}).filter(
+      (entry): entry is [string, number] =>
+        typeof entry[1] === "number" && Number.isFinite(entry[1]),
+    ),
+  );
+
+const USAGE_LABELS: Record<string, string> = {
+  prompt_tokens: "Input tokens",
+  completion_tokens: "Output tokens",
+  total_tokens: "Total tokens",
+  cache_read_input_tokens: "Cache read tokens",
+  cache_creation_input_tokens: "Cache write tokens",
+  reasoning_tokens: "Reasoning tokens",
+  "prompt_tokens_details.audio_tokens": "Input audio tokens",
+  "completion_tokens_details.audio_tokens": "Output audio tokens",
+};
+const ORIGINAL_USAGE_ALIASES: Record<string, string> = {
+  cache_read_input_tokens: "cache_read_input_tokens",
+  cache_creation_input_tokens: "cache_creation_input_tokens",
+  "prompt_tokens_details.cached_tokens": "cache_read_input_tokens",
+  "input_tokens_details.cached_tokens": "cache_read_input_tokens",
+  "completion_tokens_details.reasoning_tokens": "reasoning_tokens",
+  "output_tokens_details.reasoning_tokens": "reasoning_tokens",
+  "prompt_tokens_details.audio_tokens": "prompt_tokens_details.audio_tokens",
+  "completion_tokens_details.audio_tokens":
+    "completion_tokens_details.audio_tokens",
+};
+
+export const getDisplayUsage = (usage?: MessageUsage) => {
+  const values = numericUsage(usage);
+  const display = Object.fromEntries(
+    Object.entries(values).filter(
+      ([key]) => !key.startsWith("original_usage."),
+    ),
+  );
+  for (const [original, canonical] of Object.entries(ORIGINAL_USAGE_ALIASES)) {
+    const value = values[`original_usage.${original}`];
+    if (display[canonical] === undefined && value !== undefined)
+      display[canonical] = value;
+  }
+  return Object.entries(display).map(([key, value]) => ({
+    key,
+    value,
+    label:
+      USAGE_LABELS[key] ??
+      startCase(key)
+        .toLowerCase()
+        .replace(/^./, (letter) => letter.toUpperCase()),
+  }));
+};

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks.ts
@@ -40,9 +40,19 @@ export const useSyntaxHighlighterCode = (
   mode: MODE_TYPE,
   prettifyConfig?: PrettifyConfig,
 ): CodeOutput => {
+  const fieldType = prettifyConfig?.fieldType;
+  const openInferenceHint = prettifyConfig?.openInferenceHint;
+  const openInferenceInput = prettifyConfig?.openInferenceInput;
   return useMemo(
-    () => generateSyntaxHighlighterCode(data, mode, prettifyConfig),
-    [mode, data, prettifyConfig],
+    () =>
+      generateSyntaxHighlighterCode(
+        data,
+        mode,
+        fieldType
+          ? { fieldType, openInferenceHint, openInferenceInput }
+          : undefined,
+      ),
+    [mode, data, fieldType, openInferenceHint, openInferenceInput],
   );
 };
 
@@ -50,9 +60,14 @@ export const useSyntaxHighlighterOptions = (
   prettifyConfig?: PrettifyConfig,
   canBePrettified: boolean = false,
 ) => {
+  const fieldType = prettifyConfig?.fieldType;
   return useMemo(
-    () => generateSelectOptions(prettifyConfig, canBePrettified),
-    [prettifyConfig, canBePrettified],
+    () =>
+      generateSelectOptions(
+        fieldType ? { fieldType } : undefined,
+        canBePrettified,
+      ),
+    [fieldType, canBePrettified],
   );
 };
 

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/types.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/types.ts
@@ -3,6 +3,8 @@ import { MODE_TYPE } from "@/shared/SyntaxHighlighter/constants";
 
 export type PrettifyConfig = {
   fieldType: "input" | "output";
+  openInferenceHint?: boolean;
+  openInferenceInput?: object | string;
 };
 
 export type CodeOutput = {

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/types.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/types.ts
@@ -1,10 +1,9 @@
+import { PrettifyMessageConfig } from "@/lib/traces";
 import type { Node } from "unist";
 import { MODE_TYPE } from "@/shared/SyntaxHighlighter/constants";
 
-export type PrettifyConfig = {
-  fieldType: "input" | "output";
-  openInferenceHint?: boolean;
-  openInferenceInput?: object | string;
+export type PrettifyConfig = Omit<PrettifyMessageConfig, "type"> & {
+  fieldType: PrettifyMessageConfig["type"];
 };
 
 export type CodeOutput = {

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/utils.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/utils.ts
@@ -14,6 +14,8 @@ export const generateSyntaxHighlighterCode = (
   const response = prettifyConfig
     ? prettifyMessage(data, {
         type: prettifyConfig.fieldType,
+        openInferenceHint: prettifyConfig.openInferenceHint,
+        openInferenceInput: prettifyConfig.openInferenceInput,
       })
     : {
         message: data,

--- a/apps/opik-frontend/src/shared/SyntaxHighlighter/utils.ts
+++ b/apps/opik-frontend/src/shared/SyntaxHighlighter/utils.ts
@@ -14,8 +14,7 @@ export const generateSyntaxHighlighterCode = (
   const response = prettifyConfig
     ? prettifyMessage(data, {
         type: prettifyConfig.fieldType,
-        openInferenceHint: prettifyConfig.openInferenceHint,
-        openInferenceInput: prettifyConfig.openInferenceInput,
+        ...prettifyConfig,
       })
     : {
         message: data,

--- a/apps/opik-frontend/src/types/traces.ts
+++ b/apps/opik-frontend/src/types/traces.ts
@@ -1,4 +1,4 @@
-import { UsageData } from "@/types/shared";
+import { JsonNode, UsageData } from "@/types/shared";
 import { PROVIDER_TYPE } from "@/types/providers";
 import { CommentItems } from "./comment";
 import { GuardrailValidation } from "./guardrails";
@@ -137,8 +137,8 @@ export interface Thread {
   start_time: string;
   end_time: string;
   duration: number;
-  first_message: object;
-  last_message: object;
+  first_message?: JsonNode;
+  last_message?: JsonNode;
   number_of_messages: number;
   usage?: UsageData;
   total_estimated_cost?: number;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/DetailsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/DetailsTab.tsx
@@ -12,12 +12,14 @@ type DetailsTabProps = {
   data: Trace | Span;
   isLoading: boolean;
   search?: string;
+  openInferenceHint: boolean;
 };
 
 const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
   data,
   isLoading,
   search,
+  openInferenceHint,
 }) => {
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
@@ -36,7 +38,7 @@ const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
           <CodeBlock
             title="Input"
             data={transformedInput}
-            prettifyConfig={{ fieldType: "input" }}
+            prettifyConfig={{ fieldType: "input", openInferenceHint }}
             preserveKey="syntax-highlighter-trace-sidebar-input"
             search={search}
             withSearch
@@ -51,7 +53,11 @@ const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
           <CodeBlock
             title="Output"
             data={transformedOutput}
-            prettifyConfig={{ fieldType: "output" }}
+            prettifyConfig={{
+              fieldType: "output",
+              openInferenceHint,
+              openInferenceInput: transformedInput,
+            }}
             preserveKey="syntax-highlighter-trace-sidebar-output"
             search={search}
             withSearch

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/DetailsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/DetailsTab.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Span, Trace } from "@/types/traces";
+import { getPrettifyConfig } from "@/lib/traces";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
 import { MediaProvider } from "@/shared/PrettyLLMMessage/llmMessages";
 import CollapsibleSection from "@/v2/pages-shared/traces/TraceDetailsPanel/CollapsibleSection";
@@ -12,16 +13,20 @@ type DetailsTabProps = {
   data: Trace | Span;
   isLoading: boolean;
   search?: string;
-  openInferenceHint: boolean;
 };
 
 const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
   data,
   isLoading,
   search,
-  openInferenceHint,
 }) => {
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
+
+  const prettifySource = {
+    metadata: data.metadata,
+    input: transformedInput,
+    output: transformedOutput,
+  };
 
   const hasMetadata = Boolean(data.metadata);
   const hasTokenUsage = Boolean(data.usage);
@@ -38,7 +43,10 @@ const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
           <CodeBlock
             title="Input"
             data={transformedInput}
-            prettifyConfig={{ fieldType: "input", openInferenceHint }}
+            prettifyConfig={{
+              ...getPrettifyConfig(prettifySource, "input"),
+              fieldType: "input",
+            }}
             preserveKey="syntax-highlighter-trace-sidebar-input"
             search={search}
             withSearch
@@ -54,9 +62,8 @@ const DetailsTab: React.FunctionComponent<DetailsTabProps> = ({
             title="Output"
             data={transformedOutput}
             prettifyConfig={{
+              ...getPrettifyConfig(prettifySource, "output"),
               fieldType: "output",
-              openInferenceHint,
-              openInferenceInput: transformedInput,
             }}
             preserveKey="syntax-highlighter-trace-sidebar-output"
             search={search}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -37,6 +37,7 @@ type MessagesTabProps = {
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
   formatHint?: LLMMessageFormat;
+  formatHintIsAuthoritative?: boolean;
   spanUsage?: PrettyLLMMessageUsageProps["usage"];
 };
 
@@ -60,17 +61,23 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   isLoading,
   scrollContainerRef,
   formatHint,
+  formatHintIsAuthoritative,
   spanUsage,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
     () =>
-      mapAndCombineMessages(
-        transformedInput,
-        transformedOutput,
+      mapAndCombineMessages(transformedInput, transformedOutput, {
         formatHint,
+        formatHintIsAuthoritative,
         spanUsage,
-      ),
-    [formatHint, spanUsage, transformedInput, transformedOutput],
+      }),
+    [
+      formatHint,
+      formatHintIsAuthoritative,
+      spanUsage,
+      transformedInput,
+      transformedOutput,
+    ],
   );
 
   const allMessageIds = useMemo(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -13,6 +13,7 @@ import {
   mapAndCombineMessages,
   LLMMessageDescriptor,
   LLMBlockDescriptor,
+  LLMMessageFormat,
 } from "@/shared/PrettyLLMMessage/llmMessages";
 import { Button } from "@/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
@@ -21,6 +22,7 @@ import PrettyLLMMessage from "@/shared/PrettyLLMMessage";
 import { useLLMMessagesExpandAll } from "@/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks";
 import Loader from "@/shared/Loader/Loader";
 import CollapsibleSection from "@/v2/pages-shared/traces/TraceDetailsPanel/CollapsibleSection";
+import { PrettyLLMMessageUsageProps } from "@/shared/PrettyLLMMessage/types";
 
 const ESTIMATED_COLLAPSED_HEIGHT = 36; // single header row height in px
 const ESTIMATED_EXPANDED_HEIGHT = 200; // fallback for expanded items before measurement
@@ -29,11 +31,13 @@ const VIRTUAL_OVERSCAN = 10; // extra items rendered outside viewport
 const TOGGLE_SUPPRESS_MS = 300; // ignore scroll adjustments after expand/collapse
 
 type MessagesTabProps = {
-  transformedInput: object;
-  transformedOutput: object;
+  transformedInput: unknown;
+  transformedOutput: unknown;
   media: UnifiedMediaItem[];
   isLoading: boolean;
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
+  formatHint?: LLMMessageFormat;
+  spanUsage?: PrettyLLMMessageUsageProps["usage"];
 };
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
@@ -55,10 +59,18 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   media,
   isLoading,
   scrollContainerRef,
+  formatHint,
+  spanUsage,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
-    () => mapAndCombineMessages(transformedInput, transformedOutput),
-    [transformedInput, transformedOutput],
+    () =>
+      mapAndCombineMessages(
+        transformedInput,
+        transformedOutput,
+        formatHint,
+        spanUsage,
+      ),
+    [formatHint, spanUsage, transformedInput, transformedOutput],
   );
 
   const allMessageIds = useMemo(

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/MessagesTab.tsx
@@ -14,6 +14,7 @@ import {
   LLMMessageDescriptor,
   LLMBlockDescriptor,
   LLMMessageFormat,
+  LLMMessageFormatDetectionResult,
 } from "@/shared/PrettyLLMMessage/llmMessages";
 import { Button } from "@/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip";
@@ -22,7 +23,7 @@ import PrettyLLMMessage from "@/shared/PrettyLLMMessage";
 import { useLLMMessagesExpandAll } from "@/shared/SyntaxHighlighter/hooks/useSyntaxHighlighterHooks";
 import Loader from "@/shared/Loader/Loader";
 import CollapsibleSection from "@/v2/pages-shared/traces/TraceDetailsPanel/CollapsibleSection";
-import { PrettyLLMMessageUsageProps } from "@/shared/PrettyLLMMessage/types";
+import { MessageUsage } from "@/shared/PrettyLLMMessage/usage";
 
 const ESTIMATED_COLLAPSED_HEIGHT = 36; // single header row height in px
 const ESTIMATED_EXPANDED_HEIGHT = 200; // fallback for expanded items before measurement
@@ -38,7 +39,11 @@ type MessagesTabProps = {
   scrollContainerRef?: React.RefObject<HTMLDivElement>;
   formatHint?: LLMMessageFormat;
   formatHintIsAuthoritative?: boolean;
-  spanUsage?: PrettyLLMMessageUsageProps["usage"];
+  spanUsage?: MessageUsage;
+  detections?: {
+    input: LLMMessageFormatDetectionResult;
+    output: LLMMessageFormatDetectionResult;
+  };
 };
 
 function renderBlock(descriptor: LLMBlockDescriptor, key: string) {
@@ -63,6 +68,7 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
   formatHint,
   formatHintIsAuthoritative,
   spanUsage,
+  detections,
 }) => {
   const { messages: combinedMessages, usage } = useMemo(
     () =>
@@ -70,11 +76,13 @@ const MessagesTab: React.FunctionComponent<MessagesTabProps> = ({
         formatHint,
         formatHintIsAuthoritative,
         spanUsage,
+        detections,
       }),
     [
       formatHint,
       formatHintIsAuthoritative,
       spanUsage,
+      detections,
       transformedInput,
       transformedOutput,
     ],

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -37,11 +37,12 @@ import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
 import {
+  canShowLLMMessages,
   detectLLMMessages,
   LLMMessageFormat,
 } from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
-import { hasOpenInferenceHint } from "@/lib/openinference";
+import { resolveOpenInferenceHint } from "@/lib/openinference";
 
 type TraceDataViewerProps = {
   graphData?: AgentGraphData;
@@ -84,39 +85,40 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
-  const formatHint: LLMMessageFormat | undefined = useMemo(
+  const openInferenceHint = useMemo(
     () =>
-      hasOpenInferenceHint(data.metadata, transformedInput, transformedOutput)
-        ? "openinference"
-        : undefined,
+      resolveOpenInferenceHint(
+        data.metadata,
+        transformedInput,
+        transformedOutput,
+      ),
     [data.metadata, transformedInput, transformedOutput],
   );
+  const formatHint: LLMMessageFormat | undefined = openInferenceHint.detected
+    ? "openinference"
+    : undefined;
+  const formatHintIsAuthoritative = openInferenceHint.authoritative;
 
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
     const input = detectLLMMessages(
       transformedInput,
-      { fieldType: "input" },
+      { fieldType: "input", formatHintIsAuthoritative },
       formatHint,
     );
     const output = detectLLMMessages(
       transformedOutput,
-      { fieldType: "output" },
+      { fieldType: "output", formatHintIsAuthoritative },
       formatHint,
     );
 
-    const hasValid = input.supported || output.supported;
-    if (formatHint === "openinference") {
-      return (
-        input.format === "openinference" || output.format === "openinference"
-      );
-    }
-    const hasInvalid =
-      (!input.supported && !input.empty) ||
-      (!output.supported && !output.empty);
-
-    return hasValid && !hasInvalid;
-  }, [formatHint, transformedInput, transformedOutput]);
+    return canShowLLMMessages(input, output, formatHint === "openinference");
+  }, [
+    formatHint,
+    formatHintIsAuthoritative,
+    transformedInput,
+    transformedOutput,
+  ]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -337,6 +339,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
                 formatHint={formatHint}
+                formatHintIsAuthoritative={formatHintIsAuthoritative}
                 spanUsage={data.usage}
               />
             </TabsContent>
@@ -346,6 +349,7 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               data={data}
               isLoading={isSpanInputOutputLoading}
               search={search}
+              openInferenceHint={openInferenceHint.detected}
             />
           </TabsContent>
           <TabsContent value="feedback_scores">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -36,8 +36,12 @@ import { EXPLAINER_ID, EXPLAINERS_MAP } from "@/v2/constants/explainers";
 import ExplainerIcon from "@/shared/ExplainerIcon/ExplainerIcon";
 import useTraceFeedbackScoreDeleteMutation from "@/api/traces/useTraceFeedbackScoreDeleteMutation";
 import ConfigurableFeedbackScoreTable from "./FeedbackScoreTable/ConfigurableFeedbackScoreTable";
-import { detectLLMMessages } from "@/shared/PrettyLLMMessage/llmMessages";
+import {
+  detectLLMMessages,
+  LLMMessageFormat,
+} from "@/shared/PrettyLLMMessage/llmMessages";
 import { useUnifiedMedia } from "@/hooks/useUnifiedMedia";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 type TraceDataViewerProps = {
   graphData?: AgentGraphData;
@@ -80,20 +84,39 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
 
   const { media, transformedInput, transformedOutput } = useUnifiedMedia(data);
 
+  const formatHint: LLMMessageFormat | undefined = useMemo(
+    () =>
+      hasOpenInferenceHint(data.metadata, transformedInput, transformedOutput)
+        ? "openinference"
+        : undefined,
+    [data.metadata, transformedInput, transformedOutput],
+  );
+
   // Show Messages tab when at least one field is supported and neither is invalid
   const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(transformedInput, { fieldType: "input" });
-    const output = detectLLMMessages(transformedOutput, {
-      fieldType: "output",
-    });
+    const input = detectLLMMessages(
+      transformedInput,
+      { fieldType: "input" },
+      formatHint,
+    );
+    const output = detectLLMMessages(
+      transformedOutput,
+      { fieldType: "output" },
+      formatHint,
+    );
 
     const hasValid = input.supported || output.supported;
+    if (formatHint === "openinference") {
+      return (
+        input.format === "openinference" || output.format === "openinference"
+      );
+    }
     const hasInvalid =
       (!input.supported && !input.empty) ||
       (!output.supported && !output.empty);
 
     return hasValid && !hasInvalid;
-  }, [transformedInput, transformedOutput]);
+  }, [formatHint, transformedInput, transformedOutput]);
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -313,6 +336,8 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 media={media}
                 isLoading={isSpanInputOutputLoading}
                 scrollContainerRef={rootScrollRef}
+                formatHint={formatHint}
+                spanUsage={data.usage}
               />
             </TabsContent>
           )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx
@@ -100,25 +100,31 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
   const formatHintIsAuthoritative = openInferenceHint.authoritative;
 
   // Show Messages tab when at least one field is supported and neither is invalid
-  const canShowMessagesTab = useMemo(() => {
-    const input = detectLLMMessages(
-      transformedInput,
-      { fieldType: "input", formatHintIsAuthoritative },
+  const messageDetections = useMemo(() => {
+    const input = detectLLMMessages(transformedInput, {
+      fieldType: "input",
+      formatHintIsAuthoritative,
       formatHint,
-    );
-    const output = detectLLMMessages(
-      transformedOutput,
-      { fieldType: "output", formatHintIsAuthoritative },
+    });
+    const output = detectLLMMessages(transformedOutput, {
+      fieldType: "output",
+      formatHintIsAuthoritative,
       formatHint,
-    );
+    });
 
-    return canShowLLMMessages(input, output, formatHint === "openinference");
+    return { input, output };
   }, [
     formatHint,
     formatHintIsAuthoritative,
     transformedInput,
     transformedOutput,
   ]);
+
+  const canShowMessagesTab = canShowLLMMessages(
+    messageDetections.input,
+    messageDetections.output,
+    formatHint === "openinference",
+  );
 
   const defaultTab = canShowMessagesTab ? "messages" : "details";
 
@@ -340,7 +346,8 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
                 scrollContainerRef={rootScrollRef}
                 formatHint={formatHint}
                 formatHintIsAuthoritative={formatHintIsAuthoritative}
-                spanUsage={data.usage}
+                spanUsage={isTrace ? undefined : data.usage}
+                detections={messageDetections}
               />
             </TabsContent>
           )}
@@ -349,7 +356,6 @@ const TraceDataViewer: React.FunctionComponent<TraceDataViewerProps> = ({
               data={data}
               isLoading={isSpanInputOutputLoading}
               search={search}
-              openInferenceHint={openInferenceHint.detected}
             />
           </TabsContent>
           <TabsContent value="feedback_scores">

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceLogsView/TraceLogsView.tsx
@@ -1,3 +1,4 @@
+import { getPrettifyConfig } from "@/lib/traces";
 import React, { useCallback, useMemo, useState } from "react";
 import { keepPreviousData } from "@tanstack/react-query";
 import {
@@ -159,6 +160,7 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "input",
+      getPrettifyConfig,
     },
   },
   {
@@ -169,6 +171,7 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "output",
+      getPrettifyConfig,
     },
   },
   {

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Trace } from "@/types/traces";
+import TraceMessage from "./TraceMessage";
+
+vi.mock("./LikeFeedback", () => ({ default: () => null }));
+const trace: Trace = {
+  id: "trace-1",
+  project_id: "project-1",
+  name: "Example",
+  input: {},
+  output: {},
+  metadata: {},
+  start_time: "2026-09-10T00:00:00Z",
+  end_time: "2026-09-10T00:00:01Z",
+  duration: 1,
+  created_at: "2026-09-10T00:00:00Z",
+  last_updated_at: "2026-09-10T00:00:01Z",
+  tags: [],
+  comments: [],
+};
+describe("TraceMessage previews", () => {
+  it("renders legacy output recovered from input", () => {
+    const html = renderToStaticMarkup(
+      <TraceMessage
+        trace={{
+          ...trace,
+          input: {
+            "llm.output_messages.0.message.content": "Recovered answer",
+          },
+        }}
+        handleOpenTrace={() => {}}
+      />,
+    );
+    expect(html).toContain("Recovered answer");
+  });
+  it("prefers the current answer over the historical output", () => {
+    const html = renderToStaticMarkup(
+      <TraceMessage
+        trace={{
+          ...trace,
+          input: {
+            "llm.input_messages.0.message.content": "Question",
+            "llm.output_messages.0.message.content": "Stale answer",
+          },
+          output: { answer: "Current answer" },
+        }}
+        handleOpenTrace={() => {}}
+      />,
+    );
+    expect(html).toContain("Current answer");
+    expect(html).not.toContain("Stale answer");
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
@@ -13,6 +13,7 @@ import { USER_FEEDBACK_NAME } from "@/constants/shared";
 import { prettifyMessage } from "@/lib/traces";
 import { toString } from "@/lib/utils";
 import { useJsonViewTheme } from "@/hooks/useJsonViewTheme";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 type TraceMessageProps = {
   trace: Trace;
@@ -24,6 +25,11 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   handleOpenTrace,
 }) => {
   const jsonViewTheme = useJsonViewTheme();
+  const openInferenceHint = hasOpenInferenceHint(
+    trace.metadata,
+    trace.input,
+    trace.output,
+  );
 
   const userFeedback = useMemo(() => {
     return (trace.feedback_scores ?? []).find(
@@ -32,7 +38,10 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   }, [trace.feedback_scores]);
 
   const input = useMemo(() => {
-    const message = prettifyMessage(trace.input).message;
+    const message = prettifyMessage(trace.input, {
+      type: "input",
+      openInferenceHint,
+    }).message;
 
     if (isObject(message)) {
       return (
@@ -49,12 +58,13 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
     } else {
       return <MarkdownPreview>{toString(message)}</MarkdownPreview>;
     }
-  }, [trace.input, jsonViewTheme]);
+  }, [trace.input, jsonViewTheme, openInferenceHint]);
 
   const output = useMemo(() => {
     const message = prettifyMessage(trace.output, {
       type: "output",
       openInferenceInput: trace.input,
+      openInferenceHint,
     }).message;
 
     if (isObject(message)) {
@@ -72,7 +82,7 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
     } else {
       return <MarkdownPreview>{toString(message)}</MarkdownPreview>;
     }
-  }, [trace.input, trace.output, jsonViewTheme]);
+  }, [trace.input, trace.output, jsonViewTheme, openInferenceHint]);
 
   return (
     <div className="flex flex-col gap-2" data-trace-message-id={trace.id}>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
@@ -52,7 +52,10 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   }, [trace.input, jsonViewTheme]);
 
   const output = useMemo(() => {
-    const message = prettifyMessage(trace.output, { type: "output" }).message;
+    const message = prettifyMessage(trace.output, {
+      type: "output",
+      openInferenceInput: trace.input,
+    }).message;
 
     if (isObject(message)) {
       return (
@@ -69,7 +72,7 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
     } else {
       return <MarkdownPreview>{toString(message)}</MarkdownPreview>;
     }
-  }, [trace.output, jsonViewTheme]);
+  }, [trace.input, trace.output, jsonViewTheme]);
 
   return (
     <div className="flex flex-col gap-2" data-trace-message-id={trace.id}>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceMessages/TraceMessage.tsx
@@ -10,10 +10,9 @@ import LikeFeedback from "@/v2/pages-shared/traces/TraceMessages/LikeFeedback";
 import { Separator } from "@/ui/separator";
 import { Button } from "@/ui/button";
 import { USER_FEEDBACK_NAME } from "@/constants/shared";
-import { prettifyMessage } from "@/lib/traces";
+import { prettifyTraceField } from "@/lib/traces";
 import { toString } from "@/lib/utils";
 import { useJsonViewTheme } from "@/hooks/useJsonViewTheme";
-import { hasOpenInferenceHint } from "@/lib/openinference";
 
 type TraceMessageProps = {
   trace: Trace;
@@ -25,11 +24,6 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   handleOpenTrace,
 }) => {
   const jsonViewTheme = useJsonViewTheme();
-  const openInferenceHint = hasOpenInferenceHint(
-    trace.metadata,
-    trace.input,
-    trace.output,
-  );
 
   const userFeedback = useMemo(() => {
     return (trace.feedback_scores ?? []).find(
@@ -38,10 +32,7 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
   }, [trace.feedback_scores]);
 
   const input = useMemo(() => {
-    const message = prettifyMessage(trace.input, {
-      type: "input",
-      openInferenceHint,
-    }).message;
+    const message = prettifyTraceField(trace, "input").message;
 
     if (isObject(message)) {
       return (
@@ -58,14 +49,10 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
     } else {
       return <MarkdownPreview>{toString(message)}</MarkdownPreview>;
     }
-  }, [trace.input, jsonViewTheme, openInferenceHint]);
+  }, [trace, jsonViewTheme]);
 
   const output = useMemo(() => {
-    const message = prettifyMessage(trace.output, {
-      type: "output",
-      openInferenceInput: trace.input,
-      openInferenceHint,
-    }).message;
+    const message = prettifyTraceField(trace, "output").message;
 
     if (isObject(message)) {
       return (
@@ -82,7 +69,7 @@ const TraceMessage: React.FC<TraceMessageProps> = ({
     } else {
       return <MarkdownPreview>{toString(message)}</MarkdownPreview>;
     }
-  }, [trace.input, trace.output, jsonViewTheme, openInferenceHint]);
+  }, [trace, jsonViewTheme]);
 
   return (
     <div className="flex flex-col gap-2" data-trace-message-id={trace.id}>

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { csv2json } from "json-2-csv";
+import { TooltipProvider } from "@/ui/tooltip";
+import {
+  ANNOTATION_QUEUE_SCOPE,
+  AnnotationQueue,
+} from "@/types/annotation-queues";
+import { JsonNode } from "@/types/shared";
+import { Thread } from "@/types/traces";
+import { ThreadStatus } from "@/types/thread";
+import ExportAnnotatedDataButton from "./ExportAnnotatedDataButton";
+
+const mocks = vi.hoisted(() => ({
+  saveAs: vi.fn<(blob: Blob, name: string) => void>(),
+  refetchThreads: vi.fn(),
+  refetchTraces: vi.fn(),
+}));
+vi.mock("file-saver", () => ({ saveAs: mocks.saveAs }));
+vi.mock("@/api/traces/useThreadsList", () => ({
+  default: () => ({ refetch: mocks.refetchThreads }),
+}));
+vi.mock("@/api/traces/useTracesList", () => ({
+  default: () => ({ refetch: mocks.refetchTraces }),
+}));
+vi.mock("@/contexts/feature-toggles-provider", () => ({
+  useIsFeatureEnabled: () => true,
+}));
+
+const queue: AnnotationQueue = {
+  id: "queue-1",
+  project_id: "project-1",
+  project_name: "Project",
+  name: "Review",
+  scope: ANNOTATION_QUEUE_SCOPE.THREAD,
+  comments_enabled: true,
+  feedback_definition_names: [],
+  items_count: 1,
+  created_at: "2026-09-11T00:00:00Z",
+  created_by: "reviewer",
+  last_updated_at: "2026-09-11T00:00:00Z",
+  last_updated_by: "reviewer",
+  last_scored_at: "2026-09-11T00:00:00Z",
+};
+const thread = (first_message?: JsonNode, last_message?: JsonNode): Thread => ({
+  id: "thread-1",
+  thread_model_id: "model-1",
+  project_id: "project-1",
+  start_time: "2026-09-11T00:00:00Z",
+  end_time: "2026-09-11T00:00:01Z",
+  duration: 1,
+  first_message,
+  last_message,
+  number_of_messages: 2,
+  status: ThreadStatus.INACTIVE,
+  created_at: "2026-09-11T00:00:00Z",
+  last_updated_at: "2026-09-11T00:00:01Z",
+  created_by: "reviewer",
+});
+
+async function exportFile(format: "JSON" | "CSV") {
+  render(
+    <TooltipProvider>
+      <ExportAnnotatedDataButton annotationQueue={queue} />
+    </TooltipProvider>,
+  );
+  await act(async () => {
+    fireEvent.keyDown(screen.getByRole("button", { name: "Export queue" }), {
+      key: "ArrowDown",
+    });
+  });
+  const menuItem = await screen.findByRole("menuitem", {
+    name: `As ${format}`,
+  });
+  await act(async () => {
+    fireEvent.click(menuItem);
+  });
+  await waitFor(() => expect(mocks.saveAs).toHaveBeenCalledOnce());
+  const [blob, filename] = mocks.saveAs.mock.calls[0];
+  expect(filename).toBe(`annotated-thread-Review.${format.toLowerCase()}`);
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () =>
+      typeof reader.result === "string"
+        ? resolve(reader.result)
+        : reject(new Error("Expected text"));
+    reader.onerror = reject;
+    reader.readAsText(blob);
+  });
+}
+
+describe("thread annotation exports", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("preserves omitted message fields from the API", async () => {
+    mocks.refetchThreads.mockResolvedValue({ data: { content: [thread()] } });
+    expect(JSON.parse(await exportFile("JSON"))).toEqual([{ id: "thread-1" }]);
+  });
+
+  const first_message = {
+    messages: [
+      { role: "system", content: "Instructions" },
+      { role: "user", content: "Question" },
+    ],
+  };
+  const last_message = {
+    messages: [
+      {
+        role: "assistant",
+        content: "Earlier answer",
+        tool_calls: [
+          {
+            id: "call-1",
+            function: { name: "search", arguments: '{"query":"topic"}' },
+          },
+        ],
+      },
+      { role: "tool", tool_call_id: "call-1", content: "Tool result" },
+      {
+        role: "assistant",
+        content: "Final answer",
+        contents: [{ image: { url: "https://example.com/image.png" } }],
+      },
+    ],
+  };
+
+  it("preserves all turns, tool calls, and media in JSON", async () => {
+    mocks.refetchThreads.mockResolvedValue({
+      data: { content: [thread(first_message, last_message)] },
+    });
+    expect(JSON.parse(await exportFile("JSON"))).toEqual([
+      { id: "thread-1", first_message, last_message },
+    ]);
+  });
+
+  it("preserves structured message fields in CSV cells", async () => {
+    mocks.refetchThreads.mockResolvedValue({
+      data: { content: [thread(first_message, last_message)] },
+    });
+    const rows = csv2json(await exportFile("CSV"));
+    expect(rows).toEqual([{ id: "thread-1", first_message, last_message }]);
+  });
+
+  it.each([0, false, null])(
+    "preserves scalar/null payload %j in JSON",
+    async (value) => {
+      mocks.refetchThreads.mockResolvedValue({
+        data: { content: [thread(value, value)] },
+      });
+      expect(JSON.parse(await exportFile("JSON"))).toEqual([
+        { id: "thread-1", first_message: value, last_message: value },
+      ]);
+    },
+  );
+});

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -31,6 +31,7 @@ import { JsonNode } from "@/types/shared";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const MAX_EXPORT_ITEMS = 15000;
 const MESSAGES_KEYS = ["input", "output", "first_message", "last_message"];
@@ -119,13 +120,21 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       if (!traces?.length) return [];
 
       return traces.map((trace: Trace) => {
+        const openInferenceHint = hasOpenInferenceHint(
+          trace.metadata,
+          trace.input,
+          trace.output,
+        );
         const baseData: ExportTraceData = {
           id: trace.id,
-          input: prettifyMessage(trace.input, { type: "input" })
-            .message as JsonNode,
+          input: prettifyMessage(trace.input, {
+            type: "input",
+            openInferenceHint,
+          }).message as JsonNode,
           output: prettifyMessage(trace.output, {
             type: "output",
             openInferenceInput: trace.input,
+            openInferenceHint,
           }).message as JsonNode,
           metadata: trace.metadata ?? {},
         };

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -123,8 +123,10 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
           id: trace.id,
           input: prettifyMessage(trace.input, { type: "input" })
             .message as JsonNode,
-          output: prettifyMessage(trace.output, { type: "output" })
-            .message as JsonNode,
+          output: prettifyMessage(trace.output, {
+            type: "output",
+            openInferenceInput: trace.input,
+          }).message as JsonNode,
           metadata: trace.metadata ?? {},
         };
 

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -26,12 +26,11 @@ import {
   getFeedbackScoresByUser,
   getCommentsByUser,
 } from "@/lib/annotation-queues";
-import { prettifyMessage } from "@/lib/traces";
+import { prettifyMessage, prettifyTraceField } from "@/lib/traces";
 import { JsonNode } from "@/types/shared";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
 import { FeatureToggleKeys } from "@/types/feature-toggles";
-import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const MAX_EXPORT_ITEMS = 15000;
 const MESSAGES_KEYS = ["input", "output", "first_message", "last_message"];
@@ -120,22 +119,10 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       if (!traces?.length) return [];
 
       return traces.map((trace: Trace) => {
-        const openInferenceHint = hasOpenInferenceHint(
-          trace.metadata,
-          trace.input,
-          trace.output,
-        );
         const baseData: ExportTraceData = {
           id: trace.id,
-          input: prettifyMessage(trace.input, {
-            type: "input",
-            openInferenceHint,
-          }).message as JsonNode,
-          output: prettifyMessage(trace.output, {
-            type: "output",
-            openInferenceInput: trace.input,
-            openInferenceHint,
-          }).message as JsonNode,
+          input: prettifyTraceField(trace, "input").message as JsonNode,
+          output: prettifyTraceField(trace, "output").message as JsonNode,
           metadata: trace.metadata ?? {},
         };
 

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -26,7 +26,7 @@ import {
   getFeedbackScoresByUser,
   getCommentsByUser,
 } from "@/lib/annotation-queues";
-import { prettifyThreadField, prettifyTraceField } from "@/lib/traces";
+import { prettifyTraceField } from "@/lib/traces";
 import { JsonNode } from "@/types/shared";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
@@ -55,8 +55,8 @@ interface ExportTraceData {
 
 interface ExportThreadData {
   id: string;
-  first_message: JsonNode;
-  last_message: JsonNode;
+  first_message?: JsonNode;
+  last_message?: JsonNode;
   [reviewerName: string]: unknown;
 }
 
@@ -170,10 +170,9 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       return threads.map((thread: Thread) => {
         const baseData: ExportThreadData = {
           id: thread.id,
-          first_message: prettifyThreadField(thread, "input")
-            .message as JsonNode,
-          last_message: prettifyThreadField(thread, "output")
-            .message as JsonNode,
+          // Export stored payloads, not UI previews that omit turns/tools/media.
+          first_message: thread.first_message,
+          last_message: thread.last_message,
         };
 
         reviewers.forEach((reviewerName) => {

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/ExportAnnotatedDataButton.tsx
@@ -26,7 +26,7 @@ import {
   getFeedbackScoresByUser,
   getCommentsByUser,
 } from "@/lib/annotation-queues";
-import { prettifyMessage, prettifyTraceField } from "@/lib/traces";
+import { prettifyThreadField, prettifyTraceField } from "@/lib/traces";
 import { JsonNode } from "@/types/shared";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import { useIsFeatureEnabled } from "@/contexts/feature-toggles-provider";
@@ -170,10 +170,9 @@ const ExportAnnotatedDataButton: React.FC<ExportAnnotatedDataButtonProps> = ({
       return threads.map((thread: Thread) => {
         const baseData: ExportThreadData = {
           id: thread.id,
-          first_message: prettifyMessage(thread.first_message, {
-            type: "input",
-          }).message as JsonNode,
-          last_message: prettifyMessage(thread.last_message, { type: "output" })
+          first_message: prettifyThreadField(thread, "input")
+            .message as JsonNode,
+          last_message: prettifyThreadField(thread, "output")
             .message as JsonNode,
         };
 

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/ThreadQueueItemsTab.tsx
@@ -46,6 +46,7 @@ import DataTableEmptyContent from "@/shared/DataTableNoData/DataTableEmptyConten
 import DataTablePagination from "@/shared/DataTablePagination/DataTablePagination";
 import IdCell from "@/shared/DataTableCells/IdCell";
 import PrettyCell from "@/shared/DataTableCells/PrettyCell";
+import { getThreadPrettifyConfig } from "@/lib/traces";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import CostCell from "@/shared/DataTableCells/CostCell";
 import CommentsCell from "@/shared/DataTableCells/CommentsCell";
@@ -78,6 +79,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "input",
+      getPrettifyConfig: getThreadPrettifyConfig,
     },
   },
   {
@@ -88,6 +90,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "output",
+      getPrettifyConfig: getThreadPrettifyConfig,
     },
   },
   {

--- a/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/AnnotationQueuePage/QueueItemsTab/TraceQueueItemsTab.tsx
@@ -1,3 +1,4 @@
+import { getPrettifyConfig } from "@/lib/traces";
 import React, { useMemo, useState } from "react";
 import {
   JsonParam,
@@ -121,6 +122,7 @@ const TRACE_COLUMNS: ColumnData<Trace>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "input",
+      getPrettifyConfig,
     },
   },
   {
@@ -131,6 +133,7 @@ const TRACE_COLUMNS: ColumnData<Trace>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "output",
+      getPrettifyConfig,
     },
   },
   {

--- a/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/ThreadsTab/ThreadsTab.tsx
@@ -60,6 +60,7 @@ import DataTablePagination from "@/shared/DataTablePagination/DataTablePaginatio
 import IdCell from "@/shared/DataTableCells/IdCell";
 import DurationCell from "@/shared/DataTableCells/DurationCell";
 import PrettyCell from "@/shared/DataTableCells/PrettyCell";
+import { getThreadPrettifyConfig } from "@/lib/traces";
 import CostCell from "@/shared/DataTableCells/CostCell";
 import RefreshButton from "@/shared/RefreshButton/RefreshButton";
 import ThreadDetailsPanel from "@/v2/pages-shared/traces/ThreadDetailsPanel/ThreadDetailsPanel";
@@ -129,6 +130,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "input",
+      getPrettifyConfig: getThreadPrettifyConfig,
       colorIndicator: true,
     },
   },
@@ -140,6 +142,7 @@ const SHARED_COLUMNS: ColumnData<Thread>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "output",
+      getPrettifyConfig: getThreadPrettifyConfig,
       colorIndicator: true,
     },
   },

--- a/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/LogsPage/TracesSpansTab/TracesSpansTab.tsx
@@ -1,3 +1,4 @@
+import { getPrettifyConfig } from "@/lib/traces";
 import React, { useCallback, useMemo, useState, useEffect } from "react";
 import {
   JsonParam,
@@ -193,6 +194,7 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "input",
+      getPrettifyConfig,
       colorIndicator: true,
     },
   },
@@ -204,6 +206,7 @@ const SHARED_COLUMNS: ColumnData<BaseTraceData>[] = [
     cell: PrettyCell as never,
     customMeta: {
       fieldType: "output",
+      getPrettifyConfig,
       colorIndicator: true,
     },
   },

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.test.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Thread } from "@/types/traces";
+import { ThreadStatus } from "@/types/thread";
+import ItemsSidebar from "./ItemsSidebar";
+
+const mockUseSMEFlow = vi.hoisted(() => vi.fn());
+vi.mock("../SMEFlowContext", async () => ({
+  ITEM_STATE: (await import("@/lib/annotation-queues")).ITEM_STATE,
+  useSMEFlow: mockUseSMEFlow,
+}));
+
+describe("ItemsSidebar thread previews", () => {
+  it.each([0, false, null])(
+    "renders thread output %j without a truthiness gate",
+    (last_message) => {
+      const thread: Thread = {
+        id: "thread-1",
+        thread_model_id: "model-1",
+        project_id: "project-1",
+        start_time: "2026-09-11T00:00:00Z",
+        end_time: "2026-09-11T00:00:01Z",
+        duration: 1,
+        first_message: "Question",
+        last_message,
+        number_of_messages: 2,
+        created_at: "2026-09-11T00:00:00Z",
+        last_updated_at: "2026-09-11T00:00:01Z",
+        created_by: "reviewer",
+        status: ThreadStatus.INACTIVE,
+      };
+      mockUseSMEFlow.mockReturnValue({
+        queueItems: [thread],
+        currentIndex: 0,
+        itemStates: {},
+        shuffledItemIds: [thread.thread_model_id],
+        navigateToItem: vi.fn(),
+      });
+      const html = renderToStaticMarkup(<ItemsSidebar />);
+      expect(html).toContain("Question");
+      if (last_message === null) {
+        expect(html).not.toContain(">null</");
+      } else {
+        expect(html).toContain(`>${last_message}</`);
+      }
+    },
+  );
+});

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
@@ -17,11 +17,11 @@ import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
 const getPreviewText = (
   obj: object | undefined,
   type: "input" | "output",
+  openInferenceInput?: object,
 ): string => {
-  if (!obj) return "";
-  const result = prettifyMessage(obj, { type });
+  const result = prettifyMessage(obj, { type, openInferenceInput });
   if (typeof result.message === "string") return result.message;
-  return JSON.stringify(obj).slice(0, 80);
+  return obj ? JSON.stringify(obj).slice(0, 80) : "";
 };
 
 const getItemPreviews = (
@@ -44,7 +44,7 @@ const getItemPreviews = (
   return {
     name: trace.name || trace.id.slice(-12),
     input: getPreviewText(trace.input, "input"),
-    output: getPreviewText(trace.output, "output"),
+    output: getPreviewText(trace.output, "output", trace.input),
   };
 };
 

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
@@ -13,13 +13,19 @@ import { Trace, Thread } from "@/types/traces";
 import { isObjectThread } from "@/lib/traces";
 import { prettifyMessage } from "@/lib/traces";
 import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const getPreviewText = (
   obj: object | undefined,
   type: "input" | "output",
   openInferenceInput?: object,
+  openInferenceHint?: boolean,
 ): string => {
-  const result = prettifyMessage(obj, { type, openInferenceInput });
+  const result = prettifyMessage(obj, {
+    type,
+    openInferenceInput,
+    openInferenceHint,
+  });
   if (typeof result.message === "string") return result.message;
   return obj ? JSON.stringify(obj).slice(0, 80) : "";
 };
@@ -41,10 +47,20 @@ const getItemPreviews = (
     };
   }
   const trace = item as Trace;
+  const openInferenceHint = hasOpenInferenceHint(
+    trace.metadata,
+    trace.input,
+    trace.output,
+  );
   return {
     name: trace.name || trace.id.slice(-12),
-    input: getPreviewText(trace.input, "input"),
-    output: getPreviewText(trace.output, "output", trace.input),
+    input: getPreviewText(trace.input, "input", undefined, openInferenceHint),
+    output: getPreviewText(
+      trace.output,
+      "output",
+      trace.input,
+      openInferenceHint,
+    ),
   };
 };
 

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
@@ -11,16 +11,12 @@ import {
 } from "@/lib/annotation-queues";
 import { Trace, Thread } from "@/types/traces";
 import { isObjectThread } from "@/lib/traces";
-import { prettifyMessage, prettifyTraceField } from "@/lib/traces";
+import { prettifyThreadField, prettifyTraceField } from "@/lib/traces";
 import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
 
-const getPreviewText = (
-  obj: object | undefined,
-  type: "input" | "output",
-): string => {
-  const result = prettifyMessage(obj, {
-    type,
-  });
+const getPreviewText = (thread: Thread, type: "input" | "output"): string => {
+  const obj = type === "input" ? thread.first_message : thread.last_message;
+  const result = prettifyThreadField(thread, type);
   if (typeof result.message === "string") return result.message;
   return obj ? JSON.stringify(obj).slice(0, 80) : "";
 };
@@ -35,10 +31,8 @@ const getItemPreviews = (
       thread.id.slice(-12);
     return {
       name,
-      input: getPreviewText(thread.first_message, "input"),
-      output: thread.last_message
-        ? getPreviewText(thread.last_message, "output")
-        : "",
+      input: getPreviewText(thread, "input"),
+      output: thread.last_message ? getPreviewText(thread, "output") : "",
     };
   }
   const trace = item as Trace;

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
@@ -11,20 +11,15 @@ import {
 } from "@/lib/annotation-queues";
 import { Trace, Thread } from "@/types/traces";
 import { isObjectThread } from "@/lib/traces";
-import { prettifyMessage } from "@/lib/traces";
+import { prettifyMessage, prettifyTraceField } from "@/lib/traces";
 import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
-import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const getPreviewText = (
   obj: object | undefined,
   type: "input" | "output",
-  openInferenceInput?: object,
-  openInferenceHint?: boolean,
 ): string => {
   const result = prettifyMessage(obj, {
     type,
-    openInferenceInput,
-    openInferenceHint,
   });
   if (typeof result.message === "string") return result.message;
   return obj ? JSON.stringify(obj).slice(0, 80) : "";
@@ -47,20 +42,18 @@ const getItemPreviews = (
     };
   }
   const trace = item as Trace;
-  const openInferenceHint = hasOpenInferenceHint(
-    trace.metadata,
-    trace.input,
-    trace.output,
-  );
+  const preview = (type: "input" | "output") => {
+    const { message } = prettifyTraceField(trace, type);
+    return typeof message === "string"
+      ? message
+      : message
+        ? JSON.stringify(message).slice(0, 80)
+        : "";
+  };
   return {
     name: trace.name || trace.id.slice(-12),
-    input: getPreviewText(trace.input, "input", undefined, openInferenceHint),
-    output: getPreviewText(
-      trace.output,
-      "output",
-      trace.input,
-      openInferenceHint,
-    ),
+    input: preview("input"),
+    output: preview("output"),
   };
 };
 

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/ItemsSidebar.tsx
@@ -32,7 +32,7 @@ const getItemPreviews = (
     return {
       name,
       input: getPreviewText(thread, "input"),
-      output: thread.last_message ? getPreviewText(thread, "output") : "",
+      output: getPreviewText(thread, "output"),
     };
   }
   const trace = item as Trace;

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/TraceDataViewer.tsx
@@ -16,6 +16,7 @@ import CodeBlock from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewe
 import { manageToolFilter } from "@/v2/pages-shared/traces/spanTypeFilter";
 import TraceIdentifier from "./TraceIdentifier";
 import { Button } from "@/ui/button";
+import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const STALE_TIME = 5 * 60 * 1000;
 
@@ -135,6 +136,11 @@ const TraceContent: React.FC = () => {
 
   const { media, transformedInput, transformedOutput } =
     useUnifiedMedia(displayTrace);
+  const openInferenceHint = hasOpenInferenceHint(
+    displayTrace?.metadata,
+    transformedInput,
+    transformedOutput,
+  );
 
   return (
     <>
@@ -144,14 +150,18 @@ const TraceContent: React.FC = () => {
           <CodeBlock
             title="Input"
             data={transformedInput}
-            prettifyConfig={{ fieldType: "input" }}
+            prettifyConfig={{ fieldType: "input", openInferenceHint }}
             preserveKey="syntax-highlighter-annotation-input"
             withSearch
           />
           <CodeBlock
             title="Output"
             data={transformedOutput}
-            prettifyConfig={{ fieldType: "output" }}
+            prettifyConfig={{
+              fieldType: "output",
+              openInferenceHint,
+              openInferenceInput: transformedInput,
+            }}
             preserveKey="syntax-highlighter-annotation-output"
             withSearch
           />

--- a/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/TraceDataViewer.tsx
+++ b/apps/opik-frontend/src/v2/pages/SMEFlowPage/AnnotationView/TraceDataViewer.tsx
@@ -5,6 +5,7 @@ import { ArrowUpRight, Loader2 } from "lucide-react";
 import BaseTraceDataTypeIcon from "@/shared/BaseTraceDataTypeIcon/BaseTraceDataTypeIcon";
 import { TRACE_TYPE_FOR_TREE } from "@/constants/traces";
 import { Trace } from "@/types/traces";
+import { getPrettifyConfig } from "@/lib/traces";
 import { Filter } from "@/types/filters";
 import { useSMEFlow } from "../SMEFlowContext";
 import useTraceById from "@/api/traces/useTraceById";
@@ -16,7 +17,6 @@ import CodeBlock from "@/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewe
 import { manageToolFilter } from "@/v2/pages-shared/traces/spanTypeFilter";
 import TraceIdentifier from "./TraceIdentifier";
 import { Button } from "@/ui/button";
-import { hasOpenInferenceHint } from "@/lib/openinference";
 
 const STALE_TIME = 5 * 60 * 1000;
 
@@ -136,11 +136,11 @@ const TraceContent: React.FC = () => {
 
   const { media, transformedInput, transformedOutput } =
     useUnifiedMedia(displayTrace);
-  const openInferenceHint = hasOpenInferenceHint(
-    displayTrace?.metadata,
-    transformedInput,
-    transformedOutput,
-  );
+  const prettifySource = {
+    metadata: displayTrace?.metadata,
+    input: transformedInput,
+    output: transformedOutput,
+  };
 
   return (
     <>
@@ -150,7 +150,10 @@ const TraceContent: React.FC = () => {
           <CodeBlock
             title="Input"
             data={transformedInput}
-            prettifyConfig={{ fieldType: "input", openInferenceHint }}
+            prettifyConfig={{
+              ...getPrettifyConfig(prettifySource, "input"),
+              fieldType: "input",
+            }}
             preserveKey="syntax-highlighter-annotation-input"
             withSearch
           />
@@ -158,9 +161,8 @@ const TraceContent: React.FC = () => {
             title="Output"
             data={transformedOutput}
             prettifyConfig={{
+              ...getPrettifyConfig(prettifySource, "output"),
               fieldType: "output",
-              openInferenceHint,
-              openInferenceInput: transformedInput,
             }}
             preserveKey="syntax-highlighter-annotation-output"
             withSearch


### PR DESCRIPTION
## Details

OpenInference traces now render in the Messages tab and Pretty previews instead of appearing only as dotted-key JSON. Newly ingested spans use canonical input/output fields; historical flattened records remain readable without a backfill.

- Normalize chat and completion messages, tools, multimodal content, model/provider data, usage, cost, sessions, tags, and metadata for spans carrying `openinference.span.kind`.
- Preserve repeated conversation turns and tool calls, ordered content, malformed-value fallbacks, role-less responses, and scalar `0`/`false` previews. Indexed legacy function calls remain attached to their originating messages, independently of the separate `llm.function_call` attribute.
- Render stored media attachments while rejecting unsafe media URL schemes. Keep ordinary unmarked spans and mixed-provider responses on their existing formatting paths.
- Calculate Anthropic/Bedrock cache usage without counting cached prompt tokens twice, recognize the OpenInference `aws` provider, and charge audio tokens at audio rates.
- Merge partial span usage with provider usage and consolidate repeated regression scenarios into parameterized tests.

## Change checklist

- [x] User facing
- [x] Documentation update

## Issues

- Resolves #7686

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: OpenAI Codex desktop, GitHub CLI, Docker, Maven, Vitest, ESLint, Spotless, Prettier, local Opik stack, and browser automation
  - Model(s): OpenAI Codex (model selected by the Codex app)
  - Scope: Specification review, backend/frontend implementation, regression tests, bot-comment assessment, local verification, documentation, and PR preparation
  - Human verification: Previously reported by the author; this follow-up was verified by Codex through automated checks and browser inspection.

## Testing

Java checks ran in Docker with JDK 25; frontend checks ran in Docker with Node 20.

- `mvn -q -Dtest=OpenTelemetryMapperTest,CostServiceTest,SpanCostCalculatorTest test` — 316 tests passed.
- `mvn -q '-Dtest=OpenTelemetryResourceTest$ApiKey#testOpenInferenceSpanNormalization' test` — passed against real Testcontainers databases; Docker-specific test configuration points ClickHouse at `host.docker.internal` and uses IPv4.
- `npm run test -- --run src/shared/PrettyLLMMessage/llmMessages src/lib/traces.test.ts` — 177 tests passed across OpenInference, OpenAI, LangChain, and shared previews.
- `npm run typecheck`, `npm run lint`, and `npm run deps:validate` passed.
- Scoped `mvn -q spotless:apply`, Prettier, and `git diff --check` passed.
- `COMPOSE_BAKE=false COMPOSE_PARALLEL_LIMIT=1 ./opik.sh --build` and `./opik.sh --verify` passed; all eight services are healthy.
- Six fresh OTLP/API scenarios passed against the rebuilt stack: repeated turns, Anthropic cache pricing, Bedrock cache pricing, audio pricing, stored image attachments, and scalar `0`/`false`.
- Browser inspection confirmed that both repeated user turns remain visible, the stored image loads in Messages, a role-less response appears in the table, and `0`/`false` remain visible.
- `npm run dev` for Fern in Docker; the OpenTelemetry page, migration warning, and mapping table rendered in the browser.

Follow-up validation for indexed function calls: `mvn -q -Dtest=OpenTelemetryMapperTest test` passed all 187 tests, including two parameterized cases with and without a standalone call. The regression failed before the fix. Rebuilt the backend image, verified stack health, and confirmed both stored OTLP messages and their frontend rendering retain the correct function calls.

The full monorepo and Playwright suites were not run; validation targets the changed ingestion, cost, formatting, and preview paths.

## Documentation

Updated the OpenTelemetry integration guide with OpenInference formatting behavior and old/new online-evaluation variable mappings. **Existing rules and custom consumers that reference flattened OpenInference fields must update their paths for newly ingested spans.** Historical records retain their original paths; sparse message/content/tool-call indices are compacted during new ingestion.

