### PR TITLE
[OPIK-8254] [SDK] fix: resolve tsx locally in runner E2E test and widen registration timeout

### DIFF
--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -53,6 +53,7 @@
         "msw": "^2.11.6",
         "prettier": "^3.4.1",
         "tsup": "^8.3.6",
+        "tsx": "~4.21.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.24.0",
         "vite-tsconfig-paths": "^5.1.3",
@@ -1679,7 +1680,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -2026,7 +2026,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2864,7 +2863,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2929,7 +2927,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4599,7 +4596,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5296,7 +5292,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5518,6 +5513,25 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsx": {
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.1.tgz",
+      "integrity": "sha512-5QE2Q04cN1u0993w0LT5rPw3faZqZU1fFn1mGE0pV53N1Dn7c+QFFxQu1mBeSgeOXwFyTicZw02wVgp3Tb5cAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5549,7 +5563,6 @@
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5643,7 +5656,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5780,7 +5792,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6152,7 +6163,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -70,6 +70,7 @@
     "msw": "^2.11.6",
     "prettier": "^3.4.1",
     "tsup": "^8.3.6",
+    "tsx": "~4.21.0",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.24.0",
     "vite-tsconfig-paths": "^5.1.3",

--- a/sdks/typescript/tests/integration/runner/runner.test.ts
+++ b/sdks/typescript/tests/integration/runner/runner.test.ts
@@ -24,7 +24,7 @@ const PROJECT_NAME = `ts-runner-e2e-${Date.now()}`;
 
 const JOB_COMPLETION_TIMEOUT = 30_000;
 const TRACE_PROPAGATION_TIMEOUT = 30_000;
-const AGENT_REGISTRATION_TIMEOUT = 10_000;
+const AGENT_REGISTRATION_TIMEOUT = 30_000;
 const RUNNER_STARTUP_TIMEOUT = 15_000;
 
 function sleep(ms: number): Promise<void> {
@@ -112,9 +112,10 @@ describe.skipIf(!shouldRunApiTests)("Runner Integration Tests", () => {
       env.OPIK_WORKSPACE = process.env.OPIK_WORKSPACE;
     }
 
-    // Spawn echo_app.ts with tsx
+    // Spawn echo_app.ts with tsx. Resolve tsx through Node rather than `npx`,
+    // which would fetch it from the registry inside the registration timeout.
     outputLines = [];
-    runnerProcess = spawn("npx", ["tsx", ECHO_APP], {
+    runnerProcess = spawn(process.execPath, [require.resolve("tsx/cli"), ECHO_APP], {
       env,
       cwd: path.resolve(__dirname, "../../.."),
       stdio: ["pipe", "pipe", "pipe"],


### PR DESCRIPTION
## Details

The TypeScript SDK E2E workflow went fully red (0 green / 9 red on the day it started, against 31 green / 1 red the day before) because the runner integration test's `beforeAll` hook timed out waiting for the `echo` / `echo_config` agents to register. The test spawned its fixture with `npx tsx`, but `tsx` was never a declared dependency — so `npm ci` did not install it and `npx` fetched it from the npm registry *inside* the 10s registration window on every CI run. That margin had always been thin: on the last green run `beforeAll` consumed ~9.0s of its 10s budget and passed by a hair.

This is not a code regression — no SDK source changed, and the lockfile had not moved since a green run. The fix removes the unpinned network fetch from the timed path and gives the wait a budget consistent with the rest of the file.

- Add `tsx` to `devDependencies`, pinned to the `4.21` line (`~4.21.0`) so it resolves against the `esbuild 0.27.2` already pinned via `tsup` rather than nesting a second native binary. The `4.23` line wants `esbuild ~0.28.0` and would add a duplicate ~10MB binary to every install.
- Spawn the fixture via `process.execPath` + `require.resolve("tsx/cli")` instead of `npx`, so resolution goes through Node against the installed dependency and never touches the registry.
- Raise `AGENT_REGISTRATION_TIMEOUT` from 10s to 30s, matching `JOB_COMPLETION_TIMEOUT` and `TRACE_PROPAGATION_TIMEOUT` in the same file. The `beforeAll` hook timeout is derived from that constant, so it widens automatically.

Note that `test:integration` already runs with `--retry 2` and it did not help: Vitest does not retry a failed `beforeAll` hook the way it retries test bodies.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8254

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation — CI log analysis, root-cause diagnosis, and the fix
- Human verification: developer reviewed the diagnosis and chose the `tsx` version pin and spawn form; changes verified locally against a running Opik backend

## Testing

Verified locally against a local Opik server (`OPIK_URL_OVERRIDE=http://localhost:8080`) on macOS.

Commands run, from `sdks/typescript`:

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx eslint tests/integration/runner/runner.test.ts` — clean
- `npx vitest run tests/integration/runner/runner.test.ts` — 5 consecutive runs, 5/5 passed (3.3–3.9s each)
- `npx vitest run tests/integration --retry 2` — the runner test passes under the full parallel suite (5864ms), which is the CPU-contention condition that reproduced the CI failure
- Pre-commit ran the `eslint — typescript sdk` and `typecheck — typescript sdk` hooks on commit; both passed

Scenarios validated:

- Fixture boot: instrumented `echo_app.ts` startup reaches "Runner activated" in ~1.7s via the locally resolved `tsx`, versus an unbounded registry fetch previously — measured against both the old 10s and new 30s budgets.
- Dependency resolution: confirmed a single `node_modules/esbuild@0.27.2` on disk after install, with no nested copy under `node_modules/tsx/`. An earlier attempt with `^4.21.0` resolved to 4.23.13 and did nest a duplicate, which is why the spec is a tilde rather than a caret.
- Module resolution: confirmed `require.resolve("tsx/cli")` works in this suite's transpiled-to-CJS test environment (the file already relies on `__dirname`), resolving to the local `node_modules/tsx/dist/cli.mjs`.
- Re-ran the runner test after rebasing onto latest `main` — still green.

Not run locally: the LLM-backed evaluation suites, which need `OPENAI_API_KEY` / `ANTHROPIC_API_KEY`. Those 31 failures in the full-suite run are environmental and unrelated to this change; CI has the keys and covers them.

## Documentation

N/A — no user-facing or API surface change. The only non-test change is a dev dependency addition.
