### PR TITLE
[NA] [BE] feat: add task tiling and chapter summaries to cipx_session_analysis

### DIFF
--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000121_add_tasks_to_cipx_session_analysis.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000121_add_tasks_to_cipx_session_analysis.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+--changeset andriid:000121_add_tasks_to_cipx_session_analysis
+--comment: Task tiling and chapter summaries for the cost API session analysis
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_session_analysis ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS `segments.summary`      Array(String),
+    ADD COLUMN IF NOT EXISTS `tasks.start_turn`      Array(UInt32),
+    ADD COLUMN IF NOT EXISTS `tasks.end_turn`        Array(UInt32),
+    ADD COLUMN IF NOT EXISTS `tasks.first_trace_id`  Array(FixedString(36)),
+    ADD COLUMN IF NOT EXISTS `tasks.last_trace_id`   Array(FixedString(36)),
+    ADD COLUMN IF NOT EXISTS `tasks.name`            Array(String),
+    ADD COLUMN IF NOT EXISTS `tasks.summary`         Array(String),
+    ADD COLUMN IF NOT EXISTS session_summary         String DEFAULT '';
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_session_analysis ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS `segments.summary`, DROP COLUMN IF EXISTS `tasks.start_turn`, DROP COLUMN IF EXISTS `tasks.end_turn`, DROP COLUMN IF EXISTS `tasks.first_trace_id`, DROP COLUMN IF EXISTS `tasks.last_trace_id`, DROP COLUMN IF EXISTS `tasks.name`, DROP COLUMN IF EXISTS `tasks.summary`, DROP COLUMN IF EXISTS session_summary;
+

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000122_add_tasks_to_cipx_session_analysis.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000122_add_tasks_to_cipx_session_analysis.sql
@@ -1,5 +1,5 @@
 --liquibase formatted sql
---changeset andriid:000121_add_tasks_to_cipx_session_analysis
+--changeset andriid:000122_add_tasks_to_cipx_session_analysis
 --comment: Task tiling and chapter summaries for the cost API session analysis
 
 ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_session_analysis ON CLUSTER '{cluster}'


### PR DESCRIPTION
## Details

Adds the columns the cost API's session-analysis task needs now that it emits two tilings per session instead of one. Additive `ALTER` on `cipx_session_analysis` (created in #8101) — no backfill, no rewrite, and nothing in the sort key changes.

- `tasks.*` — a second flat tiling beside `segments.*`: start/end turn, boundary trace ids, name and summary. Every task boundary is also a chapter boundary, so the two tile the same turn range at different granularity.
- `segments.summary` — chapters carry their own summary now; previously only the phase and title were stored.
- `session_summary` — one whole-session summary written by a post-merge pass over the merged task list, the one thing no single analysis window can see. `DEFAULT ''` so existing rows read as unsummarised rather than NULL.

Every column is `ADD COLUMN IF NOT EXISTS` with a matching `--rollback`, so re-running against a partially migrated cluster is a no-op.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- NA

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: code review + applied against the local ClickHouse dev stack

## Testing

- Applied against the local dev ClickHouse via the standard liquibase run — the eight columns land on `cipx_session_analysis` and the writer in the cost API populates them end to end.
- Re-ran the changeset against an already-migrated database: no-op, as `ADD COLUMN IF NOT EXISTS` intends.
- Verified `000121` is the next free number against `origin/main` (latest is `000120`) and against every open PR touching `db-app-analytics/migrations/`.
- Not run: no `mvn test` / `mvn compile`. This change is one `.sql` file picked up by the `includeAll` in `db-app-analytics/changelog.xml`; no Java source, config or changelog registration is touched.

## Documentation

N/A — internal analytics table, no user-facing documentation.
