### PR TITLE
docs: correct the OOM-arm discharge in RedisStreamCodec — no publish-time guard ships

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisStreamCodec.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/redis/RedisStreamCodec.java
@@ -164,8 +164,9 @@ public enum RedisStreamCodec {
      * a cause, and keep consuming — masking it. The recovery measured above is single-threaded and
      * proves the decode path, not a loaded service; an allocation large enough to fail can still starve
      * a different thread, which throws where nothing catches it. The counter to that is a size guard at
-     * publish time, which is what {@code onlineScoring.dropOversizedPayloads} does, not anything this
-     * codec can do on read.
+     * publish time. No such guard ships today -- #8060 applied the codec's stream-read limits but added
+     * no publisher-side size check -- so this residual risk is open rather than delegated. It is not
+     * something this codec can address on read.
      * <p>
      * No other {@link Error} is absorbed — a {@link StackOverflowError} still propagates.
      */


### PR DESCRIPTION
## Details

Follow-up to review feedback on #8089, which merged before the comment was addressed.

`RedisStreamCodec`'s javadoc justified absorbing an `OutOfMemoryError` by pointing at a publish-time size guard as the control covering the residual risk, naming `onlineScoring.dropOversizedPayloads`. **That key does not exist** — a repo-wide grep returns exactly one hit, the sentence itself:

```
$ grep -rn "dropOversizedPayloads" . --exclude-dir=.git
apps/.../RedisStreamCodec.java:167:  * publish time, which is what {@code onlineScoring.dropOversizedPayloads} does, ...
```

It never shipped. #8060 merged as the Guice/Dropwizard ordering fix that made the codec actually receive `maxStringLength`; the publisher-side drop guard it originally carried was cut from that PR before merge, under this or any other name.

That matters more than a stale reference normally would, because of the job the sentence was doing. The paragraph above it makes the most serious admission in the design — under real heap pressure this arm absorbs an OOM that was a *symptom* rather than a cause and keeps consuming, masking it — and this sentence was its discharge. With no such guard, that risk is **open, not delegated**, and someone auditing the decision later would go looking for a control that was never built.

Wording as suggested in review.

## Change checklist
- [ ] User facing
- [ ] Documentation update

Comment-only. No behaviour change: the OOM-absorbing call itself is unchanged and was not in question — `values.yaml` ships `-XX:+UseG1GC -XX:MaxRAMPercentage=80.0` with no `ExitOnOutOfMemoryError` anywhere in the repo, so the process already survives an OOM, and not absorbing it would buy a live pod with a wedged stream.

## Issues

- OPIK-8192 (follow-up)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: verifying the reviewer's claim, the wording change, and this description.
- Human verification: the grep result above was run against this branch; `mvn -o compile` passes. Comment-only change.

## Testing

`mvn -o compile -DskipTests` — BUILD SUCCESS. No test changes: the diff is a javadoc comment.