### PR TITLE
[NA] [GHA] Skip npm audit in TS SDK CI installs and raise the publish job timeout to 15m

### DIFF
--- a/.github/actions/typescript-sdk-build-and-publish/action.yml
+++ b/.github/actions/typescript-sdk-build-and-publish/action.yml
@@ -66,7 +66,12 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working_directory }}
-      run: npm ci
+      # `--no-audit` drops the post-install vulnerability report. That report is a
+      # separate call to npm's audit endpoint, which stalled for npm's full 300s
+      # fetch-timeout during a registry incident (run 33867982882) and pushed the
+      # SDK publish job past its limit. Nothing here acts on the report, and it
+      # does not change what gets installed.
+      run: npm ci --no-audit
 
     - name: Generate version
       id: version

--- a/.github/actions/typescript-sdk-build-and-publish/action.yml
+++ b/.github/actions/typescript-sdk-build-and-publish/action.yml
@@ -66,11 +66,8 @@ runs:
     - name: Install dependencies
       shell: bash
       working-directory: ${{ inputs.working_directory }}
-      # `--no-audit` drops the post-install vulnerability report. That report is a
-      # separate call to npm's audit endpoint, which stalled for npm's full 300s
-      # fetch-timeout during a registry incident (run 33867982882) and pushed the
-      # SDK publish job past its limit. Nothing here acts on the report, and it
-      # does not change what gets installed.
+      # The audit call can hang for npm's 300s fetch-timeout when the registry
+      # misbehaves (run 33867982882). Nothing here reads the report.
       run: npm ci --no-audit
 
     - name: Generate version

--- a/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_compatibility_v1_e2e_tests.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install TypeScript SDK dependencies
         working-directory: sdks/typescript
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Build TypeScript SDK
         working-directory: sdks/typescript

--- a/.github/workflows/typescript_sdk_e2e_tests.yml
+++ b/.github/workflows/typescript_sdk_e2e_tests.yml
@@ -125,7 +125,7 @@ jobs:
 
       - name: Install TypeScript SDK dependencies
         working-directory: sdks/typescript
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Build TypeScript SDK
         working-directory: sdks/typescript

--- a/.github/workflows/typescript_sdk_library_integration_tests.yml
+++ b/.github/workflows/typescript_sdk_library_integration_tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: echo "::warning::ANTHROPIC_API_KEY is not set - live LLM tests will be skipped (deterministic tests still run)."
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -53,9 +53,8 @@ concurrency:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    # 15, not 5: npm's default per-request fetch-timeout is 300s, so a 5-minute
-    # job cannot outlast a single stalled registry request. Matches
-    # typescript_sdk_integration_publish.yml.
+    # npm's per-request fetch-timeout is 300s; a 5-minute job cannot outlast one
+    # stalled request. Matches typescript_sdk_integration_publish.yml.
     timeout-minutes: 15
     permissions:
       # `contents: write` — the release path commits the version bump and pushes it.

--- a/.github/workflows/typescript_sdk_publish.yml
+++ b/.github/workflows/typescript_sdk_publish.yml
@@ -53,7 +53,10 @@ concurrency:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 15, not 5: npm's default per-request fetch-timeout is 300s, so a 5-minute
+    # job cannot outlast a single stalled registry request. Matches
+    # typescript_sdk_integration_publish.yml.
+    timeout-minutes: 15
     permissions:
       # `contents: write` — the release path commits the version bump and pushes it.
       # `id-token: write` — mints the OIDC token npm trusted publishing exchanges for

--- a/.github/workflows/typescript_sdk_unit_tests.yml
+++ b/.github/workflows/typescript_sdk_unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: ${{ matrix.node-version || '20' }}
 
       - name: Install dependencies (npm)
-        run: npm ci
+        run: npm ci --no-audit
 
       - name: Run tests (npm)
         run: npm run test


### PR DESCRIPTION
## Details

Today's release run [33867982882](https://github.com/comet-ml/opik/actions/runs/33867982882) was cancelled: the `release-typescript-sdk / build-and-publish` job hit its `timeout-minutes: 5` while `npm ci` sat waiting on npm's audit endpoint. npm's status page opened the incident "npm audits endpoint is having issues" at 11:29 UTC, one minute after the install step started. Everything else in the release went through, and `opik@2.2.50` was published by re-running the failed jobs once the endpoint recovered enough.

The root cause is a mismatch between two timeouts:

- `npm ci` runs a post-install audit: a separate request to the registry's advisory endpoint. Failure is non-fatal, but npm waits for the answer up to its default `fetch-timeout` of 300s before giving up.
- The SDK publish job's limit of 5 minutes is shorter than that single wait, so one stalled request kills the job. The five integration packages ran the same composite action in the same run under `timeout-minutes: 15`; their `npm ci` took 152s to 301s and all of them published.

Three changes:

1. `npm ci --no-audit` in `.github/actions/typescript-sdk-build-and-publish/action.yml`. One line covers the SDK and all five integrations. It does not change what gets installed.
2. `timeout-minutes: 5` → `15` in `typescript_sdk_publish.yml`, matching `typescript_sdk_integration_publish.yml`. Safety net for the next stall, whichever endpoint it comes from.
3. `npm ci --no-audit` in the four TS SDK test workflows that install from the same lockfile (unit tests, both E2E suites, library integration tests). Their 15-30m limits absorb a stall, but not for free: today's E2E run spent 7 minutes in `npm ci` on it. Same lockfile, same unused output, so the flag is applied consistently (raised in review).

What we give up: the vulnerability count printed at the end of the publish log (yesterday: "15 vulnerabilities (4 moderate, 10 high, 1 critical)"). Nothing in the job acts on it, and it carries no debugging value for install or build failures. The same signal already lives in the Security tab: Dependabot alerts scan `sdks/typescript/package-lock.json` (32 open alerts today), per package and persistent, so the log line was a weaker duplicate. If we want a hard gate on vulnerabilities, an explicit `npm audit --audit-level=high` step in the unit-test workflow is the place for it, not a side effect of publishing.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues
- NA. Follow-up to release run 33867982882 (attempt 1 cancelled, attempt 2 green).

## Testing
- Compared `npm ci` durations across runs: yesterday's SDK job 6s; today's SDK job killed at ~4.6 min; today's integration jobs 152s / 157s / 254s / 301s / 301s. The 301s ones are npm's 300s `fetch-timeout`, and their output has no "audited N packages" line, i.e. the audit call gave up and npm carried on.
- Both files parse as YAML (Ruby's `YAML.load_file`). `actionlint` is not available locally.
- This PR touches `typescript_sdk_publish.yml`, which is in that workflow's `pull_request` path filter, so the build-only path (with `--no-audit`) runs on this PR.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5.1
- Scope: root-cause investigation from the Actions logs and npm status page, the workflow change, and the PR text
- Human verification: pending review

## Documentation

N/A. CI-only change; no user-facing or developer-facing documentation surface.
