### PR TITLE
[issue-7860] [SDK] fix: guard streaming usage helpers against IndexError and TypeError

### DIFF
--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_usage_extractor.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/anthropic_usage_extractor.py
@@ -89,7 +89,7 @@ def _try_get_model_name(run_dict: Dict[str, Any]) -> Optional[str]:
                 model = run_dict["outputs"]["generations"][-1][-1]["message"]["kwargs"][
                     "response_metadata"
                 ][model_name_key]
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, TypeError):
             continue
 
     if model is None:

--- a/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/langchain_run_helpers/helpers.py
+++ b/sdks/python/src/opik/integrations/langchain/provider_usage_extractors/langchain_run_helpers/helpers.py
@@ -23,15 +23,22 @@ def try_get_token_usage(run_dict: Dict[str, Any]) -> langchain_usage.LangChainUs
 def try_get_streaming_token_usage(
     run_dict: Dict[str, Any],
 ) -> Optional[langchain_usage.LangChainUsage]:
-    if "message" in run_dict["outputs"]["generations"][-1][-1]:
-        usage_metadata = run_dict["outputs"]["generations"][-1][-1]["message"][
-            "kwargs"
-        ].get("usage_metadata")
+    try:
+        last_gen = run_dict["outputs"]["generations"][-1][-1]
+    except (IndexError, KeyError, TypeError):
+        return None
 
-        if usage_metadata is not None:
-            return langchain_usage.LangChainUsage.from_original_usage_dict(
-                usage_metadata
-            )
+    if "message" not in last_gen:
+        return None
+
+    message = last_gen["message"]
+    # usage_metadata can live directly on message or nested under message["kwargs"]
+    usage_metadata = message.get("usage_metadata") or (
+        message.get("kwargs") or {}
+    ).get("usage_metadata")
+
+    if usage_metadata is not None:
+        return langchain_usage.LangChainUsage.from_original_usage_dict(usage_metadata)
 
     return None
 

--- a/sdks/python/tests/library_integration/langchain/test_model_name_resilience.py
+++ b/sdks/python/tests/library_integration/langchain/test_model_name_resilience.py
@@ -157,3 +157,47 @@ def test_try_get_streaming_token_usage__usage_metadata_on_message__returns_usage
     assert isinstance(result, langchain_usage.LangChainUsage)
     assert result.input_tokens == 5
     assert result.output_tokens == 8
+
+
+def _anthropic_vertexai_run_with_usage() -> Dict[str, Any]:
+    """Valid Anthropic VertexAI invocation shape with streaming usage_metadata."""
+    return {
+        "serialized": {},
+        "extra": {
+            "invocation_params": {
+                "_type": "ChatAnthropicVertexAI",
+                "model_name": "claude-3-5-sonnet@20241022",
+            }
+        },
+        "outputs": {
+            "llm_output": None,
+            "generations": [
+                [
+                    {
+                        "message": {
+                            "usage_metadata": {
+                                "input_tokens": 15,
+                                "output_tokens": 25,
+                                "total_tokens": 40,
+                            }
+                        }
+                    }
+                ]
+            ],
+        },
+    }
+
+
+def test_try_extract_provider_usage_data__anthropic_vertexai__returns_usage_and_model() -> None:
+    """Full public-API path: AnthropicVertexAIUsageExtractor reached, usage and model extracted."""
+    import opik
+
+    run_dict = _anthropic_vertexai_run_with_usage()
+    info = usage_extractor.try_extract_provider_usage_data(run_dict)
+
+    assert info is not None, "Anthropic VertexAI run must yield usage info"
+    assert info.provider == opik.LLMProvider.ANTHROPIC_VERTEXAI
+    assert info.model == "claude-3-5-sonnet@20241022"
+    assert info.usage is not None
+    assert info.usage.prompt_tokens == 15
+    assert info.usage.completion_tokens == 25

--- a/sdks/python/tests/library_integration/langchain/test_model_name_resilience.py
+++ b/sdks/python/tests/library_integration/langchain/test_model_name_resilience.py
@@ -86,3 +86,74 @@ def test_try_extract_provider_usage_data__missing_model_metadata__returns_usage_
     assert info.usage is not None
     assert info.usage.prompt_tokens == 10
     assert info.model is None
+
+
+def _anthropic_run_with_empty_generations() -> Dict[str, Any]:
+    """Anthropic run where generations list is empty — must not raise IndexError."""
+    return {
+        "serialized": {"kwargs": {"anthropic_api_key": "fixture-value"}},
+        "extra": {},
+        "outputs": {"llm_output": None, "generations": []},
+    }
+
+
+def _anthropic_run_with_null_outputs() -> Dict[str, Any]:
+    """Anthropic run where outputs is an unexpected type — must not raise TypeError."""
+    return {
+        "serialized": {"kwargs": {"anthropic_api_key": "fixture-value"}},
+        "extra": {},
+        "outputs": None,
+    }
+
+
+def test_try_get_streaming_token_usage__empty_generations__returns_none() -> None:
+    from opik.integrations.langchain.provider_usage_extractors.langchain_run_helpers import (
+        helpers,
+    )
+
+    run_dict = _anthropic_run_with_empty_generations()
+    result = helpers.try_get_streaming_token_usage(run_dict)
+    assert result is None, "empty generations must return None, not raise IndexError"
+
+
+def test_try_get_streaming_token_usage__null_outputs__returns_none() -> None:
+    from opik.integrations.langchain.provider_usage_extractors.langchain_run_helpers import (
+        helpers,
+    )
+
+    run_dict = _anthropic_run_with_null_outputs()
+    result = helpers.try_get_streaming_token_usage(run_dict)
+    assert result is None, "null outputs must return None, not raise TypeError"
+
+
+def test_try_get_streaming_token_usage__usage_metadata_on_message__returns_usage() -> (
+    None
+):
+    """usage_metadata lives directly on the message dict, not inside message.kwargs."""
+    from opik.integrations.langchain.provider_usage_extractors.langchain_run_helpers import (
+        helpers,
+        langchain_usage,
+    )
+
+    run_dict = {
+        "outputs": {
+            "generations": [
+                [
+                    {
+                        "message": {
+                            "kwargs": {},
+                            "usage_metadata": {
+                                "input_tokens": 5,
+                                "output_tokens": 8,
+                                "total_tokens": 13,
+                            },
+                        }
+                    }
+                ]
+            ]
+        }
+    }
+    result = helpers.try_get_streaming_token_usage(run_dict)
+    assert isinstance(result, langchain_usage.LangChainUsage)
+    assert result.input_tokens == 5
+    assert result.output_tokens == 8


### PR DESCRIPTION
## What

Fixes two bugs in the LangChain provider usage extractors that caused valid token usage to be silently discarded.

### Bug 1 — `IndexError` on empty `generations` in `try_get_streaming_token_usage`

`helpers.try_get_streaming_token_usage` accessed `run_dict["outputs"]["generations"][-1][-1]` unconditionally. When the generations list was empty (`[]`), this raised `IndexError`. The error propagated to the caller (`try_get_token_usage`), then to `anthropic_vertexai_usage_extractor._try_get_token_usage`'s broad `except Exception` block, which returned `None` — discarding any extractable usage.

**Fix:** wrap the index access in `try/except (IndexError, KeyError, TypeError)` and return `None` safely.

### Bug 2 — `usage_metadata` only searched inside `message["kwargs"]`

`try_get_streaming_token_usage` searched for `message["kwargs"]["usage_metadata"]`, but recent versions of `langchain-core` set `usage_metadata` directly on `message`, not inside `kwargs`. This caused the Anthropic-VertexAI streaming path to miss usage even when it was present.

**Fix:** probe `message.get("usage_metadata")` first, then fall back to `message["kwargs"].get("usage_metadata")`.

### Bug 3 — `TypeError` not caught in `anthropic_usage_extractor._try_get_model_name`

`_try_get_model_name` caught `(KeyError, IndexError)` but not `TypeError`. If `run_dict["outputs"]` was `None` or any non-subscriptable type, the inner access raised `TypeError`, which propagated through `get_llm_usage_info` to `try_extract_provider_usage_data`'s catch block — returning `None` and discarding valid usage data.

**Fix:** extend the except tuple to `(KeyError, IndexError, TypeError)`.

## Tests

Three new unit tests in `test_model_name_resilience.py`:
- `test_try_get_streaming_token_usage__empty_generations__returns_none` — empty `generations` list returns `None`, not `IndexError`
- `test_try_get_streaming_token_usage__null_outputs__returns_none` — `None` `outputs` returns `None`, not `TypeError`
- `test_try_get_streaming_token_usage__usage_metadata_on_message__returns_usage` — `usage_metadata` at the `message` level is extracted correctly

## Related

Closes #7860

## Checklist
- [ ] I have added unit tests for the changes
- [ ] The tests are all passing
- [ ] The code follows the style guidelines of this project