### PR TITLE
[NA] [BE] feat: persist per-call usage units on cipx_spends and cipx_spend_blocks

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxMetadata.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxMetadata.java
@@ -1,6 +1,7 @@
 package com.comet.opik.domain;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import lombok.experimental.UtilityClass;
 
 /**
@@ -18,5 +19,13 @@ public class CipxMetadata {
 
     public boolean hasIdentity(JsonNode metadata) {
         return metadata != null && metadata.path("cipx").path("session").path("identity").isObject();
+    }
+
+    /** Per-call usage units reported by the provider; a missing node when the span carries none. */
+    public JsonNode copilotUsage(JsonNode metadata) {
+        if (metadata == null) {
+            return MissingNode.getInstance();
+        }
+        return metadata.path("github").path("usage").path("copilot_usage");
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendBlockDAO.java
@@ -8,6 +8,7 @@ import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Builder;
@@ -90,7 +91,10 @@ public class CipxSpendBlockDAO {
             @NonNull String label,
             int isDefinition,
             double alloc,
-            @NonNull String contentSha256) {
+            @NonNull String contentSha256,
+            /** The block's share of the span's usage units (alloc x its tier's per-token rate);
+             * null when the span reports none. */
+            @Nullable Double aiuNano) {
 
         /**
          * Derives all rows for one cipx span: one attributed row per non-identity block (keeping the
@@ -120,6 +124,8 @@ public class CipxSpendBlockDAO {
                     && cacheCreation.path("ephemeral_1h_input_tokens").asLong(0) == 0
                             ? "cache_creation_5m"
                             : "cache_creation_1h";
+
+            double[] aiuRates = aiuRatesPerToken(CipxMetadata.copilotUsage(metadata));
 
             JsonNode blocks = metadata.path("cipx").path("blocks");
             long[] tierChars = new long[TIER_NAMES.length];
@@ -151,15 +157,44 @@ public class CipxSpendBlockDAO {
                     if (isIdentityContext(block)) {
                         continue;
                     }
-                    rows.add(attributed(base, idx, block, tierTokens, tierChars, writeTier));
+                    rows.add(attributed(base, idx, block, tierTokens, tierChars, writeTier, aiuRates));
                 }
             }
             for (int tier = 0; tier < TIER_NAMES.length; tier++) {
                 if (!tierPresent[tier] && tierTokens[tier] > 0) {
-                    rows.add(residual(base, tier, tierTokens[tier], writeTier));
+                    rows.add(residual(base, tier, tierTokens[tier], writeTier, aiuRates));
                 }
             }
             return rows;
+        }
+
+        /** Usage units per token, indexed by tier ordinal; null when the span reports none. */
+        private static double[] aiuRatesPerToken(JsonNode copilotUsage) {
+            if (!copilotUsage.isObject()) {
+                return null;
+            }
+            double[] rates = new double[TIER_NAMES.length];
+            for (JsonNode detail : copilotUsage.path("token_details")) {
+                int tier = switch (detail.path("token_type").asText("")) {
+                    case "input" -> 0;
+                    case "cache_read" -> 1;
+                    case "cache_write" -> CACHE_CREATION_TIER;
+                    case "output" -> 3;
+                    default -> -1;
+                };
+                long batchSize = detail.path("batch_size").asLong(0);
+                if (tier >= 0 && batchSize > 0) {
+                    rates[tier] = detail.path("cost_per_batch").asDouble(0) / batchSize;
+                }
+            }
+            return rates;
+        }
+
+        private static Double aiuNano(double[] aiuRates, int tier, double tokens) {
+            if (aiuRates == null) {
+                return null;
+            }
+            return tier >= 0 ? tokens * aiuRates[tier] : 0.0;
         }
 
         /** cache_creation (ordinal 2) is written as its per-span TTL variant; the rest are fixed. */
@@ -168,7 +203,7 @@ public class CipxSpendBlockDAO {
         }
 
         private static BlockRow attributed(BlockRowBuilder base, int idx, JsonNode block, long[] tierTokens,
-                long[] tierChars, String writeTier) {
+                long[] tierChars, String writeTier, double[] aiuRates) {
             String category = block.path("category").asText("");
             String side = block.path("side").asText("");
             String cacheStatus = block.path("cache_status").asText("");
@@ -203,10 +238,12 @@ public class CipxSpendBlockDAO {
                     .isDefinition(isDefinition(category))
                     .alloc(alloc)
                     .contentSha256(block.path("sha256").asText(""))
+                    .aiuNano(aiuNano(aiuRates, tier, alloc))
                     .build();
         }
 
-        private static BlockRow residual(BlockRowBuilder base, int tier, long tokens, String writeTier) {
+        private static BlockRow residual(BlockRowBuilder base, int tier, long tokens, String writeTier,
+                double[] aiuRates) {
             return base
                     .blockIdx(RESIDUAL_IDX_BASE + tier)
                     .src(SRC_RESIDUAL)
@@ -228,6 +265,7 @@ public class CipxSpendBlockDAO {
                     .isDefinition(0)
                     .alloc(tokens)
                     .contentSha256("")
+                    .aiuNano(aiuNano(aiuRates, tier, tokens))
                     .build();
         }
 
@@ -407,6 +445,7 @@ public class CipxSpendBlockDAO {
         node.put("is_definition", row.isDefinition());
         node.put("alloc", row.alloc());
         node.put("content_sha256", row.contentSha256());
+        node.put("aiu_nano", row.aiuNano());
         node.put("start_time", ClickHouseDateTimeFormat.formatNanos(row.startTime()));
         out.append(node).append('\n');
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/CipxSpendDAO.java
@@ -7,6 +7,7 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
+import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.Builder;
@@ -60,13 +61,16 @@ public class CipxSpendDAO {
             @NonNull String thinkingType,
             long maxTokens,
             @NonNull String contextManagement,
-            @NonNull String speed) {
+            @NonNull String speed,
+            /** Provider-reported usage units for the call; null when the span reports none. */
+            @Nullable Long aiuNano) {
 
         public static SpanRow from(UUID spanId, UUID traceId, UUID projectId, JsonNode metadata, Instant startTime) {
             JsonNode call = metadata.path("cipx").path("call");
             JsonNode usage = call.path("usage");
             JsonNode cacheCreation = usage.path("cache_creation");
             JsonNode config = call.path("config");
+            JsonNode copilotUsage = CipxMetadata.copilotUsage(metadata);
             return SpanRow.builder()
                     .spanId(spanId.toString())
                     .traceId(traceId.toString())
@@ -84,6 +88,7 @@ public class CipxSpendDAO {
                     .maxTokens(config.path("max_tokens").asLong(0))
                     .contextManagement(config.path("context_management").asText(""))
                     .speed(config.path("speed").asText(""))
+                    .aiuNano(copilotUsage.isObject() ? copilotUsage.path("total_nano_aiu").asLong(0) : null)
                     .build();
         }
     }
@@ -94,7 +99,7 @@ public class CipxSpendDAO {
             INSERT INTO cipx_spends
                 (workspace_id, project_id, trace_id, span_id, start_time, model,
                  u_input, u_cache_read, u_cache_creation, u_cache_creation_5m, u_cache_creation_1h, u_output,
-                 effort, thinking_type, max_tokens, context_management, speed)
+                 effort, thinking_type, max_tokens, context_management, speed, aiu_nano)
             SETTINGS log_comment = '<log_comment>'
             FORMAT Values
                 <items:{item |
@@ -115,7 +120,8 @@ public class CipxSpendDAO {
                         :thinking_type<item.index>,
                         :max_tokens<item.index>,
                         :context_management<item.index>,
-                        :speed<item.index>
+                        :speed<item.index>,
+                        :aiu_nano<item.index>
                     )
                     <if(item.hasNext)>,<endif>
                 }>
@@ -144,7 +150,7 @@ public class CipxSpendDAO {
         // Positional binds: the driver resolves named binds with a linear indexOf over the statement's
         // parameter list (quadratic per statement), while bind(int) is a direct array write. Indices
         // follow the placeholders' first-appearance order in the rendered SQL: workspace_id once at 0
-        // (repeats dedup), then 16 parameters per row tuple in template order.
+        // (repeats dedup), then 17 parameters per row tuple in template order.
         statement.bind(0, workspaceId);
         int index = 1;
         for (SpanRow row : rows) {
@@ -164,6 +170,11 @@ public class CipxSpendDAO {
                     .bind(index++, row.maxTokens())
                     .bind(index++, row.contextManagement())
                     .bind(index++, row.speed());
+            if (row.aiuNano() != null) {
+                statement.bind(index++, row.aiuNano());
+            } else {
+                statement.bindNull(index++, Long.class);
+            }
         }
 
         return statement.execute();

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000121_add_aiu_nano_to_cipx_tables.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-analytics/migrations/000121_add_aiu_nano_to_cipx_tables.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+--changeset boryst:000121_add_aiu_nano_to_cipx_tables
+--comment: Add the per-call provider usage units to cipx_spends and cipx_spend_blocks
+
+-- NULL when the span reports no usage units; per block, the block's share of the span's total.
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS aiu_nano Nullable(Int64);
+
+ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spend_blocks ON CLUSTER '{cluster}'
+    ADD COLUMN IF NOT EXISTS aiu_nano Nullable(Float64);
+
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spends ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS aiu_nano;
+--rollback ALTER TABLE ${ANALYTICS_DB_DATABASE_NAME}.cipx_spend_blocks ON CLUSTER '{cluster}' DROP COLUMN IF EXISTS aiu_nano;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/CostIntelligenceIngestionTest.java
@@ -166,12 +166,16 @@ class CostIntelligenceIngestionTest {
                 assertThat(row.get().contextManagement()).isEqualTo("clear_thinking_20251015");
                 // speed: selects the rate table, so it must survive ingestion
                 assertThat(row.get().speed()).isEqualTo("fast");
+                assertThat(row.get().aiuNano()).isNull();
             });
 
             // Carried on every block row too.
             var blocks = getCipxBlocks(cipxSpan.id(), ws.workspaceId());
             assertThat(blocks).isNotEmpty();
-            assertThat(blocks).allSatisfy(block -> assertThat(block.speed()).isEqualTo("fast"));
+            assertThat(blocks).allSatisfy(block -> {
+                assertThat(block.speed()).isEqualTo("fast");
+                assertThat(block.aiuNano()).isNull();
+            });
 
             // The non-cipx span shared the same create event, so once the cipx row is present the
             // listener has already decided this one: it must not have produced a row.
@@ -401,6 +405,76 @@ class CostIntelligenceIngestionTest {
                 assertThat(identityContext.bdLane()).isEqualTo("static_overhead");
                 assertThat(identityContext.label()).isEqualTo("identity_context");
                 assertThat(identityContext.isDefinition()).isEqualTo(0);
+            });
+        }
+
+        @Test
+        @DisplayName("span with usage units lands with the total on the span and a per-tier share on its blocks")
+        void copilotSpanLandsWithAiuOnSpendAndBlocks() {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(copilotCipxMetadata(1, 13419, 22488, 687,
+                            180_000_000_000L, 18_000_000_000L, 225_000_000_000L, 900_000_000_000L,
+                            5_919_822_000L))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                var row = getCipxSpend(span.id(), ws.workspaceId());
+                assertThat(row).isPresent();
+                assertThat(row.get().model()).isEqualTo("github_copilot:claude-sonnet-5");
+                assertThat(row.get().aiuNano()).isEqualTo(5_919_822_000L);
+
+                // alloc x the tier's per-token rate: the read tier splits across its two blocks by
+                // chars, the write and output blocks absorb their tiers, input lands on a residual row.
+                var rows = getCipxBlocks(span.id(), ws.workspaceId());
+                assertThat(rows).hasSize(5);
+                var memory = rows.get(0);
+                assertThat(memory.tier()).isEqualTo("cache_read");
+                assertThat(memory.alloc()).isCloseTo(13419 * 100 / 400.0, within(1e-9));
+                assertThat(memory.aiuNano()).isCloseTo(13419 * 100 / 400.0 * 18_000, within(1e-3));
+                var skills = rows.get(1);
+                assertThat(skills.tier()).isEqualTo("cache_read");
+                assertThat(skills.aiuNano()).isCloseTo(13419 * 300 / 400.0 * 18_000, within(1e-3));
+                var write = rows.get(2);
+                assertThat(write.tier()).isEqualTo("cache_creation_5m");
+                assertThat(write.aiuNano()).isCloseTo(22488 * 225_000.0, within(1e-3));
+                var output = rows.get(3);
+                assertThat(output.tier()).isEqualTo("output");
+                assertThat(output.aiuNano()).isCloseTo(687 * 900_000.0, within(1e-3));
+                var residualInput = rows.get(4);
+                assertThat(residualInput.src()).isEqualTo("r");
+                assertThat(residualInput.tier()).isEqualTo("input");
+                assertThat(residualInput.aiuNano()).isCloseTo(1 * 180_000.0, within(1e-3));
+
+                double blockTotal = rows.stream().mapToDouble(CipxBlockRow::aiuNano).sum();
+                assertThat(blockTotal).isCloseTo(5_919_822_000.0, within(1e-3));
+            });
+        }
+
+        @Test
+        @DisplayName("span reporting 0 usage units lands as 0, not NULL")
+        void copilotZeroAiuLandsAsZero() {
+            var ws = newWorkspace();
+            String projectName = "cipx-" + UUID.randomUUID();
+
+            var span = factory.manufacturePojo(Span.class).toBuilder()
+                    .projectName(projectName)
+                    .metadata(copilotCipxMetadata(254, 0, 0, 9, 0, 0, 0, 0, 0))
+                    .build();
+            spanResourceClient.createSpan(span, ws.apiKey(), ws.workspaceName());
+
+            await().atMost(30, SECONDS).untilAsserted(() -> {
+                var row = getCipxSpend(span.id(), ws.workspaceId());
+                assertThat(row).isPresent();
+                assertThat(row.get().aiuNano()).isZero();
+
+                var rows = getCipxBlocks(span.id(), ws.workspaceId());
+                assertThat(rows).isNotEmpty();
+                assertThat(rows).allSatisfy(block -> assertThat(block.aiuNano()).isZero());
             });
         }
 
@@ -680,6 +754,55 @@ class CostIntelligenceIngestionTest {
                         .formatted(model, lump == 0 ? 50 : lump, cacheCreation5m, cacheCreation1h));
     }
 
+    private static JsonNode copilotCipxMetadata(long input, long cacheRead, long cacheCreation, long output,
+            long inputRate, long cacheReadRate, long cacheWriteRate, long outputRate, long totalNanoAiu) {
+        return JsonUtils.getJsonNodeFromString(
+                """
+                        {
+                          "cipx": {
+                            "call": {
+                              "model": "github_copilot:claude-sonnet-5",
+                              "usage": {
+                                "input_tokens": %d,
+                                "cache_read_input_tokens": %d,
+                                "cache_creation_input_tokens": %d,
+                                "cache_creation": {
+                                  "ephemeral_5m_input_tokens": %d,
+                                  "ephemeral_1h_input_tokens": 0
+                                },
+                                "output_tokens": %d
+                              }
+                            },
+                            "blocks": [
+                              {"category":"memory","side":"input","cache_status":"read","parent_category":"context","chars":100,"tool_name":"","tool_server":"","tool_use_id":"","resource":"copilot-instructions.md","kind":"text"},
+                              {"category":"skills_loaded","side":"input","cache_status":"read","parent_category":"context","chars":300,"tool_name":"","tool_server":"","tool_use_id":"","resource":"dataviz","kind":"text"},
+                              {"category":"system_prompt","side":"input","cache_status":"write","parent_category":"context","chars":200,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"},
+                              {"category":"assistant_text","side":"output","cache_status":"none","parent_category":"assistant","chars":50,"tool_name":"","tool_server":"","tool_use_id":"","resource":"","kind":"text"}
+                            ]
+                          },
+                          "github": {
+                            "usage": {
+                              "input_tokens": %d,
+                              "output_tokens": %d,
+                              "copilot_usage": {
+                                "token_details": [
+                                  {"batch_size": 1000000, "cost_per_batch": %d, "token_count": %d, "token_type": "input"},
+                                  {"batch_size": 1000000, "cost_per_batch": %d, "token_count": %d, "token_type": "cache_read"},
+                                  {"batch_size": 1000000, "cost_per_batch": %d, "token_count": %d, "token_type": "cache_write"},
+                                  {"batch_size": 1000000, "cost_per_batch": %d, "token_count": %d, "token_type": "output"}
+                                ],
+                                "total_nano_aiu": %d
+                              }
+                            }
+                          }
+                        }
+                        """
+                        .formatted(input, cacheRead, cacheCreation, cacheCreation, output,
+                                input, output,
+                                inputRate, input, cacheReadRate, cacheRead, cacheWriteRate, cacheCreation,
+                                outputRate, output, totalNanoAiu));
+    }
+
     private static JsonNode systemToolsCipxMetadata(String model, long cacheRead) {
         return JsonUtils.getJsonNodeFromString(
                 """
@@ -783,7 +906,7 @@ class CostIntelligenceIngestionTest {
                     toUnixTimestamp64Milli(start_time) AS start_ms,
                     model AS model,
                     u_input, u_cache_read, u_cache_creation, u_cache_creation_5m, u_cache_creation_1h, u_output,
-                    effort, thinking_type, max_tokens, context_management, speed
+                    effort, thinking_type, max_tokens, context_management, speed, aiu_nano
                 FROM cipx_spends FINAL
                 WHERE workspace_id = :workspace_id AND span_id = :span_id
                 """;
@@ -806,7 +929,8 @@ class CostIntelligenceIngestionTest {
                             row.get("thinking_type", String.class),
                             row.get("max_tokens", Long.class),
                             row.get("context_management", String.class),
-                            row.get("speed", String.class)))));
+                            row.get("speed", String.class),
+                            row.get("aiu_nano", Long.class)))));
         }).blockOptional();
     }
 
@@ -822,6 +946,7 @@ class CostIntelligenceIngestionTest {
                     side, cache_status, parent_category, chars,
                     tool_name, tool_server, tool_use_id, resource, kind, subcategory,
                     content_sha256,
+                    aiu_nano,
                     toUnixTimestamp64Milli(start_time) AS start_ms
                 FROM cipx_spend_blocks FINAL
                 WHERE workspace_id = :workspace_id AND span_id = :span_id
@@ -855,6 +980,7 @@ class CostIntelligenceIngestionTest {
                             row.get("kind", String.class),
                             row.get("subcategory", String.class),
                             row.get("content_sha256", String.class),
+                            row.get("aiu_nano", Double.class),
                             row.get("start_ms", Long.class))))
                     .collectList();
         }).block();
@@ -933,14 +1059,15 @@ class CostIntelligenceIngestionTest {
 
     private record CipxSpendRow(String projectId, Long startMs, String model, Long uInput, Long uCacheRead,
             Long uCacheCreation, Long uCacheCreation5m, Long uCacheCreation1h, Long uOutput, String effort,
-            String thinkingType, Long maxTokens, String contextManagement, String speed) {
+            String thinkingType, Long maxTokens, String contextManagement, String speed, Long aiuNano) {
     }
 
     private record CipxBlockRow(Integer blockIdx, String src, String category, String tier, String lane,
             String bdLane, String label, Integer isDefinition, Double alloc, String model, String speed,
             String side,
             String cacheStatus, String parentCategory, Long chars, String toolName, String toolServer,
-            String toolUseId, String resource, String kind, String subcategory, String contentSha256, Long startMs) {
+            String toolUseId, String resource, String kind, String subcategory, String contentSha256,
+            Double aiuNano, Long startMs) {
     }
 
     @Builder


### PR DESCRIPTION
## Details
Some providers report a per-call usage figure alongside the token counts. This stores it on the span row (`cipx_spends.aiu_nano`, NULL when the span reports none) and splits it across the span's blocks by tier the way the token allocation already is (`cipx_spend_blocks.aiu_nano`), so a span's blocks sum back to its total.

- Additive migration `000121`, both columns nullable; existing rows read NULL.
- `CipxSpendDAO` reads the span total; `CipxSpendBlockDAO` derives the per-block share.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Claude Code
  - Model(s): Claude Fable 5.1
  - Scope: migration, DAO changes, tests
  - Human verification: reviewed; verified end to end against a local stack

## Testing
- `mvn test -Dtest=CostIntelligenceIngestionTest`: 13 passed, including a span whose blocks reconcile to its total, a span reporting 0, and a span reporting nothing (NULL on both tables).
- `pre-commit` on the changed files (spotless, semgrep) passes.
- Verified against a local stack with live traffic: block sums reconcile with the span total on every span.

## Documentation
Column semantics are in the migration and the DAO javadoc.
