### PR TITLE
fix(evaluation): tolerate missing LLM provider SDKs in the rate-limit error analyzer

### DIFF
--- a/sdks/python/src/opik/evaluation/engine/exception_analyzer.py
+++ b/sdks/python/src/opik/evaluation/engine/exception_analyzer.py
@@ -1,14 +1,22 @@
 def is_llm_provider_rate_limit_error(exception: Exception) -> bool:
-    import openai
-    import litellm.exceptions
+    known_rate_limit_error_types = []
 
-    rate_limit_error_known_types = (
-        openai.RateLimitError,
-        litellm.exceptions.RateLimitError,
-    )
+    try:
+        import openai
 
-    is_rate_limit_error = isinstance(exception, rate_limit_error_known_types) or (
-        hasattr(exception, "status_code") and exception.status_code == 429
-    )
+        known_rate_limit_error_types.append(openai.RateLimitError)
+    except ImportError:
+        pass
+
+    try:
+        import litellm.exceptions
+
+        known_rate_limit_error_types.append(litellm.exceptions.RateLimitError)
+    except ImportError:
+        pass
+
+    is_rate_limit_error = isinstance(
+        exception, tuple(known_rate_limit_error_types)
+    ) or (hasattr(exception, "status_code") and exception.status_code == 429)
 
     return is_rate_limit_error

--- a/sdks/python/tests/unit/evaluation/test_exception_analyzer.py
+++ b/sdks/python/tests/unit/evaluation/test_exception_analyzer.py
@@ -1,0 +1,66 @@
+import sys
+
+from opik.evaluation.engine import exception_analyzer
+
+
+class _HttpStatusError(Exception):
+    """Mimics a provider error carrying a status code without needing either SDK."""
+
+    status_code = 429
+
+
+def test_openai_rate_limit_error_is_detected():
+    import httpx
+    import openai
+
+    response = httpx.Response(
+        429, request=httpx.Request("POST", "https://api.example.com")
+    )
+    error = openai.RateLimitError("slow down", response=response, body=None)
+
+    assert exception_analyzer.is_llm_provider_rate_limit_error(error) is True
+
+
+def test_status_code_fallback_classifies_429_without_litellm():
+    """litellm is not installed in this environment; the status_code fallback must still classify."""
+    assert (
+        exception_analyzer.is_llm_provider_rate_limit_error(
+            _HttpStatusError("retry me")
+        )
+        is True
+    )
+
+
+def test_missing_provider_sdks_do_not_crash_the_analyzer(monkeypatch):
+    """#8134 defect 4: the analyzer runs inside metric error handlers. With neither
+    provider SDK importable it must answer from the status_code fallback instead of
+    raising ImportError out of the handler's except block and aborting the run."""
+    monkeypatch.setitem(sys.modules, "openai", None)
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    monkeypatch.setitem(sys.modules, "litellm.exceptions", None)
+
+    assert (
+        exception_analyzer.is_llm_provider_rate_limit_error(
+            ValueError("tolerated error")
+        )
+        is False
+    )
+    assert (
+        exception_analyzer.is_llm_provider_rate_limit_error(
+            _HttpStatusError("429 without SDKs")
+        )
+        is True
+    )
+
+
+def test_exception_without_status_code_is_not_rate_limit(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openai", None)
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    monkeypatch.setitem(sys.modules, "litellm.exceptions", None)
+
+    assert (
+        exception_analyzer.is_llm_provider_rate_limit_error(
+            ValueError("tolerated error")
+        )
+        is False
+    )

--- a/sdks/python/tests/unit/evaluation/test_exception_analyzer.py
+++ b/sdks/python/tests/unit/evaluation/test_exception_analyzer.py
@@ -21,8 +21,13 @@ def test_openai_rate_limit_error_is_detected():
     assert exception_analyzer.is_llm_provider_rate_limit_error(error) is True
 
 
-def test_status_code_fallback_classifies_429_without_litellm():
-    """litellm is not installed in this environment; the status_code fallback must still classify."""
+def test_status_code_fallback_classifies_429_without_provider_sdks(monkeypatch):
+    """The status_code fallback must classify 429 on its own, independent of
+    whether the provider SDKs happen to be importable in this environment."""
+    monkeypatch.setitem(sys.modules, "openai", None)
+    monkeypatch.setitem(sys.modules, "litellm", None)
+    monkeypatch.setitem(sys.modules, "litellm.exceptions", None)
+
     assert (
         exception_analyzer.is_llm_provider_rate_limit_error(
             _HttpStatusError("retry me")


### PR DESCRIPTION
**Note on this description**: it is a reconstruction written on 09-18 after I accidentally overwrote the original body with a withdrawal message through a malformed `PATCH`. The original text is not recoverable from my side or from the API (no PR-body history endpoint), so this summary was rebuilt from the commits and the linked report and is not the original wording.

**What the change did**: hardened the rate-limit error analyzer path against an optional provider SDK being absent during 429 handling, plus unit tests.

**Why it is closed**: the premise could not be demonstrated on a real code path in my own testing, so the change is withdrawn instead of left in reviewers' queue. The comment on this PR carries the full wording, including the accidental-overwrite disclosure.

**Diff scope**: see the Files tab; nothing here was merged.