### PR TITLE
[NA] [SDK] fix: interpolate missing item id into DatasetItemUpdateOperationRequiresItemId messages

### DIFF
--- a/sdks/python/src/opik/api_objects/dataset/dataset.py
+++ b/sdks/python/src/opik/api_objects/dataset/dataset.py
@@ -1035,7 +1035,7 @@ class Dataset(DatasetExportOperations):
         for item in items:
             if "id" not in item:
                 raise exceptions.DatasetItemUpdateOperationRequiresItemId(
-                    "Missing id for dataset item to update: %s", item
+                    f"Missing id for dataset item to update: {item}"
                 )
 
         self.insert(items, deduplication=deduplication)

--- a/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
+++ b/sdks/python/src/opik/api_objects/dataset/test_suite/test_suite.py
@@ -682,7 +682,7 @@ class TestSuite:
         for item in items:
             if "id" not in item:
                 raise opik_exceptions.DatasetItemUpdateOperationRequiresItemId(
-                    "Missing id for test suite item to update: %s", item
+                    f"Missing id for test suite item to update: {item}"
                 )
 
         self.insert(items, deduplication=deduplication)

--- a/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_dataset_client.py
@@ -8,6 +8,7 @@ import pytest
 from opik.api_objects import constants
 from opik.api_objects.dataset import dataset_item
 from opik.api_objects.dataset.dataset import Dataset
+from opik import exceptions
 
 
 def _make_items(count: int) -> list:
@@ -736,3 +737,24 @@ def test_insert__repeated_inserts__backend_version_probed_once(monkeypatch):
         "Parallel upload is the default, so the version gate must be probed once "
         "per dataset rather than once per insert"
     )
+
+
+def test_update__item_without_id__raises_with_item_in_message():
+    mock_rest_client = Mock()
+
+    dataset = Dataset(
+        name="test_dataset",
+        description="Test description",
+        project_name="Test project",
+        rest_client=mock_rest_client,
+    )
+
+    item = {"input": {"key": "value"}}
+
+    with pytest.raises(
+        exceptions.DatasetItemUpdateOperationRequiresItemId,
+        match=r"Missing id for dataset item to update: .*'input'.*",
+    ):
+        dataset.update([item])
+
+    mock_rest_client.datasets.create_or_update_dataset_items.assert_not_called()

--- a/sdks/python/tests/unit/api_objects/dataset/test_suite/test_test_suite.py
+++ b/sdks/python/tests/unit/api_objects/dataset/test_suite/test_test_suite.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 from unittest import mock
 
+from opik import exceptions as opik_exceptions
 from opik.api_objects.dataset.test_suite import test_suite
 from opik.api_objects.dataset.test_suite import suite_result_constructor
 from opik.api_objects.dataset.test_suite import types as suite_types
@@ -1069,3 +1070,23 @@ class TestImportExport:
         assert inserted[0].execution_policy is not None
         assert inserted[0].execution_policy.runs_per_item == 3
         assert inserted[0].execution_policy.pass_threshold == 2
+
+
+def test_update__item_without_id__raises_with_item_in_message():
+    mock_dataset = mock.Mock()
+    mock_dataset.get_items.return_value = []
+
+    suite = test_suite.TestSuite(
+        name="test-suite",
+        dataset_=mock_dataset,
+    )
+
+    item = {"input": {"key": "value"}}
+
+    with pytest.raises(
+        opik_exceptions.DatasetItemUpdateOperationRequiresItemId,
+        match=r"Missing id for test suite item to update: .*'input'.*",
+    ):
+        suite.update([item])
+
+    mock_dataset.insert.assert_not_called()


### PR DESCRIPTION
## Details
`DatasetItemUpdateOperationRequiresItemId` inherits from `OpikException`, which does no printf-style formatting — so `raise ...("Missing id for dataset item to update: %s", item)` rendered as a literal tuple `("Missing id ... %s", {'id': ...})` instead of an interpolated message. The same pattern existed in the test-suite copy of the check. Switched both to f-strings; no tests assert the old message text.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: ZCode (AI coding agent)
- Model(s): GLM
- Scope: identified the exception formatting defect in the two `update()` paths; human verified both call sites and that no test pins the old message
- Human verification: yes — reproduced the raw-tuple rendering with `python3 -c` against `OpikException` semantics before fixing

## Testing
`python3 -m compileall` on both touched files; the change is message-only (`str(exception)` previously showed the tuple). Not run: full pytest suite (local env lacks the SDK's full dependency set); the touched paths have no message assertions in `sdks/python/tests`.

## Documentation
None needed.
