### PR TITLE
[OPIK-8240] [QA] Proposed e2e spec from the #8137 exploration — thread-scope LLM judge over a failing provider

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -680,6 +680,7 @@ areas:
       - online-evaluation/online-evaluation-python-metric-errors.spec.ts
       - online-evaluation/online-evaluation-sampling-rate.spec.ts
       - online-evaluation/online-evaluation-smoke.spec.ts
+      - online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts
       - online-evaluation/online-evaluation-thread-scope-batch-close.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
@@ -695,7 +696,15 @@ areas:
       # trace_thread_user_defined_metric_python rule, reads the discriminator
       # back, and drives it end to end through a batch close. `tier` records the
       # stronger of the two.
-      rule-scope-thread-span:  { covered: true,  tier: t2-cuj, note: "span/thread scope flags, both halves covered: span scope by online-evaluation-oversized-payload.spec.ts (t3), thread scope by online-evaluation-thread-scope-batch-close.spec.ts (t2) — six threads closed in ONE PUT /threads/close, each carrying exactly one score, with a mid-batch thread whose metric raises scoring nothing while its siblings do. Scoped: since #8162 the close fans out to one stream entry PER thread id, so what the spec pins is the grouped publish reaching every sampled id, not a scorer walking a multi-id message. A duplicate score WRITE is not observable — thread feedback scores upsert by name, so 'exactly once' is asserted as exactly one stored row per thread, held across a quiet period, not as insert multiplicity. Rule filters on either scope are a different key (rule-filters) and are still uncovered" }
+      #
+      # Thread scope is covered twice over, and deliberately: batch-close pins
+      # the SUCCESS path of the python metric shape, and
+      # online-evaluation-thread-judge-provider-failure.spec.ts (t2) pins the
+      # FAILURE path of the OTHER thread-scope rule shape
+      # (trace_thread_llm_as_judge). Neither subsumes the other — a fold that
+      # kept one sibling's failure, or one that never terminated the message,
+      # is invisible to a spec whose provider answers.
+      rule-scope-thread-span:  { covered: true,  tier: t2-cuj, note: "span/thread scope flags, both halves covered: span scope by online-evaluation-oversized-payload.spec.ts (t3), thread scope by online-evaluation-thread-scope-batch-close.spec.ts (t2) — six threads closed in ONE PUT /threads/close, each carrying exactly one score, with a mid-batch thread whose metric raises scoring nothing while its siblings do. Scoped: since #8162 the close fans out to one stream entry PER thread id, so what the spec pins is the grouped publish reaching every sampled id, not a scorer walking a multi-id message. A duplicate score WRITE is not observable — thread feedback scores upsert by name, so 'exactly once' is asserted as exactly one stored row per thread, held across a quiet period, not as insert multiplicity. Thread scope is also covered for the trace_thread_llm_as_judge shape by online-evaluation-thread-judge-provider-failure.spec.ts (t2), over an unreachable provider: two threads closed in one call, each reporting its OWN provider failure exactly once and neither carrying a thread score. Rule filters on either scope are a different key (rule-filters) and are still uncovered" }
       rule-filters:            { covered: false }
       sampling-rate:           { covered: true,  tier: t2-cuj, note: "50% rule vs 100% control over one 30-trace batch, binomial band 15-85%; plus a 0%-rate rule at trigger_scope=both, which must skip every SDK trace and still score experiment/playground/optimization ones" }
       clone-rule:              { covered: false }
@@ -722,12 +731,11 @@ areas:
       edit-rule:               { covered: true,  tier: t2-cuj, note: "plain-string prompt: edit-dialog hydration + no-op re-save, byte-for-byte; content_array prompt: API-only read-then-write re-save, no dialog gesture; model custom_parameters: rule seeded over REST, saved unchanged through the edit dialog, PATCH body and persisted blob both asserted to carry the thinking block and an unrelated free-form key; editing a field through the dialog is not covered" }
       enable-disable-rule:     { covered: true,  tier: t2-cuj, note: "edit-dialog switch; control rule proves scoring stopped, then resumed" }
       delete-rule:             { covered: true,  tier: t2-cuj, note: "row kebab delete; control rule proves scoring stopped" }
-      # Deliberately still false. online-evaluation-python-metric-errors.spec.ts
-      # asserts a rule's log stream through GET /automations/evaluators/{id}/logs,
-      # but this key names the /$workspaceName/automation-logs PAGE, which no spec
-      # opens. Flipping it on the strength of an API read would mark a UI nobody
-      # tested as tested for good.
-      automation-logs:         { covered: false }
+      # Flipped by online-evaluation-thread-judge-provider-failure.spec.ts, which
+      # opens the /$workspaceName/automation-logs PAGE itself (AutomationLogsPage)
+      # and asserts the rendered ERROR rows — not, as the API-only specs do, the
+      # GET /automations/evaluators/{id}/logs stream behind it.
+      automation-logs:         { covered: true,  tier: t2-cuj, note: "rule_id-scoped log stream renders: one ERROR row per failed thread and no others" }
 
     visual:
       online-evaluation-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E11" }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -2232,6 +2232,76 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       }
       return id;
     },
+    /**
+     * Create a THREAD-scope LLM-as-judge rule and return its id.
+     *
+     * A sibling of `createLlmJudgeRule` rather than a flag on it: the two are
+     * the same `code` shape but not the same contract. A trace-scope judge
+     * binds `variables` to fields of one trace; a thread-scope judge is handed
+     * the rendered conversation under the scorer's own `{{context}}` and takes
+     * no `variables` at all, so one builder would carry a field that is
+     * meaningless in half its calls.
+     *
+     * Raw REST for the same two reasons as its siblings: creation answers 201
+     * with an empty body, so the id exists only in the `Location` header that
+     * the pinned SDK's `void` return discards, and reading the id back by name
+     * would silently pick up a rule an earlier run left under the same
+     * namespace.
+     */
+    async createTraceThreadLlmAsJudgeRule(args: {
+      projectId: string;
+      name: string;
+      /** Fraction in [0, 1], the backend's own units — not the dialog's percentage. */
+      samplingRate: number;
+      /** Fully-qualified model id, e.g. `custom-llm/<providerName>/<modelName>`. */
+      model: string;
+      /** Score name the judge's output schema declares, and the score it would write. */
+      scoreName: string;
+      enabled?: boolean;
+    }): Promise<string> {
+      const { status, message, location } = await rawFetch(
+        'POST',
+        '/v1/private/automations/evaluators/',
+        {
+          body: {
+            type: 'trace_thread_llm_as_judge',
+            action: 'evaluator',
+            name: args.name,
+            project_ids: [args.projectId],
+            sampling_rate: args.samplingRate,
+            enabled: args.enabled ?? true,
+            code: {
+              model: { name: args.model, temperature: 0 },
+              // `{{context}}` is the thread scorer's own variable for the
+              // rendered conversation — the judge has to reference it or the
+              // rule would be evaluating an empty prompt.
+              messages: [
+                {
+                  role: 'USER',
+                  content: `Rate this conversation from 0 to 1: {{context}}`,
+                },
+              ],
+              schema: [
+                { name: args.scoreName, type: 'DOUBLE', description: 'thread score' },
+              ],
+            },
+          },
+        },
+      );
+      if (status !== 201) {
+        throw new Error(
+          `createTraceThreadLlmAsJudgeRule: expected 201 for '${args.name}', got ${status}: ${message}`,
+        );
+      }
+      const id = location?.split('/').filter(Boolean).pop();
+      if (!id) {
+        throw new Error(
+          `createTraceThreadLlmAsJudgeRule: 201 for '${args.name}' carried no usable Location ` +
+            `header (got '${location}') — cannot address the rule.`,
+        );
+      }
+      return id;
+    },
 
     /**
      * The `code.model` block of an `llm_as_judge` rule.

--- a/tests_end_to_end/e2e/core/provider-keys.ts
+++ b/tests_end_to_end/e2e/core/provider-keys.ts
@@ -60,6 +60,12 @@ export async function createProviderKey(payload: {
   provider: string;
   provider_name: string;
   base_url: string;
+  /**
+   * Static bearer, for providers that are not in OAuth2 token-auth mode. The
+   * endpoint requires one whenever `auth_config` is absent, so a static-auth
+   * provider cannot be created without it.
+   */
+  api_key?: string;
   configuration?: Record<string, string>;
   auth_config?: ProviderAuthConfig;
 }): Promise<void> {

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,6 +1,7 @@
 export { test, expect } from './summarised-datasets.fixture';
 export type {
   OauthProviderSeed,
+  UnreachableProviderSeed,
   ProviderKeysFixture,
   ProviderKeyFixtures,
 } from './provider-key.fixture';

--- a/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
@@ -14,12 +14,46 @@ export interface OauthProviderSeed {
   modelName?: string;
 }
 
+export interface UnreachableProviderSeed {
+  providerName: string;
+  /** Model name; unique per test so parallel specs never collide. */
+  modelName?: string;
+}
+
+/**
+ * Base URL for a provider that can never answer.
+ *
+ * The discard port on the backend's own loopback: nothing listens there, so the
+ * connect is REFUSED immediately and every scoring call through this provider
+ * fails in milliseconds, with no dependency on the mock gateway, on an external
+ * host, or on the runner being reachable from the backend at all. That last
+ * point is why this is not `mockGatewayUrlForBackend` with a forced status: the
+ * mock binds to the test runner, which a remote deployment cannot reach (see
+ * `mockAuthSkipReason`), so a mock-based failure spec can only ever run locally.
+ *
+ * A blackholed address (`192.0.2.1`) would also fail, but by TIMING OUT — that
+ * turns a one-second failure into a connect-timeout wait and, worse, can leave
+ * the provider call still in flight when the scoring message is reclaimed.
+ * Refusal is the deterministic shape.
+ */
+const UNREACHABLE_BASE_URL = 'http://127.0.0.1:9/v1';
+
 export interface ProviderKeysFixture {
   /**
    * REST-seeds a Custom provider in OAuth2 token-auth mode against the suite's mock
    * token service; registered for teardown deletion.
    */
   createOauth(seed: OauthProviderSeed): Promise<void>;
+  /**
+   * REST-seeds a Custom provider whose base URL refuses every connection, so any
+   * rule pointed at it fails deterministically; registered for teardown deletion.
+   *
+   * Returns the fully-qualified model id to put on a rule, rather than leaving
+   * the caller to rebuild `custom-llm/<provider>/<model>`: a rule naming a model
+   * string the provider does not declare fails for the wrong reason, and the
+   * two spellings drifting apart would be invisible in the log stream.
+   */
+  createUnreachable(seed: UnreachableProviderSeed): Promise<string>;
   /**
    * Registers a provider name for teardown deletion without seeding — for tests where
    * UI creation is itself the behavior under test. Cleanup runs even when the test fails.
@@ -58,6 +92,20 @@ export const test = baseTest.extend<ProviderKeyFixtures>({
             ],
           },
         });
+      },
+      async createUnreachable({ providerName, modelName = 'unreachable-model' }) {
+        registered.push(providerName);
+        const model = `custom-llm/${providerName}/${modelName}`;
+        await createProviderKey({
+          provider: 'custom-llm',
+          provider_name: providerName,
+          base_url: UNREACHABLE_BASE_URL,
+          // Required whenever `auth_config` is absent. Never sent anywhere: the
+          // connection is refused before a request is written.
+          api_key: 'unused-the-connection-is-refused',
+          configuration: { models: model },
+        });
+        return model;
       },
       register(providerName) {
         registered.push(providerName);

--- a/tests_end_to_end/e2e/pom/automation-logs.page.ts
+++ b/tests_end_to_end/e2e/pom/automation-logs.page.ts
@@ -1,0 +1,88 @@
+import { test, type Page, type Locator } from '@playwright/test';
+import { loadEnvConfig } from '../config/env.config';
+
+/** The levels the rule log stream renders in its Level column. */
+export type AutomationLogLevel = 'INFO' | 'WARN' | 'ERROR';
+
+/**
+ * `/$workspaceName/automation-logs?rule_id=<id>` — the page behind an online
+ * evaluation rule's **Show logs**, and the only place in the product where a
+ * user can see whether their rule ran, what it sent, and why it failed.
+ *
+ * The table is the shared `DataTable`, so rows carry `data-row-id` and cells
+ * carry `data-cell-id="<rowId>_<columnId>"`. Columns are addressed by that id
+ * suffix rather than by position: a marker column (`marker_thread_model_id`)
+ * appears only when the rendered lines carry markers, so the Message column is
+ * the third cell for a trace-scope rule and the fourth for a thread-scope one.
+ * `nth-child` would therefore read the wrong column depending on which rule
+ * you opened.
+ */
+export class AutomationLogsPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(ruleId: string): Promise<void> {
+    return test.step(`Open automation logs for rule ${ruleId}`, async () => {
+      const env = loadEnvConfig();
+      await this.page.goto(
+        `${env.baseUrl}/${env.workspace}/automation-logs?rule_id=${encodeURIComponent(ruleId)}`,
+      );
+    });
+  }
+
+  /**
+   * Settle on either a rendered table or the page's own empty state, so a spec
+   * asserting an absence waits for the page to finish rather than racing it.
+   */
+  async waitForReady(): Promise<void> {
+    return test.step('Wait for the automation logs table', async () => {
+      await Promise.race([
+        this.rows().first().waitFor({ state: 'visible' }),
+        this.emptyState.waitFor({ state: 'visible' }),
+      ]);
+    });
+  }
+
+  get emptyState(): Locator {
+    return this.page.getByText('There are no logs for this rule.');
+  }
+
+  /** Every rendered log row. */
+  rows(): Locator {
+    return this.page.locator('tbody tr[data-row-id]');
+  }
+
+  /**
+   * Rows whose Level cell reads exactly `level`.
+   *
+   * Anchored, so `INFO` cannot also match a hypothetical `INFO_DEBUG`; the
+   * Level column holds one word per row.
+   */
+  rowsAtLevel(level: AutomationLogLevel): Locator {
+    return this.rows().filter({
+      has: this.page.locator('td[data-cell-id$="_level"]', {
+        hasText: new RegExp(`^\\s*${level}\\s*$`),
+      }),
+    });
+  }
+
+  /**
+   * Rows at `level` whose message names `threadId '<threadId>'`.
+   *
+   * The quotes the backend puts around the id are part of the match, and they
+   * are what makes it exact: an unquoted `hasText` on `<ns>-thread-a` would
+   * also match a row about `<ns>-thread-ab`, so two sibling threads could not
+   * be told apart — which is precisely the claim these specs make.
+   */
+  rowsForThreadAtLevel(level: AutomationLogLevel, threadId: string): Locator {
+    return this.rowsAtLevel(level).filter({
+      has: this.page.locator('td[data-cell-id$="_message"]', {
+        hasText: new RegExp(`threadId '${escapeForRegExp(threadId)}'`),
+      }),
+    });
+  }
+}
+
+/** Ids are namespaced with `-`, but escape the whole string rather than assume that. */
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests_end_to_end/e2e/pom/automation-logs.page.ts
+++ b/tests_end_to_end/e2e/pom/automation-logs.page.ts
@@ -1,8 +1,16 @@
 import { test, type Page, type Locator } from '@playwright/test';
 import { loadEnvConfig } from '../config/env.config';
 
-/** The levels the rule log stream renders in its Level column. */
-export type AutomationLogLevel = 'INFO' | 'WARN' | 'ERROR';
+/**
+ * The levels the rule log stream renders in its Level column.
+ *
+ * All five the product defines, not just the three today's specs assert on:
+ * the backend's `LogItem.LogLevel` and the frontend's `EVALUATOR_LOG_LEVEL`
+ * both carry `DEBUG` and `TRACE`, and a union narrower than the surface would
+ * make a future spec reach for a type escape to address a row the page can
+ * genuinely render.
+ */
+export type AutomationLogLevel = 'INFO' | 'WARN' | 'ERROR' | 'DEBUG' | 'TRACE';
 
 /**
  * `/$workspaceName/automation-logs?rule_id=<id>` — the page behind an online

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts
@@ -1,0 +1,212 @@
+import { test, expect } from '@e2e/fixtures';
+import type { AutomationRuleLogRef } from '@e2e/core/backend';
+import { AutomationLogsPage } from '@e2e/pom/automation-logs.page';
+
+/** Emitted once per thread, when the scorer starts preparing that thread's request. */
+const EVALUATING_LINE = 'Evaluating threadId';
+/** Emitted once per thread, immediately before the provider call. */
+const SENDING_LINE = 'Sending threadId';
+/** The thread scorer's own wording for a failure raised while scoring a thread. */
+const SCORING_FAILURE_LINE = 'Unexpected error while scoring threadId';
+
+/** Both the INFO and the ERROR lines name the thread they are about, in quotes. */
+const THREAD_ID_IN_MESSAGE = /threadId '([^']+)'/;
+
+function threadIdOf(line: AutomationRuleLogRef): string {
+  const match = THREAD_ID_IN_MESSAGE.exec(line.message);
+  if (!match) {
+    // Not a soft assertion and not a filter: a line that should name a thread
+    // and does not is either a wording change or a different code path, and
+    // either way the counts below would be computed over the wrong lines.
+    throw new Error(`log line names no threadId: ${line.level} ${line.message}`);
+  }
+  return match[1];
+}
+
+test.describe('Online Evaluation — thread-scope LLM judge over a failing provider', { tag: ['@t2-cuj', '@area:online-evaluation'] }, () => {
+  test('Two threads closed in one call each report their own provider failure, and neither is scored', { tag: ['@cap:online-evaluation.rule-scope-thread-span', '@cap:online-evaluation.automation-logs'] }, async ({
+    project,
+    sdkClient,
+    backendClient,
+    providerKeys,
+    testNamespace,
+    automationRulesCleanup,
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    // Closing several threads in ONE call is the whole point: a thread-scope
+    // rule then fans a single stream message out over both thread ids, and the
+    // two evaluations are siblings of that one message. Each sibling must
+    // report its own failure — a fold that keeps only one of them, or one that
+    // never terminates the message, is invisible with a single thread.
+    const threadIds = [`${testNamespace}-thread-a`, `${testNamespace}-thread-b`];
+    const ruleName = `${testNamespace}-thread-judge`;
+    const scoreName = `${testNamespace}-thread-score`;
+
+    const model = await test.step('Seed a custom-llm provider that refuses every connection', async () => {
+      return providerKeys.createUnreachable({
+        providerName: `${testNamespace}-broken-provider`,
+        modelName: 'unreachable-model',
+      });
+    });
+
+    const ruleId = await test.step('Create a thread-scope LLM-judge rule at 100% sampling', async () => {
+      return backendClient.createTraceThreadLlmAsJudgeRule({
+        projectId: project.id,
+        name: ruleName,
+        samplingRate: 1,
+        model,
+        scoreName,
+      });
+    });
+
+    await test.step('Seed two turns under each of two threads', async () => {
+      for (const threadId of threadIds) {
+        for (let turn = 0; turn < 2; turn++) {
+          await sdkClient.python.createTrace({
+            project_name: project.name,
+            name: `${testNamespace}-${threadId}-turn-${turn}`,
+            input: 'what is the capital of France?',
+            output: 'Paris.',
+            thread_id: threadId,
+          });
+        }
+      }
+    });
+
+    await test.step('Both threads exist and are still open before the close', async () => {
+      // The precondition the batch close needs, asserted rather than assumed:
+      // if the threads were already inactive here, the evaluations below would
+      // have been triggered by the 15-minute inactivity job instead of by the
+      // one call this test makes, and the fan-out would not be the shape under
+      // test.
+      await expect
+        .poll(
+          async () => (await backendClient.listThreads({ projectId: project.id })).total,
+          {
+            timeout: 60_000,
+            intervals: [1_000, 2_000],
+            message: 'both seeded threads must be queryable before they are closed',
+          },
+        )
+        .toBe(2);
+
+      const { threads } = await backendClient.listThreads({ projectId: project.id });
+      expect(
+        threads.map((t) => t.id).sort(),
+        'the project holds exactly the two seeded threads and nothing else',
+      ).toEqual([...threadIds].sort());
+      for (const thread of threads) {
+        expect(thread.status, `thread '${thread.id}' is open before the close`).toBe('active');
+      }
+    });
+
+    await test.step('Close both threads in a single request', async () => {
+      await backendClient.closeThreads({ projectName: project.name, threadIds });
+    });
+
+    const logs = await test.step('Wait for the rule to report a failure for both threads', async () => {
+      let stream: AutomationRuleLogRef[] = [];
+      await expect
+        .poll(
+          async () => {
+            stream = await backendClient.getAutomationRuleLogs(ruleId);
+            const failed = new Set(
+              stream.filter((l) => l.level === 'ERROR').map((l) => threadIdOf(l)),
+            );
+            return threadIds.filter((id) => failed.has(id)).length;
+          },
+          {
+            timeout: 180_000,
+            intervals: [2_000, 5_000],
+            message:
+              `rule '${ruleName}' never reported a failure for both threads — its provider ` +
+              'cannot answer, so a stream missing one of them means that thread was never ' +
+              'evaluated or its failure was swallowed',
+          },
+        )
+        .toBe(2);
+      return stream;
+    });
+
+    await test.step('Each thread was evaluated exactly once, and no other thread was', async () => {
+      // Asserted as the whole set rather than "mine is in there": one thread
+      // appearing twice (a sibling processed twice) and a third thread
+      // appearing (a fan-out over the wrong ids) are both bugs this rules out,
+      // and neither would fail a per-thread `find()`.
+      const evaluating = logs.filter((l) => l.message.startsWith(EVALUATING_LINE));
+      expect(
+        evaluating.map(threadIdOf).sort(),
+        'exactly one Evaluating line per closed thread',
+      ).toEqual([...threadIds].sort());
+    });
+
+    await test.step('Each thread reached the provider on the rule\'s own model', async () => {
+      // Without this the failures below could equally be a rule that never got
+      // as far as a provider call — a template that failed to render, say —
+      // which is a different bug wearing the same ERROR line.
+      const sending = logs.filter((l) => l.message.startsWith(SENDING_LINE));
+      expect(sending.map(threadIdOf).sort(), 'exactly one provider call per thread').toEqual(
+        [...threadIds].sort(),
+      );
+      for (const line of sending) {
+        expect(line.message, 'the call names the unreachable provider model').toContain(
+          `model='${model}'`,
+        );
+      }
+    });
+
+    await test.step('Each thread reported its own failure, exactly once', async () => {
+      // The claim the thread scorer's failure fold is responsible for: sibling
+      // evaluations of one fanned-out message must each surface their own
+      // error. Keeping one and dropping the rest would leave a thread that was
+      // evaluated, was not scored, and says nothing about why.
+      const errors = logs.filter((l) => l.level === 'ERROR');
+      expect(errors.map(threadIdOf).sort(), 'exactly one ERROR per closed thread').toEqual(
+        [...threadIds].sort(),
+      );
+      for (const line of errors) {
+        expect(line.message, 'the failure is raised while scoring the thread').toContain(
+          SCORING_FAILURE_LINE,
+        );
+      }
+    });
+
+    await test.step('Both threads are closed and neither carries a score', async () => {
+      const { total, threads } = await backendClient.listThreads({ projectId: project.id });
+      expect(total, 'still exactly the two seeded threads').toBe(2);
+      for (const thread of threads) {
+        expect(thread.status, `thread '${thread.id}' is closed`).toBe('inactive');
+      }
+
+      for (const threadId of threadIds) {
+        const detail = await backendClient.getThread({ projectId: project.id, threadId });
+        expect(
+          detail.feedbackScores.map((s) => s.name),
+          `a failed evaluation must write nothing to thread '${threadId}'`,
+        ).toEqual([]);
+      }
+    });
+
+    await test.step('The automation logs page shows one failure per thread', async () => {
+      // The API assertions above read the same stream this page renders, but
+      // only through the page can a user actually see it — and this is the one
+      // place the product says whether a rule ran at all.
+      const logsPage = new AutomationLogsPage(page);
+      await logsPage.goto(ruleId);
+      await logsPage.waitForReady();
+
+      for (const threadId of threadIds) {
+        await expect(
+          logsPage.rowsForThreadAtLevel('ERROR', threadId),
+          `one rendered failure row for thread '${threadId}'`,
+        ).toHaveCount(1);
+      }
+      await expect(
+        logsPage.rowsAtLevel('ERROR'),
+        'and no failure rows beyond those two — the view is scoped to this rule',
+      ).toHaveCount(2);
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts
@@ -2,15 +2,35 @@ import { test, expect } from '@e2e/fixtures';
 import type { AutomationRuleLogRef } from '@e2e/core/backend';
 import { AutomationLogsPage } from '@e2e/pom/automation-logs.page';
 
-/** Emitted once per thread, when the scorer starts preparing that thread's request. */
-const EVALUATING_LINE = 'Evaluating threadId';
-/** Emitted once per thread, immediately before the provider call. */
-const SENDING_LINE = 'Sending threadId';
-/** The thread scorer's own wording for a failure raised while scoring a thread. */
-const SCORING_FAILURE_LINE = 'Unexpected error while scoring threadId';
+/** Line PREFIX, emitted once per thread when the scorer starts preparing that thread's request. */
+const EVALUATING_PREFIX = 'Evaluating threadId';
+/** Line PREFIX, emitted once per thread immediately before the provider call. */
+const SENDING_PREFIX = 'Sending threadId';
+/**
+ * Substring, not a prefix: the thread scorer's own wording for a failure raised
+ * while scoring a thread, which the line wraps in surrounding context.
+ */
+const SCORING_FAILURE_PHRASE = 'Unexpected error while scoring threadId';
 
 /** Both the INFO and the ERROR lines name the thread they are about, in quotes. */
 const THREAD_ID_IN_MESSAGE = /threadId '([^']+)'/;
+
+/**
+ * How long the log stream must stop changing before its contents count as an
+ * answer rather than as a snapshot caught mid-retry.
+ *
+ * A provider failure the subscriber classifies as transient leaves the message
+ * pending until `XAUTOCLAIM` reclaims it, and a replay appends a second
+ * `Sending`/ERROR pair per thread. Asserting "exactly once" the instant both
+ * threads have failed once would therefore pass over a stream that is still
+ * growing — and then contradict the page assertion below, which reads later.
+ *
+ * A duration, not a state wait, and deliberately so: the claim IS that nothing
+ * changes over an interval, which no response or locator can stand in for.
+ * Same reasoning as `QUIET_PERIOD_MS` in
+ * `online-evaluation-thread-scope-batch-close.spec.ts`.
+ */
+const QUIET_PERIOD_MS = 30_000;
 
 function threadIdOf(line: AutomationRuleLogRef): string {
   const match = THREAD_ID_IN_MESSAGE.exec(line.message);
@@ -33,7 +53,9 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
     automationRulesCleanup,
     page,
   }) => {
-    test.setTimeout(240_000);
+    // 180s for the failure poll, plus the quiet period, plus seeding and the
+    // page read — the previous 240s left no room once the settle was added.
+    test.setTimeout(300_000);
 
     // Closing several threads in ONE call is the whole point: a thread-scope
     // rule then fans a single stream message out over both thread ids, and the
@@ -106,12 +128,11 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
       await backendClient.closeThreads({ projectName: project.name, threadIds });
     });
 
-    const logs = await test.step('Wait for the rule to report a failure for both threads', async () => {
-      let stream: AutomationRuleLogRef[] = [];
+    await test.step('Wait for the rule to report a failure for both threads', async () => {
       await expect
         .poll(
           async () => {
-            stream = await backendClient.getAutomationRuleLogs(ruleId);
+            const stream = await backendClient.getAutomationRuleLogs(ruleId);
             const failed = new Set(
               stream.filter((l) => l.level === 'ERROR').map((l) => threadIdOf(l)),
             );
@@ -127,7 +148,15 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
           },
         )
         .toBe(2);
-      return stream;
+    });
+
+    const logs = await test.step('Let the stream settle, then read it once', async () => {
+      // Every count below is computed over THIS read, and the page assertion at
+      // the end re-reads the same settled stream through the UI. Asserting the
+      // poll's own first-success snapshot instead would compare two different
+      // moments and call the difference a product bug.
+      await new Promise((resolve) => setTimeout(resolve, QUIET_PERIOD_MS));
+      return backendClient.getAutomationRuleLogs(ruleId);
     });
 
     await test.step('Each thread was evaluated exactly once, and no other thread was', async () => {
@@ -135,7 +164,7 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
       // appearing twice (a sibling processed twice) and a third thread
       // appearing (a fan-out over the wrong ids) are both bugs this rules out,
       // and neither would fail a per-thread `find()`.
-      const evaluating = logs.filter((l) => l.message.startsWith(EVALUATING_LINE));
+      const evaluating = logs.filter((l) => l.message.startsWith(EVALUATING_PREFIX));
       expect(
         evaluating.map(threadIdOf).sort(),
         'exactly one Evaluating line per closed thread',
@@ -146,7 +175,7 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
       // Without this the failures below could equally be a rule that never got
       // as far as a provider call — a template that failed to render, say —
       // which is a different bug wearing the same ERROR line.
-      const sending = logs.filter((l) => l.message.startsWith(SENDING_LINE));
+      const sending = logs.filter((l) => l.message.startsWith(SENDING_PREFIX));
       expect(sending.map(threadIdOf).sort(), 'exactly one provider call per thread').toEqual(
         [...threadIds].sort(),
       );
@@ -168,7 +197,7 @@ test.describe('Online Evaluation — thread-scope LLM judge over a failing provi
       );
       for (const line of errors) {
         expect(line.message, 'the failure is raised while scoring the thread').toContain(
-          SCORING_FAILURE_LINE,
+          SCORING_FAILURE_PHRASE,
         );
       }
     });


### PR DESCRIPTION
## Where this came from

Exploratory testing of **#8137** (`[OPIK-8240] [BE] fix: split provider-error retryability by status, resume XAUTOCLAIM from its cursor`), driven by hand against that PR's own deployed environment, `https://pr-8137.dev.comet.com` serving `2.2.50-6535`. The flow below was reached and observed there before any code was written for it; this PR turns the one candidate that could be made deterministic into a permanent spec.

**Base branch.** This targets `thiagohora/OPIK-8240-scoring-retry-split-and-claim-cursor`, not `main`, because that is the build the spec was written and run against (commit `ee62711f6ea743832c521b1916745ebcfe7c176f`). To be straight about it: the behaviour asserted here is not *new* in #8137 — it is regression cover for the fold that PR rewrote (`collectList().flatMap(errors.getFirst())` → `reduce(preferRetryable)`) in `OnlineScoringTraceThreadLlmAsJudgeScorer`, so it should hold on `main` too. If a reviewer would rather have it land independently of #8137, retargeting to `main` should be safe; it is based here so the spec sits on top of the change it covers.

## The spec

`tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts` — one test, `@t2-cuj`.

**Capabilities**

| `@cap:` | Why this spec earns it |
|---|---|
| `online-evaluation.rule-scope-thread-span` | Was `covered: false`. The spec creates a `trace_thread_llm_as_judge` rule and asserts it fires per thread. Flipped with a `note:` scoping it to **thread** scope — **span** scope is still uncovered and stays that way. |
| `online-evaluation.automation-logs` | Was deliberately `covered: false`, with a comment saying the existing specs read `GET /automations/evaluators/{id}/logs` but nobody opens the `/$workspaceName/automation-logs` **page**. This spec opens the page (new `AutomationLogsPage` POM) and asserts the rendered rows, so the comment no longer applies; it is replaced rather than deleted. |

**What it asserts.** Two threads are seeded, then closed in a **single** `PUT /v1/private/traces/threads/close` — that batch call is the point, because it makes the rule fan one stream message out over both thread ids, so the two evaluations are siblings of one message. Against a provider that cannot answer, the spec then asserts:

- exactly one `Evaluating threadId` line **per closed thread and no others** — asserted as the whole set, so a thread processed twice and a fan-out over a third thread both fail;
- exactly one provider call per thread, naming the rule's own model, so "it failed" cannot be satisfied by a rule that never got as far as a provider call;
- exactly one `ERROR` per thread, each raised *while scoring* that thread — no sibling's failure swallowed, none duplicated;
- both threads end up `inactive` and **neither carries a feedback score**;
- the same two failures render on the automation-logs page, one row per thread and no others.

It also asserts, before closing, that both threads exist and are still `active` — otherwise the evaluations could have been triggered by the 15-minute inactivity job rather than by the one call the test makes, and the fan-out would not be the shape under test.

**Verification: passed, on the first run, against the environment the exploration used.**

```
$ cd tests_end_to_end/e2e
$ npx playwright test tests/online-evaluation/online-evaluation-thread-judge-provider-failure.spec.ts \
    --reporter=list --workers=1
  ✓  1 [chromium] › …-thread-judge-provider-failure.spec.ts:27:7 › … (22.7s)
  1 passed (29.4s)
```

against `OPIK_BASE_URL=https://pr-8137.dev.comet.com`, workspace `default`. Also green: `tsc --noEmit` (clean apart from a pre-existing `Duplicate identifier 'deleteDashboard'` in `core/backend/client.ts`, untouched by this PR) and `tag_lint.py` — `60 specs checked, 1 exempt, 0 problem(s)`.

Because this adds a POM and touches shared seeding code, the whole feature directory was run too — `npx playwright test tests/online-evaluation/ --workers=2` → **7 passed, 1 skipped, 1 failed**. The new spec passed again there, under parallelism. The two others:

- *skipped*: `online-evaluation-smoke.spec.ts` LLM-judge case — no `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` on this runner.
- *failed*: `online-evaluation-python-metric-errors.spec.ts` — the python evaluator on this environment answers `500 Internal Server Error: Failed to execute code` where the spec expects the classified `400 Bad Request: Execution failed: the metric produced no output`. **Pre-existing, not caused by this PR**: I re-ran that spec with every change here reverted to `ee62711` and it fails identically, with the same backend message. Flagging it because it is worth someone's attention on this deployment, not as something this PR should fix.

## Supporting changes, all additive

- `backendClient.createTraceThreadLlmAsJudgeRule` — a sibling of `createAutomationRule` rather than a `type` flag on it, because the two rule shapes share no `code` field. Same raw-REST/`Location`-header treatment, for the same reasons.
- `backendClient.closeThreads` — the batch close, through the public SDK.
- `providerKeys.createUnreachable` — a `custom-llm` provider whose base URL is the discard port on the backend's own loopback, so the connect is **refused in milliseconds**. Deliberately not the suite's mock gateway with a forced status: the mock binds to the test runner, which a remote deployment cannot reach (`mockAuthSkipReason` documents exactly this), so a mock-based failure spec could only ever run locally. Deliberately not a blackholed address either — that fails by *timing out*, which can leave the provider call in flight when the message is reclaimed. Teardown is the existing provider-key fixture's; no cleanup in the test body.
- `AutomationLogsPage` — columns addressed by `data-cell-id` suffix, not position: a marker column appears only when the rendered lines carry markers, so Message is the third cell for a trace-scope rule and the fourth for a thread-scope one.

## What I deliberately did not write

The exploration produced two strong candidates. **One is proposed here; one was dropped.**

- **Dropped — "a permanent provider 4xx drops an evaluation after one attempt, while a retryable failure is re-attempted."** This is the headline of #8137 and it is the one I most wanted. Two things stopped it being a spec that could be *run*:
  1. **No controllable failure status.** It needs one provider forced to a permanent 4xx and one forced to a retryable status. The suite's mock gateway has no forced-status hook at all, and it is unreachable from any remote deployment anyway. The exploration got there with real external endpoints (`example.com` → 405), which is not something a permanent spec should depend on.
  2. **The retry half is only observable after `onlineScoring.pendingMessageDuration`** — 10 minutes by default, and 10 minutes on the environment I ran against. That is a 25-minute test.

  It becomes writable once the e2e compose sets `REDIS_SCORING_PENDING_MESSAGE_DURATION` to something like `30s` *and* the mock gateway grows a per-model forced-status hook. Both are small; neither is in this PR's scope, and shipping a spec that skips on every environment we have would be worse than saying so.
- Already excluded by the exploration, and I agree: the `XAUTOCLAIM` cursor resumption (needs >100 delivered-and-unacked PEL entries and Redis-level assertions), `preferRetryable`'s tie-break with mixed sibling classes (one rule has one model, so every sibling fails identically — the product offers no per-sibling control), and the transient-4xx half of the split (408/425/429), which nothing reachable emits on demand.

Note also what this spec **cannot** distinguish, for the same reason the tie-break was skipped: with one model every sibling fails with the same class, so it pins "no sibling's failure is lost" but not *which* Throwable `preferRetryable` chooses.

## Please review before merging

Generated by the QA test-radar side flow from the #8137 exploration. It has been run and is green, but no human has read the assertions yet — that is what this draft is for. Not marked ready, no reviewers requested.

<!-- comet-qa-test-radar: propose -->


[OPIK-8240]: https://comet-ml.atlassian.net/browse/OPIK-8240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ