### PR TITLE
[OPIK-8262] [QA] Proposed e2e spec from the #8162 exploration: thread-scoped rule fan-out

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringBaseScorer.java
@@ -3,6 +3,7 @@ package com.comet.opik.api.resources.v1.events;
 import com.comet.opik.api.FeedbackScoreItem;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
+import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.events.RedisSubscriberMessage;
 import com.comet.opik.api.filter.Operator;
@@ -12,6 +13,7 @@ import com.comet.opik.domain.FeedbackScoreService;
 import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceSearchCriteria;
 import com.comet.opik.domain.TraceService;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.OnlineScoringStreamConfigurationAdapter;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -31,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
@@ -251,5 +254,45 @@ public abstract class OnlineScoringBaseScorer<M extends RedisSubscriberMessage> 
                             .concatWith(Flux
                                     .defer(() -> retrieveFullThreadContext(threadId, lastReceivedIdRef, projectId)));
                 }));
+    }
+
+    /**
+     * Routes a trace-thread entry down one of two branches: an entry carrying several thread ids was
+     * written by an older build and is <b>migrated</b> — republished as one entry per id, never scored —
+     * while the single-id entries this build writes are <b>scored</b> normally. Completion therefore does
+     * not mean "scored", so per-outcome logging belongs inside {@code scoreThread} or in the migrate
+     * branch, never on the returned Mono.
+     *
+     * <p>Migrating rather than scoring avoids needing a rule for reducing N per-thread outcomes into the
+     * one verdict a stream entry gets, which must mis-serve somebody when a permanent failure and a
+     * retryable one land together. Each replacement entry gets its own retry budget instead.
+     *
+     * <p>The ack is implicit: this returns the republish, so a failure leaves the entry unacked and it
+     * redelivers. If the republish succeeds but the ack fails, the entry splits twice and some threads are
+     * scored twice — tolerable because {@code feedback_scores} is a {@code ReplacingMergeTree} versioned on
+     * {@code last_updated_at}, so the second score overwrites rather than duplicating.
+     *
+     * <p>The migrate branch is a temporary shim, deletable once no pre-split entry can be in flight.
+     */
+    protected Mono<Void> migrateOrScoreThreadIds(@NonNull M message, @NonNull List<String> threadIds,
+            @NonNull OnlineScorePublisher publisher, @NonNull Function<String, M> singleThreadIdCopy,
+            @NonNull Function<String, Mono<Void>> scoreThread) {
+        if (threadIds.size() > 1) {
+            // Logged on success, and worded so it can never be mistaken for a scoring log.
+            return publisher.enqueueMessage(threadIds.stream().map(singleThreadIdCopy).toList(), type)
+                    .doOnSuccess(unused -> log.info(
+                            "Migrated '{}' legacy thread ids to single-id entries for workspace '{}'; "
+                                    + "no scoring performed for this entry",
+                            threadIds.size(), message.workspaceId()));
+        }
+        // @NotEmpty says this cannot happen; if it does, no retry would help, so let it be acked away.
+        if (threadIds.isEmpty()) {
+            log.warn("Discarding trace-thread entry with no thread ids for workspace '{}'", message.workspaceId());
+            return Mono.empty();
+        }
+        return scoreThread.apply(threadIds.getFirst())
+                .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
+                        .put(RequestContext.USER_NAME, message.userName())
+                        .put(RequestContext.VISIBILITY, Visibility.PRIVATE));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorer.java
@@ -4,7 +4,6 @@ import com.comet.opik.api.Project;
 import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
-import com.comet.opik.api.Visibility;
 import com.comet.opik.api.attachment.EntityType;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.evaluators.LlmAsJudgeMessage;
@@ -19,6 +18,7 @@ import com.comet.opik.domain.evaluation.EvaluatedThread;
 import com.comet.opik.domain.evaluation.EvaluationRecorder;
 import com.comet.opik.domain.evaluation.OnlineEvaluationRecorder;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.domain.llm.ChatCompletionService;
 import com.comet.opik.domain.llm.LlmProviderFactory;
@@ -35,7 +35,6 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
@@ -70,6 +69,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
     private final ServiceTogglesConfig serviceTogglesConfig;
     private final OnlineEvaluationRecorder onlineEvaluationRecorder;
     private final AttachmentService attachmentService;
+    private final OnlineScorePublisher onlineScorePublisher;
 
     @Inject
     public OnlineScoringTraceThreadLlmAsJudgeScorer(@NonNull @Config("onlineScoring") OnlineScoringConfig config,
@@ -85,7 +85,8 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
             @NonNull AgenticScoringService agenticScoringService,
             @NonNull SpanService spanService,
             @NonNull OnlineEvaluationRecorder onlineEvaluationRecorder,
-            @NonNull AttachmentService attachmentService) {
+            @NonNull AttachmentService attachmentService,
+            @NonNull OnlineScorePublisher onlineScorePublisher) {
         super(config, redisson, feedbackScoreService, traceService, spanService, TRACE_THREAD_LLM_AS_JUDGE,
                 Constants.TRACE_THREAD_LLM_AS_JUDGE);
         this.aiProxyService = aiProxyService;
@@ -97,6 +98,7 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         this.serviceTogglesConfig = serviceTogglesConfig;
         this.onlineEvaluationRecorder = onlineEvaluationRecorder;
         this.attachmentService = attachmentService;
+        this.onlineScorePublisher = onlineScorePublisher;
         this.userFacingLogger = UserFacingLoggingFactory.getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
     }
 
@@ -112,25 +114,14 @@ public class OnlineScoringTraceThreadLlmAsJudgeScorer extends OnlineScoringBaseS
         log.info("Message received with projectId: '{}', ruleId: '{}', threadIds: '{}' for workspace '{}'",
                 message.projectId(), message.ruleId(), message.threadIds(), message.workspaceId());
 
-        return Flux.fromIterable(message.threadIds())
-                // Score each thread id independently: a single thread's failure must not stop scoring the
-                // sibling thread ids. Per-thread errors are materialized (onErrorResume) so the flatMap
-                // completes for every thread; the batch's first failure is then re-surfaced below. This keeps
-                // the failure on the Mono error path handled by BaseRedisSubscriber.processMessage's
-                // onErrorResume — classified as a processing error, following the normal retryable/
-                // non-retryable path — instead of leaking into the enclosing onErrorContinue via Flux.flatMap
-                // (which would drop the element and count it as an "unexpected" error).
-                .flatMap(threadId -> processThreadScores(message, threadId)
-                        .then(Mono.<Throwable>empty())
-                        .onErrorResume(Mono::just))
-                .collectList()
-                .flatMap(errors -> errors.isEmpty() ? Mono.<Void>empty() : Mono.error(errors.getFirst()))
-                .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName())
-                        .put(RequestContext.VISIBILITY, Visibility.PRIVATE))
-                .doOnSuccess(unused -> log.info(
-                        "Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
-                        message.projectId(), message.ruleId(), message.workspaceId()))
+        // The success log sits inside the scoring callback: a migrated entry completes this chain without
+        // scoring anything, so a doOnSuccess out here would claim work that never happened.
+        return migrateOrScoreThreadIds(message, message.threadIds(), onlineScorePublisher,
+                threadId -> message.toBuilder().threadIds(List.of(threadId)).build(),
+                threadId -> processThreadScores(message, threadId)
+                        .doOnSuccess(unused -> log.info(
+                                "Processed trace thread '{}' for projectId '{}', ruleId '{}' for workspace '{}'",
+                                threadId, message.projectId(), message.ruleId(), message.workspaceId())))
                 .doOnError(error -> log.error(
                         "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}'",
                         message.projectId(), message.ruleId(), message.workspaceId(), error))

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -4,7 +4,6 @@ import com.comet.opik.api.Project;
 import com.comet.opik.api.ScoreSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
-import com.comet.opik.api.Visibility;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluator;
 import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.domain.FeedbackScoreService;
@@ -12,6 +11,7 @@ import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.SpanService;
 import com.comet.opik.domain.TraceService;
 import com.comet.opik.domain.evaluators.AutomationRuleEvaluatorService;
+import com.comet.opik.domain.evaluators.OnlineScorePublisher;
 import com.comet.opik.domain.evaluators.UserLog;
 import com.comet.opik.domain.evaluators.python.PythonEvaluatorService;
 import com.comet.opik.domain.threads.TraceThreadService;
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.redisson.api.RedissonReactiveClient;
 import org.slf4j.Logger;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 import ru.vyarus.dropwizard.guice.module.installer.feature.eager.EagerSingleton;
@@ -62,6 +61,7 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
     private final ProjectService projectService;
     private final AutomationRuleEvaluatorService automationRuleEvaluatorService;
     private final AgenticScoringService agenticScoringService;
+    private final OnlineScorePublisher onlineScorePublisher;
 
     @Inject
     public OnlineScoringTraceThreadUserDefinedMetricPythonScorer(
@@ -75,7 +75,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
             @NonNull ProjectService projectService,
             @NonNull AutomationRuleEvaluatorService automationRuleEvaluatorService,
             @NonNull SpanService spanService,
-            @NonNull AgenticScoringService agenticScoringService) {
+            @NonNull AgenticScoringService agenticScoringService,
+            @NonNull OnlineScorePublisher onlineScorePublisher) {
         super(config, redisson, feedbackScoreService, traceService, spanService,
                 TRACE_THREAD_USER_DEFINED_METRIC_PYTHON,
                 Constants.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
@@ -85,6 +86,7 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         this.projectService = projectService;
         this.automationRuleEvaluatorService = automationRuleEvaluatorService;
         this.agenticScoringService = agenticScoringService;
+        this.onlineScorePublisher = onlineScorePublisher;
         this.userFacingLogger = UserFacingLoggingFactory
                 .getLogger(OnlineScoringTraceThreadUserDefinedMetricPythonScorer.class);
     }
@@ -104,25 +106,14 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
         log.info("Message received with projectId '{}', ruleId '{}' for workspace '{}'",
                 message.projectId(), message.ruleId(), message.workspaceId());
 
-        return Flux.fromIterable(message.threadIds())
-                // Score each thread id independently: a single thread's failure must not stop scoring the
-                // sibling thread ids. Per-thread errors are materialized (onErrorResume) so the flatMap
-                // completes for every thread; the batch's first failure is then re-surfaced below. This keeps
-                // the failure on the Mono error path handled by BaseRedisSubscriber.processMessage's
-                // onErrorResume — classified as a processing error, following the normal retryable/
-                // non-retryable path — instead of leaking into the enclosing onErrorContinue via Flux.flatMap
-                // (which would drop the element and count it as an "unexpected" error).
-                .flatMap(threadId -> processThreadScores(message, threadId)
-                        .then(Mono.<Throwable>empty())
-                        .onErrorResume(Mono::just))
-                .collectList()
-                .flatMap(errors -> errors.isEmpty() ? Mono.<Void>empty() : Mono.error(errors.getFirst()))
-                .contextWrite(context -> context.put(RequestContext.WORKSPACE_ID, message.workspaceId())
-                        .put(RequestContext.USER_NAME, message.userName())
-                        .put(RequestContext.VISIBILITY, Visibility.PRIVATE))
-                .doOnSuccess(unused -> log.info(
-                        "Processed trace threads for projectId '{}', ruleId '{}' for workspace '{}'",
-                        message.projectId(), message.ruleId(), message.workspaceId()))
+        // The success log sits inside the scoring callback: a migrated entry completes this chain without
+        // scoring anything, so a doOnSuccess out here would claim work that never happened.
+        return migrateOrScoreThreadIds(message, message.threadIds(), onlineScorePublisher,
+                threadId -> message.toBuilder().threadIds(List.of(threadId)).build(),
+                threadId -> processThreadScores(message, threadId)
+                        .doOnSuccess(unused -> log.info(
+                                "Processed trace thread '{}' for projectId '{}', ruleId '{}' for workspace '{}'",
+                                threadId, message.projectId(), message.ruleId(), message.workspaceId())))
                 .doOnError(error -> log.error(
                         "Error processing trace thread for projectId '{}', ruleId '{}' for workspace '{}'",
                         message.projectId(), message.ruleId(), message.workspaceId(), error))

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/ManualEvaluationService.java
@@ -185,8 +185,8 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                 .toList();
         Mono<Void> traceThreadMono = Flux.fromIterable(traceThreadRules)
                 .flatMap(rule -> {
-                    log.info("Enqueueing trace-thread evaluation for rule '{}' with '{}' trace IDs", rule.getId(),
-                            traceIdStrings.size());
+                    log.info("Enqueueing '{}' trace-thread evaluation messages, one per trace ID, for rule '{}'",
+                            traceIdStrings.size(), rule.getId());
                     return onlineScorePublisher.enqueueThreadMessage(traceIdStrings, rule, projectId, workspaceId,
                             userName);
                 })
@@ -384,8 +384,8 @@ class ManualEvaluationServiceImpl implements ManualEvaluationService {
                     // reactive context. enqueueThreadMessage does a blocking rule lookup, so defer onto boundedElastic.
                     return Flux.fromIterable(rules)
                             .flatMap(rule -> {
-                                log.info("Enqueueing evaluation for rule '{}' with '{}' thread IDs", rule.getId(),
-                                        threadIds.size());
+                                log.info("Enqueueing '{}' evaluation messages, one per thread ID, for rule '{}'",
+                                        threadIds.size(), rule.getId());
                                 return onlineScorePublisher.enqueueThreadMessage(threadIds, rule, projectId,
                                         workspaceId, userName);
                             })

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/evaluators/OnlineScorePublisher.java
@@ -56,29 +56,29 @@ public interface OnlineScorePublisher {
     Mono<Void> enqueueMessage(List<?> messages, AutomationRuleEvaluatorType type);
 
     /**
-     * Enqueues a thread message for scoring based on the provided rule. The returned publisher must be subscribed
-     * for the enqueue to happen.
+     * Enqueues thread messages for scoring — <b>one stream entry per thread id</b>, not one for the batch.
+     * The returned publisher must be subscribed for the enqueue to happen.
      *
-     * @param threadIds   the IDs of the threads to score
+     * @param threadIds   the IDs of the threads to score; one message is published per element
      * @param ruleId      the ID of the rule to apply
      * @param projectId   the ID of the project
      * @param workspaceId the ID of the workspace
      * @param userName    the name of the user who initiated the scoring
-     * @return a {@link Mono} that completes once the message is enqueued
+     * @return a {@link Mono} that completes once all messages are enqueued
      */
     Mono<Void> enqueueThreadMessage(List<String> threadIds, UUID ruleId, UUID projectId, String workspaceId,
             String userName);
 
     /**
-     * Enqueues a thread message for an already-resolved rule, avoiding the blocking rule lookup that the
-     * {@code ruleId} overload performs. Prefer this when the caller already holds the {@link AutomationRuleEvaluator}.
+     * Enqueues thread messages for an already-resolved rule, avoiding the blocking rule lookup that the
+     * {@code ruleId} overload performs. Publishes <b>one stream entry per thread id</b>.
      *
-     * @param threadIds   the IDs of the threads to score
+     * @param threadIds   the IDs of the threads to score; one message is published per element
      * @param rule        the already-resolved automation rule evaluator
      * @param projectId   the ID of the project
      * @param workspaceId the ID of the workspace
      * @param userName    the name of the user who initiated the scoring
-     * @return a {@link Mono} that completes once the message is enqueued
+     * @return a {@link Mono} that completes once all messages are enqueued
      */
     Mono<Void> enqueueThreadMessage(List<String> threadIds, AutomationRuleEvaluator<?, ?> rule, UUID projectId,
             String workspaceId, String userName);
@@ -185,16 +185,27 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
             @NonNull AutomationRuleEvaluator<?, ?> rule, @NonNull UUID projectId, @NonNull String workspaceId,
             @NonNull String userName) {
 
-        // Caller already holds the resolved rule — no findById needed.
+        // Caller already holds the resolved rule -- no findById needed.
+        //
+        // One message PER THREAD ID, not one carrying the whole list: the subscriber acks and removes per
+        // stream entry, so an entry holding N ids forces N independent outcomes through a single verdict.
+        // Splitting means a retry replays exactly the thread that failed. Costs N entries where there was
+        // one; the streams are capped by streamMaxLen and trimmed non-strictly.
         return switch (rule) {
             case AutomationRuleEvaluatorTraceThreadLlmAsJudge llmAsJudge -> enqueueMessage(
-                    List.of(toLlmAsJudgeMessage(threadIds, rule.getId(), projectId, workspaceId, userName,
-                            llmAsJudge.getCode())),
+                    threadIds.stream()
+                            .map(threadId -> toLlmAsJudgeMessage(threadId, rule.getId(), projectId, workspaceId,
+                                    userName, llmAsJudge.getCode()))
+                            .toList(),
                     rule.getType());
             case AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython definedMetricPython -> {
                 if (serviceTogglesConfig.isTraceThreadPythonEvaluatorEnabled()) {
-                    yield enqueueMessage(List.of(toDefinedMetricPython(threadIds, rule.getId(), projectId,
-                            workspaceId, userName, definedMetricPython.getCode())), rule.getType());
+                    yield enqueueMessage(
+                            threadIds.stream()
+                                    .map(threadId -> toDefinedMetricPython(threadId, rule.getId(), projectId,
+                                            workspaceId, userName, definedMetricPython.getCode()))
+                                    .toList(),
+                            rule.getType());
                 }
                 log.warn("Trace Thread online scoring python evaluator is disabled, skipping enqueueing "
                         + "for ruleId: '{}'", rule.getId());
@@ -204,10 +215,14 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
         };
     }
 
-    private TraceThreadToScoreLlmAsJudge toLlmAsJudgeMessage(List<String> threadIds, UUID ruleId, UUID projectId,
+    /**
+     * {@code threadIds} stays a list even though this puts one id in it: narrowing the field would make
+     * the multi-id entries left by the previous build undecodable during the rolling upgrade.
+     */
+    private TraceThreadToScoreLlmAsJudge toLlmAsJudgeMessage(String threadId, UUID ruleId, UUID projectId,
             String workspaceId, String userName, TraceThreadLlmAsJudgeCode code) {
         return TraceThreadToScoreLlmAsJudge.builder()
-                .threadIds(threadIds)
+                .threadIds(List.of(threadId))
                 .ruleId(ruleId)
                 .projectId(projectId)
                 .workspaceId(workspaceId)
@@ -216,10 +231,11 @@ class OnlineScorePublisherImpl implements OnlineScorePublisher {
                 .build();
     }
 
-    private TraceThreadToScoreUserDefinedMetricPython toDefinedMetricPython(List<String> threadIds, UUID ruleId,
+    /** @see #toLlmAsJudgeMessage on why {@code threadIds} stays a list. */
+    private TraceThreadToScoreUserDefinedMetricPython toDefinedMetricPython(String threadId, UUID ruleId,
             UUID projectId, String workspaceId, String userName, TraceThreadUserDefinedMetricPythonCode code) {
         return TraceThreadToScoreUserDefinedMetricPython.builder()
-                .threadIds(threadIds)
+                .threadIds(List.of(threadId))
                 .ruleId(ruleId)
                 .projectId(projectId)
                 .workspaceId(workspaceId)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -3,6 +3,9 @@ package com.comet.opik.domain.llm;
 import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.utils.ChunkedOutputHandlers;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import dev.langchain4j.exception.AuthenticationException;
 import dev.langchain4j.exception.HttpException;
@@ -36,6 +39,7 @@ import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
@@ -135,8 +139,9 @@ public class ChatCompletionService {
         try {
             log.info("Initiating chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
-            chatResponse = retryPolicy
-                    .withRetry(() -> failFastOnUnsupportedFeature(() -> languageModelClient.chat(chatRequest)));
+            chatResponse = retryPolicy.withRetry(
+                    () -> failFastOnPermanentFailure(
+                            () -> failFastOnUnsupportedFeature(() -> languageModelClient.chat(chatRequest))));
             log.info("Completed chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             return chatResponse;
@@ -147,16 +152,29 @@ public class ChatCompletionService {
 
             Optional<ErrorMessage> providerError = provider.getLlmProviderError(runtimeException);
 
-            providerError
-                    .ifPresent(llmProviderError -> failHandlingLLMProviderError(runtimeException, llmProviderError));
+            // Deliberately NOT failHandlingLLMProviderError here, unlike create() and the streaming handler:
+            // those answer an HTTP caller and want the status verbatim, whereas this answers the online-
+            // scoring subscribers, where the thrown TYPE decides retryability. Recovering the status here
+            // would make the whole 4xx family non-retryable, transient 408s and 429s included.
+            //
+            // Permanence is decided only from a status the provider actually sent. The mappers synthesize
+            // one when they cannot parse the body (CustomLlm 400, OpenAi 500) and nothing downstream can
+            // tell that apart from a real 400, so consulting them would drop every unparseable CustomLlm
+            // failure on its first delivery. Retrying a permanent error costs maxRetries attempts; dropping
+            // an unknown one loses the evaluation, so an absent status stays retryable.
+            var wireStatus = findProviderHttpStatus(runtimeException);
 
-            // No failIfProviderReportedHttpStatus here, unlike create() and the streaming handler. This method is
-            // called only by the online-scoring subscribers, never from a resource, so a recovered status reaches no
-            // HTTP client — while BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS lists ClientErrorException, so turning
-            // a rate limit into a 429 or a provider timeout into a 408 would make the subscriber ack and drop the
-            // evaluation instead of honouring onlineScoring.maxRetries. Both are RetriableException upstream, so the
-            // blanket 500 is what keeps them retryable.
             log.warn(UNEXPECTED_ERROR_CALLING_LLM_PROVIDER, runtimeException);
+
+            if (wireStatus.filter(ChatCompletionService::isPermanentFailure).isPresent()) {
+                // The subscriber acks and removes on the first delivery rather than burning
+                // maxRetries x pendingMessageDuration on a request whose outcome cannot change.
+                throw new ClientErrorException(buildDetailedErrorMessage(runtimeException), wireStatus.get(),
+                        runtimeException);
+            }
+            // Everything else stays a blanket 500 so it lands outside NON_RETRYABLE_EXCEPTIONS and honours
+            // onlineScoring.maxRetries -- including transient 4xx, a distinction ClientErrorException
+            // cannot express on its own.
             throw new InternalServerErrorException(buildDetailedErrorMessage(runtimeException), runtimeException);
         } finally {
             // Close the Vertex client (reused across retries) to release its GAX threads; other providers self-reclaim.
@@ -177,6 +195,25 @@ public class ChatCompletionService {
      * {@code withRetry} give up on the first attempt while leaving genuinely transient provider errors retryable. The
      * original exception is kept as the cause, so {@link #failIfUnsupportedFeature} still recognises it downstream.
      */
+    /**
+     * Skips the in-process retries for a provider status that can never succeed, mirroring
+     * {@link #failFastOnUnsupportedFeature}. Applied only on the scoreTrace path: {@code create()} answers an HTTP
+     * caller, and narrowing its retry behaviour is not this change's business. Mainly reached for VertexAI, whose GAX
+     * exceptions langchain4j does not model as {@code NonRetriableException}; the mapped providers already fail fast
+     * on their own. The cause is preserved, so the catch block still classifies from the same status.
+     */
+    private <T> T failFastOnPermanentFailure(Callable<T> action) throws Exception {
+        try {
+            return action.call();
+        } catch (RuntimeException runtimeException) {
+            if (findProviderHttpStatus(runtimeException).filter(ChatCompletionService::isPermanentFailure)
+                    .isPresent()) {
+                throw new NonRetriableException(runtimeException);
+            }
+            throw runtimeException;
+        }
+    }
+
     private <T> T failFastOnUnsupportedFeature(Callable<T> action) throws Exception {
         try {
             return action.call();
@@ -292,6 +329,47 @@ public class ChatCompletionService {
         return family == Response.Status.Family.CLIENT_ERROR || family == Response.Status.Family.SERVER_ERROR;
     }
 
+    /** 425 Too Early has no {@link Response.Status} constant; 408 and 429 do and are used directly. */
+    private static final int TOO_EARLY_STATUS = 425;
+
+    /**
+     * 4xx statuses that say "not now", not "not ever", so family alone can't decide retryability.
+     * langchain4j agrees on 408 and 429 but maps 425 to a non-retriable {@code InvalidRequestException};
+     * we diverge deliberately per RFC 8470, which is safe because retryability is read from the wire
+     * status, not the mapped type.
+     */
+    private static final Set<Integer> TRANSIENT_CLIENT_ERRORS = Set.of(
+            Response.Status.REQUEST_TIMEOUT.getStatusCode(),
+            TOO_EARLY_STATUS,
+            Response.Status.TOO_MANY_REQUESTS.getStatusCode());
+
+    /**
+     * Whether this exact request can never succeed, so the caller should give up rather than retry.
+     * Server errors are excluded: a 5xx is the textbook retry case. Anything unrecognised is retryable,
+     * matching {@code BaseRedisSubscriber}'s "unknown defaults to retryable for safety".
+     */
+    @VisibleForTesting
+    static boolean isPermanentFailure(int status) {
+        return familyOf(status) == Response.Status.Family.CLIENT_ERROR
+                && !TRANSIENT_CLIENT_ERRORS.contains(status);
+    }
+
+    /**
+     * VertexAI is the one provider whose client raises no {@link HttpException}: the Google Cloud SDK throws GAX
+     * {@code ApiException}, which is also not a {@code NonRetriableException}, so without this a permanent Vertex
+     * failure consumed the whole retry budget. The status is GAX's own transport-neutral translation, identical for
+     * the gRPC and HTTP-JSON transports, rather than a table of our own. An exception GAX itself marks retryable
+     * yields no status at all, so this can only ever prevent a drop, never cause one.
+     */
+    private static Optional<Integer> gaxHttpStatus(ApiException apiException) {
+        if (apiException.isRetryable()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(apiException.getStatusCode())
+                .map(StatusCode::getCode)
+                .map(StatusCode.Code::getHttpStatusCode);
+    }
+
     /**
      * The status langchain4j's own exception types stand for, used for providers whose clients raise them without an
      * {@link HttpException} in the chain. {@code ContentFilteredException} is covered by its
@@ -305,6 +383,7 @@ public class ChatCompletionService {
             case TimeoutException ignored -> Optional.of(Response.Status.REQUEST_TIMEOUT.getStatusCode());
             case RateLimitException ignored -> Optional.of(Response.Status.TOO_MANY_REQUESTS.getStatusCode());
             case InternalServerException ignored -> Optional.of(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+            case ApiException apiException -> gaxHttpStatus(apiException);
             default -> Optional.empty();
         };
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -20,6 +21,8 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class TraceThreadOnlineScorerPublisher {
+
+    private static final int THREAD_ID_LOG_SAMPLE = 10;
 
     private final @NonNull OnlineScorePublisher onlineScorePublisher;
 
@@ -49,18 +52,27 @@ class TraceThreadOnlineScorerPublisher {
                         Set<String> threadIds = ruleIdToThreadIds.getValue();
 
                         log.info(
-                                "Enqueuing threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                threadIds, ruleId, projectId, workspaceId);
+                                "Enqueuing '{}' stream entries, one per trace thread '{}' for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
+                                threadIds.size(), sampleOf(threadIds), ruleId, projectId, workspaceId);
 
                         // Composed into the deferContextual chain so the enqueue inherits this workspace context.
                         return onlineScorePublisher.enqueueThreadMessage(List.copyOf(threadIds), ruleId, projectId,
                                 workspaceId, userName)
                                 .doOnSuccess(unused -> log.info(
-                                        "Enqueued threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                        threadIds, ruleId, projectId, workspaceId));
+                                        "Enqueued '{}' stream entries, one per trace thread '{}' for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
+                                        threadIds.size(), sampleOf(threadIds), ruleId, projectId, workspaceId));
                     })
                     .then();
         });
+    }
+
+    /** Bounded so an arbitrarily large close batch can't dump its whole id list into the logs. */
+    private static String sampleOf(Collection<String> threadIds) {
+        if (threadIds.size() <= THREAD_ID_LOG_SAMPLE) {
+            return threadIds.toString();
+        }
+        return "%s (and %d more)".formatted(
+                threadIds.stream().limit(THREAD_ID_LOG_SAMPLE).toList(), threadIds.size() - THREAD_ID_LOG_SAMPLE);
     }
 
     private boolean isSampled(Map.Entry<UUID, Boolean> entry) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadLlmAsJudgeScorerTest.java
@@ -37,6 +37,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,6 +111,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     private OnlineEvaluationRecorder onlineEvaluationRecorder;
     @Mock
     private com.comet.opik.domain.attachment.AttachmentService attachmentService;
+    @Mock
+    private com.comet.opik.domain.evaluators.OnlineScorePublisher onlineScorePublisher;
 
     private OnlineScoringTraceThreadLlmAsJudgeScorer scorer;
     private AgenticScoringService agenticScoringService;
@@ -168,7 +171,8 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 agenticScoringService,
                 spanService,
                 onlineEvaluationRecorder,
-                attachmentService);
+                attachmentService,
+                onlineScorePublisher);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();
@@ -503,7 +507,7 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
     class ScoringTests {
 
         // Real evaluator code so prepareThreadLlmRequest renders against a valid schema.
-        private static final String EVALUATOR_JSON = """
+        static final String EVALUATOR_JSON = """
                 {
                   "model": { "name": "gpt-4o", "temperature": 0.3 },
                   "messages": [
@@ -518,7 +522,7 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                 """;
 
         // Matches the schema above; toFeedbackScores parses this into two FeedbackScoreBatchItem entries.
-        private static final String LLM_RESPONSE = """
+        static final String LLM_RESPONSE = """
                 {
                   "Relevance":   { "score": 4,   "reason": "on-topic" },
                   "Conciseness": { "score": 3.5, "reason": "could be tighter" }
@@ -781,6 +785,184 @@ class OnlineScoringTraceThreadLlmAsJudgeScorerTest {
                     eq(loggedMessage));
             verify(aiProxyService, never()).scoreTrace(any(), any(), any());
             verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+    }
+
+    /**
+     * OPIK-8262 split-on-read. This build writes one thread id per entry, so the ordinary path scores a
+     * single id and {@link BaseRedisSubscriber}'s per-entry ack retires exactly that thread's work. An
+     * entry carrying several ids was written by the PREVIOUS build; rather than score it under a second
+     * set of semantics (which would need a rule for reducing N outcomes into one verdict, and would have
+     * to mis-serve somebody when a permanent and a retryable failure land together), it is republished as
+     * N single-id entries and the original is acked away.
+     */
+    @Nested
+    @DisplayName("Split-on-read migration of legacy multi-id entries")
+    class SplitOnReadTests {
+
+        @Test
+        @DisplayName("A multi-id entry is republished one id per entry and never scored")
+        void multiIdEntryIsSplitAndNotScored() {
+            var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var message = sampleMessage().toBuilder()
+                    .threadIds(List.of(threadId, otherThreadId))
+                    .build();
+            when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher).enqueueMessage(captor.capture(),
+                    eq(com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE));
+            List<TraceThreadToScoreLlmAsJudge> republished = captor.getValue();
+            assertThat(republished)
+                    .as("one replacement entry per thread id")
+                    .hasSize(2);
+            assertThat(republished).allSatisfy(entry -> assertThat(entry.threadIds()).hasSize(1));
+            assertThat(republished.stream().map(entry -> entry.threadIds().getFirst()).toList())
+                    .containsExactlyInAnyOrder(threadId, otherThreadId);
+            assertThat(republished).allSatisfy(entry -> {
+                assertThat(entry.ruleId()).isEqualTo(message.ruleId());
+                assertThat(entry.projectId()).isEqualTo(message.projectId());
+                assertThat(entry.workspaceId()).isEqualTo(message.workspaceId());
+                assertThat(entry.userName()).isEqualTo(message.userName());
+                assertThat(entry.code()).isEqualTo(message.code());
+            });
+
+            // Migrated, not scored: nothing in the scoring chain is touched for the original entry.
+            verify(traceService, never()).search(anyInt(), any(TraceSearchCriteria.class));
+            verify(traceThreadService, never()).getThreadModelId(any(), any());
+            verify(aiProxyService, never()).scoreTrace(any(), any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        /**
+         * The ack is implicit — the base subscriber acks on a successful {@code score()}. So "not acked"
+         * is expressed as "score() errors", which is what makes the entry redeliver and the split retry.
+         */
+        @Test
+        @DisplayName("A failed republish fails the entry, so it is not acked and the split is retried")
+        void failedRepublishIsNotAcked() {
+            var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var message = sampleMessage().toBuilder()
+                    .threadIds(List.of(threadId, otherThreadId))
+                    .build();
+            var republishFailure = new IllegalStateException("redis unavailable");
+            when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.error(republishFailure));
+
+            assertThatThrownBy(() -> scorer.score(message).block())
+                    .as("acking a split that never landed would lose every thread id in the entry")
+                    .isSameAs(republishFailure);
+
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        @DisplayName("A single-id entry scores normally and republishes nothing")
+        void singleIdEntryIsScoredNotSplit() {
+            var code = JsonUtils.readValue(ScoringTests.EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+            var message = sampleMessage().toBuilder().code(code).build();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
+            stubSingleThreadHappyPath(trace, project, rule, code);
+
+            scorer.score(message).block();
+
+            verify(feedbackScoreService).scoreBatchOfThreads(any());
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
+        }
+
+        /**
+         * The migration path must not claim work it did not do. Before this was fixed the caller hung a
+         * {@code doOnSuccess} logging "Processed trace threads ..." off the whole chain, which completes on
+         * the migrate branch too — so a legacy entry that scored nothing logged as if it had. Diagnostics
+         * that misrepresent what happened are what made the originating incident take days to read, so the
+         * two outcomes are asserted to be distinguishable in a log search.
+         */
+        @Test
+        @DisplayName("Migrating a legacy entry never logs the scoring-success line")
+        void migrationDoesNotLogScoringSuccess() {
+            var scorerLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                    .getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
+            var baseLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                    .getLogger(OnlineScoringBaseScorer.class);
+            var appender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+            appender.start();
+            scorerLogger.addAppender(appender);
+            baseLogger.addAppender(appender);
+            try {
+                var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+                var message = sampleMessage().toBuilder()
+                        .threadIds(List.of(threadId, otherThreadId))
+                        .build();
+                when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
+
+                scorer.score(message).block();
+
+                var logged = appender.list.stream()
+                        .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                        .toList();
+                assertThat(logged)
+                        .as("nothing was scored, so no log may say it was")
+                        .noneMatch(line -> line.startsWith("Processed trace thread"));
+                assertThat(logged)
+                        .as("the migration needs its own greppable line, distinct from any scoring log")
+                        .anyMatch(line -> line.contains("Migrated '2' legacy thread ids to single-id entries"));
+            } finally {
+                scorerLogger.detachAppender(appender);
+                baseLogger.detachAppender(appender);
+                appender.stop();
+            }
+        }
+
+        @Test
+        @DisplayName("Scoring a single-id entry does log the scoring-success line")
+        void scoringLogsScoringSuccess() {
+            var scorerLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                    .getLogger(OnlineScoringTraceThreadLlmAsJudgeScorer.class);
+            var appender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+            appender.start();
+            scorerLogger.addAppender(appender);
+            try {
+                var code = JsonUtils.readValue(ScoringTests.EVALUATOR_JSON, TraceThreadLlmAsJudgeCode.class);
+                var message = sampleMessage().toBuilder().code(code).build();
+                var trace = sampleTrace();
+                var project = Project.builder().id(projectId).name("test-project").build();
+                var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder().name(ruleName).code(code).build();
+                stubSingleThreadHappyPath(trace, project, rule, code);
+
+                scorer.score(message).block();
+
+                assertThat(appender.list.stream()
+                        .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage).toList())
+                        .as("the scoring path is the one that may claim it scored")
+                        .anyMatch(line -> line.startsWith("Processed trace thread")
+                                && line.contains(threadId));
+            } finally {
+                scorerLogger.detachAppender(appender);
+                appender.stop();
+            }
+        }
+
+        private void stubSingleThreadHappyPath(Trace trace, Project project,
+                AutomationRuleEvaluatorTraceThreadLlmAsJudge rule, TraceThreadLlmAsJudgeCode code) {
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId)).thenReturn(rule);
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(llmProviderFactory.getStructuredOutputStrategy("gpt-4o")).thenReturn(new ToolCallingStrategy());
+            when(aiProxyService.scoreTrace(any(ChatRequest.class), eq(code.model()), eq(workspaceId)))
+                    .thenReturn(ChatResponse.builder()
+                            .aiMessage(AiMessage.aiMessage(ScoringTests.LLM_RESPONSE)).build());
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            Mockito.lenient().when(spanService.getSpansSizeByTraceIds(Set.of(trace.id())))
+                    .thenReturn(Mono.just(0L));
+            Mockito.lenient().when(spanService.getByTraceIds(Set.of(trace.id()))).thenReturn(Flux.empty());
+            Mockito.lenient()
+                    .when(attachmentService.hasAnyAttachmentByEntityIds(EntityType.TRACE, Set.of(trace.id())))
+                    .thenReturn(Mono.just(false));
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -29,6 +29,7 @@ import jakarta.ws.rs.NotFoundException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -96,6 +97,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
     private AutomationRuleEvaluatorService automationRuleEvaluatorService;
     @Mock
     private SpanService spanService;
+    @Mock
+    private com.comet.opik.domain.evaluators.OnlineScorePublisher onlineScorePublisher;
 
     private OnlineScoringTraceThreadUserDefinedMetricPythonScorer scorer;
     private MockedStatic<UserFacingLoggingFactory> mockedFactory;
@@ -146,7 +149,8 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                 projectService,
                 automationRuleEvaluatorService,
                 spanService,
-                agenticScoringService);
+                agenticScoringService,
+                onlineScorePublisher);
 
         projectId = UUID.randomUUID();
         ruleId = UUID.randomUUID();
@@ -498,6 +502,135 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
                     eq(ruleName),
                     eq(loggedMessage));
             verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+    }
+
+    /**
+     * OPIK-8262 split-on-read, mirrored from {@code OnlineScoringTraceThreadLlmAsJudgeScorerTest}. Both
+     * trace-thread scorers now share {@code OnlineScoringBaseScorer.migrateOrScoreThreadIds}, and a shared
+     * migration path tested through only one of them is exactly the drift risk that made sharing it the
+     * right call — the Python scorer supplies its own message-copy and scoring callbacks, so those are
+     * what these cases pin.
+     */
+    @Nested
+    @DisplayName("Split-on-read migration of legacy multi-id entries")
+    class SplitOnReadTests {
+
+        @Test
+        @DisplayName("A multi-id entry is republished one id per entry and never scored")
+        void multiIdEntryIsSplitAndNotScored() {
+            var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var message = sampleMessage().toBuilder()
+                    .threadIds(List.of(threadId, otherThreadId))
+                    .build();
+            when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(onlineScorePublisher).enqueueMessage(captor.capture(),
+                    eq(com.comet.opik.api.evaluators.AutomationRuleEvaluatorType.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON));
+            List<TraceThreadToScoreUserDefinedMetricPython> republished = captor.getValue();
+            assertThat(republished).hasSize(2);
+            assertThat(republished).allSatisfy(entry -> assertThat(entry.threadIds()).hasSize(1));
+            assertThat(republished.stream().map(entry -> entry.threadIds().getFirst()).toList())
+                    .containsExactlyInAnyOrder(threadId, otherThreadId);
+            // The Python scorer's own copy callback must preserve the metric code verbatim -- the migration
+            // does no rule lookup, so a dropped field here would silently change what gets evaluated.
+            assertThat(republished).allSatisfy(entry -> {
+                assertThat(entry.ruleId()).isEqualTo(message.ruleId());
+                assertThat(entry.projectId()).isEqualTo(message.projectId());
+                assertThat(entry.workspaceId()).isEqualTo(message.workspaceId());
+                assertThat(entry.userName()).isEqualTo(message.userName());
+                assertThat(entry.code()).isEqualTo(message.code());
+            });
+
+            verify(traceService, never()).search(anyInt(), any(TraceSearchCriteria.class));
+            verify(traceThreadService, never()).getThreadModelId(any(), any());
+            verify(pythonEvaluatorService, never()).evaluateThread(any(), any());
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        /** Ack is implicit, so "not acked" is expressed as "score() errors" -- see the base-class javadoc. */
+        @Test
+        @DisplayName("A failed republish fails the entry, so it is not acked and the split is retried")
+        void failedRepublishIsNotAcked() {
+            var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var message = sampleMessage().toBuilder()
+                    .threadIds(List.of(threadId, otherThreadId))
+                    .build();
+            var republishFailure = new IllegalStateException("redis unavailable");
+            when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.error(republishFailure));
+
+            assertThatThrownBy(() -> scorer.score(message).block()).isSameAs(republishFailure);
+
+            verify(feedbackScoreService, never()).scoreBatchOfThreads(any());
+        }
+
+        @Test
+        @DisplayName("A single-id entry scores normally and republishes nothing")
+        void singleIdEntryIsScoredNotSplit() {
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            var pythonScore = PythonScoreResult.builder()
+                    .name("test_score").value(BigDecimal.valueOf(0.95)).reason("ok").build();
+            stubMinimalPythonHappyPath(trace, project);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(pythonScore)));
+
+            scorer.score(message).block();
+
+            verify(feedbackScoreService).scoreBatchOfThreads(any());
+            verify(onlineScorePublisher, never()).enqueueMessage(any(), any());
+        }
+
+        @Test
+        @DisplayName("Migrating a legacy entry never logs the scoring-success line")
+        void migrationDoesNotLogScoringSuccess() {
+            var scorerLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                    .getLogger(OnlineScoringTraceThreadUserDefinedMetricPythonScorer.class);
+            var baseLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+                    .getLogger(OnlineScoringBaseScorer.class);
+            var appender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+            appender.start();
+            scorerLogger.addAppender(appender);
+            baseLogger.addAppender(appender);
+            try {
+                var otherThreadId = "thread-" + RandomStringUtils.secure().nextAlphanumeric(32);
+                var message = sampleMessage().toBuilder()
+                        .threadIds(List.of(threadId, otherThreadId))
+                        .build();
+                when(onlineScorePublisher.enqueueMessage(any(), any())).thenReturn(Mono.empty());
+
+                scorer.score(message).block();
+
+                var logged = appender.list.stream()
+                        .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+                        .toList();
+                assertThat(logged)
+                        .as("nothing was scored, so no log may say it was")
+                        .noneMatch(line -> line.startsWith("Processed trace thread"));
+                assertThat(logged)
+                        .anyMatch(line -> line.contains("Migrated '2' legacy thread ids to single-id entries"));
+            } finally {
+                scorerLogger.detachAppender(appender);
+                baseLogger.detachAppender(appender);
+                appender.stop();
+            }
+        }
+
+        private void stubMinimalPythonHappyPath(Trace trace, Project project) {
+            when(traceService.search(anyInt(), any(TraceSearchCriteria.class)))
+                    .thenReturn(Flux.just(trace), Flux.empty());
+            when(traceThreadService.getThreadModelId(projectId, threadId)).thenReturn(Mono.just(threadModelId));
+            when(automationRuleEvaluatorService.findById(ruleId, Set.of(projectId), workspaceId))
+                    .thenReturn(ruleFor(ruleName));
+            when(projectService.get(projectId, workspaceId)).thenReturn(project);
+            when(feedbackScoreService.scoreBatchOfThreads(any())).thenReturn(Mono.empty());
+            lenient().when(onlineScoringConfig.getAgenticToolsMaxPreloadMb()).thenReturn(64);
+            lenient().when(spanService.getSpansSizeByTraceIds(Set.of(trace.id()))).thenReturn(Mono.just(0L));
+            lenient().when(spanService.getByTraceIds(Set.of(trace.id()))).thenReturn(Flux.empty());
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherIntegrationTest.java
@@ -1,0 +1,234 @@
+package com.comet.opik.domain.evaluators;
+
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
+import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.infrastructure.OnlineScoringConfig;
+import com.comet.opik.infrastructure.ServiceTogglesConfig;
+import com.comet.opik.infrastructure.redis.RedisStreamCodec;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.redisson.Redisson;
+import org.redisson.api.RStreamReactive;
+import org.redisson.api.RedissonReactiveClient;
+import org.redisson.api.stream.StreamMessageId;
+import org.redisson.config.Config;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.UUID;
+
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * OPIK-8262, cross-layer half. The unit tests assert what the publisher is asked to write; this asserts what
+ * actually lands on a real Redis stream and survives the shipped codec — one entry per thread id, each decodable
+ * with its own id intact.
+ *
+ * <p>Covers the migration republish too: {@code OnlineScoringBaseScorer.migrateOrScoreThreadIds} rewrites a legacy
+ * multi-id entry by handing the same {@code enqueueMessage} a list of single-id copies, which is the second case
+ * below. It deliberately stops at the stream rather than driving the scorer end to end — the scorer's own branching
+ * is unit-tested, and standing up the full scoring stack (ClickHouse traces, an LLM provider) to re-observe a Redis
+ * write would test the harness more than the change.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OnlineScorePublisherIntegrationTest {
+
+    private final RedisContainer redis = RedisContainerUtils.newRedisContainer();
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+    private final ServiceTogglesConfig serviceTogglesConfig = new ServiceTogglesConfig();
+
+    @Mock
+    private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+
+    private RedissonReactiveClient redissonClient;
+    private OnlineScoringConfig config;
+    private String streamName;
+    private String pythonStreamName;
+
+    @BeforeAll
+    void setUpAll() {
+        redis.start();
+        var redissonConfig = new Config();
+        redissonConfig.useSingleServer().setAddress(redis.getRedisURI()).setDatabase(0);
+        redissonClient = Redisson.create(redissonConfig).reactive();
+
+        streamName = randomStreamName();
+        pythonStreamName = randomStreamName();
+        // The Python evaluator is behind a toggle; without it the publisher skips the enqueue entirely.
+        serviceTogglesConfig.setTraceThreadPythonEvaluatorEnabled(true);
+        config = OnlineScoringConfig.builder()
+                .streamMaxLen(10_000)
+                .streamTrimLimit(100)
+                .streams(List.of(
+                        OnlineScoringConfig.StreamConfiguration.builder()
+                                .scorer(AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE.getType())
+                                .streamName(streamName)
+                                .codec(RedisStreamCodec.JAVA.getName())
+                                .build(),
+                        OnlineScoringConfig.StreamConfiguration.builder()
+                                .scorer(AutomationRuleEvaluatorType.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON.getType())
+                                .streamName(pythonStreamName)
+                                .codec(RedisStreamCodec.JAVA.getName())
+                                .build()))
+                .build();
+    }
+
+    // Same shape as RedisStreamCodecTest, the closest sibling: null-guarded shutdown then stop.
+    @AfterAll
+    void tearDownAll() {
+        if (redissonClient != null) {
+            redissonClient.shutdown();
+        }
+        if (redis != null) {
+            redis.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("A batch enqueue lands one decodable entry per thread id on the stream")
+    void enqueueThreadMessageWritesOneEntryPerThreadId() {
+        var publisher = newPublisher();
+        var threadIds = List.of("thread-a-" + suffix(), "thread-b-" + suffix(), "thread-c-" + suffix());
+        var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                .id(UUID.randomUUID())
+                .name(podamFactory.manufacturePojo(String.class))
+                .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
+                .build();
+
+        var projectId = UUID.randomUUID();
+
+        publisher.enqueueThreadMessage(threadIds, rule, projectId, "workspace", "user").block();
+
+        // Compared whole, against independently built expectations: asserting only the thread ids would pass
+        // while the codec silently dropped the evaluator code, the user, or the project. Plain element
+        // equality is enough -- every type in the payload is a record, so generated equals covers each
+        // component and picks up any added later.
+        var expected = threadIds.stream()
+                .map(threadId -> TraceThreadToScoreLlmAsJudge.builder()
+                        .threadIds(List.of(threadId))
+                        .ruleId(rule.getId())
+                        .projectId(projectId)
+                        .workspaceId("workspace")
+                        .userName("user")
+                        .code(rule.getCode())
+                        .build())
+                .toList();
+
+        var written = readStream();
+        assertThat(written)
+                .as("the subscriber acks per entry, so each thread id needs its own entry to be retried alone")
+                .hasSize(threadIds.size());
+        assertThat(written).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    /**
+     * The Python payload's mirror of the case above. Without it, the Python side is only ever asserted on the
+     * arguments handed to the publisher, before serialization — so a codec regression losing
+     * {@code code.metric} would leave the evaluator with nothing to run and no test would notice. This PR
+     * changes the fan-out for both payload types, so both need the same end-to-end check.
+     */
+    @Test
+    @DisplayName("A Python batch enqueue lands one decodable entry per thread id on its own stream")
+    void enqueueThreadMessageWritesOnePythonEntryPerThreadId() {
+        var publisher = newPublisher();
+        var threadIds = List.of("thread-a-" + suffix(), "thread-b-" + suffix(), "thread-c-" + suffix());
+        var projectId = UUID.randomUUID();
+        var rule = AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.builder()
+                .id(UUID.randomUUID())
+                .name(podamFactory.manufacturePojo(String.class))
+                .code(podamFactory.manufacturePojo(TraceThreadUserDefinedMetricPythonCode.class))
+                .build();
+
+        publisher.enqueueThreadMessage(threadIds, rule, projectId, "workspace", "user").block();
+
+        var expected = threadIds.stream()
+                .map(threadId -> TraceThreadToScoreUserDefinedMetricPython.builder()
+                        .threadIds(List.of(threadId))
+                        .ruleId(rule.getId())
+                        .projectId(projectId)
+                        .workspaceId("workspace")
+                        .userName("user")
+                        .code(rule.getCode())
+                        .build())
+                .toList();
+
+        List<TraceThreadToScoreUserDefinedMetricPython> written = readStream(pythonStreamName);
+        assertThat(written)
+                .as("the Python payload needs the same per-entry granularity as the LLM one")
+                .hasSize(threadIds.size());
+        assertThat(written).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    /**
+     * The shape the migration shim produces: single-id copies of one legacy entry, handed to the same
+     * {@code enqueueMessage} the scorer calls. Asserts they survive the codec with their ids and rule intact.
+     */
+    @Test
+    @DisplayName("A migration republish lands each single-id copy intact")
+    void migrationRepublishWritesEachSingleIdCopy() {
+        var publisher = newPublisher();
+        var legacy = podamFactory.manufacturePojo(TraceThreadToScoreLlmAsJudge.class).toBuilder()
+                .threadIds(List.of("legacy-a-" + suffix(), "legacy-b-" + suffix()))
+                .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
+                .build();
+        var copies = legacy.threadIds().stream()
+                .map(threadId -> legacy.toBuilder().threadIds(List.of(threadId)).build())
+                .toList();
+
+        publisher.enqueueMessage(copies, AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE).block();
+
+        var written = readStream();
+        assertThat(written).hasSize(2);
+        // Whole-object comparison against the copies actually handed to the publisher. A migration that loses
+        // the evaluator code would still score, silently, against a null definition -- ids alone cannot see it.
+        assertThat(written)
+                .as("a migrated entry must round-trip every field, not just its thread id")
+                .containsExactlyInAnyOrderElementsOf(copies);
+    }
+
+    private OnlineScorePublisher newPublisher() {
+        redissonClient.getStream(streamName, RedisStreamCodec.JAVA.getCodec()).delete().block();
+        redissonClient.getStream(pythonStreamName, RedisStreamCodec.JAVA.getCodec()).delete().block();
+        return new OnlineScorePublisherImpl(config, serviceTogglesConfig, redissonClient,
+                automationRuleEvaluatorService);
+    }
+
+    private List<TraceThreadToScoreLlmAsJudge> readStream() {
+        return readStream(streamName);
+    }
+
+    private <T> List<T> readStream(String name) {
+        RStreamReactive<String, T> stream = redissonClient.getStream(name, RedisStreamCodec.JAVA.getCodec());
+        return stream.range(StreamMessageId.MIN, StreamMessageId.MAX).block()
+                .values().stream()
+                .map(entry -> entry.get(OnlineScoringConfig.PAYLOAD_FIELD))
+                .toList();
+    }
+
+    private static String randomStreamName() {
+        return "test-stream-%s".formatted(RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase());
+    }
+
+    private static String suffix() {
+        return RandomStringUtils.secure().nextAlphanumeric(16);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherTest.java
@@ -1,13 +1,21 @@
 package com.comet.opik.domain.evaluators;
 
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge;
+import com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython;
 import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
+import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
+import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.redis.RedisStreamCodec;
 import com.comet.opik.podam.PodamFactoryUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,12 +27,17 @@ import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
 
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
+import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -79,9 +92,116 @@ class OnlineScorePublisherTest {
         });
     }
 
+    /**
+     * OPIK-8262. {@code enqueueThreadMessage} used to build ONE stream entry carrying the whole thread-id
+     * list. {@code BaseRedisSubscriber} acks and removes per entry, so N thread ids under one entry share a
+     * single retry verdict — and once {@code ChatCompletionService.scoreTrace} classifies provider errors by
+     * status (same change), a permanent 400 and a transient 429 can land under one entry and whichever the
+     * consumer surfaces mis-serves the other. Publishing one entry per thread id makes failure granularity
+     * match ack granularity, so a retry replays only the thread that failed.
+     */
+    @Nested
+    @DisplayName("One stream entry per thread id")
+    class ThreadMessageFanOutTests {
+
+        @ParameterizedTest(name = "llm-as-judge: {0} thread ids -> {0} entries, one id each")
+        @ValueSource(ints = {1, 2, 5})
+        void shouldPublishOneLlmAsJudgeEntryPerThreadId(int threadCount) {
+            var config = createConfig(AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE);
+            var publisher = createPublisher(config);
+            var threadIds = threadIds(threadCount);
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                    .id(UUID.randomUUID())
+                    .name(podamFactory.manufacturePojo(String.class))
+                    .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
+                    .build();
+
+            publisher.enqueueThreadMessage(threadIds, rule, UUID.randomUUID(),
+                    podamFactory.manufacturePojo(String.class), podamFactory.manufacturePojo(String.class)).block();
+
+            var published = capturePayloads(TraceThreadToScoreLlmAsJudge.class);
+            assertThat(published)
+                    .as("one stream entry per thread id, so the subscriber's per-entry ack retires exactly one"
+                            + " thread's work")
+                    .hasSize(threadCount);
+            assertThat(published)
+                    .allSatisfy(message -> assertThat(message.threadIds())
+                            .as("each entry carries exactly one thread id — the whole point of the split")
+                            .hasSize(1));
+            assertThat(published.stream().map(message -> message.threadIds().getFirst()).toList())
+                    .as("every requested thread id is still enqueued, none lost in the split")
+                    .containsExactlyInAnyOrderElementsOf(threadIds);
+        }
+
+        @ParameterizedTest(name = "python: {0} thread ids -> {0} entries, one id each")
+        @ValueSource(ints = {1, 2, 5})
+        void shouldPublishOnePythonEntryPerThreadId(int threadCount) {
+            serviceTogglesConfig.setTraceThreadPythonEvaluatorEnabled(true);
+            var config = createConfig(AutomationRuleEvaluatorType.TRACE_THREAD_USER_DEFINED_METRIC_PYTHON);
+            var publisher = createPublisher(config);
+            var threadIds = threadIds(threadCount);
+            var rule = AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.builder()
+                    .id(UUID.randomUUID())
+                    .name(podamFactory.manufacturePojo(String.class))
+                    .code(podamFactory.manufacturePojo(TraceThreadUserDefinedMetricPythonCode.class))
+                    .build();
+
+            publisher.enqueueThreadMessage(threadIds, rule, UUID.randomUUID(),
+                    podamFactory.manufacturePojo(String.class), podamFactory.manufacturePojo(String.class)).block();
+
+            var published = capturePayloads(TraceThreadToScoreUserDefinedMetricPython.class);
+            assertThat(published).hasSize(threadCount);
+            assertThat(published).allSatisfy(message -> assertThat(message.threadIds()).hasSize(1));
+            assertThat(published.stream().map(message -> message.threadIds().getFirst()).toList())
+                    .containsExactlyInAnyOrderElementsOf(threadIds);
+        }
+
+        /**
+         * An empty list used to publish one entry whose {@code threadIds} violated the record's
+         * {@code @NotEmpty} — a message no consumer could do anything with. Zero ids now means zero entries.
+         */
+        @Test
+        @DisplayName("An empty thread-id list publishes nothing at all")
+        void shouldPublishNothingForAnEmptyThreadIdList() {
+            var config = createConfig(AutomationRuleEvaluatorType.TRACE_THREAD_LLM_AS_JUDGE);
+            var publisher = createPublisherWithoutStreamStubs(config);
+            var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                    .id(UUID.randomUUID())
+                    .name(podamFactory.manufacturePojo(String.class))
+                    .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
+                    .build();
+
+            publisher.enqueueThreadMessage(List.of(), rule, UUID.randomUUID(),
+                    podamFactory.manufacturePojo(String.class), podamFactory.manufacturePojo(String.class)).block();
+
+            verify(stream, never()).add(any());
+        }
+
+        private List<String> threadIds(int count) {
+            return IntStream.range(0, count)
+                    .mapToObj(index -> "thread-%d-%s".formatted(index,
+                            RandomStringUtils.secure().nextAlphanumeric(16)))
+                    .toList();
+        }
+
+        private <T> List<T> capturePayloads(Class<T> messageType) {
+            ArgumentCaptor<StreamAddParams<Object, Object>> captor = ArgumentCaptor.forClass(StreamAddParams.class);
+            verify(stream, atLeastOnce()).add(captor.capture());
+            return captor.getAllValues().stream()
+                    .map(params -> params.getEntries().get(OnlineScoringConfig.PAYLOAD_FIELD))
+                    .map(messageType::cast)
+                    .toList();
+        }
+    }
+
     private OnlineScorePublisher createPublisher(OnlineScoringConfig onlineScoringConfig) {
-        when(redisClient.getStream(anyString(), any())).thenReturn(stream);
         when(stream.add(any())).thenReturn(Mono.just(new StreamMessageId(System.currentTimeMillis(), 0)));
+        return createPublisherWithoutStreamStubs(onlineScoringConfig);
+    }
+
+    /** For the cases that assert nothing is ever added — strict stubbing rejects an unused {@code add} stub. */
+    private OnlineScorePublisher createPublisherWithoutStreamStubs(OnlineScoringConfig onlineScoringConfig) {
+        when(redisClient.getStream(anyString(), any())).thenReturn(stream);
         return new OnlineScorePublisherImpl(
                 onlineScoringConfig, serviceTogglesConfig, redisClient, automationRuleEvaluatorService);
     }
@@ -97,8 +217,17 @@ class OnlineScorePublisherTest {
     }
 
     private OnlineScoringConfig createConfig(Integer perStreamMaxLen, Integer perStreamTrimLimit) {
+        return createConfig(AutomationRuleEvaluatorType.LLM_AS_JUDGE, perStreamMaxLen, perStreamTrimLimit);
+    }
+
+    private OnlineScoringConfig createConfig(AutomationRuleEvaluatorType type) {
+        return createConfig(type, null, null);
+    }
+
+    private OnlineScoringConfig createConfig(AutomationRuleEvaluatorType type, Integer perStreamMaxLen,
+            Integer perStreamTrimLimit) {
         var streamConfiguration = OnlineScoringConfig.StreamConfiguration.builder()
-                .scorer(AutomationRuleEvaluatorType.LLM_AS_JUDGE.getType())
+                .scorer(type.getType())
                 .streamName("test-stream-%s".formatted(
                         RandomStringUtils.secure().nextAlphanumeric(10).toLowerCase()))
                 .codec(RedisStreamCodec.JAVA.getName())

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -4,6 +4,8 @@ import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.ChunkedOutputHandlers;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.AuthenticationException;
 import dev.langchain4j.exception.HttpException;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -38,6 +41,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -627,35 +631,422 @@ class ChatCompletionServiceTest {
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
         }
 
-        @ParameterizedTest(name = "scoreTrace: when {0}, then stay a retryable 500")
-        @MethodSource("providerStatusProvider")
-        @DisplayName("Online scoring deliberately keeps the blanket 500, so the subscriber still retries")
-        void scoreTrace__whenProviderErrorUnparsed__thenStayRetryable(
+        /**
+         * The statuses the retryability split treats as permanent, spelled out as a literal. The
+         * parameterised cases below partition the shared rows with this instead of asking
+         * {@code isPermanentFailure} where each row belongs — a test that derives its expectation from
+         * the classifier under test cannot fail when the classifier is wrong.
+         */
+        private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 403, 404, 413, 422);
+
+        /** The shared rows whose status is permanent, so their scoreTrace case needs no branch. */
+        private static Stream<Arguments> permanentProviderStatuses() {
+            return providerStatusProvider().filter(row -> PERMANENT_STATUSES.contains(row.get()[2]));
+        }
+
+        /** The complement, kept separate for the same reason. */
+        private static Stream<Arguments> transientProviderStatuses() {
+            return providerStatusProvider().filter(row -> !PERMANENT_STATUSES.contains(row.get()[2]));
+        }
+
+        /**
+         * OPIK-8240. The redaction-limit incident: Uber's gateway rejects an oversized scoring request with
+         * a plain-text 400 that getLlmProviderError cannot parse (no JSON envelope, so no '{' for
+         * extractErrorJson to find). scoreTrace used to answer every unparsed provider error with a blanket
+         * 500, which lands outside BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS - so a request that could
+         * never succeed was replayed maxRetries times, once per pendingMessageDuration, before being
+         * dropped.
+         *
+         * <p>The status now comes off the HttpException in the cause chain (findProviderHttpStatus) rather
+         * than the unparseable body, and a permanent 4xx becomes a ClientErrorException so the subscriber
+         * retires it on the first delivery.
+         */
+        @ParameterizedTest(name = "scoreTrace: permanent {0} -> non-retryable ClientErrorException")
+        @CsvSource({
+                "400, Bad Request",
+                "401, Unauthorized",
+                "403, Forbidden",
+                "404, Not Found",
+                "413, Payload Too Large",
+                "422, Unprocessable Entity",
+        })
+        @DisplayName("A permanent provider 4xx becomes non-retryable, so the evaluation is dropped not replayed")
+        void scoreTrace__whenPermanentClientError__thenNonRetryable(int status, String label) {
+            // Plain-text body, exactly like the real gateway rejection - unparseable, so the status has to
+            // come from the HttpException itself.
+            var providerFailure = new InvalidRequestException(
+                    "error, status code: %d, status: , message: %s".formatted(status, label),
+                    new HttpException(status, label));
+
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertNonRetryable(thrown, status);
+        }
+
+        /**
+         * The other half of the split, and the reason family-level classification was not enough: 408, 425
+         * and 429 are client-error-family by numbering but transient in meaning. Dropping them on the first
+         * failure - which any blanket "4xx is non-retryable" rule would do - would discard an evaluation
+         * over a rate limit that clears in seconds.
+         */
+        @ParameterizedTest(name = "scoreTrace: transient {0} -> stays retryable")
+        @CsvSource({
+                "408, Request Timeout",
+                "425, Too Early",
+                "429, Too Many Requests",
+                "500, Internal Server Error",
+                "502, Bad Gateway",
+                "503, Service Unavailable",
+        })
+        @DisplayName("A transient status stays retryable, so maxRetries is still honoured")
+        void scoreTrace__whenTransientStatus__thenStaysRetryable(int status, String label) {
+            var thrown = whenScoreTraceFails(new RuntimeException(new HttpException(status, label)),
+                    Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Review finding on #8162: with no status on the wire, the mapper's code must NOT decide
+         * retryability -- in either direction.
+         *
+         * <p>An earlier revision fell back to {@code providerError.getCode()} when
+         * {@code findProviderHttpStatus} came up empty. But the mappers synthesize a code when they cannot
+         * parse the body ({@code CustomLlmErrorMessage} defaults to 400, {@code OpenAiErrorMessage} to
+         * 500), and nothing downstream can tell a genuinely parsed 400 from that default. So any
+         * unparseable failure of a CustomLlm provider -- a connection reset, a proxy hiccup, a truncated
+         * body -- was classified permanent and dropped on its first delivery. Silent loss of an evaluation
+         * that a retry might well have completed.
+         *
+         * <p>The asymmetry settles it: needlessly retrying a genuinely permanent error wastes at most
+         * {@code maxRetries} attempts, whereas dropping an unknown failure loses it forever. So <b>every</b>
+         * mapper-only status is now retryable, 400 included. The permanent classification requires a real
+         * wire status, which the cases above and below supply via {@code HttpException}.
+         */
+        @ParameterizedTest(name = "scoreTrace: mapper-only {0}, no wire status -> stays retryable")
+        @CsvSource({"400", "401", "403", "408", "429", "500", "503"})
+        @DisplayName("Without a wire status the mapper's code never makes a failure permanent")
+        void scoreTrace__whenNoWireStatus__thenStaysRetryableWhateverTheMapperSays(int mappedStatus) {
+            var thrown = whenScoreTraceFails(new RuntimeException("no HTTP status in this chain"),
+                    Optional.of(new ErrorMessage(mappedStatus, "provider body says " + mappedStatus)));
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Regression for the precedence bug caught in review of OPIK-8240.
+         *
+         * <p>The provider mappers synthesize a status when they cannot read one off the body:
+         * {@code CustomLlmErrorMessage} defaults to 400, {@code OpenAiErrorMessage} to 500. If a synthetic
+         * value outranks the code the provider actually put on the wire, retryability is decided from a
+         * number nobody sent. This is the damaging direction: a transient provider outage hidden behind
+         * CustomLlm's synthetic 400 would be classified permanent and dropped on its first delivery.
+         */
+        @ParameterizedTest(name = "transient wire {0} behind synthetic {1} -> stays retryable")
+        @CsvSource({
+                "503, 400",
+                "429, 400",
+        })
+        @DisplayName("A transient status on the wire outranks a synthetic permanent mapper fallback")
+        void scoreTrace__whenTransientWireStatusBehindSyntheticPermanent__thenStaysRetryable(
+                int wireStatus, int syntheticStatus) {
+            var providerFailure = new RuntimeException(new HttpException(wireStatus, "upstream said " + wireStatus));
+
+            var thrown = whenScoreTraceFails(providerFailure,
+                    Optional.of(new ErrorMessage(syntheticStatus, "synthetic mapper fallback")));
+
+            assertRetryable(thrown);
+        }
+
+        /** The harmless direction of the same precedence rule, kept so the rule is pinned both ways. */
+        @ParameterizedTest(name = "permanent wire {0} behind synthetic {1} -> stays non-retryable")
+        @CsvSource({
+                "400, 500",
+                "403, 500",
+        })
+        @DisplayName("A permanent status on the wire outranks a synthetic transient mapper fallback")
+        void scoreTrace__whenPermanentWireStatusBehindSyntheticTransient__thenStaysNonRetryable(
+                int wireStatus, int syntheticStatus) {
+            var providerFailure = new RuntimeException(new HttpException(wireStatus, "upstream said " + wireStatus));
+
+            var thrown = whenScoreTraceFails(providerFailure,
+                    Optional.of(new ErrorMessage(syntheticStatus, "synthetic mapper fallback")));
+
+            assertNonRetryable(thrown, wireStatus);
+        }
+
+        @ParameterizedTest(name = "isPermanentFailure({0}) -> {1}")
+        @CsvSource({
+                // Client-error family, minus the transient carve-outs.
+                "400, true",
+                "401, true",
+                "403, true",
+                "499, true",
+                // Transient client errors: "not now", not "not ever".
+                "408, false",
+                "425, false",
+                "429, false",
+                // Server errors are the textbook retry case.
+                "500, false",
+                "503, false",
+                // Outside the error families entirely - unknown defaults to retryable.
+                "200, false",
+                "302, false",
+        })
+        @DisplayName("isPermanentFailure: the split itself, including the family boundary")
+        void isPermanentFailure__classifiesTheStatus(int status, boolean expectedPermanent) {
+            assertThat(ChatCompletionService.isPermanentFailure(status)).isEqualTo(expectedPermanent);
+        }
+
+        /**
+         * The shared production-shaped rows, run through scoreTrace. Split into a permanent and a transient
+         * case rather than one case that branches: scoreTrace has no JAX-RS caller, so the thrown TYPE is
+         * read for retryability rather than as an HTTP status, and each category deserves an assertion that
+         * says which one it belongs to. Before OPIK-8240 this path answered every failure with a blanket
+         * 500, which kept transient 408/429 retryable (correct) but also replayed permanent 400/401
+         * failures that could never succeed (the redaction-limit incident).
+         */
+        @ParameterizedTest(name = "scoreTrace: when {0}, then non-retryable {2}")
+        @MethodSource("permanentProviderStatuses")
+        @DisplayName("Online scoring drops a permanent provider status instead of replaying it")
+        void scoreTrace__whenPermanentProviderErrorUnparsed__thenNonRetryable(
                 String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {
-            // Given — scoreTrace has no JAX-RS caller: the three OnlineScoring*LlmAsJudgeScorer subscribers are the
-            // only callers, so a recovered status would reach no HTTP client. It would, however, reach
-            // BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS, which lists ClientErrorException — so a recovered 429 or
-            // 408 (both RetriableException upstream) would be acked and dropped instead of retried up to
-            // onlineScoring.maxRetries. Whatever the provider reported, this path must stay a 500.
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertThat(thrown).hasMessageContaining(expectedMessagePart);
+            assertNonRetryable(thrown, expectedStatus);
+        }
+
+        /** {@code expectedStatus} is unused on purpose: every retryable failure is flattened to 500. */
+        @ParameterizedTest(name = "scoreTrace: when {0}, then retryable")
+        @MethodSource("transientProviderStatuses")
+        @DisplayName("Online scoring keeps a transient provider status retryable, honouring maxRetries")
+        void scoreTrace__whenTransientProviderErrorUnparsed__thenRetryable(
+                String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertThat(thrown).hasMessageContaining(expectedMessagePart);
+            assertRetryable(thrown);
+        }
+
+        /**
+         * VertexAI is the only provider whose client raises no {@code HttpException}: the Google Cloud SDK throws
+         * GAX {@code ApiException}, which langchain4j also does not model as {@code NonRetriableException}. Before
+         * this, a permanent Vertex failure was retried in-process AND redelivered by the subscriber. The status now
+         * comes from GAX's own transport-neutral translation, so it classifies like any other provider.
+         */
+        /**
+         * Review finding: the permanent cases above assert the thrown TYPE but not that the call was made once.
+         * {@code InvalidRequestException} is already a {@code NonRetriableException}, so those cases pass with
+         * {@code failFastOnPermanentFailure} deleted — they do not exercise the HTTP-status path they claim to.
+         * These drive a raw {@code HttpException}, which is NOT a {@code NonRetriableException}, so only the
+         * status classification can stop the retry.
+         */
+        @ParameterizedTest(name = "permanent HTTP {0} is attempted exactly once")
+        @CsvSource({
+                "400, Bad Request",
+                "403, Forbidden",
+                "404, Not Found",
+                "413, Payload Too Large",
+                "422, Unprocessable Entity",
+        })
+        @DisplayName("A permanent wire status does not consume the in-process retry budget")
+        void scoreTrace__whenPermanentHttpStatus__thenNotRetriedInProcess(int status, String label) {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
             var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
             var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
-            var workspaceId = "test-workspace-id";
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(new HttpException(status, label)));
+            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(ClientErrorException.class);
+
+            verify(chatModel, times(1)).chat(any(ChatRequest.class));
+        }
+
+        @ParameterizedTest(name = "transient HTTP {0} is still retried")
+        @CsvSource({"429, Too Many Requests", "503, Service Unavailable"})
+        @DisplayName("A transient wire status still consumes the retry budget")
+        void scoreTrace__whenTransientHttpStatus__thenStillRetriedInProcess(int status, String label) {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(new HttpException(status, label)));
+            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(InternalServerErrorException.class);
+
+            verify(chatModel, atLeast(2)).chat(any(ChatRequest.class));
+        }
+
+        @ParameterizedTest(name = "GAX {0} -> HTTP {1}, non-retryable")
+        @CsvSource({
+                "INVALID_ARGUMENT, 400",
+                "FAILED_PRECONDITION, 400",
+                "OUT_OF_RANGE, 400",
+                "UNAUTHENTICATED, 401",
+                "PERMISSION_DENIED, 403",
+                "NOT_FOUND, 404",
+        })
+        @DisplayName("A permanent VertexAI GAX failure is retired on the first delivery")
+        void scoreTrace__whenPermanentGaxStatus__thenNonRetryable(StatusCode.Code code, int expectedStatus) {
+            // Wrapped in RuntimeException because that is the shape VertexAiGeminiChatModel actually throws.
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, false)), Optional.empty());
+
+            assertNonRetryable(thrown, expectedStatus);
+        }
+
+        @ParameterizedTest(name = "GAX {0} stays retryable")
+        @CsvSource({"RESOURCE_EXHAUSTED", "DEADLINE_EXCEEDED", "UNAVAILABLE", "INTERNAL", "UNKNOWN"})
+        @DisplayName("A transient VertexAI GAX failure still honours maxRetries")
+        void scoreTrace__whenTransientGaxStatus__thenRetryable(StatusCode.Code code) {
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, false)), Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * The safety valve. GAX's own {@code isRetryable()} can only ever prevent a drop, never cause one, so a code
+         * that would otherwise map to a permanent status stays retryable when GAX says it is worth retrying. Guards
+         * the cases where the gRPC-to-HTTP translation disagrees with retry semantics (ABORTED, CANCELLED).
+         */
+        @ParameterizedTest(name = "GAX {0} marked retryable stays retryable despite a permanent status")
+        @CsvSource({"INVALID_ARGUMENT", "PERMISSION_DENIED", "ABORTED", "CANCELLED"})
+        @DisplayName("GAX's own retryable verdict is never overridden into a drop")
+        void scoreTrace__whenGaxSaysRetryable__thenRetryable(StatusCode.Code code) {
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, true)), Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Precedence is unchanged by the GAX addition: a real {@code HttpException} anywhere in the chain still wins
+         * over anything a typed exception implies. A 503 on the wire must not be collapsed into GAX's permanent 400.
+         */
+        @Test
+        @DisplayName("A wire HttpException still outranks a GAX status in the same chain")
+        void scoreTrace__whenHttpExceptionAndGaxInSameChain__thenHttpExceptionWins() {
+            var chain = new RuntimeException(
+                    gaxException(StatusCode.Code.INVALID_ARGUMENT, false, new HttpException(503, "upstream 503")));
+
+            var thrown = whenScoreTraceFails(chain, Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        @Test
+        @DisplayName("A permanent GAX failure does not consume the in-process retry budget")
+        void scoreTrace__whenPermanentGaxStatus__thenNotRetriedInProcess() {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.INVALID_ARGUMENT, false)));
+            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(ClientErrorException.class);
+
+            // GAX ApiException is not a NonRetriableException, so without failFastOnPermanentFailure langchain4j's
+            // RetryPolicy would replay a call that can never succeed.
+            verify(chatModel, times(1)).chat(any(ChatRequest.class));
+        }
+
+        @Test
+        @DisplayName("A transient GAX failure is still retried in-process")
+        void scoreTrace__whenTransientGaxStatus__thenStillRetriedInProcess() {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.UNAVAILABLE, false)));
+            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(InternalServerErrorException.class);
+
+            verify(chatModel, atLeast(2)).chat(any(ChatRequest.class));
+        }
+
+        private static ApiException gaxException(StatusCode.Code code, boolean retryable) {
+            return gaxException(code, retryable, new RuntimeException("vertex transport failure"));
+        }
+
+        /** A transport-free {@link StatusCode}: gRPC and HTTP-JSON both reduce to the same neutral {@code Code}. */
+        private static ApiException gaxException(StatusCode.Code code, boolean retryable, Throwable cause) {
+            return new ApiException(cause, new StatusCode() {
+                @Override
+                public Code getCode() {
+                    return code;
+                }
+
+                @Override
+                public Object getTransportCode() {
+                    return null;
+                }
+            }, retryable);
+        }
+
+        /** Drives scoreTrace to failure and returns what it threw. */
+        private Throwable whenScoreTraceFails(RuntimeException providerFailure,
+                Optional<ErrorMessage> mappedProviderError) {
+            var chatRequest = ChatRequest.builder()
+                    .messages(UserMessage.from(podamFactory.manufacturePojo(String.class)))
+                    .build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+            var workspaceId = podamFactory.manufacturePojo(String.class);
 
             when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
             when(chatModel.chat(any(ChatRequest.class))).thenThrow(providerFailure);
             when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
-            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(mappedProviderError);
 
-            // When
-            var thrown = catchThrowable(
+            return catchThrowable(
                     () -> chatCompletionService.scoreTrace(chatRequest, modelParameters, workspaceId));
+        }
 
-            // Then — InternalServerErrorException is absent from NON_RETRYABLE_EXCEPTIONS, which is what keeps the
-            // evaluation retryable; expectedStatus is deliberately unused here
+        /**
+         * ClientErrorException is what BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS matches on: the entry is
+         * acked and removed on the first delivery. The status is carried through so the caller-visible
+         * verdict stays the provider's own.
+         */
+        private void assertNonRetryable(Throwable thrown, int expectedStatus) {
             assertThat(thrown)
+                    .as("status %d can never succeed on retry, so it must be non-retryable", expectedStatus)
+                    .isInstanceOf(ClientErrorException.class)
+                    .isNotInstanceOf(InternalServerErrorException.class);
+            assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
+        }
+
+        /**
+         * Everything else lands outside NON_RETRYABLE_EXCEPTIONS and is replayed up to
+         * onlineScoring.maxRetries. Flattened to 500 deliberately: no HTTP caller reads this status, and
+         * recovering a 429 or 408 verbatim would put the failure back in the non-retryable family.
+         */
+        private void assertRetryable(Throwable thrown) {
+            assertThat(thrown)
+                    .as("a status that may clear on retry must stay outside NON_RETRYABLE_EXCEPTIONS")
                     .isInstanceOf(InternalServerErrorException.class)
-                    .isNotInstanceOf(ClientErrorException.class)
-                    .hasMessageContaining(expectedMessagePart);
+                    .isNotInstanceOf(ClientErrorException.class);
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(500);
         }
 

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -648,6 +648,7 @@ areas:
       - online-evaluation/online-evaluation-sampling-rate.spec.ts
       - online-evaluation/online-evaluation-python-metric-errors.spec.ts
       - online-evaluation/online-evaluation-non-object-sections.spec.ts
+      - online-evaluation/online-evaluation-thread-fanout.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
       llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
@@ -655,7 +656,12 @@ areas:
       python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0; t2 also covers sub-path mappings over non-object sections and the 400-class classification of a metric that exits 0 without a result line" }
       scores-in-trace-panel:   { covered: true,  tier: t1-smoke }
       list-rules:              { covered: false }
-      rule-scope-thread-span:  { covered: false, note: "span/thread scope flags" }
+      # THREAD scope only. A thread-scoped python rule is driven over a 3-thread
+      # cohort via manual evaluation, asserting one evaluator call per thread
+      # (not 1, not 9), the score on each thread server-side, and the score
+      # rendered in each thread's panel. SPAN scope is still untested — no spec
+      # creates a span-scoped rule.
+      rule-scope-thread-span:  { covered: true,  tier: t2-cuj, note: "thread scope only; span scope still uncovered" }
       rule-filters:            { covered: false }
       sampling-rate:           { covered: true,  tier: t2-cuj, note: "50% rule vs 100% control over one 30-trace batch, binomial band 15-85%; plus a 0%-rate rule at trigger_scope=both, which must skip every SDK trace and still score experiment/playground/optimization ones" }
       clone-rule:              { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -221,6 +221,15 @@ export interface AnnotationQueueDetail {
  */
 export interface ThreadRowRef {
   id: string;
+  /**
+   * The thread's own UUID, distinct from `id` (which is the user-supplied
+   * `thread_id` string). Every thread-addressed write takes this one —
+   * `POST /v1/private/manual-evaluation/threads` rejects anything that is not a
+   * UUID — while every read above takes `id`. Nullable because the field is
+   * optional on the generated type; callers that need it must reject a missing
+   * value rather than defaulting, since there is no id to substitute.
+   */
+  threadModelId: string | null;
   numberOfMessages: number | null;
   totalEstimatedCost: number | null;
   usage: Record<string, number> | null;
@@ -1510,24 +1519,58 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       samplingRate: number;
       /** Python source for the metric class. */
       metric: string;
-      /** `score()` parameter name -> extraction path (e.g. `output.answer`). */
-      arguments: Record<string, string>;
+      /**
+       * `score()` parameter name -> extraction path (e.g. `output.answer`).
+       *
+       * Trace-scoped rules only. `TraceThreadUserDefinedMetricPythonCode`
+       * carries a `metric` and nothing else — the thread scorer hands the whole
+       * conversation to `score()` positionally, so there is no per-argument
+       * mapping to declare — and the field is dropped below rather than sent
+       * and ignored, so a caller that passes one for a thread rule is a type
+       * error instead of a silent no-op.
+       */
+      arguments?: Record<string, string>;
+      /**
+       * Which evaluator the rule is. Defaults to the trace-scoped python
+       * metric; `trace_thread_user_defined_metric_python` is the thread-scoped
+       * one, which fires per conversation rather than per trace.
+       */
+      type?: 'user_defined_metric_python' | 'trace_thread_user_defined_metric_python';
       triggerScope?: 'production' | 'experiment' | 'both';
       enabled?: boolean;
     }): Promise<string> {
+      const type = args.type ?? 'user_defined_metric_python';
+      const isThreadScoped = type === 'trace_thread_user_defined_metric_python';
+      if (isThreadScoped && args.arguments) {
+        throw new Error(
+          `createAutomationRule: '${args.name}' is thread-scoped, which takes no argument ` +
+            'map — the conversation is passed to score() positionally.',
+        );
+      }
+      if (!isThreadScoped && !args.arguments) {
+        // The backend refuses to call the evaluator with an empty argument map,
+        // so an omitted one fails the rule before its metric ever runs — a
+        // failure that reads exactly like a broken metric.
+        throw new Error(
+          `createAutomationRule: '${args.name}' is trace-scoped and needs an argument map.`,
+        );
+      }
       const { status, message, location } = await rawFetch(
         'POST',
         '/v1/private/automations/evaluators/',
         {
           body: {
-            type: 'user_defined_metric_python',
+            type,
             action: 'evaluator',
             name: args.name,
             project_ids: [args.projectId],
             sampling_rate: args.samplingRate,
             enabled: args.enabled ?? true,
             ...(args.triggerScope ? { trigger_scope: args.triggerScope } : {}),
-            code: { metric: args.metric, arguments: args.arguments },
+            code: {
+              metric: args.metric,
+              ...(isThreadScoped ? {} : { arguments: args.arguments }),
+            },
           },
         },
       );
@@ -1600,6 +1643,54 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       }));
     },
 
+    /**
+     * `POST /v1/private/manual-evaluation/threads` — the "Evaluate" action the
+     * Threads view offers on a selection, which enqueues the chosen threads
+     * against the chosen rules regardless of their sampling rate.
+     *
+     * Through `rawFetch` because the pinned SDK has no manual-evaluation
+     * client at all. `entity_type` is mandatory even on the `/threads` route
+     * (omitting it is a 422 naming `entityType`), and the ids are thread MODEL
+     * ids — `ThreadRowRef.threadModelId`, not the `thread_id` string.
+     *
+     * The response is returned rather than swallowed: `entities_queued` is the
+     * only place the backend states how many entries the request became, which
+     * is the difference between a fan-out that split and one that collapsed.
+     */
+    async evaluateThreadsManually(args: {
+      projectId: string;
+      threadModelIds: string[];
+      ruleIds: string[];
+    }): Promise<{ entitiesQueued: number; rulesApplied: number }> {
+      const { status, message, json } = await rawFetch(
+        'POST',
+        '/v1/private/manual-evaluation/threads',
+        {
+          body: {
+            project_id: args.projectId,
+            entity_ids: args.threadModelIds,
+            rule_ids: args.ruleIds,
+            entity_type: 'thread',
+          },
+        },
+      );
+      if (status !== 202) {
+        throw new Error(
+          `evaluateThreadsManually: expected 202 for ${args.threadModelIds.length} thread(s), ` +
+            `got ${status}: ${message}`,
+        );
+      }
+      const body = json as { entities_queued?: number; rules_applied?: number } | null;
+      if (typeof body?.entities_queued !== 'number' || typeof body?.rules_applied !== 'number') {
+        // Defaulting either count would present as a plausible number and make
+        // the assertion they exist for unfalsifiable.
+        throw new Error(
+          `evaluateThreadsManually: 202 carried no usable counts (got ${JSON.stringify(json)})`,
+        );
+      }
+      return { entitiesQueued: body.entities_queued, rulesApplied: body.rules_applied };
+    },
+
     async deleteAutomationRule(projectId: string, ruleId: string): Promise<void> {
       try {
         await opik.api.automationRuleEvaluators.deleteAutomationRuleEvaluatorBatch({
@@ -1636,6 +1727,7 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         total: Number(page.total ?? 0),
         threads: (page.content ?? []).map((t) => ({
           id: String(t.id ?? ''),
+          threadModelId: t.threadModelId ?? null,
           // null and 0 are different answers from this endpoint (an absent
           // aggregate is not a zero one), so they must not be collapsed.
           numberOfMessages: t.numberOfMessages ?? null,

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -1547,12 +1547,14 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
             'map — the conversation is passed to score() positionally.',
         );
       }
-      if (!isThreadScoped && !args.arguments) {
+      if (!isThreadScoped && Object.keys(args.arguments ?? {}).length === 0) {
         // The backend refuses to call the evaluator with an empty argument map,
         // so an omitted one fails the rule before its metric ever runs — a
-        // failure that reads exactly like a broken metric.
+        // failure that reads exactly like a broken metric. An explicitly empty
+        // `{}` reaches PythonEvaluatorService the same way an omitted map does,
+        // so it is rejected here too rather than only checking for absence.
         throw new Error(
-          `createAutomationRule: '${args.name}' is trace-scoped and needs an argument map.`,
+          `createAutomationRule: '${args.name}' is trace-scoped and needs a non-empty argument map.`,
         );
       }
       const { status, message, location } = await rawFetch(

--- a/tests_end_to_end/e2e/core/metrics/index.ts
+++ b/tests_end_to_end/e2e/core/metrics/index.ts
@@ -1,5 +1,6 @@
 export {
   buildConstantScoreMetric,
+  buildConstantThreadScoreMetric,
   buildSilentMetric,
   buildUnparseableMetric,
 } from './python-metric-source';

--- a/tests_end_to_end/e2e/core/metrics/python-metric-source.ts
+++ b/tests_end_to_end/e2e/core/metrics/python-metric-source.ts
@@ -54,6 +54,43 @@ ${params}
 }
 
 /**
+ * The thread-scoped counterpart of {@link buildConstantScoreMetric}: a constant
+ * 1.0 for whatever conversation it is handed.
+ *
+ * A separate builder rather than a `scoreArgs` variant, because the runner
+ * calls the two differently. For a `trace_thread_*` rule the python backend
+ * dispatches `metric.score(data)` — one POSITIONAL argument carrying the whole
+ * conversation — while the trace-scoped path spreads the argument map as
+ * keywords (`metric.score(**data)`). A `score()` whose first parameter is named
+ * `output` would still be called successfully here, which is precisely why this
+ * is worth stating: the parameter name is inert on this path, so the thread
+ * metric declares the name the backend documents (`CONTEXT_ARG_NAME`) instead
+ * of borrowing a trace-shaped one that would read as though it mattered.
+ *
+ * Constant rather than derived from the conversation: the specs using this ask
+ * whether every thread in a fan-out was evaluated, not what the metric
+ * concluded — a value that varied with the input would make "scored the wrong
+ * thread" and "scored correctly" produce the same number.
+ */
+export function buildConstantThreadScoreMetric(scoreName: string): string {
+  return `from typing import Any
+from opik.evaluation.metrics import base_metric, score_result
+
+SCORE_NAME = ${JSON.stringify(scoreName)}
+
+class ConstantThreadScore(base_metric.BaseMetric):
+    def __init__(self, name: str = SCORE_NAME):
+        self.name = name
+
+    def score(
+        self,
+        context: Any = None,
+        **ignored_kwargs: Any,
+    ) -> score_result.ScoreResult:
+        return score_result.ScoreResult(value=1.0, name=self.name)`;
+}
+
+/**
  * A metric that exits 0 without ever printing its result line.
  *
  * `os._exit` is deliberate: it ends the interpreter immediately, so the runner's

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './alert.fixture';
+export { test, expect } from './thread-cohort.fixture';
 export type {
   OauthProviderSeed,
   ProviderKeysFixture,
@@ -113,4 +113,10 @@ export type {
   AlertFixtures,
 } from './alert.fixture';
 export { ALERT_EVENT_TYPE, ALERT_EVENT_TITLE } from './alert.fixture';
+export type {
+  ThreadCohortRef,
+  ThreadCohortThreadRef,
+  ThreadCohortTurnRef,
+  ThreadCohortFixtures,
+} from './thread-cohort.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/thread-cohort.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/thread-cohort.fixture.ts
@@ -1,0 +1,146 @@
+import { test as baseTest } from './alert.fixture';
+import type { BackendClient } from '../core/backend';
+
+/** One turn of a cohort conversation: a single trace carrying the thread id. */
+export interface ThreadCohortTurnRef {
+  traceId: string;
+  input: string;
+  output: string;
+}
+
+export interface ThreadCohortThreadRef {
+  /** The `thread_id` the traces were logged under — what every read addresses. */
+  threadId: string;
+  /** The thread's own UUID — what `manual-evaluation/threads` addresses. */
+  threadModelId: string;
+  turns: ThreadCohortTurnRef[];
+}
+
+export interface ThreadCohortRef {
+  projectId: string;
+  projectName: string;
+  /** In seed order, so a spec can talk about "the second thread" reproducibly. */
+  threads: ThreadCohortThreadRef[];
+}
+
+export interface ThreadCohortFixtures {
+  threadCohort: ThreadCohortRef;
+}
+
+/**
+ * Three distinct conversations, not one — the whole point is that a request
+ * naming several threads has several threads to get wrong.
+ */
+const COHORT_SIZE = 3;
+
+/** Two turns each: enough that a thread is a conversation rather than a trace. */
+const TURNS = [
+  { input: 'What is the capital of France?', output: 'The capital of France is Paris.' },
+  { input: 'What is its population?', output: 'Paris has about 2.1 million residents.' },
+] as const;
+
+/**
+ * A cohort of independent threads in one project, each resolved to the thread
+ * model id that thread-addressed writes take.
+ *
+ * Exists because the estate's other thread fixture (`conversation`) seeds a
+ * single thread, and a single thread cannot distinguish a fan-out that split
+ * correctly from one that collapsed to its first entry — with N = 1 those are
+ * the same observation.
+ *
+ * Seeded through the public SDK bridge, one trace per turn, with a gap between
+ * turns so their chronological order is deterministic (turn order is derived
+ * from start_time, and two calls can otherwise land in the same millisecond).
+ *
+ * The model-id resolution is a precondition, not a convenience: thread rows are
+ * aggregated asynchronously from trace ingestion, so this polls until all three
+ * exist and throws naming what is missing if they never do. A spec handed a
+ * short cohort would assert over whatever did arrive and pass having tested a
+ * smaller fan-out than it claims.
+ *
+ * No teardown — the traces, the threads and their scores all live in `project`,
+ * whose own fixture deletes it.
+ */
+export const test = baseTest.extend<ThreadCohortFixtures>({
+  threadCohort: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
+    const threadIds = Array.from(
+      { length: COHORT_SIZE },
+      (_, i) => `${testNamespace}-thread-${i + 1}`,
+    );
+
+    const turnsByThread = new Map<string, ThreadCohortTurnRef[]>();
+    for (const threadId of threadIds) {
+      const turns: ThreadCohortTurnRef[] = [];
+      for (let i = 0; i < TURNS.length; i++) {
+        const { input, output } = TURNS[i];
+        const created = await sdkClient.python.createTrace({
+          project_name: project.name,
+          name: `${threadId}-turn-${i + 1}`,
+          input,
+          output,
+          thread_id: threadId,
+        });
+        turns.push({ traceId: created.id, input, output });
+        await new Promise((r) => setTimeout(r, 50));
+      }
+      turnsByThread.set(threadId, turns);
+    }
+
+    const modelIds = await resolveThreadModelIds(backendClient, project.id, threadIds);
+
+    const ref: ThreadCohortRef = {
+      projectId: project.id,
+      projectName: project.name,
+      threads: threadIds.map((threadId) => ({
+        threadId,
+        threadModelId: modelIds.get(threadId)!,
+        turns: turnsByThread.get(threadId)!,
+      })),
+    };
+
+    await testInfo.attach('opik.threadCohort', {
+      body: JSON.stringify(ref, null, 2),
+      contentType: 'application/json',
+    });
+
+    await use(ref);
+  },
+});
+
+/**
+ * Poll the Threads list until every seeded thread has been aggregated, and
+ * return its model id. Throws — rather than returning a partial map — because
+ * an unresolved thread is a broken precondition, and the only honest thing a
+ * fixture can do with one is refuse to hand it over.
+ */
+async function resolveThreadModelIds(
+  backendClient: BackendClient,
+  projectId: string,
+  threadIds: string[],
+  timeoutMs = 60_000,
+): Promise<Map<string, string>> {
+  const deadline = Date.now() + timeoutMs;
+  let seen: string[] = [];
+  for (;;) {
+    const { threads } = await backendClient.listThreads({ projectId });
+    const resolved = new Map<string, string>();
+    for (const row of threads) {
+      if (threadIds.includes(row.id) && row.threadModelId) {
+        resolved.set(row.id, row.threadModelId);
+      }
+    }
+    if (resolved.size === threadIds.length) return resolved;
+    seen = threads.map((t) => t.id);
+    if (Date.now() >= deadline) {
+      const missing = threadIds.filter((id) => !resolved.has(id));
+      throw new Error(
+        `threadCohort fixture: ${missing.length} of ${threadIds.length} threads never got a ` +
+          `thread_model_id within ${timeoutMs}ms (missing: ${missing.join(', ')}; ` +
+          `project reported: ${seen.join(', ') || '<none>'})`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 2_000));
+  }
+}
+
+export { expect } from './alert.fixture';

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+import type { AutomationRuleLogRef } from '@e2e/core/backend';
+import { buildConstantThreadScoreMetric } from '@e2e/core/metrics';
+
+/** Emitted once per evaluator call, immediately before the HTTP request. */
+const EVALUATOR_CALL_LINE = 'to Python evaluator';
+
+/** Emitted once per thread whose scores were persisted — the end of one cycle. */
+const SCORES_STORED_LINE = 'stored successfully';
+
+/**
+ * Online evaluation of a THREAD-scoped rule over several threads at once
+ * (OPIK-8262).
+ *
+ * A request naming N threads becomes N entries on the scoring stream, one per
+ * thread. The estate has no spec that drives a thread-scoped rule at all, and
+ * the two ways the fan-out can go wrong are both invisible from any single
+ * thread's point of view:
+ *
+ *   - an id dropped in the split — fewer evaluator calls than threads, and a
+ *     thread that silently never gets scored;
+ *   - an entry still carrying the whole list — N x N evaluator calls, each
+ *     thread scored repeatedly.
+ *
+ * Counting evaluator calls is what separates those from a correct run, because
+ * all three end with every thread carrying a score: the duplicate case
+ * overwrites its own value, so the scores alone read identically.
+ *
+ * Deterministic by construction: a constant-1.0 python thread metric needs no
+ * provider key and no model verdict, and the rule sits at sampling_rate 0 so
+ * the manual request is the only thing that can trigger it.
+ */
+test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-cuj', '@area:online-evaluation'] }, () => {
+  test('a manual evaluation of N threads scores every one of them exactly once', { tag: ['@cap:online-evaluation.rule-scope-thread-span'] }, async ({
+    threadCohort,
+    backendClient,
+    testNamespace,
+    automationRulesCleanup,
+    page,
+  }) => {
+    test.setTimeout(300_000);
+
+    const { projectId, threads } = threadCohort;
+    const threadIds = threads.map((t) => t.threadId);
+    const scoreName = `${testNamespace}-thread-score`;
+
+    const ruleId = await test.step('Create a thread-scoped python rule that can only fire on request', async () => {
+      // sampling_rate 0: the production sampler skips every thread, so anything
+      // this rule scores is attributable to the manual request below. At any
+      // other rate a passing assertion would also be satisfied by ordinary
+      // sampling, which is not the path under test.
+      return backendClient.createAutomationRule({
+        projectId,
+        name: `${testNamespace}-thread-rule`,
+        type: 'trace_thread_user_defined_metric_python',
+        samplingRate: 0,
+        metric: buildConstantThreadScoreMetric(scoreName),
+      });
+    });
+
+    await test.step('No thread carries a score before the request', async () => {
+      // The complement of the sampling_rate 0 argument above, asserted rather
+      // than assumed: if the threads arrived already scored, every assertion
+      // after this one would hold without the fan-out having run at all.
+      for (const { threadId } of threads) {
+        const thread = await backendClient.getThread({ projectId, threadId });
+        expect(
+          thread.feedbackScores,
+          `thread '${threadId}' must start unscored for the manual trigger to be attributable`,
+        ).toEqual([]);
+      }
+    });
+
+    await test.step('The request reports one queued entry per thread', async () => {
+      const queued = await backendClient.evaluateThreadsManually({
+        projectId,
+        threadModelIds: threads.map((t) => t.threadModelId),
+        ruleIds: [ruleId],
+      });
+      // The first place the split is observable. A request that collapsed to a
+      // single entry still answers 202.
+      expect(queued.entitiesQueued, 'one entry per thread named in the request').toBe(
+        threads.length,
+      );
+      expect(queued.rulesApplied, 'exactly the one rule was applied').toBe(1);
+    });
+
+    const logs = await test.step('Wait for the rule to finish all three threads', async () => {
+      let observed: AutomationRuleLogRef[] = [];
+      await expect
+        .poll(
+          async () => {
+            observed = await backendClient.getAutomationRuleLogs(ruleId);
+            return observed.filter((l) => l.message.includes(SCORES_STORED_LINE)).length;
+          },
+          {
+            timeout: 180_000,
+            intervals: [2_000, 5_000],
+            message:
+              'the rule never reported storing scores for every thread — a stream entry was ' +
+              'lost, or the trace-thread python evaluator is disabled on this deployment',
+          },
+        )
+        .toBe(threads.length);
+      return observed;
+    });
+
+    await test.step('The evaluator was called once per thread, and once for each', async () => {
+      const callLines = logs.filter((l) => l.message.includes(EVALUATOR_CALL_LINE));
+      // Both halves of the fan-out failure mode, as one count: N-1 or fewer
+      // means an id was dropped in the split, N*N means each entry still
+      // carried the whole list.
+      expect(
+        callLines.map((l) => l.message),
+        `the evaluator must be called exactly ${threads.length} times, not once and not ${threads.length ** 2} times`,
+      ).toHaveLength(threads.length);
+
+      // The count alone would still pass if one thread were evaluated three
+      // times and the other two never — so pin which threads those calls were
+      // for.
+      for (const threadId of threadIds) {
+        expect(
+          callLines.filter((l) => l.message.includes(`'${threadId}'`)),
+          `thread '${threadId}' must be sent to the evaluator exactly once`,
+        ).toHaveLength(1);
+      }
+    });
+
+    await test.step('Every thread carries the rule score, and only it', async () => {
+      // Compared as the whole score set per thread rather than by looking this
+      // rule's score up among others: a run that also wrote something it should
+      // not have is exactly what a find()-then-compare would pass through.
+      for (const { threadId } of threads) {
+        const thread = await backendClient.getThread({ projectId, threadId });
+        expect(
+          thread.feedbackScores.map((s) => ({ name: s.name, value: s.value, source: s.source })),
+          `thread '${threadId}' must carry the rule's score once, written by online scoring`,
+        ).toEqual([{ name: scoreName, value: 1.0, source: 'online_scoring' }]);
+      }
+    });
+
+    await test.step('The project holds exactly the cohort and nothing else', async () => {
+      // Guards the reading of every assertion above: they iterate the threads
+      // the fixture seeded, so a run that scored those three AND invented a
+      // fourth would satisfy all of them.
+      const { total, threads: rows } = await backendClient.listThreads({ projectId });
+      expect(total, 'the seeded cohort is the whole project').toBe(threads.length);
+      expect(rows.map((r) => r.id).sort()).toEqual([...threadIds].sort());
+    });
+
+    await test.step('Each thread shows the score in its panel', async () => {
+      // Where a user reads a thread-level score: the Threads table hides
+      // feedback-score columns by default, so the panel's own tab is the
+      // rendered surface for this. Every thread is opened, not a sample —
+      // "one of the three renders it" is the observation a collapsed fan-out
+      // would also produce.
+      const logsPage = new LogsPage(page);
+      await logsPage.gotoThreads(projectId);
+      await logsPage.waitForThreadsReady(threadIds[0]);
+
+      for (const { threadId } of threads) {
+        const panel = await logsPage.openThreadById(threadId);
+        await panel.waitForFullyLoaded();
+        await panel.openFeedbackScoresTab();
+        await expect(
+          panel.feedbackScoreRow(scoreName),
+          `thread '${threadId}' must render exactly one row for the rule's score`,
+        ).toHaveCount(1);
+        expect(await panel.readFeedbackScoreValue(scoreName)).toBeCloseTo(1.0, 6);
+      }
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
@@ -39,6 +39,11 @@ test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-c
     automationRulesCleanup,
     page,
   }) => {
+    // Budget for the longest chain: the cohort fixture's 60s thread-aggregation
+    // poll, the 180s wait for the rule to store scores, then three thread panels
+    // opened in sequence. Kept just above the 180s inner poll so that one fires
+    // first — it fails naming the threads that never got scored, which beats an
+    // opaque "test timeout exceeded".
     test.setTimeout(300_000);
 
     const { projectId, threads } = threadCohort;
@@ -146,7 +151,10 @@ test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-c
       // fourth would satisfy all of them.
       const { total, threads: rows } = await backendClient.listThreads({ projectId });
       expect(total, 'the seeded cohort is the whole project').toBe(threads.length);
-      expect(rows.map((r) => r.id).sort()).toEqual([...threadIds].sort());
+      expect(
+        rows.map((r) => r.id).sort(),
+        'the project holds the seeded threads and no others',
+      ).toEqual([...threadIds].sort());
     });
 
     await test.step('Each thread shows the score in its panel', async () => {
@@ -167,7 +175,10 @@ test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-c
           panel.feedbackScoreRow(scoreName),
           `thread '${threadId}' must render exactly one row for the rule's score`,
         ).toHaveCount(1);
-        expect(await panel.readFeedbackScoreValue(scoreName)).toBeCloseTo(1.0, 6);
+        expect(
+          await panel.readFeedbackScoreValue(scoreName),
+          `thread '${threadId}' must render the rule's score as 1.0`,
+        ).toBeCloseTo(1.0, 6);
       }
     });
   });

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-thread-fanout.spec.ts
@@ -32,19 +32,21 @@ const SCORES_STORED_LINE = 'stored successfully';
  * the manual request is the only thing that can trigger it.
  */
 test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-cuj', '@area:online-evaluation'] }, () => {
-  test('a manual evaluation of N threads scores every one of them exactly once', { tag: ['@cap:online-evaluation.rule-scope-thread-span'] }, async ({
+  test('A manual evaluation of N threads scores every one of them exactly once', { tag: ['@cap:online-evaluation.rule-scope-thread-span'] }, async ({
     threadCohort,
     backendClient,
     testNamespace,
     automationRulesCleanup,
     page,
   }) => {
-    // Budget for the longest chain: the cohort fixture's 60s thread-aggregation
-    // poll, the 180s wait for the rule to store scores, then three thread panels
-    // opened in sequence. Kept just above the 180s inner poll so that one fires
-    // first — it fails naming the threads that never got scored, which beats an
-    // opaque "test timeout exceeded".
-    test.setTimeout(300_000);
+    // A backstop above the sum of the inner ceilings, not a budget the test is
+    // expected to spend: the cohort fixture's 60s thread-aggregation poll, the
+    // 180s wait for the rule to store scores, then three thread panels opened in
+    // sequence at up to 60s each (waitForFullyLoaded waits 30s for the panel root
+    // and 30s for its first turn), plus navigation. Deliberately larger than that
+    // total so an inner timeout always fires first — each of those names what it
+    // was waiting for, which beats an opaque "test timeout exceeded".
+    test.setTimeout(600_000);
 
     const { projectId, threads } = threadCohort;
     const threadIds = threads.map((t) => t.threadId);
@@ -77,15 +79,21 @@ test.describe('Online Evaluation — thread-scoped rule fan-out', { tag: ['@t2-c
       }
     });
 
-    await test.step('The request reports one queued entry per thread', async () => {
+    await test.step('The request is accepted for the whole cohort', async () => {
       const queued = await backendClient.evaluateThreadsManually({
         projectId,
         threadModelIds: threads.map((t) => t.threadModelId),
         ruleIds: [ruleId],
       });
-      // The first place the split is observable. A request that collapsed to a
-      // single entry still answers 202.
-      expect(queued.entitiesQueued, 'one entry per thread named in the request').toBe(
+      // NOT evidence of the fan-out. ManualEvaluationService.evaluateThreads
+      // answers `threadModelIds.size()` — the count it was handed — after the
+      // enqueue chain completes, so a request that packed all three ids into one
+      // stream entry reports 3 here too. What it does rule out is the cohort
+      // being rejected or partially resolved before enqueueing (that path
+      // answers 0), which is worth pinning because every later assertion would
+      // otherwise fail with no indication that the request never landed.
+      // The fan-out itself is asserted from the evaluator-call count below.
+      expect(queued.entitiesQueued, 'every thread in the request was accepted').toBe(
         threads.length,
       );
       expect(queued.rulesApplied, 'exactly the one rule was applied').toBe(1);


### PR DESCRIPTION
## What this is

One new e2e spec proposed by the QA test-radar side flow, written from a human-verified
exploration of **#8162** ([OPIK-8262] classify provider errors by status and stop collapsing
trace-thread fan-out).

**This PR targets `thiagohora/OPIK-8262-retry-classification-and-fanout`, not `main`.** The spec was
written and run against that branch's head, `c20c9e018a23b9fc45927d0224c80959cc7208ae`, which is
also the commit deployed to the PR environment the exploration used. It is a regression guard on
the fan-out this PR rewrote, so it belongs on top of the change it tests; retargeting it to `main`
once #8162 merges is a rebase, not a rewrite.

**Generated by an automated QA flow. It needs human review before merge and is deliberately a
draft.** No reviewers requested — a human promotes it.

## Where it came from

The exploration ran on the PR's own deployment (`pr-8162.dev.comet.com`, 2.2.53-8162-merge-3189,
OSS install, workspace `default`) and reached both halves of the change by hand before any spec
existed. It produced two strong candidates; this PR contains the one of them that can be written
as a deterministic, self-contained spec. The other is dropped, with reasons, below.

## The spec

### `tests/online-evaluation/online-evaluation-thread-fanout.spec.ts` — ✅ passes

`@t2-cuj` · `@area:online-evaluation` · `@cap:online-evaluation.rule-scope-thread-span`

**What it asserts.** A manual evaluation naming N threads against one thread-scoped rule becomes
N independent scoring cycles — the behaviour `OnlineScorePublisher.enqueueThreadMessage` now
produces by emitting one stream entry per thread id instead of one entry carrying the whole list.
Concretely, over a 3-thread cohort:

- the request answers `entities_queued: 3`, `rules_applied: 1`;
- the rule's log stream carries **exactly 3** "to Python evaluator" lines — not 1 (an id lost in
  the split) and not 9 (each entry still carrying all three) — and each thread id appears in
  exactly one of them;
- every thread carries exactly one feedback score, value `1.0`, `source: online_scoring`, compared
  as the whole score set per thread rather than by looking this rule's score up among others;
- the project holds exactly the three seeded threads and nothing else;
- each of the three threads renders that score in its detail panel's **Feedback scores** tab.

The evaluator-call count is the load-bearing assertion. All three failure modes end with every
thread carrying a score — the duplicate case overwrites its own value — so the scores alone cannot
tell a correct fan-out from a collapsed one. Only the call count can.

**Why it is deterministic.** A constant-1.0 python thread metric: no provider key, no model
verdict, no wall-clock dependence. The rule sits at `sampling_rate: 0`, so the production sampler
can never fire it and the manual request is the only possible trigger — and the spec asserts every
thread is *unscored* before the request, so the later assertions are attributable to the fan-out
rather than to ordinary sampling.

**What it does not prove.** On the happy path the pre-#8162 code also scored all three threads: it
iterated the id list inside a single stream entry. So this is a regression guard on the split
(nothing lost, nothing duplicated), **not** a before/after discriminator. The behaviour only the
new code has — a per-thread retry budget, so one thread's retryable failure replays only that
thread — needs a retryable failure in the thread scorer, which the exploration could not provoke on
this estate (the python evaluator's failures are terminal 400s, and the thread LLM path needs a
provider key). It is deliberately out of scope here rather than asserted weakly.

### Supporting changes

- **`fixtures/thread-cohort.fixture.ts`** (new) — seeds three independent threads (2 turns each)
  through the public SDK bridge and resolves each to its `thread_model_id`, which is what
  `manual-evaluation/threads` addresses. It polls until all three threads have been aggregated and
  **throws naming the missing ones** if they never are: a spec handed a short cohort would assert
  over whatever arrived and pass having tested a smaller fan-out than it claims. No teardown — the
  traces, threads and scores all live in the `project` fixture's project, and the rule is cleaned
  up by the existing `automationRulesCleanup` fixture. The suite's own run-prefix sweep reported
  nothing left behind after the verification run.
- **`core/backend/client.ts`** — `createAutomationRule` gains a `type` so it can build a
  `trace_thread_user_defined_metric_python` rule (thread code carries a `metric` and no argument
  map; passing one is now a hard error rather than a field sent and ignored); new
  `evaluateThreadsManually`, which the pinned SDK cannot express at all; `ThreadRowRef` gains
  `threadModelId`.
- **`core/metrics/python-metric-source.ts`** — `buildConstantThreadScoreMetric`. A separate builder
  from `buildConstantScoreMetric` because the python backend dispatches the two differently:
  `metric.score(data)` positionally for `trace_thread_*` rules, `metric.score(**data)` for
  trace-scoped ones.
- **`coverage/taxonomy.yaml`** — spec added to the area's `specs:` list;
  `online-evaluation.rule-scope-thread-span` flipped to `covered: true, tier: t2-cuj` with a note
  scoping it to **thread scope only** — no spec creates a span-scoped rule, so that half stays
  untested and the note says so rather than letting the key read as fully covered.
  `online-evaluation.automation-logs` is deliberately left `covered: false`: this spec reads the
  rule log stream over `GET /automations/evaluators/{id}/logs` and never opens the
  `/$workspaceName/automation-logs` page that key names, which is exactly the distinction the
  existing comment on that entry asks callers to respect.

## Verification

Run against the PR's own deployment — the same environment and build the exploration used:

```bash
cd tests_end_to_end/e2e
OPIK_DEPLOYMENT=oss OPIK_BASE_URL=https://pr-8162.dev.comet.com OPIK_WORKSPACE=default \
OPIK_API_KEY=oss-no-auth WORKERS=1 \
  npx playwright test tests/online-evaluation/online-evaluation-thread-fanout.spec.ts --reporter=list
# 1 passed (24.0s)
```

`OPIK_API_KEY` is set only because this target's hostname ends in `comet.com`, which makes the
pinned TS SDK demand a key even though the install has no auth. It is not needed for a local OSS
run and the spec does not depend on it.

Also run:

- `python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml
  --estate tests_end_to_end` → `60 specs checked, 1 exempt, 0 problem(s)`.
- A deliberate mutation of the evaluator-call assertion (`3` → `4`) was run and **failed** as
  intended, so that assertion is known to discriminate rather than merely to pass.
- **`tests/online-evaluation/` in full**, because `core/backend/client.ts` and `fixtures/index.ts`
  are shared: **7 passed, 1 skipped, 1 failed (1.7m)**.

  The one failure is `online-evaluation-python-metric-errors.spec.ts`, and it is **not caused by
  this change** — it fails identically on the unmodified branch, verified by re-running it with
  these changes stashed. On this deployment a python metric that exits 0 without a result line is
  still reported as `Python evaluation failed (HTTP '500'): 500 Internal Server Error: Failed to
  execute code`, where that spec expects the classified `400 Bad Request: Execution failed: the
  metric produced no output`. Worth someone's attention — either the classification fix is not in
  this build's python backend, or it has regressed — but it is out of scope here and nothing in
  this PR touches it.

**Typecheck, with a caveat you should know about.** `npx tsc --noEmit` does not run on this branch
today, and did not before this change: `tsconfig.json` still sets `baseUrl`, which the pinned
`typescript@^7.0.2` removed (`error TS5102`). It was typechecked with TypeScript 5.9 instead, which
reports exactly one error — a pre-existing duplicate `deleteDashboard` in `core/backend/client.ts`
present on the unmodified branch too. Zero new errors from this change. Both are worth fixing, but
not in a QA spec PR.

## What was deliberately not written

The exploration's other strong candidate — **"a permanent provider failure is attempted once; a
transient one is retried"**, the retry-classification half of this PR — is **dropped**. It is the
more valuable of the two and it was verified by hand (401 → 1 delivery held over 30 minutes;
429 → 3 deliveries at exact 10-minute intervals), but it cannot currently be written as a spec this
suite should own:

1. **It needs a backend-reachable endpoint that answers a chosen HTTP status.** The suite's only
   such facility is the mock gateway in `services/mock-token-auth/`, which answers 401 only and,
   per `core/mock-auth.ts`'s `mockAuthSkipReason()`, is reachable only from a **local** backend —
   never from a deployment, including the one where this behaviour can be observed. The
   exploration's substitute was `https://httpbingo.org/status/<code>?x=`; a permanent spec whose
   verdict depends on a third-party service is a flake source and is ruled out by the estate's own
   determinism rule.
2. **Even with that endpoint, the discriminating assertion costs a full
   `onlineScoring.pendingMessageDuration`** — 10 minutes, deployment configuration, not settable
   from a test. Both halves of the pair need it: without waiting out a redelivery window, "attempted
   once" and "attempted once so far" are the same observation.

Asserting only the permanent half would be worse than nothing: it would pass equally well if every
provider error had been made non-retryable, which is the direction that silently loses evaluations.

The prerequisite is a small one — teach `services/mock-token-auth/mock_token_auth_service.py` to
answer a caller-chosen status, then write the spec against `mockGatewayUrlForBackend` on a local
OSS run where `REDIS_SCORING_PENDING_MESSAGE_DURATION` can be turned down. That is a change worth
making, and it needs a local OSS backend to verify on, which this flow did not have. Shipping the
spec unverified against that unbuilt facility would have been a guess.

Also not covered, and named here so the list reads as filtered rather than exhausted: the automatic
thread-close fan-out path (`TraceThreadOnlineScorerPublisher` — same split, same scorer, different
caller; gated behind a 15-minute inactivity timeout), the VertexAI/GAX branch, and the legacy
multi-id migrate branch. The exploration could not reach any of them either.

## Review notes

- Read against `.agents/skills/writing-e2e-tests/SKILL.md` and `conventions.md` on `main`. One step
  of that workflow was not run: **step 3, live-UI discovery via the Playwright MCP**, which is not
  available to this flow. No new page object was written to compensate — the spec drives the
  existing `LogsPage` and `ThreadPanelPage` only, and adds no new selector.
- The Threads table's own feedback-score column is **not** asserted. Enabling it needs a
  column-picker interaction no POM in the estate models, and the thread panel's Feedback scores tab
  is where a user actually reads a thread-level score (the table hides those columns by default) —
  so the spec asserts there, for all three threads rather than a sample.

Related: #8162

[OPIK-8262]: https://comet-ml.atlassian.net/browse/OPIK-8262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- comet-qa-test-radar: propose -->
