### PR TITLE
[issue-8132] [BE] fix: support span cost breakdowns

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownField.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownField.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * Compatibility with metric types is based on entity type:
  * - Trace metrics: DURATION, TRACE_COUNT, TOKEN_USAGE, COST, FEEDBACK_SCORES, GUARDRAILS_FAILED_COUNT
  * - Thread metrics: THREAD_COUNT, THREAD_DURATION, THREAD_FEEDBACK_SCORES
- * - Span metrics: SPAN_COUNT, SPAN_DURATION, SPAN_TOKEN_USAGE, SPAN_FEEDBACK_SCORES
+ * - Span metrics: SPAN_COUNT, SPAN_DURATION, SPAN_TOKEN_USAGE, SPAN_FEEDBACK_SCORES, SPAN_COST
  */
 @RequiredArgsConstructor
 @Getter
@@ -55,7 +55,8 @@ public enum BreakdownField {
             MetricType.SPAN_COUNT,
             MetricType.SPAN_DURATION,
             MetricType.SPAN_TOKEN_USAGE,
-            MetricType.SPAN_FEEDBACK_SCORES);
+            MetricType.SPAN_FEEDBACK_SCORES,
+            MetricType.SPAN_COST);
 
     /**
      * Check if this group by field is compatible with the given metric type.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -1125,6 +1125,17 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
 
+    private static final String GET_SPAN_COST_WITH_BREAKDOWN = """
+            %s
+            SELECT <bucket> AS bucket,
+                   <group_expression> AS group_name,
+                   sum(total_estimated_cost) AS value
+            FROM spans_filtered s
+            GROUP BY bucket, group_name
+            ORDER BY bucket, group_name
+            SETTINGS log_comment = '<log_comment>';
+            """.formatted(SPAN_FILTERED_PREFIX);
+
     private static final String GET_SPAN_ERROR_RATE = """
             %s
             SELECT <bucket> AS bucket,
@@ -1498,8 +1509,14 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
 
     @Override
     public Mono<List<Entry>> getSpanCost(@NonNull UUID projectId, @NonNull ProjectMetricRequest request) {
-        return fetchSingleMetric(projectId, request, GET_SPAN_COST, "spanCost",
-                row -> NAME_SPAN_COST, row -> row.get("value", BigDecimal.class));
+        return template.nonTransaction(connection -> getMetric(projectId, request, connection,
+                request.hasBreakdown() ? GET_SPAN_COST_WITH_BREAKDOWN : GET_SPAN_COST, "spanCost")
+                .flatMapMany(result -> request.hasBreakdown()
+                        ? rowToDataPointWithBreakdown(result, row -> NAME_SPAN_COST,
+                                row -> row.get("value", BigDecimal.class))
+                        : rowToDataPoint(result, row -> NAME_SPAN_COST,
+                                row -> row.get("value", BigDecimal.class)))
+                .collectList());
     }
 
     @Override

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/metrics/BreakdownQueryBuilderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/metrics/BreakdownQueryBuilderTest.java
@@ -7,9 +7,35 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BreakdownQueryBuilderTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"TAGS", "NAME", "MODEL", "PROVIDER"})
+    @DisplayName("validate: allows span cost breakdown fields")
+    void validate_allowsSpanCostBreakdownFields(String fieldName) {
+        var breakdown = BreakdownConfig.builder()
+                .field(BreakdownField.valueOf(fieldName))
+                .build();
+
+        assertThatCode(() -> BreakdownQueryBuilder.validate(breakdown, MetricType.SPAN_COST))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"TAGS", "NAME", "MODEL", "PROVIDER"})
+    @DisplayName("getBreakdownGroupExpression: uses span alias for span cost")
+    void getBreakdownGroupExpression_usesSpanAliasForSpanCost(String fieldName) {
+        var breakdown = BreakdownConfig.builder()
+                .field(BreakdownField.valueOf(fieldName))
+                .build();
+
+        assertThat(BreakdownQueryBuilder.getBreakdownGroupExpression(MetricType.SPAN_COST, breakdown))
+                .contains("s.")
+                .doesNotContain("t.");
+    }
 
     @ParameterizedTest
     @CsvSource({"p50,0.5", "p90,0.9", "p99,0.99", "P50,0.5", "P99,0.99"})

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/metrics/BreakdownQueryBuilderTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/metrics/BreakdownQueryBuilderTest.java
@@ -13,28 +13,33 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class BreakdownQueryBuilderTest {
 
     @ParameterizedTest
-    @ValueSource(strings = {"TAGS", "NAME", "MODEL", "PROVIDER"})
+    @ValueSource(strings = {"TAGS", "METADATA", "NAME", "ERROR_INFO", "ERROR_TYPE", "MODEL", "PROVIDER", "TYPE"})
     @DisplayName("validate: allows span cost breakdown fields")
     void validate_allowsSpanCostBreakdownFields(String fieldName) {
-        var breakdown = BreakdownConfig.builder()
-                .field(BreakdownField.valueOf(fieldName))
-                .build();
+        var breakdown = spanCostBreakdown(fieldName);
 
         assertThatCode(() -> BreakdownQueryBuilder.validate(breakdown, MetricType.SPAN_COST))
                 .doesNotThrowAnyException();
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"TAGS", "NAME", "MODEL", "PROVIDER"})
+    @ValueSource(strings = {"TAGS", "METADATA", "NAME", "ERROR_INFO", "ERROR_TYPE", "MODEL", "PROVIDER", "TYPE"})
     @DisplayName("getBreakdownGroupExpression: uses span alias for span cost")
     void getBreakdownGroupExpression_usesSpanAliasForSpanCost(String fieldName) {
-        var breakdown = BreakdownConfig.builder()
-                .field(BreakdownField.valueOf(fieldName))
-                .build();
+        var breakdown = spanCostBreakdown(fieldName);
 
         assertThat(BreakdownQueryBuilder.getBreakdownGroupExpression(MetricType.SPAN_COST, breakdown))
                 .contains("s.")
                 .doesNotContain("t.");
+    }
+
+    private static BreakdownConfig spanCostBreakdown(String fieldName) {
+        var field = BreakdownField.valueOf(fieldName);
+        var builder = BreakdownConfig.builder().field(field);
+        if (field == BreakdownField.METADATA) {
+            builder.metadataKey("env");
+        }
+        return builder.build();
     }
 
     @ParameterizedTest

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsWithBreakdownResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsWithBreakdownResourceTest.java
@@ -215,6 +215,14 @@ class ProjectMetricsWithBreakdownResourceTest {
                 Arguments.of(BreakdownField.TYPE));
     }
 
+    static Stream<Arguments> spanCostBreakdownFields() {
+        return Stream.of(
+                Arguments.of(BreakdownField.TAGS),
+                Arguments.of(BreakdownField.NAME),
+                Arguments.of(BreakdownField.MODEL),
+                Arguments.of(BreakdownField.PROVIDER));
+    }
+
     /**
      * Invalid breakdown fields for Span metrics: METADATA without metadata_key
      */
@@ -1068,6 +1076,59 @@ class ProjectMetricsWithBreakdownResourceTest {
     }
 
     @Nested
+    @DisplayName("Span Cost with Breakdown")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class SpanCostWithBreakdownTest {
+
+        @ParameterizedTest
+        @MethodSource("com.comet.opik.api.resources.v1.priv.ProjectMetricsWithBreakdownResourceTest#spanCostBreakdownFields")
+        @DisplayName("happyPath: returns per-group cost totals in every time bucket")
+        void happyPath(BreakdownField breakdownField) {
+            mockTargetWorkspace();
+            TimeInterval interval = TimeInterval.HOURLY;
+            Instant marker = getIntervalStart(interval);
+            String projectName = RandomStringUtils.secure().nextAlphabetic(10);
+            var projectId = projectResourceClient.createProject(projectName, API_KEY, WORKSPACE_NAME);
+
+            Instant bucket1 = subtract(marker, 2, interval);
+            Instant bucket2 = subtract(marker, 1, interval);
+            createSpansWithCostForBreakdown(projectName, bucket1, breakdownField, "group-a", 2,
+                    new BigDecimal("1.25"));
+            createSpansWithCostForBreakdown(projectName, bucket2, breakdownField, "group-a", 2,
+                    new BigDecimal("1.25"));
+            createSpansWithCostForBreakdown(projectName, bucket1, breakdownField, "group-b", 2,
+                    new BigDecimal("2.50"));
+            createSpansWithCostForBreakdown(projectName, bucket2, breakdownField, "group-b", 2,
+                    new BigDecimal("2.50"));
+
+            var request = ProjectMetricRequest.builder()
+                    .metricType(MetricType.SPAN_COST)
+                    .interval(interval)
+                    .intervalStart(subtract(marker, 3, interval))
+                    .intervalEnd(Instant.now())
+                    .breakdown(BreakdownConfig.builder().field(breakdownField).build())
+                    .build();
+
+            var response = projectMetricsResourceClient.getProjectMetrics(projectId, request,
+                    BigDecimal.class, API_KEY, WORKSPACE_NAME);
+
+            assertThat(response.projectId()).isEqualTo(projectId);
+            assertThat(response.metricType()).isEqualTo(MetricType.SPAN_COST);
+            assertThat(response.results())
+                    .extracting(result -> result.name())
+                    .containsExactly("group-b", "group-a");
+            assertThat(response.results().getFirst().data())
+                    .hasSize(2)
+                    .extracting(dataPoint -> dataPoint.value())
+                    .allSatisfy(value -> assertThat(value).isEqualByComparingTo(new BigDecimal("5.00")));
+            assertThat(response.results().getLast().data())
+                    .hasSize(2)
+                    .extracting(dataPoint -> dataPoint.value())
+                    .allSatisfy(value -> assertThat(value).isEqualByComparingTo(new BigDecimal("2.50")));
+        }
+    }
+
+    @Nested
     @DisplayName("Span Duration with Breakdown")
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class SpanDurationWithBreakdownTest {
@@ -1644,6 +1705,24 @@ class ProjectMetricsWithBreakdownResourceTest {
                             .projectName(projectName)
                             .startTime(spanStartTime)
                             .usage(Map.of("completion_tokens", 100, "prompt_tokens", 50));
+
+                    applyBreakdownFieldToSpan(builder, breakdownField, groupValue);
+                    return builder.build();
+                })
+                .toList();
+        spanResourceClient.batchCreateSpans(spans, API_KEY, WORKSPACE_NAME);
+    }
+
+    private void createSpansWithCostForBreakdown(String projectName, Instant marker,
+            BreakdownField breakdownField, String groupValue, int count, BigDecimal cost) {
+        List<Span> spans = IntStream.range(0, count)
+                .mapToObj(i -> {
+                    Instant spanStartTime = marker.plus(i, ChronoUnit.SECONDS);
+                    var builder = factory.manufacturePojo(Span.class).toBuilder()
+                            .id(idGenerator.generateId(spanStartTime))
+                            .projectName(projectName)
+                            .startTime(spanStartTime)
+                            .totalEstimatedCost(cost);
 
                     applyBreakdownFieldToSpan(builder, breakdownField, groupValue);
                     return builder.build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsWithBreakdownResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsWithBreakdownResourceTest.java
@@ -79,6 +79,7 @@ import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 @Slf4j
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -218,9 +219,13 @@ class ProjectMetricsWithBreakdownResourceTest {
     static Stream<Arguments> spanCostBreakdownFields() {
         return Stream.of(
                 Arguments.of(BreakdownField.TAGS),
+                Arguments.of(BreakdownField.METADATA),
                 Arguments.of(BreakdownField.NAME),
+                Arguments.of(BreakdownField.ERROR_INFO),
+                Arguments.of(BreakdownField.ERROR_TYPE),
                 Arguments.of(BreakdownField.MODEL),
-                Arguments.of(BreakdownField.PROVIDER));
+                Arguments.of(BreakdownField.PROVIDER),
+                Arguments.of(BreakdownField.TYPE));
     }
 
     /**
@@ -1095,36 +1100,49 @@ class ProjectMetricsWithBreakdownResourceTest {
             createSpansWithCostForBreakdown(projectName, bucket1, breakdownField, "group-a", 2,
                     new BigDecimal("1.25"));
             createSpansWithCostForBreakdown(projectName, bucket2, breakdownField, "group-a", 2,
-                    new BigDecimal("1.25"));
+                    new BigDecimal("1.50"));
             createSpansWithCostForBreakdown(projectName, bucket1, breakdownField, "group-b", 2,
                     new BigDecimal("2.50"));
             createSpansWithCostForBreakdown(projectName, bucket2, breakdownField, "group-b", 2,
-                    new BigDecimal("2.50"));
+                    new BigDecimal("3.00"));
 
-            var request = ProjectMetricRequest.builder()
+            var requestBuilder = ProjectMetricRequest.builder()
                     .metricType(MetricType.SPAN_COST)
                     .interval(interval)
                     .intervalStart(subtract(marker, 3, interval))
-                    .intervalEnd(Instant.now())
-                    .breakdown(BreakdownConfig.builder().field(breakdownField).build())
-                    .build();
+                    .intervalEnd(Instant.now());
 
-            var response = projectMetricsResourceClient.getProjectMetrics(projectId, request,
+            if (breakdownField == BreakdownField.METADATA) {
+                requestBuilder.breakdown(BreakdownConfig.builder()
+                        .field(breakdownField)
+                        .metadataKey("env")
+                        .build());
+            } else {
+                requestBuilder.breakdown(BreakdownConfig.builder().field(breakdownField).build());
+            }
+
+            var response = projectMetricsResourceClient.getProjectMetrics(projectId, requestBuilder.build(),
                     BigDecimal.class, API_KEY, WORKSPACE_NAME);
 
             assertThat(response.projectId()).isEqualTo(projectId);
             assertThat(response.metricType()).isEqualTo(MetricType.SPAN_COST);
             assertThat(response.results())
                     .extracting(result -> result.name())
-                    .containsExactly("group-b", "group-a");
+                    .containsExactly(
+                            expectedSpanBreakdownGroupName(breakdownField, "group-b"),
+                            expectedSpanBreakdownGroupName(breakdownField, "group-a"));
             assertThat(response.results().getFirst().data())
                     .hasSize(2)
-                    .extracting(dataPoint -> dataPoint.value())
-                    .allSatisfy(value -> assertThat(value).isEqualByComparingTo(new BigDecimal("5.00")));
+                    .extracting(dataPoint -> dataPoint.time(), dataPoint -> dataPoint.value())
+                    .containsExactly(
+                            tuple(bucket1, new BigDecimal("5.00")),
+                            tuple(bucket2, new BigDecimal("6.00")));
             assertThat(response.results().getLast().data())
                     .hasSize(2)
-                    .extracting(dataPoint -> dataPoint.value())
-                    .allSatisfy(value -> assertThat(value).isEqualByComparingTo(new BigDecimal("2.50")));
+                    .extracting(dataPoint -> dataPoint.time(), dataPoint -> dataPoint.value())
+                    .containsExactly(
+                            tuple(bucket1, new BigDecimal("2.50")),
+                            tuple(bucket2, new BigDecimal("3.00")));
         }
     }
 
@@ -1763,16 +1781,33 @@ class ProjectMetricsWithBreakdownResourceTest {
             case NAME -> builder.name(groupValue);
             case ERROR_INFO -> {
                 if ("group-a".equals(groupValue)) {
-                    builder.errorInfo(ErrorInfo.builder().message("Some error").build());
+                    builder.errorInfo(ErrorInfo.builder()
+                            .exceptionType("TestError")
+                            .message("Some error")
+                            .traceback("Test traceback")
+                            .build());
                 } else {
                     builder.errorInfo(null);
                 }
             }
+            case ERROR_TYPE -> builder.errorInfo(ErrorInfo.builder()
+                    .exceptionType(groupValue)
+                    .message("Some error")
+                    .traceback("Test traceback")
+                    .build());
             case MODEL -> builder.model(groupValue);
             case PROVIDER -> builder.provider(groupValue);
             case TYPE -> builder.type("group-a".equals(groupValue) ? SpanType.llm : SpanType.tool);
             default -> {
             }
         }
+    }
+
+    private static String expectedSpanBreakdownGroupName(BreakdownField breakdownField, String groupValue) {
+        return switch (breakdownField) {
+            case ERROR_INFO -> "group-a".equals(groupValue) ? "Has Error" : "No Error";
+            case TYPE -> "group-a".equals(groupValue) ? SpanType.llm.name() : SpanType.tool.name();
+            default -> groupValue;
+        };
     }
 }


### PR DESCRIPTION
## Details

Adds `SPAN_COST` to span breakdown compatibility and routes grouped cost rows through a dedicated span-cost SQL query. This fixes the 422 response for tags, name, model, and provider breakdowns while preserving the existing non-breakdown behavior.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8132
- No Jira ticket (external issue)

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: OpenAI Codex, GitHub CLI
  - Model(s): GPT-5 family
  - Scope: Root-cause verification, backend implementation, focused tests, formatting, and pull request drafting.
  - Human verification: Pending contributor confirmation; Codex reviewed the final diff and local test output, and the Docker-backed resource cases remain for CI or a healthy local Docker runtime.

## Testing

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH mvn -q -f apps/opik-backend/pom.xml -Dmaven.repo.local=/Users/original/Project/github/solve_issue/targets/opik-8132/.m2-cache/repository -DskipITs -Dtest=BreakdownQueryBuilderTest test` — 18 tests passed, 0 failures/errors/skips. Before the fix, the 8 new compatibility/alias cases failed as expected.
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH pre-commit run spotless --files apps/opik-backend/src/main/java/com/comet/opik/api/metrics/BreakdownField.java apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java apps/opik-backend/src/test/java/com/comet/opik/api/metrics/BreakdownQueryBuilderTest.java apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectMetricsWithBreakdownResourceTest.java` — passed.
- `git diff --check` — passed before commit.
- `TESTCONTAINERS_RYUK_DISABLED=true JAVA_HOME=/opt/homebrew/opt/openjdk@25 PATH=/opt/homebrew/opt/openjdk@25/bin:$PATH mvn -q -Dmaven.repo.local=/Users/original/Project/github/solve_issue/targets/opik-8132/.m2-cache/repository -Dtest='ProjectMetricsWithBreakdownResourceTest$SpanCostWithBreakdownTest' test` — attempted from `apps/opik-backend` on Apple Silicon macOS 15.7.8 with Docker Desktop; Testcontainers could not reach a stable Docker socket after the daemon stalled while starting dependency containers, so the four resource cases did not reach application assertions and remain for CI.
- Video: N/A; this is a backend-only query/validation change with no visible UI workflow.

## Documentation

N/A — no documentation or configuration behavior changed.

