### PR TITLE
[NA] [SDK] docs: document entrypoint/environment args and fix garbled task_threads docstring

### DIFF
--- a/sdks/python/src/opik/api_objects/opik_client.py
+++ b/sdks/python/src/opik/api_objects/opik_client.py
@@ -313,6 +313,8 @@ class Opik:
             thread_id: Used to group multiple traces into a thread.
                 The identifier is user-defined and has to be unique per project.
             attachments: The list of attachments to be uploaded to the trace.
+            environment: The environment in which the trace was created, e.g. 'production'
+                or 'development'. If not provided, falls back to the client's configured environment.
 
         Returns:
             trace.Trace: The created trace object.

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -92,6 +92,10 @@ class BaseTrackDecorator(abc.ABC):
             project_name: The name of the project to log data.
             create_duplicate_root_span: Whether to create a root span duplicating the root trace data.
             source: The source of the trace.
+            entrypoint: Whether the decorated function is an entrypoint. Entrypoints
+                are shown separately in the Opik UI.
+            environment: The environment in which the trace was created, e.g. 'production'
+                or 'development'. Defaults to the configured environment when not set.
 
         Returns:
             Callable: The decorated function(if used without parentheses)

--- a/sdks/python/src/opik/decorator/base_track_decorator.py
+++ b/sdks/python/src/opik/decorator/base_track_decorator.py
@@ -92,8 +92,9 @@ class BaseTrackDecorator(abc.ABC):
             project_name: The name of the project to log data.
             create_duplicate_root_span: Whether to create a root span duplicating the root trace data.
             source: The source of the trace.
-            entrypoint: Whether the decorated function is an entrypoint. Entrypoints
-                are shown separately in the Opik UI.
+            entrypoint: Whether the decorated function is an entrypoint. Marked
+                agents are collected for the Opik UI's agent view, which currently
+                renders the first registered entrypoint only.
             environment: The environment in which the trace was created, e.g. 'production'
                 or 'development'. Defaults to the configured environment when not set.
 

--- a/sdks/python/src/opik/evaluation/evaluator.py
+++ b/sdks/python/src/opik/evaluation/evaluator.py
@@ -206,8 +206,8 @@ def evaluate(
         nb_samples: number of samples to evaluate. If no value is provided, all samples in the dataset will be evaluated.
 
         task_threads: number of thread workers to run tasks. If set to 1, no additional
-            threads are created, all tasks executed in the current thread sequentially.
-            are executed sequentially in the current thread.
+            threads are created and all tasks are executed sequentially in the current
+            thread.
             Use more than 1 worker if your task object is compatible with sharing across threads.
 
         prompt: Prompt object to link with experiment. Deprecated, use `prompts` argument instead.
@@ -1366,8 +1366,8 @@ def evaluate_optimization_trial(
         nb_samples: number of samples to evaluate. If no value is provided, all samples in the dataset will be evaluated.
 
         task_threads: number of thread workers to run tasks. If set to 1, no additional
-            threads are created, all tasks executed in the current thread sequentially.
-            are executed sequentially in the current thread.
+            threads are created and all tasks are executed sequentially in the current
+            thread.
             Use more than 1 worker if your task object is compatible with sharing across threads.
 
         prompt: Prompt object to link with experiment. Deprecated, use `prompts` argument instead.


### PR DESCRIPTION
## Details
Docstring-only fix in the Python SDK: `BaseTrackDecorator.track()` documented neither `entrypoint` nor `environment` (both real keyword parameters), `Opik.trace()` documented neither `environment` nor its fallback to the client-configured environment, and the `task_threads` docstring in `evaluator.py` (both `evaluate()` and `evaluate_dataframe()`/variant) contained a duplicated, broken sentence from two merged revisions. No behavior change.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: ZCode (AI coding agent)
- Model(s): GLM
- Scope: docstring/signature cross-check over sdks/python; wording for the two new Args entries follows the surrounding style; the environment fallback wording mirrors the actual `if environment is None: environment = self._config.environment` logic
- Human verification: yes — every claimed-missing parameter was checked against its signature

## Testing
`python3 -m compileall` on the three touched files passes. Docstring-only; no tests assert these texts.

## Documentation
Docstrings feed the published SDK API reference, which is the point of the fix.
