### PR TITLE
[OPIK-8253] [SDK] [DOCS] feat: parallel chunked dataset item reads

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -415,14 +415,11 @@ You can download a dataset from Opik using the `get_dataset` method:
   ```
 </CodeBlocks>
 
-### Downloading large datasets
+### Downloading large datasets faster
 
-`get_items()` returns the whole dataset as a single list, so the call does not return until every
-item has been downloaded and the full result is held in memory.
-
-`stream_items()` reads the same items in chunks instead, yielding each chunk as soon as it
-arrives. Use it when you want to start processing before the download finishes, or when the
-dataset is too large to hold in memory all at once:
+Dataset items are fetched a page at a time, and those pages are downloaded concurrently. Raise
+`num_threads` to speed up a large read — the default is 4, and 8 is usually worth trying on
+datasets of tens of thousands of items:
 
 ```python title="Python" language="python"
 from opik import Opik
@@ -430,18 +427,46 @@ from opik import Opik
 client = Opik()
 dataset = client.get_dataset(name="My dataset")
 
-for chunk in dataset.stream_items(num_threads=8):
-    process(chunk)  # chunk is a list of dicts, exactly as get_items() returns them
+# The whole dataset as one list, downloaded over 8 threads
+items = dataset.get_items(num_threads=8)
 ```
 
-It accepts the same `filter_string` as `get_items()`, and `nb_samples` to stop after a given
-number of items. Chunks arrive in dataset order; only the last one may be shorter than
-`chunk_size`.
+The thread count never changes the result, only how quickly it arrives.
+
+`get_items()` returns the whole dataset as a single list, so the call does not return until every
+item has been downloaded and the full result is held in memory. `stream_items()` reads the same
+items in chunks instead, yielding each chunk as soon as it arrives. Use it when you want to start
+processing before the download finishes, or when the dataset is too large to hold in memory all at
+once:
+
+```python title="Python" language="python"
+from opik import Opik
+
+client = Opik()
+dataset = client.get_dataset(name="My dataset")
+
+# One chunk at a time, instead of the whole dataset at once
+for chunk in dataset.stream_items(chunk_size=5000, num_threads=8):
+    process(chunk)  # a list of dicts, exactly as get_items() returns them
+```
+
+Chunks arrive in dataset order; only the last one may be shorter than `chunk_size`. Both methods
+accept the same `filter_string`, and `nb_samples` to stop after a given number of items:
+
+```python title="Python" language="python"
+for chunk in dataset.stream_items(
+    num_threads=8,
+    filter_string='data.category = "geography"',
+    nb_samples=10_000,
+):
+    process(chunk)
+```
 
 <Note>
-  Both methods fetch pages concurrently — `get_items()` is built on `stream_items()` — so raising
-  `num_threads` speeds up either read. The default of 4 is a safe starting point; 8 is usually
-  worth trying on datasets of tens of thousands of items.
+  `chunk_size` controls how many items each request fetches (default 2000). Fetching a chunk costs
+  a fixed overhead whatever its size, so lowering it makes the whole read slower — raise it to
+  trade memory for speed. Lower it only when individual items are large, since up to
+  `2 * num_threads` chunks are held in memory at once.
 </Note>
 
 ## Filtering datasets programmatically

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -418,8 +418,7 @@ You can download a dataset from Opik using the `get_dataset` method:
 ### Downloading large datasets faster
 
 Dataset items are fetched a page at a time, and those pages are downloaded concurrently. Raise
-`num_threads` to speed up a large read — the default is 4, and 8 is usually worth trying on
-datasets of tens of thousands of items:
+`num_threads` to speed up a large read — the default is 4:
 
 ```python title="Python" language="python"
 from opik import Opik
@@ -451,7 +450,7 @@ for chunk in dataset.stream_items(chunk_size=5000, num_threads=8):
 ```
 
 Chunks arrive in dataset order; only the last one may be shorter than `chunk_size`. Both methods
-accept the same `filter_string`, and `nb_samples` to stop after a given number of items:
+accept the same `filter_string`, and `nb_samples` to read only the first N items:
 
 ```python title="Python" language="python"
 for chunk in dataset.stream_items(
@@ -462,11 +461,15 @@ for chunk in dataset.stream_items(
     process(chunk)
 ```
 
+`nb_samples` must be a positive integer — omit it or pass `None` to read everything. Passing `0`
+or a negative value raises `ValueError` rather than being treated as a limit.
+
 <Note>
-  `chunk_size` controls how many items each request fetches (default 2000). Fetching a chunk costs
-  a fixed overhead whatever its size, so lowering it makes the whole read slower — raise it to
-  trade memory for speed. Lower it only when individual items are large, since up to
-  `2 * num_threads` chunks are held in memory at once.
+  `chunk_size` controls how many items each request fetches. It defaults to 2000, which is also
+  the maximum — a larger value raises `ValueError`, so that peak memory stays bounded. Fetching a
+  chunk costs a fixed overhead whatever its size, so lowering it makes the whole read slower;
+  lower it only when individual items are large, since up to `2 * num_threads` chunks are held in
+  memory at once.
 </Note>
 
 ## Filtering datasets programmatically

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -430,7 +430,7 @@ from opik import Opik
 client = Opik()
 dataset = client.get_dataset(name="My dataset")
 
-for chunk in dataset.stream_items(chunk_size=1000, num_threads=8):
+for chunk in dataset.stream_items(num_threads=8):
     process(chunk)  # chunk is a list of dicts, exactly as get_items() returns them
 ```
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -417,13 +417,12 @@ You can download a dataset from Opik using the `get_dataset` method:
 
 ### Downloading large datasets
 
-`get_items()` downloads every item and converts each one into a typed object before it returns.
-On datasets of tens of thousands of items or more, that conversion — not the network — is what
-dominates the wait.
+`get_items()` returns the whole dataset as a single list, so the call does not return until every
+item has been downloaded and the full result is held in memory.
 
-`stream_items()` is the fast path for those cases: it fetches pages concurrently and yields them
-as chunks of plain dictionaries, so you can start processing before the whole dataset has been
-downloaded.
+`stream_items()` reads the same items in chunks instead, yielding each chunk as soon as it
+arrives. Use it when you want to start processing before the download finishes, or when the
+dataset is too large to hold in memory all at once:
 
 ```python title="Python" language="python"
 from opik import Opik
@@ -432,12 +431,18 @@ client = Opik()
 dataset = client.get_dataset(name="My dataset")
 
 for chunk in dataset.stream_items(chunk_size=1000, num_threads=8):
-    process(chunk)  # chunk is a list of dicts, each item's data plus its `id`
+    process(chunk)  # chunk is a list of dicts, exactly as get_items() returns them
 ```
 
 It accepts the same `filter_string` as `get_items()`, and `nb_samples` to stop after a given
 number of items. Chunks arrive in dataset order; only the last one may be shorter than
 `chunk_size`.
+
+<Note>
+  Both methods fetch pages concurrently — `get_items()` is built on `stream_items()` — so raising
+  `num_threads` speeds up either read. The default of 4 is a safe starting point; 8 is usually
+  worth trying on datasets of tens of thousands of items.
+</Note>
 
 ## Filtering datasets programmatically
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx
@@ -415,6 +415,30 @@ You can download a dataset from Opik using the `get_dataset` method:
   ```
 </CodeBlocks>
 
+### Downloading large datasets
+
+`get_items()` downloads every item and converts each one into a typed object before it returns.
+On datasets of tens of thousands of items or more, that conversion — not the network — is what
+dominates the wait.
+
+`stream_items()` is the fast path for those cases: it fetches pages concurrently and yields them
+as chunks of plain dictionaries, so you can start processing before the whole dataset has been
+downloaded.
+
+```python title="Python" language="python"
+from opik import Opik
+
+client = Opik()
+dataset = client.get_dataset(name="My dataset")
+
+for chunk in dataset.stream_items(chunk_size=1000, num_threads=8):
+    process(chunk)  # chunk is a list of dicts, each item's data plus its `id`
+```
+
+It accepts the same `filter_string` as `get_items()`, and `nb_samples` to stop after a given
+number of items. Chunks arrive in dataset order; only the last one may be shorter than
+`chunk_size`.
+
 ## Filtering datasets programmatically
 
 You can filter dataset items using the `filter_string` parameter on the `get_items()` method or when

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -21,6 +21,13 @@ DELETE_TRACE_BATCH_SIZE = 1000
 
 DATASET_STREAM_BATCH_SIZE = 2000
 
+DATASET_ITEMS_READ_CHUNK_SIZE = 1000
+DATASET_ITEMS_READ_NUM_THREADS = 8
+# Ceiling on dataset read threads. The SDK's httpx client pools 100
+# connections, so a caller passing an arbitrarily large num_threads would
+# otherwise queue pages behind the pool instead of speeding anything up.
+DATASET_ITEMS_READ_MAX_THREADS = 32
+
 # Parallel dataset insert requires a backend that serializes concurrent dataset
 # version writes. On backends older than this version, concurrent batches
 # sharing one batch_group_id raced and could 500 or silently drop rows; 2.2.8 is

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -22,7 +22,7 @@ DELETE_TRACE_BATCH_SIZE = 1000
 DATASET_STREAM_BATCH_SIZE = 2000
 
 DATASET_ITEMS_READ_CHUNK_SIZE = 1000
-DATASET_ITEMS_READ_NUM_THREADS = 8
+DATASET_ITEMS_READ_NUM_THREADS = 4
 # Ceiling on dataset read threads. The SDK's httpx client pools 100
 # connections, so a caller passing an arbitrarily large num_threads would
 # otherwise queue pages behind the pool instead of speeding anything up.

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -21,7 +21,6 @@ DELETE_TRACE_BATCH_SIZE = 1000
 
 DATASET_STREAM_BATCH_SIZE = 2000
 
-DATASET_ITEMS_READ_CHUNK_SIZE = 1000
 DATASET_ITEMS_READ_NUM_THREADS = 4
 # Ceiling on dataset read threads. The SDK's httpx client pools 100
 # connections, so a caller passing an arbitrarily large num_threads would

--- a/sdks/python/src/opik/api_objects/constants.py
+++ b/sdks/python/src/opik/api_objects/constants.py
@@ -22,6 +22,13 @@ DELETE_TRACE_BATCH_SIZE = 1000
 DATASET_STREAM_BATCH_SIZE = 2000
 
 DATASET_ITEMS_READ_NUM_THREADS = 4
+# Page-size ceiling for reads, deliberately the same as the batch size above: a
+# read should never ask the backend for a bigger page than the SDK's own read
+# batch, so peak memory stays bounded the way it was before pages were fetched
+# in parallel. Unlike the thread ceiling this one rejects rather than clamps --
+# silently handing back smaller pages than asked for would look like the
+# argument had no effect.
+DATASET_ITEMS_READ_MAX_CHUNK_SIZE = DATASET_STREAM_BATCH_SIZE
 # Ceiling on dataset read threads. The SDK's httpx client pools 100
 # connections, so a caller passing an arbitrarily large num_threads would
 # otherwise queue pages behind the pool instead of speeding anything up.

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -145,13 +145,13 @@ class DatasetExportOperations(abc.ABC):
         Returns:
             A list of dictionaries representing the dataset items.
         """
-        dataset_items_as_dicts = [
-            {"id": item.id, **item.get_content()}
-            for item in self.__internal_api__stream_items_as_dataclasses__(
-                nb_samples=nb_samples, filter_string=filter_string
+        return [
+            item
+            for chunk in self.stream_items(
+                filter_string=filter_string, nb_samples=nb_samples
             )
+            for item in chunk
         ]
-        return dataset_items_as_dicts
 
     def stream_items(
         self,
@@ -163,22 +163,20 @@ class DatasetExportOperations(abc.ABC):
         """
         Read dataset items in chunks, fetching the chunks concurrently.
 
-        The fast counterpart to :meth:`get_items`: chunks are fetched in
-        parallel and are handed back as raw dictionaries without going through
-        the typed REST layer, which is what makes it noticeably faster on large
-        datasets. Prefer it when reading tens of thousands of items or more, or
-        whenever you want to start processing before the whole dataset has been
-        downloaded.
+        The chunked counterpart to :meth:`get_items`, which is itself built on
+        this method: chunks are fetched in parallel and are handed back as
+        plain dictionaries without going through the typed REST layer. Prefer
+        it over :meth:`get_items` when you want to start processing before the
+        whole dataset has been downloaded, or when the dataset is too large to
+        hold in memory all at once.
 
-        Each item is its stored data plus its ``id``. Unlike :meth:`get_items`,
-        data keys that happen to collide with internal item fields (``source``,
-        ``description``, ``trace_id``, ``span_id``) are preserved; only ``id``
-        is always the item's real id.
+        Items have exactly the shape :meth:`get_items` returns: the item's
+        data plus its ``id``.
 
         Args:
             chunk_size: Number of items per chunk. Defaults to 1000.
             num_threads: Number of chunks fetched concurrently. Must be a
-                positive integer, defaults to 8; pass ``1`` to fetch
+                positive integer, defaults to 4; pass ``1`` to fetch
                 sequentially. Capped at
                 ``constants.DATASET_ITEMS_READ_MAX_THREADS``.
             filter_string: Optional OQL filter string to filter dataset items.
@@ -198,6 +196,11 @@ class DatasetExportOperations(abc.ABC):
         Example:
             >>> for chunk in dataset.stream_items(chunk_size=2000, num_threads=8):
             ...     process(chunk)
+
+        Note:
+            ``nb_samples`` items are read starting from the beginning of the
+            dataset, so the same call reads the same items whatever the thread
+            count.
         """
         if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
             raise ValueError("chunk_size must be a positive integer")
@@ -499,6 +502,11 @@ class Dataset(DatasetExportOperations):
         # Backend may already hold items we haven't seen; lazy-sync on first
         # insert so content-hash dedup still works without paying a sync now.
         dataset_.__internal_api__hashes_synced__ = False
+        # The response already carries the id, so seed the cached_property
+        # rather than paying a get-dataset-by-name round trip the first time
+        # something (a read, an item delete) needs it.
+        if dataset_fern.id is not None:
+            dataset_.__dict__["id"] = dataset_fern.id
         return dataset_
 
     @functools.cached_property

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -155,7 +155,7 @@ class DatasetExportOperations(abc.ABC):
 
     def stream_items(
         self,
-        chunk_size: int = constants.DATASET_ITEMS_READ_CHUNK_SIZE,
+        chunk_size: int = constants.DATASET_STREAM_BATCH_SIZE,
         num_threads: int = constants.DATASET_ITEMS_READ_NUM_THREADS,
         filter_string: Optional[str] = None,
         nb_samples: Optional[int] = None,
@@ -174,7 +174,13 @@ class DatasetExportOperations(abc.ABC):
         data plus its ``id``.
 
         Args:
-            chunk_size: Number of items per chunk. Defaults to 1000.
+            chunk_size: Number of items per chunk, defaulting to the same
+                batch size the typed item stream reads with
+                (``constants.DATASET_STREAM_BATCH_SIZE``). Fetching a chunk
+                costs a fixed overhead whatever its size, so lowering this
+                makes the whole read slower; raise it to trade memory for
+                speed, bearing in mind that up to ``2 * num_threads`` chunks
+                are held at once.
             num_threads: Number of chunks fetched concurrently. Must be a
                 positive integer, defaults to 4; pass ``1`` to fetch
                 sequentially. Capped at

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -121,12 +121,20 @@ class DatasetExportOperations(abc.ABC):
         self,
         nb_samples: Optional[int] = None,
         filter_string: Optional[str] = None,
+        num_threads: int = constants.DATASET_ITEMS_READ_NUM_THREADS,
     ) -> List[Dict[str, Any]]:
         """
         Retrieve dataset items as a list of dictionaries.
 
         Args:
             nb_samples: Maximum number of items to retrieve. If not set, all items are returned.
+            num_threads: Number of item pages fetched concurrently. Must be a
+                positive integer, defaults to 4; pass ``1`` to fetch
+                sequentially. Raising it speeds up large reads at the cost of
+                more load on the backend. Capped at
+                ``constants.DATASET_ITEMS_READ_MAX_THREADS``. Use
+                :meth:`stream_items` instead when the dataset is too large to
+                hold in memory all at once.
             filter_string: Optional OQL filter string to filter dataset items.
                 Supports filtering by tags, data fields, metadata, etc.
 
@@ -144,11 +152,17 @@ class DatasetExportOperations(abc.ABC):
 
         Returns:
             A list of dictionaries representing the dataset items.
+
+        Raises:
+            ValueError: If ``num_threads`` is not a positive integer, or
+                ``nb_samples`` is not a positive integer.
         """
         return [
             item
             for chunk in self.stream_items(
-                filter_string=filter_string, nb_samples=nb_samples
+                filter_string=filter_string,
+                nb_samples=nb_samples,
+                num_threads=num_threads,
             )
             for item in chunk
         ]

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -127,7 +127,9 @@ class DatasetExportOperations(abc.ABC):
         Retrieve dataset items as a list of dictionaries.
 
         Args:
-            nb_samples: Maximum number of items to retrieve. If not set, all items are returned.
+            nb_samples: Maximum number of items to retrieve. Must be a positive
+                integer; omit it or pass ``None`` to return all items. Zero and
+                negative values raise rather than being treated as a limit.
             num_threads: Number of item pages fetched concurrently. Must be a
                 positive integer, defaults to 4; pass ``1`` to fetch
                 sequentially. Raising it speeds up large reads at the cost of
@@ -188,21 +190,23 @@ class DatasetExportOperations(abc.ABC):
         data plus its ``id``.
 
         Args:
-            chunk_size: Number of items per chunk, defaulting to the same
-                batch size the typed item stream reads with
+            chunk_size: Number of items per chunk, defaulting to and capped at
+                the same batch size the typed item stream reads with
                 (``constants.DATASET_STREAM_BATCH_SIZE``). Fetching a chunk
                 costs a fixed overhead whatever its size, so lowering this
-                makes the whole read slower; raise it to trade memory for
-                speed, bearing in mind that up to ``2 * num_threads`` chunks
-                are held at once.
+                makes the whole read slower; lower it when the items are
+                individually large, bearing in mind that up to
+                ``2 * num_threads`` chunks are held in memory at once.
             num_threads: Number of chunks fetched concurrently. Must be a
                 positive integer, defaults to 4; pass ``1`` to fetch
                 sequentially. Capped at
                 ``constants.DATASET_ITEMS_READ_MAX_THREADS``.
             filter_string: Optional OQL filter string to filter dataset items.
                 Accepts the same expressions as :meth:`get_items`.
-            nb_samples: Maximum number of items to read. If not set, the whole
-                dataset is read.
+            nb_samples: Maximum number of items to read. Must be a positive
+                integer; omit it or pass ``None`` to read the whole dataset.
+                Zero and negative values raise rather than being treated as a
+                limit.
 
         Yields:
             Lists of dictionaries representing the dataset items, in dataset
@@ -210,8 +214,10 @@ class DatasetExportOperations(abc.ABC):
             chunks are never yielded.
 
         Raises:
-            ValueError: If ``chunk_size`` or ``num_threads`` is not a positive
-                integer, or ``nb_samples`` is not a positive integer.
+            ValueError: If ``num_threads`` is not a positive integer, if
+                ``chunk_size`` is not a positive integer or exceeds
+                ``constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE``, or if
+                ``nb_samples`` is not a positive integer.
 
         Example:
             >>> for chunk in dataset.stream_items(chunk_size=2000, num_threads=8):
@@ -226,6 +232,11 @@ class DatasetExportOperations(abc.ABC):
             raise ValueError("chunk_size must be a positive integer")
         if chunk_size < 1:
             raise ValueError("chunk_size must be a positive integer")
+        if chunk_size > constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE:
+            raise ValueError(
+                "chunk_size must not exceed "
+                f"{constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE}, got {chunk_size}"
+            )
         if isinstance(num_threads, bool) or not isinstance(num_threads, int):
             raise ValueError("num_threads must be a positive integer")
         if num_threads < 1:
@@ -1117,7 +1128,10 @@ class Dataset(DatasetExportOperations):
         nb_samples: Optional[int],
         filter_string: Optional[str],
     ) -> Iterator[List[Dict[str, Any]]]:
-        return rest_operations.stream_dataset_item_chunks(
+        # A generator, so `self.id` -- which resolves the dataset by name over
+        # REST when it hasn't been seeded -- is not touched until the caller
+        # actually starts iterating. Keeps `stream_items()` free of I/O.
+        yield from rest_operations.stream_dataset_item_chunks(
             rest_client=self._rest_client,
             dataset_id=self.id,
             chunk_size=chunk_size,

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -73,6 +73,28 @@ class DatasetExportOperations(abc.ABC):
         """
         raise NotImplementedError
 
+    @abc.abstractmethod
+    def __internal_api__stream_item_chunks__(
+        self,
+        chunk_size: int,
+        num_threads: int,
+        nb_samples: Optional[int],
+        filter_string: Optional[str],
+    ) -> Iterator[List[Dict[str, Any]]]:
+        """
+        Stream dataset items as chunks of raw dictionaries.
+
+        Args:
+            chunk_size: Number of items per chunk.
+            num_threads: Number of chunks fetched concurrently.
+            nb_samples: Maximum number of items to retrieve.
+            filter_string: Optional OQL filter string to filter dataset items.
+
+        Yields:
+            Lists of dictionaries representing the dataset items.
+        """
+        raise NotImplementedError
+
     def to_pandas(self) -> "pd.DataFrame":
         """
         Convert the dataset items to a pandas DataFrame.
@@ -130,6 +152,74 @@ class DatasetExportOperations(abc.ABC):
             )
         ]
         return dataset_items_as_dicts
+
+    def stream_items(
+        self,
+        chunk_size: int = constants.DATASET_ITEMS_READ_CHUNK_SIZE,
+        num_threads: int = constants.DATASET_ITEMS_READ_NUM_THREADS,
+        filter_string: Optional[str] = None,
+        nb_samples: Optional[int] = None,
+    ) -> Iterator[List[Dict[str, Any]]]:
+        """
+        Read dataset items in chunks, fetching the chunks concurrently.
+
+        The fast counterpart to :meth:`get_items`: chunks are fetched in
+        parallel and are handed back as raw dictionaries without going through
+        the typed REST layer, which is what makes it noticeably faster on large
+        datasets. Prefer it when reading tens of thousands of items or more, or
+        whenever you want to start processing before the whole dataset has been
+        downloaded.
+
+        Each item is its stored data plus its ``id``. Unlike :meth:`get_items`,
+        data keys that happen to collide with internal item fields (``source``,
+        ``description``, ``trace_id``, ``span_id``) are preserved; only ``id``
+        is always the item's real id.
+
+        Args:
+            chunk_size: Number of items per chunk. Defaults to 1000.
+            num_threads: Number of chunks fetched concurrently. Must be a
+                positive integer, defaults to 8; pass ``1`` to fetch
+                sequentially. Capped at
+                ``constants.DATASET_ITEMS_READ_MAX_THREADS``.
+            filter_string: Optional OQL filter string to filter dataset items.
+                Accepts the same expressions as :meth:`get_items`.
+            nb_samples: Maximum number of items to read. If not set, the whole
+                dataset is read.
+
+        Yields:
+            Lists of dictionaries representing the dataset items, in dataset
+            order. The last chunk may be shorter than ``chunk_size``; empty
+            chunks are never yielded.
+
+        Raises:
+            ValueError: If ``chunk_size`` or ``num_threads`` is not a positive
+                integer, or ``nb_samples`` is not a positive integer.
+
+        Example:
+            >>> for chunk in dataset.stream_items(chunk_size=2000, num_threads=8):
+            ...     process(chunk)
+        """
+        if isinstance(chunk_size, bool) or not isinstance(chunk_size, int):
+            raise ValueError("chunk_size must be a positive integer")
+        if chunk_size < 1:
+            raise ValueError("chunk_size must be a positive integer")
+        if isinstance(num_threads, bool) or not isinstance(num_threads, int):
+            raise ValueError("num_threads must be a positive integer")
+        if num_threads < 1:
+            raise ValueError("num_threads must be a positive integer")
+        if nb_samples is not None and (
+            isinstance(nb_samples, bool)
+            or not isinstance(nb_samples, int)
+            or nb_samples < 1
+        ):
+            raise ValueError("nb_samples must be a positive integer")
+
+        return self.__internal_api__stream_item_chunks__(
+            chunk_size=chunk_size,
+            num_threads=min(num_threads, constants.DATASET_ITEMS_READ_MAX_THREADS),
+            nb_samples=nb_samples,
+            filter_string=filter_string,
+        )
 
     @abc.abstractmethod
     def get_version_info(
@@ -279,6 +369,24 @@ class DatasetVersion(DatasetExportOperations):
             nb_samples=nb_samples,
             batch_size=batch_size,
             dataset_item_ids=dataset_item_ids,
+            filter_string=filter_string,
+            dataset_version=self._version_info.version_hash,
+        )
+
+    @override
+    def __internal_api__stream_item_chunks__(
+        self,
+        chunk_size: int,
+        num_threads: int,
+        nb_samples: Optional[int],
+        filter_string: Optional[str],
+    ) -> Iterator[List[Dict[str, Any]]]:
+        return rest_operations.stream_dataset_item_chunks(
+            rest_client=self._rest_client,
+            dataset_id=self._dataset_id,
+            chunk_size=chunk_size,
+            num_threads=num_threads,
+            nb_samples=nb_samples,
             filter_string=filter_string,
             dataset_version=self._version_info.version_hash,
         )
@@ -969,6 +1077,24 @@ class Dataset(DatasetExportOperations):
             nb_samples=nb_samples,
             batch_size=batch_size,
             dataset_item_ids=dataset_item_ids,
+            filter_string=filter_string,
+            dataset_version=None,
+        )
+
+    @override
+    def __internal_api__stream_item_chunks__(
+        self,
+        chunk_size: int,
+        num_threads: int,
+        nb_samples: Optional[int],
+        filter_string: Optional[str],
+    ) -> Iterator[List[Dict[str, Any]]]:
+        return rest_operations.stream_dataset_item_chunks(
+            rest_client=self._rest_client,
+            dataset_id=self.id,
+            chunk_size=chunk_size,
+            num_threads=num_threads,
+            nb_samples=nb_samples,
             filter_string=filter_string,
             dataset_version=None,
         )

--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -122,6 +122,7 @@ class DatasetExportOperations(abc.ABC):
         nb_samples: Optional[int] = None,
         filter_string: Optional[str] = None,
         num_threads: int = constants.DATASET_ITEMS_READ_NUM_THREADS,
+        chunk_size: int = constants.DATASET_STREAM_BATCH_SIZE,
     ) -> List[Dict[str, Any]]:
         """
         Retrieve dataset items as a list of dictionaries.
@@ -137,6 +138,10 @@ class DatasetExportOperations(abc.ABC):
                 ``constants.DATASET_ITEMS_READ_MAX_THREADS``. Use
                 :meth:`stream_items` instead when the dataset is too large to
                 hold in memory all at once.
+            chunk_size: Number of items fetched per request. See
+                :meth:`stream_items` for how to pick it; the whole result is
+                materialized either way, so this only trades request count
+                against per-request size.
             filter_string: Optional OQL filter string to filter dataset items.
                 Supports filtering by tags, data fields, metadata, etc.
 
@@ -156,12 +161,15 @@ class DatasetExportOperations(abc.ABC):
             A list of dictionaries representing the dataset items.
 
         Raises:
-            ValueError: If ``num_threads`` is not a positive integer, or
+            ValueError: If ``num_threads`` is not a positive integer, if
+                ``chunk_size`` is not a positive integer or exceeds
+                ``constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE``, or if
                 ``nb_samples`` is not a positive integer.
         """
         return [
             item
             for chunk in self.stream_items(
+                chunk_size=chunk_size,
                 filter_string=filter_string,
                 nb_samples=nb_samples,
                 num_threads=num_threads,
@@ -188,6 +196,13 @@ class DatasetExportOperations(abc.ABC):
 
         Items have exactly the shape :meth:`get_items` returns: the item's
         data plus its ``id``.
+
+        The read is pinned to a single dataset version, so items inserted or
+        deleted while it is in progress do not affect it. On backends where
+        dataset versioning is unavailable there is no version to pin to and the
+        live state is read instead; a concurrent insert can then shift the
+        remaining pages, returning one item twice and skipping another. Read a
+        :class:`DatasetVersion` explicitly if you need that guarantee there.
 
         Args:
             chunk_size: Number of items per chunk, defaulting to and capped at
@@ -1138,8 +1153,36 @@ class Dataset(DatasetExportOperations):
             num_threads=num_threads,
             nb_samples=nb_samples,
             filter_string=filter_string,
-            dataset_version=None,
+            dataset_version=self._resolve_read_version(),
         )
+
+    def _resolve_read_version(self) -> Optional[str]:
+        """The version hash every page of one read is pinned to, if there is one.
+
+        Pages are addressed by offset, and the backend sorts newest id first, so
+        an item inserted mid-read lands at offset 0 and shifts every page that
+        has not been fetched yet -- returning one item twice and skipping
+        another. Reading a single version instead makes the whole read a
+        snapshot, which is what the cursor-based stream got for free from its
+        ``id < last_retrieved_id`` seek.
+
+        Returns None when the backend has no version to pin to (versioning
+        disabled, or a dataset with no versions yet); the read then falls back
+        to the live state and stays vulnerable to that shift, which is called
+        out on :meth:`stream_items`.
+        """
+        version_info = self.get_version_info()
+        version_hash = version_info.version_hash if version_info else None
+
+        if version_hash is None:
+            LOGGER.debug(
+                "No dataset version to pin the read of dataset %s to; reading "
+                "the live state, which may return an item twice or skip one if "
+                "items are inserted or deleted while the read is in progress.",
+                self._name,
+            )
+
+        return version_hash
 
     def insert_from_json(
         self,

--- a/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
+++ b/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
@@ -1,0 +1,183 @@
+"""Parallel reader for dataset items built on the paginated items endpoint.
+
+Deliberately bypasses the Fern-generated REST client. The generated path
+validates every field and rebuilds each item as a pydantic model, and on
+datasets of hundreds of thousands of items that conversion, not the network,
+dominates the wall-clock time. This reader issues the same requests through the
+SDK's own httpx client and hands back the raw JSON dicts.
+
+The paginated endpoint is used instead of the cursor-chained
+``/items/stream``: pages are addressable independently, which is what makes
+fetching them concurrently possible at all.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import math
+from concurrent import futures
+from typing import Any, Callable, Deque, Dict, Iterator, List, Optional
+import collections
+
+from opik.rest_api import client as rest_api_client
+from opik.rest_api.core import api_error as rest_api_error
+from opik.rest_client_configurator import retry_decorator
+
+LOGGER = logging.getLogger(__name__)
+
+
+def stream_item_chunks(
+    rest_client: rest_api_client.OpikApi,
+    dataset_id: str,
+    chunk_size: int,
+    num_threads: int,
+    max_items: Optional[int] = None,
+    filters: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+) -> Iterator[List[Dict[str, Any]]]:
+    """Yield dataset items in page-sized chunks, fetching pages concurrently.
+
+    Args:
+        rest_client: The REST API client. Only its httpx client and auth
+            headers are used; no generated endpoint method is called.
+        dataset_id: Id of the dataset to read.
+        chunk_size: Number of items per page, and therefore per yielded chunk.
+        num_threads: Number of pages fetched concurrently.
+        max_items: Stop after this many items. ``None`` reads the whole dataset.
+        filters: Serialized JSON filter expressions, as the endpoint's
+            ``filters`` query parameter expects them.
+        dataset_version: Version hash or tag to pin the read to. ``None`` reads
+            the current state.
+
+    Yields:
+        Lists of raw item dicts, in page order. The last chunk may be shorter
+        than ``chunk_size``; empty chunks are never yielded.
+    """
+    items_yielded = 0
+
+    for page_items in _read_pages(
+        fetch_page=_build_page_fetcher(
+            rest_client=rest_client,
+            dataset_id=dataset_id,
+            chunk_size=chunk_size,
+            filters=filters,
+            dataset_version=dataset_version,
+        ),
+        chunk_size=chunk_size,
+        num_threads=num_threads,
+        max_items=max_items,
+    ):
+        if max_items is not None:
+            page_items = page_items[: max_items - items_yielded]
+
+        if page_items:
+            yield page_items
+            items_yielded += len(page_items)
+
+        if max_items is not None and items_yielded >= max_items:
+            return
+
+
+def _read_pages(
+    fetch_page: Callable[[int], Dict[str, Any]],
+    chunk_size: int,
+    num_threads: int,
+    max_items: Optional[int],
+) -> Iterator[List[Dict[str, Any]]]:
+    """Yield the raw contents of every page that holds a wanted item, in order.
+
+    The first page is fetched on its own because its ``total`` is what tells us
+    how many pages there are to fan out over.
+    """
+    first_page = fetch_page(1)
+    yield _page_items(first_page)
+
+    total = first_page.get("total") or 0
+    wanted = total if max_items is None else min(total, max_items)
+    last_page = math.ceil(wanted / chunk_size)
+    if last_page <= 1:
+        return
+
+    remaining_pages = iter(range(2, last_page + 1))
+    worker_count = min(num_threads, last_page - 1)
+
+    LOGGER.debug(
+        "Reading %d dataset items over %d pages of %d using %d thread(s)",
+        wanted,
+        last_page,
+        chunk_size,
+        worker_count,
+    )
+
+    with futures.ThreadPoolExecutor(
+        max_workers=worker_count, thread_name_prefix="opik_dataset_items_read"
+    ) as pool:
+        # Two pages in flight per worker: enough that a worker always has the
+        # next page waiting, while keeping the reader's memory bounded by the
+        # look-ahead rather than by the size of the dataset. A consumer that
+        # stops iterating leaves at most this many requests to drain.
+        in_flight: Deque[futures.Future] = collections.deque(
+            pool.submit(fetch_page, page)
+            for page in itertools.islice(remaining_pages, worker_count * 2)
+        )
+
+        while in_flight:
+            page = in_flight.popleft().result()
+
+            next_page = next(remaining_pages, None)
+            if next_page is not None:
+                in_flight.append(pool.submit(fetch_page, next_page))
+
+            yield _page_items(page)
+
+
+def _build_page_fetcher(
+    rest_client: rest_api_client.OpikApi,
+    dataset_id: str,
+    chunk_size: int,
+    filters: Optional[str],
+    dataset_version: Optional[str],
+) -> Callable[[int], Dict[str, Any]]:
+    httpx_client = rest_client._client_wrapper.httpx_client
+    path = f"v1/private/datasets/{dataset_id}/items"
+
+    @retry_decorator.opik_rest_retry
+    def fetch_page(page: int) -> Dict[str, Any]:
+        response = httpx_client.request(
+            path,
+            method="GET",
+            params={
+                "page": page,
+                "size": chunk_size,
+                "version": dataset_version,
+                "filters": filters,
+            },
+        )
+
+        # The httpx client returns the response as-is, so the status has to be
+        # turned into an ApiError by hand for the retry decorator to see the
+        # retryable ones.
+        if response.status_code != 200:
+            raise rest_api_error.ApiError(
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                body=response.text,
+            )
+
+        result: Dict[str, Any] = response.json()
+        return result
+
+    return fetch_page
+
+
+def _page_items(page: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten a page's items into ``data`` dicts carrying their item id.
+
+    The stored ``data`` is returned untouched apart from ``id``, which always
+    holds the item's real id even when the data itself has an ``id`` key.
+    """
+    return [
+        {**(item.get("data") or {}), "id": item.get("id")}
+        for item in (page.get("content") or [])
+    ]

--- a/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
+++ b/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
@@ -20,11 +20,18 @@ from concurrent import futures
 from typing import Any, Callable, Deque, Dict, Iterator, List, Optional
 import collections
 
+import opik.exceptions as exceptions
 from opik.rest_api import client as rest_api_client
 from opik.rest_api.core import api_error as rest_api_error
 from opik.rest_client_configurator import retry_decorator
 
 LOGGER = logging.getLogger(__name__)
+
+_MALFORMED_PAGE = (
+    "Malformed response from the dataset items endpoint. "
+    "The page count for the rest of the read is derived from this response, so "
+    "continuing would silently return only part of the dataset."
+)
 
 
 def stream_item_chunks(
@@ -91,9 +98,9 @@ def _read_pages(
     how many pages there are to fan out over.
     """
     first_page = fetch_page(1)
+    total = _page_total(first_page)
     yield _page_items(first_page)
 
-    total = first_page.get("total") or 0
     wanted = total if max_items is None else min(total, max_items)
     last_page = math.ceil(wanted / chunk_size)
     if last_page <= 1:
@@ -172,5 +179,38 @@ def _build_page_fetcher(
 
 
 def _page_items(page: Dict[str, Any]) -> List[Dict[str, Any]]:
-    content: List[Dict[str, Any]] = page.get("content") or []
+    content = page.get("content")
+    if content is None:
+        content = []
+    if not isinstance(content, list):
+        raise exceptions.OpikException(
+            f"{_MALFORMED_PAGE} Expected 'content' to be a list, got "
+            f"{type(content).__name__}."
+        )
     return content
+
+
+def _page_total(page: Dict[str, Any]) -> int:
+    """Read the item count the rest of the read is planned against.
+
+    Validated rather than defaulted: the page count is derived from ``total``,
+    so a missing or non-numeric value would silently cap the read at the first
+    page and hand back part of the dataset as if it were all of it.
+    """
+    if not isinstance(page, dict):
+        raise exceptions.OpikException(
+            f"{_MALFORMED_PAGE} Expected a JSON object, got {type(page).__name__}."
+        )
+
+    total = page.get("total")
+    # bool is an int subclass, and True would silently read as 1 item.
+    if isinstance(total, bool) or not isinstance(total, int):
+        raise exceptions.OpikException(
+            f"{_MALFORMED_PAGE} Expected an integer 'total', got {total!r}."
+        )
+    if total < 0:
+        raise exceptions.OpikException(
+            f"{_MALFORMED_PAGE} Expected a non-negative 'total', got {total}."
+        )
+
+    return total

--- a/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
+++ b/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
@@ -117,13 +117,19 @@ def _read_pages(
         worker_count,
     )
 
-    with futures.ThreadPoolExecutor(
+    # Deliberately not a `with` block: its __exit__ is shutdown(wait=True), and
+    # because the yields below happen inside it, closing the generator -- an
+    # early `break`, or garbage collection -- would block the caller until every
+    # outstanding page came back. At a 2000-item page that is a visible stall on
+    # what looks like a plain `break`, and at GC time it would surface on an
+    # unrelated line.
+    pool = futures.ThreadPoolExecutor(
         max_workers=worker_count, thread_name_prefix="opik_dataset_items_read"
-    ) as pool:
+    )
+    try:
         # Two pages in flight per worker: enough that a worker always has the
         # next page waiting, while keeping the reader's memory bounded by the
-        # look-ahead rather than by the size of the dataset. A consumer that
-        # stops iterating leaves at most this many requests to drain.
+        # look-ahead rather than by the size of the dataset.
         in_flight: Deque[futures.Future] = collections.deque(
             pool.submit(fetch_page, page)
             for page in itertools.islice(remaining_pages, worker_count * 2)
@@ -137,6 +143,11 @@ def _read_pages(
                 in_flight.append(pool.submit(fetch_page, next_page))
 
             yield _page_items(page)
+    finally:
+        # Drops the pages that haven't started and doesn't join the ones that
+        # have, so abandoning the iterator returns immediately. On the normal
+        # path there is nothing left in flight, so this is a no-op.
+        pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _build_page_fetcher(

--- a/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
+++ b/sdks/python/src/opik/api_objects/dataset/parallel_items_reader.py
@@ -51,8 +51,8 @@ def stream_item_chunks(
             the current state.
 
     Yields:
-        Lists of raw item dicts, in page order. The last chunk may be shorter
-        than ``chunk_size``; empty chunks are never yielded.
+        Lists of raw REST item dicts, in page order. The last chunk may be
+        shorter than ``chunk_size``; empty chunks are never yielded.
     """
     items_yielded = 0
 
@@ -172,12 +172,5 @@ def _build_page_fetcher(
 
 
 def _page_items(page: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Flatten a page's items into ``data`` dicts carrying their item id.
-
-    The stored ``data`` is returned untouched apart from ``id``, which always
-    holds the item's real id even when the data itself has an ``id`` key.
-    """
-    return [
-        {**(item.get("data") or {}), "id": item.get("id")}
-        for item in (page.get("content") or [])
-    ]
+    content: List[Dict[str, Any]] = page.get("content") or []
+    return content

--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -24,6 +24,13 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
+# Data keys that collide with a DatasetItem field cannot survive being unpacked
+# into one, so both read paths drop them and say so once per read.
+SHADOWED_KEYS_WARNING = (
+    "Dataset item data contains keys that shadow DatasetItem fields and will be ignored: %s. "
+    "Rename these keys in your dataset to preserve them."
+)
+
 
 def stream_dataset_items(
     rest_client: OpikApi,
@@ -125,11 +132,7 @@ def stream_dataset_items(
             )
             if conflicting and not _conflicting_keys_warned:
                 _conflicting_keys_warned = True
-                LOGGER.warning(
-                    "Dataset item data contains keys that shadow DatasetItem fields and will be ignored: %s. "
-                    "Rename these keys in your dataset to preserve them.",
-                    sorted(conflicting),
-                )
+                LOGGER.warning(SHADOWED_KEYS_WARNING, sorted(conflicting))
             extra_data = {
                 k: v
                 for k, v in item.data.items()
@@ -187,9 +190,12 @@ def stream_dataset_item_chunks(
         dataset_version: Optional dataset version hash to read a specific version.
 
     Yields:
-        Lists of raw item dictionaries, in dataset order.
+        Lists of item dictionaries, in dataset order, each holding the item's
+        data plus its id -- the shape :meth:`Dataset.get_items` returns.
     """
-    return parallel_items_reader.stream_item_chunks(
+    # Not a generator, so a malformed filter string is rejected on the call
+    # rather than on the first chunk the caller pulls.
+    raw_chunks = parallel_items_reader.stream_item_chunks(
         rest_client=rest_client,
         dataset_id=dataset_id,
         chunk_size=chunk_size,
@@ -198,6 +204,41 @@ def stream_dataset_item_chunks(
         filters=_serialize_dataset_item_filters(filter_string),
         dataset_version=dataset_version,
     )
+
+    return _to_item_dict_chunks(raw_chunks)
+
+
+def _to_item_dict_chunks(
+    raw_chunks: Iterator[List[Dict[str, Any]]],
+) -> Iterator[List[Dict[str, Any]]]:
+    """Project raw REST items into the dicts the read APIs hand to users.
+
+    Mirrors what unpacking a REST item into a ``DatasetItem`` and reading its
+    content back does: the item's real id wins, and data keys shadowing a
+    DatasetItem field are dropped. The warn-once state deliberately spans the
+    whole read rather than a single chunk.
+    """
+    shadowed_keys_warned = False
+    reserved_keys = dataset_item.DatasetItem.model_fields.keys()
+
+    for raw_chunk in raw_chunks:
+        chunk = []
+        for raw_item in raw_chunk:
+            data: Dict[str, Any] = raw_item.get("data") or {}
+
+            shadowed = data.keys() & reserved_keys
+            if shadowed and not shadowed_keys_warned:
+                shadowed_keys_warned = True
+                LOGGER.warning(SHADOWED_KEYS_WARNING, sorted(shadowed))
+
+            chunk.append(
+                {
+                    "id": raw_item.get("id"),
+                    **{k: v for k, v in data.items() if k not in reserved_keys},
+                }
+            )
+
+        yield chunk
 
 
 def _serialize_dataset_item_filters(filter_string: Optional[str]) -> Optional[str]:
@@ -271,6 +312,10 @@ def get_datasets(
                 rest_client=rest_client,
                 dataset_items_count=dataset_fern.dataset_items_count,
             )
+            # Seed the id from the listing so reads don't re-resolve each
+            # dataset by name.
+            if dataset_fern.id is not None:
+                dataset_.__dict__["id"] = dataset_fern.id
 
             if sync_items:
                 dataset_.__internal_api__sync_hashes__()

--- a/sdks/python/src/opik/api_objects/dataset/rest_operations.py
+++ b/sdks/python/src/opik/api_objects/dataset/rest_operations.py
@@ -13,7 +13,7 @@ import opik.exceptions as exceptions
 from opik.message_processing import streamer
 from opik.rest_client_configurator import retry_decorator
 from opik.api_objects import opik_query_language, rest_stream_parser
-from . import dataset, dataset_item, execution_policy
+from . import dataset, dataset_item, execution_policy, parallel_items_reader
 from .. import experiment, constants, rest_helpers
 from ..experiment import experiments_client
 from ...rest_api.core.api_error import ApiError
@@ -62,12 +62,7 @@ def stream_dataset_items(
     )
     _conflicting_keys_warned = False
 
-    filters: Optional[str] = None
-    if filter_string:
-        oql = opik_query_language.OpikQueryLanguage.for_dataset_items(filter_string)
-        filter_expressions = oql.get_filter_expressions()
-        if filter_expressions:
-            filters = json.dumps(filter_expressions)
+    filters = _serialize_dataset_item_filters(filter_string)
 
     while should_retrieve_more_items:
 
@@ -168,6 +163,54 @@ def stream_dataset_items(
             "The following dataset items were not found in the dataset: %s",
             dataset_items_ids_left,
         )
+
+
+def stream_dataset_item_chunks(
+    rest_client: OpikApi,
+    dataset_id: str,
+    chunk_size: int,
+    num_threads: int,
+    nb_samples: Optional[int] = None,
+    filter_string: Optional[str] = None,
+    dataset_version: Optional[str] = None,
+) -> Iterator[List[Dict[str, Any]]]:
+    """
+    Read dataset items as chunks of raw dictionaries, fetching chunks in parallel.
+
+    Args:
+        rest_client: The REST API client.
+        dataset_id: Id of the dataset to read items from.
+        chunk_size: Number of items per chunk.
+        num_threads: Number of chunks fetched concurrently.
+        nb_samples: Maximum number of items to retrieve. If None, all items are read.
+        filter_string: Optional OQL filter string to filter dataset items.
+        dataset_version: Optional dataset version hash to read a specific version.
+
+    Yields:
+        Lists of raw item dictionaries, in dataset order.
+    """
+    return parallel_items_reader.stream_item_chunks(
+        rest_client=rest_client,
+        dataset_id=dataset_id,
+        chunk_size=chunk_size,
+        num_threads=num_threads,
+        max_items=nb_samples,
+        filters=_serialize_dataset_item_filters(filter_string),
+        dataset_version=dataset_version,
+    )
+
+
+def _serialize_dataset_item_filters(filter_string: Optional[str]) -> Optional[str]:
+    """Turn an OQL filter string into the JSON the items endpoints expect."""
+    if not filter_string:
+        return None
+
+    oql = opik_query_language.OpikQueryLanguage.for_dataset_items(filter_string)
+    filter_expressions = oql.get_filter_expressions()
+    if not filter_expressions:
+        return None
+
+    return json.dumps(filter_expressions)
 
 
 def find_version_by_name(

--- a/sdks/python/tests/e2e/test_dataset.py
+++ b/sdks/python/tests/e2e/test_dataset.py
@@ -462,22 +462,22 @@ def _stream_all_items(dataset, **stream_kwargs):
     return [item for chunk in chunks for item in chunk]
 
 
-def test_stream_items__small_dataset__returns_same_items_as_get_items(
+def test_stream_items__small_dataset__returns_inserted_items_with_their_ids(
     opik_client: opik.Opik, dataset_name: str
 ):
-    """stream_items is the fast path for the same data get_items returns."""
+    """Items come back as the inserted data plus an id, and get_items -- which
+    is built on this method -- flattens to exactly the same list."""
     dataset = opik_client.create_dataset(
         dataset_name, description="E2E stream_items dataset", project_name=PROJECT_NAME
     )
-    dataset.insert(
-        [
-            {
-                "input": {"question": f"question {i}"},
-                "expected_output": {"output": f"answer {i}"},
-            }
-            for i in range(5)
-        ]
-    )
+    inserted = [
+        {
+            "input": {"question": f"question {i}"},
+            "expected_output": {"output": f"answer {i}"},
+        }
+        for i in range(5)
+    ]
+    dataset.insert(inserted)
 
     success = synchronization.until(
         lambda: len(_stream_all_items(dataset)) == 5,
@@ -486,11 +486,13 @@ def test_stream_items__small_dataset__returns_same_items_as_get_items(
     assert success, "Inserted items did not become readable in time"
 
     streamed = _stream_all_items(dataset)
-    expected = dataset.get_items()
 
-    assert sorted(streamed, key=lambda item: item["id"]) == sorted(
-        expected, key=lambda item: item["id"]
+    content = [{k: v for k, v in item.items() if k != "id"} for item in streamed]
+    assert sorted(content, key=lambda item: item["input"]["question"]) == inserted, (
+        "Items must carry the inserted data verbatim"
     )
+    assert all(item["id"] for item in streamed)
+    assert streamed == dataset.get_items()
 
 
 def test_stream_items__many_items_and_threads__reads_every_item_exactly_once(

--- a/sdks/python/tests/e2e/test_dataset.py
+++ b/sdks/python/tests/e2e/test_dataset.py
@@ -6,7 +6,7 @@ import opik.exceptions
 from opik import synchronization
 
 from opik.api_objects.dataset import dataset_item
-from opik.api_objects import helpers
+from opik.api_objects import constants, helpers
 from . import verifiers
 from ..testlib import generate_project_name
 import pytest
@@ -449,7 +449,7 @@ def test_dataset_items_count__returns_correct_count_after_insert(
 
 def _stream_all_items(dataset, **stream_kwargs):
     """Flatten stream_items() into a single list, asserting chunk sizes."""
-    chunk_size = stream_kwargs.get("chunk_size", 1000)
+    chunk_size = stream_kwargs.get("chunk_size", constants.DATASET_STREAM_BATCH_SIZE)
     chunks = list(dataset.stream_items(**stream_kwargs))
 
     for chunk in chunks[:-1]:

--- a/sdks/python/tests/e2e/test_dataset.py
+++ b/sdks/python/tests/e2e/test_dataset.py
@@ -445,3 +445,181 @@ def test_dataset_items_count__returns_correct_count_after_insert(
         max_try_seconds=30,
     )
     assert success, f"Expected dataset_items_count=3, got {dataset.dataset_items_count}"
+
+
+def _stream_all_items(dataset, **stream_kwargs):
+    """Flatten stream_items() into a single list, asserting chunk sizes."""
+    chunk_size = stream_kwargs.get("chunk_size", 1000)
+    chunks = list(dataset.stream_items(**stream_kwargs))
+
+    for chunk in chunks[:-1]:
+        assert len(chunk) == chunk_size, (
+            "Only the last chunk may be shorter than chunk_size"
+        )
+    for chunk in chunks:
+        assert len(chunk) > 0, "Empty chunks must never be yielded"
+
+    return [item for chunk in chunks for item in chunk]
+
+
+def test_stream_items__small_dataset__returns_same_items_as_get_items(
+    opik_client: opik.Opik, dataset_name: str
+):
+    """stream_items is the fast path for the same data get_items returns."""
+    dataset = opik_client.create_dataset(
+        dataset_name, description="E2E stream_items dataset", project_name=PROJECT_NAME
+    )
+    dataset.insert(
+        [
+            {
+                "input": {"question": f"question {i}"},
+                "expected_output": {"output": f"answer {i}"},
+            }
+            for i in range(5)
+        ]
+    )
+
+    success = synchronization.until(
+        lambda: len(_stream_all_items(dataset)) == 5,
+        max_try_seconds=30,
+    )
+    assert success, "Inserted items did not become readable in time"
+
+    streamed = _stream_all_items(dataset)
+    expected = dataset.get_items()
+
+    assert sorted(streamed, key=lambda item: item["id"]) == sorted(
+        expected, key=lambda item: item["id"]
+    )
+
+
+def test_stream_items__many_items_and_threads__reads_every_item_exactly_once(
+    opik_client: opik.Opik, dataset_name: str
+):
+    """The threaded, multi-chunk read must not drop, duplicate or reorder items.
+
+    10k items at a 1000-item chunk size is 10 pages, so 8 workers really do fan
+    out. Timing is logged rather than asserted: CI runs a single backend
+    container, so it is backend-bound and understates the speedup.
+    """
+    N_ITEMS = 10_000
+    CHUNK_SIZE = 1_000
+
+    dataset = opik_client.create_dataset(
+        dataset_name,
+        description="E2E stream_items parallel dataset",
+        project_name=PROJECT_NAME,
+    )
+    dataset.insert(
+        [{"input": {"question": f"question {i}"}} for i in range(N_ITEMS)],
+        num_threads=8,
+    )
+
+    success = synchronization.until(
+        lambda: len(_stream_all_items(dataset, chunk_size=CHUNK_SIZE)) == N_ITEMS,
+        max_try_seconds=120,
+    )
+    assert success, "Inserted items did not become readable in time"
+
+    start = time.perf_counter()
+    items = _stream_all_items(dataset, chunk_size=CHUNK_SIZE, num_threads=8)
+    elapsed = time.perf_counter() - start
+    LOGGER.info(
+        "stream_items read %d items in %.2fs (%.0f rows/s)",
+        len(items),
+        elapsed,
+        len(items) / elapsed if elapsed else 0,
+    )
+
+    assert len(items) == N_ITEMS
+    assert len({item["id"] for item in items}) == N_ITEMS
+    assert {item["input"]["question"] for item in items} == {
+        f"question {i}" for i in range(N_ITEMS)
+    }
+
+    # Same content whatever the thread count, and the order is the backend's
+    # page order either way.
+    sequential_items = _stream_all_items(dataset, chunk_size=CHUNK_SIZE, num_threads=1)
+    assert [item["id"] for item in sequential_items] == [item["id"] for item in items]
+
+
+def test_stream_items__nb_samples__stops_after_requested_number_of_items(
+    opik_client: opik.Opik, dataset_name: str
+):
+    dataset = opik_client.create_dataset(
+        dataset_name,
+        description="E2E stream_items nb_samples dataset",
+        project_name=PROJECT_NAME,
+    )
+    dataset.insert([{"input": {"question": f"question {i}"}} for i in range(50)])
+
+    success = synchronization.until(
+        lambda: len(_stream_all_items(dataset)) == 50,
+        max_try_seconds=30,
+    )
+    assert success, "Inserted items did not become readable in time"
+
+    items = _stream_all_items(dataset, chunk_size=10, num_threads=4, nb_samples=25)
+
+    assert len(items) == 25
+    assert len({item["id"] for item in items}) == 25
+
+
+def test_stream_items__filter_string__returns_only_matching_items(
+    opik_client: opik.Opik, dataset_name: str
+):
+    dataset = opik_client.create_dataset(
+        dataset_name,
+        description="E2E stream_items filter dataset",
+        project_name=PROJECT_NAME,
+    )
+    dataset.insert(
+        [
+            {
+                "input": {"question": "What is the capital of France?"},
+                "category": "geo",
+            },
+            {"input": {"question": "What is 2 + 2?"}, "category": "math"},
+            {
+                "input": {"question": "What is the capital of Poland?"},
+                "category": "geo",
+            },
+        ]
+    )
+
+    success = synchronization.until(
+        lambda: len(_stream_all_items(dataset)) == 3,
+        max_try_seconds=30,
+    )
+    assert success, "Inserted items did not become readable in time"
+
+    items = _stream_all_items(dataset, filter_string='data.category = "geo"')
+
+    assert len(items) == 2
+    assert {item["input"]["question"] for item in items} == {
+        "What is the capital of France?",
+        "What is the capital of Poland?",
+    }
+
+
+def test_stream_items__dataset_version__reads_that_version_snapshot(
+    opik_client: opik.Opik, dataset_name: str
+):
+    dataset = opik_client.create_dataset(
+        dataset_name,
+        description="E2E stream_items version dataset",
+        project_name=PROJECT_NAME,
+    )
+
+    dataset.insert([{"input": {"question": "What is the capital of France?"}}])
+    _wait_for_version(dataset, "v1")
+
+    dataset.insert([{"input": {"question": "What is the capital of Germany?"}}])
+    _wait_for_version(dataset, "v2")
+
+    v1_items = _stream_all_items(dataset.get_version_view("v1"))
+    v2_items = _stream_all_items(dataset.get_version_view("v2"))
+
+    assert len(v1_items) == 1
+    assert v1_items[0]["input"] == {"question": "What is the capital of France?"}
+    assert len(v2_items) == 2

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_items_count.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_items_count.py
@@ -176,3 +176,38 @@ def test_backend_returns_none_count__property_returns_none():
 
     assert count is None
     mock_rest_client.datasets.get_dataset_by_id.assert_called_once()
+
+
+def test_from_public__response_carries_id__id_returned_without_a_lookup():
+    """The get-dataset response already holds the id, so reads must not pay a
+    second by-name lookup for it."""
+    mock_rest_client = Mock()
+    mock_dataset_public = DatasetPublic(
+        id="01a06bd3-f379-7231-a8ff-842808c8ba38",
+        name="test_dataset",
+        dataset_items_count=7,
+    )
+
+    dataset = Dataset.from_public(
+        dataset_fern=mock_dataset_public,
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    assert dataset.id == "01a06bd3-f379-7231-a8ff-842808c8ba38"
+    mock_rest_client.datasets.get_dataset_by_identifier.assert_not_called()
+
+
+def test_from_public__response_without_id__falls_back_to_the_lookup():
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = "looked-up"
+    mock_dataset_public = DatasetPublic(name="test_dataset")
+
+    dataset = Dataset.from_public(
+        dataset_fern=mock_dataset_public,
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    assert dataset.id == "looked-up"
+    mock_rest_client.datasets.get_dataset_by_identifier.assert_called_once()

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from opik.api_objects import constants
 from opik.api_objects.dataset import rest_operations
 from opik.api_objects.dataset.dataset import Dataset
 from opik.rest_api.core.api_error import ApiError
@@ -306,15 +307,19 @@ def test_stream_items__invalid_arguments__raises_before_any_request():
 def test_get_items__reads_through_the_parallel_paginated_endpoint():
     """get_items() is a thin wrapper over the chunked reader, not the
     cursor-chained typed stream it used to call."""
-    endpoint = FakeItemsEndpoint(_rest_items(2500))
+    total = constants.DATASET_STREAM_BATCH_SIZE * 2 + 1
+    endpoint = FakeItemsEndpoint(_rest_items(total))
     dataset = _build_dataset(endpoint)
 
     items = dataset.get_items()
 
-    assert len(items) == 2500
-    assert [item["id"] for item in items] == [f"item-{i}" for i in range(2500)]
-    # Default chunk_size, so 2500 items is 3 pages of the paginated endpoint.
+    assert len(items) == total
+    assert [item["id"] for item in items] == [f"item-{i}" for i in range(total)]
+    # Just over two default-sized chunks, so three pages of the endpoint.
     assert sorted(endpoint.requested_pages) == [1, 2, 3]
+    assert [call["params"]["size"] for call in endpoint.calls] == [
+        constants.DATASET_STREAM_BATCH_SIZE
+    ] * 3
     assert all(
         call["path"] == f"v1/private/datasets/{DATASET_ID}/items"
         for call in endpoint.calls
@@ -347,12 +352,14 @@ def test_get_items__data_shadowing_item_fields__keys_dropped_as_before():
 
 
 def test_get_items__nb_samples__limits_items_and_pages():
-    endpoint = FakeItemsEndpoint(_rest_items(5000))
+    chunk = constants.DATASET_STREAM_BATCH_SIZE
+    endpoint = FakeItemsEndpoint(_rest_items(chunk * 5))
     dataset = _build_dataset(endpoint)
 
-    items = dataset.get_items(nb_samples=1200)
+    items = dataset.get_items(nb_samples=chunk + 200)
 
-    assert len(items) == 1200
+    assert len(items) == chunk + 200
+    # Only the two pages holding wanted items are fetched, not all five.
     assert sorted(endpoint.requested_pages) == [1, 2]
 
 

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -385,3 +385,48 @@ def test_get_items__empty_dataset__returns_empty_list():
     dataset = _build_dataset(endpoint)
 
     assert dataset.get_items() == []
+
+
+def test_get_items__num_threads__forwarded_to_the_reader():
+    chunk = constants.DATASET_STREAM_BATCH_SIZE
+    endpoint = FakeItemsEndpoint(_rest_items(chunk * 4), delay_seconds=0.05)
+    dataset = _build_dataset(endpoint)
+
+    items = dataset.get_items(num_threads=4)
+
+    assert len(items) == chunk * 4
+    assert endpoint.max_in_flight > 1
+
+
+def test_get_items__num_threads_one__fetches_pages_sequentially():
+    chunk = constants.DATASET_STREAM_BATCH_SIZE
+    endpoint = FakeItemsEndpoint(_rest_items(chunk * 3), delay_seconds=0.05)
+    dataset = _build_dataset(endpoint)
+
+    items = dataset.get_items(num_threads=1)
+
+    assert len(items) == chunk * 3
+    assert endpoint.max_in_flight == 1
+
+
+def test_get_items__thread_count_does_not_change_the_result():
+    endpoint = FakeItemsEndpoint(_rest_items(constants.DATASET_STREAM_BATCH_SIZE * 3))
+    dataset = _build_dataset(endpoint)
+
+    assert dataset.get_items(num_threads=1) == dataset.get_items(num_threads=8)
+
+
+@pytest.mark.parametrize("num_threads", [0, -1, True, "4"])
+def test_get_items__invalid_num_threads__raises_value_error(num_threads):
+    dataset = _build_dataset(endpoint=None)
+
+    with pytest.raises(ValueError):
+        dataset.get_items(num_threads=num_threads)
+
+
+def test_get_items__positional_args_unchanged__nb_samples_still_first():
+    """num_threads was appended, so existing positional callers are unaffected."""
+    endpoint = FakeItemsEndpoint(_rest_items(50))
+    dataset = _build_dataset(endpoint)
+
+    assert len(dataset.get_items(10)) == 10

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+import time
 from typing import Any, Dict, List, Optional
 from unittest.mock import Mock, patch
 
@@ -81,17 +82,36 @@ def _rest_items(count: int) -> List[Dict[str, Any]]:
     ]
 
 
-def _build_dataset(endpoint: Optional[FakeItemsEndpoint]) -> Dataset:
+def _mock_rest_client(endpoint=None, version_hash: Optional[str] = None) -> Mock:
+    """A rest client whose dataset-id and version lookups are both controlled.
+
+    ``version_hash=None`` models a backend with no version to pin a read to,
+    which is the default so the assertions about the ``version`` query
+    parameter stay meaningful.
+    """
     mock_rest_client = Mock()
     mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
+
+    versions_page = Mock()
+    versions_page.content = (
+        [Mock(version_hash=version_hash)] if version_hash is not None else []
+    )
+    mock_rest_client.datasets.list_dataset_versions.return_value = versions_page
+
     if endpoint is not None:
         mock_rest_client._client_wrapper.httpx_client.request.side_effect = endpoint
 
+    return mock_rest_client
+
+
+def _build_dataset(
+    endpoint: Optional[FakeItemsEndpoint], version_hash: Optional[str] = None
+) -> Dataset:
     return Dataset(
         name="test-dataset",
         description=None,
         project_name=None,
-        rest_client=mock_rest_client,
+        rest_client=_mock_rest_client(endpoint, version_hash),
     )
 
 
@@ -466,16 +486,11 @@ def test_stream_items__malformed_total__raises_instead_of_truncating(total):
     if total is not None:
         body["total"] = total
 
-    mock_rest_client = Mock()
-    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
-    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
-        _endpoint_returning(body)
-    )
     dataset = Dataset(
         name="test-dataset",
         description=None,
         project_name=None,
-        rest_client=mock_rest_client,
+        rest_client=_mock_rest_client(_endpoint_returning(body)),
     )
 
     with pytest.raises(exceptions.OpikException, match="Malformed response"):
@@ -483,16 +498,13 @@ def test_stream_items__malformed_total__raises_instead_of_truncating(total):
 
 
 def test_stream_items__non_list_content__raises():
-    mock_rest_client = Mock()
-    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
-    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
-        _endpoint_returning({"total": 2, "content": {"not": "a list"}})
-    )
     dataset = Dataset(
         name="test-dataset",
         description=None,
         project_name=None,
-        rest_client=mock_rest_client,
+        rest_client=_mock_rest_client(
+            _endpoint_returning({"total": 2, "content": {"not": "a list"}})
+        ),
     )
 
     with pytest.raises(exceptions.OpikException, match="Malformed response"):
@@ -501,16 +513,11 @@ def test_stream_items__non_list_content__raises():
 
 def test_stream_items__total_zero_with_empty_content__reads_nothing():
     """A genuinely empty dataset is not malformed."""
-    mock_rest_client = Mock()
-    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
-    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
-        _endpoint_returning({"total": 0, "content": []})
-    )
     dataset = Dataset(
         name="test-dataset",
         description=None,
         project_name=None,
-        rest_client=mock_rest_client,
+        rest_client=_mock_rest_client(_endpoint_returning({"total": 0, "content": []})),
     )
 
     assert list(dataset.stream_items()) == []
@@ -560,4 +567,128 @@ def test_get_items__chunk_size_cap_applies_through_get_items():
     assert all(
         call["params"]["size"] <= constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE
         for call in endpoint.calls
+    )
+
+
+def test_stream_items__version_available__every_page_pinned_to_it():
+    """Pages are addressed by offset, so they must all read one version --
+    otherwise an insert landing at offset 0 shifts the unfetched pages."""
+    endpoint = FakeItemsEndpoint(_rest_items(25))
+    dataset = _build_dataset(endpoint, version_hash="v-hash-abc")
+
+    list(dataset.stream_items(chunk_size=10, num_threads=4))
+
+    assert len(endpoint.calls) == 3
+    assert {call["params"]["version"] for call in endpoint.calls} == {"v-hash-abc"}
+
+
+def test_stream_items__no_version_available__reads_the_live_state():
+    endpoint = FakeItemsEndpoint(_rest_items(25))
+    dataset = _build_dataset(endpoint, version_hash=None)
+
+    list(dataset.stream_items(chunk_size=10, num_threads=4))
+
+    assert {call["params"]["version"] for call in endpoint.calls} == {None}
+
+
+def test_stream_items__version_resolved_once__not_per_page():
+    endpoint = FakeItemsEndpoint(_rest_items(50))
+    dataset = _build_dataset(endpoint, version_hash="v-hash-abc")
+
+    list(dataset.stream_items(chunk_size=10, num_threads=4))
+
+    assert dataset._rest_client.datasets.list_dataset_versions.call_count == 1
+
+
+def test_stream_items__version_lookup_deferred_until_iteration():
+    endpoint = FakeItemsEndpoint(_rest_items(10))
+    dataset = _build_dataset(endpoint, version_hash="v-hash-abc")
+    versions = dataset._rest_client.datasets.list_dataset_versions
+
+    stream = dataset.stream_items()
+
+    assert versions.call_count == 0
+    next(iter(stream))
+    assert versions.call_count == 1
+
+
+def test_get_items__pins_the_read_to_a_version_too():
+    endpoint = FakeItemsEndpoint(_rest_items(25))
+    dataset = _build_dataset(endpoint, version_hash="v-hash-abc")
+
+    dataset.get_items(chunk_size=10)
+
+    assert {call["params"]["version"] for call in endpoint.calls} == {"v-hash-abc"}
+
+
+class ShiftingItemsEndpoint(FakeItemsEndpoint):
+    """Simulates an insert landing between page 1 and page 2.
+
+    Ids sort newest-first, so a new item takes offset 0 and pushes every later
+    item one slot further down -- the exact shift that makes an offset-paged
+    read of a live dataset return one item twice and skip another.
+    """
+
+    def __call__(self, path, *, method, params):
+        response = super().__call__(path, method=method, params=params)
+        if params["page"] == 1 and params.get("version") is None:
+            self._items.insert(0, {"id": "i-new", "data": {"question": "inserted"}})
+        return response
+
+
+def test_stream_items__unversioned_read_with_a_concurrent_insert__shifts():
+    """Documents the failure mode the version pin exists to prevent, so a
+    regression in the pinning shows up as this test starting to pass."""
+    endpoint = ShiftingItemsEndpoint(
+        [{"id": f"i{i}", "data": {"question": f"q{i}"}} for i in range(4)]
+    )
+    dataset = _build_dataset(endpoint, version_hash=None)
+
+    ids = [
+        item["id"]
+        for chunk in dataset.stream_items(chunk_size=2, num_threads=1)
+        for item in chunk
+    ]
+
+    # i1 is returned twice and i3 never arrives.
+    assert len(ids) != len(set(ids)), (
+        "expected the unversioned read to duplicate an item once the dataset shifted"
+    )
+
+
+def test_stream_items__version_pinned_read_is_unaffected_by_a_concurrent_insert():
+    endpoint = ShiftingItemsEndpoint(
+        [{"id": f"i{i}", "data": {"question": f"q{i}"}} for i in range(4)]
+    )
+    dataset = _build_dataset(endpoint, version_hash="v-hash-abc")
+
+    ids = [
+        item["id"]
+        for chunk in dataset.stream_items(chunk_size=2, num_threads=1)
+        for item in chunk
+    ]
+
+    assert ids == ["i0", "i1", "i2", "i3"]
+    assert len(ids) == len(set(ids))
+
+
+def test_stream_items__abandoned_early__does_not_block_on_in_flight_pages():
+    """Closing the generator must not join the outstanding requests: the yields
+    happen inside the pool's scope, so a `with` block would turn a plain
+    `break` into a wait for every page still in flight."""
+    page_delay = 0.5
+    endpoint = FakeItemsEndpoint(_rest_items(200), delay_seconds=page_delay)
+    dataset = _build_dataset(endpoint)
+
+    stream = dataset.stream_items(chunk_size=10, num_threads=4)
+    for _ in stream:
+        break  # abandon after the first chunk, with pages still in flight
+
+    started = time.perf_counter()
+    stream.close()
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < page_delay, (
+        f"closing the stream blocked for {elapsed:.2f}s; it must not wait for "
+        "in-flight pages"
     )

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -1,0 +1,273 @@
+"""Unit tests for Dataset.stream_items() and its parallel paginated reader."""
+
+import json
+import threading
+from typing import Any, Dict, List, Optional
+from unittest.mock import Mock
+
+import pytest
+
+from opik.api_objects.dataset.dataset import Dataset
+from opik.rest_api.core.api_error import ApiError
+
+DATASET_ID = "dataset-id-1"
+
+
+class FakeItemsEndpoint:
+    """Serves ``GET /v1/private/datasets/{id}/items`` from an in-memory list.
+
+    Records every call, and tracks how many were in flight at once so the tests
+    can tell a parallel read from a sequential one.
+    """
+
+    def __init__(
+        self,
+        items: List[Dict[str, Any]],
+        status_code: int = 200,
+        delay_seconds: float = 0.0,
+    ) -> None:
+        self._items = items
+        self._status_code = status_code
+        self._delay_seconds = delay_seconds
+        self._lock = threading.Lock()
+        self._in_flight = 0
+
+        self.calls: List[Dict[str, Any]] = []
+        self.max_in_flight = 0
+
+    def __call__(self, path: str, *, method: str, params: Dict[str, Any]) -> Mock:
+        with self._lock:
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+            self.calls.append({"path": path, "method": method, "params": params})
+
+        try:
+            if self._delay_seconds:
+                # Long enough that a sequential reader could not overlap two
+                # calls, so max_in_flight > 1 really does mean parallelism.
+                threading.Event().wait(self._delay_seconds)
+
+            page = params["page"]
+            size = params["size"]
+            content = self._items[(page - 1) * size : page * size]
+
+            response = Mock()
+            response.status_code = self._status_code
+            response.headers = {}
+            response.text = "error body"
+            response.json.return_value = {
+                "content": content,
+                "page": page,
+                "size": size,
+                "total": len(self._items),
+            }
+            return response
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+
+    @property
+    def requested_pages(self) -> List[int]:
+        return [call["params"]["page"] for call in self.calls]
+
+
+def _rest_items(count: int) -> List[Dict[str, Any]]:
+    return [
+        {"id": f"item-{i}", "source": "sdk", "data": {"question": f"q-{i}"}}
+        for i in range(count)
+    ]
+
+
+def _build_dataset(endpoint: Optional[FakeItemsEndpoint]) -> Dataset:
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
+    if endpoint is not None:
+        mock_rest_client._client_wrapper.httpx_client.request.side_effect = endpoint
+
+    return Dataset(
+        name="test-dataset",
+        description=None,
+        project_name=None,
+        rest_client=mock_rest_client,
+    )
+
+
+def test_stream_items__single_page__yields_one_chunk():
+    endpoint = FakeItemsEndpoint(_rest_items(3))
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10))
+
+    assert chunks == [
+        [
+            {"question": "q-0", "id": "item-0"},
+            {"question": "q-1", "id": "item-1"},
+            {"question": "q-2", "id": "item-2"},
+        ]
+    ]
+    assert endpoint.requested_pages == [1]
+    assert endpoint.calls[0]["path"] == f"v1/private/datasets/{DATASET_ID}/items"
+    assert endpoint.calls[0]["method"] == "GET"
+
+
+def test_stream_items__empty_dataset__yields_nothing():
+    endpoint = FakeItemsEndpoint([])
+    dataset = _build_dataset(endpoint)
+
+    assert list(dataset.stream_items()) == []
+    assert endpoint.requested_pages == [1]
+
+
+def test_stream_items__multiple_pages__yields_chunks_in_dataset_order():
+    endpoint = FakeItemsEndpoint(_rest_items(25))
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10, num_threads=4))
+
+    assert [len(chunk) for chunk in chunks] == [10, 10, 5]
+    assert [item["id"] for chunk in chunks for item in chunk] == [
+        f"item-{i}" for i in range(25)
+    ]
+    assert sorted(endpoint.requested_pages) == [1, 2, 3]
+
+
+def test_stream_items__num_threads_above_one__fetches_pages_concurrently():
+    endpoint = FakeItemsEndpoint(_rest_items(40), delay_seconds=0.2)
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10, num_threads=4))
+
+    assert len(chunks) == 4
+    assert endpoint.max_in_flight > 1
+
+
+def test_stream_items__single_thread__fetches_pages_one_at_a_time():
+    endpoint = FakeItemsEndpoint(_rest_items(40), delay_seconds=0.05)
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10, num_threads=1))
+
+    assert len(chunks) == 4
+    assert endpoint.max_in_flight == 1
+
+
+def test_stream_items__nb_samples_below_total__trims_and_skips_unneeded_pages():
+    endpoint = FakeItemsEndpoint(_rest_items(100))
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10, num_threads=4, nb_samples=25))
+
+    assert [len(chunk) for chunk in chunks] == [10, 10, 5]
+    assert sorted(endpoint.requested_pages) == [1, 2, 3]
+
+
+def test_stream_items__nb_samples_above_total__reads_everything():
+    endpoint = FakeItemsEndpoint(_rest_items(12))
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items(chunk_size=10, nb_samples=1000))
+
+    assert [len(chunk) for chunk in chunks] == [10, 2]
+
+
+def test_stream_items__lazy__no_request_until_iterated():
+    endpoint = FakeItemsEndpoint(_rest_items(10))
+    dataset = _build_dataset(endpoint)
+
+    stream = dataset.stream_items()
+
+    assert endpoint.calls == []
+    next(iter(stream))
+    assert endpoint.requested_pages == [1]
+
+
+def test_stream_items__data_with_id_key__real_item_id_wins():
+    endpoint = FakeItemsEndpoint(
+        [{"id": "real-id", "source": "sdk", "data": {"id": "COLLISION", "q": "?"}}]
+    )
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(dataset.stream_items())
+
+    assert chunks == [[{"id": "real-id", "q": "?"}]]
+
+
+def test_stream_items__filter_string__sent_as_serialized_filter_expressions():
+    endpoint = FakeItemsEndpoint(_rest_items(1))
+    dataset = _build_dataset(endpoint)
+
+    list(dataset.stream_items(filter_string='data.category = "test"'))
+
+    filters = endpoint.calls[0]["params"]["filters"]
+    assert json.loads(filters) == [
+        {
+            "field": "data",
+            "key": "category",
+            "operator": "=",
+            "type": "map",
+            "value": "test",
+        }
+    ]
+
+
+def test_stream_items__no_filter_string__filters_left_unset():
+    endpoint = FakeItemsEndpoint(_rest_items(1))
+    dataset = _build_dataset(endpoint)
+
+    list(dataset.stream_items())
+
+    assert endpoint.calls[0]["params"]["filters"] is None
+    assert endpoint.calls[0]["params"]["version"] is None
+
+
+def test_stream_items__chunk_size__sent_as_page_size():
+    endpoint = FakeItemsEndpoint(_rest_items(5))
+    dataset = _build_dataset(endpoint)
+
+    list(dataset.stream_items(chunk_size=3))
+
+    assert [call["params"]["size"] for call in endpoint.calls] == [3, 3]
+
+
+def test_stream_items__non_retryable_error_response__raises_api_error():
+    endpoint = FakeItemsEndpoint(_rest_items(5), status_code=404)
+    dataset = _build_dataset(endpoint)
+
+    with pytest.raises(ApiError) as exc_info:
+        list(dataset.stream_items())
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"chunk_size": 0},
+        {"chunk_size": -1},
+        {"chunk_size": True},
+        {"chunk_size": "10"},
+        {"num_threads": 0},
+        {"num_threads": -1},
+        {"num_threads": True},
+        {"num_threads": "4"},
+        {"nb_samples": 0},
+        {"nb_samples": -1},
+        {"nb_samples": True},
+        {"nb_samples": "10"},
+    ],
+)
+def test_stream_items__invalid_arguments__raises_value_error(kwargs):
+    dataset = _build_dataset(endpoint=None)
+
+    with pytest.raises(ValueError):
+        dataset.stream_items(**kwargs)
+
+
+def test_stream_items__invalid_arguments__raises_before_any_request():
+    endpoint = FakeItemsEndpoint(_rest_items(5))
+    dataset = _build_dataset(endpoint)
+
+    with pytest.raises(ValueError):
+        dataset.stream_items(num_threads=0)
+
+    assert endpoint.calls == []

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import opik.exceptions as exceptions
 from opik.api_objects import constants
 from opik.api_objects.dataset import rest_operations
 from opik.api_objects.dataset.dataset import Dataset
@@ -173,14 +174,21 @@ def test_stream_items__nb_samples_above_total__reads_everything():
 
 
 def test_stream_items__lazy__no_request_until_iterated():
+    """No I/O at all before the first chunk is pulled -- including the
+    by-name dataset-id lookup, which is a REST call of its own."""
     endpoint = FakeItemsEndpoint(_rest_items(10))
     dataset = _build_dataset(endpoint)
+    lookup = dataset._rest_client.datasets.get_dataset_by_identifier
 
     stream = dataset.stream_items()
 
     assert endpoint.calls == []
+    assert lookup.call_count == 0
+
     next(iter(stream))
+
     assert endpoint.requested_pages == [1]
+    assert lookup.call_count == 1
 
 
 def test_stream_items__data_with_id_key__real_item_id_wins():
@@ -430,3 +438,126 @@ def test_get_items__positional_args_unchanged__nb_samples_still_first():
     dataset = _build_dataset(endpoint)
 
     assert len(dataset.get_items(10)) == 10
+
+
+def _endpoint_returning(body: Dict[str, Any]) -> Mock:
+    """An items endpoint that returns one fixed, possibly malformed, page."""
+
+    def call(path: str, *, method: str, params: Dict[str, Any]) -> Mock:
+        response = Mock()
+        response.status_code = 200
+        response.headers = {}
+        response.text = ""
+        response.json.return_value = body
+        return response
+
+    return call
+
+
+@pytest.mark.parametrize(
+    "total",
+    [None, "abc", 1.5, True, -1],
+    ids=["missing", "string", "float", "bool", "negative"],
+)
+def test_stream_items__malformed_total__raises_instead_of_truncating(total):
+    """A bad `total` would cap the read at page 1 and look like a short
+    dataset, so it has to fail loudly rather than silently."""
+    body: Dict[str, Any] = {"content": _rest_items(2)}
+    if total is not None:
+        body["total"] = total
+
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
+    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
+        _endpoint_returning(body)
+    )
+    dataset = Dataset(
+        name="test-dataset",
+        description=None,
+        project_name=None,
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(exceptions.OpikException, match="Malformed response"):
+        list(dataset.stream_items())
+
+
+def test_stream_items__non_list_content__raises():
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
+    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
+        _endpoint_returning({"total": 2, "content": {"not": "a list"}})
+    )
+    dataset = Dataset(
+        name="test-dataset",
+        description=None,
+        project_name=None,
+        rest_client=mock_rest_client,
+    )
+
+    with pytest.raises(exceptions.OpikException, match="Malformed response"):
+        list(dataset.stream_items())
+
+
+def test_stream_items__total_zero_with_empty_content__reads_nothing():
+    """A genuinely empty dataset is not malformed."""
+    mock_rest_client = Mock()
+    mock_rest_client.datasets.get_dataset_by_identifier.return_value.id = DATASET_ID
+    mock_rest_client._client_wrapper.httpx_client.request.side_effect = (
+        _endpoint_returning({"total": 0, "content": []})
+    )
+    dataset = Dataset(
+        name="test-dataset",
+        description=None,
+        project_name=None,
+        rest_client=mock_rest_client,
+    )
+
+    assert list(dataset.stream_items()) == []
+
+
+def test_stream_items__chunk_size_at_the_cap__accepted():
+    endpoint = FakeItemsEndpoint(_rest_items(10))
+    dataset = _build_dataset(endpoint)
+
+    chunks = list(
+        dataset.stream_items(chunk_size=constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE)
+    )
+
+    assert sum(len(chunk) for chunk in chunks) == 10
+
+
+@pytest.mark.parametrize(
+    "chunk_size",
+    [
+        constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE + 1,
+        10**9,
+        2**31,
+    ],
+)
+def test_stream_items__chunk_size_above_the_cap__raises_before_any_request(chunk_size):
+    """Oversized pages are rejected client-side; forwarding them would let the
+    backend materialize an unbounded response, and values beyond int32 would
+    only fail after the request went out."""
+    endpoint = FakeItemsEndpoint(_rest_items(10))
+    dataset = _build_dataset(endpoint)
+
+    with pytest.raises(ValueError, match="chunk_size must not exceed"):
+        dataset.stream_items(chunk_size=chunk_size)
+
+    assert endpoint.calls == []
+
+
+def test_get_items__chunk_size_cap_applies_through_get_items():
+    """get_items() never exceeds the cap, since it uses the default."""
+    endpoint = FakeItemsEndpoint(
+        _rest_items(constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE + 5)
+    )
+    dataset = _build_dataset(endpoint)
+
+    dataset.get_items()
+
+    assert all(
+        call["params"]["size"] <= constants.DATASET_ITEMS_READ_MAX_CHUNK_SIZE
+        for call in endpoint.calls
+    )

--- a/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_stream_item_chunks.py
@@ -3,10 +3,11 @@
 import json
 import threading
 from typing import Any, Dict, List, Optional
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
+from opik.api_objects.dataset import rest_operations
 from opik.api_objects.dataset.dataset import Dataset
 from opik.rest_api.core.api_error import ApiError
 
@@ -192,6 +193,35 @@ def test_stream_items__data_with_id_key__real_item_id_wins():
     assert chunks == [[{"id": "real-id", "q": "?"}]]
 
 
+def test_stream_items__data_shadowing_item_fields__dropped_and_warned_once():
+    """Same contract as the typed read path: shadowing keys cannot survive."""
+    endpoint = FakeItemsEndpoint(
+        [
+            {
+                "id": f"real-{i}",
+                "source": "sdk",
+                "data": {"source": "SHADOW", "description": "SHADOW", "q": f"?{i}"},
+            }
+            for i in range(3)
+        ]
+    )
+    dataset = _build_dataset(endpoint)
+
+    with patch.object(rest_operations.LOGGER, "warning") as mock_warn:
+        chunks = list(dataset.stream_items())
+
+    assert chunks == [
+        [
+            {"id": "real-0", "q": "?0"},
+            {"id": "real-1", "q": "?1"},
+            {"id": "real-2", "q": "?2"},
+        ]
+    ]
+    mock_warn.assert_called_once_with(
+        rest_operations.SHADOWED_KEYS_WARNING, ["description", "source"]
+    )
+
+
 def test_stream_items__filter_string__sent_as_serialized_filter_expressions():
     endpoint = FakeItemsEndpoint(_rest_items(1))
     dataset = _build_dataset(endpoint)
@@ -271,3 +301,80 @@ def test_stream_items__invalid_arguments__raises_before_any_request():
         dataset.stream_items(num_threads=0)
 
     assert endpoint.calls == []
+
+
+def test_get_items__reads_through_the_parallel_paginated_endpoint():
+    """get_items() is a thin wrapper over the chunked reader, not the
+    cursor-chained typed stream it used to call."""
+    endpoint = FakeItemsEndpoint(_rest_items(2500))
+    dataset = _build_dataset(endpoint)
+
+    items = dataset.get_items()
+
+    assert len(items) == 2500
+    assert [item["id"] for item in items] == [f"item-{i}" for i in range(2500)]
+    # Default chunk_size, so 2500 items is 3 pages of the paginated endpoint.
+    assert sorted(endpoint.requested_pages) == [1, 2, 3]
+    assert all(
+        call["path"] == f"v1/private/datasets/{DATASET_ID}/items"
+        for call in endpoint.calls
+    )
+
+
+def test_get_items__same_items_as_stream_items():
+    endpoint = FakeItemsEndpoint(_rest_items(30))
+    dataset = _build_dataset(endpoint)
+
+    from_get_items = dataset.get_items()
+    streamed = [item for chunk in dataset.stream_items(chunk_size=7) for item in chunk]
+
+    assert from_get_items == streamed
+
+
+def test_get_items__data_shadowing_item_fields__keys_dropped_as_before():
+    endpoint = FakeItemsEndpoint(
+        [
+            {
+                "id": "real-id",
+                "source": "sdk",
+                "data": {"id": "SHADOW", "trace_id": "SHADOW", "q": "?"},
+            }
+        ]
+    )
+    dataset = _build_dataset(endpoint)
+
+    assert dataset.get_items() == [{"id": "real-id", "q": "?"}]
+
+
+def test_get_items__nb_samples__limits_items_and_pages():
+    endpoint = FakeItemsEndpoint(_rest_items(5000))
+    dataset = _build_dataset(endpoint)
+
+    items = dataset.get_items(nb_samples=1200)
+
+    assert len(items) == 1200
+    assert sorted(endpoint.requested_pages) == [1, 2]
+
+
+def test_get_items__filter_string__forwarded_to_the_endpoint():
+    endpoint = FakeItemsEndpoint(_rest_items(1))
+    dataset = _build_dataset(endpoint)
+
+    dataset.get_items(filter_string='data.category = "test"')
+
+    assert json.loads(endpoint.calls[0]["params"]["filters"]) == [
+        {
+            "field": "data",
+            "key": "category",
+            "operator": "=",
+            "type": "map",
+            "value": "test",
+        }
+    ]
+
+
+def test_get_items__empty_dataset__returns_empty_list():
+    endpoint = FakeItemsEndpoint([])
+    dataset = _build_dataset(endpoint)
+
+    assert dataset.get_items() == []


### PR DESCRIPTION
## Details

`get_items()` walked the cursor-chained `/items/stream` endpoint and rebuilt every row into a typed `DatasetItem` before returning, so a large read was one serial request chain plus per-item pydantic validation. This adds `Dataset.stream_items()` — a chunked reader that fetches pages of the id-addressed `GET /v1/private/datasets/{id}/items` endpoint concurrently through the SDK's own httpx client, bypassing the Fern-generated typed layer — and rewires `get_items()` on top of it.

- `stream_items(chunk_size, num_threads, filter_string, nb_samples)` yields lists of item dicts in dataset order. The read is pinned to a single dataset version, so it is a snapshot: items inserted or deleted while it runs do not affect it. Page 1 is fetched first for its `total`; the rest fan out over a thread pool behind an ordered queue with a bounded look-ahead of `2 * num_threads` chunks, so a slow consumer cannot make the reader buffer the whole dataset.
- `get_items()` keeps its payload exactly — it is now a flatten of `stream_items()`. Both share a single projection, so data keys that shadow `DatasetItem` fields are still dropped and still warned about once per read. It also gains optional `num_threads` and `chunk_size` (appended to the signature, so existing positional callers are unaffected), since it would otherwise be stuck on the defaults.
- `DatasetVersion` gets the same method, pinned to its version hash.
- The backend-fetch factories (`Dataset.from_public`, `rest_operations.get_datasets`) now seed `Dataset.id` from the response they already hold, so moving to the id-addressed endpoint costs no extra round trip. This also removes that lookup from `delete()`, `get_version_info()` and `dataset_items_count`.
- The paginated endpoint is used rather than the streaming one because its pages are independently addressable, which is what makes concurrent fetching possible at all. Its ordering (`ORDER BY (workspace_id, dataset_id, id) DESC`) is equivalent to the stream's (`id DESC`) within a workspace and dataset, verified empirically below.

**Behavior change.** `get_items(nb_samples=0)` (or a negative value) previously returned a *single* item: the stream parser's `len(result) == nb_samples` check never fires, and the caller loop then stops after the first yield. It now raises `ValueError`. Everything else about the payload is unchanged.

**Follow-up worth a separate ticket (no action needed here).** `DatasetItemDAO.getItems` runs `Mono.zip(countMono, columnsMono)` on every page, so each page request costs three ClickHouse queries — the items query plus a full `COUNT` over the filtered dataset and a column-types scan — where the stream endpoint runs one. A 100k read at the default chunk size therefore issues roughly 150 queries instead of 50, and all but the first `COUNT` is unused (the reader only needs `total` from page 1). Measured per-request cost is 22% higher than the stream endpoint at identical page size, which is why the sequential case does not improve. A `total=false` / skip-count query parameter on that endpoint would make this path strictly faster than the cursor stream at every thread count.

**Review round 2** (2 findings from @petrotiurin, 3 from `baz-reviewer[bot]`):

- **Reads were not snapshot-consistent** — pages are addressed by offset and the backend sorts newest id first, so an item inserted mid-read landed at offset 0 and shifted every unfetched page, returning one item twice and skipping another. The cursor stream got snapshot semantics for free from its `id < last_retrieved_id` seek, so this was a genuine regression against it, and it landed on callers that match items by exact equality. Every page now carries one version hash, resolved once per read; backends without dataset versioning fall back to a live read, documented on `stream_items()`. Regression tests drive an insert at offset 0 between pages and assert the unversioned read duplicates (so a regression in the pinning surfaces as that test passing) while the pinned read does not.
- **Abandoning the iterator blocked** — the yields happen inside the thread pool's `with` scope, so closing the generator ran `shutdown(wait=True)` and waited for every outstanding page, potentially at GC time on an unrelated line. Now `try/finally` with `cancel_futures=True, wait=False`; test asserts `close()` returns in under one page delay with pages in flight.
- Two test-quality findings were acknowledged and deliberately not taken here: driving the real `HttpClient` via `httpx.MockTransport` (worth doing SDK-wide rather than in this PR — the plumbing is covered e2e today), and tightening the cap test's assertions (correct, but the same count and content are asserted by neighbouring tests).

Because version pinning changes which backend query runs, the payload parity check was re-run against the previous implementation: byte-identical, and still identical across 3-50 pages at 1 and 8 threads.

**Review round 1** (5 findings from `baz-reviewer[bot]`, all addressed):

- A missing, non-numeric or negative `total` in a page response silently capped the read at page 1 and returned part of the dataset as if it were all of it. `total` and `content` are now validated, raising `OpikException` that says why continuing would be wrong.
- `chunk_size` was unbounded and forwarded straight to the endpoint's `size`, so oversized values could materialize an unbounded page and values above int32 failed only after the request went out. Now capped at `DATASET_STREAM_BATCH_SIZE`. This one **rejects** rather than clamps, unlike the thread ceiling — handing back smaller pages than asked for would look like the argument had no effect.
- `stream_items()` resolved the dataset id eagerly, doing a by-name REST lookup before iteration began. The `Dataset` hook is now a generator, so it defers to first iteration; the laziness test previously only checked httpx and would have passed regardless, and now asserts the lookup itself.
- The `nb_samples` `ValueError` was undocumented. Both docstrings and the guide now state the valid range and what to pass for an unbounded read.
- The `Dataset.from_public` id seeding had no test. Added, plus the fallback case where the response carries no id.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-8253

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation, tests, benchmarking, and documentation
- Human verification: author review; `chunk_size` default and API shape chosen by the author against the measurements below

## Testing

### Automated

```bash
# unit — full SDK suite
cd sdks/python && venv/bin/python -m pytest tests/unit -q          # 5208 passed, 4 skipped

# e2e — against a local backend (./opik.sh)
OPIK_URL_OVERRIDE=http://localhost:5173/api/ venv/bin/python -m pytest \
  tests/e2e/test_dataset.py tests/e2e/compatibility_v1/test_dataset.py \
  tests/e2e/test_cli_import_export.py tests/e2e/evaluation -q      # 107 passed

# lint / types
pre-commit run --files <changed files>                             # ruff, ruff-format, mypy clean
```

New unit coverage (61 tests) drives a fake items endpoint that records every call and tracks peak in-flight requests: chunk ordering, real concurrency at `num_threads > 1` versus strictly serial at `1`, `nb_samples` limiting both items *and* pages fetched, filter serialization, laziness, error mapping, and argument validation. Separate tests pin `get_items()` to the new path, assert it equals `stream_items()` output, and cover its `num_threads` argument — that it is forwarded (real concurrency observed), that `1` is strictly serial, that the thread count never changes the result, that invalid values raise, and that positional calls like `get_items(10)` still mean `nb_samples`.

New e2e coverage: 10k items over 10 pages at 8 threads, asserting every item exactly once and that the 8-thread id order matches the 1-thread order; plus `nb_samples`, `filter_string`, and a `DatasetVersion` snapshot read. `test_cli_import_export.py` is included deliberately — the CLI import path matches dataset items by exact dict equality minus `id`, so any drift in the returned payload fails it.

### Payload parity with the previous implementation

`__internal_api__stream_items_as_dataclasses__` is unchanged on this branch, so the old `get_items()` expression could be run in the same process as the new one and compared directly. Ordered (not set) comparison, all **byte-identical**:

- Values: nested dicts/lists, int, int > 2^53, float, both bools, `None`, empty dict/list/string, zero, unicode + emoji, list-of-dicts.
- An item written through REST with all seven shadowing keys (`id`, `source`, `description`, `trace_id`, `span_id`, `evaluators`, `execution_policy`) inside its `data` — both paths reduce it identically and both warn once.
- `filter_string` matching some rows and none; `nb_samples` at 1/2/3 and at the exact item count.
- Ordering across 2, 5, 10, 20, 50 and 200 pages at 1 and 8 threads — identical every time.

### Performance

100k items, local Docker backend, small rows (~480 bytes). Baseline is `main` checked out in a separate worktree, 3+ repeats each, fresh client and `get_dataset()` per repeat.

| | median | vs baseline |
|---|---|---|
| baseline `get_items()` | 3.82 s | 1.0x |
| `get_items()` (default: 2000 x 4 threads) | **1.35 s** | **2.8x** |

`stream_items()` by thread count, `chunk_size=2000`:

| num_threads | median | vs baseline |
|---|---|---|
| 1 | 4.01 s | 0.9x |
| 2 | 2.06 s | 1.9x |
| 4 (default) | 1.17 s | 3.3x |
| 8 | 0.77 s | 5.0x |
| 16 | 0.98 s | 3.9x |
| 32 | 1.12 s | 3.4x |

Read honestly: **the gain here is parallelism, not the Fern bypass.** Decomposing a sequential read shows the bypass does work as intended — client-side parsing drops from 0.64 s to 0.21 s, a 3x saving — but it is outweighed by the paginated endpoint's 22% higher per-request server cost described under Details, which is why `num_threads=1` lands slightly behind the baseline. Larger pages amortize it (measured at 5000: 2.43 s sequential, 1.8x faster than baseline, and 5.5x at 4 threads), but `chunk_size` is deliberately capped at `DATASET_STREAM_BATCH_SIZE` so a read can never request a bigger page than the typed stream's own batch and peak memory stays bounded as before. `chunk_size` is therefore a downward knob, for datasets whose individual items are large; the sequential case is left to the backend follow-up above rather than bought with unbounded pages. Two caveats on the absolute numbers: a single local backend container understates network latency (which parallelism helps more with) and overstates backend contention (which it helps less with), and these rows are small, so this measures request overhead rather than parse throughput — heavier per-item payloads should favor the Fern bypass more.

### Not run

Backend, frontend and TypeScript SDK suites — no changes in those areas.

## Documentation

- `apps/opik-documentation/documentation/fern/docs-v2/evaluation/advanced/manage_datasets.mdx` — new "Downloading large datasets faster" section leading with `get_items(num_threads=8)`, then `stream_items()` for datasets too large to hold in memory, a `filter_string`/`nb_samples` example, and a note on the `chunk_size` tradeoff.
- Docstrings on `get_items()` and `stream_items()` cover `num_threads`, the returned shape, the `2 * num_threads` look-ahead, and which direction to move `chunk_size`.
