### PR TITLE
[issue-8134] [SDK] fix(g-eval): locate the score token by content instead of a fixed offset

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
@@ -1,6 +1,7 @@
 import logging
 import json
 import math
+import re
 from typing import Any, Dict, TYPE_CHECKING
 import opik.exceptions as exceptions
 from opik.evaluation.metrics import score_result
@@ -60,34 +61,21 @@ def parse_litellm_model_output(
 
         log_probs = _to_dict(choice_dict.get("logprobs"))
         entries = log_probs.get("content") or []
-        score_token_position = 3
-        if len(entries) <= score_token_position:
+        if len(entries) <= 3:
             return _extract_score_from_text_content(choice_dict, name=name)
 
-        entry_dict = _to_dict(entries[score_token_position])
-        top_logprobs = entry_dict.get("top_logprobs") or []
-        token_candidate = str(entry_dict.get("token", ""))
+        # Locate the score token(s) by content instead of assuming a fixed
+        # offset: tokenizers differ on where the whitespace after `"score":`
+        # lands, and a two-digit score ("10") spans two tokens.
+        entry_indices = _locate_score_entries(entries)
+        if entry_indices is None:
+            entry_indices = [3]
 
-        linear_probs_sum = 0.0
-        weighted_score_sum = 0.0
-
-        for candidate in top_logprobs:
-            token_info = _to_dict(candidate)
-            token_str = str(token_info.get("token", ""))
-            if not token_str.isdecimal():
-                continue
-
-            score = int(token_str)
-            if not 0 <= score <= 10:
-                continue
-
-            log_prob = token_info.get("logprob")
-            if log_prob is None:
-                continue
-
-            linear_prob = math.exp(float(log_prob))
-            linear_probs_sum += linear_prob
-            weighted_score_sum += linear_prob * score
+        (
+            linear_probs_sum,
+            weighted_score_sum,
+            token_candidate,
+        ) = _weighted_score_sums(entries, entry_indices)
 
         if linear_probs_sum != 0.0:
             final_score: float = weighted_score_sum / linear_probs_sum / 10
@@ -107,6 +95,93 @@ def parse_litellm_model_output(
     except Exception as exception:
         LOGGER.error(f"Failed to parse model output: {exception}", exc_info=True)
         raise exceptions.MetricComputationError(GEVAL_SCORE_CALC_FAILED) from exception
+
+
+_SCORE_KEY_RE = re.compile(r'"score"\s*:\s*(\d+)')
+
+
+def _locate_score_entries(entries: list) -> list[int] | None:
+    """Find the entry indices whose tokens carry the score digits.
+
+    Reconstructs the decoded text from the token stream and locates the
+    digits after `"score":`; returns the one or two indices covering them,
+    or None when the key cannot be found in the reconstructed text (the
+    caller then falls back to the legacy fixed offset).
+    """
+    token_texts = [str(_to_dict(entry).get("token", "")) for entry in entries]
+    full_text = "".join(token_texts)
+    match = _SCORE_KEY_RE.search(full_text)
+    if match is None:
+        return None
+    start, end = match.start(1), match.end(1)
+    offsets = []
+    position = 0
+    for text in token_texts:
+        offsets.append((position, position + len(text)))
+        position += len(text)
+    indices = [
+        index
+        for index, (begin, stop) in enumerate(offsets)
+        if stop > start and begin < end
+    ]
+    if not 1 <= len(indices) <= 2:
+        return None
+    return indices
+
+
+def _decimal_candidates(entry) -> list:
+    return [
+        (str(info.get("token", "")).strip(), math.exp(float(info["logprob"])))
+        for info in (_to_dict(cand) for cand in (entry.get("top_logprobs") or []))
+        if str(info.get("token", "")).strip().isdecimal()
+        and info.get("logprob") is not None
+    ]
+
+
+def _weighted_score_sums(entries: list, entry_indices: list[int]) -> tuple:
+    """Weighted [0, 10] score mass over the candidate space of the score token(s).
+
+    A single-entry span averages that entry's decimal candidates (the
+    legacy behaviour, plus leading/trailing whitespace tolerance). A
+    two-entry span additionally combines the two positions' candidates
+    ("1" + "0" -> 10) and counts a first-position candidate only when it
+    covers the whole digit span ("10"), so the chosen digits are not
+    double-counted.
+    """
+    token_candidate = "".join(
+        str(_to_dict(entries[index]).get("token", "")) for index in entry_indices
+    ).strip()
+
+    linear_probs_sum = 0.0
+    weighted_score_sum = 0.0
+
+    if len(entry_indices) == 1:
+        for token, prob in _decimal_candidates(entries[entry_indices[0]]):
+            score = int(token)
+            if not 0 <= score <= 10:
+                continue
+            linear_probs_sum += prob
+            weighted_score_sum += prob * score
+        return linear_probs_sum, weighted_score_sum, token_candidate
+
+    digits = token_candidate
+    first_candidates = _decimal_candidates(entries[entry_indices[0]])
+    second_candidates = _decimal_candidates(entries[entry_indices[1]])
+
+    for token_a, prob_a in first_candidates:
+        if token_a == digits and 0 <= int(token_a) <= 10:
+            # one token covering the whole span (alternative tokenization)
+            linear_probs_sum += prob_a
+            weighted_score_sum += prob_a * int(token_a)
+        for token_b, prob_b in second_candidates:
+            combined = token_a + token_b
+            if not combined.isdecimal() or not 0 <= int(combined) <= 10:
+                continue
+            prob = prob_a * prob_b
+            linear_probs_sum += prob
+            weighted_score_sum += prob * int(combined)
+
+    return linear_probs_sum, weighted_score_sum, token_candidate
 
 
 def _extract_score_from_text_content(

--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
@@ -107,12 +107,17 @@ def _locate_score_entries(entries: list) -> list[int] | None:
     digits after `"score":`; returns the one or two indices covering them,
     or None when the key cannot be found in the reconstructed text (the
     caller then falls back to the legacy fixed offset).
+
+    Uses the LAST match so duplicate `"score"` keys resolve the same way
+    json.loads does — to the final one, which is also what the no-logprob
+    text path reads via `dict_content["score"]`.
     """
     token_texts = [str(_to_dict(entry).get("token", "")) for entry in entries]
     full_text = "".join(token_texts)
-    match = _SCORE_KEY_RE.search(full_text)
-    if match is None:
+    matches = list(_SCORE_KEY_RE.finditer(full_text))
+    if not matches:
         return None
+    match = matches[-1]
     start, end = match.start(1), match.end(1)
     offsets = []
     position = 0

--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
@@ -69,6 +69,12 @@ def parse_litellm_model_output(
         # lands, and a two-digit score ("10") spans two tokens.
         entry_indices = _locate_score_entries(entries)
         if entry_indices is None:
+            LOGGER.debug(
+                "g_eval score key not found in the reconstructed response; "
+                "falling back to the legacy fixed token offset. Reconstructed "
+                "response: %r",
+                "".join(str(_to_dict(entry).get("token", "")) for entry in entries),
+            )
             entry_indices = [3]
 
         (

--- a/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
+++ b/sdks/python/src/opik/evaluation/metrics/llm_judges/g_eval/parser.py
@@ -50,8 +50,9 @@ def parse_litellm_model_output(
     between 0 and 10.
 
     In order to make the score computation more robust, we look at the top logprobs of the score token and compute
-    a weighted average of the scores. Since we try to enforce the format of the model's response, we can assume that
-    the score token is always the fourth token in the response (first token is `{"`, followed by `score` and `":`).
+    a weighted average of the scores. The score token is located by content (the digits after the `"score":` key,
+    last-wins on duplicates, mirroring json.loads); only when the key cannot be located do we fall back to the
+    legacy fixed token offset for backwards compatibility.
     """
     try:
         choice_dict = _normalise_first_choice(content)

--- a/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
+++ b/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
@@ -144,3 +144,67 @@ def test_single_digit_score_at_position_three_unchanged():
         log_probs_supported=True,
     )
     assert 0.60 < result.value < 0.65
+
+
+def test_duplicate_score_keys_last_wins_like_the_text_path():
+    # json.loads (and therefore the no-logprob text path) resolves
+    # duplicate "score" keys to the LAST one. The token-stream locator
+    # must mirror that: a first-occurrence scan scores from the first,
+    # stale key instead.
+    entries = [
+        _entry('{\"', -0.01),
+        _entry("score", -0.01),
+        _entry('\":', -0.01),
+        _entry(" ", -0.01),
+        _entry("9", -0.5, top=[{"token": "9", "logprob": -0.01}, {"token": "5", "logprob": -3.00}]),
+        _entry(",", -0.01),
+        _entry(" ", -0.01),
+        _entry("\"score", -0.01),
+        _entry('\":', -0.01),
+        _entry(" ", -0.01),
+        _entry("7", -0.1, top=[{"token": "7", "logprob": -0.1}, {"token": "1", "logprob": -2.00}]),
+        _entry(",", -0.01),
+        _entry(" ", -0.01),
+        _entry("\"", -0.01),
+        _entry("reason", -0.01),
+        _entry('\":', -0.01),
+        _entry(" ", -0.01),
+        _entry("\"ok\"", -0.01),
+        _entry("}", -0.01),
+    ]
+    content = '{"score": 9, "score": 7, "reason": "ok"}'
+    result = parser.parse_litellm_model_output(
+        _response(content, entries),
+        name="g_eval",
+        log_probs_supported=True,
+    )
+    assert 0.55 < result.value < 0.68, f"scored from the stale key: {result.value}"
+
+
+def test_escaped_quote_echo_is_not_a_matchable_key():
+    # Control: a rubric quote inside the reason has escaped quotes, so
+    # the literal "score": n there can never match the key regex -- the
+    # locator stays on the real key. Guards against a looser rewrite
+    # that would scan bare text.
+    entries = [
+        _entry('{\"', -0.01),
+        _entry("reason", -0.01),
+        _entry('\":', -0.01),
+        _entry(' "the rubric said \\"', -0.01),
+        _entry("score", -0.01),
+        _entry('\\": ', -0.01),
+        _entry("9", -0.5, top=[{"token": "9", "logprob": -0.01}, {"token": "5", "logprob": -3.00}]),
+        _entry(" here\", ", -0.01),
+        _entry("\"score", -0.01),
+        _entry('\":', -0.01),
+        _entry(" ", -0.01),
+        _entry("7", -0.1, top=[{"token": "7", "logprob": -0.1}, {"token": "1", "logprob": -2.00}]),
+        _entry("}", -0.01),
+    ]
+    content = '{"reason": "the rubric said \\"score\\": 9 here", "score": 7}'
+    result = parser.parse_litellm_model_output(
+        _response(content, entries),
+        name="g_eval",
+        log_probs_supported=True,
+    )
+    assert 0.55 < result.value < 0.68, f"unexpected value {result.value}"

--- a/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
+++ b/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
@@ -16,3 +16,131 @@ def test_g_eval__parse_model_output_string__score_out_of_range__MetricComputatio
             content=invalid_model_output,
             metric_name="g_eval",
         )
+
+
+# --- deterministic logprob stubs -------------------------------------------
+# Shape mirrors what parse_litellm_model_output normalises via _to_dict.
+
+
+def _entry(token, logprob, top=None):
+    return {
+        "token": token,
+        "logprob": logprob,
+        "top_logprobs": top
+        if top is not None
+        else [{"token": token, "logprob": logprob}],
+    }
+
+
+def _response(content, entries):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message={"content": content},
+                logprobs={"content": entries},
+            )
+        ]
+    )
+
+
+def test_two_digit_score_split_across_tokens_scores_near_one():
+    # {"score":10} tokenizes as {" score ": "1" "0" ...}; the score is 10 but
+    # position 3 only sees the first digit "1", so the weighted average of
+    # digit candidates lands near 0.1 instead of 1.0.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            "1",
+            -0.05,
+            top=[
+                {"token": "1", "logprob": -0.05},
+                {"token": "0", "logprob": -2.30},
+                {"token": "2", "logprob": -2.40},
+            ],
+        ),
+        _entry(
+            "0",
+            -0.02,
+            top=[{"token": "0", "logprob": -0.02}, {"token": "1", "logprob": -3.00}],
+        ),
+        _entry(",", -0.01),
+        _entry(" ", -0.01),
+        _entry('"', -0.01),
+        _entry("reason", -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"excellent"', -0.01),
+        _entry("}", -0.01),
+    ]
+    result = parser.parse_litellm_model_output(
+        _response('{"score":10, "reason": "excellent"}', entries),
+        name="g_eval",
+        log_probs_supported=True,
+    )
+    assert result.value > 0.9, f"score 10 parsed as {result.value}"
+
+
+def test_leading_space_score_token_is_scored_not_rejected():
+    # {"score": 0} tokenizes the space into the score token (" 0"); the
+    # candidate filter rejects every candidate (none isdecimal) and the
+    # chosen-token fallback raises on " 0" as well.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            " 0",
+            -0.02,
+            top=[
+                {"token": " 0", "logprob": -0.02},
+                {"token": " 1", "logprob": -2.00},
+                {"token": " 10", "logprob": -2.50},
+            ],
+        ),
+        _entry(",", -0.01),
+        _entry(" ", -0.01),
+        _entry('"', -0.01),
+        _entry("reason", -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"none"', -0.01),
+        _entry("}", -0.01),
+    ]
+    result = parser.parse_litellm_model_output(
+        _response('{"score": 0, "reason": "none"}', entries),
+        name="g_eval",
+        log_probs_supported=True,
+    )
+    assert 0.0 < result.value < 0.09, f"unexpected value {result.value}"
+
+
+def test_single_digit_score_at_position_three_unchanged():
+    # Control: the no-space, single-digit case must keep today's exact value.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            "7",
+            -0.1,
+            top=[{"token": "7", "logprob": -0.1}, {"token": "1", "logprob": -2.0}],
+        ),
+        _entry(",", -0.01),
+        _entry(" ", -0.01),
+        _entry('"', -0.01),
+        _entry("reason", -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"ok"', -0.01),
+        _entry("}", -0.01),
+    ]
+    result = parser.parse_litellm_model_output(
+        _response('{"score":7, "reason": "ok"}', entries),
+        name="g_eval",
+        log_probs_supported=True,
+    )
+    assert 0.60 < result.value < 0.65

--- a/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
+++ b/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
@@ -1,5 +1,10 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+
 from opik import logging_messages, exceptions
 from opik.evaluation.metrics.llm_judges.g_eval import parser
+from opik.evaluation.metrics.llm_judges.g_eval.metric import GEval
+from opik.evaluation.models import base_model
 import pytest
 
 
@@ -178,7 +183,12 @@ def test_duplicate_score_keys_last_wins_like_the_text_path():
         name="g_eval",
         log_probs_supported=True,
     )
-    assert 0.55 < result.value < 0.68, f"scored from the stale key: {result.value}"
+    # Exact weighted value of the second key's candidates (7 @ -0.1,
+    # 1 @ -2.0): (7*e^-0.1 + e^-2)/(e^-0.1 + e^-2)/10. A first-match locator
+    # scores the stale "9" key instead (0.88084...) and fails here.
+    assert result.value == pytest.approx(0.6219349153822014, abs=1e-9), (
+        f"scored from the stale key: {result.value}"
+    )
 
 
 def test_escaped_quote_echo_is_not_a_matchable_key():
@@ -207,4 +217,127 @@ def test_escaped_quote_echo_is_not_a_matchable_key():
         name="g_eval",
         log_probs_supported=True,
     )
-    assert 0.55 < result.value < 0.68, f"unexpected value {result.value}"
+    # Same distribution as the duplicate-key test pins the locator on the
+    # real key; see the derivation there.
+    assert result.value == pytest.approx(0.6219349153822014, abs=1e-9), (
+        f"unexpected value {result.value}"
+    )
+
+
+# --- provider-shaped GEval coverage ----------------------------------------
+# The tests above call parse_litellm_model_output directly with hand-built
+# token dicts. These go through the public GEval.score LiteLLM branch with
+# a provider-shaped raw response, so an incorrectly bounded result on the
+# real path cannot pass unnoticed.
+
+
+def _provider_response(content, entries):
+    """Provider-shaped raw LiteLLM response: a dict-style choice carrying the
+    message content plus the logprobs token stream, as yielded by
+    get_provider_response on the LiteLLM branch."""
+    return SimpleNamespace(
+        choices=[{"message": {"content": content}, "logprobs": {"content": entries}}]
+    )
+
+
+def _geval_on_stubbed_provider(monkeypatch, content, entries):
+    """GEval wired to a stubbed LiteLLM provider: chain-of-thought generation
+    is stubbed, and the scoring call yields the given provider-shaped
+    response. Returns (metric, captured_provider_kwargs)."""
+    metric = GEval(
+        task_introduction="provider-path split-score intro",
+        evaluation_criteria="provider-path split-score criteria",
+        model="gpt-4o",
+        track=False,
+    )
+    # The subject here is the logprob parser branch, not model capability
+    # detection (covered by test_geval_passes_logprobs_only_when_supported).
+    metric._log_probs_supported = True
+    monkeypatch.setattr(
+        metric._model,
+        "generate_chat_completion",
+        lambda *args, **kwargs: {"content": "stub chain of thought"},
+    )
+    captured = {}
+
+    @contextmanager
+    def fake_get_provider_response(model_provider, messages, **kwargs):
+        captured.update(kwargs)
+        yield _provider_response(content, entries)
+
+    monkeypatch.setattr(base_model, "get_provider_response", fake_get_provider_response)
+    return metric, captured
+
+
+def test_geval_litellm_path_split_score_scores_near_one(monkeypatch):
+    # {"score":10} split across "1" + "0" must score near 1.0 end to end. A
+    # legacy fixed-offset read of entries[3] alone averages to ~0.099.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            "1",
+            -0.05,
+            top=[
+                {"token": "1", "logprob": -0.05},
+                {"token": "0", "logprob": -2.30},
+                {"token": "2", "logprob": -2.40},
+            ],
+        ),
+        _entry(
+            "0",
+            -0.02,
+            top=[{"token": "0", "logprob": -0.02}, {"token": "1", "logprob": -3.00}],
+        ),
+        _entry(",", -0.01),
+        _entry('"reason"', -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"excellent"', -0.01),
+        _entry("}", -0.01),
+    ]
+    content = '{"score":10, "reason": "excellent"}'
+    metric, captured = _geval_on_stubbed_provider(monkeypatch, content, entries)
+
+    result = metric.score("any input")
+
+    assert captured["logprobs"] is True
+    assert captured["top_logprobs"] == 20
+    assert result.value == pytest.approx(0.9007723389857002, abs=1e-9)
+    assert result.reason == "excellent"
+
+
+def test_geval_litellm_path_folded_whitespace_is_scored(monkeypatch):
+    # The space after the colon folds into the score token (" 0"); the
+    # end-to-end path must score it instead of raising
+    # MetricComputationError on a perfectly parseable response.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            " 0",
+            -0.02,
+            top=[
+                {"token": " 0", "logprob": -0.02},
+                {"token": " 1", "logprob": -2.00},
+                {"token": " 10", "logprob": -2.50},
+            ],
+        ),
+        _entry(",", -0.01),
+        _entry('"reason"', -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"none"', -0.01),
+        _entry("}", -0.01),
+    ]
+    content = '{"score": 0, "reason": "none"}'
+    metric, captured = _geval_on_stubbed_provider(monkeypatch, content, entries)
+
+    result = metric.score("any input")
+
+    assert captured["logprobs"] is True
+    assert captured["top_logprobs"] == 20
+    assert result.value == pytest.approx(0.07984052568223204, abs=1e-9)
+    assert result.reason == "none"

--- a/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
+++ b/sdks/python/tests/unit/evaluation/metrics/llm_judges/g_eval/test_parser.py
@@ -1,4 +1,4 @@
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from types import SimpleNamespace
 
 from opik import logging_messages, exceptions
@@ -258,6 +258,15 @@ def _geval_on_stubbed_provider(monkeypatch, content, entries):
         "generate_chat_completion",
         lambda *args, **kwargs: {"content": "stub chain of thought"},
     )
+
+    async def fake_agenerate_chat_completion(*args, **kwargs):
+        return {"content": "stub chain of thought"}
+
+    monkeypatch.setattr(
+        metric._model,
+        "agenerate_chat_completion",
+        fake_agenerate_chat_completion,
+    )
     captured = {}
 
     @contextmanager
@@ -266,6 +275,15 @@ def _geval_on_stubbed_provider(monkeypatch, content, entries):
         yield _provider_response(content, entries)
 
     monkeypatch.setattr(base_model, "get_provider_response", fake_get_provider_response)
+
+    @asynccontextmanager
+    async def fake_aget_provider_response(model_provider, messages, **kwargs):
+        captured.update(kwargs)
+        yield _provider_response(content, entries)
+
+    monkeypatch.setattr(
+        base_model, "aget_provider_response", fake_aget_provider_response
+    )
     return metric, captured
 
 
@@ -336,6 +354,87 @@ def test_geval_litellm_path_folded_whitespace_is_scored(monkeypatch):
     metric, captured = _geval_on_stubbed_provider(monkeypatch, content, entries)
 
     result = metric.score("any input")
+
+    assert captured["logprobs"] is True
+    assert captured["top_logprobs"] == 20
+    assert result.value == pytest.approx(0.07984052568223204, abs=1e-9)
+    assert result.reason == "none"
+
+
+# --- async provider-shaped GEval coverage ------------------------------------
+# GEval.ascore goes through aget_provider_response (an independent call site)
+# into the same parser, so the sync tests above cannot catch an async-only
+# regression. Fixtures and expectations mirror the sync twins exactly: the
+# parser is synchronous and shared, so identical entries/content must yield
+# identical values.
+
+
+@pytest.mark.asyncio
+async def test_geval_litellm_path_split_score_scores_near_one_async(monkeypatch):
+    # Async twin of test_geval_litellm_path_split_score_scores_near_one.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            "1",
+            -0.05,
+            top=[
+                {"token": "1", "logprob": -0.05},
+                {"token": "0", "logprob": -2.30},
+                {"token": "2", "logprob": -2.40},
+            ],
+        ),
+        _entry(
+            "0",
+            -0.02,
+            top=[{"token": "0", "logprob": -0.02}, {"token": "1", "logprob": -3.00}],
+        ),
+        _entry(",", -0.01),
+        _entry('"reason"', -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"excellent"', -0.01),
+        _entry("}", -0.01),
+    ]
+    content = '{"score":10, "reason": "excellent"}'
+    metric, captured = _geval_on_stubbed_provider(monkeypatch, content, entries)
+
+    result = await metric.ascore("any input")
+
+    assert captured["logprobs"] is True
+    assert captured["top_logprobs"] == 20
+    assert result.value == pytest.approx(0.9007723389857002, abs=1e-9)
+    assert result.reason == "excellent"
+
+
+@pytest.mark.asyncio
+async def test_geval_litellm_path_folded_whitespace_is_scored_async(monkeypatch):
+    # Async twin of test_geval_litellm_path_folded_whitespace_is_scored.
+    entries = [
+        _entry('{"', -0.01),
+        _entry("score", -0.01),
+        _entry('":', -0.01),
+        _entry(
+            " 0",
+            -0.02,
+            top=[
+                {"token": " 0", "logprob": -0.02},
+                {"token": " 1", "logprob": -2.00},
+                {"token": " 10", "logprob": -2.50},
+            ],
+        ),
+        _entry(",", -0.01),
+        _entry('"reason"', -0.01),
+        _entry('":', -0.01),
+        _entry(" ", -0.01),
+        _entry('"none"', -0.01),
+        _entry("}", -0.01),
+    ]
+    content = '{"score": 0, "reason": "none"}'
+    metric, captured = _geval_on_stubbed_provider(monkeypatch, content, entries)
+
+    result = await metric.ascore("any input")
 
     assert captured["logprobs"] is True
     assert captured["top_logprobs"] == 20


### PR DESCRIPTION
## Details

- The G-Eval logprob scorer located the score digit at a hardcoded token offset and assumed single-digit scores. A two-digit score (`"score": 10`) tokenizes across two tokens, so only the first digit was averaged: a confident **10 parsed as ~0.099**. A tokenizer folding the whitespace after the colon into the score token (`" 0"`) made every candidate fail the decimal check and raised `MetricComputationError` on a perfectly parseable response.
- The score digits are now located by reconstructing the token stream and walking the first JSON object once, stepping over whole strings and reading the `"score"` key only at depth 1, stopping when that object closes. Last assignment wins, so duplicate top-level keys resolve the way `json.loads` does, and a nested `"score"` cannot capture the position because it sits deeper. Candidate tokens are stripped before the decimal check; a two-token span combines both positions' candidates (`"1" + "0"` -> 10).
- When the located span carries no probability mass (digits span punctuation-carrying tokens), the parser degrades to the text path like the short-stream and no-logprob branches instead of raising.
- Falls back to the legacy fixed offset when the first object holds no top-level key.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

Related: #8134 (defect 3 of 4 — `Resolves` intentionally avoided so the four-defect issue stays open for defects 1 and 2)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: OpenCode (Sisyphus agent session)
- Model(s): muse-spark
- Scope: review-feedback commits only — `5486cc3` (typehints, `_to_dict` wrap, no-mass degrade, content-free log line, test dedup/parametrize, punctuation-split regression test), `3b8cfe9` (DEBUG fallback log + message assertion), `0e48cce` (locator value-agreement fix, two regression tests, two docstring corrections), `ae048eadf` (locator brace-depth fix + one regression test), `670fdd61e` (one test-only commit closing a coverage hole the depth rule opened), `3b056b5d9` (locator rewritten to a single-pass structural walk, design and reference implementation from `petrotiurin` on the thread, plus three regression tests)

- Human verification: `pytest tests/unit/evaluation/metrics/llm_judges/g_eval/` (18 passed at `3b056b5d9`, 15 at `670fdd61e`, 13 at `0e48cce`), `pytest tests/unit/evaluation/metrics/llm_judges/` 126 passed, new tests verified to fail on the pre-fix parser, `ruff@0.14.14` check + format clean, `mypy@1.19.1` clean; mutation table below re-run whole at each head, each mutation restoring the file byte-for-byte


## Testing

At `3b056b5d9`:

- `PYTHONPATH=src python -m pytest tests/unit/evaluation/metrics/llm_judges/g_eval/ -q` → `18 passed`
- `PYTHONPATH=src python -m pytest tests/unit/evaluation/metrics/llm_judges/ -q` → `126 passed`
- The three tests added in `3b056b5d9` fail against `670fdd61e`'s `src/` and only those three do; the fifteen existing tests pass unmodified on the new locator
- `uvx ruff@0.14.14 check` + `format --check` on both touched files → clean; `uvx mypy@1.19.1 --config-file pyproject.toml --disable-error-code misc --ignore-missing-imports` on `parser.py` → `Success: no issues found in 1 source file`
- `PYTHONPATH=src python -m pytest tests/unit -q --tb=no -rf` → `1 failed, 5161 passed, 3 skipped in 243.78s`. The failure is `tests/unit/evaluation/metrics/test_heuristics.py::test_evaluation__levenshtein_ratio`, in a file this diff does not touch; `importlib.util.find_spec("rapidfuzz")` returns `None` here, so an optional dependency is missing rather than anything in this change being wrong
- E2E not run (needs a live backend stack)

Historical, at earlier heads: `test_punctuation_carrying_split_digits_degrade_to_text_path` fails on the pre-PR parser with `MetricComputationError` and passes post-fix with `1.0`. A broader `tests/unit/evaluation/` sweep at that time showed the same failure count on the clean tree (91 failed / 927 passed) and on this branch (91 failed / 930 passed); those 91 are pre-existing environment failures unrelated to this diff.

## Documentation

N/A — no user-facing API or config change.


---

**Follow-up round (3b8cfe9).** On Baz's question, the zero-probability-mass fallback now logs at DEBUG with the metric name, matching the sibling locator-failure branch, and `test_punctuation_carrying_split_digits_degrade_to_text_path` asserts the message as well as the value. Measured against its immediate predecessor 5486cc358, which degrades silently, the assertion fails on an empty capture; against the pre-PR parser the test fails outright with `MetricComputationError`. Post-fix: 11 passed in `tests/unit/evaluation/metrics/llm_judges/g_eval/`, `ruff check` and `ruff format --check` clean, `mypy` clean on `parser.py`.


---

**Follow-up round (`0e48cce`, addressing the nested-key concern).** Reproduced first, then applied the suggested agreement check. Measured on `{"score":7, "reason": "ok", "breakdown": {"score":3}}`, with the top-level digit at entry 3 and the nested one last in text order:

| tree | located entry | score |
|---|---|---|
| merge base `d53961c4` | fixed offset 3 | 0.6219349153822014 |
| `3b8cfe9` (before this round) | 13, the nested `3` | 0.27397830512740046 |
| `0e48cce` | 3 | 0.6219349153822014 |
| text path (no logprobs) | — | 0.7 |

Two tests added:

- `test_nested_score_key_does_not_capture_the_located_token` — fails on `3b8cfe9` with `AssertionError: scored from the nested key: 0.27397830512740046`, passes here.
- `test_unparseable_reconstruction_keeps_the_positional_match` — pins the fallback when the reconstructed stream is not valid JSON.

Mutations, each restoring `parser.py` byte-for-byte (sha256 checked) and re-running the suite:

| mutation | tests that die |
|---|---|
| drop the agreement check (positional last match, i.e. `3b8cfe9`) | nested-key test, 1 |
| positional *first* match (`matches[0]`) | duplicate-key test, 1 — **retracted in the next round: re-run at `0e48cce` it kills nothing** |
| agreement check without the `except` | truncated-stream test + 5 existing tests, 6 |

The third row is why the fallback stays: removing it fails 6 of the 13 tests, not just the new one, because the reconstructed text is not valid JSON in several existing fixtures (their token streams stop before the document closes). In those cases the positional choice is kept, which is today's behaviour.

Two notes on the suggestion. I did not hoist the `json.loads` into the one further down: that one parses `choice_dict`'s message content, this one parses the reconstructed token text, and those can differ (the truncated-stream case), so the parses are not interchangeable. And the two docstring claims that said last-match-wins mirrors `json.loads` were true for top-level duplicates only, so both now state the value-agreement rule.

Verification: 13 passed in `tests/unit/evaluation/metrics/llm_judges/g_eval/`; `uvx ruff@0.14.14 check` and `format --check` clean on both files; `uvx mypy@1.19.1 --config-file sdks/python/pyproject.toml --disable-error-code misc` clean on `parser.py` (run with `--ignore-missing-imports` locally, since this environment has no `litellm` stubs).


---

**Follow-up round (`ae048eadf` + `670fdd61e`, on the three remaining locator claims).**
Each claim was measured as one response per claim across three trees — `origin/main`, this
PR at `0e48cce`, and after the change at `670fdd61e` — instead of being reasoned about:

| response | `json.loads` | `main` | `0e48cce` | `670fdd61e` | text path |
|---|---|---|---|---|---|
| `{"score":7, "reason": "ok", "breakdown": {"score":7}}` | 7 | 0.6219349153822014 | **0.7809998433984686** | 0.6219349153822014 | 0.7 |
| `{"\u0073core": 7, "reason": "ok"}` | 7 | `MetricComputationError` | 0.7 | 0.7 | 0.7 |
| `{"score": 1e1, "reason": "ok"}` | 10.0 | 0.20408677949039836 | 0.20408677949039836 | 0.20408677949039836 | 1.0 |

**Row 1 is real and is fixed here.** Value agreement does not identify a position: when a
breakdown restates the top-level score, both digits agree, so the reversed scan kept
returning the nested one and the weighted average came off the breakdown token's
distribution. `main` scores 0.6219349153822014 on that response, so this was a regression
the previous round introduced — and a worse shape than the differing-value case, because it
yields a plausible number rather than an obviously wrong one. The rule is now: take the
agreeing matches, restrict them to the shallowest brace depth, then take the last of those,
which keeps duplicate top-level keys resolving to the final one.

`test_nested_score_key_with_the_same_value_does_not_win_the_locator` fails pre-fix with
`assert [13] == [3]` and passes post-fix. Selection differential over 32 reconstructed texts
(top level only; breakdown with the same and with a different value; two criteria; criteria
inside an array; braces inside a string; duplicate top-level keys; doubly nested) changes
the chosen span in 5 of them, and all 5 are the equal-valued-nested family — the other 27
select the same span as before.

**Rows 2 and 3 are not changed, and the numbers say why.** The escaped key returns `None`
from the locator, so the caller falls back to the fixed offset and lands on 0.7, the same
value `json.loads` gives, and better than `main`, which raises `MetricComputationError` on
that response. This PR therefore does not worsen the escaped-key case; it leaves it on a
path that already resolves it. The exponent row is identical on all three trees, so it is
inherited rather than introduced; consuming the full number grammar would also extend the
digit span onto `e1`, which `_weighted_score_sums` cannot weight because it filters
candidates on `isdecimal()`. Fixing that means changing the weighting code, and it is only
reachable if the integer contract in `_COT_SYSTEM_PROMPT` ("SCORE VALUE MUST BE AN INTEGER")
is relaxed. Left out rather than widening this diff.

**Corrections to my own previous round, found while measuring this one.**

- The `matches[0]` row in the table above is retracted. Re-run at `0e48cce` it kills nothing
  (13 passed): the value-agreement step overrides the positional default whenever any match
  agrees, so first-vs-last only survives on an unparseable reconstruction, and the test for
  that path used a single score key. The row was true of an earlier head and I carried it
  forward without re-measuring it.
- `670fdd61e` closes the coverage hole that explanation describes: two score keys in a
  truncated stream, where last-wins is the only rule left standing. It passes on `0e48cce`
  too, so it demonstrates missing coverage rather than a fixed defect.

Mutation table at `670fdd61e`, 15 tests as the baseline. Each mutation was applied to
`parser.py`, the suite run, then the file restored byte-for-byte (sha256 `e81072a313fb`,
checked before and after). **This table is superseded by the one at `3b056b5d9` below: the
code it mutates no longer exists.**

| mutation | tests that die |
|---|---|
| drop the depth rule (`match = agreed[-1][0]`) | equal-valued nested test, 1 |
| drop value agreement *and* depth (bare `matches[-1]`, i.e. `3b8cfe9`) | both nested tests, 2 |
| positional *first* match (`matches[0]`) | unparseable duplicate-key test, 1 |
| remove the unparseable fallback (raise instead of keeping positional) | the 3 locator-fallback tests + 4 provider-path e2e cases, 7 |

The last row is why the fallback stays load-bearing: it takes the punctuation-split
degradation test and both unparseable-reconstruction tests, plus all four provider-path e2e
cases (sync and async, two parameterizations each).

Verification at `670fdd61e`: `PYTHONPATH=src pytest
tests/unit/evaluation/metrics/llm_judges/g_eval/` → 15 passed; `uvx ruff@0.14.14 check` and
`format --check` clean on both files; `uvx mypy@1.19.1 --config-file pyproject.toml
--ignore-missing-imports` clean on `parser.py` (the `--ignore-missing-imports` is local
only, this machine has no `litellm` stubs; CI runs without it, and `tests/` is excluded from
mypy by `.pre-commit-config.yaml`). Source diff is 23 lines added / 5 removed in
`parser.py`; the rest is tests.


---

**Follow-up round (`3b056b5d9`, the depth rule replaced by a structural walk).**

`petrotiurin` reproduced two defects in the rule the previous round added, and supplied the
design and a reference implementation. Both reproduce here, measured before changing
anything.

The depth rule counted `{` and `}` characters in the text preceding each match, so braces
inside a JSON string value read as structure. With `}}}` in a reason the top-level key came
out at depth 1 and the nested one at depth 0, so "shallowest agreeing match" selected the
nested key. The same rule copied a growing prefix and ran two full `.count()` scans per
agreeing match, which is quadratic in the response length.

| response | `main` | `670fdd61e` | `3b056b5d9` |
|---|---|---|---|
| `{"score":7, "reason": "returns }}} here", "breakdown": {"score": 7}}` | 0.6219349153822014 | entry 13, **0.7809998433984686** | entry 3, 0.6219349153822014 |
| `{"reason": "ok", "breakdown": {"score": 7}}`, the only score nested | `MetricComputationError` | entry 9, 0.6219349153822014 | `None`, `MetricComputationError` |

Timing on a rubric-shaped response that doubles each step (top-level score plus N criteria,
each `{"name": ..., "score": 7}`, four-character tokens):

| bytes | criteria | `670fdd61e` | `3b056b5d9` |
|---|---|---|---|
| 4119 | 143 | 0.443 ms | 0.307 ms |
| 8208 | 284 | 1.253 ms | 0.659 ms |
| 16386 | 566 | 4.229 ms | 1.297 ms |
| 32783 | 1127 | 15.244 ms | 2.721 ms |
| 65543 | 2219 | 58.116 ms | 5.461 ms |

The walk is one pass: `_STRUCTURE_RE` matches either a whole JSON string, escapes included
and an unterminated tail tolerated, or a single brace. Strings are consumed whole, so
neither a brace nor a `"score"` echo inside a reason can move the structure. The key is read
only at depth 1 and the walk stops when that object closes. Last assignment wins, so
duplicate top-level keys still resolve as `json.loads` does. Nothing is validated, so a
truncated reconstruction behaves exactly as before, which lets the `json.loads` agreement
check and its bare `except` go away. `json` stays imported: `parser.py:111` still uses it.

Three tests added. The fifteen existing ones pass unmodified, and against `670fdd61e`'s
`src/` the file gives three failures which are exactly the three new tests.

- `test_braces_inside_a_string_do_not_shift_the_score_depth` — fails pre-fix with
  `assert [13] == [3]`.
- `test_score_only_nested_falls_back_instead_of_scoring_from_it` — pins the decision on the
  consequence below; fails pre-fix, which scored 0.6219349153822014 from the nested key.
- `test_walk_stops_at_the_first_object_close` — `{"score": 7} and {"score": 3}` located
  entry 9 pre-fix, entry 4 now.

**The consequence flagged on the thread is taken, not absorbed.** A response whose only
`"score"` is nested now returns `None`, falls through to the legacy offset and raises,
matching `main` and the text path. Otherwise the same response succeeds or fails purely on
whether the provider returned logprobs.

**One shape where the walk is stricter than the rule it replaces.** Prose carrying a complete
brace pair before the JSON, `Use {this} format: {"score": 7}`: the walk closes on the prose
brace and returns `None`, where the old rule reached the real key. On that input all three
trees still end in `MetricComputationError`, because `parser.py:111` parses the message
content with a strict `json.loads` and rejects anything prose-wrapped before the located
score matters. So the narrowing changes no outcome today, and where it eventually shows up it
degrades to the legacy offset, which is `main`'s behaviour. Raised on the thread rather than
silently widened; continuing past a close while `span` is still `None` is a one-line change
and is deliberately not made here.

**A distinction Baz's report and the thread did not separate.** Baz's literal example,
`{"reason":"{", "score":7}`, does not reproduce: it has one match, so the shallowest-of-
agreeing step has nothing to choose between and it locates correctly. `main` is what raises
there, because the fixed offset lands on the `{` token and the zero-mass degrade did not
exist before this PR. Only the `}}}` variant breaks the depth rule, since the comparison
needs a second match to pick wrongly.

Mutation table at `3b056b5d9`, 18 tests as the baseline, each mutation restored
byte-for-byte with sha256 `765c826e` checked before and after:

| mutation | tests that die |
|---|---|
| read the key at `depth >= 1` instead of `== 1` | 4: braces-in-string, both nested-key tests, nested-only |
| do not stop when the first object closes | 1: `test_walk_stops_at_the_first_object_close` |
| keep the first span instead of the last | 2: duplicate-key, unparseable duplicate-key |
| match braces only, do not consume whole strings | 9 |
| raise instead of returning `None` when there is no top-level key | 1: nested-only |

No test pins the linear scan. A timing bound loose enough to survive a loaded runner would
not kill the quadratic version either, since 58 ms at 64KB passes anything sane, so that
measurement lives in this description rather than in the suite.

**Follow-up, not touched here.** `parser.py:111` reads the reason with a strict `json.loads`
on the raw message content, while every other read goes through
`parsing_helpers.extract_json_content_or_raise` (`:21`). That is why a prose-wrapped or
markdown-fenced response fails on the logprob path and succeeds without logprobs. Verified,
and out of scope for this diff.

Verification at `3b056b5d9`: 18 passed in
`tests/unit/evaluation/metrics/llm_judges/g_eval/`, 126 passed in
`tests/unit/evaluation/metrics/llm_judges/`; `uvx ruff@0.14.14 check` and `format --check`
clean on both touched files; `uvx mypy@1.19.1 --config-file pyproject.toml
--disable-error-code misc --ignore-missing-imports` on `parser.py` → `Success: no issues
found in 1 source file`. The commit is 36 lines added / 36 removed in `parser.py` plus 108
lines of tests. Full `tests/unit` at this head: 1 failed, 5161 passed, 3 skipped in 243.78s,
the failure being `test_evaluation__levenshtein_ratio` on a missing optional `rapidfuzz` in a
file outside the diff.
