### PR TITLE
[OPIK-8138] [SDK] fix: handle incomplete OpenAI Responses streams

### DIFF
--- a/sdks/python/src/opik/integrations/openai/response_events_aggregator.py
+++ b/sdks/python/src/opik/integrations/openai/response_events_aggregator.py
@@ -25,6 +25,9 @@ def aggregate(
             )
         ]
 
+        if not completed_event:
+            return None
+
         response = completed_event[0].response
         return response
     except Exception as exception:

--- a/sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py
+++ b/sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py
@@ -1,0 +1,22 @@
+import logging
+
+from openai.types import responses as openai_responses
+
+from opik.integrations.openai import response_events_aggregator
+
+
+def test_aggregate_non_terminal_events_returns_none_without_error(caplog):
+    event = openai_responses.ResponseCreatedEvent.model_construct(
+        response=None,
+        sequence_number=0,
+        type="response.created",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=response_events_aggregator.LOGGER.name):
+        result = response_events_aggregator.aggregate([event])
+
+    assert result is None
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+    assert not any(
+        "list index out of range" in record.message for record in caplog.records
+    )


### PR DESCRIPTION
## Details

An abandoned OpenAI Responses stream can contain only non-terminal events. The Responses aggregator indexed the empty terminal-event list, causing an IndexError traceback to be logged at error level during stream finalization.

Return None when no terminal event has been collected, while preserving the existing error path for failures after a terminal event is present.

## Issues

Resolves #8138

## Testing

- PYTHONPATH=src python -m pytest tests/unit/integrations/openai/test_response_events_aggregator.py -q
- ruff check src/opik/integrations/openai/response_events_aggregator.py tests/unit/integrations/openai/test_response_events_aggregator.py
- ruff format --check src/opik/integrations/openai/response_events_aggregator.py tests/unit/integrations/openai/test_response_events_aggregator.py
- mypy src/opik/integrations/openai/response_events_aggregator.py
- pre-commit run --files sdks/python/src/opik/integrations/openai/response_events_aggregator.py sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py