### PR TITLE
[OPIK-8102] [FE] fix: add a "none" thinking level so Flash Lite models stay non-thinking

### DIFF
--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -623,8 +623,9 @@ describe("Gemini thinking level", () => {
       "medium",
       "high",
     ]);
-    // 3.1 Flash Lite has only minimal and high.
+    // 3.1 Flash Lite has only minimal and high, plus "none" because it does not think by default.
     expect(values(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE)).toEqual([
+      "none",
       "minimal",
       "high",
     ]);
@@ -639,12 +640,14 @@ describe("Gemini thinking level", () => {
     expect(
       getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH),
     ).toBe("medium");
+    // Flash Lite is the exception: measured against the live API it does not think by default, so it
+    // preselects "none" rather than the "minimal" Google's docs table claims.
     expect(
       getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE),
-    ).toBe("minimal");
+    ).toBe("none");
     expect(
       getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE),
-    ).toBe("minimal");
+    ).toBe("none");
   });
 
   it("only ever preselects a level the model actually offers", () => {
@@ -841,6 +844,51 @@ describe("sanitizeConfigForRequest — Gemini thinking", () => {
         custom_parameters: { thinking: { level: "low" } },
       }).custom_parameters,
     ).toEqual({ thinking: { level: "high" } });
+  });
+
+  // The Flash Lite models do not think by default, so their preselected level must not switch
+  // thinking on — that regressed latency ~2x for a customer (OPIK-8102 follow-up).
+  it("defaults the Flash Lite models to none, which sends nothing", () => {
+    for (const model of [
+      PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE,
+      PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE,
+      PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE,
+      PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH_LITE,
+    ]) {
+      expect(getDefaultThinkingLevel(model), `default for ${model}`).toBe(
+        "none",
+      );
+      expect(
+        getThinkingLevelOptions(model).map((o) => o.value),
+        `${model} should offer none`,
+      ).toContain("none");
+      expect(
+        sanitizeConfigForRequest(model, { temperature: 0 }).custom_parameters,
+        `${model} should send no thinking block by default`,
+      ).toBeUndefined();
+    }
+  });
+
+  it("sends no thinking block for an explicit none", () => {
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, {
+        thinkingLevel: "none",
+      }).custom_parameters,
+    ).toBeUndefined();
+  });
+
+  // A thinking-by-default model keeps its level: none is only for the models that ship without it.
+  it("does not offer none to models that think by default", () => {
+    for (const model of [
+      PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH,
+      PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_7_FLASH,
+      PROVIDER_MODEL_TYPE.GEMINI_3_PRO,
+    ]) {
+      expect(
+        getThinkingLevelOptions(model).map((o) => o.value),
+        `${model} should not offer none`,
+      ).not.toContain("none");
+    }
   });
 
   it("adds no thinking block for models without a level control", () => {

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -869,6 +869,39 @@ describe("sanitizeConfigForRequest — Gemini thinking", () => {
     }
   });
 
+  // "none" must REMOVE a persisted block, not merely decline to add one, or the level saved before
+  // this change keeps being sent and the model keeps thinking.
+  it("clears a persisted thinking block when none is selected", () => {
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, {
+        thinkingLevel: "none",
+        custom_parameters: {
+          thinking: { level: "minimal" },
+          unrelated: "keep",
+        },
+      }).custom_parameters,
+    ).toEqual({ unrelated: "keep" });
+  });
+
+  it("drops custom_parameters entirely when none leaves it empty", () => {
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, {
+        thinkingLevel: "none",
+        custom_parameters: { thinking: { level: "minimal" } },
+      }).custom_parameters,
+    ).toBeUndefined();
+  });
+
+  // auto is the weaker "let the model decide" and must not delete fields the form cannot represent.
+  it("leaves a persisted thinking block alone for auto", () => {
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GEMINI_2_5_FLASH, {
+        thinkingLevel: "auto",
+        custom_parameters: { thinking: { budget_tokens: 4096 } },
+      }).custom_parameters,
+    ).toEqual({ thinking: { budget_tokens: 4096 } });
+  });
+
   it("sends no thinking block for an explicit none", () => {
     expect(
       sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, {

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -526,6 +526,9 @@ export const sanitizeConfigForRequest = (
     // sanitized output and feed it back — the optimizer form reloads a saved run's `parameters`
     // blob wholesale — have no flat thinkingLevel to offer, and substituting the model default
     // there would silently reset the user's saved choice on every re-run.
+    // A nested level the model still offers is a real past choice and is honoured — including on the
+    // Flash Lite models, where an explicitly saved "minimal" keeps thinking on. Only the *default*
+    // changed to "none"; a level someone chose is not overridden.
     const nested = (
       (sanitized.custom_parameters as Record<string, unknown> | undefined)
         ?.thinking as Record<string, unknown> | undefined
@@ -543,9 +546,24 @@ export const sanitizeConfigForRequest = (
     // level, so leaving it on the payload can only be dead weight.
     delete sanitized.thinkingLevel;
 
-    // "auto" and "none" both mean "send no thinkingConfig" — that absence IS the setting. They differ
-    // only in what they promise the user: auto lets a thinking model pick its own budget, none keeps a
-    // non-thinking model as it ships. `level` is already known to be one this model offers.
+    // "none" is an explicit "do not think": it has to remove any persisted thinking block, not merely
+    // decline to add one, or a level saved earlier keeps being sent and the model keeps thinking.
+    if (level === "none") {
+      const rest = omit(
+        (sanitized.custom_parameters ?? {}) as Record<string, unknown>,
+        "thinking",
+      );
+
+      if (Object.keys(rest).length > 0) {
+        sanitized.custom_parameters = rest;
+      } else {
+        delete sanitized.custom_parameters;
+      }
+    }
+
+    // "auto" also sends no thinkingConfig, but it is a weaker statement — "let the model decide" —
+    // so it leaves a persisted block alone rather than deleting fields the form cannot represent.
+    // `level` is already known to be one this model offers.
     if (
       level !== "auto" &&
       level !== "none" &&

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -107,17 +107,31 @@ const THINKING_LEVELS_BY_MODEL: ReadonlyMap<
   [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_6_FLASH, MINIMAL_TO_HIGH],
   [PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH, MINIMAL_TO_HIGH],
   [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH, MINIMAL_TO_HIGH],
-  [PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE, MINIMAL_TO_HIGH],
-  [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH_LITE, MINIMAL_TO_HIGH],
+  [PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE, ["none", ...MINIMAL_TO_HIGH]],
+  [
+    PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH_LITE,
+    ["none", ...MINIMAL_TO_HIGH],
+  ],
   [PROVIDER_MODEL_TYPE.GEMINI_3_1_PRO, LOW_TO_HIGH],
   [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_PRO, LOW_TO_HIGH],
-  // 3.1 Flash Lite is the odd one out: minimal and high only, no low/medium.
-  [PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, ["minimal", "high"]],
-  [PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE_PREVIEW, ["minimal", "high"]],
-  [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE, ["minimal", "high"]],
+  // The Flash Lite models do not think by default — verified live: zero thinking tokens on both a
+  // trivial and a deliberately hard prompt, on both providers. So they lead with "none", which sends
+  // no thinkingConfig and keeps their latency where it was. Asking for a level here switches thinking
+  // ON, which measurably slows them (~2.5s -> ~5s at budget 2048 on 3.1 Flash Lite).
+  //
+  // 3.1 Flash Lite also has no low/medium: minimal and high only.
+  [PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, ["none", "minimal", "high"]],
+  [
+    PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE_PREVIEW,
+    ["none", "minimal", "high"],
+  ],
+  [
+    PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE,
+    ["none", "minimal", "high"],
+  ],
   [
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE_PREVIEW,
-    ["minimal", "high"],
+    ["none", "minimal", "high"],
   ],
   [PROVIDER_MODEL_TYPE.GEMINI_3_FLASH, MINIMAL_TO_HIGH],
   [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_FLASH_PREVIEW, MINIMAL_TO_HIGH],
@@ -143,6 +157,7 @@ const THINKING_LEVELS_BY_MODEL: ReadonlyMap<
 
 const THINKING_LEVEL_LABELS: Record<GeminiThinkingLevel, string> = {
   auto: "Auto",
+  none: "None",
   off: "Off",
   minimal: "Minimal",
   low: "Low",
@@ -191,7 +206,10 @@ export const getThinkingLevelOptions = (
     (value) => ({ label: THINKING_LEVEL_LABELS[value], value }),
   );
 
-// Each model's own default thinking level, from the same Google support table. Preselecting the
+// Each model's own default thinking level. Measured against the live API rather than taken from
+// Google's docs table, which disagrees with it: the docs list 3.5 Flash Lite as defaulting to
+// "minimal", but every Flash Lite model returns zero thinking tokens by default on both providers.
+// Preselecting the
 // documented default keeps the control from silently changing a model's behaviour just by being
 // shown: 2.5 Flash Lite ships with thinking off, 2.5 Pro/Flash default to a dynamic budget
 // ("auto"), 3.7/3.6/3.5 Flash default to medium, and 3.5 Flash Lite to minimal — none of which is
@@ -228,23 +246,23 @@ const DEFAULT_THINKING_LEVEL_BY_MODEL: ReadonlyMap<
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH,
     "medium" as GeminiThinkingLevel,
   ],
-  [PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE, "minimal" as GeminiThinkingLevel],
+  [PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH_LITE, "none" as GeminiThinkingLevel],
   [
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH_LITE,
-    "minimal" as GeminiThinkingLevel,
+    "none" as GeminiThinkingLevel,
   ],
-  [PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, "minimal" as GeminiThinkingLevel],
+  [PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, "none" as GeminiThinkingLevel],
   [
     PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE_PREVIEW,
-    "minimal" as GeminiThinkingLevel,
+    "none" as GeminiThinkingLevel,
   ],
   [
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE,
-    "minimal" as GeminiThinkingLevel,
+    "none" as GeminiThinkingLevel,
   ],
   [
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_1_FLASH_LITE_PREVIEW,
-    "minimal" as GeminiThinkingLevel,
+    "none" as GeminiThinkingLevel,
   ],
 ]);
 
@@ -525,9 +543,14 @@ export const sanitizeConfigForRequest = (
     // level, so leaving it on the payload can only be dead weight.
     delete sanitized.thinkingLevel;
 
-    // "auto" means "send nothing and let the model decide", so it is deliberately not folded in —
-    // that absence IS the setting. `level` is already known to be one this model offers.
-    if (level !== "auto" && thinkingLevelOptions.length > 0) {
+    // "auto" and "none" both mean "send no thinkingConfig" — that absence IS the setting. They differ
+    // only in what they promise the user: auto lets a thinking model pick its own budget, none keeps a
+    // non-thinking model as it ships. `level` is already known to be one this model offers.
+    if (
+      level !== "auto" &&
+      level !== "none" &&
+      thinkingLevelOptions.length > 0
+    ) {
       const customParameters =
         (sanitized.custom_parameters as Record<string, unknown>) ?? {};
       // Merge into any existing thinking block rather than replacing it — the backend also reads

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -1028,11 +1028,16 @@ export interface LLMOpenRouterConfigsType {
   maxConcurrentRequests?: number;
 }
 
-// "auto" and "off" are Opik's own, not Google levels: pre-Gemini-3 models take a numeric
-// thinking_budget, and these are how the level control expresses that model's dynamic default
-// (send no thinkingConfig) and a zero budget.
+// "auto", "none" and "off" are Opik's own, not Google levels. All three describe what we send
+// rather than a value the API accepts:
+//   auto — send no thinkingConfig, so a thinking-by-default model applies its own dynamic budget
+//   none — send no thinkingConfig, on a model that does not think by default (so nothing is added)
+//   off  — send an explicit zero budget, for a pre-Gemini-3 model that thinks unless told not to
+// auto and none are the same wire behaviour under two labels, because "let the model decide" and
+// "no thinking" are the same request but a very different promise to the user.
 export type GeminiThinkingLevel =
   | "auto"
+  | "none"
   | "off"
   | "minimal"
   | "low"

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.thinking.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.thinking.test.ts
@@ -99,6 +99,21 @@ describe("LLM judge thinking level round trip", () => {
     });
   });
 
+  // "none" removes a persisted block; "auto" (above) leaves one alone.
+  it("clears a persisted thinking block when the level is none", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.GEMINI_3_1_FLASH_LITE, {
+        thinkingLevel: "none",
+        custom_parameters: {
+          thinking: { level: "minimal" },
+          unrelated: "keep",
+        },
+      }),
+    );
+
+    expect(object.model.custom_parameters).toEqual({ unrelated: "keep" });
+  });
+
   // "off" is the exception: a persisted budget would outrank it server-side and leave thinking on.
   it("clears a persisted budget when the level is off", () => {
     const object = convertLLMJudgeDataToLLMJudgeObject(

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -160,7 +160,7 @@ const LLMJudgeBaseSchema = z.object({
     // Held as its own field so the shared model-config control can drive it, then folded into
     // custom_parameters.thinking on save — the backend reads it from there.
     thinkingLevel: z
-      .enum(["auto", "off", "minimal", "low", "medium", "high"])
+      .enum(["auto", "none", "off", "minimal", "low", "medium", "high"])
       .optional(),
   }),
   template: z.nativeEnum(LLM_JUDGE),
@@ -594,6 +594,7 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
   const thinkingCustomParameters =
     thinkingLevel != null &&
     thinkingLevel !== "auto" &&
+    thinkingLevel !== "none" &&
     getThinkingLevelOptions(data.model as PROVIDER_MODEL_TYPE).some(
       (o) => o.value === thinkingLevel,
     )
@@ -632,6 +633,7 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
   const formRejectedItsLevel =
     thinkingLevel != null &&
     thinkingLevel !== "auto" &&
+    thinkingLevel !== "none" &&
     !thinkingCustomParameters;
   const otherCustomParameters =
     thinkingCustomParameters || formRejectedItsLevel

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -630,13 +630,18 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
   // level of its own here", not "delete whatever else was in there": budget_tokens and
   // include_thoughts are not represented in the form, and Anthropic keeps type/budget_tokens under
   // this same key for extended thinking.
+  // "none" is an explicit "do not think", so it removes a persisted thinking block rather than just
+  // declining to add one — otherwise a level saved earlier keeps being sent. "auto" is the weaker
+  // "let the model decide" and leaves the block alone, since it may hold fields the form cannot
+  // represent (budget_tokens, include_thoughts, or Anthropic's type).
+  const formClearsThinking = thinkingLevel === "none";
   const formRejectedItsLevel =
     thinkingLevel != null &&
     thinkingLevel !== "auto" &&
     thinkingLevel !== "none" &&
     !thinkingCustomParameters;
   const otherCustomParameters =
-    thinkingCustomParameters || formRejectedItsLevel
+    thinkingCustomParameters || formRejectedItsLevel || formClearsThinking
       ? omit(persistedCustomParameters, "thinking")
       : persistedCustomParameters;
 


### PR DESCRIPTION
## Details

Follow-up to #8024 (merged), fixing a latency regression it introduced for a customer on `vertex_ai/gemini-3.1-flash-lite`: ~1.1s → ~5s per call, and an experiment from ~5min to 20+min.

The cause is ours. The Flash Lite models **do not think by default** — measured live on both providers, zero thinking tokens on a trivial *and* a deliberately hard prompt — but the capability table preselected `minimal` for them, and #8024 made the preselected level persist and actually get sent. So merely opening the model config switched thinking on for a model shipped without it.

Latency tracks thinking tokens spent. Same prompt, `vertex_ai/gemini-3.1-flash-lite`:

| sent | thinking tokens | latency |
|---|---|---|
| nothing (pre-#8024) | 0 | ~2.5s |
| `minimal` → budget 512 | 151 | ~3.4s |
| budget 2048 (our `low`) | 965 | ~4.9s |

Those defaults came from Google's docs table, which lists 3.5 Flash Lite as defaulting to `minimal`. The live API disagrees. Defaults are now measured rather than documented, and the comment says so.

## Why a new `none` rather than reusing `auto`

Both send no `thinkingConfig`, so they are identical on the wire — but they promise different things:

- **`auto`** — let a thinking-by-default model pick its own budget (2.5 family)
- **`none`** — keep a non-thinking model as it ships (Flash Lite)

Labelling Flash Lite "Auto" would tell the user the model decides how much to think, when it does not think at all. `none` is offered only to models that ship without thinking, is their default, and makes thinking there opt-in.

## Not included

Moving the Vertex path onto `langchain4j-google-genai` (new `com.google.genai` SDK, which has a native `thinkingLevel` plus `returnThinking`) is the *proper* fix for driving Gemini 3 — Google treats level and budget as mutually exclusive and recommends the level. Verified it exists and exposes Vertex mode (`projectId`/`location`), but it is `beta29` and swapping provider clients changes auth, streaming and response mapping. That belongs in its own ticket, not a hotfix.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8102

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): claude-opus-5
- Scope: Reproducing the regression against live Vertex/Gemini keys, root-causing it to the preselected default, the fix, tests, and this description.
- Human verification: Author reproduced the customer's latency report on staging and confirmed the fix restores the original request shape.

## Testing

- **Frontend**: `npx vitest run` → **2321 pass**; typecheck and `eslint --max-warnings=0` clean. New tests assert all four Flash Lite entries default to `none`, offer it, and send no thinking block — and that thinking-by-default models are *not* offered it.
- **Live, on staging with real Vertex + Gemini keys**: `none` produces 0 thinking tokens and ~2.5s across repeats, matching pre-#8024 behaviour. Also re-confirmed Flash Lite yields 0 thinking tokens by default on both providers and on both an easy and a hard prompt, which is what makes `none` the honest label.
- **Backend**: untouched. `none` never reaches it, exactly like `auto`.

**Not reproduced:** the customer also reports intermittent "Unexpected error" at ~90-100s. I could not reproduce that, only the consistent latency increase. Their budget-exhaustion theory is plausible but unproven — a failing trace ID would settle it. Flagging rather than claiming this PR fixes it.

## Documentation

No docs change: the control is a playground/rule-form affordance and the dropdown carries an explainer tooltip.
