### PR TITLE
[OPIK-8262] [BE] fix: classify provider errors by status, not 4xx/5xx family

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -3,7 +3,11 @@ package com.comet.opik.domain.llm;
 import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.utils.ChunkedOutputHandlers;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
+import com.openai.errors.OpenAIServiceException;
 import dev.langchain4j.exception.AuthenticationException;
 import dev.langchain4j.exception.HttpException;
 import dev.langchain4j.exception.InternalServerException;
@@ -36,8 +40,10 @@ import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static jakarta.ws.rs.core.Response.Status.Family.familyOf;
 
@@ -135,28 +141,39 @@ public class ChatCompletionService {
         try {
             log.info("Initiating chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
-            chatResponse = retryPolicy
-                    .withRetry(() -> failFastOnUnsupportedFeature(() -> languageModelClient.chat(chatRequest)));
+            chatResponse = retryPolicy.withRetry(
+                    () -> failFastOnPermanentFailure(
+                            () -> failFastOnUnsupportedFeature(() -> languageModelClient.chat(chatRequest))));
             log.info("Completed chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             return chatResponse;
         } catch (RuntimeException runtimeException) {
             failIfUnsupportedFeature(runtimeException);
 
-            LlmProviderService provider = llmProviderFactory.getService(workspaceId, modelParameters.name());
+            // Deliberately NOT failHandlingLLMProviderError here, unlike create() and the streaming handler:
+            // those answer an HTTP caller and want the status verbatim, whereas this answers the online-
+            // scoring subscribers, where the thrown TYPE decides retryability. BaseRedisSubscriber matches
+            // ClientErrorException by class, so recovering the status here would make the whole 4xx family
+            // non-retryable, transient 408s and 429s included.
+            //
+            // Permanence is decided only from a status the provider actually sent. The mappers synthesize
+            // one when they cannot parse the body (CustomLlm 400, OpenAi 500) and nothing downstream can
+            // tell that apart from a real 400, so consulting them would drop every unparseable CustomLlm
+            // failure on its first delivery. Retrying a permanent error costs maxRetries attempts; dropping
+            // an unknown one loses the evaluation, so an absent status stays retryable.
+            var wireStatus = findProviderHttpStatus(runtimeException);
 
-            Optional<ErrorMessage> providerError = provider.getLlmProviderError(runtimeException);
-
-            providerError
-                    .ifPresent(llmProviderError -> failHandlingLLMProviderError(runtimeException, llmProviderError));
-
-            // No failIfProviderReportedHttpStatus here, unlike create() and the streaming handler. This method is
-            // called only by the online-scoring subscribers, never from a resource, so a recovered status reaches no
-            // HTTP client — while BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS lists ClientErrorException, so turning
-            // a rate limit into a 429 or a provider timeout into a 408 would make the subscriber ack and drop the
-            // evaluation instead of honouring onlineScoring.maxRetries. Both are RetriableException upstream, so the
-            // blanket 500 is what keeps them retryable.
             log.warn(UNEXPECTED_ERROR_CALLING_LLM_PROVIDER, runtimeException);
+
+            if (wireStatus.filter(ChatCompletionService::isPermanentFailure).isPresent()) {
+                // The subscriber acks and removes on the first delivery rather than burning
+                // maxRetries x pendingMessageDuration on a request whose outcome cannot change.
+                throw new ClientErrorException(buildDetailedErrorMessage(runtimeException), wireStatus.get(),
+                        runtimeException);
+            }
+            // Everything else stays a blanket 500 so it lands outside NON_RETRYABLE_EXCEPTIONS and honours
+            // onlineScoring.maxRetries -- including transient 4xx, a distinction ClientErrorException
+            // cannot express on its own while the subscriber matches it by class.
             throw new InternalServerErrorException(buildDetailedErrorMessage(runtimeException), runtimeException);
         } finally {
             // Close the Vertex client (reused across retries) to release its GAX threads; other providers self-reclaim.
@@ -178,10 +195,34 @@ public class ChatCompletionService {
      * original exception is kept as the cause, so {@link #failIfUnsupportedFeature} still recognises it downstream.
      */
     private <T> T failFastOnUnsupportedFeature(Callable<T> action) throws Exception {
+        return failFastWhen(action, runtimeException -> findUnsupportedFeature(runtimeException).isPresent());
+    }
+
+    /**
+     * Skips the in-process retries for a provider status that can never succeed, mirroring
+     * {@link #failFastOnUnsupportedFeature}. Applied only on the scoreTrace path: {@code create()} answers an HTTP
+     * caller, and narrowing its retry behaviour is not this change's business. Mainly reached for VertexAI, whose GAX
+     * exceptions langchain4j does not model as {@code NonRetriableException}; the mapped providers already fail fast
+     * on their own. The cause is preserved, so the catch block still classifies from the same status.
+     */
+    private <T> T failFastOnPermanentFailure(Callable<T> action) throws Exception {
+        return failFastWhen(action,
+                runtimeException -> findProviderHttpStatus(runtimeException)
+                        .filter(ChatCompletionService::isPermanentFailure)
+                        .isPresent());
+    }
+
+    /**
+     * Shared mechanism for both fail-fast wrappers: run the action, and rewrap a matching failure as
+     * {@link NonRetriableException} so {@code RetryPolicy.withRetry} gives up on the first attempt. Only the
+     * predicate differs between the two, so keeping one copy of the propagation means a future change to how
+     * NonRetriableException is raised cannot apply to one and not the other. The cause is always preserved.
+     */
+    private <T> T failFastWhen(Callable<T> action, Predicate<RuntimeException> nonRetriable) throws Exception {
         try {
             return action.call();
         } catch (RuntimeException runtimeException) {
-            if (findUnsupportedFeature(runtimeException).isPresent()) {
+            if (nonRetriable.test(runtimeException)) {
                 throw new NonRetriableException(runtimeException);
             }
             throw runtimeException;
@@ -267,16 +308,21 @@ public class ChatCompletionService {
     private Optional<Integer> findProviderHttpStatus(Throwable throwable) {
         List<Throwable> chain = ExceptionUtils.getThrowableList(throwable);
 
+        // Filtered at EACH stage, not once at the end. Filtering only the winner lets a non-error
+        // HttpException anywhere in the chain (a 302, or a synthetic 0) satisfy findFirst, suppress the
+        // typed fallback, and then be discarded -- losing the real status. That matters most for VertexAI
+        // and the OpenAI Responses SDK, whose statuses come only from that fallback.
         return chain.stream()
                 .filter(HttpException.class::isInstance)
                 .map(HttpException.class::cast)
                 .map(HttpException::statusCode)
+                .filter(ChatCompletionService::isErrorStatus)
                 .findFirst()
                 .or(() -> chain.stream()
                         .map(this::canonicalStatusOf)
                         .flatMap(Optional::stream)
-                        .findFirst())
-                .filter(ChatCompletionService::isErrorStatus);
+                        .filter(ChatCompletionService::isErrorStatus)
+                        .findFirst());
     }
 
     /**
@@ -293,6 +339,53 @@ public class ChatCompletionService {
     }
 
     /**
+     * VertexAI is one of two providers whose client raises no {@link HttpException}: the Google Cloud SDK throws GAX
+     * {@code ApiException}, which is also not a {@code NonRetriableException}, so without this a permanent Vertex
+     * failure consumed the whole retry budget. The status is GAX's own transport-neutral translation, identical for
+     * the gRPC and HTTP-JSON transports, rather than a table of our own.
+     *
+     * <p>An exception GAX marks retryable yields no status, so <em>within this method</em> the mapping can only
+     * prevent a drop, never cause one. Scoped deliberately: {@link #findProviderHttpStatus} consults a real
+     * {@code HttpException} in the chain first, and a wire status legitimately outranks GAX's {@code isRetryable},
+     * which is a configured judgment rather than something the server said. Not reachable for VertexAI in any case —
+     * {@code VertexAiGeminiChatModel} goes through the Google Cloud SDK and never produces a langchain4j
+     * {@code HttpException} — but that is the intended precedence if it ever were.
+     */
+    private static Optional<Integer> gaxHttpStatus(ApiException apiException) {
+        if (apiException.isRetryable()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(apiException.getStatusCode())
+                .map(StatusCode::getCode)
+                .map(StatusCode.Code::getHttpStatusCode);
+    }
+
+    /** 425 Too Early has no {@link Response.Status} constant; 408 and 429 do and are used directly. */
+    private static final int TOO_EARLY_STATUS = 425;
+
+    /**
+     * 4xx statuses that say "not now", not "not ever", so family alone can't decide retryability.
+     * langchain4j agrees on 408 and 429 but maps 425 to a non-retriable {@code InvalidRequestException};
+     * we diverge deliberately per RFC 8470, which is safe because retryability is read from the wire
+     * status, not the mapped type.
+     */
+    private static final Set<Integer> TRANSIENT_CLIENT_ERRORS = Set.of(
+            Response.Status.REQUEST_TIMEOUT.getStatusCode(),
+            TOO_EARLY_STATUS,
+            Response.Status.TOO_MANY_REQUESTS.getStatusCode());
+
+    /**
+     * Whether this exact request can never succeed, so the caller should give up rather than retry.
+     * Server errors are excluded: a 5xx is the textbook retry case. Anything unrecognised is retryable,
+     * matching {@code BaseRedisSubscriber}'s "unknown defaults to retryable for safety".
+     */
+    @VisibleForTesting
+    static boolean isPermanentFailure(int status) {
+        return familyOf(status) == Response.Status.Family.CLIENT_ERROR
+                && !TRANSIENT_CLIENT_ERRORS.contains(status);
+    }
+
+    /**
      * The status langchain4j's own exception types stand for, used for providers whose clients raise them without an
      * {@link HttpException} in the chain. {@code ContentFilteredException} is covered by its
      * {@link InvalidRequestException} supertype.
@@ -305,6 +398,8 @@ public class ChatCompletionService {
             case TimeoutException ignored -> Optional.of(Response.Status.REQUEST_TIMEOUT.getStatusCode());
             case RateLimitException ignored -> Optional.of(Response.Status.TOO_MANY_REQUESTS.getStatusCode());
             case InternalServerException ignored -> Optional.of(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+            case ApiException apiException -> gaxHttpStatus(apiException);
+            case OpenAIServiceException responsesException -> Optional.of(responsesException.statusCode());
             default -> Optional.empty();
         };
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/threads/TraceThreadOnlineScorerPublisher.java
@@ -10,7 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,8 +20,6 @@ import java.util.stream.Collectors;
 @Slf4j
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 class TraceThreadOnlineScorerPublisher {
-
-    private static final int THREAD_ID_LOG_SAMPLE = 10;
 
     private final @NonNull OnlineScorePublisher onlineScorePublisher;
 
@@ -52,30 +49,18 @@ class TraceThreadOnlineScorerPublisher {
                         Set<String> threadIds = ruleIdToThreadIds.getValue();
 
                         log.info(
-                                "Enqueuing threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                sampleOf(threadIds), ruleId, projectId, workspaceId);
+                                "Enqueuing trace threads: count='{}' ruleId='{}' projectId='{}' workspaceId='{}'",
+                                threadIds.size(), ruleId, projectId, workspaceId);
 
                         // Composed into the deferContextual chain so the enqueue inherits this workspace context.
                         return onlineScorePublisher.enqueueThreadMessage(List.copyOf(threadIds), ruleId, projectId,
                                 workspaceId, userName)
                                 .doOnSuccess(unused -> log.info(
-                                        "Enqueued threads: '{}' trace threads for ruleId: '{}' in projectId '{}' for workspaceId '{}'",
-                                        sampleOf(threadIds), ruleId, projectId, workspaceId));
+                                        "Enqueued trace threads: count='{}' ruleId='{}' projectId='{}' workspaceId='{}'",
+                                        threadIds.size(), ruleId, projectId, workspaceId));
                     })
                     .then();
         });
-    }
-
-    /**
-     * Bounded so an arbitrarily large close batch can't dump its whole id list into the logs. Substituted into
-     * the existing message unchanged — the template and its parameter order are what dashboards group on.
-     */
-    private static String sampleOf(Collection<String> threadIds) {
-        if (threadIds.size() <= THREAD_ID_LOG_SAMPLE) {
-            return threadIds.toString();
-        }
-        return "%s (and %d more)".formatted(
-                threadIds.stream().limit(THREAD_ID_LOG_SAMPLE).toList(), threadIds.size() - THREAD_ID_LOG_SAMPLE);
     }
 
     private boolean isSampled(Map.Entry<UUID, Boolean> entry) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/evaluators/OnlineScorePublisherIntegrationTest.java
@@ -6,6 +6,8 @@ import com.comet.opik.api.evaluators.AutomationRuleEvaluatorType;
 import com.comet.opik.api.events.TraceThreadToScoreLlmAsJudge;
 import com.comet.opik.api.events.TraceThreadToScoreUserDefinedMetricPython;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
 import com.comet.opik.infrastructure.OnlineScoringConfig;
 import com.comet.opik.infrastructure.ServiceTogglesConfig;
 import com.comet.opik.infrastructure.redis.RedisStreamCodec;
@@ -17,11 +19,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.mockito.junit.jupiter.MockitoSettings;
-import org.mockito.quality.Strictness;
 import org.redisson.Redisson;
 import org.redisson.api.RStreamReactive;
 import org.redisson.api.RedissonReactiveClient;
@@ -30,11 +27,12 @@ import org.redisson.config.Config;
 import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.List;
-import java.util.UUID;
 
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadLlmAsJudge.TraceThreadLlmAsJudgeCode;
 import static com.comet.opik.api.evaluators.AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.TraceThreadUserDefinedMetricPythonCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * OPIK-8262, cross-layer half. The unit tests assert what the publisher is asked to write; this asserts what
@@ -45,16 +43,22 @@ import static org.assertj.core.api.Assertions.assertThat;
  * traces, an LLM provider) to re-observe a Redis write would test the harness more than the change.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension.class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class OnlineScorePublisherIntegrationTest {
 
     private final RedisContainer redis = RedisContainerUtils.newRedisContainer();
     private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
     private final ServiceTogglesConfig serviceTogglesConfig = new ServiceTogglesConfig();
 
-    @Mock
-    private AutomationRuleEvaluatorService automationRuleEvaluatorService;
+    /**
+     * Required by the publisher's constructor but never exercised: these tests use the overload that takes an
+     * already-resolved rule, so no findById lookup happens. Deliberately unstubbed, and each test asserts
+     * {@code verifyNoInteractions} on it — a bare mock alone is not enough, because findById would return
+     * {@code null}, which the ruleId overload turns into an empty Mono and the test would still pass.
+     */
+    private final AutomationRuleEvaluatorService automationRuleEvaluatorService = mock(
+            AutomationRuleEvaluatorService.class);
+
+    private final IdGenerator idGenerator = TestIdGeneratorFactory.create();
 
     private RedissonReactiveClient redissonClient;
     private OnlineScoringConfig config;
@@ -105,15 +109,14 @@ class OnlineScorePublisherIntegrationTest {
     void enqueueThreadMessageWritesOneEntryPerThreadId() {
         var publisher = newPublisher();
         var threadIds = List.of("thread-a-" + suffix(), "thread-b-" + suffix(), "thread-c-" + suffix());
-        var rule = AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
-                .id(UUID.randomUUID())
-                .name(podamFactory.manufacturePojo(String.class))
-                .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
-                .build();
-
-        var projectId = UUID.randomUUID();
+        var rule = llmRule();
+        var projectId = idGenerator.generateId();
 
         publisher.enqueueThreadMessage(threadIds, rule, projectId, "workspace", "user").block();
+
+        // The resolved-rule overload must never reach the rule service; without this the bare mock would
+        // return null, the ruleId overload would map that to an empty Mono, and the test would still pass.
+        verifyNoInteractions(automationRuleEvaluatorService);
 
         // Compared whole, against independently built expectations: asserting only the thread ids would pass
         // while the codec silently dropped the evaluator code, the user, or the project. Plain element
@@ -148,14 +151,12 @@ class OnlineScorePublisherIntegrationTest {
     void enqueueThreadMessageWritesOnePythonEntryPerThreadId() {
         var publisher = newPublisher();
         var threadIds = List.of("thread-a-" + suffix(), "thread-b-" + suffix(), "thread-c-" + suffix());
-        var projectId = UUID.randomUUID();
-        var rule = AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.builder()
-                .id(UUID.randomUUID())
-                .name(podamFactory.manufacturePojo(String.class))
-                .code(podamFactory.manufacturePojo(TraceThreadUserDefinedMetricPythonCode.class))
-                .build();
+        var projectId = idGenerator.generateId();
+        var rule = pythonRule();
 
         publisher.enqueueThreadMessage(threadIds, rule, projectId, "workspace", "user").block();
+
+        verifyNoInteractions(automationRuleEvaluatorService);
 
         var expected = threadIds.stream()
                 .map(threadId -> TraceThreadToScoreUserDefinedMetricPython.builder()
@@ -173,6 +174,22 @@ class OnlineScorePublisherIntegrationTest {
                 .as("the Python payload needs the same per-entry granularity as the LLM one")
                 .hasSize(threadIds.size());
         assertThat(written).containsExactlyInAnyOrderElementsOf(expected);
+    }
+
+    private AutomationRuleEvaluatorTraceThreadLlmAsJudge llmRule() {
+        return AutomationRuleEvaluatorTraceThreadLlmAsJudge.builder()
+                .id(idGenerator.generateId())
+                .name(podamFactory.manufacturePojo(String.class))
+                .code(podamFactory.manufacturePojo(TraceThreadLlmAsJudgeCode.class))
+                .build();
+    }
+
+    private AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython pythonRule() {
+        return AutomationRuleEvaluatorTraceThreadUserDefinedMetricPython.builder()
+                .id(idGenerator.generateId())
+                .name(podamFactory.manufacturePojo(String.class))
+                .code(podamFactory.manufacturePojo(TraceThreadUserDefinedMetricPythonCode.class))
+                .build();
     }
 
     private OnlineScorePublisher newPublisher() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -4,6 +4,9 @@ import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.ChunkedOutputHandlers;
+import com.google.api.gax.rpc.ApiException;
+import com.google.api.gax.rpc.StatusCode;
+import com.openai.errors.OpenAIServiceException;
 import dev.langchain4j.data.message.UserMessage;
 import dev.langchain4j.exception.AuthenticationException;
 import dev.langchain4j.exception.HttpException;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -38,6 +42,7 @@ import uk.co.jemos.podam.api.PodamFactory;
 import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -627,35 +632,523 @@ class ChatCompletionServiceTest {
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
         }
 
-        @ParameterizedTest(name = "scoreTrace: when {0}, then stay a retryable 500")
-        @MethodSource("providerStatusProvider")
-        @DisplayName("Online scoring deliberately keeps the blanket 500, so the subscriber still retries")
-        void scoreTrace__whenProviderErrorUnparsed__thenStayRetryable(
+        /**
+         * The statuses the subscriber must retire, spelled out as a literal and used both to partition the
+         * shared rows below and to assert every retryability outcome. Deliberately NOT
+         * {@code HttpStatusRetryability.isPermanent}: a test that derives its expectation from the predicate
+         * under test agrees with that predicate even when it is wrong, so production and tests would regress
+         * together silently. The predicate's own mapping is pinned separately, also with literals, in
+         * {@code HttpStatusRetryabilityTest}.
+         */
+        /**
+         * Exact attempt count for the retry-budget tests, which set {@code getMaxAttempts()} to 3. That value is
+         * passed to langchain4j as {@code RetryPolicy.maxRetries}, and its contract is "the action can be executed
+         * up to maxRetries + 1 times" — so a fully-consumed budget is 4 calls, not 3. Asserted exactly rather than
+         * with {@code atLeast}, so an implementation that retries fewer times fails.
+         */
+        private static final int EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3 = 4;
+
+        private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 403, 404, 413, 422, 499);
+
+        /** The shared rows whose status is permanent, so their scoreTrace case needs no branch. */
+        private static Stream<Arguments> permanentProviderStatuses() {
+            return providerStatusProvider().filter(row -> PERMANENT_STATUSES.contains(row.get()[2]));
+        }
+
+        /** The complement, kept separate for the same reason. */
+        private static Stream<Arguments> transientProviderStatuses() {
+            return providerStatusProvider().filter(row -> !PERMANENT_STATUSES.contains(row.get()[2]));
+        }
+
+        /**
+         * OPIK-8240. The redaction-limit incident: Uber's gateway rejects an oversized scoring request with
+         * a plain-text 400 that getLlmProviderError cannot parse (no JSON envelope, so no '{' for
+         * extractErrorJson to find). scoreTrace used to answer every unparsed provider error with a blanket
+         * 500, which lands outside BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS - so a request that could
+         * never succeed was replayed maxRetries times, once per pendingMessageDuration, before being
+         * dropped.
+         *
+         * <p>The status now comes off the HttpException in the cause chain (findProviderHttpStatus) rather
+         * than the unparseable body, and a permanent 4xx becomes a ClientErrorException so the subscriber
+         * retires it on the first delivery.
+         */
+        @ParameterizedTest(name = "scoreTrace: permanent {0} -> non-retryable ClientErrorException")
+        @CsvSource({
+                "400, Bad Request",
+                "401, Unauthorized",
+                "403, Forbidden",
+                "404, Not Found",
+                "413, Payload Too Large",
+                "422, Unprocessable Entity",
+        })
+        @DisplayName("A permanent provider 4xx becomes non-retryable, so the evaluation is dropped not replayed")
+        void scoreTrace__whenPermanentClientError__thenNonRetryable(int status, String label) {
+            // Plain-text body, exactly like the real gateway rejection - unparseable, so the status has to
+            // come from the HttpException itself.
+            var providerFailure = new InvalidRequestException(
+                    "error, status code: %d, status: , message: %s".formatted(status, label),
+                    new HttpException(status, label));
+
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertNonRetryable(thrown, status);
+        }
+
+        /**
+         * The other half of the split, and the reason family-level classification was not enough: 408, 425
+         * and 429 are client-error-family by numbering but transient in meaning. Dropping them on the first
+         * failure - which any blanket "4xx is non-retryable" rule would do - would discard an evaluation
+         * over a rate limit that clears in seconds.
+         */
+        @ParameterizedTest(name = "scoreTrace: transient {0} -> stays retryable")
+        @CsvSource({
+                "408, Request Timeout",
+                "425, Too Early",
+                "429, Too Many Requests",
+                "500, Internal Server Error",
+                "502, Bad Gateway",
+                "503, Service Unavailable",
+        })
+        @DisplayName("A transient status stays retryable, so maxRetries is still honoured")
+        void scoreTrace__whenTransientStatus__thenStaysRetryable(int status, String label) {
+            var thrown = whenScoreTraceFails(new RuntimeException(new HttpException(status, label)),
+                    Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Review finding on #8162: with no status on the wire, the mapper's code must NOT decide
+         * retryability -- in either direction.
+         *
+         * <p>An earlier revision fell back to {@code providerError.getCode()} when
+         * {@code findProviderHttpStatus} came up empty. But the mappers synthesize a code when they cannot
+         * parse the body ({@code CustomLlmErrorMessage} defaults to 400, {@code OpenAiErrorMessage} to
+         * 500), and nothing downstream can tell a genuinely parsed 400 from that default. So any
+         * unparseable failure of a CustomLlm provider -- a connection reset, a proxy hiccup, a truncated
+         * body -- was classified permanent and dropped on its first delivery. Silent loss of an evaluation
+         * that a retry might well have completed.
+         *
+         * <p>The asymmetry settles it: needlessly retrying a genuinely permanent error wastes at most
+         * {@code maxRetries} attempts, whereas dropping an unknown failure loses it forever. So <b>every</b>
+         * mapper-only status is now retryable, 400 included. The permanent classification requires a real
+         * wire status, which the cases above and below supply via {@code HttpException}.
+         */
+        @ParameterizedTest(name = "scoreTrace: mapper-only {0}, no wire status -> stays retryable")
+        @CsvSource({"400", "401", "403", "408", "429", "500", "503"})
+        @DisplayName("Without a wire status the mapper's code never makes a failure permanent")
+        void scoreTrace__whenNoWireStatus__thenStaysRetryableWhateverTheMapperSays(int mappedStatus) {
+            var thrown = whenScoreTraceFails(new RuntimeException("no HTTP status in this chain"),
+                    Optional.of(new ErrorMessage(mappedStatus, "provider body says " + mappedStatus)));
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Regression for the precedence bug caught in review of OPIK-8240.
+         *
+         * <p>The provider mappers synthesize a status when they cannot read one off the body:
+         * {@code CustomLlmErrorMessage} defaults to 400, {@code OpenAiErrorMessage} to 500. If a synthetic
+         * value outranks the code the provider actually put on the wire, retryability is decided from a
+         * number nobody sent. This is the damaging direction: a transient provider outage hidden behind
+         * CustomLlm's synthetic 400 would be classified permanent and dropped on its first delivery.
+         */
+        @ParameterizedTest(name = "transient wire {0} behind synthetic {1} -> stays retryable")
+        @CsvSource({
+                "503, 400",
+                "429, 400",
+        })
+        @DisplayName("A transient status on the wire outranks a synthetic permanent mapper fallback")
+        void scoreTrace__whenTransientWireStatusBehindSyntheticPermanent__thenStaysRetryable(
+                int wireStatus, int syntheticStatus) {
+            var providerFailure = new RuntimeException(new HttpException(wireStatus, "upstream said " + wireStatus));
+
+            var thrown = whenScoreTraceFails(providerFailure,
+                    Optional.of(new ErrorMessage(syntheticStatus, "synthetic mapper fallback")));
+
+            assertRetryable(thrown);
+        }
+
+        /** The harmless direction of the same precedence rule, kept so the rule is pinned both ways. */
+        @ParameterizedTest(name = "permanent wire {0} behind synthetic {1} -> stays non-retryable")
+        @CsvSource({
+                "400, 500",
+                "403, 500",
+        })
+        @DisplayName("A permanent status on the wire outranks a synthetic transient mapper fallback")
+        void scoreTrace__whenPermanentWireStatusBehindSyntheticTransient__thenStaysNonRetryable(
+                int wireStatus, int syntheticStatus) {
+            var providerFailure = new RuntimeException(new HttpException(wireStatus, "upstream said " + wireStatus));
+
+            var thrown = whenScoreTraceFails(providerFailure,
+                    Optional.of(new ErrorMessage(syntheticStatus, "synthetic mapper fallback")));
+
+            assertNonRetryable(thrown, wireStatus);
+        }
+
+        /**
+         * The shared production-shaped rows, run through scoreTrace. Split into a permanent and a transient
+         * case rather than one case that branches: scoreTrace has no JAX-RS caller, so the thrown TYPE is
+         * read for retryability rather than as an HTTP status, and each category deserves an assertion that
+         * says which one it belongs to. Before OPIK-8240 this path answered every failure with a blanket
+         * 500, which kept transient 408/429 retryable (correct) but also replayed permanent 400/401
+         * failures that could never succeed (the redaction-limit incident).
+         */
+        @ParameterizedTest(name = "scoreTrace: when {0}, then non-retryable {2}")
+        @MethodSource("permanentProviderStatuses")
+        @DisplayName("Online scoring drops a permanent provider status instead of replaying it")
+        void scoreTrace__whenPermanentProviderErrorUnparsed__thenNonRetryable(
                 String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {
-            // Given — scoreTrace has no JAX-RS caller: the three OnlineScoring*LlmAsJudgeScorer subscribers are the
-            // only callers, so a recovered status would reach no HTTP client. It would, however, reach
-            // BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS, which lists ClientErrorException — so a recovered 429 or
-            // 408 (both RetriableException upstream) would be acked and dropped instead of retried up to
-            // onlineScoring.maxRetries. Whatever the provider reported, this path must stay a 500.
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertThat(thrown).hasMessageContaining(expectedMessagePart);
+            assertNonRetryable(thrown, expectedStatus);
+        }
+
+        @ParameterizedTest(name = "scoreTrace: when {0}, then retryable")
+        @MethodSource("transientProviderStatuses")
+        @DisplayName("Online scoring keeps a transient provider status retryable, honouring maxRetries")
+        void scoreTrace__whenTransientProviderErrorUnparsed__thenRetryable(
+                String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {
+            var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
+
+            assertThat(thrown).hasMessageContaining(expectedMessagePart);
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Review finding: the permanent cases above assert the thrown TYPE but not that the call was made once.
+         * {@code InvalidRequestException} is already a {@code NonRetriableException}, so those cases pass with
+         * {@code failFastOnPermanentFailure} deleted — they do not exercise the HTTP-status path they claim to.
+         * These drive a raw {@code HttpException}, which is NOT a {@code NonRetriableException}, so only the
+         * status classification can stop the retry.
+         */
+        @ParameterizedTest(name = "permanent HTTP {0} is attempted exactly once")
+        @CsvSource({
+                "400, Bad Request",
+                "403, Forbidden",
+                "404, Not Found",
+                "413, Payload Too Large",
+                "422, Unprocessable Entity",
+        })
+        @DisplayName("A permanent wire status does not consume the in-process retry budget")
+        void scoreTrace__whenPermanentHttpStatus__thenNotRetriedInProcess(int status, String label) {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
             var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
             var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
-            var workspaceId = "test-workspace-id";
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(new HttpException(status, label)));
+            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
+                    .thenReturn(llmProviderService);
+            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(ClientErrorException.class);
+
+            verify(chatModel, times(1)).chat(any(ChatRequest.class));
+        }
+
+        @ParameterizedTest(name = "transient HTTP {0} is still retried")
+        @CsvSource({"429, Too Many Requests", "503, Service Unavailable"})
+        @DisplayName("A transient wire status still consumes the retry budget")
+        void scoreTrace__whenTransientHttpStatus__thenStillRetriedInProcess(int status, String label) {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(new HttpException(status, label)));
+            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
+                    .thenReturn(llmProviderService);
+            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            // The status is now reported verbatim, so this asserts retryability rather than a flattened 500.
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(InternalServerErrorException.class);
+
+            verify(chatModel, times(EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3)).chat(any(ChatRequest.class));
+        }
+
+        /**
+         * VertexAI is one of two providers whose client raises no {@code HttpException} — the OpenAI Responses
+         * SDK is the other, covered below. The Google Cloud SDK throws GAX {@code ApiException}, which
+         * langchain4j also does not model as {@code NonRetriableException}, so a permanent Vertex failure was
+         * retried in-process AND redelivered by the subscriber. The status now comes from GAX's own
+         * transport-neutral translation, so it classifies like any other provider.
+         */
+        @ParameterizedTest(name = "GAX {0} -> HTTP {1}, non-retryable")
+        @CsvSource({
+                "INVALID_ARGUMENT, 400",
+                "FAILED_PRECONDITION, 400",
+                "OUT_OF_RANGE, 400",
+                "UNAUTHENTICATED, 401",
+                "PERMISSION_DENIED, 403",
+                "NOT_FOUND, 404",
+        })
+        @DisplayName("A permanent VertexAI GAX failure is retired on the first delivery")
+        void scoreTrace__whenPermanentGaxStatus__thenNonRetryable(StatusCode.Code code, int expectedStatus) {
+            // Wrapped in RuntimeException because that is the shape VertexAiGeminiChatModel actually throws.
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, false)), Optional.empty());
+
+            assertNonRetryable(thrown, expectedStatus);
+        }
+
+        @ParameterizedTest(name = "GAX {0} stays retryable")
+        @CsvSource({"RESOURCE_EXHAUSTED", "DEADLINE_EXCEEDED", "UNAVAILABLE", "INTERNAL", "UNKNOWN"})
+        @DisplayName("A transient VertexAI GAX failure still honours maxRetries")
+        void scoreTrace__whenTransientGaxStatus__thenRetryable(StatusCode.Code code) {
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, false)), Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * The safety valve. GAX's own {@code isRetryable()} can only ever prevent a drop, never cause one, so a code
+         * that would otherwise map to a permanent status stays retryable when GAX says it is worth retrying. Guards
+         * the cases where the gRPC-to-HTTP translation disagrees with retry semantics (ABORTED, CANCELLED).
+         */
+        @ParameterizedTest(name = "GAX {0} marked retryable stays retryable despite a permanent status")
+        @CsvSource({"INVALID_ARGUMENT", "PERMISSION_DENIED", "ABORTED", "CANCELLED"})
+        @DisplayName("GAX's own retryable verdict is never overridden into a drop")
+        void scoreTrace__whenGaxSaysRetryable__thenRetryable(StatusCode.Code code) {
+            var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, true)), Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Precedence is unchanged by the GAX addition: a real {@code HttpException} anywhere in the chain still wins
+         * over anything a typed exception implies. A 503 on the wire must not be collapsed into GAX's permanent 400.
+         */
+        @Test
+        @DisplayName("A wire HttpException still outranks a GAX status in the same chain")
+        void scoreTrace__whenHttpExceptionAndGaxInSameChain__thenHttpExceptionWins() {
+            var chain = new RuntimeException(
+                    gaxException(StatusCode.Code.INVALID_ARGUMENT, false, new HttpException(503, "upstream 503")));
+
+            var thrown = whenScoreTraceFails(chain, Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        @Test
+        @DisplayName("A permanent GAX failure does not consume the in-process retry budget")
+        void scoreTrace__whenPermanentGaxStatus__thenNotRetriedInProcess() {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.INVALID_ARGUMENT, false)));
+            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
+                    .thenReturn(llmProviderService);
+            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(ClientErrorException.class);
+
+            // GAX ApiException is not a NonRetriableException, so without failFastOnPermanentFailure langchain4j's
+            // RetryPolicy would replay a call that can never succeed.
+            verify(chatModel, times(1)).chat(any(ChatRequest.class));
+        }
+
+        @Test
+        @DisplayName("A transient GAX failure is still retried in-process")
+        void scoreTrace__whenTransientGaxStatus__thenStillRetriedInProcess() {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
+            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+
+            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.UNAVAILABLE, false)));
+            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
+                    .thenReturn(llmProviderService);
+            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+
+            // The status is now reported verbatim, so this asserts retryability rather than a flattened 500.
+            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
+                    .isInstanceOf(InternalServerErrorException.class);
+
+            verify(chatModel, times(EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3)).chat(any(ChatRequest.class));
+        }
+
+        /**
+         * Review finding, and my earlier refutation of it was wrong. I checked
+         * {@code OpenAILlmServiceProvider.getLanguageModel} — which unconditionally calls
+         * {@code newOpenAiChatLanguageModel} — and concluded the Responses SDK was unreachable from
+         * scoreTrace. It isn't: that generator method itself switches on the pipeline mode and returns
+         * {@code OpenAiOfficialResponsesChatModel} for {@code RESPONSES_API}, which is backed by openai-java
+         * and raises {@code OpenAIServiceException}. That carries a real wire status but is neither an
+         * {@code HttpException} nor a langchain4j typed exception, so a permanent 400 was falling through to
+         * the retryable 500 and being replayed to exhaustion.
+         */
+        @ParameterizedTest(name = "Responses SDK {0} -> non-retryable")
+        @CsvSource({"400", "403", "404", "422"})
+        @DisplayName("A permanent OpenAI Responses failure is retired on the first delivery")
+        void scoreTrace__whenPermanentResponsesSdkStatus__thenNonRetryable(int status) {
+            var thrown = whenScoreTraceFails(new RuntimeException(responsesException(status)), Optional.empty());
+
+            assertNonRetryable(thrown, status);
+        }
+
+        @ParameterizedTest(name = "Responses SDK {0} -> retryable")
+        @CsvSource({"408", "429", "500", "503"})
+        @DisplayName("A transient OpenAI Responses failure stays retryable")
+        void scoreTrace__whenTransientResponsesSdkStatus__thenRetryable(int status) {
+            var thrown = whenScoreTraceFails(new RuntimeException(responsesException(status)), Optional.empty());
+
+            assertRetryable(thrown);
+        }
+
+        /**
+         * Review finding. {@code findProviderHttpStatus} filtered to error statuses only once, on the winner,
+         * so a non-error {@code HttpException} anywhere in the chain satisfied {@code findFirst}, suppressed
+         * the typed fallback, and was then discarded — leaving no status at all. For VertexAI and the OpenAI
+         * Responses SDK that fallback is the only source of status, so a permanent 400 silently became a
+         * retryable 500 and was replayed to exhaustion. The filter now runs at each stage.
+         */
+        @ParameterizedTest(name = "GAX {0} survives a non-error HttpException at {1} in the chain")
+        @CsvSource({
+                "INVALID_ARGUMENT, 302, 400",
+                "PERMISSION_DENIED, 302, 403",
+                "INVALID_ARGUMENT, 0, 400",
+        })
+        @DisplayName("A non-error status in the chain must not mask the real provider status")
+        void scoreTrace__whenNonErrorHttpExceptionPrecedesGaxStatus__thenRealStatusWins(
+                StatusCode.Code code, int noiseStatus, int expectedStatus) {
+            // The GAX exception carries the stray HttpException as its cause, so the chain is
+            // [ApiException, HttpException(noise)] -- the noise is found first by the HttpException pass.
+            var providerFailure = gaxException(code, false, new HttpException(noiseStatus, "not an error"));
+
+            var thrown = whenScoreTraceFails(new RuntimeException(providerFailure), Optional.empty());
+
+            assertNonRetryable(thrown, expectedStatus);
+        }
+
+        @Test
+        @DisplayName("A non-error status in the chain must not mask an OpenAI Responses status")
+        void scoreTrace__whenNonErrorHttpExceptionPrecedesResponsesStatus__thenRealStatusWins() {
+            var responses = responsesException(400, new HttpException(302, "not an error"));
+
+            var thrown = whenScoreTraceFails(new RuntimeException(responses), Optional.empty());
+
+            assertNonRetryable(thrown, 400);
+        }
+
+        /** Minimal stand-in for the openai-java SDK's exception: only {@code statusCode()} is consulted. */
+        private static OpenAIServiceException responsesException(int status) {
+            return responsesException(status, null);
+        }
+
+        private static OpenAIServiceException responsesException(int status, Throwable cause) {
+            return new OpenAIServiceException("responses api failed with " + status, cause) {
+                @Override
+                public int statusCode() {
+                    return status;
+                }
+
+                @Override
+                public com.openai.core.http.Headers headers() {
+                    return com.openai.core.http.Headers.builder().build();
+                }
+
+                @Override
+                public com.openai.core.JsonValue body() {
+                    return com.openai.core.JsonValue.from(null);
+                }
+
+                @Override
+                public Optional<String> code() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> param() {
+                    return Optional.empty();
+                }
+
+                @Override
+                public Optional<String> type() {
+                    return Optional.empty();
+                }
+            };
+        }
+
+        private static ApiException gaxException(StatusCode.Code code, boolean retryable) {
+            return gaxException(code, retryable, new RuntimeException("vertex transport failure"));
+        }
+
+        /** A transport-free {@link StatusCode}: gRPC and HTTP-JSON both reduce to the same neutral {@code Code}. */
+        private static ApiException gaxException(StatusCode.Code code, boolean retryable, Throwable cause) {
+            return new ApiException(cause, new StatusCode() {
+                @Override
+                public Code getCode() {
+                    return code;
+                }
+
+                @Override
+                public Object getTransportCode() {
+                    return null;
+                }
+            }, retryable);
+        }
+
+        /** Drives scoreTrace to failure and returns what it threw. */
+        private Throwable whenScoreTraceFails(RuntimeException providerFailure,
+                Optional<ErrorMessage> mappedProviderError) {
+            var chatRequest = ChatRequest.builder()
+                    .messages(UserMessage.from(podamFactory.manufacturePojo(String.class)))
+                    .build();
+            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+            var workspaceId = podamFactory.manufacturePojo(String.class);
 
             when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
             when(chatModel.chat(any(ChatRequest.class))).thenThrow(providerFailure);
-            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
-            when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
+            // scoreTrace no longer consults the provider mapper -- retryability comes from the wire status
+            // alone. Kept lenient rather than deleted so these stay regression guards: if the mapper is ever
+            // wired back in, the precedence cases below fail instead of silently passing.
+            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
+                    .thenReturn(llmProviderService);
+            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(mappedProviderError);
 
-            // When
-            var thrown = catchThrowable(
+            return catchThrowable(
                     () -> chatCompletionService.scoreTrace(chatRequest, modelParameters, workspaceId));
+        }
 
-            // Then — InternalServerErrorException is absent from NON_RETRYABLE_EXCEPTIONS, which is what keeps the
-            // evaluation retryable; expectedStatus is deliberately unused here
+        private void assertNonRetryable(Throwable thrown, int expectedStatus) {
+            assertThat(PERMANENT_STATUSES)
+                    .as("test-case error: %d is not one of the statuses this assertion is for", expectedStatus)
+                    .contains(expectedStatus);
             assertThat(thrown)
+                    .as("a permanent status must arrive as ClientErrorException, which the subscriber retires")
+                    .isInstanceOf(ClientErrorException.class);
+            assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
+        }
+
+        /**
+         * The provider's status is now reported verbatim, so this no longer pins a flattened 500 — it pins
+         * the property that matters: the subscriber will redeliver rather than drop.
+         */
+        /**
+         * Every retryable failure is flattened to a blanket 500 on this path: BaseRedisSubscriber matches
+         * ClientErrorException by class, so a truthful 429 would be acked and dropped. The status is
+         * therefore deliberately NOT the provider's own here — that only becomes safe once the subscriber
+         * classifies by status.
+         */
+        private void assertRetryable(Throwable thrown) {
+            assertThat(thrown)
+                    .as("a status that may clear on retry must stay outside NON_RETRYABLE_EXCEPTIONS")
                     .isInstanceOf(InternalServerErrorException.class)
-                    .isNotInstanceOf(ClientErrorException.class)
-                    .hasMessageContaining(expectedMessagePart);
+                    .isNotInstanceOf(ClientErrorException.class);
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(500);
         }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -636,12 +636,12 @@ class ChatCompletionServiceTest {
         /**
          * The statuses the subscriber must retire, spelled out as a literal and used both to partition the
          * shared rows below and to assert every retryability outcome. Deliberately NOT
-         * {@code HttpStatusRetryability.isPermanent}: a test that derives its expectation from the predicate
-         * under test agrees with that predicate even when it is wrong, so production and tests would regress
-         * together silently. The predicate's own mapping is pinned separately, also with literals, in
-         * {@code HttpStatusRetryabilityTest}.
+         * {@link ChatCompletionService#isPermanentFailure}: a test that derives its expectation from the
+         * predicate under test agrees with that predicate even when it is wrong, so production and tests
+         * would regress together silently. The predicate's own mapping is pinned against its own literals
+         * by {@link #isPermanentFailure__whenStatus__thenMatchLiteralTable()}.
          */
-        private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 403, 404, 413, 422, 499);
+        private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 402, 403, 404, 413, 422, 499);
 
         /** The shared rows whose status is permanent, so their scoreTrace case needs no branch. */
         private static Stream<Arguments> permanentProviderStatuses() {
@@ -669,10 +669,15 @@ class ChatCompletionServiceTest {
         @CsvSource({
                 "400, Bad Request",
                 "401, Unauthorized",
+                // 402 is what OpenAiCompatStatusCodes maps insufficient_quota to, so it is the permanent
+                // status most likely to actually arrive; 499 is nginx's client-closed-request, which the
+                // predicate classifies permanent because nothing marks it transient.
+                "402, Payment Required",
                 "403, Forbidden",
                 "404, Not Found",
                 "413, Payload Too Large",
                 "422, Unprocessable Entity",
+                "499, Client Closed Request",
         })
         @DisplayName("A permanent provider 4xx becomes non-retryable, so the evaluation is dropped not replayed")
         void scoreTrace__whenPermanentClientError__thenNonRetryable(int status, String label) {
@@ -735,6 +740,66 @@ class ChatCompletionServiceTest {
                     Optional.of(new ErrorMessage(mappedStatus, "provider body says " + mappedStatus)));
 
             assertRetryable(thrown);
+        }
+
+        /**
+         * The out-of-credits path, which is the one 429 that reaches here carrying no wire status at all.
+         * {@code QuotaAwareHttpClient} rethrows {@link NonRetriableException} with the response body as its
+         * <b>message and deliberately no cause</b>, so langchain4j's {@code ExceptionMapper.findRoot()}
+         * cannot unwrap to the {@code HttpException} and re-map the 429 back to a retryable
+         * {@code RateLimitException}. {@code findProviderHttpStatus} pays the same price: no
+         * {@code HttpException} anywhere in the chain, and a bare {@code NonRetriableException} has no
+         * canonical status either, so the classification falls through to retryable.
+         *
+         * <p>Asserted as the deliberate contract, not as an oversight. It follows the asymmetry the cases
+         * above pin -- an absent status stays retryable, because needlessly retrying costs at most
+         * {@code maxRetries} attempts whereas dropping an unknown failure loses the evaluation for good --
+         * and the waste is bounded: {@code NonRetriableException} already stops langchain4j's inner retry
+         * and Opik's outer {@code withRetry} on the first attempt, so an exhausted key costs one provider
+         * call per redelivery rather than an error storm.
+         *
+         * <p>Retiring it on the first delivery instead would mean carrying the status on a dedicated
+         * exception type that {@code canonicalStatusOf} recognises, since the mapper's 402 must keep being
+         * ignored here. That is a production change on the OpenAI client, out of scope for this PR.
+         */
+        @Test
+        @DisplayName("An out-of-credits 429 carries no wire status, so it stays retryable by design")
+        void scoreTrace__whenInsufficientQuotaCarriesNoWireStatus__thenStaysRetryable() {
+            // Byte-for-byte the exception QuotaAwareHttpClient raises: body as message, no cause.
+            var providerFailure = new NonRetriableException(
+                    "{\"error\":{\"message\":\"You exceeded your current quota\",\"type\":\"insufficient_quota\"}}");
+
+            // The mapper's 402 is supplied precisely to prove it is not consulted on this path.
+            var thrown = whenScoreTraceFails(providerFailure,
+                    Optional.of(new ErrorMessage(402, "insufficient_quota")));
+
+            assertRetryable(thrown);
+            assertThat(thrown)
+                    .as("the provider body must survive for diagnostics even though it decides nothing")
+                    .hasMessageContaining("insufficient_quota");
+        }
+
+        /**
+         * The companion {@link #PERMANENT_STATUSES} promises. {@link ChatCompletionService#isPermanentFailure}
+         * is the predicate production actually consults, so its mapping is pinned here against a hand-written
+         * table rather than against {@code PERMANENT_STATUSES} -- deriving either from the other is exactly
+         * what would let production and tests regress together.
+         */
+        @ParameterizedTest(name = "isPermanentFailure({0}) == {1}")
+        @CsvSource({
+                // Client errors with nothing transient about them: this exact request can never succeed.
+                "400, true", "401, true", "402, true", "403, true", "404, true",
+                "413, true", "422, true", "499, true",
+                // 4xx by numbering, "not now" by meaning -- the whole reason family alone cannot decide.
+                "408, false", "425, false", "429, false",
+                // Server errors are the textbook retry case.
+                "500, false", "502, false", "503, false", "504, false",
+                // Outside the error families, so never permanent.
+                "200, false", "302, false",
+        })
+        @DisplayName("isPermanentFailure classifies each status, pinned independently of the suite's own table")
+        void isPermanentFailure__whenStatus__thenMatchLiteralTable(int status, boolean expectedPermanent) {
+            assertThat(ChatCompletionService.isPermanentFailure(status)).isEqualTo(expectedPermanent);
         }
 
         /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -780,10 +780,14 @@ class ChatCompletionServiceTest {
         }
 
         /**
-         * The companion {@link #PERMANENT_STATUSES} promises. {@link ChatCompletionService#isPermanentFailure}
-         * is the predicate production actually consults, so its mapping is pinned here against a hand-written
-         * table rather than against {@code PERMANENT_STATUSES} -- deriving either from the other is exactly
-         * what would let production and tests regress together.
+         * Pins the status-to-retryability mapping of {@link ChatCompletionService#isPermanentFailure}, the
+         * predicate production consults to decide whether a request can never succeed and so must be
+         * retired rather than retried.
+         *
+         * <p>This is the companion test {@link #PERMANENT_STATUSES} refers to. The expectations are the
+         * hand-written table below rather than {@code PERMANENT_STATUSES} itself: that set records which
+         * statuses the subscriber must retire, and deriving either from the other is exactly what would let
+         * production and tests regress together.
          */
         @ParameterizedTest(name = "isPermanentFailure({0}) == {1}")
         @CsvSource({

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -640,14 +641,6 @@ class ChatCompletionServiceTest {
          * together silently. The predicate's own mapping is pinned separately, also with literals, in
          * {@code HttpStatusRetryabilityTest}.
          */
-        /**
-         * Exact attempt count for the retry-budget tests, which set {@code getMaxAttempts()} to 3. That value is
-         * passed to langchain4j as {@code RetryPolicy.maxRetries}, and its contract is "the action can be executed
-         * up to maxRetries + 1 times" — so a fully-consumed budget is 4 calls, not 3. Asserted exactly rather than
-         * with {@code atLeast}, so an implementation that retries fewer times fails.
-         */
-        private static final int EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3 = 4;
-
         private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 403, 404, 413, 422, 499);
 
         /** The shared rows whose status is permanent, so their scoreTrace case needs no branch. */
@@ -817,61 +810,58 @@ class ChatCompletionServiceTest {
         }
 
         /**
-         * Review finding: the permanent cases above assert the thrown TYPE but not that the call was made once.
-         * {@code InvalidRequestException} is already a {@code NonRetriableException}, so those cases pass with
-         * {@code failFastOnPermanentFailure} deleted — they do not exercise the HTTP-status path they claim to.
-         * These drive a raw {@code HttpException}, which is NOT a {@code NonRetriableException}, so only the
-         * status classification can stop the retry.
+         * Review finding: these hard-coded {@code maxAttempts} to 3, so they only ever exercised four
+         * executions and never the boundaries. They are now parameterised over the budget itself, because the
+         * relationship being asserted is langchain4j's {@code maxRetries + 1} contract — and {@code 0} is
+         * where an off-by-one would show, since a zero-retry budget must still make the initial call.
+         *
+         * <p>Both drive a raw {@code HttpException}, which is NOT a {@code NonRetriableException}, so only
+         * the status classification can stop the retry — an {@code InvalidRequestException} would be stopped
+         * by langchain4j regardless and would not exercise this path at all.
+         *
+         * <p>Status coverage is not duplicated here; which statuses are permanent is pinned by
+         * {@code scoreTrace__whenPermanentClientError__thenNonRetryable} and its transient counterpart. These
+         * use one representative of each and vary only the budget.
          */
-        @ParameterizedTest(name = "permanent HTTP {0} is attempted exactly once")
-        @CsvSource({
-                "400, Bad Request",
-                "403, Forbidden",
-                "404, Not Found",
-                "413, Payload Too Large",
-                "422, Unprocessable Entity",
-        })
-        @DisplayName("A permanent wire status does not consume the in-process retry budget")
-        void scoreTrace__whenPermanentHttpStatus__thenNotRetriedInProcess(int status, String label) {
-            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
-            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
-            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
-            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+        @ParameterizedTest(name = "maxRetries={0}: a permanent status is attempted once")
+        @ValueSource(ints = {0, 1, 2, 3})
+        @DisplayName("A permanent wire status is attempted exactly once, whatever the retry budget")
+        void scoreTrace__whenPermanentStatus__thenAttemptedOnceWhateverTheBudget(int maxRetries) {
+            var thrown = scoreTraceWithBudget(maxRetries,
+                    new RuntimeException(new HttpException(400, "Bad Request")));
 
-            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
-            when(chatModel.chat(any(ChatRequest.class)))
-                    .thenThrow(new RuntimeException(new HttpException(status, label)));
-            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
-                    .thenReturn(llmProviderService);
-            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
-                    .isInstanceOf(ClientErrorException.class);
-
+            assertNonRetryable(thrown, 400);
             verify(chatModel, times(1)).chat(any(ChatRequest.class));
         }
 
-        @ParameterizedTest(name = "transient HTTP {0} is still retried")
-        @CsvSource({"429, Too Many Requests", "503, Service Unavailable"})
-        @DisplayName("A transient wire status still consumes the retry budget")
-        void scoreTrace__whenTransientHttpStatus__thenStillRetriedInProcess(int status, String label) {
-            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
+        @ParameterizedTest(name = "maxRetries={0}: a transient status is attempted {1} times")
+        @CsvSource({"0, 1", "1, 2", "2, 3"})
+        @DisplayName("A transient wire status consumes the whole budget: maxRetries + 1 attempts")
+        void scoreTrace__whenTransientStatus__thenConsumesTheWholeBudget(int maxRetries, int expectedAttempts) {
+            var thrown = scoreTraceWithBudget(maxRetries,
+                    new RuntimeException(new HttpException(429, "Too Many Requests")));
+
+            assertRetryable(thrown);
+            verify(chatModel, times(expectedAttempts)).chat(any(ChatRequest.class));
+        }
+
+        /**
+         * Drives scoreTrace against a service built with the given retry budget. Shared so the three budget
+         * cases do not each repeat the construction, which is what let them drift to a single hard-coded value.
+         */
+        private Throwable scoreTraceWithBudget(int maxRetries, RuntimeException providerFailure) {
+            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(maxRetries);
             var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
             var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
             var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
 
             when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
-            when(chatModel.chat(any(ChatRequest.class)))
-                    .thenThrow(new RuntimeException(new HttpException(status, label)));
+            when(chatModel.chat(any(ChatRequest.class))).thenThrow(providerFailure);
             lenient().when(llmProviderFactory.getService(anyString(), anyString()))
                     .thenReturn(llmProviderService);
             lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
 
-            // The status is now reported verbatim, so this asserts retryability rather than a flattened 500.
-            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
-                    .isInstanceOf(InternalServerErrorException.class);
-
-            verify(chatModel, times(EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3)).chat(any(ChatRequest.class));
+            return catchThrowable(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"));
         }
 
         /**
@@ -939,46 +929,23 @@ class ChatCompletionServiceTest {
         @Test
         @DisplayName("A permanent GAX failure does not consume the in-process retry budget")
         void scoreTrace__whenPermanentGaxStatus__thenNotRetriedInProcess() {
-            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
-            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
-            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
-            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+            var thrown = scoreTraceWithBudget(2,
+                    new RuntimeException(gaxException(StatusCode.Code.INVALID_ARGUMENT, false)));
 
-            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
-            when(chatModel.chat(any(ChatRequest.class)))
-                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.INVALID_ARGUMENT, false)));
-            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
-                    .thenReturn(llmProviderService);
-            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
-                    .isInstanceOf(ClientErrorException.class);
-
-            // GAX ApiException is not a NonRetriableException, so without failFastOnPermanentFailure langchain4j's
-            // RetryPolicy would replay a call that can never succeed.
+            // GAX ApiException is not a NonRetriableException, so without failFastOnPermanentFailure
+            // langchain4j's RetryPolicy would replay a call that can never succeed.
+            assertNonRetryable(thrown, 400);
             verify(chatModel, times(1)).chat(any(ChatRequest.class));
         }
 
         @Test
         @DisplayName("A transient GAX failure is still retried in-process")
         void scoreTrace__whenTransientGaxStatus__thenStillRetriedInProcess() {
-            when(llmProviderClientConfig.getMaxAttempts()).thenReturn(3);
-            var retryingService = new ChatCompletionService(llmProviderClientConfig, llmProviderFactory);
-            var chatRequest = ChatRequest.builder().messages(UserMessage.from("score this")).build();
-            var modelParameters = podamFactory.manufacturePojo(LlmAsJudgeModelParameters.class);
+            var thrown = scoreTraceWithBudget(2,
+                    new RuntimeException(gaxException(StatusCode.Code.UNAVAILABLE, false)));
 
-            when(llmProviderFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
-            when(chatModel.chat(any(ChatRequest.class)))
-                    .thenThrow(new RuntimeException(gaxException(StatusCode.Code.UNAVAILABLE, false)));
-            lenient().when(llmProviderFactory.getService(anyString(), anyString()))
-                    .thenReturn(llmProviderService);
-            lenient().when(llmProviderService.getLlmProviderError(any())).thenReturn(Optional.empty());
-
-            // The status is now reported verbatim, so this asserts retryability rather than a flattened 500.
-            assertThatThrownBy(() -> retryingService.scoreTrace(chatRequest, modelParameters, "workspace"))
-                    .isInstanceOf(InternalServerErrorException.class);
-
-            verify(chatModel, times(EXPECTED_ATTEMPTS_AT_MAX_RETRIES_3)).chat(any(ChatRequest.class));
+            assertRetryable(thrown);
+            verify(chatModel, times(3)).chat(any(ChatRequest.class));
         }
 
         /**
@@ -1134,10 +1101,6 @@ class ChatCompletionServiceTest {
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
         }
 
-        /**
-         * The provider's status is now reported verbatim, so this no longer pins a flattened 500 — it pins
-         * the property that matters: the subscriber will redeliver rather than drop.
-         */
         /**
          * Every retryable failure is flattened to a blanket 500 on this path: BaseRedisSubscriber matches
          * ClientErrorException by class, so a truthful 429 would be acked and dropped. The status is


### PR DESCRIPTION
## Details

**2 of 3.** #8162 has merged, so this now targets `main` directly. #8170 stacks on top of it.

**Log format note.** The trace-thread enqueue lines are deliberately `Enqueuing trace threads: count='{}' ruleId='{}' …` — a stable literal prefix first, then `key='{}'` pairs. Leading with the count breaks prefix search and log grouping; that regressed once already when size-only logging was applied, so please don't simplify it back.

Also carries three non-blocking review comments from @andrescrz that arrived on #8162 after it merged, since all three touch files now on `main`: the trace-thread enqueue logs interpolate `threadIds.size()` instead of a bounded sample (helper and constant deleted), the publisher integration test drops its lenient Mockito settings and the Mockito extension in favour of one explicit bare mock, and its ids come from `TestIdGeneratorFactory` (UUIDv7) rather than `UUID.randomUUID()`. Removing the leniency surfaced nothing — the test stubbed nothing at all, so it was covering no stubs.

`ChatCompletionService.scoreTrace` answered **every** provider failure with a blanket `InternalServerErrorException`. That type is absent from `BaseRedisSubscriber.NON_RETRYABLE_EXCEPTIONS`, so a request the provider can never accept was replayed `maxRetries` times, once per `pendingMessageDuration`, before being retired.

It now classifies by **status code** rather than by 4xx/5xx family:

| Status | Thrown | Subscriber behaviour |
|---|---|---|
| 400, 401, 403, 404, 413, 422, … | `ClientErrorException` | acked and removed on the first delivery |
| 408, 425, 429 | `InternalServerErrorException` (500) | retried up to `maxRetries` |
| all 5xx, anything unrecognised | `InternalServerErrorException` (500) | retried up to `maxRetries` |

Family alone is too blunt: 408/425/429 mean "not now", not "not ever".

**The blanket 500 for transient statuses is still required here**, and is removed in PR 3 of the stack. `BaseRedisSubscriber` matches `ClientErrorException` by class, so reporting a truthful 429 today would have it acked and dropped. PR 3 makes the subscriber status-aware and removes the workaround in the same change — the two cannot be separated safely, which is why they are ordered this way rather than merged.

### Permanence comes only from a real wire status

The provider mappers synthesize a code when they cannot parse the body — `CustomLlmErrorMessage` defaults to 400, `OpenAiErrorMessage` to 500 — and nothing downstream can distinguish that from a genuinely parsed 400. Consulting them would retire every unparseable CustomLlm failure (a connection reset, a proxy hiccup, a truncated body) on its first delivery. An absent status falls through to the retryable 500: burning `maxRetries` on a doomed request costs attempts, losing an unknown failure costs the evaluation.

### Two SDKs bypass `HttpException` and needed explicit recovery

- **VertexAI** raises GAX `ApiException`, which is neither an `HttpException` nor a langchain4j `NonRetriableException`, so a permanent Vertex failure was retried in-process *and* redelivered. Its status now comes from GAX's own transport-neutral `StatusCode.Code.getHttpStatusCode()` — identical for the gRPC and HTTP-JSON transports — rather than a hand-written table. `ApiException.isRetryable()` is used only as a one-way safety valve: an exception GAX marks retryable yields no status and stays retryable, so the mapping can only prevent a drop, never cause one. That matters for `ABORTED`→409 and `CANCELLED`→499, where the HTTP translation disagrees with retry semantics.
- **OpenAI Responses.** `OpenAILlmServiceProvider.getLanguageModel` calls `newOpenAiChatLanguageModel` unconditionally, but *that* method switches on the pipeline mode and returns `OpenAiOfficialResponsesChatModel` for `RESPONSES_API`, backed by openai-java, which raises `OpenAIServiceException`. Its `statusCode()` is the real wire status and is now recovered too.

### Status recovery filters at each stage

`findProviderHttpStatus` previously filtered to error statuses once, on the winner, so a non-error `HttpException` in the chain (a 302, or a synthetic 0) could satisfy the first pass, suppress the typed fallback, and then be discarded — leaving no status at all. That mattered most for the two SDKs above, whose status comes *only* from that fallback, silently turning a permanent 400 into a retryable 500. Wire-status precedence is unchanged; only non-error values are skipped.

### Fail-fast in-process

A permanent status short-circuits inside the retry action, so the in-process attempts are skipped as well as the subscriber's. Both fail-fast wrappers now share one mechanism (`failFastWhen`), differing only in their predicate, so a future change to how `NonRetriableException` is raised cannot apply to one and not the other. Scoped to `scoreTrace`; `create()` answers an HTTP caller and is unchanged.

## Customer impact

A customer's gateway rejects oversized scoring requests with a plain-text 400, affecting roughly **6% of their traces**. At production defaults (`pendingMessageDuration` 10m, `maxRetries` 3) each doomed entry was delivered at t≈0, t≈10m and t≈20m before being retired, and cost **3 calls against their own rate-limited gateway instead of 1** — enough wasted load, at their volume, to provoke 429s for legitimate traffic. Size-rejected requests are by definition the large ones: judge entries averaged ~12 MB and user-defined-metric entries ~56 MB against a Redis footprint that reached 19.66 GiB, so the population with the worst memory cost per entry was the one lingering longest.

**Stated precisely:** this does **not** unblock a stuck queue — a permanent failure was already clearing after 3 attempts. It removes queue catch-up delay, memory residency of the largest entries, wasted gateway load, and head-of-line occupancy. The separate cursor fix (**OPIK-8240**, #8137, merged) is the one that made an unreachable backlog reachable.

## Change checklist

- [x] User facing
- [ ] Documentation update

Behaviour change: a permanently-failing provider response is dropped on its first delivery instead of after ~20 minutes and 3 attempts. Transient statuses are unaffected in this PR. No new configuration keys.

## Issues

- OPIK-8262

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: the implementation, the tests, the mutation checks, and this description.
- Human verification: every result below was produced by running the listed commands and reading the output. The gaps under "Known gaps" are stated because they were checked for and found, not assumed.

## Testing

```bash
cd apps/opik-backend
mvn -o surefire:test -Dtest='ChatCompletionServiceTest,BaseRedisSubscriberTest,BaseRedisSubscriberUnitTest,\
OnlineScorePublisherTest,OnlineScorePublisherIntegrationTest,OnlineScoringLlmAsJudgeScorerTest,\
OnlineScoringTraceThreadLlmAsJudgeScorerTest,OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest,\
TraceThreadOnlineScoringSamplerListenerTest'
# Tests run: 245, Failures: 0, Errors: 0, Skipped: 0
```

Run on this branch alone, on base `main` — not with #8170 applied.

**Transient behaviour is verified unchanged in isolation.** `BaseRedisSubscriber` is byte-identical to `main` on this branch, so `ClientErrorException` is still matched by class, and `assertRetryable` asserts every transient case is `InternalServerErrorException`, **not** a `ClientErrorException`, with status 500. All transient rows (408/425/429, 5xx, GAX transient, Responses transient, no-wire-status) pass under that assertion, so nothing on this branch can produce a droppable exception for a status that should retry.

| Test | Asserts |
|---|---|
| `scoreTrace__whenPermanentClientError__thenNonRetryable` | 400/401/403/404/413/422 become `ClientErrorException` carrying that status |
| `scoreTrace__whenTransientStatus__thenStaysRetryable` | 408/425/429/5xx stay a retryable 500, never a `ClientErrorException` |
| `…whenNoWireStatus__thenStaysRetryableWhateverTheMapperSays` | a mapper-only status never makes a failure permanent |
| `…whenTransientWireStatusBehindSyntheticPermanent…` / `…whenPermanentWireStatusBehindSyntheticTransient…` | wire status outranks a synthetic mapper value, both directions |
| `…scoreTrace__when{Permanent,Transient}GaxStatus__…` | VertexAI GAX codes map through GAX's own translation; `isRetryable()` never overridden into a drop |
| `…scoreTrace__when{Permanent,Transient}ResponsesSdkStatus__…` | OpenAI Responses `statusCode()` is recovered |
| `…whenNonErrorHttpExceptionPrecedes{Gax,Responses}Status__thenRealStatusWins` | a 302 or synthetic 0 in the chain no longer masks the real status |
| `…__thenNotRetriedInProcess` / `…__thenStillRetriedInProcess` | the fail-fast skips in-process retries for permanent statuses only, with an exact attempt count |

### Mutation checks

| Mutation | Result |
|---|---|
| `isPermanentFailure` → `false` | 14 cases |
| mapper consulted for retryability | 3 cases at 400/401/403 — exactly what `CustomLlmErrorMessage` can synthesize |
| GAX branch removed | 7 cases |
| GAX `isRetryable()` valve dropped | 4 cases |
| OpenAI Responses status branch removed | 7 cases |
| single trailing `isErrorStatus` filter restored | 4 cases — the masked-status bug |
| GAX status allowed to outrank a real `HttpException` | 8 cases, including two pre-existing `create`/stream tests |
| shared fail-fast wrapper stops rewrapping | 7 cases, including the pre-existing `create__whenUnsupportedFeatureException__thenNotRetried` |
| retry budget clamped to 1 retry | 3 cases |
| off-by-one in the budget (`maxRetries + 1`) | 4 cases. The budget tests are parameterised over `(maxRetries, expectedAttempts)` = (0,1), (1,2), (2,3) rather than hard-coding one value, so the zero-retry boundary — where an off-by-one shows first — is covered |

Test oracles are literal: the retryability assertions compare against a literal `PERMANENT_STATUSES` set rather than calling the classifier under test.

### Not verified

- Full `mvn verify` — relying on CI.
- The customer figures (6%, ~12 MB / ~56 MB, 19.66 GiB) come from the incident report, not from anything reproduced here.

## Known gaps, left deliberately

1. **langchain4j's inner retry on GAX exceptions.** The fail-fast skips *our* retry policy's attempts, but `VertexAiGeminiChatModel`'s own `withRetryMappingExceptions` still retries an `ApiException` before it reaches us, because it is not a `NonRetriableException`. Bounded and in-process (seconds) against the subscriber's minutes. So "permanent Vertex errors are never retried" is **not literally true**; fixing it means wrapping the model.
2. **`XADD` partial-enqueue reconciliation.** `enqueueMessage` is `flatMap(stream::add)` with no reconciliation, so a mid-batch failure leaves some entries written and some not. Pre-existing at six call sites (`OnlineScoringSamplerSupport`, `TestSuiteAssertionSampler:151`, `ManualEvaluationService:240/264/330/353`). Failures are counted (`online_scoring_enqueue_total{result=error}`) and logged. Deserves its own ticket across all publishers.
3. **`extractErrorDetails`' `ConnectException` branch** is the one place a host/port from a user-configured provider URL can echo into logs. Unchanged here; a narrower separate ticket, since redacting only in `scoreTrace` would leave the two paths that *do* answer an HTTP caller untouched.

## For a human decision

**GAX import in `domain.llm`.** `ChatCompletionService` now imports `com.google.api.gax.rpc.ApiException`/`StatusCode`. It compiles with **no pom change** — GAX is already compile-scope via the directly-declared `google-cloud-vertexai:1.52.0` — so no dependency was added and class-name matching proved unnecessary. But this is the **first direct GAX import in `opik-backend`**, and it puts a provider-specific type in the provider-neutral core. The argument for it: `canonicalStatusOf` already knows langchain4j's exception zoo and its whole job is recovering a status from whatever the provider threw. It is a coupling judgment, not a mechanical one, and worth an explicit call.

## Documentation

No documentation change. No new configuration keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
