### PR TITLE
[OPIK-8262] [QA] e2e: provider error classification on the LLM-judge path

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -738,11 +738,19 @@ areas:
       # behind it. That distinction is why this key stayed false while
       # online-evaluation-python-metric-errors.spec.ts asserted the same stream.
       #   - thread-judge-provider-failure.spec.ts: ERROR rows, one per failed
-      #     thread and no others — the row set is pinned by exhaustion.
+      #     thread and no others — the row set is pinned by exhaustion. Its
+      #     provider is the backend's own discard port, so it needs nothing from
+      #     the test runner and runs on EVERY deployment.
       #   - provider-error-classification.spec.ts: the INFO Evaluating / Sending
       #     rows as well as the ERROR one, matched on a seeded TRACE id, so the
-      #     non-error half of the stream is rendered-and-asserted too.
-      automation-logs:         { covered: true,  tier: t2-cuj, note: "rule_id-scoped log stream renders: one ERROR row per failed thread and no others (thread-judge-provider-failure); and Evaluating / Sending / ERROR rows for one seeded trace id on a failed LLM-judge rule (provider-error-classification). Both are deliberately silent on refresh, expand-all and marker columns" }
+      #     non-error half of the stream is rendered-and-asserted too. This one
+      #     needs the backend to reach the host-run mock gateway, so it skips on
+      #     any deployment other than oss (mockAuthSkipReason) — the same gate as
+      #     configuration's ai-provider-add / ai-provider-token-refetch.
+      #
+      # So the flag itself is not oss-only: the thread-judge spec holds it up
+      # everywhere, and the classification spec deepens it on oss.
+      automation-logs:         { covered: true,  tier: t2-cuj, note: "rule_id-scoped log stream renders: one ERROR row per failed thread and no others (thread-judge-provider-failure, every deployment); and Evaluating / Sending / ERROR rows for one seeded trace id on a failed LLM-judge rule (provider-error-classification, oss only — it needs the host-run mock gateway). Both are deliberately silent on refresh, expand-all and marker columns" }
 
     visual:
       online-evaluation-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E11" }

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -677,6 +677,7 @@ areas:
       - online-evaluation/online-evaluation-judge-prompt-round-trip.spec.ts
       - online-evaluation/online-evaluation-non-object-sections.spec.ts
       - online-evaluation/online-evaluation-oversized-payload.spec.ts
+      - online-evaluation/online-evaluation-provider-error-classification.spec.ts
       - online-evaluation/online-evaluation-python-metric-errors.spec.ts
       - online-evaluation/online-evaluation-sampling-rate.spec.ts
       - online-evaluation/online-evaluation-smoke.spec.ts
@@ -684,7 +685,7 @@ areas:
       - online-evaluation/online-evaluation-thread-scope-batch-close.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
-      llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
+      llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe; t2 also covers provider-failure classification (OPIK-8262) — a permanent status costs exactly one upstream call, a transient one the whole retry budget, and neither writes a score" }
       create-python-rule:      { covered: true,  tier: t1-smoke }
       python-rule-scores:      { covered: true,  tier: t1-smoke, note: "deterministic 3x1.0 / 2x0.0; t2 also covers sub-path mappings over non-object sections and the 400-class classification of a metric that exits 0 without a result line; t3 covers a span-scope rule still scoring the spans logged AFTER a 21M-character span, which is the OPIK-8164 wedge — the oversized span's own score is deliberately not asserted, since whether it is scored depends on the deployment's Jackson stream-read limits; t2 also covers the THREAD-scope metric contract, where the runner hands the metric the whole conversation positionally instead of a mapped argument map (online-evaluation-thread-scope-batch-close.spec.ts)" }
       scores-in-trace-panel:   { covered: true,  tier: t1-smoke }
@@ -731,11 +732,17 @@ areas:
       edit-rule:               { covered: true,  tier: t2-cuj, note: "plain-string prompt: edit-dialog hydration + no-op re-save, byte-for-byte; content_array prompt: API-only read-then-write re-save, no dialog gesture; model custom_parameters: rule seeded over REST, saved unchanged through the edit dialog, PATCH body and persisted blob both asserted to carry the thinking block and an unrelated free-form key; editing a field through the dialog is not covered" }
       enable-disable-rule:     { covered: true,  tier: t2-cuj, note: "edit-dialog switch; control rule proves scoring stopped, then resumed" }
       delete-rule:             { covered: true,  tier: t2-cuj, note: "row kebab delete; control rule proves scoring stopped" }
-      # Flipped by online-evaluation-thread-judge-provider-failure.spec.ts, which
-      # opens the /$workspaceName/automation-logs PAGE itself (AutomationLogsPage)
-      # and asserts the rendered ERROR rows — not, as the API-only specs do, the
-      # GET /automations/evaluators/{id}/logs stream behind it.
-      automation-logs:         { covered: true,  tier: t2-cuj, note: "rule_id-scoped log stream renders: one ERROR row per failed thread and no others" }
+      # Flipped by two specs that open the /$workspaceName/automation-logs PAGE
+      # itself (AutomationLogsPage) and assert the rendered rows — not, as the
+      # API-only specs do, the GET /automations/evaluators/{id}/logs stream
+      # behind it. That distinction is why this key stayed false while
+      # online-evaluation-python-metric-errors.spec.ts asserted the same stream.
+      #   - thread-judge-provider-failure.spec.ts: ERROR rows, one per failed
+      #     thread and no others — the row set is pinned by exhaustion.
+      #   - provider-error-classification.spec.ts: the INFO Evaluating / Sending
+      #     rows as well as the ERROR one, matched on a seeded TRACE id, so the
+      #     non-error half of the stream is rendered-and-asserted too.
+      automation-logs:         { covered: true,  tier: t2-cuj, note: "rule_id-scoped log stream renders: one ERROR row per failed thread and no others (thread-judge-provider-failure); and Evaluating / Sending / ERROR rows for one seeded trace id on a failed LLM-judge rule (provider-error-classification). Both are deliberately silent on refresh, expand-all and marker columns" }
 
     visual:
       online-evaluation-empty: { covered: true,  state: empty,   spec: "empty-states.spec.ts E11" }

--- a/tests_end_to_end/e2e/core/mock-auth.ts
+++ b/tests_end_to_end/e2e/core/mock-auth.ts
@@ -32,9 +32,10 @@ export const mockTokenUrlForBackend = `${mockAuthBaseUrlForBackend}/oauth/token`
 export const mockGatewayUrlForBackend = `${mockAuthBaseUrlForBackend}/v1`;
 
 /**
- * Counter map from /stats. Global outcome counters (tokens_issued, chat_ok,
- * chat_refused_unknown, ...) plus model-scoped variants (`chat_ok:<model>`) so
- * parallel specs can assert on their own traffic via unique model names.
+ * Counter map from /stats. Global outcome counters (chat_request, tokens_issued,
+ * chat_ok, chat_refused_unknown, ...) plus model-scoped variants
+ * (`chat_request:<model>`, `chat_ok:<model>`) so parallel specs can assert on their
+ * own traffic via unique model names.
  */
 export type MockAuthStats = Record<string, number>;
 
@@ -44,9 +45,50 @@ export async function mockAuthStats(): Promise<MockAuthStats> {
   return (await response.json()) as MockAuthStats;
 }
 
+/**
+ * How many chat requests the gateway has received for one model, counted before any
+ * outcome branch.
+ *
+ * The number of ATTEMPTS is the only place a retry decision is observable: a retried
+ * evaluation writes the same single "Sending … to LLM" line to the rule log as one that
+ * gave up immediately, so counting log lines cannot tell the two apart.
+ */
+export function mockAuthChatRequests(stats: MockAuthStats, modelName: string): number {
+  return stats[`chat_request:${modelName}`] ?? 0;
+}
+
 export async function mockAuthRevokeAll(): Promise<void> {
   const response = await fetch(`${mockAuthBaseUrl}/revoke`, { method: 'POST' });
   if (!response.ok) throw new Error(`mock-auth /revoke returned ${response.status}`);
+}
+
+/**
+ * Make the gateway answer `status` for every chat request naming `modelName`.
+ *
+ * Scoped to a model rather than the process so one provider can serve several statuses
+ * at once — which is what lets a spec compare two classifications over a single trace,
+ * with the rule shape held constant.
+ *
+ * Prefer `providerKeys.forceChatStatus`, which registers the reset for teardown.
+ */
+export async function mockAuthForceChatStatus(modelName: string, status: number): Promise<void> {
+  await postChatStatus({ model: modelName, status });
+}
+
+/** Drops a forced status, so the model is served normally again. */
+export async function mockAuthClearChatStatus(modelName: string): Promise<void> {
+  await postChatStatus({ model: modelName });
+}
+
+async function postChatStatus(body: { model: string; status?: number }): Promise<void> {
+  const response = await fetch(`${mockAuthBaseUrl}/chat-status`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`mock-auth /chat-status returned ${response.status}: ${await response.text()}`);
+  }
 }
 
 const AUTH_CONFIG_TEST_PATH = '/auth-config/test';

--- a/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
@@ -137,19 +137,25 @@ export const test = baseTest.extend<ProviderKeyFixtures>({
       },
     });
 
+    // Cleared unconditionally, unlike the provider keys below. Retention exists so a
+    // failed run leaves INSPECTABLE state in the workspace; a forced status is not that.
+    // It is mutable global state on the mock process, which outlives this test and
+    // serves every other spec in the run, so leaving one set turns one failure into a
+    // second, unrelated one that is very hard to read.
+    for (const modelName of forcedStatusModels) {
+      try {
+        await mockAuthClearChatStatus(modelName);
+      } catch (err) {
+        console.warn(`[provider-key fixture] status-hook reset warning for ${modelName}:`, err);
+      }
+    }
+
     if (!shouldLeaveArtifacts(testInfo)) {
       for (const name of registered) {
         try {
           await deleteProviderKeyByName(name);
         } catch (err) {
           console.warn(`[provider-key fixture] delete warning for ${name}:`, err);
-        }
-      }
-      for (const modelName of forcedStatusModels) {
-        try {
-          await mockAuthClearChatStatus(modelName);
-        } catch (err) {
-          console.warn(`[provider-key fixture] status-hook reset warning for ${modelName}:`, err);
         }
       }
     }

--- a/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/provider-key.fixture.ts
@@ -3,6 +3,8 @@ import { shouldLeaveArtifacts } from '../core/artifacts';
 import {
   MOCK_AUTH_CLIENT_ID,
   MOCK_AUTH_CLIENT_SECRET,
+  mockAuthClearChatStatus,
+  mockAuthForceChatStatus,
   mockGatewayUrlForBackend,
   mockTokenUrlForBackend,
 } from '../core/mock-auth';
@@ -10,8 +12,15 @@ import { createProviderKey, deleteProviderKeyByName } from '../core/provider-key
 
 export interface OauthProviderSeed {
   providerName: string;
-  /** Model the mock gateway will echo; unique per test so parallel specs never collide. */
-  modelName?: string;
+  /**
+   * Models the mock gateway will echo; unique per test so parallel specs never collide.
+   *
+   * A list rather than a single name because the mock's counters and its forced-status
+   * hook are both keyed on the model in the request body, so several models on ONE
+   * provider is how a spec gets several gateway behaviours over one trace without
+   * changing anything else about the rule.
+   */
+  modelNames?: string[];
 }
 
 export interface UnreachableProviderSeed {
@@ -55,6 +64,15 @@ export interface ProviderKeysFixture {
    */
   createUnreachable(seed: UnreachableProviderSeed): Promise<string>;
   /**
+   * Makes the mock gateway answer `status` for every chat request naming `modelName`,
+   * and clears it at teardown.
+   *
+   * The hook lives on the mock process, which outlives the test, so it is registered
+   * here rather than reset in the test body — a trailing reset step is skipped exactly
+   * when an assertion has already failed.
+   */
+  forceChatStatus(modelName: string, status: number): Promise<void>;
+  /**
    * Registers a provider name for teardown deletion without seeding — for tests where
    * UI creation is itself the behavior under test. Cleanup runs even when the test fails.
    */
@@ -73,15 +91,18 @@ export const test = baseTest.extend<ProviderKeyFixtures>({
   // eslint-disable-next-line no-empty-pattern
   providerKeys: async ({}, use, testInfo) => {
     const registered: string[] = [];
+    const forcedStatusModels: string[] = [];
 
     await use({
-      async createOauth({ providerName, modelName = 'mock-model' }) {
+      async createOauth({ providerName, modelNames = ['mock-model'] }) {
         registered.push(providerName);
         await createProviderKey({
           provider: 'custom-llm',
           provider_name: providerName,
           base_url: mockGatewayUrlForBackend,
-          configuration: { models: `custom-llm/${providerName}/${modelName}` },
+          configuration: {
+            models: modelNames.map((model) => `custom-llm/${providerName}/${model}`).join(','),
+          },
           auth_config: {
             token_url: mockTokenUrlForBackend,
             send_as: 'basic',
@@ -107,6 +128,10 @@ export const test = baseTest.extend<ProviderKeyFixtures>({
         });
         return model;
       },
+      async forceChatStatus(modelName, status) {
+        forcedStatusModels.push(modelName);
+        await mockAuthForceChatStatus(modelName, status);
+      },
       register(providerName) {
         registered.push(providerName);
       },
@@ -118,6 +143,13 @@ export const test = baseTest.extend<ProviderKeyFixtures>({
           await deleteProviderKeyByName(name);
         } catch (err) {
           console.warn(`[provider-key fixture] delete warning for ${name}:`, err);
+        }
+      }
+      for (const modelName of forcedStatusModels) {
+        try {
+          await mockAuthClearChatStatus(modelName);
+        } catch (err) {
+          console.warn(`[provider-key fixture] status-hook reset warning for ${modelName}:`, err);
         }
       }
     }

--- a/tests_end_to_end/e2e/pom/automation-logs.page.ts
+++ b/tests_end_to_end/e2e/pom/automation-logs.page.ts
@@ -74,6 +74,22 @@ export class AutomationLogsPage {
   }
 
   /**
+   * Rows whose Message cell contains `text`, optionally narrowed to one level.
+   *
+   * `text` is matched as a substring on purpose: every line the scorer writes
+   * embeds a trace id and a rule name, so callers identify a line by the
+   * fragment that names it. The level, when given, is still matched exactly
+   * through `rowsAtLevel`, because `WARN` must never satisfy a check for
+   * `ERROR`.
+   */
+  rowsWithMessage(text: string, level?: AutomationLogLevel): Locator {
+    const base = level === undefined ? this.rows() : this.rowsAtLevel(level);
+    return base.filter({
+      has: this.page.locator('td[data-cell-id$="_message"]', { hasText: text }),
+    });
+  }
+
+  /**
    * Rows at `level` whose message names `threadId '<threadId>'`.
    *
    * The quotes the backend puts around the id are part of the match, and they

--- a/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
+++ b/tests_end_to_end/e2e/services/mock-token-auth/mock_token_auth_service.py
@@ -17,9 +17,16 @@ One process, two roles:
 Test hooks:
 
   GET  /health                Liveness for Playwright's webServer probe.
-  GET  /stats                 Counters (tokens_issued, chat_ok, chat_refused_*)
-                              for clock-free refetch assertions.
+  GET  /stats                 Counters (chat_request, tokens_issued, chat_ok,
+                              chat_refused_*) for clock-free refetch and
+                              retry-budget assertions.
   POST /revoke                Invalidate every issued token (reactive-retry path).
+  POST /chat-status           {"model": "<name>", "status": <int>} makes the
+                              gateway answer that HTTP status for every chat
+                              request naming that model; omit "status" to clear
+                              it. Scoped per model so one provider can serve a
+                              different status per model name, which is how a
+                              spec compares two statuses over one trace.
 
 Spawned automatically by the suite's `webServer` config; run by hand with
     python3 mock_token_auth_service.py --port 9878 --ttl 3600
@@ -41,6 +48,7 @@ STATIC_API_KEY = "mock-static-key"  # accepted as a bearer, for the static-auth 
 
 TTL_SECONDS = 3600
 ISSUED_TOKENS = {}  # token -> expiry epoch seconds
+FORCED_CHAT_STATUS = {}  # model name -> HTTP status the gateway must answer for it
 STATS = Counter()
 
 
@@ -102,6 +110,8 @@ class Handler(BaseHTTPRequestHandler):
             STATS["revocations"] += 1
             log(f"REVOKED all {count} issued tokens (gateway will 401 until a fresh fetch)")
             self._reply(200, {"revoked": count})
+        elif self.path == "/chat-status":
+            self._handle_chat_status(raw_body)
         elif self.path.endswith("/chat/completions"):
             self._handle_chat(raw_body)
         else:
@@ -153,6 +163,33 @@ class Handler(BaseHTTPRequestHandler):
             **({"scope": scope} if scope else {}),
         })
 
+    def _handle_chat_status(self, raw_body):
+        """Register (or clear) the HTTP status the gateway must answer for one model.
+
+        Per model rather than per process so a single provider can serve several statuses
+        at once: a spec that compares a permanent status against a transient one wants both
+        judged over the SAME trace, which means both must be live simultaneously.
+        """
+        try:
+            request = json.loads(raw_body)
+        except Exception:
+            self._reply(400, {"error": "invalid_json"})
+            return
+
+        model = request.get("model")
+        if not model:
+            self._reply(400, {"error": "model_required"})
+            return
+
+        status = request.get("status")
+        if status is None:
+            FORCED_CHAT_STATUS.pop(model, None)
+            log(f"chat status hook CLEARED for model={model}")
+        else:
+            FORCED_CHAT_STATUS[model] = int(status)
+            log(f"chat status hook SET model={model} -> HTTP {status}")
+        self._reply(200, {"model": model, "status": status})
+
     def _handle_chat(self, raw_body):
         try:
             request = json.loads(raw_body)
@@ -165,6 +202,12 @@ class Handler(BaseHTTPRequestHandler):
         def count(outcome):
             STATS[outcome] += 1
             STATS[f"{outcome}:{model}"] += 1
+
+        # Counted before any outcome branch, so it is the number of times the provider was
+        # CALLED for this model. The per-outcome counters below cannot answer that once a
+        # single evaluation produces several attempts, which is exactly what a retry-budget
+        # assertion has to count.
+        count("chat_request")
 
         auth = self.headers.get("Authorization") or ""
         token = auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else None
@@ -186,6 +229,20 @@ class Handler(BaseHTTPRequestHandler):
             count("chat_refused_expired")
             log(f"chat request REFUSED: expired token ...{token[-8:]} (model={model})")
             self._reply(401, {"error": {"message": "token expired", "type": "invalid_request_error"}})
+            return
+
+        # Applied only after the bearer checks above: a forced status is about how the
+        # CALLER classifies a provider failure, so it must not double as a way to pass a
+        # request that presented no valid token.
+        forced_status = FORCED_CHAT_STATUS.get(model)
+        if forced_status is not None:
+            count(f"chat_forced_{forced_status}")
+            log(f"chat request FORCED to HTTP {forced_status} (model={model})")
+            self._reply(forced_status, {"error": {
+                "message": f"mock gateway forced HTTP {forced_status} for model '{model}'",
+                "type": "mock_forced_status",
+                "code": forced_status,
+            }})
             return
 
         content = json.dumps(synthesize_reply(request))

--- a/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
+++ b/tests_end_to_end/e2e/tests/ai-providers/token-auth-refetch.spec.ts
@@ -33,7 +33,7 @@ test.describe('AI Providers — OAuth2 reactive token refetch', { tag: ['@t1-smo
     // unique model name so parallel specs can't collide in the model selector
     const modelName = `${testNamespace}-mock-model`;
 
-    await providerKeys.createOauth({ providerName, modelName });
+    await providerKeys.createOauth({ providerName, modelNames: [modelName] });
 
     const playground = new PlaygroundPage(page, project.id);
 

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts
@@ -145,22 +145,23 @@ test.describe('Online Evaluation — LLM provider error classification', { tag: 
           },
         )
         .toBeGreaterThan(0);
-      return backendClient.getAutomationRuleLogs(ruleId);
     };
 
-    const permanentLogs = await test.step('Both judges reach a terminal failure', async () => {
-      const logs = await waitForTerminalError(rules.permanent, permanentRuleName);
+    await test.step('Both judges reach a terminal failure', async () => {
+      await waitForTerminalError(rules.permanent, permanentRuleName);
       await waitForTerminalError(rules.transient, transientRuleName);
-      return logs;
     });
 
     await test.step(
       `A ${PERMANENT_STATUS} costs exactly one call; a ${TRANSIENT_STATUS} costs the whole retry budget`,
       async () => {
         // Polled, not read once: the transient rule's last attempts can still be in flight
-        // when its ERROR line lands, so a single read would race the retry loop. The
-        // permanent count is re-asserted afterwards on the same settled snapshot, which is
-        // what proves it did not merely lag behind.
+        // when its ERROR line lands, so a single read would race the retry loop.
+        //
+        // The permanent count is then read from a FRESH snapshot taken once that poll has
+        // settled. Order matters: by the time a sibling rule has spent four attempts on the
+        // same gateway, a permanent rule that was quietly retrying would have registered
+        // its extra calls, so a 1 here is a settled 1 rather than one that merely lagged.
         await expect
           .poll(
             async () => mockAuthChatRequests(await mockAuthStats(), transientModel),
@@ -186,6 +187,14 @@ test.describe('Online Evaluation — LLM provider error classification', { tag: 
       // Complements the call count from the other side: the call count would also read 1 if
       // the rule had been dropped before the request, and these lines would also read 1 if
       // it had silently retried. Together they pin one delivery that made one call.
+      //
+      // Re-read rather than reusing the snapshot that ended the wait above. That one was
+      // taken the instant the FIRST error line landed, so a redelivery arriving moments
+      // later would still count as one — an "exactly once" claim proved against a stream
+      // that had not finished. This read happens after the transient rule has spent its
+      // whole budget, by which point a duplicate delivery of the permanent rule would
+      // long since have been written.
+      const permanentLogs = await backendClient.getAutomationRuleLogs(rules.permanent);
       expect(
         permanentLogs.filter((l) => l.message.includes(EVALUATING_LINE)),
         `rule '${permanentRuleName}' must be delivered exactly once`,

--- a/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts
+++ b/tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect } from '@e2e/fixtures';
+import { AutomationLogsPage } from '@e2e/pom/automation-logs.page';
+import { buildConstantScoreMetric } from '@e2e/core/metrics';
+import { mockAuthChatRequests, mockAuthSkipReason, mockAuthStats } from '@e2e/core/mock-auth';
+
+/**
+ * OPIK-8262: an LLM judge whose provider answers a PERMANENT status must give up on the
+ * first call, while a TRANSIENT one must still consume the retry budget. The backend
+ * decides that from the wire status — the 4xx family minus {408, 425, 429} — not from the
+ * status family, so two statuses that used to behave identically now must not.
+ *
+ * The separation is only observable by counting UPSTREAM CALLS. Both rules write the same
+ * three log lines (Evaluating / Sending / ERROR) whichever way they were classified,
+ * because the in-process retries happen inside one delivery and log nothing extra. So the
+ * assertion reads the mock gateway's own per-model request counters, which is also why
+ * this spec cannot run against a remote deployment: the mock is bound to the test runner.
+ */
+
+/** Emitted once per delivery, immediately before the provider call. */
+const SENDING_LINE = 'to LLM';
+/** Emitted once per delivery, when the rule starts judging a sampled trace. */
+const EVALUATING_LINE = 'sampled by rule';
+
+/**
+ * A client error the PR classifies as permanent: it can never succeed, so the caller
+ * must not spend an attempt finding that out twice.
+ */
+const PERMANENT_STATUS = 409;
+/**
+ * A client error the PR keeps transient. Same family as 409, opposite handling — which is
+ * precisely the distinction family-based classification could not express.
+ */
+const TRANSIENT_STATUS = 429;
+
+/**
+ * Lower bound on the calls a transient status must cost: `LLM_PROVIDER_CLIENT_MAX_ATTEMPTS`
+ * defaults to 3 retries, so the outer policy makes 4 attempts.
+ *
+ * A floor rather than an equality because the langchain4j client nests retries of its own
+ * inside each outer attempt (observed: 12 calls). That inner count is not what this change
+ * governs, and pinning it would make the spec fail on an unrelated client upgrade. The
+ * permanent side IS pinned exactly — "exactly one call" is the whole claim there.
+ */
+const MIN_TRANSIENT_ATTEMPTS = 4;
+
+test.describe('Online Evaluation — LLM provider error classification', { tag: ['@t2-cuj', '@area:online-evaluation'] }, () => {
+  // The classification is asserted through the mock gateway's counters, so a backend that
+  // cannot reach the mock would report zero calls rather than a connectivity problem.
+  test.beforeAll(async () => {
+    const reason = await mockAuthSkipReason();
+    test.skip(reason !== null, reason ?? '');
+  });
+
+  test('A permanent provider status costs one call and a transient one consumes the retry budget, and neither scores the trace', { tag: ['@cap:online-evaluation.llm-judge-scores', '@cap:online-evaluation.automation-logs'] }, async ({
+    page,
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    providerKeys,
+    automationRulesCleanup,
+  }) => {
+    test.setTimeout(300_000);
+
+    const providerName = `${testNamespace}-errclass`;
+    // Model names are the axis: the mock keys both its counters and its forced status on
+    // the model in the request body, so one provider serves two statuses and the two rules
+    // differ in nothing else.
+    const permanentModel = `${testNamespace}-permanent`;
+    const transientModel = `${testNamespace}-transient`;
+
+    const permanentRuleName = `${testNamespace}-judge-permanent`;
+    const transientRuleName = `${testNamespace}-judge-transient`;
+    const controlRuleName = `${testNamespace}-control`;
+
+    await test.step('Register one mock provider serving a permanent and a transient status', async () => {
+      await providerKeys.createOauth({
+        providerName,
+        modelNames: [permanentModel, transientModel],
+      });
+      await providerKeys.forceChatStatus(permanentModel, PERMANENT_STATUS);
+      await providerKeys.forceChatStatus(transientModel, TRANSIENT_STATUS);
+    });
+
+    const rules = await test.step('Create one LLM-judge rule per model, plus a python control rule', async () => {
+      const judge = (name: string, model: string) =>
+        backendClient.createLlmJudgeRule({
+          projectId: project.id,
+          name,
+          samplingRate: 1,
+          // The full provider-qualified identifier the model selector shows: the backend
+          // strips both prefixes before putting `<model>` in the outgoing request body,
+          // which is the key the mock gateway counts and forces a status on.
+          model: `custom-llm/${providerName}/${model}`,
+          messages: [{ role: 'USER', content: 'Rate this output: {{output}}' }],
+          variables: { output: 'output.output' },
+          schema: [{ name: 'quality', type: 'INTEGER', description: '0 or 1' }],
+        });
+      return {
+        permanent: await judge(permanentRuleName, permanentModel),
+        transient: await judge(transientRuleName, transientModel),
+        // A rule that cannot fail for provider reasons. Without it, two judges that logged
+        // nothing would be indistinguishable from two judges that were never invoked.
+        control: await backendClient.createAutomationRule({
+          projectId: project.id,
+          name: controlRuleName,
+          samplingRate: 1,
+          metric: buildConstantScoreMetric(controlRuleName),
+          arguments: { output: 'output.output' },
+        }),
+      };
+    });
+
+    const trace = await test.step('Seed one trace for all three rules to judge', async () => {
+      // One trace, three rules: the two judges are then provably given identical input, so
+      // a difference in outcome is a difference in the provider's status and nothing else.
+      return sdkClient.python.createTrace({
+        project_name: project.name,
+        name: `${testNamespace}-trace`,
+        input: 'whatever',
+        output: 'seed output',
+      });
+    });
+
+    await test.step('Control: the trace was sampled and the scoring pipeline fired', async () => {
+      const score = await backendClient.pollTraceForFeedbackScore(trace.id, controlRuleName, {
+        timeoutMs: 180_000,
+      });
+      expect(score.value, 'the control metric returns a constant 1.0').toBe(1.0);
+    });
+
+    const waitForTerminalError = async (ruleId: string, ruleName: string) => {
+      await expect
+        .poll(
+          async () => {
+            const logs = await backendClient.getAutomationRuleLogs(ruleId);
+            return logs.filter((l) => l.level === 'ERROR').length;
+          },
+          {
+            timeout: 120_000,
+            intervals: [1_000, 2_000],
+            message:
+              `rule '${ruleName}' never reported a terminal failure — its provider always ` +
+              'answers an error status, so a silent stream means the rule never ran',
+          },
+        )
+        .toBeGreaterThan(0);
+      return backendClient.getAutomationRuleLogs(ruleId);
+    };
+
+    const permanentLogs = await test.step('Both judges reach a terminal failure', async () => {
+      const logs = await waitForTerminalError(rules.permanent, permanentRuleName);
+      await waitForTerminalError(rules.transient, transientRuleName);
+      return logs;
+    });
+
+    await test.step(
+      `A ${PERMANENT_STATUS} costs exactly one call; a ${TRANSIENT_STATUS} costs the whole retry budget`,
+      async () => {
+        // Polled, not read once: the transient rule's last attempts can still be in flight
+        // when its ERROR line lands, so a single read would race the retry loop. The
+        // permanent count is re-asserted afterwards on the same settled snapshot, which is
+        // what proves it did not merely lag behind.
+        await expect
+          .poll(
+            async () => mockAuthChatRequests(await mockAuthStats(), transientModel),
+            {
+              timeout: 60_000,
+              intervals: [1_000, 2_000],
+              message:
+                `a ${TRANSIENT_STATUS} must be retried: the subscriber classifies it as ` +
+                'transient, so the provider client spends its attempts before giving up',
+            },
+          )
+          .toBeGreaterThanOrEqual(MIN_TRANSIENT_ATTEMPTS);
+
+        const stats = await mockAuthStats();
+        expect(
+          mockAuthChatRequests(stats, permanentModel),
+          `a ${PERMANENT_STATUS} can never succeed, so the judge must call the provider once and stop`,
+        ).toBe(1);
+      },
+    );
+
+    await test.step(`The ${PERMANENT_STATUS} rule reported exactly one delivery and one failure`, async () => {
+      // Complements the call count from the other side: the call count would also read 1 if
+      // the rule had been dropped before the request, and these lines would also read 1 if
+      // it had silently retried. Together they pin one delivery that made one call.
+      expect(
+        permanentLogs.filter((l) => l.message.includes(EVALUATING_LINE)),
+        `rule '${permanentRuleName}' must be delivered exactly once`,
+      ).toHaveLength(1);
+      expect(
+        permanentLogs.filter((l) => l.message.includes(SENDING_LINE)),
+        `rule '${permanentRuleName}' must reach the provider exactly once`,
+      ).toHaveLength(1);
+      expect(
+        permanentLogs.filter((l) => l.level === 'ERROR'),
+        `rule '${permanentRuleName}' must report its terminal failure exactly once`,
+      ).toHaveLength(1);
+    });
+
+    await test.step('A failed judge writes no feedback score', async () => {
+      const detail = await backendClient.getTrace(trace.id);
+      expect(detail, 'the seeded trace must still exist to be asserted about').not.toBeNull();
+      expect(
+        detail!.feedbackScores.map((s) => s.name).sort(),
+        'only the control rule may have written a score — a failed judge must store nothing',
+      ).toEqual([controlRuleName]);
+    });
+
+    await test.step('The automation logs page renders the failed delivery', async () => {
+      const logsPage = new AutomationLogsPage(page);
+      await logsPage.goto(rules.permanent);
+      await logsPage.waitForReady();
+
+      // Each line is matched by the seeded trace id, so the page is proved to be rendering
+      // THIS rule's stream rather than any stream at all.
+      await expect(
+        logsPage.rowsWithMessage(trace.id, 'INFO').filter({ hasText: EVALUATING_LINE }),
+        'the page shows the trace being sampled by the rule',
+      ).toHaveCount(1);
+      await expect(
+        logsPage.rowsWithMessage(trace.id, 'INFO').filter({ hasText: SENDING_LINE }),
+        'the page shows the single provider call',
+      ).toHaveCount(1);
+      await expect(
+        logsPage.rowsWithMessage(trace.id, 'ERROR'),
+        'the page shows the terminal failure, and only one of them',
+      ).toHaveCount(1);
+    });
+  });
+});


### PR DESCRIPTION
## Details

**Generated by the QA test-radar side flow. Not human-written — please review before merge.** It is a draft on purpose and must not be promoted or merged without a human reading the assertions.

### Where this came from

opik#8169 — *[OPIK-8262] [BE] fix: classify provider errors by status, not 4xx/5xx family*.

A human-driven exploration ran against that PR's own deployed environment (`pr-8169.dev.comet.com`, 2.2.53-6553, fresh OSS install, workspace `default`) and verified the flow by hand before any spec was written: 400/403/404/409 produced **one** upstream call and one terminal ERROR (0.11–0.25 s), while 408/429/500 consumed the retry budget (8.4–8.7 s) on the same trace with the same rule shape — a ~70× separation, not a timing race.

That exploration drove the provider through `httpbin.org` because the estate's own mock is unreachable from a remote deployment, which meant it could only *infer* attempt counts from elapsed time. This spec closes that gap: it drives the estate's mock gateway instead and asserts the exact per-model request count.

### Base branch — read this before retargeting

This targets **`thiagohora/OPIK-8262-2-provider-error-classification`**, not `main`.

The spec asserts behaviour that only exists in #8169. On `main` today the permanent-status rule would consume the retry budget like any other 4xx, and the "exactly one call" assertion would fail. Once #8169 lands, retarget to `main` (or to whatever the stack collapses into — #8169 is itself based on `thiagohora/OPIK-8262-retry-classification-and-fanout`).

### The spec

`tests_end_to_end/e2e/tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts` — one test, `@t2-cuj @area:online-evaluation`.

**Setup.** One Custom (`custom-llm`) provider against the suite's mock token gateway, serving two models: one forced to answer `409`, one forced to answer `429`. Two LLM-judge rules at `sampling_rate: 1`, one per model, plus a python constant-score control rule. One trace, seeded through the Python SDK, judged by all three.

**What it asserts**

| Claim | `@cap:` |
|---|---|
| The control rule scored the trace, so a silent judge stream means "never invoked", not "silently fine" | `online-evaluation.llm-judge-scores` |
| A `409` costs **exactly one** upstream call | `online-evaluation.llm-judge-scores` |
| A `429` costs at least `LLM_PROVIDER_CLIENT_MAX_ATTEMPTS + 1` calls | `online-evaluation.llm-judge-scores` |
| The `409` rule logged exactly one delivery, one provider call, one terminal ERROR | `online-evaluation.llm-judge-scores` |
| Neither failed judge wrote a feedback score — the trace carries the control's score and nothing else | `online-evaluation.llm-judge-scores` |
| `/$workspaceName/automation-logs?rule_id=` renders the Evaluating / Sending / ERROR rows for the seeded trace id | `online-evaluation.automation-logs` |

**Two deliberate choices worth a reviewer's attention:**

- **The counts come from the mock, not from the rule log.** Both rules write the same three log lines whichever way they were classified, because the in-process retries all happen inside a single delivery and log nothing extra. Counting log lines cannot distinguish the two; counting upstream calls can. This is also why the spec cannot run against a remote deployment — the mock binds to the test runner.
- **The permanent side is pinned exactly (`=== 1`); the transient side is a floor (`>= 4`).** "Exactly one call" is the whole claim of the change. The transient count observed locally is 12, not 4, because the langchain4j client nests retries of its own inside each of the outer policy's 4 attempts — an inner count this PR does not govern, and pinning it would break the spec on an unrelated client upgrade.

### Estate changes it needed

| File | Why |
|---|---|
| `services/mock-token-auth/mock_token_auth_service.py` | `POST /chat-status` forces an HTTP status **per model**, so one provider serves two statuses over one trace with the rule shape held constant. New `chat_request[:model]` counter, incremented before any outcome branch — the existing per-outcome counters cannot express "how many attempts" once one evaluation makes several. The forced status is applied **after** the bearer checks, so it can never turn an unauthenticated request into a pass. |
| `core/mock-auth.ts` | `mockAuthForceChatStatus` / `mockAuthClearChatStatus` / `mockAuthChatRequests`. |
| `fixtures/provider-key.fixture.ts` | `createOauth` takes `modelNames: string[]` (was `modelName`), and a new `forceChatStatus` registers the hook reset for teardown rather than leaving a trailing reset step that a failing assertion would skip. The one existing caller passing `modelName` is updated. |
| `core/backend/client.ts` | `createLlmJudgeAutomationRule` — the two rule types share only their envelope, so it is a sibling of `createAutomationRule` rather than a flag on it. The `Location`-header id parsing both need is extracted to one helper. |
| `pom/automation-logs.page.ts` | New. Rows are addressed through their `level` / `message` cells: this page's `data-row-id` is a content hash, not an entity id, so a test cannot predict it. |
| `coverage/taxonomy.yaml` | Registers the spec; extends `llm-judge-scores`; flips `automation-logs` to `covered: true`. That key was deliberately `false` because no spec *opened the page* — this one does, so the comment explaining the distinction is updated rather than deleted. |

### Verification

Run against a **local OSS stack built from this PR's own images** (`OPIK_VERSION=2.2.53-6553`, i.e. the same build the exploration used), because the mock gateway must be reachable by the backend — that is CI's own topology (`MOCK_AUTH_URL_FOR_BACKEND=http://172.17.0.1:9878`).

```
OPIK_BASE_URL=http://localhost:5173 OPIK_DEPLOYMENT=oss OPIK_WORKSPACE=default \
MOCK_AUTH_URL_FOR_BACKEND=http://172.17.0.1:9878 \
npx playwright test tests/online-evaluation/online-evaluation-provider-error-classification.spec.ts \
  --repeat-each=3 --retries=0 --reporter=list
```

- **PASSED — 3 of 3, 46.3 s** (single run: 12.6 s). No retries, no flake across the three.
- `python3 tests_end_to_end/coverage/tag_lint.py …` → **0 problem(s)**.
- `tests/ai-providers/` (the 5 specs that share the mock and the provider fixture) → **5 passed**.

**Two things a reviewer should know about, neither introduced here:**

- `online-evaluation-python-metric-errors.spec.ts` **fails on this environment** — the python evaluator answers `500 Internal Server Error: Failed to execute code:` where the spec expects the classified `400`. Reproduced on a pristine checkout of `c8f9be46` with none of this branch's changes applied, so it is pre-existing on this base and not caused by the shared-client refactor here.
- `npx tsc --noEmit` **cannot run** on the estate as configured: `typescript` is pinned to `^7.0.2`, which removed `baseUrl`, and `tsconfig.json` still sets it (`error TS5102`). Also reproduced pristine. Typechecked instead with a scratch config that drops `baseUrl` and keeps the `@e2e/*` paths: the estate has 2 pre-existing errors (duplicate `deleteDashboard` in `core/backend/client.ts`) and **none in any file this branch touches**.

**Also run against `$OPIK_BASE_URL` (`https://pr-8169.dev.comet.com`), as asked: `1 skipped`.** The suite's own `mockAuthSkipReason()` gate fires because the mock gateway is bound to the test runner and a remote backend can never call it — this is the constraint `core/mock-auth.ts` documents, not a defect. (Before that, `global-setup` refuses to start against a non-localhost URL without `OPIK_API_KEY` at all.) A remote deployment is structurally the wrong target for this spec; CI's local-backend topology is the right one, and that is where it passes.

### What I deliberately did not write

**One candidate dropped of two.**

*"A permanent provider status is acked on first delivery; a transient one is redelivered by the online-scoring subscriber."* This is the PR's real user-visible payoff, and the exploration did verify it by hand — 10 m 32 s after the first delivery the 429 rule had a second one while the 409 and 403 rules on the same trace still had one. It is not automatable as written: the gap is set by `REDIS_SCORING_PENDING_MESSAGE_DURATION`, which defaults to **10 minutes**, far past any spec budget. It becomes writable the day the e2e deployment sets `REDIS_SCORING_LLM_AS_JUDGE_PENDING_MESSAGE_DURATION` (or the global override) under a minute; until then a spec for it would either time out or need a sleep longer than the rest of the suite combined.

Also not written, and out of scope for a spec here: the exploration's low-confidence observation that the terminal ERROR names neither the status nor the cause when the provider returns an empty body (`OnlineScoringLlmAsJudgeScorer` logs `error.getCause().getMessage()` in preference to the exception's own message). That logger line is not in this diff, and asserting today's wording would pin a bug rather than a contract.

---

Source PR: comet-ml/opik#8169 (OPIK-8262). This branch adds coverage **for** that change and touches no product code.

<!-- comet-qa-test-radar: propose -->


[OPIK-8262]: https://comet-ml.atlassian.net/browse/OPIK-8262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Change checklist

- [x] Specs run before the PR was opened (see Testing)
- [x] Reviewed by the generated-test review job; its fixes are pushed
- [ ] Reviewed by a human — this PR is a draft until then

## Issues

OPIK-8262

## Testing

Run by the generator before the PR was opened, and re-reviewed by
`review_generated_tests.yml` afterwards. Per-spec results and the
verification commands are in the Details section above and in the review
comment on this PR.

## Documentation

No documentation change — this adds end-to-end test coverage only.
