### PR TITLE
[OPIK-7791] [QA] Proposed e2e specs from the 2.2.51 → 2.2.52 release exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -509,8 +509,11 @@ areas:
       - datasets/dataset-version-counters.spec.ts
       - datasets/dataset-version-repeated-item-id.spec.ts
       - datasets/dataset-version-concurrent-writes.spec.ts
+      - datasets/dataset-item-count.spec.ts
+      - datasets/dataset-parallel-item-read.spec.ts
+      - datasets/dataset-read-version-pinning.spec.ts
     capabilities:
-      list-datasets:          { covered: true,  tier: t1-smoke }
+      list-datasets:          { covered: true,  tier: t1-smoke, note: "row is listed (t1); t2 also asserts the Item count column against the items endpoint on a page mixing a versioned dataset (items_total) with a version-less one (legacy count scan), and follows it through an item delete" }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }
       create-dataset-sdk:     { covered: true,  tier: t1-smoke }
       view-items:             { covered: true,  tier: t1-smoke }
@@ -520,7 +523,7 @@ areas:
       filter-scoped-batch-update: { covered: true,  tier: t3-nightly, note: "tags exactly the filter-matched items; bystanders asserted present and untouched; ungrouped form only (no batch_group_id), so version-commit semantics are not asserted" }
       filter-scoped-mutation-validation: { covered: true,  tier: t3-nightly, note: "unsupported operator -> 400 naming field+operator; malformed filter list -> 422; asserted on both delete and batch-update" }
       search-items:           { covered: true,  tier: t3-nightly }
-      sdk-round-trip:         { covered: true,  tier: t1-smoke }
+      sdk-round-trip:         { covered: true,  tier: t1-smoke, note: "single-page get_items() round trip (t1); t2 also covers the multi-page parallel read — 5000 items over 3 default-chunk pages, list-equal across thread/chunk settings and against a REST enumeration, nb_samples as an exact prefix, and the documented ValueError arguments — plus the read's version pin holding against an insert committed mid-read" }
       version-history-view:   { covered: true,  tier: t2-cuj, note: "sequential + parallel multi-batch insert counters, rendered as Item count; plus a batch repeating one item id (51 entries -> items_total 50) and a grouped insert racing ungrouped mutate-latest batches (API-level: exactly one new version, one is_latest, counters accounting for every entry sent)" }
       export-dataset:         { covered: false, note: "DATASET_EXPORT_ENABLED" }
       import-huggingface:     { covered: false }

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -65,6 +65,28 @@ export interface RawApiResult {
   location?: string | null;
 }
 
+/**
+ * One row of `GET /v1/private/datasets`, as the Datasets list page reads it.
+ *
+ * `datasetItemsCount` is the "Item count" column, and the backend answers it
+ * two different ways in the same response: from the latest version's
+ * `items_total` where there is one, and from a `count(DISTINCT id)` scan over
+ * `dataset_items` where there is not. `latestVersionName` is what tells a test
+ * which of the two a given row took — the enrichment falls back exactly when it
+ * has no version to read `items_total` from.
+ *
+ * (One case the pair cannot distinguish: a version carrying the
+ * `ITEMS_TOTAL_NOT_MIGRATED` sentinel also falls back while still reporting a
+ * `latest_version`. It needs versions predating the `000046` backfill, so it is
+ * not reachable on a current deployment.)
+ */
+export interface DatasetSummaryRef {
+  id: string;
+  name: string;
+  datasetItemsCount: number;
+  latestVersionName: string | null;
+}
+
 /** One row of the dataset's Version history tab. */
 export interface DatasetVersionRef {
   versionName: string;
@@ -710,6 +732,65 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         }));
     },
 
+    /**
+     * One page of `GET /v1/private/datasets` for a project, with the two fields
+     * the Datasets list renders its "Item count" column from — exactly the read
+     * the page issues.
+     *
+     * Through `rawFetch` rather than the pinned SDK because `latest_version` is
+     * the only signal for *which* branch of the count enrichment a row took, and
+     * the generated client drops it.
+     *
+     * `total` comes back alongside the rows so a caller can assert the whole
+     * project fitted in this single request: the enrichment mixes versioned and
+     * fallback rows per response, so a spec about that mix is only asserting it
+     * if every seeded dataset was on the one page.
+     *
+     * Both fields are required rather than defaulted. `dataset_items_count` is
+     * `@Nullable` in the API, and defaulting a missing count to 0 would read as
+     * "an empty dataset" — indistinguishable from the answer for a genuinely
+     * empty one, and so a count assertion that cannot fail.
+     */
+    async listDatasetSummaries(args: {
+      projectId: string;
+      size?: number;
+    }): Promise<{ rows: DatasetSummaryRef[]; total: number }> {
+      const query = new URLSearchParams({
+        project_id: args.projectId,
+        page: '1',
+        size: String(args.size ?? 100),
+      });
+      const { status, message, json } = await rawFetch('GET', '/v1/private/datasets', { query });
+      if (status !== 200) {
+        throw new Error(`listDatasetSummaries: GET /v1/private/datasets -> ${status}: ${message}`);
+      }
+      const page = json as {
+        content?: Array<{
+          id?: string;
+          name?: string;
+          dataset_items_count?: number | null;
+          latest_version?: { version_name?: string } | null;
+        }>;
+        total?: number;
+      };
+      const rows = (page.content ?? []).map((d) => {
+        if (typeof d.dataset_items_count !== 'number') {
+          throw new Error(
+            `listDatasetSummaries: dataset '${d.name}' came back without a ` +
+              `dataset_items_count (${JSON.stringify(d.dataset_items_count)}) — ` +
+              `there is no count to assert on.`,
+          );
+        }
+        return {
+          id: String(d.id),
+          name: String(d.name),
+          datasetItemsCount: d.dataset_items_count,
+          latestVersionName: d.latest_version?.version_name ?? null,
+        };
+      });
+      return { rows, total: Number(page.total ?? rows.length) };
+    },
+
     async findDatasetByName(name: string, projectName?: string): Promise<DatasetRef | null> {
       try {
         const dataset = await opik.api.datasets.getDatasetByIdentifier({
@@ -917,6 +998,24 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       await opik.api.datasets.deleteDatasetItems({
         datasetId: args.datasetId,
         filters: args.filters as SdkDatasetItemFilters,
+      });
+    },
+
+    /**
+     * Delete named dataset items — `POST /v1/private/datasets/items/delete` in
+     * its id-scoped form, the counterpart to `deleteDatasetItemsByFilter`.
+     *
+     * Grouped: a `batch_group_id` is always sent, so the delete commits as a new
+     * dataset version rather than mutating the latest one in place. That is the
+     * path the UI's row/bulk delete takes, and the one that moves a version's
+     * `items_total` — which is what a caller asserting a rendered item count
+     * after a delete is reading.
+     */
+    async deleteDatasetItemsByIds(itemIds: string[]): Promise<void> {
+      if (itemIds.length === 0) return;
+      await opik.api.datasets.deleteDatasetItems({
+        itemIds,
+        batchGroupId: crypto.randomUUID(),
       });
     },
 

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -6,6 +6,7 @@ export {
   type DatasetRef as BackendDatasetRef,
   type DatasetItemRef,
   type DatasetItemWithTagsRef,
+  type DatasetSummaryRef,
   type DatasetVersionRef,
   type RawApiResult,
   type BackendSort,

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -68,6 +68,52 @@ export interface PythonSdkClient {
     num_threads?: number;
     workspace?: string;
   }): Promise<{ dataset_id: string; inserted: number }>;
+  /**
+   * One `Dataset.get_items(...)`, reduced to the item ids it returned **in the
+   * order it returned them** — the property a concurrent paged read has to
+   * preserve, and the one a set comparison would not notice losing.
+   *
+   * Omit a knob to exercise the SDK's own default for it; the bridge only
+   * forwards the ones set here. `num_threads`, `chunk_size` and `nb_samples`
+   * are deliberately unconstrained so a caller can assert the SDK's own
+   * validation: an argument it refuses comes back as `value_error` carrying the
+   * ValueError's message, with no items, rather than as a bridge failure.
+   */
+  readDatasetItems(args: {
+    dataset_name: string;
+    project_name: string;
+    nb_samples?: number;
+    num_threads?: number;
+    chunk_size?: number;
+    filter_string?: string;
+    workspace?: string;
+  }): Promise<{ item_ids: string[]; value_error: string | null }>;
+  /**
+   * A chunked `stream_items()` read with an insert committed part-way through
+   * it — the scenario the read's version pin exists for.
+   *
+   * The interleaving is deterministic, not raced: the bridge consumes
+   * `pause_after_chunks` chunks, runs the insert to completion, then consumes
+   * the remaining pages, which are therefore all fetched against a backend that
+   * already holds the new items. `chunk_size * (pause_after_chunks + 2 *
+   * num_threads)` must stay well under the dataset size, or the reader's
+   * look-ahead will have fetched everything before the insert lands and the
+   * scenario silently degrades into an ordinary read.
+   */
+  readDatasetItemsWithMidReadInsert(args: {
+    dataset_name: string;
+    project_name: string;
+    items: Array<Record<string, unknown>>;
+    chunk_size: number;
+    num_threads?: number;
+    pause_after_chunks: number;
+    workspace?: string;
+  }): Promise<{
+    item_ids: string[];
+    chunk_sizes: number[];
+    chunks_before_insert: number;
+    inserted: number;
+  }>;
   evaluateExperiment(args: {
     project_name: string;
     dataset_name: string;
@@ -328,6 +374,25 @@ export function makePythonSdkClient(opts: { bridgeUrl?: string } = {}): PythonSd
         args,
         { timeoutMs: 180_000 },
       );
+    },
+    async readDatasetItems(args) {
+      // A multi-page read of a few thousand items is well inside the default
+      // budget, but a `num_threads=1` pass over small chunks is not.
+      return request<{ item_ids: string[]; value_error: string | null }>(
+        'POST',
+        '/datasets/read-items',
+        args,
+        { timeoutMs: 180_000 },
+      );
+    },
+    async readDatasetItemsWithMidReadInsert(args) {
+      // Holds a whole chunked read AND an insert open on one request.
+      return request<{
+        item_ids: string[];
+        chunk_sizes: number[];
+        chunks_before_insert: number;
+        inserted: number;
+      }>('POST', '/datasets/read-with-mid-read-insert', args, { timeoutMs: 180_000 });
     },
     async compareSeed(args) {
       return request<{

--- a/tests_end_to_end/e2e/pom/datasets.page.ts
+++ b/tests_end_to_end/e2e/pom/datasets.page.ts
@@ -28,6 +28,21 @@ export class DatasetsPage {
       .filter({ has: this.page.getByRole('cell', { name, exact: true }) });
   }
 
+  /**
+   * The "Item count" cell of a dataset's row, as rendered.
+   *
+   * Addressed by the table's own `data-cell-id` (`<rowId>_<columnId>`) rather
+   * than a positional nth(): the column is user-configurable in both order and
+   * visibility, so position is not stable. `dataset_items_count` is the column
+   * id `DatasetListPage` registers, and it is in the default selected set.
+   *
+   * Unlike the Version history tab's Item count, this column has no
+   * `accessorFn`, so the number is rendered raw — "2500", not "2,500".
+   */
+  datasetItemCount(name: string): Locator {
+    return this.datasetRow(name).locator('[data-cell-id$="_dataset_items_count"]');
+  }
+
   async openDatasetByName(name: string): Promise<DatasetItemsPage> {
     if (!this.projectId) {
       throw new Error('DatasetsPage.openDatasetByName: call goto(projectId) first');

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -169,7 +169,11 @@ def read_dataset_with_mid_read_insert(
     client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
     item_ids: list[str] = []
     chunk_sizes: list[int] = []
-    inserted = False
+    # How many chunks had actually been consumed when the insert ran. Observed
+    # rather than echoed from the request: a caller asserting the read was
+    # genuinely mid-flight has to be reading a number the read produced, not one
+    # it supplied.
+    chunks_before_insert: int | None = None
     try:
         dataset = client.get_dataset(
             name=body.dataset_name, project_name=body.project_name
@@ -180,14 +184,14 @@ def read_dataset_with_mid_read_insert(
             chunk_sizes.append(len(chunk))
             item_ids.extend(str(item["id"]) for item in chunk)
 
-            if not inserted and len(chunk_sizes) == body.pause_after_chunks:
+            if chunks_before_insert is None and len(chunk_sizes) == body.pause_after_chunks:
                 insert_mid_read()
-                inserted = True
+                chunks_before_insert = len(chunk_sizes)
     finally:
         client.end(flush=False)
         atexit.unregister(client.end)
 
-    if not inserted:
+    if chunks_before_insert is None:
         raise HTTPException(
             status_code=422,
             detail=(
@@ -200,6 +204,6 @@ def read_dataset_with_mid_read_insert(
     return DatasetReadWithMidReadInsertResponse(
         item_ids=item_ids,
         chunk_sizes=chunk_sizes,
-        chunks_before_insert=body.pause_after_chunks,
+        chunks_before_insert=chunks_before_insert,
         inserted=len(body.items),
     )

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/routes/datasets.py
@@ -1,12 +1,16 @@
 import atexit
 
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, HTTPException
 
 from ..opik_factory import make_opik_client
 from ..schemas import (
     DatasetCreate,
     DatasetInsertItemsRequest,
     DatasetInsertItemsResponse,
+    DatasetReadItemsRequest,
+    DatasetReadItemsResponse,
+    DatasetReadWithMidReadInsertRequest,
+    DatasetReadWithMidReadInsertResponse,
     DatasetResponse,
 )
 
@@ -67,3 +71,135 @@ def insert_dataset_items(
         atexit.unregister(client.end)
 
     return DatasetInsertItemsResponse(dataset_id=dataset_id, inserted=len(body.items))
+
+
+@router.post("/read-items", response_model=DatasetReadItemsResponse, status_code=200)
+def read_dataset_items(
+    body: DatasetReadItemsRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> DatasetReadItemsResponse:
+    """One `Dataset.get_items(...)`, reduced to the ids it returned, in order.
+
+    Order is the assertion, not an incidental: `get_items` fans its pages out
+    over a thread pool and reassembles them, so a read that returned the right
+    items in the wrong order — or one item twice and another not at all — is
+    exactly the corruption this exists to catch, and a set comparison would miss
+    all of it.
+
+    A `ValueError` from the SDK's argument validation is reported as a 200 with
+    `value_error` set rather than raised: it is a documented outcome of some of
+    these calls, and the caller has to be able to assert the message.
+    """
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    try:
+        dataset = client.get_dataset(
+            name=body.dataset_name, project_name=body.project_name
+        )
+        # Only the knobs the caller actually set are passed on, so an omitted
+        # one exercises the SDK's own default rather than a value chosen here.
+        kwargs = {
+            name: value
+            for name, value in (
+                ("nb_samples", body.nb_samples),
+                ("num_threads", body.num_threads),
+                ("chunk_size", body.chunk_size),
+                ("filter_string", body.filter_string),
+            )
+            if value is not None
+        }
+        try:
+            items = dataset.get_items(**kwargs)
+        except ValueError as err:
+            return DatasetReadItemsResponse(item_ids=[], value_error=str(err))
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+
+    return DatasetReadItemsResponse(item_ids=[str(item["id"]) for item in items])
+
+
+@router.post(
+    "/read-with-mid-read-insert",
+    response_model=DatasetReadWithMidReadInsertResponse,
+    status_code=200,
+)
+def read_dataset_with_mid_read_insert(
+    body: DatasetReadWithMidReadInsertRequest,
+    x_opik_api_key: str | None = Header(default=None),
+) -> DatasetReadWithMidReadInsertResponse:
+    """Read a dataset in chunks with an insert committed part-way through.
+
+    `stream_items()` pins the read to the dataset version that was latest when
+    iteration began, so items inserted while it runs must not affect it. Without
+    that pin the read is vulnerable in a specific way: pages are addressed by
+    offset and the backend sorts newest id first, so an insert shifts every page
+    not yet fetched — returning one item twice and skipping another, with no
+    error anywhere.
+
+    Making that deterministic is the whole reason it runs here rather than as
+    two racing HTTP calls. The reader consumes `pause_after_chunks` chunks, then
+    inserts and waits for the write to commit, and only then consumes the rest —
+    so every remaining page is fetched against a backend that already holds the
+    new items, rather than against whichever state the network happened to
+    order. The reader's look-ahead is bounded at `2 * num_threads` pages in
+    flight, so pages genuinely remain unfetched at the pause provided the
+    dataset is much larger than
+    `chunk_size * (pause_after_chunks + 2 * num_threads)`.
+
+    The insert goes through a client of its own: the reader is suspended
+    mid-iteration on the shared one, and the write has to reach the backend the
+    way an independent caller's would.
+    """
+    if body.pause_after_chunks < 1:
+        raise HTTPException(
+            status_code=422,
+            detail="pause_after_chunks must be >= 1 so the read is in progress",
+        )
+
+    def insert_mid_read() -> None:
+        writer = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+        try:
+            writer.get_dataset(
+                name=body.dataset_name, project_name=body.project_name
+            ).insert(body.items)
+        finally:
+            writer.end(flush=True)
+            atexit.unregister(writer.end)
+
+    client = make_opik_client(workspace=body.workspace, api_key=x_opik_api_key)
+    item_ids: list[str] = []
+    chunk_sizes: list[int] = []
+    inserted = False
+    try:
+        dataset = client.get_dataset(
+            name=body.dataset_name, project_name=body.project_name
+        )
+        for chunk in dataset.stream_items(
+            chunk_size=body.chunk_size, num_threads=body.num_threads
+        ):
+            chunk_sizes.append(len(chunk))
+            item_ids.extend(str(item["id"]) for item in chunk)
+
+            if not inserted and len(chunk_sizes) == body.pause_after_chunks:
+                insert_mid_read()
+                inserted = True
+    finally:
+        client.end(flush=False)
+        atexit.unregister(client.end)
+
+    if not inserted:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"the read produced only {len(chunk_sizes)} chunk(s), so it ended "
+                f"before chunk {body.pause_after_chunks} where the insert was due; "
+                "seed more items or lower chunk_size"
+            ),
+        )
+
+    return DatasetReadWithMidReadInsertResponse(
+        item_ids=item_ids,
+        chunk_sizes=chunk_sizes,
+        chunks_before_insert=body.pause_after_chunks,
+        inserted=len(body.items),
+    )

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -217,11 +217,25 @@ class DatasetReadWithMidReadInsertRequest(BaseModel):
 
 
 class DatasetReadWithMidReadInsertResponse(BaseModel):
+    """What the pinned read returned, and evidence the insert landed inside it.
+
+    `item_ids` is the whole read in the order it was reassembled — the pinned
+    result, which must be exactly the pre-insert dataset. The other three fields
+    exist to prove the scenario actually happened, because a read that finished
+    before the write started returns that same list and would pass on it alone.
+    """
+
     item_ids: list[str]
+    # One entry per chunk the read yielded, in order. Short chunks before the
+    # last one, or fewer chunks than the dataset needs, mean the read did not
+    # cover the dataset the way the caller sized it for.
     chunk_sizes: list[int]
-    # Chunks consumed before the insert ran, echoed back so the caller can
-    # assert the read really was mid-flight and not already finished.
+    # Chunks actually consumed at the moment the insert ran — observed by the
+    # route, not echoed from the request. Compared against the dataset's total
+    # chunk count it shows how many pages were still unfetched behind the write.
     chunks_before_insert: int
+    # Items the mid-read insert sent. Zero means nothing was written, so a
+    # "nothing changed" result proves nothing.
     inserted: int
 
 

--- a/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
+++ b/tests_end_to_end/e2e/services/opik-sdk-driver/src/opik_sdk_driver/schemas.py
@@ -153,6 +153,78 @@ class DatasetInsertItemsResponse(BaseModel):
     inserted: int
 
 
+class DatasetReadItemsRequest(BaseModel):
+    """One `Dataset.get_items(...)` call, with its read knobs exposed verbatim.
+
+    `num_threads`/`chunk_size`/`nb_samples` are plain ints rather than
+    constrained ones on purpose: the SDK's own validation of them (0, negative,
+    over the chunk cap) is part of what a caller reads this route to assert, so
+    pydantic must not reject those values before the SDK sees them.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    project_name: str
+    # Omitted keys are left to the SDK's defaults rather than restated here, so
+    # a caller asking for "the defaults" really gets them.
+    nb_samples: int | None = None
+    num_threads: int | None = None
+    chunk_size: int | None = None
+    filter_string: str | None = None
+    workspace: str | None = None
+
+
+class DatasetReadItemsResponse(BaseModel):
+    """What one read returned, or why the SDK refused to start it.
+
+    Items are reduced to their ids in dataset order: a caller comparing two
+    reads is asserting which items came back and in what order, and shipping
+    whole payloads back over the bridge for a few-thousand-item dataset is a
+    cost with no assertion behind it.
+    """
+
+    item_ids: list[str]
+    # The ValueError message when the SDK rejected the arguments, else None. The
+    # route answers 200 either way so the caller can assert on the message; a
+    # rejected read has no items, never an empty result that looks like one.
+    value_error: str | None = None
+
+
+class DatasetReadWithMidReadInsertRequest(BaseModel):
+    """A `stream_items()` read with an insert committed in the middle of it.
+
+    The interleaving is driven here rather than by racing two HTTP calls from
+    the caller: the reader consumes `pause_after_chunks` chunks, runs the insert
+    to completion, and only then consumes the rest. That makes the overlap
+    structural — every remaining page is fetched against a backend that already
+    holds the new items — where a timing race would leave the test asserting
+    whatever the network happened to order.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_name: str
+    project_name: str
+    items: list[dict[str, Any]]
+    chunk_size: int
+    num_threads: int = 1
+    # Must be >= 1 (so the read is genuinely in progress) and low enough that
+    # pages remain unfetched at the pause — see the route's docstring for the
+    # look-ahead the reader keeps in flight.
+    pause_after_chunks: int
+    workspace: str | None = None
+
+
+class DatasetReadWithMidReadInsertResponse(BaseModel):
+    item_ids: list[str]
+    chunk_sizes: list[int]
+    # Chunks consumed before the insert ran, echoed back so the caller can
+    # assert the read really was mid-flight and not already finished.
+    chunks_before_insert: int
+    inserted: int
+
+
 class ExperimentItemSeed(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/tests_end_to_end/e2e/tests/datasets/dataset-item-count.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-item-count.spec.ts
@@ -66,7 +66,7 @@ test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
       const smallName = `${testNamespace}-small`;
       const multiName = `${testNamespace}-multi`;
 
-      const datasetIds = await test.step(
+      const datasetIdsByName = await test.step(
         `Seed one dataset with no items, one with ${SMALL_SIZE} and one with ${MULTI_SIZE}`,
         async () => {
           const ids: Record<string, string> = {};
@@ -111,9 +111,21 @@ test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
         // Which branch each row took. The empty dataset was never inserted
         // into, so it has no version to read items_total from and is the only
         // row the fallback scan can answer; the other two have one.
+        //
+        // This pair of assertions is also what pins the deployment mode: with
+        // TOGGLE_DATASET_VERSIONING_ENABLED=false (it defaults to true) an
+        // insert cuts no version, every row is answered by the fallback scan,
+        // and these fail here rather than letting the branch claims below pass
+        // against a backend that never took the items_total branch at all.
         expect(byName.get(emptyName)!.latestVersionName, 'no version => fallback branch').toBeNull();
-        expect(byName.get(smallName)!.latestVersionName).toBe('v1');
-        expect(byName.get(multiName)!.latestVersionName).toBe('v1');
+        expect(
+          byName.get(smallName)!.latestVersionName,
+          'insert cut a version => items_total branch (needs dataset versioning enabled)',
+        ).toBe('v1');
+        expect(
+          byName.get(multiName)!.latestVersionName,
+          'insert cut a version => items_total branch (needs dataset versioning enabled)',
+        ).toBe('v1');
 
         expect(byName.get(emptyName)!.datasetItemsCount).toBe(EMPTY_SIZE);
         expect(byName.get(smallName)!.datasetItemsCount).toBe(SMALL_SIZE);
@@ -129,7 +141,7 @@ test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
           [smallName, SMALL_SIZE],
           [multiName, MULTI_SIZE],
         ] as const) {
-          const itemIds = await backendClient.listDatasetItemIds(datasetIds[name]);
+          const itemIds = await backendClient.listDatasetItemIds(datasetIdsByName[name]);
           expect(itemIds, `${name}: no item stored twice`).toHaveLength(
             new Set(itemIds).size,
           );
@@ -154,7 +166,7 @@ test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
       const survivingSmallIds = await test.step(
         `Delete ${DELETED_FROM_SMALL} items from the ${SMALL_SIZE}-item dataset`,
         async () => {
-          const itemIds = await backendClient.listDatasetItemIds(datasetIds[smallName]);
+          const itemIds = await backendClient.listDatasetItemIds(datasetIdsByName[smallName]);
           await backendClient.deleteDatasetItemsByIds(itemIds.slice(0, DELETED_FROM_SMALL));
           return itemIds.slice(DELETED_FROM_SMALL);
         },
@@ -163,7 +175,7 @@ test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
       await test.step('The count follows the delete on both surfaces', async () => {
         const remaining = SMALL_SIZE - DELETED_FROM_SMALL;
 
-        const itemIds = await backendClient.listDatasetItemIds(datasetIds[smallName]);
+        const itemIds = await backendClient.listDatasetItemIds(datasetIdsByName[smallName]);
         expect(new Set(itemIds), 'exactly the items that were not deleted survive').toEqual(
           new Set(survivingSmallIds),
         );

--- a/tests_end_to_end/e2e/tests/datasets/dataset-item-count.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-item-count.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect } from '@e2e/fixtures';
+import { DatasetsPage } from '@e2e/pom/datasets.page';
+
+/**
+ * The Datasets list's "Item count" column is a backend-computed number, and the
+ * backend computes it two different ways in the same response: from the latest
+ * dataset version's `items_total` where there is one, and from a
+ * `count(DISTINCT id)` scan over `dataset_items` where there is not
+ * (`DatasetService.versionItemsTotal`). OPIK-8175 narrowed that scan to only
+ * the datasets that still need it, so the interesting page is one that mixes
+ * both kinds — a row answered from the wrong branch, or dropped from the
+ * narrowed id set entirely, is a wrong number on the default landing page that
+ * nobody re-derives by hand.
+ *
+ * Nothing in the estate reads that column: `dataset-crud-smoke.spec.ts` asserts
+ * a dataset's *row* is listed, and `dataset-version-counters.spec.ts` asserts
+ * the Version history tab's own Item count (`items_total`), which is a
+ * different column on a different page fed straight from the version row.
+ *
+ * Driven on both surfaces, which is the point of the spec: the number is
+ * asserted against ground truth through the API, and then read off the rendered
+ * cell, so a backend that computes it correctly and a page that renders a stale
+ * or mis-keyed one are distinguishable failures.
+ *
+ * Shape of the seed, chosen so one list response covers both branches:
+ *  - EMPTY_SIZE is 0 and the dataset is never inserted into, so it has no
+ *    version at all and can only be answered by the legacy fallback;
+ *  - the other two are seeded through `Dataset.insert()`, which cuts a version,
+ *    so they are answered from `items_total`;
+ *  - MULTI_SIZE is above the SDK's 1000-item batch size, so its count also has
+ *    to survive an insert that reached the backend as several batches.
+ */
+const EMPTY_SIZE = 0;
+const SMALL_SIZE = 7;
+const MULTI_SIZE = 2500;
+
+/** Items removed from the small dataset once every count has been asserted. */
+const DELETED_FROM_SMALL = 3;
+
+function seedItems(count: number, label: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    input: `${label} input ${index}`,
+    expected_output: `${label} output ${index}`,
+    // Dataset.insert() drops duplicate entries by content hash, so every item
+    // has to differ in something. The index is what guarantees `count` items
+    // are actually stored rather than silently deduplicated to fewer.
+    seq: index,
+  }));
+}
+
+test.describe('Dataset item count', { tag: ['@area:datasets'] }, () => {
+  /** The Item count column is off-screen at the default 1280px viewport. */
+  test.use({ viewport: { width: 1600, height: 900 } });
+
+  /**
+   * A 2500-item insert against a cloud backend outruns the default budget.
+   * Measured at ~11s against staging, so this is headroom rather than need.
+   */
+  test.slow();
+
+  test(
+    'The list reports each dataset\'s item count from the branch that applies to it, and the page renders those numbers',
+    { tag: ['@t2-cuj', '@cap:datasets.list-datasets'] },
+    async ({ project, sdkClient, backendClient, registerDatasetCleanup, testNamespace, page }) => {
+      const emptyName = `${testNamespace}-empty`;
+      const smallName = `${testNamespace}-small`;
+      const multiName = `${testNamespace}-multi`;
+
+      const datasetIds = await test.step(
+        `Seed one dataset with no items, one with ${SMALL_SIZE} and one with ${MULTI_SIZE}`,
+        async () => {
+          const ids: Record<string, string> = {};
+          for (const [name, size] of [
+            [emptyName, EMPTY_SIZE],
+            [smallName, SMALL_SIZE],
+            [multiName, MULTI_SIZE],
+          ] as const) {
+            const created = await sdkClient.python.createDataset({
+              project_name: project.name,
+              name,
+              description: `item count, ${size} items`,
+            });
+            registerDatasetCleanup(created.id, name);
+            ids[name] = created.id;
+            if (size > 0) {
+              await sdkClient.python.insertDatasetItems({
+                project_name: project.name,
+                dataset_name: name,
+                items: seedItems(size, name),
+              });
+            }
+          }
+          return ids;
+        },
+      );
+
+      await test.step('One list response covers both count branches at once', async () => {
+        const { rows, total } = await backendClient.listDatasetSummaries({
+          projectId: project.id,
+        });
+        // The narrowing this spec is about happens per response: the fallback
+        // scan is issued for the subset of rows on the page that need it. If
+        // the three datasets came back over several requests, none of that is
+        // being exercised.
+        expect(total, 'the project holds exactly the three seeded datasets').toBe(3);
+        expect(rows.map((r) => r.name).sort()).toEqual(
+          [emptyName, smallName, multiName].sort(),
+        );
+
+        const byName = new Map(rows.map((r) => [r.name, r]));
+        // Which branch each row took. The empty dataset was never inserted
+        // into, so it has no version to read items_total from and is the only
+        // row the fallback scan can answer; the other two have one.
+        expect(byName.get(emptyName)!.latestVersionName, 'no version => fallback branch').toBeNull();
+        expect(byName.get(smallName)!.latestVersionName).toBe('v1');
+        expect(byName.get(multiName)!.latestVersionName).toBe('v1');
+
+        expect(byName.get(emptyName)!.datasetItemsCount).toBe(EMPTY_SIZE);
+        expect(byName.get(smallName)!.datasetItemsCount).toBe(SMALL_SIZE);
+        expect(byName.get(multiName)!.datasetItemsCount).toBe(MULTI_SIZE);
+      });
+
+      await test.step('Each count agrees with the items the dataset actually holds', async () => {
+        // The seed sizes above are what was asked for; this is what was stored.
+        // Asserting the column against the items endpoint is what makes the
+        // check independent of the enrichment that produced it.
+        for (const [name, expected] of [
+          [emptyName, EMPTY_SIZE],
+          [smallName, SMALL_SIZE],
+          [multiName, MULTI_SIZE],
+        ] as const) {
+          const itemIds = await backendClient.listDatasetItemIds(datasetIds[name]);
+          expect(itemIds, `${name}: no item stored twice`).toHaveLength(
+            new Set(itemIds).size,
+          );
+          expect(itemIds, `${name}: items endpoint agrees with the list count`).toHaveLength(
+            expected,
+          );
+        }
+      });
+
+      const datasets = await test.step('The Datasets page renders the same three numbers', async () => {
+        const datasetsPage = new DatasetsPage(page);
+        await datasetsPage.goto(project.id);
+        await datasetsPage.waitForReady();
+        // Rendered raw, not thousands-separated — this column has no
+        // accessorFn, unlike the Version history tab's Item count.
+        await expect(datasetsPage.datasetItemCount(emptyName)).toHaveText(String(EMPTY_SIZE));
+        await expect(datasetsPage.datasetItemCount(smallName)).toHaveText(String(SMALL_SIZE));
+        await expect(datasetsPage.datasetItemCount(multiName)).toHaveText(String(MULTI_SIZE));
+        return datasetsPage;
+      });
+
+      const survivingSmallIds = await test.step(
+        `Delete ${DELETED_FROM_SMALL} items from the ${SMALL_SIZE}-item dataset`,
+        async () => {
+          const itemIds = await backendClient.listDatasetItemIds(datasetIds[smallName]);
+          await backendClient.deleteDatasetItemsByIds(itemIds.slice(0, DELETED_FROM_SMALL));
+          return itemIds.slice(DELETED_FROM_SMALL);
+        },
+      );
+
+      await test.step('The count follows the delete on both surfaces', async () => {
+        const remaining = SMALL_SIZE - DELETED_FROM_SMALL;
+
+        const itemIds = await backendClient.listDatasetItemIds(datasetIds[smallName]);
+        expect(new Set(itemIds), 'exactly the items that were not deleted survive').toEqual(
+          new Set(survivingSmallIds),
+        );
+
+        const { rows } = await backendClient.listDatasetSummaries({ projectId: project.id });
+        const byName = new Map(rows.map((r) => [r.name, r]));
+        expect(byName.get(smallName)!.datasetItemsCount).toBe(remaining);
+        // The delete committed a new version, so this row is still answered
+        // from items_total — and the two datasets it did not touch must be
+        // unmoved, which a count computed over the wrong id set would not be.
+        expect(byName.get(smallName)!.latestVersionName).toBe('v2');
+        expect(byName.get(emptyName)!.datasetItemsCount).toBe(EMPTY_SIZE);
+        expect(byName.get(multiName)!.datasetItemsCount).toBe(MULTI_SIZE);
+
+        await page.reload();
+        await datasets.waitForReady();
+        await expect(datasets.datasetItemCount(smallName)).toHaveText(String(remaining));
+        await expect(datasets.datasetItemCount(multiName)).toHaveText(String(MULTI_SIZE));
+        await expect(datasets.datasetItemCount(emptyName)).toHaveText(String(EMPTY_SIZE));
+      });
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/datasets/dataset-parallel-item-read.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-parallel-item-read.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect } from '@e2e/fixtures';
+
+/**
+ * OPIK-8253 replaced the Python SDK's cursor-chained item stream with a
+ * parallel fan-out over the paginated items endpoint: `get_items()` fetches the
+ * first page to learn the total, then reads the rest concurrently and
+ * reassembles them (`parallel_items_reader.stream_item_chunks`). A page dropped
+ * or reassembled out of order corrupts an evaluation silently — no error is
+ * raised anywhere, the caller just gets the wrong items — so the assertion has
+ * to be on the list, not the set: the same 5000 ids in a different order is a
+ * failure, and `toEqual` on an array is what sees it.
+ *
+ * The fan-out only runs on a dataset bigger than one page. Every existing
+ * `get_items()` call in the estate is against a 2- or 3-item dataset
+ * (`dataset-crud-smoke.spec.ts`, the `dataset` fixture), which is a single page
+ * — so nothing here exercises the concurrent path at all today.
+ *
+ * API-level throughout, deliberately: the claim is about what the SDK returns,
+ * and no UI reads a dataset through `get_items()`.
+ *
+ * SEED_SIZE is three pages at the SDK's default `chunk_size` of 2000, so the
+ * default call fans out over two concurrent pages rather than degenerating to a
+ * single extra fetch.
+ */
+const SEED_SIZE = 5000;
+
+/** Two `nb_samples` values: one inside the first page, one straddling it. */
+const SAMPLE_WITHIN_FIRST_PAGE = 500;
+const SAMPLE_ACROSS_PAGES = 2200;
+
+/**
+ * Read settings that must all return the identical list. `chunk_size: 500` with
+ * 8 threads is 10 pages over 8 workers, the deepest fan-out available under the
+ * 2000-item chunk cap; `num_threads: 1000` is above the SDK's 32-thread cap and
+ * must clamp rather than raise.
+ */
+const EQUIVALENT_READS = [
+  { label: 'the defaults', args: {} },
+  { label: 'num_threads=1 (sequential)', args: { num_threads: 1 } },
+  { label: 'chunk_size=500, num_threads=8', args: { chunk_size: 500, num_threads: 8 } },
+  { label: 'num_threads=1000 (clamped)', args: { num_threads: 1000 } },
+];
+
+/**
+ * Arguments `stream_items()` documents as rejected, with the message each one
+ * raises. `nb_samples=0` is the upgrade hazard: it used to be accepted, so a
+ * caller passing it now gets a ValueError where it previously got items.
+ */
+const REJECTED_ARGS = [
+  { label: 'nb_samples=0', args: { nb_samples: 0 }, message: /nb_samples must be a positive integer/ },
+  { label: 'nb_samples=-1', args: { nb_samples: -1 }, message: /nb_samples must be a positive integer/ },
+  { label: 'num_threads=0', args: { num_threads: 0 }, message: /num_threads must be a positive integer/ },
+  { label: 'chunk_size=0', args: { chunk_size: 0 }, message: /chunk_size must be a positive integer/ },
+  { label: 'chunk_size=2001', args: { chunk_size: 2001 }, message: /chunk_size must not exceed 2000/ },
+];
+
+test.describe('Dataset items — parallel SDK read', { tag: ['@area:datasets'] }, () => {
+  test(
+    'get_items() returns every item of a multi-page dataset exactly once, in the same order, whatever the thread and chunk settings',
+    { tag: ['@t2-cuj', '@cap:datasets.sdk-round-trip'] },
+    async ({ project, sdkClient, backendClient, registerDatasetCleanup, testNamespace }) => {
+      /**
+       * Seeding 5000 items against a cloud backend outruns the default budget.
+       * Measured at ~2.2 min against staging, of which ~45s was the SDK backing
+       * off a 429 — the reads themselves are seconds. Only the first test needs
+       * this; the validation one below runs on the shared 3-item fixture.
+       */
+      test.slow();
+
+      const datasetName = `${testNamespace}-multipage`;
+
+      const datasetId = await test.step(`Seed a dataset with ${SEED_SIZE} items`, async () => {
+        const created = await sdkClient.python.createDataset({
+          project_name: project.name,
+          name: datasetName,
+          description: 'parallel item read',
+        });
+        registerDatasetCleanup(created.id, datasetName);
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          // Every item differs by index: Dataset.insert() drops duplicates by
+          // content hash, so identical items would seed fewer than SEED_SIZE
+          // and quietly shrink the read below one page.
+          items: Array.from({ length: SEED_SIZE }, (_, seq) => ({
+            input: `item ${seq}`,
+            expected_output: `output ${seq}`,
+            seq,
+          })),
+        });
+        return created.id;
+      });
+
+      const expectedIds = await test.step(
+        'Enumerate the dataset directly over REST — the ground truth',
+        async () => {
+          // Read page by page through the items endpoint without the SDK, so
+          // the comparison below is against the backend rather than against
+          // another run of the code under test.
+          const ids = await backendClient.listDatasetItemIds(datasetId);
+          expect(ids, 'the seed stored every item').toHaveLength(SEED_SIZE);
+          expect(new Set(ids).size, 'and stored none of them twice').toBe(SEED_SIZE);
+          return ids;
+        },
+      );
+
+      for (const { label, args } of EQUIVALENT_READS) {
+        await test.step(`get_items() with ${label} returns the same list`, async () => {
+          const { item_ids, value_error } = await sdkClient.python.readDatasetItems({
+            project_name: project.name,
+            dataset_name: datasetName,
+            ...args,
+          });
+          expect(value_error, `${label} must not be rejected`).toBeNull();
+          // List equality, not set equality: a fan-out that reassembles its
+          // pages in the wrong order returns the right items in the wrong
+          // sequence, and every downstream evaluation misaligns.
+          expect(item_ids, `${label}: same items, same order as REST`).toEqual(expectedIds);
+        });
+      }
+
+      for (const nbSamples of [SAMPLE_WITHIN_FIRST_PAGE, SAMPLE_ACROSS_PAGES]) {
+        await test.step(`nb_samples=${nbSamples} returns that many items, from the start`, async () => {
+          const { item_ids, value_error } = await sdkClient.python.readDatasetItems({
+            project_name: project.name,
+            dataset_name: datasetName,
+            nb_samples: nbSamples,
+          });
+          expect(value_error).toBeNull();
+          // "From the beginning of the dataset" means the endpoint's own order,
+          // which is newest id first — so the sample must be an exact prefix of
+          // the full read, not merely a subset of it.
+          expect(item_ids).toEqual(expectedIds.slice(0, nbSamples));
+        });
+      }
+    },
+  );
+
+  test(
+    'get_items() rejects the argument values it documents as invalid',
+    { tag: ['@t2-cuj', '@cap:datasets.sdk-round-trip'] },
+    async ({ dataset, project, sdkClient }) => {
+      // Validation runs before any page is fetched, so the shared 3-item
+      // dataset fixture is enough — the size of the dataset is irrelevant here.
+      for (const { label, args, message } of REJECTED_ARGS) {
+        await test.step(`${label} raises ValueError`, async () => {
+          const { item_ids, value_error } = await sdkClient.python.readDatasetItems({
+            project_name: project.name,
+            dataset_name: dataset.name,
+            ...args,
+          });
+          expect(value_error, `${label} must be rejected, not silently accepted`).not.toBeNull();
+          expect(value_error!).toMatch(message);
+          expect(item_ids, 'a rejected read returns nothing').toEqual([]);
+        });
+      }
+
+      await test.step('A read with valid arguments still returns the items', async () => {
+        // Without this the test above would pass just as well against an SDK
+        // that rejected every call.
+        const { item_ids, value_error } = await sdkClient.python.readDatasetItems({
+          project_name: project.name,
+          dataset_name: dataset.name,
+        });
+        expect(value_error).toBeNull();
+        expect(item_ids).toHaveLength(dataset.items.length);
+      });
+    },
+  );
+});

--- a/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
@@ -92,13 +92,20 @@ test.describe('Dataset item read — version pinning', { tag: ['@area:datasets']
         // Without this the assertions below would hold just as well for a read
         // that had already finished before the write started — which is the
         // scenario every implementation passes.
+        //
+        // What rules that out is the bridge rather than the echo below: it 422s
+        // if the read ran out of chunks before the pause, so a 200 carrying
+        // EXPECTED_CHUNKS chunks means the insert ran with
+        // EXPECTED_CHUNKS - PAUSE_AFTER_CHUNKS pages still unfetched.
         expect(result.inserted, 'the write was issued').toBe(INSERT_SIZE);
-        expect(result.chunks_before_insert).toBe(PAUSE_AFTER_CHUNKS);
         expect(
-          result.chunk_sizes.length,
-          `pages remained to be fetched after chunk ${PAUSE_AFTER_CHUNKS}`,
-        ).toBe(EXPECTED_CHUNKS);
-        expect(result.chunk_sizes.every((size) => size === CHUNK_SIZE)).toBe(true);
+          result.chunks_before_insert,
+          'the bridge paused where it was asked to',
+        ).toBe(PAUSE_AFTER_CHUNKS);
+        expect(
+          result.chunk_sizes,
+          `every page came back full, and pages remained to be fetched after chunk ${PAUSE_AFTER_CHUNKS}`,
+        ).toEqual(new Array(EXPECTED_CHUNKS).fill(CHUNK_SIZE));
       });
 
       await test.step('The read returned exactly the pre-insert dataset, in order', async () => {

--- a/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
@@ -93,15 +93,20 @@ test.describe('Dataset item read — version pinning', { tag: ['@area:datasets']
         // that had already finished before the write started — which is the
         // scenario every implementation passes.
         //
-        // What rules that out is the bridge rather than the echo below: it 422s
-        // if the read ran out of chunks before the pause, so a 200 carrying
-        // EXPECTED_CHUNKS chunks means the insert ran with
-        // EXPECTED_CHUNKS - PAUSE_AFTER_CHUNKS pages still unfetched.
+        // `chunks_before_insert` is what the bridge counted at the moment it
+        // ran the insert, not the number it was asked for, so this is an
+        // observation rather than an echo. Together with the full chunk list
+        // below it puts the write at chunk PAUSE_AFTER_CHUNKS of
+        // EXPECTED_CHUNKS, leaving the rest of the pages still unfetched.
         expect(result.inserted, 'the write was issued').toBe(INSERT_SIZE);
         expect(
           result.chunks_before_insert,
           'the bridge paused where it was asked to',
         ).toBe(PAUSE_AFTER_CHUNKS);
+        expect(
+          EXPECTED_CHUNKS - result.chunks_before_insert,
+          'pages remained unfetched when the insert committed',
+        ).toBeGreaterThan(0);
         expect(
           result.chunk_sizes,
           `every page came back full, and pages remained to be fetched after chunk ${PAUSE_AFTER_CHUNKS}`,

--- a/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
+++ b/tests_end_to_end/e2e/tests/datasets/dataset-read-version-pinning.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@e2e/fixtures';
+
+/**
+ * The SDK's parallel item reader (OPIK-8253) addresses pages by offset, and the
+ * items endpoint sorts newest id first. So an item inserted while a read is in
+ * progress lands at offset 0 and shifts every page not yet fetched: the read
+ * returns one item twice and skips another, with no error raised anywhere and
+ * nothing in the result to show it happened. `Dataset._resolve_read_version()`
+ * is what prevents it — the whole read is pinned to the version that was latest
+ * when iteration began, so a concurrent write cannot move it.
+ *
+ * The property is exact, not statistical: zero duplicates, zero losses, zero
+ * intruders. Nothing in the estate covers it — the reads in
+ * `dataset-parallel-item-read.spec.ts` run against a dataset nobody is writing
+ * to, which is precisely the case where an unpinned read also passes.
+ *
+ * API-level, and deterministic rather than raced. The bridge consumes
+ * PAUSE_AFTER_CHUNKS chunks, runs the insert to completion, and only then reads
+ * the remaining pages — so the write is committed before the pages that would
+ * have shifted are fetched, every run, instead of whenever the timing happens
+ * to work out. `CHUNK_SIZE * (PAUSE_AFTER_CHUNKS + 2 * num_threads)` is 700
+ * items against a SEED_SIZE of 4000, so the reader's look-ahead is nowhere near
+ * having fetched the dataset when the insert lands.
+ */
+const SEED_SIZE = 4000;
+const INSERT_SIZE = 500;
+const CHUNK_SIZE = 100;
+const PAUSE_AFTER_CHUNKS = 5;
+
+const EXPECTED_CHUNKS = SEED_SIZE / CHUNK_SIZE;
+
+function seedItems(count: number, offset: number, label: string) {
+  return Array.from({ length: count }, (_, index) => ({
+    input: `${label} input ${offset + index}`,
+    expected_output: `${label} output ${offset + index}`,
+    // Dataset.insert() drops duplicates by content hash; the offset keeps the
+    // mid-read batch distinct from the seed so all INSERT_SIZE items are stored.
+    seq: offset + index,
+  }));
+}
+
+test.describe('Dataset item read — version pinning', { tag: ['@area:datasets'] }, () => {
+  /**
+   * Seeding 4000 items and reading them back in 40 chunks outruns the default
+   * budget. Measured at ~2.0 min against staging, most of it the seed.
+   */
+  test.slow();
+
+  test(
+    'An insert committed mid-read cannot duplicate, skip or leak an item into the read that was already running',
+    { tag: ['@t2-cuj', '@cap:datasets.sdk-round-trip'] },
+    async ({ project, sdkClient, backendClient, registerDatasetCleanup, testNamespace }) => {
+      const datasetName = `${testNamespace}-pinned`;
+
+      const datasetId = await test.step(`Seed a dataset with ${SEED_SIZE} items`, async () => {
+        const created = await sdkClient.python.createDataset({
+          project_name: project.name,
+          name: datasetName,
+          description: 'read version pinning',
+        });
+        registerDatasetCleanup(created.id, datasetName);
+        await sdkClient.python.insertDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+          items: seedItems(SEED_SIZE, 0, 'seed'),
+        });
+        return created.id;
+      });
+
+      const beforeIds = await test.step('Record the ids the read is entitled to return', async () => {
+        const ids = await backendClient.listDatasetItemIds(datasetId);
+        expect(ids, 'the seed stored every item').toHaveLength(SEED_SIZE);
+        expect(new Set(ids).size, 'and stored none of them twice').toBe(SEED_SIZE);
+        return ids;
+      });
+
+      const result = await test.step(
+        `Read in ${CHUNK_SIZE}-item chunks, inserting ${INSERT_SIZE} more after chunk ${PAUSE_AFTER_CHUNKS}`,
+        async () => {
+          return sdkClient.python.readDatasetItemsWithMidReadInsert({
+            project_name: project.name,
+            dataset_name: datasetName,
+            items: seedItems(INSERT_SIZE, SEED_SIZE, 'mid-read'),
+            chunk_size: CHUNK_SIZE,
+            num_threads: 1,
+            pause_after_chunks: PAUSE_AFTER_CHUNKS,
+          });
+        },
+      );
+
+      await test.step('The insert really did land in the middle of the read', async () => {
+        // Without this the assertions below would hold just as well for a read
+        // that had already finished before the write started — which is the
+        // scenario every implementation passes.
+        expect(result.inserted, 'the write was issued').toBe(INSERT_SIZE);
+        expect(result.chunks_before_insert).toBe(PAUSE_AFTER_CHUNKS);
+        expect(
+          result.chunk_sizes.length,
+          `pages remained to be fetched after chunk ${PAUSE_AFTER_CHUNKS}`,
+        ).toBe(EXPECTED_CHUNKS);
+        expect(result.chunk_sizes.every((size) => size === CHUNK_SIZE)).toBe(true);
+      });
+
+      await test.step('The read returned exactly the pre-insert dataset, in order', async () => {
+        // Three distinct failures collapse into this one comparison: an item
+        // returned twice, an item skipped, and one of the new items appearing
+        // in a read that was pinned before they existed.
+        expect(result.item_ids, 'no item was duplicated or skipped').toHaveLength(SEED_SIZE);
+        expect(new Set(result.item_ids).size, 'every id came back once').toBe(SEED_SIZE);
+        expect(result.item_ids, 'the pinned read is unmoved by the insert').toEqual(beforeIds);
+      });
+
+      await test.step('And the insert was real — a fresh read sees all of it', async () => {
+        // The pinned read seeing 4000 items would also be satisfied by an
+        // insert that silently failed. This is what rules that out.
+        const afterIds = await backendClient.listDatasetItemIds(datasetId);
+        expect(afterIds).toHaveLength(SEED_SIZE + INSERT_SIZE);
+        expect(new Set(afterIds).size).toBe(SEED_SIZE + INSERT_SIZE);
+        const afterIdSet = new Set(afterIds);
+        expect(
+          beforeIds.filter((id) => !afterIdSet.has(id)),
+          'the insert added items rather than replacing any',
+        ).toEqual([]);
+
+        const { item_ids, value_error } = await sdkClient.python.readDatasetItems({
+          project_name: project.name,
+          dataset_name: datasetName,
+        });
+        expect(value_error).toBeNull();
+        expect(item_ids, 'a read started now is pinned to the new version').toHaveLength(
+          SEED_SIZE + INSERT_SIZE,
+        );
+      });
+    },
+  );
+});


### PR DESCRIPTION
## Where these came from

The QA exploration of the **2.2.51 → 2.2.52** release on staging
(`https://staging.dev.comet.com/opik`, backend `/is-alive/ver` reporting `2.2.52`).
A human worked each flow by hand there first; these three specs are the flows
that were both verified and worth keeping permanently.

**Written and run against the `2.2.52` tag**, which is where the exploration and
the backend/SDK changes under test live. `2.2.52` is a tag, not a branch, so this
PR is based on **`main`** — which will have moved on. Please read the specs
against the release ref if anything looks out of date.

## What's here

| Spec | Capability | Result |
|---|---|---|
| `datasets/dataset-item-count.spec.ts` | `@cap:datasets.list-datasets` | ✅ passed (11s) |
| `datasets/dataset-parallel-item-read.spec.ts` (2 tests) | `@cap:datasets.sdk-round-trip` | ✅ passed (2.2m / 1.5s) |
| `datasets/dataset-read-version-pinning.spec.ts` | `@cap:datasets.sdk-round-trip` | ✅ passed (2.0m) |

### `dataset-item-count.spec.ts` — the Datasets list "Item count" column

Covers OPIK-8175 / #8075, which narrowed the `count(DISTINCT id)` fallback scan
to only the datasets that still need it. The failure that narrowing could
introduce is a *page* where one row is answered from its version's `items_total`
and another from the fallback — so the seed is exactly that: one dataset never
inserted into (no version at all → fallback branch) alongside a 7-item and a
2500-item one (both `v1` → `items_total`), asserted in **one** list response.

Both surfaces, which is the point: each count is checked against
`GET /datasets/{id}/items` (ground truth, not the enrichment that produced it),
then read off the rendered cell. Then 3 items are deleted and both surfaces are
asserted to follow, with the two untouched datasets asserted unmoved.

Nothing in the estate read this column before — `dataset-crud-smoke` asserts the
*row* is listed, and `dataset-version-counters` asserts the Version history tab's
own Item count, which is a different column fed straight from the version row.

**Not covered, deliberately:** the `ITEMS_TOTAL_NOT_MIGRATED` (`-1`) sentinel
branch. It needs versions predating the `000046` backfill and is not reachable on
any current deployment — the exploration scanned every version in the workspace
and found none. `latest_version == null` is therefore used as the signal for
"took the fallback branch", which is exact everywhere except that unreachable
case; the spec says so in a comment.

### `dataset-parallel-item-read.spec.ts` — `get_items()` over multiple pages

Covers OPIK-8253 / #8156, which replaced the cursor-chained stream with a
parallel fan-out over the paginated endpoint. A 5000-item dataset is three pages
at the SDK's default `chunk_size` of 2000, so the fan-out actually runs — every
existing `get_items()` call in the estate is against a 2- or 3-item dataset,
i.e. one page, so the concurrent path is untested today.

Asserts the four read settings (defaults, `num_threads=1`,
`chunk_size=500`/`num_threads=8`, `num_threads=1000` clamped) return
**list-equal** results — to each other and to a direct REST enumeration. Set
equality would miss the reassembly bug this exists to catch. `nb_samples` is
asserted to be an exact *prefix*, and a second (cheap, 3-item) test asserts the
five documented `ValueError` arguments are rejected, plus a valid read that still
returns items so the negative cases can't pass vacuously.

`nb_samples=0` now raising where it previously did not is a real upgrade hazard
and is pinned here.

### `dataset-read-version-pinning.spec.ts` — a read is a snapshot

Pages are addressed by offset and the endpoint sorts newest-first, so an insert
landing mid-read shifts every unfetched page: one item returned twice, another
skipped, no error anywhere. `Dataset._resolve_read_version()` is what prevents
it.

**Deterministic, not raced.** The bridge consumes 5 chunks of 100, runs the
insert to completion, then reads the remaining 35 chunks — so the write is
committed before the pages that would have shifted are fetched, on every run,
rather than whenever the timing works out. The read must return exactly the
pre-insert 4000 ids in order; a fresh read afterwards must see 4500, which is
what rules out an insert that silently did nothing.

## Verification

Run against `$OPIK_BASE_URL` (staging, `2.2.52`) with the job's credentials:

```
npx playwright test tests/datasets/dataset-item-count.spec.ts \
  tests/datasets/dataset-parallel-item-read.spec.ts \
  tests/datasets/dataset-read-version-pinning.spec.ts --reporter=list --retries=0
→ 4 passed (2.4m)
```

Run twice, green both times. Only the specs added here were run.

```
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
→ 62 specs checked, 1 exempt, 0 problem(s)
```

**`npx tsc --noEmit` does not currently run on this checkout** — `package.json`
pins `typescript@^7.0.2`, which removed `compilerOptions.baseUrl`, and
`e2e/tsconfig.json` still sets it (`error TS5102`). Pre-existing on the release
ref and untouched by this PR. Typechecking with `baseUrl` dropped and
`types: ["node"]` added reports nothing in any file this PR touches (the only
remaining error is a pre-existing duplicate `deleteDashboard` in
`core/backend/client.ts`). Worth a separate fix.

One thing a reviewer should know: staging returned **HTTP 429** during the 5000-
item seed and the SDK backed off ~45s. The test still finished well inside its
`test.slow()` budget, and the measured wall-clock is recorded in a comment on
each slow test so the budget is auditable.

## What this PR does not propose

A fourth candidate — *"a trace created and ended in the same flush keeps its
name, input and output"* — was **dropped**. It is outside this release's diff
(nothing in 2.2.51 → 2.2.52 touches trace ingestion), the exploration marked it
`weak`, and the exploration's own note says to drop it rather than encode the
current behaviour unless someone who knows the ingestion/merge path confirms it
is a defect rather than accepted batching semantics. Writing a spec would pin
whichever answer happens to be true today. It is still worth ten minutes of a
backend engineer's time — see the "Incidental" section of the exploration report.

## Supporting changes

Additive only; no existing spec or POM behaviour changes.

- `pom/datasets.page.ts` — `datasetItemCount(name)`, addressed by the table's own
  `data-cell-id` (`<rowId>_dataset_items_count`) rather than a positional
  `nth()`, since the column is user-configurable in order and visibility. No new
  FE `data-testid` was needed; this reuses the pattern
  `DatasetItemsPage.versionItemCount()` already uses. Worth knowing how it was
  derived: this job has no Playwright MCP, so the column id came from
  `DatasetListPage.tsx` rather than from a `browser_snapshot`, and the locator
  was validated by running — the rendered cell was asserted for three different
  values and again after a delete, green on both runs. If you have the MCP to
  hand, a confirming snapshot would close that gap.
- `core/backend/client.ts` — `listDatasetSummaries()` (one `GET /datasets` page
  with `dataset_items_count` + `latest_version`; through `rawFetch` because the
  generated client drops `latest_version`, and throwing rather than defaulting a
  missing count, so a null can't read as an empty dataset) and
  `deleteDatasetItemsByIds()`.
- `services/opik-sdk-driver` — two routes, `POST /datasets/read-items` and
  `POST /datasets/read-with-mid-read-insert`. The Python SDK's `get_items()` /
  `stream_items()` were not reachable through the bridge at all, and the
  mid-read insert is driven server-side precisely so the interleaving is
  structural rather than a timing race.
- `coverage/taxonomy.yaml` — the three specs added to `datasets.specs`, and the
  `list-datasets` / `sdk-round-trip` notes extended to record what is now
  asserted. **No new capability key was invented, and no capability was flipped
  from `covered: false`** — both were already `covered: true` at `t1-smoke`, and
  the tier is left there since the t1 specs still cover them; these are t2 depth
  on top.

Teardown goes through the existing `registerDatasetCleanup` fixture (following
`dataset-version-concurrent-writes.spec.ts`), not a `try`/`finally` in the test
body, so it runs on failure and timeout too.

---

🤖 Generated by the **release QA side flow** (`release-test-proposal`) from the
2.2.51 → 2.2.52 exploration. It is a **draft on purpose** — a generated spec that
asserts the wrong thing is worse than no spec, so please review the assertions
before promoting it. Nothing here has been merged, marked ready, or had reviewers
requested.
