### PR TITLE
[OPIK-7532] [QA] Proposed taxonomy changes from app surface

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -266,6 +266,7 @@ areas:
       configure-columns:      { covered: false }
       add-trace-to-dataset:   { covered: false, note: "AddToDatasetDialog" }
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
+      messages-tab:           { covered: false, note: "MessagesTab — conditional on detectLLMMessages(input/output); when present it is the panel's default tab, else Details" }
       agent-graph-tab:        { covered: false }
       prompts-tab:            { covered: false, note: "PromptsTab — conditional on opik_prompts metadata + canViewPrompts, like agent-graph-tab" }
       attachments-media:      { covered: true,  tier: t2-cuj, note: "presigned multipart upload with mime_type omitted, asserting the type tika derives from each file name (incl. the octet-stream fallback), plus every attachment rendering as a thumbnail in the trace panel" }


### PR DESCRIPTION
## Proposed by nightly taxonomy discovery

Read the app's route/nav/tab surface and compared it against `taxonomy.yaml`.
Baseline before this change: **19 areas, 203 functional capabilities**.

# Taxonomy discovery — proposal (2026-09-07)

**Target:** `opik/tests_end_to_end/coverage/taxonomy.yaml` (Opik variant)

**Measured against:**

| | |
|---|---|
| opik ref | `09e6c4e151` — *[OPIK-8050] [FE] fix: paginate prompt version history and fix version labeling (#8140)* |
| tree state | clean (`git status --porcelain` empty) |
| surface | `./surface.json`, pre-generated by the caller — 60 routes, 20 nav items, 8 tab sets, **1** unmatched surface |
| lint | `tag_lint.py --taxonomy coverage/taxonomy.yaml --estate .` → `59 specs checked, 1 exempt, 0 problem(s)` (after the edit) |

Route-wise this run reproduces the documented baseline exactly: the only entry in
`unmatched_surfaces` is `/$workspaceName/home`. That one I am now **rejecting** with
positive evidence (§2b) rather than leaving it open again.

The single proposal below came from the **tab** diff, which `unmatched_surfaces` does
not cover and which has to be done by hand.

---

## 1. What changed

One capability added. `covered: false`, no `tier:` — reconcile.py owns those.

```diff
       add-trace-to-queue:     { covered: false, note: "AddToQueueDialog — cross-links annotation-queues" }
+      messages-tab:           { covered: false, note: "MessagesTab — conditional on detectLLMMessages(input/output); when present it is the panel's default tab, else Details" }
       agent-graph-tab:        { covered: false }
```

### `traces.messages-tab`

**Evidence**

- **Tab value:** `messages`, from `surface.json` → `tabs` →
  `src/v2/pages-shared/traces/TraceDetailsPanel/TraceDataViewer/TraceDataViewer.tsx`
  (`['details', 'feedback_scores', 'graph', 'messages', 'prompts']`).
- **Rendered surface:** `TraceDataViewer.tsx:271-277` — `<TabsTrigger value="messages">Messages</TabsTrigger>`,
  content at `:309-317` rendering a dedicated `<MessagesTab>` component, structurally
  parallel to `DetailsTab` / `PromptsTab` / the agent-graph block.
- **Conditionality:** `TraceDataViewer.tsx:84-98` — `canShowMessagesTab` is derived from
  `detectLLMMessages()` over the transformed input and output; when true it also becomes
  the panel's `defaultTab`, otherwise the panel opens on Details (`:98`, fallback at `:116`).
- **Not already covered:** no functional capability in the file names it. The nearest keys
  are `traces.open-trace-panel`, whose only spec
  (`e2e/tests/trace-explore/trace-explore-smoke.spec.ts:48`) asserts
  `inputSection` / `outputSection` / `inputValue` / `outputValue` **tab-agnostically** and never
  touches the Messages/Details toggle; and `threads.turn-order-io`, which is a different
  component and surface (`ThreadDetailsPanel`, not `TraceDataViewer`).

**Why this is a capability and not a format toggle.** The skill rightly excludes view/format
switches — which is why the two `python`/`typescript` tab pairs in this sweep are rejected
below. Messages is a different shape: it is *conditionally present*, gated on the data,
exactly like its siblings `prompts-tab` ("conditional on opik_prompts metadata +
canViewPrompts") and `agent-graph-tab` — both of which the taxonomy already carries as
their own capabilities. There is a concrete assertion available that no current spec makes:
seed an LLM-message-shaped trace → the Messages tab exists and is the default; seed a plain
trace → the tab is absent and the panel opens on Details.

**One argument I deliberately did not use.** The visual dimension already splits
`trace-sidebar-messages` from `trace-sidebar-details` (`taxonomy.yaml:284-285`). That is *not*
evidence for a functional split — the file's own dimensions comment says visual keys are
page/state-shaped and get their own sub-keys "rather than being forced onto functional
capability names." The case above rests on the conditional-rendering parallel alone.

**Altitude note, stated plainly:** this takes `traces` from 21 to 22 capabilities, above the
5–15 guide. I think that is correct here — `traces` is the widest surface in the product and
the guide is explicitly for catching over-splitting, not for forcing a real area to fit — but
it is the weakest part of this proposal and the thing a reviewer should push back on if they
disagree.

---

## 2. Coverage arithmetic

Recounted from the file (both sides), per dimension, never blended. The addition is
`covered: false` and not `cloud_only`, so it lands in the denominator of both views.

| Dimension | View | Before | After |
|---|---|---|---|
| **functional** | cloud | 117/203 (57.6%) | **117/204 (57.4%)** |
| **functional** | self-hosted | 107/179 (59.8%) | **107/180 (59.4%)** |
| visual | cloud | 30/54 (55.6%) | 30/54 (55.6%) — unchanged |
| visual | self-hosted | 30/50 (60.0%) | 30/50 (60.0%) — unchanged |
| load | — | 0/9 (`status: planned`) | 0/9 — unchanged |

Area-level: `traces` functional **12/21 (57.1%) → 12/22 (54.5%)**.

Functional coverage drops by 0.2pp overall and 2.6pp in `traces`. That drop is the point —
the Messages tab was always untested; it was just not being counted.

---

## 2b. Rejected surfaces

The useful half of a near-null run: what was considered and ruled out.

### `/$workspaceName/home` — the standing borderline, now resolvable as **not** a capability

The skill records this as "a genuine borderline, left for a human on purpose." I think the
evidence now closes it:

- `src/v2/pages/HomePage/HomePage.tsx` is **21 lines total** and is a pure redirect: it renders
  `<Loader/>` and, in a `useEffect`, calls `navigate({ to: "/$workspaceName/projects", replace: true })`.
  There is no content to assert.
- `src/v2/router.tsx:157` labels it in the source itself:
  `// ----------- home (redirects to the workspace Projects tab)`.
- Its destination is already owned by `projects.list-projects`.
- **`has_nav_entry: true` is a false positive.** The nav "Home" entry is
  `projectPath("/home")` (`getMenuItems.ts:70`) — the *project-scoped* home, i.e.
  `ProjectHomePage`, which the taxonomy already carries as `projects.project-home`. The
  extractor matched on the `/home` suffix and attributed a different route's nav entry to
  this one.
- `has_api_client: false`.

In substance this is `kind: redirect`, the same class as `TracesTabRedirect`. `surface.py`
classified it as `surface` because the redirect is a `useEffect` navigate rather than an
inline `<Navigate>` in the route definition (the form used by `baseRoute`,
`workspaceIndexRoute` and `quickstartRoute`, all of which it *did* classify as redirects).
See the extractor note in §4.

### Tab sets — 8 checked, 7 fully owned

| Component | Tab values | Verdict |
|---|---|---|
| `AgentRunnerEmptyState.tsx` | `python` / `typescript` | **format toggle** — one code panel, two renderings. Excluded per the skill. |
| `CreateDatasetSidebar.tsx` | `python` / `typescript` | same — format toggle. |
| `AnnotationQueuePage.tsx` | `configuration` / `items` | owned: `annotation-queues.queue-configuration-tab`; the items tab is the surface `score-queue-item` / `skip-item` act on. |
| `TrialSidebarContent.tsx` | `prompt` / `results` | owned: `optimization-studio.best-trial-prompt`, `trial-detail`. |
| `PromptPage.tsx` | `experiments` / `prompt` | owned: `prompts.experiments-tab` (note already reads "prompt detail -> Experiments tab"), `version-history`. |
| `DatasetItemsPage.tsx` | `items` / `version-history` | owned: `datasets.view-items`, `version-history-view`. |
| `ThreadDetailsPanel.tsx` | `feedback_scores` / `messages` | owned: `threads.turn-order-io`, `thread-feedback-score`. |
| `TraceDataViewer.tsx` | `details`, `feedback_scores`, `graph`, `prompts` | owned: `open-trace-panel`, `manual-feedback-score`, `agent-graph-tab`, `prompts-tab`. `messages` → **proposed above**, the one gap in the whole tab sweep. |

### Nav items — 20 checked, all owned

Every label maps to an existing area, and every area `label:` already matches the product's
own nav vocabulary (`Logs`→`traces`, `Opik Connect`→`ollie`, `Prompt library`→`prompts`,
`Optimization runs`→`optimization-studio`, `Get started`→`onboarding`). No naming drift found.

### Matched routes I re-checked for false-positive matching

`unmatched_surfaces` only shows what the matcher *failed* on, so a sloppy match can hide a
gap. Two routes looked like plausible mismatches; both are genuinely owned, with explicit
`routes:` declarations:

- `/$workspaceName/automation-logs` → `online-evaluation.automation-logs`
  (`taxonomy.yaml:643, 671`), whose note already distinguishes the page from the
  `GET /automations/evaluators/{id}/logs` stream a spec does cover.
- `/pair/v1`, `/opik/pair/v1` → `ollie` area (`taxonomy.yaml:715`).

### Docs sections with no UI surface

The fern tree has a **Gateway** section (under Production) and an **Admin Dashboard**
section. Neither has any route or nav entry in `opik-frontend` (`grep -i gateway` over
`router.tsx` and `getMenuItems.ts` → no hits), so neither is in scope for a taxonomy whose
estate is `tests_end_to_end/` UI coverage. Not proposed.

---

## 3. Removals

**None.** No capability in the file lost its surface in this sweep — every route, nav entry
and tab the extractor found still resolves to a live component, and I have no positive
evidence of absence for anything else. Since a removal shrinks the denominator and therefore
*raises* coverage, "I did not see it" is not sufficient grounds, and I did not go looking for
removals beyond what the surface sweep showed.

---

## 4. Notes for a human

No renames proposed — a rename orphans every `@cap:` tag, and nothing here warranted one.
Two non-taxonomy findings worth someone's attention:

1. **`surface.py` misclassifies `useEffect`-based redirects.** `/$workspaceName/home` is
   reported as `kind: surface` when it is functionally a redirect (§2b). Detecting a
   `navigate({...})` in a `useEffect` alongside the existing inline-`<Navigate>` detection
   would retire this recurring borderline permanently and take `unmatched_surfaces` to zero
   on a clean tree.
2. **`surface.py`'s `has_nav_entry` matches on path suffix.** It attributed the
   project-scoped `projectPath("/home")` nav entry to the workspace-level
   `/$workspaceName/home` route. Since `has_nav_entry` is described as the *strongest*
   reachable-vs-shipped signal, a suffix false positive on it is worth tightening.
3. **The skill's Step 2 docs path is stale.** It cites
   `opik/apps/opik-documentation/documentation/fern/versions/latest.yml`, which does not
   exist at this ref; the section tree is now at `.../fern/docs.yml`. I used the latter.

---

## 5. The blind spot

> This sweep reads only what is in the opik repo. `PluginsStore.collectRoutes()` and
> `PluginsStore.sidebarSections` let the out-of-tree `comet` plugin inject routes and nav
> entries that are invisible here, so surfaces that exist only in the commercial build are
> not covered by this diff.

`surface.json` carries the same caveat from the extractor itself. Concretely, the nav gating
it did resolve shows `showOlliePage` and `showDiagnostics` both gated on the
`AssistantSidebar` plugin component — evidence that the plugin boundary is load-bearing for
real surfaces, and therefore that anything *only* on the far side of it is unmeasured here.

`cloud_only` was not set on the proposed capability: `TraceDataViewer` is ungated in
`router.tsx` and reached through the plain Logs surface, so it exists self-hosted.

---

## Files changed

`opik/tests_end_to_end/coverage/taxonomy.yaml` — **1 insertion, 0 deletions**
(`git diff --stat`: `1 file changed, 1 insertion(+)`). Line-surgery edit, house alignment
matched (`{` at column 31). YAML re-parsed clean; `tag_lint.py` passes.

Not committed, not pushed, no PR opened — later steps own that. When one is opened it must be
a **draft**: this file is reviewed by definition.

---

### Why this is a draft

The denominator is a reviewed file — adding a capability lowers coverage
until a test exists, and removing one raises it. Both need a human.
New capabilities land `covered: false` with no `tier:`; `reconcile.py`
fills those in once a tagged spec exists.

Run: https://github.com/comet-ml/comet-automation-tests/actions/runs/34086333799


[OPIK-8050]: https://comet-ml.atlassian.net/browse/OPIK-8050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ