### PR TITLE
[OPIK-8262] [BE] fix: classify subscriber retries by status, not exception class

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -6,6 +6,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.metrics.ErrorMetricsResolver;
 import com.comet.opik.infrastructure.redis.UndecodablePayloadException;
 import com.comet.opik.infrastructure.redis.UndecodableStreamMessage;
+import com.comet.opik.utils.HttpStatusRetryability;
 import io.dropwizard.lifecycle.Managed;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
@@ -58,14 +59,17 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     private static final String NOGROUP = "NOGROUP";
 
     /**
-     * Non-retryable exception types that won't succeed on retry. Checked via {@code instanceof} in
-     * {@link #isRetryableException(Throwable)}, so subclasses are automatically covered.
-     * These are usually programming, validation, client etc. exceptions.
+     * Exception types that mean the code has a bug, so retrying would just rerun the bug. Checked via
+     * {@code instanceof} in {@link #isRetryableException(Throwable)}, so subclasses are covered too.
+     *
+     * <p>{@code ClientErrorException} used to be listed here and no longer is. It is a transport type, not a
+     * bug signal, and matching it by class made the whole 4xx family permanent — including 408, 425 and 429,
+     * which are transient by definition. It is now classified by the status it carries; see
+     * {@link #isRetryableException(Throwable)}.
      */
     private static final Set<Class<? extends RuntimeException>> NON_RETRYABLE_EXCEPTIONS = Set.of(
             ArithmeticException.class,
             ClassCastException.class,
-            ClientErrorException.class,
             IllegalArgumentException.class,
             IllegalStateException.class,
             IndexOutOfBoundsException.class,
@@ -828,13 +832,19 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
     }
 
     /**
-     * Non-retryable exceptions are checked via {@code instanceof} against {@link #NON_RETRYABLE_EXCEPTIONS},
-     * so both exact types and their subclasses are covered.
-     * Non-retryable exceptions are usually programming, validation, client errors that won't succeed on retry.
-     * All other exceptions are considered retryable (transient errors like network issues, timeouts, server errors, etc.)
-     * Unknown exceptions default to retryable for safety.
+     * Whether the entry is worth redelivering. A {@link ClientErrorException} is decided from the status it
+     * carries, so a 408/425/429 is retried and the rest of the 4xx family is retired on first delivery;
+     * everything else is matched by class against {@link #NON_RETRYABLE_EXCEPTIONS}, whose members all mean
+     * the code has a bug. Anything unrecognised is retryable, so an unknown failure is never silently lost.
+     *
+     * <p>Classifying by class alone is what forced {@code ChatCompletionService.scoreTrace} to report every
+     * provider failure as a blanket 500: a truthful 429 would have been dropped here. With the status
+     * consulted, that workaround is gone and the provider's real status is reported.
      */
-    private boolean isRetryableException(Throwable exception) {
+    private static boolean isRetryableException(Throwable exception) {
+        if (exception instanceof ClientErrorException clientError) {
+            return !HttpStatusRetryability.isPermanent(clientError.getResponse().getStatus());
+        }
         return NON_RETRYABLE_EXCEPTIONS.stream()
                 .noneMatch(nonRetryable -> nonRetryable.isInstance(exception));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriber.java
@@ -841,7 +841,7 @@ public abstract class BaseRedisSubscriber<M> implements Managed {
      * provider failure as a blanket 500: a truthful 429 would have been dropped here. With the status
      * consulted, that workaround is gone and the provider's real status is reported.
      */
-    private static boolean isRetryableException(Throwable exception) {
+    private boolean isRetryableException(Throwable exception) {
         if (exception instanceof ClientErrorException clientError) {
             return !HttpStatusRetryability.isPermanent(clientError.getResponse().getStatus());
         }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -3,9 +3,9 @@ package com.comet.opik.domain.llm;
 import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.utils.ChunkedOutputHandlers;
+import com.comet.opik.utils.HttpStatusRetryability;
 import com.google.api.gax.rpc.ApiException;
 import com.google.api.gax.rpc.StatusCode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.openai.errors.OpenAIServiceException;
 import dev.langchain4j.exception.AuthenticationException;
@@ -40,7 +40,6 @@ import java.net.ConnectException;
 import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -150,31 +149,28 @@ public class ChatCompletionService {
         } catch (RuntimeException runtimeException) {
             failIfUnsupportedFeature(runtimeException);
 
-            // Deliberately NOT failHandlingLLMProviderError here, unlike create() and the streaming handler:
-            // those answer an HTTP caller and want the status verbatim, whereas this answers the online-
-            // scoring subscribers, where the thrown TYPE decides retryability. BaseRedisSubscriber matches
-            // ClientErrorException by class, so recovering the status here would make the whole 4xx family
-            // non-retryable, transient 408s and 429s included.
+            // Report the status the provider actually sent, same as create() and the streaming handler.
+            // BaseRedisSubscriber classifies a ClientErrorException by that status, so a truthful 429 is
+            // redelivered and a truthful 400 is retired; this no longer has to misreport either.
             //
-            // Permanence is decided only from a status the provider actually sent. The mappers synthesize
-            // one when they cannot parse the body (CustomLlm 400, OpenAi 500) and nothing downstream can
-            // tell that apart from a real 400, so consulting them would drop every unparseable CustomLlm
-            // failure on its first delivery. Retrying a permanent error costs maxRetries attempts; dropping
-            // an unknown one loses the evaluation, so an absent status stays retryable.
-            var wireStatus = findProviderHttpStatus(runtimeException);
+            // Only a wire status is used. The provider mappers synthesize one when they cannot parse the body
+            // (CustomLlm 400, OpenAi 500) and nothing downstream can tell that from a real 400, so consulting
+            // them would retire every unparseable CustomLlm failure on its first delivery. An absent status
+            // falls through to 500 and stays retryable: burning maxRetries on a doomed request costs attempts,
+            // losing an unknown failure costs the evaluation.
+            var status = findProviderHttpStatus(runtimeException)
+                    .orElse(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
 
             log.warn(UNEXPECTED_ERROR_CALLING_LLM_PROVIDER, runtimeException);
 
-            if (wireStatus.filter(ChatCompletionService::isPermanentFailure).isPresent()) {
-                // The subscriber acks and removes on the first delivery rather than burning
-                // maxRetries x pendingMessageDuration on a request whose outcome cannot change.
-                throw new ClientErrorException(buildDetailedErrorMessage(runtimeException), wireStatus.get(),
-                        runtimeException);
+            var detail = buildDetailedErrorMessage(runtimeException);
+            // findProviderHttpStatus only yields error statuses, so these two families are exhaustive. The
+            // cause is carried through, unlike failHandlingLLMProviderError, because this exception is logged
+            // rather than serialized to an HTTP caller and the provider stack is the diagnostic.
+            if (familyOf(status) == Response.Status.Family.CLIENT_ERROR) {
+                throw new ClientErrorException(detail, status, runtimeException);
             }
-            // Everything else stays a blanket 500 so it lands outside NON_RETRYABLE_EXCEPTIONS and honours
-            // onlineScoring.maxRetries -- including transient 4xx, a distinction ClientErrorException
-            // cannot express on its own while the subscriber matches it by class.
-            throw new InternalServerErrorException(buildDetailedErrorMessage(runtimeException), runtimeException);
+            throw new ServerErrorException(detail, status, runtimeException);
         } finally {
             // Close the Vertex client (reused across retries) to release its GAX threads; other providers self-reclaim.
             if (languageModelClient instanceof AutoCloseable closeable) {
@@ -208,7 +204,7 @@ public class ChatCompletionService {
     private <T> T failFastOnPermanentFailure(Callable<T> action) throws Exception {
         return failFastWhen(action,
                 runtimeException -> findProviderHttpStatus(runtimeException)
-                        .filter(ChatCompletionService::isPermanentFailure)
+                        .filter(HttpStatusRetryability::isPermanent)
                         .isPresent());
     }
 
@@ -358,31 +354,6 @@ public class ChatCompletionService {
         return Optional.ofNullable(apiException.getStatusCode())
                 .map(StatusCode::getCode)
                 .map(StatusCode.Code::getHttpStatusCode);
-    }
-
-    /** 425 Too Early has no {@link Response.Status} constant; 408 and 429 do and are used directly. */
-    private static final int TOO_EARLY_STATUS = 425;
-
-    /**
-     * 4xx statuses that say "not now", not "not ever", so family alone can't decide retryability.
-     * langchain4j agrees on 408 and 429 but maps 425 to a non-retriable {@code InvalidRequestException};
-     * we diverge deliberately per RFC 8470, which is safe because retryability is read from the wire
-     * status, not the mapped type.
-     */
-    private static final Set<Integer> TRANSIENT_CLIENT_ERRORS = Set.of(
-            Response.Status.REQUEST_TIMEOUT.getStatusCode(),
-            TOO_EARLY_STATUS,
-            Response.Status.TOO_MANY_REQUESTS.getStatusCode());
-
-    /**
-     * Whether this exact request can never succeed, so the caller should give up rather than retry.
-     * Server errors are excluded: a 5xx is the textbook retry case. Anything unrecognised is retryable,
-     * matching {@code BaseRedisSubscriber}'s "unknown defaults to retryable for safety".
-     */
-    @VisibleForTesting
-    static boolean isPermanentFailure(int status) {
-        return familyOf(status) == Response.Status.Family.CLIENT_ERROR
-                && !TRANSIENT_CLIENT_ERRORS.contains(status);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -141,8 +141,7 @@ public class ChatCompletionService {
             log.info("Initiating chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             chatResponse = retryPolicy.withRetry(
-                    () -> failFastOnPermanentFailure(
-                            () -> failFastOnUnsupportedFeature(() -> languageModelClient.chat(chatRequest))));
+                    () -> failFastOnUnretryableFailure(() -> languageModelClient.chat(chatRequest)));
             log.info("Completed chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             return chatResponse;
@@ -191,27 +190,44 @@ public class ChatCompletionService {
      * original exception is kept as the cause, so {@link #failIfUnsupportedFeature} still recognises it downstream.
      */
     private <T> T failFastOnUnsupportedFeature(Callable<T> action) throws Exception {
-        return failFastWhen(action, runtimeException -> findUnsupportedFeature(runtimeException).isPresent());
+        return failFastWhen(action, this::isUnsupportedFeature);
     }
 
     /**
-     * Skips the in-process retries for a provider status that can never succeed, mirroring
-     * {@link #failFastOnUnsupportedFeature}. Applied only on the scoreTrace path: {@code create()} answers an HTTP
-     * caller, and narrowing its retry behaviour is not this change's business. Mainly reached for VertexAI, whose GAX
-     * exceptions langchain4j does not model as {@code NonRetriableException}; the mapped providers already fail fast
-     * on their own. The cause is preserved, so the catch block still classifies from the same status.
+     * The scoreTrace fail-fast. Review finding on #8169: this used to be {@code failFastOnPermanentFailure} wrapped
+     * around {@code failFastOnUnsupportedFeature} at the call site — two levels of indirection for what is one
+     * decision, and awkward to reason about because neither level named what it was really asking.
+     *
+     * <p>Both conditions mean the same thing, that this exact call can never succeed, and both are raised the same
+     * way by {@link #failFastWhen}. So they belong in one predicate that names each reason instead of one wrapper
+     * per reason. Each reason is a method of its own, so it can be read — and exercised — independently.
+     *
+     * <p>Only scoreTrace fails fast on a permanent status: {@code create()} answers an HTTP caller, and narrowing
+     * its retry behaviour is not this change's business. The permanent check is mainly reached for VertexAI, whose
+     * GAX exceptions langchain4j does not model as {@code NonRetriableException}; the mapped providers already fail
+     * fast on their own. The cause is preserved either way, so the catch block still classifies from the same status.
      */
-    private <T> T failFastOnPermanentFailure(Callable<T> action) throws Exception {
-        return failFastWhen(action,
-                runtimeException -> findProviderHttpStatus(runtimeException)
-                        .filter(HttpStatusRetryability::isPermanent)
-                        .isPresent());
+    private <T> T failFastOnUnretryableFailure(Callable<T> action) throws Exception {
+        return failFastWhen(action, runtimeException -> isUnsupportedFeature(runtimeException)
+                || isPermanentProviderFailure(runtimeException));
+    }
+
+    /** A feature the selected provider cannot serve, so no number of attempts will change the answer. */
+    private boolean isUnsupportedFeature(RuntimeException runtimeException) {
+        return findUnsupportedFeature(runtimeException).isPresent();
+    }
+
+    /** A status the provider actually sent that {@link HttpStatusRetryability} classifies as never succeeding. */
+    private boolean isPermanentProviderFailure(RuntimeException runtimeException) {
+        return findProviderHttpStatus(runtimeException)
+                .filter(HttpStatusRetryability::isPermanent)
+                .isPresent();
     }
 
     /**
-     * Shared mechanism for both fail-fast wrappers: run the action, and rewrap a matching failure as
+     * Shared mechanism for the fail-fast wrappers: run the action, and rewrap a matching failure as
      * {@link NonRetriableException} so {@code RetryPolicy.withRetry} gives up on the first attempt. Only the
-     * predicate differs between the two, so keeping one copy of the propagation means a future change to how
+     * predicate differs between them, so keeping one copy of the propagation means a future change to how
      * NonRetriableException is raised cannot apply to one and not the other. The cause is always preserved.
      */
     private <T> T failFastWhen(Callable<T> action, Predicate<RuntimeException> nonRetriable) throws Exception {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/llm/ChatCompletionService.java
@@ -141,7 +141,7 @@ public class ChatCompletionService {
             log.info("Initiating chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             chatResponse = retryPolicy.withRetry(
-                    () -> failFastOnUnretryableFailure(() -> languageModelClient.chat(chatRequest)));
+                    () -> failFastOnNonRetriableFailure(() -> languageModelClient.chat(chatRequest)));
             log.info("Completed chat with model '{}' expecting structured response, workspaceId '{}'",
                     modelParameters.name(), workspaceId);
             return chatResponse;
@@ -194,20 +194,28 @@ public class ChatCompletionService {
     }
 
     /**
-     * The scoreTrace fail-fast. Review finding on #8169: this used to be {@code failFastOnPermanentFailure} wrapped
-     * around {@code failFastOnUnsupportedFeature} at the call site — two levels of indirection for what is one
-     * decision, and awkward to reason about because neither level named what it was really asking.
+     * Fails fast for {@code scoreTrace} when the failure can never succeed, so the in-process retry budget is not
+     * spent on a doomed call.
      *
-     * <p>Both conditions mean the same thing, that this exact call can never succeed, and both are raised the same
-     * way by {@link #failFastWhen}. So they belong in one predicate that names each reason instead of one wrapper
-     * per reason. Each reason is a method of its own, so it can be read — and exercised — independently.
+     * <p>Review finding on #8169: this used to be {@code failFastOnPermanentFailure} wrapped around
+     * {@code failFastOnUnsupportedFeature} at the call site — two levels of indirection for what is one decision,
+     * and awkward to reason about because neither level named what it was really asking. Both conditions mean the
+     * same thing and both are raised the same way by {@link #failFastWhen}, so they are one predicate here, with
+     * each reason its own named method so it can be read — and exercised — independently.
+     *
+     * <p>Permanence is deliberately narrow, and broadening it silently loses evaluations.
+     * {@link HttpStatusRetryability} carves 408, 425 and 429 out of the client-error family because they mean "not
+     * now" rather than "not ever" — diverging from langchain4j on 425 per RFC 8470 — and a failure that never
+     * reached the wire yields no status at all, so it stays retryable. Both carve-outs matter beyond this method:
+     * the status thrown from the catch block is also what {@code BaseRedisSubscriber} classifies by, so anything
+     * treated as permanent is acked and dropped on its first delivery instead of being redelivered.
      *
      * <p>Only scoreTrace fails fast on a permanent status: {@code create()} answers an HTTP caller, and narrowing
      * its retry behaviour is not this change's business. The permanent check is mainly reached for VertexAI, whose
      * GAX exceptions langchain4j does not model as {@code NonRetriableException}; the mapped providers already fail
      * fast on their own. The cause is preserved either way, so the catch block still classifies from the same status.
      */
-    private <T> T failFastOnUnretryableFailure(Callable<T> action) throws Exception {
+    private <T> T failFastOnNonRetriableFailure(Callable<T> action) throws Exception {
         return failFastWhen(action, runtimeException -> isUnsupportedFeature(runtimeException)
                 || isPermanentProviderFailure(runtimeException));
     }
@@ -316,6 +324,11 @@ public class ChatCompletionService {
      * chain before any typed exception is considered, because it carries the upstream code verbatim: langchain4j's
      * {@code ExceptionMapper} raises {@code InternalServerException(HttpException(503))}, and taking the outermost
      * match would collapse that 503 into the flat 500 the typed exception implies.
+     *
+     * <p>Review finding on #8170 asked whether an outer wrapper's status can shadow a nested provider one, since
+     * {@code ExceptionUtils} lists the chain outermost-first. It cannot: {@code HttpException}'s only constructor is
+     * {@code (int, String)}, so it never carries a cause and is always terminal in the chain. At most one can appear,
+     * and the {@code findFirst} here is therefore not a precedence choice between rival wire statuses.
      */
     private Optional<Integer> findProviderHttpStatus(Throwable throwable) {
         List<Throwable> chain = ExceptionUtils.getThrowableList(throwable);
@@ -357,7 +370,11 @@ public class ChatCompletionService {
      * the gRPC and HTTP-JSON transports, rather than a table of our own.
      *
      * <p>An exception GAX marks retryable yields no status, so <em>within this method</em> the mapping can only
-     * prevent a drop, never cause one. Scoped deliberately: {@link #findProviderHttpStatus} consults a real
+     * prevent a drop, never cause one. That costs reporting fidelity — such a failure is reported as a flat 500
+     * rather than, say, the 503 GAX translated — and it is kept deliberately: returning the status regardless would
+     * let a GAX-retryable client-error code that {@link HttpStatusRetryability} does not carve out (ABORTED maps to
+     * 409, for instance) be classified permanent, and both this fail-fast and {@code BaseRedisSubscriber} would then
+     * drop an evaluation GAX itself says is worth retrying. Trading a precise status for that is not worth it. Scoped deliberately: {@link #findProviderHttpStatus} consults a real
      * {@code HttpException} in the chain first, and a wire status legitimately outranks GAX's {@code isRetryable},
      * which is a configured judgment rather than something the server said. Not reachable for VertexAI in any case —
      * {@code VertexAiGeminiChatModel} goes through the Google Cloud SDK and never produces a langchain4j

--- a/apps/opik-backend/src/main/java/com/comet/opik/utils/HttpStatusRetryability.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/utils/HttpStatusRetryability.java
@@ -1,0 +1,50 @@
+package com.comet.opik.utils;
+
+import jakarta.ws.rs.core.Response;
+import lombok.experimental.UtilityClass;
+
+import java.util.Set;
+
+import static jakarta.ws.rs.core.Response.Status.Family.familyOf;
+
+/**
+ * One definition of which HTTP statuses are worth retrying, shared by the two layers that need it:
+ * {@code ChatCompletionService} (whether to spend the in-process provider retry budget) and
+ * {@code BaseRedisSubscriber} (whether to redeliver a stream entry or ack and drop it).
+ *
+ * <p>It lives here because those two disagreeing is what caused the defect this replaces. The subscriber
+ * treated every {@code ClientErrorException} as permanent, so {@code scoreTrace} could not report a
+ * truthful 429 without the evaluation being dropped, and answered every provider failure with a blanket
+ * 500 instead. With one predicate the status can be reported honestly and still retried.
+ *
+ * <p>Named to avoid colliding with {@code dev.langchain4j.internal.RetryUtils}, which
+ * {@code ChatCompletionService} already imports.
+ */
+@UtilityClass
+public class HttpStatusRetryability {
+
+    /** 425 Too Early (RFC 8470) has no {@link Response.Status} constant; 408 and 429 do. */
+    private static final int TOO_EARLY_STATUS = 425;
+
+    /**
+     * 4xx statuses that say "not now", not "not ever", so the family alone cannot decide retryability.
+     * langchain4j agrees on 408 and 429 but maps 425 to a non-retriable {@code InvalidRequestException};
+     * we diverge deliberately per RFC 8470, which is safe because retryability is read from the status
+     * rather than the mapped exception type.
+     */
+    private static final Set<Integer> TRANSIENT_CLIENT_ERRORS = Set.of(
+            Response.Status.REQUEST_TIMEOUT.getStatusCode(),
+            TOO_EARLY_STATUS,
+            Response.Status.TOO_MANY_REQUESTS.getStatusCode());
+
+    /**
+     * Whether a request answered with this status can never succeed on retry. True only for the
+     * client-error family minus {@link #TRANSIENT_CLIENT_ERRORS}: a 5xx is the textbook retry case, and
+     * anything outside both families is unrecognised and therefore retryable — the same "unknown defaults
+     * to retryable for safety" stance the subscriber takes on exception types it does not know.
+     */
+    public static boolean isPermanent(int status) {
+        return familyOf(status) == Response.Status.Family.CLIENT_ERROR
+                && !TRANSIENT_CLIENT_ERRORS.contains(status);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -346,8 +346,12 @@ class BaseRedisSubscriberTest {
                             new NullPointerException("Non-retryable")),
                     Arguments.of("NumberFormatException (subclass of IllegalArgumentException)",
                             new NumberFormatException("Non-retryable")),
-                    Arguments.of("ClientErrorException (4xx)",
+                    Arguments.of("ClientErrorException (401)",
                             new ClientErrorException("Unauthorized", 401)),
+                    Arguments.of("ClientErrorException (400)",
+                            new ClientErrorException("Bad Request", 400)),
+                    Arguments.of("ClientErrorException (403)",
+                            new ClientErrorException("Forbidden", 403)),
                     Arguments.of("NotFoundException (subclass of ClientErrorException)",
                             new NotFoundException()));
         }
@@ -369,6 +373,50 @@ class BaseRedisSubscriberTest {
             // Non-retryable errors should be removed from the stream
             waitForMessagesAckedAndRemoved();
             assertThat(subscriber.getSuccessMessageCount().get()).isZero();
+        }
+
+        /**
+         * OPIK-8262. {@code ClientErrorException} used to be matched by class, which made every 4xx permanent
+         * — including the statuses that mean "not now" rather than "not ever". That is why
+         * {@code ChatCompletionService.scoreTrace} could not report a truthful 429: it would have been acked
+         * and dropped here. These drive the real subscriber against real Redis, so the distinction is proved
+         * where it actually takes effect rather than in a unit test of the predicate.
+         */
+        @ParameterizedTest(name = "{0} is retried, not dropped")
+        @MethodSource("transientClientErrors")
+        void shouldRetainTransientClientErrorsForRetry(String description, RuntimeException exception) {
+            var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
+            var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
+                    config, redissonClient, exception));
+            subscriber.start();
+
+            publishMessagesToStream(messages);
+
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .untilAsserted(
+                            () -> assertThat(subscriber.getFailedMessageCount().get()).isEqualTo(messages.size()));
+            // Asserted with during(), not a single poll: ack-and-remove lands slightly after the failure is
+            // counted, so a one-shot size check could pass in that window and a wrongly acknowledged entry
+            // would go unnoticed. Requiring the entry to STAY in the stream, and stay pending for the group,
+            // closes that gap — a permanent classification removes it and both assertions then fail.
+            await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                    .during(Duration.ofSeconds(1))
+                    .untilAsserted(() -> {
+                        assertThat(stream.size().block())
+                                .as("a transient status must leave the entry in the stream for redelivery")
+                                .isEqualTo((long) messages.size());
+                        assertThat(pendingCount())
+                                .as("and it must still be pending for the group, i.e. never acknowledged")
+                                .isEqualTo((long) messages.size());
+                    });
+            assertThat(subscriber.getSuccessMessageCount().get()).isZero();
+        }
+
+        static Stream<Arguments> transientClientErrors() {
+            return Stream.of(
+                    Arguments.of("408 Request Timeout", new ClientErrorException("Request Timeout", 408)),
+                    Arguments.of("425 Too Early", new ClientErrorException("Too Early", 425)),
+                    Arguments.of("429 Too Many Requests", new ClientErrorException("Too Many Requests", 429)));
         }
 
         /**
@@ -694,6 +742,12 @@ class BaseRedisSubscriberTest {
     private void waitForMessagesProcessed(TestRedisSubscriber subscriber, int expectedCount) {
         await().atMost(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .untilAsserted(() -> assertThat(subscriber.getSuccessMessageCount().get()).isEqualTo(expectedCount));
+    }
+
+    /** Entries delivered but not yet acknowledged. A wrongly acked entry drops out of this count. */
+    private long pendingCount() {
+        var pending = stream.getPendingInfo(config.getConsumerGroupName()).block();
+        return pending == null ? 0L : pending.getTotal();
     }
 
     private void waitForMessagesAckedAndRemoved() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -1,11 +1,19 @@
 package com.comet.opik.api.resources.v1.events;
 
+import com.comet.opik.api.evaluators.LlmAsJudgeModelParameters;
 import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.domain.llm.ChatCompletionService;
+import com.comet.opik.domain.llm.LlmProviderFactory;
+import com.comet.opik.infrastructure.LlmProviderClientConfig;
 import com.comet.opik.infrastructure.redis.RedisStreamCodec;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.redis.testcontainers.RedisContainer;
+import dev.langchain4j.data.message.UserMessage;
+import dev.langchain4j.exception.HttpException;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.NotFoundException;
 import org.junit.jupiter.api.AfterEach;
@@ -50,6 +58,10 @@ import java.util.stream.Stream;
 import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Integration tests for {@link BaseRedisSubscriber}  using real Redis test container.
@@ -359,6 +371,11 @@ class BaseRedisSubscriberTest {
         @ParameterizedTest(name = "{0}")
         @MethodSource("nonRetryableExceptions")
         void shouldAckAndRemoveNonRetryableFailures(String description, RuntimeException exception) {
+            assertAckedAndRemoved(exception);
+        }
+
+        /** The entry must be acknowledged and gone: the failure can never succeed, so redelivery is waste. */
+        private void assertAckedAndRemoved(RuntimeException exception) {
             var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
             var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
                     config, redissonClient, exception));
@@ -385,6 +402,11 @@ class BaseRedisSubscriberTest {
         @ParameterizedTest(name = "{0} is retried, not dropped")
         @MethodSource("transientClientErrors")
         void shouldRetainTransientClientErrorsForRetry(String description, RuntimeException exception) {
+            assertRetainedForRedelivery(exception);
+        }
+
+        /** The entry must stay in the stream and stay unacknowledged, so the group redelivers it. */
+        private void assertRetainedForRedelivery(RuntimeException exception) {
             var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
             var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
                     config, redissonClient, exception));
@@ -417,6 +439,77 @@ class BaseRedisSubscriberTest {
                     Arguments.of("408 Request Timeout", new ClientErrorException("Request Timeout", 408)),
                     Arguments.of("425 Too Early", new ClientErrorException("Too Early", 425)),
                     Arguments.of("429 Too Many Requests", new ClientErrorException("Too Many Requests", 429)));
+        }
+
+        /**
+         * Review finding from baz on this PR: the rows above are hand-built {@code ClientErrorException}s
+         * and {@code OnlineScorePublisherIntegrationTest} mocks {@code ChatCompletionService}, so both
+         * halves of the contract were covered while the join between them was not. The join is the half
+         * that actually broke — the subscriber classified by exception class, {@code scoreTrace} chose the
+         * class, and the two disagreed about 429.
+         *
+         * <p>These rows are produced by driving a real {@link ChatCompletionService#scoreTrace} to failure,
+         * and the exception it genuinely throws is what is injected into the real subscriber against real
+         * Redis. The test restates no status of its own, so if either side stops agreeing about what a
+         * status means, this fails rather than the two drifting apart unnoticed.
+         */
+        @ParameterizedTest(name = "a real scoreTrace {0} is retried, not dropped")
+        @MethodSource("transientFailuresFromRealScoreTrace")
+        void shouldRetainRealScoreTraceTransientFailures(String description, RuntimeException exception) {
+            assertRetainedForRedelivery(exception);
+        }
+
+        @ParameterizedTest(name = "a real scoreTrace {0} is acked and removed")
+        @MethodSource("permanentFailuresFromRealScoreTrace")
+        void shouldAckAndRemoveRealScoreTracePermanentFailures(String description, RuntimeException exception) {
+            assertAckedAndRemoved(exception);
+        }
+
+        static Stream<Arguments> transientFailuresFromRealScoreTrace() {
+            return Stream.of(
+                    Arguments.of("408", thrownByRealScoreTrace(408, "Request Timeout")),
+                    Arguments.of("425", thrownByRealScoreTrace(425, "Too Early")),
+                    Arguments.of("429", thrownByRealScoreTrace(429, "Too Many Requests")));
+        }
+
+        static Stream<Arguments> permanentFailuresFromRealScoreTrace() {
+            return Stream.of(
+                    Arguments.of("400", thrownByRealScoreTrace(400, "Bad Request")),
+                    Arguments.of("401", thrownByRealScoreTrace(401, "Unauthorized")),
+                    Arguments.of("403", thrownByRealScoreTrace(403, "Forbidden")),
+                    Arguments.of("404", thrownByRealScoreTrace(404, "Not Found")));
+        }
+
+        /**
+         * Drives a real {@code ChatCompletionService.scoreTrace} against a provider that answers
+         * {@code status} and returns the exception it threw. Only the provider client is a mock — the
+         * classification under test is the production one.
+         */
+        private static RuntimeException thrownByRealScoreTrace(int status, String reason) {
+            var clientConfig = mock(LlmProviderClientConfig.class);
+            when(clientConfig.getMaxAttempts()).thenReturn(1);
+
+            var chatModel = mock(ChatModel.class);
+            when(chatModel.chat(any(ChatRequest.class)))
+                    .thenThrow(new RuntimeException(new HttpException(status, reason)));
+
+            var providerFactory = mock(LlmProviderFactory.class);
+            when(providerFactory.getLanguageModel(anyString(), any())).thenReturn(chatModel);
+
+            var service = new ChatCompletionService(clientConfig, providerFactory);
+            var request = ChatRequest.builder().messages(UserMessage.from("seam")).build();
+            var parameters = LlmAsJudgeModelParameters.builder().name("seam-test-model").build();
+
+            RuntimeException thrown = null;
+            try {
+                service.scoreTrace(request, parameters, "seam-workspace");
+            } catch (RuntimeException exception) {
+                thrown = exception;
+            }
+            if (thrown == null) {
+                throw new IllegalStateException("scoreTrace was expected to fail for status " + status);
+            }
+            return thrown;
         }
 
         /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/BaseRedisSubscriberTest.java
@@ -57,6 +57,7 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.TestUtils.waitForMillis;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -365,17 +366,19 @@ class BaseRedisSubscriberTest {
                     Arguments.of("ClientErrorException (403)",
                             new ClientErrorException("Forbidden", 403)),
                     Arguments.of("NotFoundException (subclass of ClientErrorException)",
-                            new NotFoundException()));
+                            new NotFoundException()),
+                    // The same contract, but with the exception a real ChatCompletionService.scoreTrace threw
+                    // rather than one built here: both halves of the seam were covered before and their
+                    // agreement was not, which is the half that originally broke.
+                    Arguments.of("permanent 400 from a real scoreTrace", thrownByRealScoreTrace(400, "Bad Request")),
+                    Arguments.of("permanent 401 from a real scoreTrace", thrownByRealScoreTrace(401, "Unauthorized")),
+                    Arguments.of("permanent 403 from a real scoreTrace", thrownByRealScoreTrace(403, "Forbidden")),
+                    Arguments.of("permanent 404 from a real scoreTrace", thrownByRealScoreTrace(404, "Not Found")));
         }
 
         @ParameterizedTest(name = "{0}")
         @MethodSource("nonRetryableExceptions")
         void shouldAckAndRemoveNonRetryableFailures(String description, RuntimeException exception) {
-            assertAckedAndRemoved(exception);
-        }
-
-        /** The entry must be acknowledged and gone: the failure can never succeed, so redelivery is waste. */
-        private void assertAckedAndRemoved(RuntimeException exception) {
             var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
             var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
                     config, redissonClient, exception));
@@ -402,11 +405,6 @@ class BaseRedisSubscriberTest {
         @ParameterizedTest(name = "{0} is retried, not dropped")
         @MethodSource("transientClientErrors")
         void shouldRetainTransientClientErrorsForRetry(String description, RuntimeException exception) {
-            assertRetainedForRedelivery(exception);
-        }
-
-        /** The entry must stay in the stream and stay unacknowledged, so the group redelivers it. */
-        private void assertRetainedForRedelivery(RuntimeException exception) {
             var messages = PodamFactoryUtils.manufacturePojoList(podamFactory, String.class);
             var subscriber = trackSubscriber(TestRedisSubscriber.failingSubscriber(
                     config, redissonClient, exception));
@@ -438,46 +436,13 @@ class BaseRedisSubscriberTest {
             return Stream.of(
                     Arguments.of("408 Request Timeout", new ClientErrorException("Request Timeout", 408)),
                     Arguments.of("425 Too Early", new ClientErrorException("Too Early", 425)),
-                    Arguments.of("429 Too Many Requests", new ClientErrorException("Too Many Requests", 429)));
-        }
-
-        /**
-         * Review finding from baz on this PR: the rows above are hand-built {@code ClientErrorException}s
-         * and {@code OnlineScorePublisherIntegrationTest} mocks {@code ChatCompletionService}, so both
-         * halves of the contract were covered while the join between them was not. The join is the half
-         * that actually broke — the subscriber classified by exception class, {@code scoreTrace} chose the
-         * class, and the two disagreed about 429.
-         *
-         * <p>These rows are produced by driving a real {@link ChatCompletionService#scoreTrace} to failure,
-         * and the exception it genuinely throws is what is injected into the real subscriber against real
-         * Redis. The test restates no status of its own, so if either side stops agreeing about what a
-         * status means, this fails rather than the two drifting apart unnoticed.
-         */
-        @ParameterizedTest(name = "a real scoreTrace {0} is retried, not dropped")
-        @MethodSource("transientFailuresFromRealScoreTrace")
-        void shouldRetainRealScoreTraceTransientFailures(String description, RuntimeException exception) {
-            assertRetainedForRedelivery(exception);
-        }
-
-        @ParameterizedTest(name = "a real scoreTrace {0} is acked and removed")
-        @MethodSource("permanentFailuresFromRealScoreTrace")
-        void shouldAckAndRemoveRealScoreTracePermanentFailures(String description, RuntimeException exception) {
-            assertAckedAndRemoved(exception);
-        }
-
-        static Stream<Arguments> transientFailuresFromRealScoreTrace() {
-            return Stream.of(
-                    Arguments.of("408", thrownByRealScoreTrace(408, "Request Timeout")),
-                    Arguments.of("425", thrownByRealScoreTrace(425, "Too Early")),
-                    Arguments.of("429", thrownByRealScoreTrace(429, "Too Many Requests")));
-        }
-
-        static Stream<Arguments> permanentFailuresFromRealScoreTrace() {
-            return Stream.of(
-                    Arguments.of("400", thrownByRealScoreTrace(400, "Bad Request")),
-                    Arguments.of("401", thrownByRealScoreTrace(401, "Unauthorized")),
-                    Arguments.of("403", thrownByRealScoreTrace(403, "Forbidden")),
-                    Arguments.of("404", thrownByRealScoreTrace(404, "Not Found")));
+                    Arguments.of("429 Too Many Requests", new ClientErrorException("Too Many Requests", 429)),
+                    // As above: the exception a real scoreTrace threw, so the seam itself is exercised.
+                    Arguments.of("transient 408 from a real scoreTrace",
+                            thrownByRealScoreTrace(408, "Request Timeout")),
+                    Arguments.of("transient 425 from a real scoreTrace", thrownByRealScoreTrace(425, "Too Early")),
+                    Arguments.of("transient 429 from a real scoreTrace",
+                            thrownByRealScoreTrace(429, "Too Many Requests")));
         }
 
         /**
@@ -500,16 +465,8 @@ class BaseRedisSubscriberTest {
             var request = ChatRequest.builder().messages(UserMessage.from("seam")).build();
             var parameters = LlmAsJudgeModelParameters.builder().name("seam-test-model").build();
 
-            RuntimeException thrown = null;
-            try {
-                service.scoreTrace(request, parameters, "seam-workspace");
-            } catch (RuntimeException exception) {
-                thrown = exception;
-            }
-            if (thrown == null) {
-                throw new IllegalStateException("scoreTrace was expected to fail for status " + status);
-            }
-            return thrown;
+            return catchThrowableOfType(RuntimeException.class,
+                    () -> service.scoreTrace(request, parameters, "seam-workspace"));
         }
 
         /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -648,12 +648,12 @@ class ChatCompletionServiceTest {
         private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 402, 403, 404, 413, 422, 499);
 
         /** The shared rows whose status is permanent, so their scoreTrace case needs no branch. */
-        private static Stream<Arguments> permanentProviderStatuses() {
+        private static Stream<Arguments> permanentProviderErrorCases() {
             return providerStatusProvider().filter(row -> PERMANENT_STATUSES.contains(row.get()[2]));
         }
 
         /** The complement, kept separate for the same reason. */
-        private static Stream<Arguments> transientProviderStatuses() {
+        private static Stream<Arguments> transientProviderErrorCases() {
             return providerStatusProvider().filter(row -> !PERMANENT_STATUSES.contains(row.get()[2]));
         }
 
@@ -877,7 +877,7 @@ class ChatCompletionServiceTest {
          * failures that could never succeed (the redaction-limit incident).
          */
         @ParameterizedTest(name = "scoreTrace: when {0}, then non-retryable {2}")
-        @MethodSource("permanentProviderStatuses")
+        @MethodSource("permanentProviderErrorCases")
         @DisplayName("Online scoring drops a permanent provider status instead of replaying it")
         void scoreTrace__whenPermanentProviderErrorUnparsed__thenNonRetryable(
                 String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {
@@ -888,7 +888,7 @@ class ChatCompletionServiceTest {
         }
 
         @ParameterizedTest(name = "scoreTrace: when {0}, then retryable as {2}")
-        @MethodSource("transientProviderStatuses")
+        @MethodSource("transientProviderErrorCases")
         @DisplayName("Online scoring keeps a transient provider status retryable, honouring maxRetries")
         void scoreTrace__whenTransientProviderErrorUnparsed__thenRetryable(
                 String testName, RuntimeException providerFailure, int expectedStatus, String expectedMessagePart) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -744,6 +744,49 @@ class ChatCompletionServiceTest {
         }
 
         /**
+         * Review finding from baz on this PR: {@code scoreTrace} reads only the wire status, while
+         * {@code create()} and the streaming handler prefer {@code getLlmProviderError}, so one failure can
+         * be reported with two different statuses. The divergence is real and deliberate, and it is pinned
+         * here rather than left to be rediscovered.
+         *
+         * <p>Unifying on the mapper is precisely what the classification PR removed. The mappers synthesize
+         * a status when they cannot parse a body ({@code CustomLlmErrorMessage} defaults to 400,
+         * {@code OpenAiErrorMessage} to 500) and nothing downstream can tell that from a genuinely parsed
+         * 400, so every unparseable CustomLlm failure would be retired on its first delivery and the
+         * evaluation lost. Unifying the other way — making {@code create()} ignore a body it did parse —
+         * would change the status HTTP callers already depend on, and buy this path nothing.
+         *
+         * <p>They diverge because they answer different questions. {@code create()} reports to a caller who
+         * reads the response, so the most specific reading of the body should win. {@code scoreTrace}
+         * decides whether a queued evaluation is redelivered or discarded, and only what the provider
+         * literally put on the wire is trustworthy enough to discard work.
+         */
+        @Test
+        @DisplayName("A mapper status disagreeing with the wire binds create(), never scoreTrace")
+        void whenMapperStatusDisagreesWithWire__thenCreateFollowsMapperAndScoreTraceFollowsWire() {
+            // The body parses to a permanent 401; the exception chain says transient 429.
+            var mapperReports401 = Optional.of(new ErrorMessage(401, "mapper parsed an auth failure"));
+
+            // create(): the parsed body wins, so the HTTP caller is told 401.
+            var request = podamFactory.manufacturePojo(ChatCompletionRequest.class);
+            when(llmProviderFactory.getService(anyString(), anyString())).thenReturn(llmProviderService);
+            when(llmProviderService.generate(any(), anyString())).thenThrow(new RateLimitException("slow down"));
+            when(llmProviderService.getLlmProviderError(any())).thenReturn(mapperReports401);
+
+            var fromCreate = catchThrowable(() -> chatCompletionService.create(request, "test-workspace-id"));
+
+            assertThat(fromCreate).isInstanceOf(WebApplicationException.class);
+            assertThat(((WebApplicationException) fromCreate).getResponse().getStatus())
+                    .as("create() answers a caller who reads the body, so the parsed status wins")
+                    .isEqualTo(401);
+
+            // scoreTrace: same failure, same mapper verdict, and the wire status still decides.
+            var fromScoreTrace = whenScoreTraceFails(new RateLimitException("slow down"), mapperReports401);
+
+            assertRetryable(fromScoreTrace, 429);
+        }
+
+        /**
          * The out-of-credits path, which is the one 429 that reaches here carrying no wire status at all.
          * {@code QuotaAwareHttpClient} rethrows {@link NonRetriableException} with the response body as its
          * <b>message and deliberately no cause</b>, so langchain4j's {@code ExceptionMapper.findRoot()}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -24,7 +24,9 @@ import io.dropwizard.jersey.errors.ErrorMessage;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,6 +49,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static jakarta.ws.rs.core.Response.Status.Family.familyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -130,7 +133,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider")
                     .hasMessageContaining(expectedMessagePart)
                     .hasCauseInstanceOf(RuntimeException.class);
@@ -151,7 +154,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider")
                     .hasMessageContaining(errorMessage)
                     .hasCauseInstanceOf(RuntimeException.class);
@@ -171,7 +174,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider")
                     .hasMessageContaining("RuntimeException")
                     .hasCauseInstanceOf(RuntimeException.class);
@@ -194,7 +197,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider")
                     .hasMessageContaining(rootCauseMessage)
                     .hasCauseInstanceOf(RuntimeException.class);
@@ -272,7 +275,7 @@ class ChatCompletionServiceTest {
 
             // Then
             assertThat(thrown)
-                    .isInstanceOf(BadRequestException.class)
+                    .isExactlyInstanceOf(BadRequestException.class)
                     .hasMessageContaining("Unsupported feature for the selected LLM provider")
                     .hasMessageContaining(UNSUPPORTED_FEATURE_MESSAGE);
             assertThat(((BadRequestException) thrown).getResponse().getStatus()).isEqualTo(400);
@@ -300,7 +303,7 @@ class ChatCompletionServiceTest {
 
             // Then
             assertThat(thrown)
-                    .isInstanceOf(BadRequestException.class)
+                    .isExactlyInstanceOf(BadRequestException.class)
                     .hasMessageContaining("Unsupported feature for the selected LLM provider")
                     .hasMessageContaining(UNSUPPORTED_FEATURE_MESSAGE);
             assertThat(((BadRequestException) thrown).getResponse().getStatus()).isEqualTo(400);
@@ -323,7 +326,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.scoreTrace(chatRequest, modelParameters, workspaceId))
-                    .isInstanceOf(BadRequestException.class);
+                    .isExactlyInstanceOf(BadRequestException.class);
 
             // The provider was never reached, so there is no provider error to map.
             verify(llmProviderFactory, never()).getService(anyString(), anyString());
@@ -395,7 +398,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> retryingService.create(request, workspaceId))
-                    .isInstanceOf(BadRequestException.class);
+                    .isExactlyInstanceOf(BadRequestException.class);
 
             // UnsupportedFeatureException extends LangChain4jException, not NonRetriableException, so without the
             // fail-fast wrapper langchain4j's RetryPolicy would retry a call that can never succeed.
@@ -418,7 +421,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> retryingService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class);
+                    .isExactlyInstanceOf(InternalServerErrorException.class);
 
             verify(llmProviderService, atLeast(2)).generate(any(), anyString());
         }
@@ -471,7 +474,7 @@ class ChatCompletionServiceTest {
             // When & Then — createAndStreamResponse runs before Response.ok() is built, so nothing is committed yet
             // and this surfaces as a genuine 400
             assertThatThrownBy(() -> chatCompletionService.createAndStreamResponse(request, workspaceId, handlers))
-                    .isInstanceOf(BadRequestException.class)
+                    .isExactlyInstanceOf(BadRequestException.class)
                     .hasMessageContaining(ChatCompletionService.ERROR_EMPTY_MESSAGES);
 
             verify(handlers, never()).handleError(any());
@@ -515,7 +518,7 @@ class ChatCompletionServiceTest {
 
             // When & Then — not a client error, so it keeps its existing behaviour rather than becoming a 200
             assertThatThrownBy(() -> chatCompletionService.createAndStreamResponse(request, workspaceId, handlers))
-                    .isInstanceOf(IllegalStateException.class)
+                    .isExactlyInstanceOf(IllegalStateException.class)
                     .hasMessage("connection pool exhausted");
 
             verify(handlers, never()).handleError(any());
@@ -534,7 +537,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider");
         }
     }
@@ -775,7 +778,7 @@ class ChatCompletionServiceTest {
 
             var fromCreate = catchThrowable(() -> chatCompletionService.create(request, "test-workspace-id"));
 
-            assertThat(fromCreate).isInstanceOf(WebApplicationException.class);
+            assertThat(fromCreate).isExactlyInstanceOf(ClientErrorException.class);
             assertThat(((WebApplicationException) fromCreate).getResponse().getStatus())
                     .as("create() answers a caller who reads the body, so the parsed status wins")
                     .isEqualTo(401);
@@ -1189,7 +1192,7 @@ class ChatCompletionServiceTest {
                     .contains(expectedStatus);
             assertThat(thrown)
                     .as("a permanent status must arrive as ClientErrorException, which the subscriber retires")
-                    .isInstanceOf(ClientErrorException.class);
+                    .isExactlyInstanceOf(ClientErrorException.class);
             assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(expectedStatus);
         }
 
@@ -1212,6 +1215,14 @@ class ChatCompletionServiceTest {
         private void assertRetryable(Throwable thrown) {
             assertThat(thrown).isInstanceOf(WebApplicationException.class);
             var status = ((WebApplicationException) thrown).getResponse().getStatus();
+            // Exact, not just assignable: scoreTrace raises only these two, and asserting
+            // ServerErrorException exactly is what fails if the blanket InternalServerErrorException(500)
+            // workaround is ever reintroduced -- it is a subclass, so isInstanceOf would still pass.
+            assertThat(thrown)
+                    .as("status %d must arrive as the type its family implies", status)
+                    .isExactlyInstanceOf(familyOf(status) == Response.Status.Family.CLIENT_ERROR
+                            ? ClientErrorException.class
+                            : ServerErrorException.class);
             assertThat(PERMANENT_STATUSES)
                     .as("status %d must stay retryable so the subscriber redelivers it", status)
                     .doesNotContain(status);
@@ -1302,7 +1313,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessage(expectedMessage);
         }
 
@@ -1322,7 +1333,7 @@ class ChatCompletionServiceTest {
 
             // When & Then
             assertThatThrownBy(() -> chatCompletionService.create(request, workspaceId))
-                    .isInstanceOf(InternalServerErrorException.class)
+                    .isExactlyInstanceOf(InternalServerErrorException.class)
                     .hasMessageContaining("Unexpected error calling LLM provider")
                     .hasMessageContaining("Service is unreachable")
                     .hasMessageContaining(customMessage);

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/llm/ChatCompletionServiceTest.java
@@ -636,10 +636,11 @@ class ChatCompletionServiceTest {
         /**
          * The statuses the subscriber must retire, spelled out as a literal and used both to partition the
          * shared rows below and to assert every retryability outcome. Deliberately NOT
-         * {@link ChatCompletionService#isPermanentFailure}: a test that derives its expectation from the
-         * predicate under test agrees with that predicate even when it is wrong, so production and tests
-         * would regress together silently. The predicate's own mapping is pinned against its own literals
-         * by {@link #isPermanentFailure__whenStatus__thenMatchLiteralTable()}.
+         * {@link com.comet.opik.utils.HttpStatusRetryability#isPermanent}: a test that derives its
+         * expectation from the predicate under test agrees with that predicate even when it is wrong, so
+         * production and tests would regress together silently. That predicate's own mapping is pinned
+         * against its own literals by {@code HttpStatusRetryabilityTest}, which lives beside it because it
+         * is now the contract between this service and {@code BaseRedisSubscriber}.
          */
         private static final Set<Integer> PERMANENT_STATUSES = Set.of(400, 401, 402, 403, 404, 413, 422, 499);
 
@@ -712,7 +713,7 @@ class ChatCompletionServiceTest {
             var thrown = whenScoreTraceFails(new RuntimeException(new HttpException(status, label)),
                     Optional.empty());
 
-            assertRetryable(thrown);
+            assertRetryable(thrown, status);
         }
 
         /**
@@ -780,33 +781,6 @@ class ChatCompletionServiceTest {
         }
 
         /**
-         * Pins the status-to-retryability mapping of {@link ChatCompletionService#isPermanentFailure}, the
-         * predicate production consults to decide whether a request can never succeed and so must be
-         * retired rather than retried.
-         *
-         * <p>This is the companion test {@link #PERMANENT_STATUSES} refers to. The expectations are the
-         * hand-written table below rather than {@code PERMANENT_STATUSES} itself: that set records which
-         * statuses the subscriber must retire, and deriving either from the other is exactly what would let
-         * production and tests regress together.
-         */
-        @ParameterizedTest(name = "isPermanentFailure({0}) == {1}")
-        @CsvSource({
-                // Client errors with nothing transient about them: this exact request can never succeed.
-                "400, true", "401, true", "402, true", "403, true", "404, true",
-                "413, true", "422, true", "499, true",
-                // 4xx by numbering, "not now" by meaning -- the whole reason family alone cannot decide.
-                "408, false", "425, false", "429, false",
-                // Server errors are the textbook retry case.
-                "500, false", "502, false", "503, false", "504, false",
-                // Outside the error families, so never permanent.
-                "200, false", "302, false",
-        })
-        @DisplayName("isPermanentFailure classifies each status, pinned independently of the suite's own table")
-        void isPermanentFailure__whenStatus__thenMatchLiteralTable(int status, boolean expectedPermanent) {
-            assertThat(ChatCompletionService.isPermanentFailure(status)).isEqualTo(expectedPermanent);
-        }
-
-        /**
          * Regression for the precedence bug caught in review of OPIK-8240.
          *
          * <p>The provider mappers synthesize a status when they cannot read one off the body:
@@ -828,7 +802,7 @@ class ChatCompletionServiceTest {
             var thrown = whenScoreTraceFails(providerFailure,
                     Optional.of(new ErrorMessage(syntheticStatus, "synthetic mapper fallback")));
 
-            assertRetryable(thrown);
+            assertRetryable(thrown, wireStatus);
         }
 
         /** The harmless direction of the same precedence rule, kept so the rule is pinned both ways. */
@@ -867,7 +841,7 @@ class ChatCompletionServiceTest {
             assertNonRetryable(thrown, expectedStatus);
         }
 
-        @ParameterizedTest(name = "scoreTrace: when {0}, then retryable")
+        @ParameterizedTest(name = "scoreTrace: when {0}, then retryable as {2}")
         @MethodSource("transientProviderStatuses")
         @DisplayName("Online scoring keeps a transient provider status retryable, honouring maxRetries")
         void scoreTrace__whenTransientProviderErrorUnparsed__thenRetryable(
@@ -875,7 +849,7 @@ class ChatCompletionServiceTest {
             var thrown = whenScoreTraceFails(providerFailure, Optional.empty());
 
             assertThat(thrown).hasMessageContaining(expectedMessagePart);
-            assertRetryable(thrown);
+            assertRetryable(thrown, expectedStatus);
         }
 
         /**
@@ -957,13 +931,19 @@ class ChatCompletionServiceTest {
             assertNonRetryable(thrown, expectedStatus);
         }
 
-        @ParameterizedTest(name = "GAX {0} stays retryable")
-        @CsvSource({"RESOURCE_EXHAUSTED", "DEADLINE_EXCEEDED", "UNAVAILABLE", "INTERNAL", "UNKNOWN"})
+        @ParameterizedTest(name = "GAX {0} stays retryable as HTTP {1}")
+        @CsvSource({
+                "RESOURCE_EXHAUSTED, 429",
+                "DEADLINE_EXCEEDED, 504",
+                "UNAVAILABLE, 503",
+                "INTERNAL, 500",
+                "UNKNOWN, 500",
+        })
         @DisplayName("A transient VertexAI GAX failure still honours maxRetries")
-        void scoreTrace__whenTransientGaxStatus__thenRetryable(StatusCode.Code code) {
+        void scoreTrace__whenTransientGaxStatus__thenRetryable(StatusCode.Code code, int expectedStatus) {
             var thrown = whenScoreTraceFails(new RuntimeException(gaxException(code, false)), Optional.empty());
 
-            assertRetryable(thrown);
+            assertRetryable(thrown, expectedStatus);
         }
 
         /**
@@ -1036,13 +1016,13 @@ class ChatCompletionServiceTest {
             assertNonRetryable(thrown, status);
         }
 
-        @ParameterizedTest(name = "Responses SDK {0} -> retryable")
+        @ParameterizedTest(name = "Responses SDK {0} -> retryable, status preserved")
         @CsvSource({"408", "429", "500", "503"})
-        @DisplayName("A transient OpenAI Responses failure stays retryable")
+        @DisplayName("A transient OpenAI Responses failure keeps its status and stays retryable")
         void scoreTrace__whenTransientResponsesSdkStatus__thenRetryable(int status) {
             var thrown = whenScoreTraceFails(new RuntimeException(responsesException(status)), Optional.empty());
 
-            assertRetryable(thrown);
+            assertRetryable(thrown, status);
         }
 
         /**
@@ -1171,17 +1151,27 @@ class ChatCompletionServiceTest {
         }
 
         /**
-         * Every retryable failure is flattened to a blanket 500 on this path: BaseRedisSubscriber matches
-         * ClientErrorException by class, so a truthful 429 would be acked and dropped. The status is
-         * therefore deliberately NOT the provider's own here — that only becomes safe once the subscriber
-         * classifies by status.
+         * For a failure that carried a real wire status: the status must be reported verbatim, not
+         * flattened. Without this, reintroducing the blanket-500 workaround would pass every retryability
+         * assertion — a 500 is retryable too, so "not permanent" alone cannot see the lie.
+         */
+        private void assertRetryable(Throwable thrown, int expectedStatus) {
+            assertRetryable(thrown);
+            assertThat(((WebApplicationException) thrown).getResponse().getStatus())
+                    .as("a transient provider status must reach the subscriber verbatim, not as a blanket 500")
+                    .isEqualTo(expectedStatus);
+        }
+
+        /**
+         * Retryable is asserted against the literal permanent set, not the production predicate, so a
+         * regression in {@code HttpStatusRetryability} cannot make these tests agree with broken behaviour.
          */
         private void assertRetryable(Throwable thrown) {
-            assertThat(thrown)
-                    .as("a status that may clear on retry must stay outside NON_RETRYABLE_EXCEPTIONS")
-                    .isInstanceOf(InternalServerErrorException.class)
-                    .isNotInstanceOf(ClientErrorException.class);
-            assertThat(((WebApplicationException) thrown).getResponse().getStatus()).isEqualTo(500);
+            assertThat(thrown).isInstanceOf(WebApplicationException.class);
+            var status = ((WebApplicationException) thrown).getResponse().getStatus();
+            assertThat(PERMANENT_STATUSES)
+                    .as("status %d must stay retryable so the subscriber redelivers it", status)
+                    .doesNotContain(status);
         }
 
         @ParameterizedTest(name = "streaming: when {0}, then stream status {2}")

--- a/apps/opik-backend/src/test/java/com/comet/opik/utils/HttpStatusRetryabilityTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/utils/HttpStatusRetryabilityTest.java
@@ -1,0 +1,45 @@
+package com.comet.opik.utils;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The single retryability rule, shared by ChatCompletionService and BaseRedisSubscriber. Lives with the
+ * predicate rather than either caller, because it is now the contract between them.
+ */
+class HttpStatusRetryabilityTest {
+
+    @ParameterizedTest(name = "isPermanent({0}) -> {1}")
+    @CsvSource({
+            // Client-error family, minus the transient carve-outs.
+            "400, true",
+            "401, true",
+            "403, true",
+            "404, true",
+            "413, true",
+            "422, true",
+            // 402 is what OpenAiCompatStatusCodes maps insufficient_quota to, so it is the permanent
+            // status most likely to actually arrive; 499 is nginx's client-closed-request.
+            "402, true",
+            "499, true",
+            // "not now", not "not ever".
+            "408, false",
+            "425, false",
+            "429, false",
+            // Server errors are the textbook retry case.
+            "500, false",
+            "502, false",
+            "503, false",
+            "504, false",
+            // Outside both error families - unrecognised defaults to retryable.
+            "200, false",
+            "302, false",
+    })
+    @DisplayName("Only the client-error family minus 408/425/429 is permanent")
+    void classifiesTheStatus(int status, boolean expectedPermanent) {
+        assertThat(HttpStatusRetryability.isPermanent(status)).isEqualTo(expectedPermanent);
+    }
+}


### PR DESCRIPTION
### Stack

1. #8162 — publish one stream entry per trace-thread id — base `main`
1. #8169 — classify provider errors by status
1. **#8170 — classify subscriber retries by status**  ← you are here

Merge bottom-up: #8162 → #8169 → #8170.

---

## Details

**3 of 3, based on #8169.** Merge #8162 then #8169 first.

This is the design fix the other two work around.

`BaseRedisSubscriber.isRetryableException` decided retry-vs-drop purely by exception class. Seven of the eight types it listed mean *the code has a bug* — `NullPointerException`, `ClassCastException`, `IllegalArgumentException` and friends — where retrying just reruns the bug. `ClientErrorException` was the odd one out: a JAX-RS transport type doing business-logic work, matched by `instanceof`, which made **every 4xx permanent** — including 408, 425 and 429, which are transient by definition.

That is why `scoreTrace` reported transient provider failures as a blanket 500. A truthful 429 would have been acked and dropped, so the status had to be misreported to keep the evaluation alive. #8169 improved *which* status was chosen but stayed inside that frame: it was still picking an HTTP status in order to steer a Redis consumer.

### What changes

A `ClientErrorException` is now classified from the status it carries; everything else keeps the existing class match, and `ClientErrorException` leaves that set — the seven that remain are all genuine bug signals.

The rule lives in `com.comet.opik.utils.HttpStatusRetryability.isPermanent(int)`, shared with `ChatCompletionService`. Those two layers disagreeing about what "transient" means is what caused the defect, so there is now one definition. Named to avoid colliding with `dev.langchain4j.internal.RetryUtils`, which `ChatCompletionService` already imports — that ruled out extending the existing `com.comet.opik.utils.RetryUtils`.

With the predicate in place the workaround is gone: `scoreTrace` reports the provider's status verbatim, the same as `create()` and the streaming handler, and retry behaviour is preserved **by the predicate rather than by the lie**.

### Sequencing

The predicate lands and is proven against real Redis — a 429 is retained for redelivery, a 400/401/403/404 is acked and removed — *before* the workaround is removed. The reverse order inverts permanent and transient and drops evaluations that should retry. This is also why this cannot be folded into #8169: that PR must keep the blanket 500 while the subscriber still matches by class.

## Subscriber audit

Seven classes extend `BaseRedisSubscriber`. Behaviour changes only where a `ClientErrorException` carrying **408/425/429** can reach the subscriber.

| Subscriber | What reaches the subscriber | Change |
|---|---|---|
| `OnlineScoringBaseScorer` | `ClientErrorException` / `ServerErrorException` from `scoreTrace`, with the provider's real status | **Yes — the target.** A transient 4xx is retried instead of dropped; a permanent 4xx is dropped on first delivery instead of consuming the full budget |
| `WebhookSubscriber` | **Nothing.** See below | None |
| `ClosingTraceThreadSubscriber` | Propagates from `traceThreadService`; DB/ClickHouse errors, no HTTP status | None |
| `ExperimentAggregatesSubscriber` | Propagates from the aggregation and lock services; `TimeoutException` handled internally | None |
| `ExperimentItemProcessingSubscriber` | Processing errors swallowed (`onErrorResume` → `Mono.just(false)`); only bookkeeping errors escape | None |
| `AgentInsightsReportSubscriber` | Nothing — `onErrorResume` swallows every failure by design (at-most-once, documented in-code) | None |
| `DatasetExportJobSubscriber` | Re-throws to prevent ACK; storage/DB errors, no HTTP status | None |

Where the other six can produce a *permanent* `ClientErrorException` (a `NotFoundException`, say), it was dropped before and is dropped now. The one place in the codebase that throws a 429 `ClientErrorException` is `RateLimitInterceptor:210`, and `@RateLimited` appears only on HTTP resource classes — it cannot reach a subscriber.

### `WebhookSubscriber` — no benefit, stated plainly

The intuition is appealing: a customer's webhook endpoint rate-limits us, we get a 429, the delivery is dropped. It is not what the code does.

- `WebhookHttpClient` raises its own `RetryUtils.RetryableHttpException` — a plain `RuntimeException` carrying `statusCode`, not a `ClientErrorException`. The predicate never sees it.
- `WebhookSubscriber.processEvent` wraps **both** paths in `onErrorResume(throwable -> handlePermanentFailure(event, throwable).then(Mono.empty()))`, converting every failure into a successful empty completion, so nothing propagates to `BaseRedisSubscriber` at all.
- Webhook retries are handled inside the client by its own retry spec.

**This change gives webhook delivery nothing.**

## Change checklist

- [x] User facing
- [ ] Documentation update

Behaviour change: a transient provider failure (408/425/429) is now reported with its real status and redelivered rather than reported as a 500; a permanent 4xx is unchanged from #8169. No new configuration keys.

## Issues

- OPIK-8262

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: the design, the implementation, the tests, the mutation checks, the subscriber audit, and this description.
- Human verification: every result below was produced by running the listed commands and reading the output.

## Testing

```bash
cd apps/opik-backend
mvn -o surefire:test -Dtest='ChatCompletionServiceTest,HttpStatusRetryabilityTest,BaseRedisSubscriberTest,\
BaseRedisSubscriberUnitTest,OnlineScorePublisherTest,OnlineScorePublisherIntegrationTest,\
OnlineScoringLlmAsJudgeScorerTest,OnlineScoringTraceThreadLlmAsJudgeScorerTest,\
OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest'
# Tests run: 253, Failures: 0, Errors: 0, Skipped: 0
```

Run on this branch alone, on base #8169.

| Test | Asserts |
|---|---|
| `BaseRedisSubscriberTest.shouldRetainTransientClientErrorsForRetry` | **real Redis** — a 408/425/429 `ClientErrorException` stays in the stream *and* stays pending for the group, asserted with `during()` so a post-failure acknowledgement cannot slip through |
| `BaseRedisSubscriberTest.shouldAckAndRemoveNonRetryableFailures` | **real Redis** — 400/401/403/404 and the bug-signal types are acked and removed on first delivery |
| `HttpStatusRetryabilityTest.classifiesTheStatus` | the shared rule, with literal expectations, including the carve-outs and both family boundaries |
| `ChatCompletionServiceTest.scoreTrace__whenTransientStatus__thenStaysRetryable` | a transient status is now reported **verbatim** and stays retryable — pins the absence of the blanket 500 |

### Mutation checks

| Mutation | Result |
|---|---|
| revert the predicate — `ClientErrorException` matched by class again | fails `shouldAckAndRemoveNonRetryableFailures` (4 cases) |
| predicate returns "everything is permanent" | fails `shouldRetainTransientClientErrorsForRetry` and `HttpStatusRetryabilityTest` (11 cases) |
| `scoreTrace` flattens transient statuses back to a blanket 500 | fails 15 cases across 4 methods. *This initially survived* — `assertRetryable` only checked "not permanent", and a flattened 500 is not permanent either, so nothing pinned the truthfulness. Status assertions were added and the mutation now dies |
| transient entry wrongly acked on first delivery | fails `shouldRetainTransientClientErrorsForRetry` (3 cases) — did **not** reliably die before the test was hardened against an ack race |
| predicate regresses, treating 400 as transient | fails at three independent layers: the predicate's own literal test, the real-Redis subscriber test, and the in-process fail-fast tests |

### Not verified

- Full `mvn verify` — relying on CI.
- No test drives a real rolling upgrade.

## Documentation

No documentation change. No new configuration keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

