### PR TITLE
[OPIK-8274] [BE] perf: stream bulk writes via the ClickHouse v2 client

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -166,8 +166,6 @@ databaseAnalyticsDataModel:
   #   observed engine, rather than serving traffic whose trace deletes are guaranteed to fail.
   tracesDistributedWrapEnabled: ${ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED:-false}
 
-# Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
-#   window, protecting data quality.
 bulkInsert:
   # false: the R2DBC bulk path (one named parameter per column per row). true: rows streamed as
   # JSONEachRow through the ClickHouse Java client v2, with no parameter binding. Both write identical
@@ -175,6 +173,8 @@ bulkInsert:
   # silently change the write path.
   v2ClientEnabled: ${ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED:-false}
 
+# Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
+#   window, protecting data quality.
 uuidValidation:
   #  Default: false
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -168,6 +168,13 @@ databaseAnalyticsDataModel:
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
+bulkInsert:
+  # false: the R2DBC bulk path (one named parameter per column per row). true: rows streamed as
+  # JSONEachRow through the ClickHouse Java client v2, with no parameter binding. Both write identical
+  # cells, so this is safe to flip either way on a running install. Default false so an upgrade does not
+  # silently change the write path.
+  v2ClientEnabled: ${ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED:-false}
+
 uuidValidation:
   #  Default: false
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -1078,11 +1078,16 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
      * client-supplied one would change which duplicate wins.
      */
     private Mono<Long> insertJsonEachRow(UUID datasetId, List<DatasetItem> items) {
+        // mapAndInsert opens and closes this segment, so without it a v2 save disappears from the
+        // dataset-item instrumentation stream instead of showing up as a fast insert.
+        Segment segment = startSegment(DATASET_ITEMS, CLICKHOUSE, "insert_dataset_items");
+
         return makeMonoContextAware((userName, workspaceId) -> jsonBulkInsert.insert(
                 "dataset_items",
                 getLogComment("save_dataset_items", workspaceId, userName, items.size()),
                 items,
-                item -> toJsonRow(item, datasetId, userName, workspaceId)));
+                item -> toJsonRow(item, datasetId, userName, workspaceId)))
+                .doFinally(signalType -> endSegment(segment));
     }
 
     private ObjectNode toJsonRow(DatasetItem item, UUID datasetId, String userName, String workspaceId) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemDAO.java
@@ -10,9 +10,12 @@ import com.comet.opik.domain.filter.FilterQueryBuilder;
 import com.comet.opik.domain.filter.FilterStrategy;
 import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.ErrorUtils;
+import com.comet.opik.utils.JsonUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -39,6 +42,7 @@ import java.util.UUID;
 
 import static com.comet.opik.api.DatasetItem.DatasetItemPage;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
+import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.Segment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
@@ -1039,6 +1043,7 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
     private final @NonNull TransactionTemplateAsync asyncTemplate;
     private final @NonNull FilterQueryBuilder filterQueryBuilder;
     private final @NonNull OpikConfiguration configuration;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull SortingFactoryDatasets sortingFactory;
 
@@ -1050,8 +1055,64 @@ class DatasetItemDAOImpl implements DatasetItemDAO {
             return Mono.empty();
         }
 
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
+            return insertJsonEachRow(datasetId, items);
+        }
+
         return asyncTemplate.nonTransaction(connection -> mapAndInsert(
                 datasetId, items, connection, INSERT_DATASET_ITEM));
+    }
+
+    /**
+     * Same rows as {@link #INSERT_DATASET_ITEM}, streamed as JSONEachRow instead of bound as 9 named
+     * parameters per row plus a shared workspace id.
+     *
+     * <p>Only {@code save} moves onto this path. {@code mapAndInsert} is also rendered with
+     * {@code BULK_UPDATE} by the bulk-update flow, which reads the pre-existing row to merge tags and
+     * so is not a plain row append.
+     *
+     * <p>{@code created_at} and {@code last_updated_at} stay absent from the row. The R2DBC template
+     * writes {@code now64(9)} for {@code created_at} and omits {@code last_updated_at} entirely; both
+     * columns are declared {@code DEFAULT now64(9)}, so omitting them here produces the same
+     * server-stamped value — and {@code last_updated_at} is the ReplacingMergeTree version, so a
+     * client-supplied one would change which duplicate wins.
+     */
+    private Mono<Long> insertJsonEachRow(UUID datasetId, List<DatasetItem> items) {
+        return makeMonoContextAware((userName, workspaceId) -> jsonBulkInsert.insert(
+                "dataset_items",
+                getLogComment("save_dataset_items", workspaceId, userName, items.size()),
+                items,
+                item -> toJsonRow(item, datasetId, userName, workspaceId)));
+    }
+
+    private ObjectNode toJsonRow(DatasetItem item, UUID datasetId, String userName, String workspaceId) {
+        var node = JsonUtils.createObjectNode();
+
+        node.put("id", item.id().toString());
+        node.put("dataset_id", datasetId.toString());
+        // Enum8 column: ClickHouse accepts the enum's name, which is what getValue() returns and what
+        // the R2DBC bind sends.
+        node.put("source", item.source().getValue());
+        // String DEFAULT '' columns, not Nullable: an absent trace/span is "" on both paths, so the
+        // same mapper the binder uses is reused rather than omitting the field.
+        node.put("trace_id", DatasetItemResultMapper.getOrDefault(item.traceId()));
+        node.put("span_id", DatasetItemResultMapper.getOrDefault(item.spanId()));
+
+        // Map(String, String): each value is the JsonNode's serialized form, exactly as
+        // DatasetItemResultMapper.getOrDefault produces for the binder.
+        var data = node.putObject("data");
+        DatasetItemResultMapper.getOrDefault(item.data()).forEach(data::put);
+
+        var tags = node.putArray("tags");
+        if (item.tags() != null) {
+            item.tags().forEach(tags::add);
+        }
+
+        node.put("workspace_id", workspaceId);
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+
+        return node;
     }
 
     private Mono<Long> mapAndInsert(

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -3974,6 +3974,13 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * Formats an Instant for ClickHouse DateTime64(9, 'UTC').
      * ClickHouse doesn't accept the 'Z' suffix from ISO-8601 format.
      */
+    private static String formatTimestamp(Instant timestamp) {
+        if (timestamp == null) {
+            return Instant.now().toString().replace("Z", "");
+        }
+        return timestamp.toString().replace("Z", "");
+    }
+
     /**
      * Same rows as {@link #BATCH_INSERT_ITEMS}, streamed as JSONEachRow instead of bound as 15 named
      * parameters per row plus 5 shared ones. This is the widest bulk write in the codebase — 23
@@ -4000,15 +4007,26 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      */
     private Mono<Long> insertItemsJsonEachRow(UUID datasetId, UUID newVersionId, List<DatasetItem> items,
             String workspaceId, String userName) {
+        // One fallback instant for the whole batch, resolved BEFORE serialization. The helper
+        // re-serializes from `items` on every invocation so the client's onRetry replays an identical
+        // body; calling formatTimestamp(null) inside the mapper would instead mint a fresh
+        // Instant.now() per attempt, so a retried row would carry different timestamp bytes under the
+        // same id. TraceDAO's v2 path takes a nowForBatch for the same reason.
+        Instant nowForBatch = Instant.now();
+        Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "insert_delta_items");
+
         return jsonBulkInsert.insert(
                 DATASET_ITEM_VERSIONS,
                 getLogComment("insert_delta_items", workspaceId, userName, items.size()),
                 items,
-                item -> toJsonRow(item, datasetId, newVersionId, workspaceId, userName));
+                item -> toJsonRow(item, datasetId, newVersionId, workspaceId, userName, nowForBatch))
+                // The R2DBC path opens and closes this segment, so without it a v2 insert vanishes
+                // from the dataset-item instrumentation stream rather than showing as fast.
+                .doFinally(signalType -> endSegment(segment));
     }
 
     private ObjectNode toJsonRow(DatasetItem item, UUID datasetId, UUID newVersionId, String workspaceId,
-            String userName) {
+            String userName, Instant nowForBatch) {
         var node = JsonUtils.createObjectNode();
 
         node.put("id", item.id().toString());
@@ -4032,8 +4050,10 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
 
         node.put("evaluators", serializeEvaluators(item.evaluators()));
         node.put("execution_policy", serializeExecutionPolicy(item.executionPolicy()));
-        node.put("item_created_at", formatTimestamp(item.createdAt()));
-        node.put("item_last_updated_at", formatTimestamp(item.lastUpdatedAt()));
+        node.put("item_created_at", formatTimestamp(
+                item.createdAt() != null ? item.createdAt() : nowForBatch));
+        node.put("item_last_updated_at", formatTimestamp(
+                item.lastUpdatedAt() != null ? item.lastUpdatedAt() : nowForBatch));
         node.put("item_created_by", item.createdBy() != null ? item.createdBy() : userName);
         node.put("item_last_updated_by", item.lastUpdatedBy() != null ? item.lastUpdatedBy() : userName);
 
@@ -4042,13 +4062,6 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
         node.put("workspace_id", workspaceId);
 
         return node;
-    }
-
-    private static String formatTimestamp(Instant timestamp) {
-        if (timestamp == null) {
-            return Instant.now().toString().replace("Z", "");
-        }
-        return timestamp.toString().replace("Z", "");
     }
 
     private static String base64Encode(String value) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DatasetItemVersionDAO.java
@@ -23,12 +23,14 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.FilterUtils;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.infrastructure.db.ZeroRowsRetryPolicy;
 import com.comet.opik.utils.ErrorUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Result;
@@ -61,6 +63,7 @@ import java.util.stream.Collectors;
 
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
+import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.Segment;
 import static com.comet.opik.infrastructure.instrumentation.InstrumentAsyncUtils.endSegment;
@@ -2736,6 +2739,7 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull SortingFactoryDatasets sortingFactory;
     private final @NonNull OpikConfiguration config;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
     private final @NonNull ExperimentAggregatesDAO experimentAggregatesDAO;
     /**
      * v2 ClickHouse client used for {@code INSERT ... SELECT} on {@code dataset_item_versions},
@@ -3694,6 +3698,15 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
                 .distinct()
                 .count();
 
+        if (config.getBulkInsert().v2ClientEnabled()) {
+            return insertItemsJsonEachRow(datasetId, newVersionId, items, workspaceId, userName)
+                    // itemCount, not the server's row count: the R2DBC path deliberately returns the
+                    // DISTINCT dataset_item_id count (OPIK-7891) because reads collapse a repeated
+                    // stable id via LIMIT 1 BY, so every version total derived from this value would
+                    // be inflated by the raw row count. Both paths must answer the same number.
+                    .thenReturn(itemCount);
+        }
+
         return asyncTemplate.nonTransaction(connection -> {
             Segment segment = startSegment(DATASET_ITEM_VERSIONS, CLICKHOUSE, "insert_delta_items");
 
@@ -3961,6 +3974,76 @@ class DatasetItemVersionDAOImpl implements DatasetItemVersionDAO {
      * Formats an Instant for ClickHouse DateTime64(9, 'UTC').
      * ClickHouse doesn't accept the 'Z' suffix from ISO-8601 format.
      */
+    /**
+     * Same rows as {@link #BATCH_INSERT_ITEMS}, streamed as JSONEachRow instead of bound as 15 named
+     * parameters per row plus 5 shared ones. This is the widest bulk write in the codebase — 23
+     * columns — so it is where the driver's per-name linear scan costs the most.
+     *
+     * <p>Column handling that has to match the binder rather than look reasonable:
+     * <ul>
+     * <li>{@code created_at} / {@code last_updated_at} are omitted so their {@code DEFAULT now64(9)}
+     * stamps them server-side, as the template's inline {@code now64(9)} does. {@code last_updated_at}
+     * is the ReplacingMergeTree version column, so supplying a client clock here would decide which
+     * duplicate wins.</li>
+     * <li>{@code item_created_at} / {@code item_last_updated_at} have NO default and are required, so
+     * they are always written, through the same {@code formatTimestamp} the binder uses (which strips
+     * the trailing {@code Z} — hence the insert's {@code date_time_input_format=best_effort}).</li>
+     * <li>{@code data_hash}, {@code description_hash}, {@code evaluators_hash},
+     * {@code execution_policy_hash} and {@code column_types} are MATERIALIZED and must stay absent;
+     * that is what {@code input_format_defaults_for_omitted_fields} is for.</li>
+     * <li>{@code metadata} is written as {@code ""} unconditionally, matching the binder — not carried
+     * from the item.</li>
+     * </ul>
+     *
+     * <p>The R2DBC template carries no {@code log_comment}; one is supplied here because the helper
+     * requires it, which also makes the two paths comparable in {@code system.query_log}.
+     */
+    private Mono<Long> insertItemsJsonEachRow(UUID datasetId, UUID newVersionId, List<DatasetItem> items,
+            String workspaceId, String userName) {
+        return jsonBulkInsert.insert(
+                DATASET_ITEM_VERSIONS,
+                getLogComment("insert_delta_items", workspaceId, userName, items.size()),
+                items,
+                item -> toJsonRow(item, datasetId, newVersionId, workspaceId, userName));
+    }
+
+    private ObjectNode toJsonRow(DatasetItem item, UUID datasetId, UUID newVersionId, String workspaceId,
+            String userName) {
+        var node = JsonUtils.createObjectNode();
+
+        node.put("id", item.id().toString());
+        node.put("dataset_item_id", item.datasetItemId().toString());
+        node.put("dataset_id", datasetId.toString());
+        node.put("dataset_version_id", newVersionId.toString());
+
+        var data = node.putObject("data");
+        DatasetItemResultMapper.getOrDefault(item.data()).forEach(data::put);
+
+        node.put("description", item.description() != null ? item.description() : "");
+        node.put("metadata", "");
+        node.put("source", item.source() != null ? item.source().getValue() : "sdk");
+        node.put("trace_id", DatasetItemResultMapper.getOrDefault(item.traceId()));
+        node.put("span_id", DatasetItemResultMapper.getOrDefault(item.spanId()));
+
+        var tags = node.putArray("tags");
+        if (item.tags() != null) {
+            item.tags().forEach(tags::add);
+        }
+
+        node.put("evaluators", serializeEvaluators(item.evaluators()));
+        node.put("execution_policy", serializeExecutionPolicy(item.executionPolicy()));
+        node.put("item_created_at", formatTimestamp(item.createdAt()));
+        node.put("item_last_updated_at", formatTimestamp(item.lastUpdatedAt()));
+        node.put("item_created_by", item.createdBy() != null ? item.createdBy() : userName);
+        node.put("item_last_updated_by", item.lastUpdatedBy() != null ? item.lastUpdatedBy() : userName);
+
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+        node.put("workspace_id", workspaceId);
+
+        return node;
+    }
+
     private static String formatTimestamp(Instant timestamp) {
         if (timestamp == null) {
             return Instant.now().toString().replace("Z", "");

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -6,6 +6,8 @@ import com.comet.opik.domain.experiments.aggregations.AggregatedExperimentCounts
 import com.comet.opik.domain.experiments.aggregations.AggregationBranchCountsCriteria;
 import com.comet.opik.domain.experiments.aggregations.ExperimentAggregatesDAO;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
+import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.google.common.base.Preconditions;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -31,6 +33,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToFlux;
+import static com.comet.opik.infrastructure.FilterUtils.getLogComment;
 import static com.comet.opik.infrastructure.FilterUtils.getSTWithLogComment;
 import static com.comet.opik.utils.AsyncUtils.makeFluxContextAware;
 import static com.comet.opik.utils.AsyncUtils.makeMonoContextAware;
@@ -600,6 +603,7 @@ class ExperimentItemDAO {
     private final @NonNull ConnectionFactory connectionFactory;
     private final @NonNull OpikConfiguration configuration;
     private final @NonNull ExperimentAggregatesDAO experimentAggregatesDAO;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
 
     @WithSpan
     public Flux<ExperimentSummary> findExperimentSummaryByDatasetIds(Set<UUID> datasetIds) {
@@ -633,8 +637,55 @@ class ExperimentItemDAO {
             return Mono.just(0L);
         }
 
+        if (JsonEachRowBulkInsert.isEnabled()) {
+            return insertJsonEachRow(experimentItems);
+        }
+
         return Mono.from(connectionFactory.create())
                 .flatMap(connection -> insert(experimentItems, connection));
+    }
+
+    /**
+     * Same rows as {@link #INSERT}, streamed as JSONEachRow through the v2 client instead of bound as
+     * ~9 named parameters per row. Behaviour the R2DBC path relies on is preserved deliberately:
+     * duplicate ids still append a new version for the ReplacingMergeTree to collapse, and the
+     * {@code log_comment} is rendered by the same {@code FilterUtils#getLogComment} so a benchmark can
+     * compare the two paths in {@code system.query_log} on equal terms.
+     */
+    private Mono<Long> insertJsonEachRow(Collection<ExperimentItem> experimentItems) {
+        return makeMonoContextAware((userName, workspaceId) -> jsonBulkInsert.insert(
+                "experiment_items",
+                getLogComment("insert_experiment_items", workspaceId, userName, experimentItems.size()),
+                experimentItems,
+                (body, item) -> appendJsonRow(body, item, userName, workspaceId)));
+    }
+
+    private void appendJsonRow(StringBuilder out, ExperimentItem item, String userName, String workspaceId) {
+        var node = JsonUtils.createObjectNode();
+
+        node.put("id", item.id().toString());
+        node.put("experiment_id", item.experimentId().toString());
+        node.put("dataset_item_id", item.datasetItemId().toString());
+        node.put("trace_id", item.traceId().toString());
+        node.put("workspace_id", workspaceId);
+
+        // Nullable(FixedString(36)): an absent project id stays NULL. Writing "" instead would be a
+        // 36-byte FixedString mismatch, and would also read back as a project rather than as absent.
+        if (item.projectId() != null) {
+            node.put("project_id", item.projectId().toString());
+        } else {
+            node.putNull("project_id");
+        }
+
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+        node.put("execution_policy", ExecutionPolicyMapper.serialize(item.executionPolicy()));
+
+        // created_at and last_updated_at stay absent from the row so their column DEFAULTs stamp them
+        // server-side, exactly as the R2DBC column list does — see the INSERT javadoc: created_at is the
+        // stalled-run reaper's liveness signal (OPIK-7459) and last_updated_at is the dedup version.
+        // This is why the insert sets input_format_defaults_for_omitted_fields.
+        out.append(node).append('\n');
     }
 
     private Mono<Long> insert(Collection<ExperimentItem> experimentItems, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ExperimentItemDAO.java
@@ -9,6 +9,7 @@ import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.template.TemplateUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
@@ -637,7 +638,7 @@ class ExperimentItemDAO {
             return Mono.just(0L);
         }
 
-        if (JsonEachRowBulkInsert.isEnabled()) {
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
             return insertJsonEachRow(experimentItems);
         }
 
@@ -657,10 +658,10 @@ class ExperimentItemDAO {
                 "experiment_items",
                 getLogComment("insert_experiment_items", workspaceId, userName, experimentItems.size()),
                 experimentItems,
-                (body, item) -> appendJsonRow(body, item, userName, workspaceId)));
+                item -> toJsonRow(item, userName, workspaceId)));
     }
 
-    private void appendJsonRow(StringBuilder out, ExperimentItem item, String userName, String workspaceId) {
+    private ObjectNode toJsonRow(ExperimentItem item, String userName, String workspaceId) {
         var node = JsonUtils.createObjectNode();
 
         node.put("id", item.id().toString());
@@ -685,7 +686,7 @@ class ExperimentItemDAO {
         // server-side, exactly as the R2DBC column list does — see the INSERT javadoc: created_at is the
         // stalled-run reaper's liveness signal (OPIK-7459) and last_updated_at is the dedup version.
         // This is why the insert sets input_format_defaults_for_omitted_fields.
-        out.append(node).append('\n');
+        return node;
     }
 
     private Mono<Long> insert(Collection<ExperimentItem> experimentItems, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/FeedbackScoreDAO.java
@@ -5,8 +5,12 @@ import com.comet.opik.api.FeedbackScore;
 import com.comet.opik.api.FeedbackScoreItem;
 import com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItemThread;
 import com.comet.opik.api.FeedbackScoreNames;
+import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.template.TemplateUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.inject.ImplementedBy;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -280,6 +284,8 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
             """;
 
     private final @NonNull TransactionTemplateAsync asyncTemplate;
+    private final @NonNull OpikConfiguration configuration;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
 
     @Override
     @WithSpan
@@ -313,6 +319,11 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
 
     private Mono<Long> insertFeedbackScores(@NonNull EntityType entityType,
             @NonNull List<? extends FeedbackScoreItem> scores, @Nullable String author) {
+
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
+            return insertJsonEachRow(entityType, scores, author);
+        }
+
         return asyncTemplate.nonTransaction(connection -> makeMonoContextAware((userName, workspaceId) -> {
 
             var logComment = getLogComment("bulk_insert_feedback_score", workspaceId, userName, scores.size());
@@ -329,6 +340,62 @@ class FeedbackScoreDAOImpl implements FeedbackScoreDAO {
                     .flatMap(Result::getRowsUpdated)
                     .reduce(Long::sum);
         }));
+    }
+
+    /**
+     * The {@link #BULK_INSERT_FEEDBACK_SCORE} rows streamed as JSONEachRow through the v2 client rather
+     * than bound as 8 named parameters per row — 10 for the authored table.
+     *
+     * <p>Batch size here is not capped the way the other bulk paths are: a feedback score batch is 1000
+     * items at most on its own endpoints, but {@code ExperimentItemBulkIngestionService} accumulates up
+     * to 100 scores per record over up to 1000 records into a single call, so this insert can be an
+     * order of magnitude wider than the {@code experiment_items} one it runs beside.
+     *
+     * <p>The table is chosen by {@code author != null}, exactly as {@code <if(author)>} does on the R2DBC
+     * template — {@code feedback_scores} has no {@code author}/{@code source_queue_id} columns, so those
+     * two fields are emitted only for the authored table.
+     */
+    private Mono<Long> insertJsonEachRow(EntityType entityType, List<? extends FeedbackScoreItem> scores,
+            @Nullable String author) {
+        return makeMonoContextAware((userName, workspaceId) -> jsonBulkInsert.insert(
+                author != null ? "authored_feedback_scores" : "feedback_scores",
+                getLogComment("bulk_insert_feedback_score", workspaceId, userName, scores.size()),
+                scores,
+                score -> toJsonRow(score, entityType, author, userName, workspaceId)));
+    }
+
+    private ObjectNode toJsonRow(FeedbackScoreItem score, EntityType entityType, @Nullable String author,
+            String userName, String workspaceId) {
+        var node = JsonUtils.createObjectNode();
+
+        node.put("entity_type", entityType.getType());
+        node.put("entity_id", score.id().toString());
+        node.put("project_id", score.projectId().toString());
+        node.put("workspace_id", workspaceId);
+        node.put("name", score.name());
+        node.put("category_name", getValueOrDefault(score.categoryName()));
+        // Decimal(18, 9) written as a quoted plain string, as SpanDAO#toJsonRow does for
+        // total_estimated_cost — no exponent notation, and no float round-tripping.
+        node.put("value", score.value().toPlainString());
+        node.put("reason", getValueOrDefault(score.reason()));
+        node.put("source", score.source().getValue());
+
+        if (author != null) {
+            node.put("author", getValueOrDefault(author));
+            // FixedString(36) with no DEFAULT: "" for an absent queue id, which the column zero-pads —
+            // the same cell the R2DBC bind writes.
+            node.put("source_queue_id",
+                    Optional.ofNullable(score.sourceQueueId()).map(UUID::toString).orElse(""));
+        }
+
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+
+        // created_at and last_updated_at stay absent so their column DEFAULTs stamp them server-side,
+        // exactly as the R2DBC column list does — last_updated_at is the ReplacingMergeTree version, so
+        // a zero there would make every later score for the same key lose to the original row. This is
+        // why the insert sets input_format_defaults_for_omitted_fields.
+        return node;
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -28,6 +28,7 @@ import com.comet.opik.utils.TruncationUtils;
 import com.comet.opik.utils.UsageUtils;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.r2dbc.spi.Connection;
@@ -1826,7 +1827,7 @@ public class SpanDAO {
 
         Preconditions.checkArgument(!spans.isEmpty(), "Spans list must not be empty");
 
-        if (JsonEachRowBulkInsert.isEnabled()) {
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
             return insertJsonEachRow(spans);
         }
 
@@ -1852,12 +1853,11 @@ public class SpanDAO {
                     "spans",
                     getLogComment("batch_insert_spans", workspaceId, userName, spans.size()),
                     spans,
-                    (body, span) -> appendJsonRow(body, span, userName, workspaceId, nowForBatch));
+                    span -> toJsonRow(span, userName, workspaceId, nowForBatch));
         });
     }
 
-    private void appendJsonRow(StringBuilder out, Span span, String userName, String workspaceId,
-            Instant nowForBatch) {
+    private ObjectNode toJsonRow(Span span, String userName, String workspaceId, Instant nowForBatch) {
 
         String inputValue = TruncationUtils.toJsonString(span.input());
         String outputValue = TruncationUtils.toJsonString(span.output());
@@ -1926,7 +1926,7 @@ public class SpanDAO {
         node.put("environment", StringUtils.defaultString(span.environment()));
 
         // Omitted rather than null when absent, so the column DEFAULT applies directly — see the same
-        // note in TraceDAO#appendJsonRow.
+        // note in TraceDAO#toJsonRow.
         if (configuration.getResponseFormatting().getTruncationSize() > 0) {
             node.put("truncation_threshold", configuration.getResponseFormatting().getTruncationSize());
         }
@@ -1935,7 +1935,7 @@ public class SpanDAO {
             node.put("source", span.source().getValue());
         }
 
-        out.append(node).append('\n');
+        return node;
     }
 
     private Publisher<? extends Result> insert(List<Span> spans, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -20,6 +20,7 @@ import com.comet.opik.domain.utils.DemoDataExclusionUtils;
 import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.ErrorUtils;
 import com.comet.opik.utils.JsonUtils;
@@ -1811,6 +1812,7 @@ public class SpanDAO {
     private final @NonNull SortingQueryBuilder sortingQueryBuilder;
     private final @NonNull OpikConfiguration configuration;
     private final @NonNull WorkspacesService workspacesService;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
 
     @WithSpan
     public Mono<Void> insert(@NonNull Span span) {
@@ -1824,10 +1826,116 @@ public class SpanDAO {
 
         Preconditions.checkArgument(!spans.isEmpty(), "Spans list must not be empty");
 
+        if (JsonEachRowBulkInsert.isEnabled()) {
+            return insertJsonEachRow(spans);
+        }
+
         return Mono.from(connectionFactory.create())
                 .flatMapMany(connection -> insert(spans, connection))
                 .flatMap(Result::getRowsUpdated)
                 .reduce(0L, Long::sum);
+    }
+
+    /**
+     * The {@link #BULK_INSERT} rows streamed as JSONEachRow through the v2 client rather than bound as
+     * 26 named parameters per row — the widest of the three bulk write paths, and so the one where the
+     * driver's per-name linear scan costs most.
+     *
+     * <p>Values come from the same helpers the R2DBC binder uses, including the batch-wide
+     * {@code nowForBatch} fallback and the cost-version rule, so both paths write identical cells.
+     */
+    private Mono<Long> insertJsonEachRow(List<Span> spans) {
+        return makeMonoContextAware((userName, workspaceId) -> {
+            Instant nowForBatch = Instant.now();
+
+            return jsonBulkInsert.insert(
+                    "spans",
+                    getLogComment("batch_insert_spans", workspaceId, userName, spans.size()),
+                    spans,
+                    (body, span) -> appendJsonRow(body, span, userName, workspaceId, nowForBatch));
+        });
+    }
+
+    private void appendJsonRow(StringBuilder out, Span span, String userName, String workspaceId,
+            Instant nowForBatch) {
+
+        String inputValue = TruncationUtils.toJsonString(span.input());
+        String outputValue = TruncationUtils.toJsonString(span.output());
+
+        var node = JsonUtils.createObjectNode();
+
+        node.put("id", span.id().toString());
+        node.put("project_id", span.projectId().toString());
+        node.put("workspace_id", workspaceId);
+        node.put("trace_id", span.traceId().toString());
+        node.put("parent_span_id", span.parentSpanId() != null ? span.parentSpanId().toString() : "");
+        node.put("name", StringUtils.defaultIfBlank(span.name(), ""));
+        node.put("type", Objects.toString(span.type(), SpanType.UNKNOWN_VALUE));
+        node.put("start_time", ClickHouseDateTimeFormat.formatNanos(span.startTime()));
+
+        // Mirrors bindEpochSentinel: epoch sentinel once the column is non-nullable, NULL while still
+        // Nullable.
+        if (spanColumnsNonNullable()) {
+            node.put("end_time", ClickHouseDateTimeFormat.formatNanos(nullToEpoch(span.endTime())));
+        } else if (span.endTime() != null) {
+            node.put("end_time", ClickHouseDateTimeFormat.formatNanos(span.endTime()));
+        } else {
+            node.putNull("end_time");
+        }
+
+        node.put("input", inputValue);
+        node.put("output", outputValue);
+        // Parity with the R2DBC binder, which uses metadata.toString() here rather than toJsonString.
+        node.put("metadata", span.metadata() != null ? span.metadata().toString() : "");
+        node.put("model", StringUtils.defaultIfBlank(span.model(), ""));
+        node.put("provider", StringUtils.defaultIfBlank(span.provider(), ""));
+
+        // Decimal128(12) written as a quoted plain string, as ExperimentAggregatesDAOImpl does for
+        // total_estimated_cost — no exponent notation, and no float round-tripping.
+        BigDecimal cost = span.totalEstimatedCost() != null ? span.totalEstimatedCost() : calculateCost(span);
+        node.put("total_estimated_cost", cost.toPlainString());
+        node.put("total_estimated_cost_version",
+                span.totalEstimatedCost() == null && cost.compareTo(BigDecimal.ZERO) > 0
+                        ? ESTIMATED_COST_VERSION
+                        : "");
+
+        var tags = node.putArray("tags");
+        Optional.ofNullable(span.tags()).ifPresent(values -> values.forEach(tags::add));
+
+        var usage = node.putObject("usage");
+        UsageUtils.sanitizeUsage(span.usage()).forEach(usage::put);
+
+        node.put("last_updated_at", ClickHouseDateTimeFormat.formatMicros(
+                span.lastUpdatedAt() != null ? span.lastUpdatedAt() : nowForBatch));
+        node.put("error_info", span.errorInfo() != null ? JsonUtils.readTree(span.errorInfo()).toString() : "");
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+        node.put("input_slim", TruncationUtils.createSlimJsonString(inputValue));
+        node.put("output_slim", TruncationUtils.createSlimJsonString(outputValue));
+
+        // Mirrors bindNanSentinel; Jackson quotes NaN, hence input_format_json_read_numbers_as_strings
+        // on the insert.
+        if (spanColumnsNonNullable()) {
+            node.put("ttft", nullToNaN(span.ttft()));
+        } else if (span.ttft() != null) {
+            node.put("ttft", span.ttft());
+        } else {
+            node.putNull("ttft");
+        }
+
+        node.put("environment", StringUtils.defaultString(span.environment()));
+
+        // Omitted rather than null when absent, so the column DEFAULT applies directly — see the same
+        // note in TraceDAO#appendJsonRow.
+        if (configuration.getResponseFormatting().getTruncationSize() > 0) {
+            node.put("truncation_threshold", configuration.getResponseFormatting().getTruncationSize());
+        }
+
+        if (span.source() != null) {
+            node.put("source", span.source().getValue());
+        }
+
+        out.append(node).append('\n');
     }
 
     private Publisher<? extends Result> insert(List<Span> spans, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -1839,7 +1839,7 @@ public class SpanDAO {
 
     /**
      * The {@link #BULK_INSERT} rows streamed as JSONEachRow through the v2 client rather than bound as
-     * 26 named parameters per row — the widest of the three bulk write paths, and so the one where the
+     * 27 named parameters per row — the widest of the three bulk write paths, and so the one where the
      * driver's per-name linear scan costs most.
      *
      * <p>Values come from the same helpers the R2DBC binder uses, including the batch-wide

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -130,6 +130,16 @@ public interface TraceDAO {
 
     Mono<Long> batchInsert(List<Trace> traces, Connection connection);
 
+    /**
+     * Batch insert without a caller-supplied connection.
+     *
+     * <p>Exists so the write-path choice is made BEFORE a connection is allocated: the JSONEachRow path
+     * uses the v2 client's own HTTP pool and needs no R2DBC connection at all, and
+     * {@code TransactionTemplateAsync#nonTransaction} does not close what it hands out. Allocating one
+     * per batch and never using it is waste on a path whose whole point is to remove per-batch overhead.
+     */
+    Mono<Long> batchInsert(List<Trace> traces);
+
     Flux<WorkspaceTraceCount> countTracesPerWorkspace(Map<UUID, Instant> excludedProjectIds);
 
     Mono<Set<UUID>> getProjectsWithTracesInRange(Collection<Pair<String, UUID>> workspaceProjectPairs, Instant from,
@@ -4375,10 +4385,6 @@ class TraceDAOImpl implements TraceDAO {
 
         Preconditions.checkArgument(!traces.isEmpty(), "traces must not be empty");
 
-        if (configuration.getBulkInsert().v2ClientEnabled()) {
-            return insertJsonEachRow(traces);
-        }
-
         return Mono.from(insert(traces, connection))
                 .flatMapMany(Result::getRowsUpdated)
                 .reduce(0L, Long::sum);
@@ -4474,6 +4480,19 @@ class TraceDAOImpl implements TraceDAO {
         }
 
         return node;
+    }
+
+    @Override
+    @WithSpan
+    public Mono<Long> batchInsert(@NonNull List<Trace> traces) {
+
+        Preconditions.checkArgument(!traces.isEmpty(), "traces must not be empty");
+
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
+            return insertJsonEachRow(traces);
+        }
+
+        return asyncTemplate.nonTransaction(connection -> batchInsert(traces, connection));
     }
 
     private Publisher<? extends Result> insert(List<Trace> traces, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -37,6 +37,7 @@ import com.comet.opik.utils.WeeklyPartitions;
 import com.comet.opik.utils.template.TemplateUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
@@ -4374,7 +4375,7 @@ class TraceDAOImpl implements TraceDAO {
 
         Preconditions.checkArgument(!traces.isEmpty(), "traces must not be empty");
 
-        if (JsonEachRowBulkInsert.isEnabled()) {
+        if (configuration.getBulkInsert().v2ClientEnabled()) {
             return insertJsonEachRow(traces);
         }
 
@@ -4401,12 +4402,11 @@ class TraceDAOImpl implements TraceDAO {
                     "traces",
                     getLogComment("batch_insert_traces", workspaceId, userName, traces.size()),
                     traces,
-                    (body, trace) -> appendJsonRow(body, trace, userName, workspaceId, nowForBatch));
+                    trace -> toJsonRow(trace, userName, workspaceId, nowForBatch));
         });
     }
 
-    private void appendJsonRow(StringBuilder out, Trace trace, String userName, String workspaceId,
-            Instant nowForBatch) {
+    private ObjectNode toJsonRow(Trace trace, String userName, String workspaceId, Instant nowForBatch) {
 
         String inputValue = TruncationUtils.toJsonString(trace.input());
         String outputValue = TruncationUtils.toJsonString(trace.output());
@@ -4473,7 +4473,7 @@ class TraceDAOImpl implements TraceDAO {
             node.put("source", trace.source().getValue());
         }
 
-        out.append(node).append('\n');
+        return node;
     }
 
     private Publisher<? extends Result> insert(List<Trace> traces, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -138,7 +138,7 @@ public interface TraceDAO {
      * {@code TransactionTemplateAsync#nonTransaction} does not close what it hands out. Allocating one
      * per batch and never using it is waste on a path whose whole point is to remove per-batch overhead.
      */
-    Mono<Long> batchInsert(List<Trace> traces);
+    Mono<Long> batchInsert(@NonNull List<Trace> traces);
 
     Flux<WorkspaceTraceCount> countTracesPerWorkspace(Map<UUID, Instant> excludedProjectIds);
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -27,6 +27,7 @@ import com.comet.opik.domain.utils.DemoDataExclusionUtils;
 import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.db.JsonEachRowBulkInsert;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.utils.ClickHouseDateTimeFormat;
 import com.comet.opik.utils.ErrorUtils;
@@ -3310,6 +3311,7 @@ class TraceDAOImpl implements TraceDAO {
     private final @NonNull ConnectionFactory connectionFactory;
     private final @NonNull WorkspacesService workspacesService;
     private final @NonNull InstantToUUIDMapper instantToUUIDMapper;
+    private final @NonNull JsonEachRowBulkInsert jsonBulkInsert;
 
     /**
      * Sort mapping applied under {@code traceColumnsNonNullable}: {@code nullIf} restores an absent (epoch)
@@ -4372,10 +4374,106 @@ class TraceDAOImpl implements TraceDAO {
 
         Preconditions.checkArgument(!traces.isEmpty(), "traces must not be empty");
 
+        if (JsonEachRowBulkInsert.isEnabled()) {
+            return insertJsonEachRow(traces);
+        }
+
         return Mono.from(insert(traces, connection))
                 .flatMapMany(Result::getRowsUpdated)
                 .reduce(0L, Long::sum);
 
+    }
+
+    /**
+     * The {@link #BATCH_INSERT} rows streamed as JSONEachRow through the v2 client rather than bound as
+     * 20 named parameters per row. The {@code connection} the interface hands us is unused here: the v2
+     * client owns its own HTTP connection pool.
+     *
+     * <p>Every value is produced by the same helper the R2DBC binder uses, so the two paths write
+     * identical cells — including the batch-wide {@code nowForBatch} fallback, which must stay one
+     * timestamp per batch to keep downstream {@code MAX(last_updated_at)} aggregations stable.
+     */
+    private Mono<Long> insertJsonEachRow(List<Trace> traces) {
+        return makeMonoContextAware((userName, workspaceId) -> {
+            Instant nowForBatch = Instant.now();
+
+            return jsonBulkInsert.insert(
+                    "traces",
+                    getLogComment("batch_insert_traces", workspaceId, userName, traces.size()),
+                    traces,
+                    (body, trace) -> appendJsonRow(body, trace, userName, workspaceId, nowForBatch));
+        });
+    }
+
+    private void appendJsonRow(StringBuilder out, Trace trace, String userName, String workspaceId,
+            Instant nowForBatch) {
+
+        String inputValue = TruncationUtils.toJsonString(trace.input());
+        String outputValue = TruncationUtils.toJsonString(trace.output());
+
+        var node = JsonUtils.createObjectNode();
+
+        node.put("id", trace.id().toString());
+        node.put("project_id", trace.projectId().toString());
+        node.put("workspace_id", workspaceId);
+        node.put("name", StringUtils.defaultIfBlank(trace.name(), ""));
+        node.put("start_time", ClickHouseDateTimeFormat.formatNanos(trace.startTime()));
+
+        // Mirrors bindEpochSentinel: the epoch sentinel once the column is non-nullable, NULL while it
+        // is still Nullable.
+        if (traceColumnsNonNullable()) {
+            node.put("end_time", ClickHouseDateTimeFormat.formatNanos(nullToEpoch(trace.endTime())));
+        } else if (trace.endTime() != null) {
+            node.put("end_time", ClickHouseDateTimeFormat.formatNanos(trace.endTime()));
+        } else {
+            node.putNull("end_time");
+        }
+
+        node.put("input", inputValue);
+        node.put("output", outputValue);
+        node.put("metadata", TruncationUtils.toJsonString(trace.metadata()));
+
+        var tags = node.putArray("tags");
+        Optional.ofNullable(trace.tags()).ifPresent(values -> values.forEach(tags::add));
+
+        node.put("last_updated_at", ClickHouseDateTimeFormat.formatMicros(
+                trace.lastUpdatedAt() != null ? trace.lastUpdatedAt() : nowForBatch));
+        node.put("error_info", trace.errorInfo() != null ? JsonUtils.readTree(trace.errorInfo()).toString() : "");
+        node.put("created_by", userName);
+        node.put("last_updated_by", userName);
+        node.put("thread_id", StringUtils.defaultIfBlank(trace.threadId(), ""));
+        node.put("visibility_mode", trace.visibilityMode() != null
+                ? trace.visibilityMode().getValue()
+                : VisibilityMode.DEFAULT.getValue());
+        node.put("input_slim", TruncationUtils.createSlimJsonString(inputValue));
+        node.put("output_slim", TruncationUtils.createSlimJsonString(outputValue));
+
+        // Mirrors bindNanSentinel. Jackson quotes NaN, which is why the insert enables
+        // input_format_json_read_numbers_as_strings.
+        if (traceColumnsNonNullable()) {
+            node.put("ttft", nullToNaN(trace.ttft()));
+        } else if (trace.ttft() != null) {
+            node.put("ttft", trace.ttft());
+        } else {
+            node.putNull("ttft");
+        }
+
+        node.put("environment", StringUtils.defaultString(trace.environment()));
+
+        // truncation_threshold (UInt64 DEFAULT 10001) and source (Enum8 DEFAULT 'unknown') are LEFT OUT
+        // of the row when absent rather than written as null. Both columns are non-nullable, so a null
+        // would only land as the default via input_format_null_as_default — which is what the R2DBC
+        // bindNull relies on today. Omitting takes the column DEFAULT directly, giving the same cell
+        // without depending on that setting.
+        if (configuration.getResponseFormatting().getTruncationSize() > 0) {
+            node.put("truncation_threshold", configuration.getResponseFormatting().getTruncationSize());
+        }
+
+        if (trace.source() != null) {
+            node.put("source", trace.source().getValue());
+        }
+
+        out.append(node).append('\n');
     }
 
     private Publisher<? extends Result> insert(List<Trace> traces, Connection connection) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -220,8 +220,7 @@ class TraceServiceImpl implements TraceService {
                             .collectList();
 
                     return resolveProjects
-                            .flatMap(traces -> template
-                                    .nonTransaction(connection -> dao.batchInsert(traces, connection))
+                            .flatMap(traces -> dao.batchInsert(traces)
                                     .doOnSuccess(__ -> {
                                         eventBus.post(new TracesCreated(traces, workspaceId, userName,
                                                 workspaceName, cipxDeviceId));

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
@@ -11,7 +11,8 @@ import lombok.Builder;
  * <ul>
  *   <li>{@code false} (default) — the R2DBC bulk path, which renders one placeholder per column per row
  *       and binds each by name. The driver resolves every bind with a linear scan over the statement's
- *       parameter names, so a 1000-row span batch carries ~26k names and binding is O(n²).</li>
+ *       parameter names, so a 1000-row span batch carries ~27k names (27 row-indexed
+ *       binds plus the shared workspace bind) and binding is O(n²).</li>
  *   <li>{@code true} — rows serialized to {@code JSONEachRow} and streamed through the ClickHouse Java
  *       client v2: one HTTP body, compressed once, parsed server-side. No parameter binding at all.</li>
  * </ul>

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
@@ -5,14 +5,16 @@ import lombok.Builder;
 /**
  * Which client the bulk write paths use.
  *
- * <p>{@code v2ClientEnabled} switches {@code ExperimentItemDAO#insert}, {@code TraceDAO#batchInsert} and
- * {@code SpanDAO#batchInsert} between two implementations of the same insert:
+ * <p>{@code v2ClientEnabled} switches every bulk row-append between two implementations of the same
+ * insert — {@code ExperimentItemDAO#insert}, {@code TraceDAO#batchInsert}, {@code SpanDAO#batchInsert},
+ * {@code DatasetItemDAO#save} and {@code DatasetItemVersionDAO#insertItems}:
  *
  * <ul>
  *   <li>{@code false} (default) — the R2DBC bulk path, which renders one placeholder per column per row
  *       and binds each by name. The driver resolves every bind with a linear scan over the statement's
  *       parameter names, so a 1000-row span batch carries ~27k names (27 row-indexed
- *       binds plus the shared workspace bind) and binding is O(n²).</li>
+ *       binds plus the shared workspace bind) and binding is O(n²). {@code dataset_item_versions} is
+ *       wider still at 23 columns, 15 of them row-indexed.</li>
  *   <li>{@code true} — rows serialized to {@code JSONEachRow} and streamed through the ClickHouse Java
  *       client v2: one HTTP body, compressed once, parsed server-side. No parameter binding at all.</li>
  * </ul>

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/BulkInsertConfig.java
@@ -1,0 +1,30 @@
+package com.comet.opik.infrastructure;
+
+import lombok.Builder;
+
+/**
+ * Which client the bulk write paths use.
+ *
+ * <p>{@code v2ClientEnabled} switches {@code ExperimentItemDAO#insert}, {@code TraceDAO#batchInsert} and
+ * {@code SpanDAO#batchInsert} between two implementations of the same insert:
+ *
+ * <ul>
+ *   <li>{@code false} (default) — the R2DBC bulk path, which renders one placeholder per column per row
+ *       and binds each by name. The driver resolves every bind with a linear scan over the statement's
+ *       parameter names, so a 1000-row span batch carries ~26k names and binding is O(n²).</li>
+ *   <li>{@code true} — rows serialized to {@code JSONEachRow} and streamed through the ClickHouse Java
+ *       client v2: one HTTP body, compressed once, parsed server-side. No parameter binding at all.</li>
+ * </ul>
+ *
+ * <p>Both paths write identical cells, so this is safe to flip in either direction on a running install
+ * and needs no coordination with a migration — unlike {@code DatabaseAnalyticsDataModelConfig}, whose
+ * flags must match the physical schema. The sentinel behaviour the v2 path emits is still governed by
+ * that config, not by this one.
+ *
+ * <p>Defaults to {@code false} so an upgrade does not silently change the write path. Keeping both in
+ * the image is deliberate for A/B measurement: an experiment then varies one setting rather than the
+ * build, which removes image-build differences as a confounder.
+ */
+@Builder(toBuilder = true)
+public record BulkInsertConfig(boolean v2ClientEnabled) {
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/OpikConfiguration.java
@@ -31,6 +31,9 @@ public class OpikConfiguration extends JobConfiguration {
     private DatabaseAnalyticsReadOnlyFreeFormSqlConfig databaseAnalyticsReadOnlyFreeFormSql = new DatabaseAnalyticsReadOnlyFreeFormSqlConfig();
 
     @Valid @NotNull @JsonProperty
+    private BulkInsertConfig bulkInsert = BulkInsertConfig.builder().build();
+
+    @Valid @NotNull @JsonProperty
     private UuidValidationConfig uuidValidation = UuidValidationConfig.builder().build();
 
     @Valid @NotNull @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -1,0 +1,108 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.insert.InsertResponse;
+import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.metrics.ServerMetrics;
+import com.clickhouse.data.ClickHouseFormat;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+/**
+ * Bulk insert through the ClickHouse Java client v2 using {@link ClickHouseFormat#JSONEachRow}.
+ *
+ * <p>Why this exists: the R2DBC bulk path renders one placeholder per column per row and binds each
+ * by name, and the driver resolves every {@code bind(name, value)} with a linear scan over the
+ * statement's parameter names. A 1000-row trace batch carries ~22k names, so binding alone is
+ * O(n²) and dominates the insert. Streaming JSONEachRow removes parameter binding from the picture
+ * entirely: one HTTP body, compressed once by the client, parsed server-side in ClickHouse's fast
+ * path. {@code ExperimentAggregatesDAOImpl} established this pattern for experiment aggregates —
+ * this class is the same approach, factored out so the trace / span / experiment-item write paths
+ * can share it rather than each growing its own copy of the plumbing.
+ *
+ * <p>The client is the shared Dropwizard-managed singleton from
+ * {@link DatabaseAnalyticsModule#getClickHouseClient()}; this class never closes it.
+ *
+ * <p>Callers own row serialization: the {@code rowWriter} appends exactly one JSON object plus a
+ * newline per item. Build rows with Jackson rather than string concatenation — the payload carries
+ * user-supplied trace input/output, so escaping has to be correct by construction.
+ */
+@Singleton
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @Inject)
+public class JsonEachRowBulkInsert {
+
+    private static final String ENABLED_PROPERTY = "opik.v2BulkInsert";
+
+    private final @NonNull Client clickHouseClient;
+
+    /**
+     * Whether the bulk write paths use this insert or the R2DBC bulk bind they replace.
+     *
+     * <p>Enabled by default; only the literal {@code -Dopik.v2BulkInsert=false} restores R2DBC, so a
+     * typo cannot silently take a deployment back to the slow path. Keeping both paths in one image
+     * is deliberate: the A/B measurement then varies a JVM flag rather than the build, which removes
+     * image-build differences as a confounder.
+     */
+    public static boolean isEnabled() {
+        return !"false".equalsIgnoreCase(System.getProperty(ENABLED_PROPERTY, "true"));
+    }
+
+    /**
+     * Inserts {@code items} into {@code table}, returning the row count ClickHouse reports as
+     * written — the server's own {@code NUM_ROWS_WRITTEN}, not {@code items.size()}, so that
+     * engine-side deduplication or truncation is visible to the caller rather than silently
+     * assumed away.
+     */
+    public <T> Mono<Long> insert(@NonNull String table,
+            @NonNull String logComment,
+            @NonNull Collection<T> items,
+            @NonNull BiConsumer<StringBuilder, T> rowWriter) {
+
+        if (items.isEmpty()) {
+            return Mono.just(0L);
+        }
+
+        return Mono.fromCallable(() -> {
+            var body = new StringBuilder();
+            items.forEach(item -> rowWriter.accept(body, item));
+            byte[] payload = body.toString().getBytes(StandardCharsets.UTF_8);
+
+            var settings = new InsertSettings()
+                    .logComment(logComment)
+                    // best_effort so the client-side formatted DateTime64 literals parse, and
+                    // defaults_for_omitted_fields so columns absent from the row (created_at,
+                    // MATERIALIZED columns) still take their DDL defaults. Both are scoped to this
+                    // request rather than set on the shared Client.Builder, so unrelated queries
+                    // keep the server defaults.
+                    .serverSetting("date_time_input_format", "best_effort")
+                    .serverSetting("input_format_defaults_for_omitted_fields", "1")
+                    // Jackson quotes non-numeric doubles (QUOTE_NON_NUMERIC_NUMBERS), so an absent
+                    // ttft reaches ClickHouse as the string "NaN" once the sentinel columns are
+                    // non-nullable. Set explicitly rather than inherited from the server default,
+                    // which would make correctness depend on an unrelated server-side setting.
+                    .serverSetting("input_format_json_read_numbers_as_strings", "1");
+
+            try (InsertResponse response = clickHouseClient
+                    .insert(table, new ByteArrayInputStream(payload), ClickHouseFormat.JSONEachRow, settings)
+                    .get()) {
+                return response.getMetrics().getMetric(ServerMetrics.NUM_ROWS_WRITTEN).getLong();
+            }
+        })
+                // The v2 client call is blocking; keep it off the reactive event loop.
+                .subscribeOn(Schedulers.boundedElastic())
+                // Log the count only — never the payload, which holds customer trace data.
+                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}'", table, items.size(),
+                        err));
+    }
+}

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -5,6 +5,7 @@ import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.data.ClickHouseFormat;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
@@ -13,10 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
-import java.io.ByteArrayInputStream;
+import java.io.BufferedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.function.BiConsumer;
+import java.util.function.Function;
 
 /**
  * Bulk insert through the ClickHouse Java client v2 using {@link ClickHouseFormat#JSONEachRow}.
@@ -25,59 +26,51 @@ import java.util.function.BiConsumer;
  * by name, and the driver resolves every {@code bind(name, value)} with a linear scan over the
  * statement's parameter names. A 1000-row trace batch carries ~22k names, so binding alone is
  * O(n²) and dominates the insert. Streaming JSONEachRow removes parameter binding from the picture
- * entirely: one HTTP body, compressed once by the client, parsed server-side in ClickHouse's fast
- * path. {@code ExperimentAggregatesDAOImpl} established this pattern for experiment aggregates —
- * this class is the same approach, factored out so the trace / span / experiment-item write paths
- * can share it rather than each growing its own copy of the plumbing.
+ * entirely: one HTTP body, parsed server-side in ClickHouse's fast path.
+ * {@code ExperimentAggregatesDAOImpl} established this pattern for experiment aggregates — this
+ * class is the same approach, factored out so the trace / span / experiment-item write paths can
+ * share it rather than each growing its own copy of the plumbing.
+ *
+ * <p>Callers reach this only when {@code bulkInsert.v2ClientEnabled} is set — see
+ * {@link com.comet.opik.infrastructure.BulkInsertConfig}.
+ *
+ * <p>The body is <b>not</b> compressed here, and must not be: the shared client is built with
+ * {@code compressClientRequest(true)} in {@code DatabaseAnalyticsFactory}, which compresses the
+ * request body itself. Compressing here would double-compress and burn CPU for nothing.
+ *
+ * <p>Rows are streamed rather than materialized. The batch is written straight into the client's
+ * output stream one row at a time, so peak memory is a single row rather than the whole payload —
+ * which matters because trace {@code input}/{@code output} can be hundreds of KiB each, and a
+ * 1000-row batch of those would otherwise be held in full (twice over, converting chars to UTF-8)
+ * per concurrent request. Rows are built with Jackson, not string concatenation: the payload carries
+ * user-supplied trace content, so escaping has to be correct by construction.
  *
  * <p>The client is the shared Dropwizard-managed singleton from
  * {@link DatabaseAnalyticsModule#getClickHouseClient()}; this class never closes it.
- *
- * <p>Callers own row serialization: the {@code rowWriter} appends exactly one JSON object plus a
- * newline per item. Build rows with Jackson rather than string concatenation — the payload carries
- * user-supplied trace input/output, so escaping has to be correct by construction.
  */
 @Singleton
 @Slf4j
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class JsonEachRowBulkInsert {
 
-    private static final String ENABLED_PROPERTY = "opik.v2BulkInsert";
-
     private final @NonNull Client clickHouseClient;
 
     /**
-     * Whether the bulk write paths use this insert or the R2DBC bulk bind they replace.
-     *
-     * <p>Enabled by default; only the literal {@code -Dopik.v2BulkInsert=false} restores R2DBC, so a
-     * typo cannot silently take a deployment back to the slow path. Keeping both paths in one image
-     * is deliberate: the A/B measurement then varies a JVM flag rather than the build, which removes
-     * image-build differences as a confounder.
-     */
-    public static boolean isEnabled() {
-        return !"false".equalsIgnoreCase(System.getProperty(ENABLED_PROPERTY, "true"));
-    }
-
-    /**
-     * Inserts {@code items} into {@code table}, returning the row count ClickHouse reports as
-     * written — the server's own {@code NUM_ROWS_WRITTEN}, not {@code items.size()}, so that
-     * engine-side deduplication or truncation is visible to the caller rather than silently
-     * assumed away.
+     * Inserts {@code items} into {@code table}, mapping each to one JSON row, and returns the row count
+     * ClickHouse reports as written — the server's own {@code NUM_ROWS_WRITTEN}, not
+     * {@code items.size()}, so engine-side deduplication or truncation is visible to the caller rather
+     * than silently assumed away.
      */
     public <T> Mono<Long> insert(@NonNull String table,
             @NonNull String logComment,
             @NonNull Collection<T> items,
-            @NonNull BiConsumer<StringBuilder, T> rowWriter) {
+            @NonNull Function<T, ObjectNode> rowMapper) {
 
         if (items.isEmpty()) {
             return Mono.just(0L);
         }
 
         return Mono.fromCallable(() -> {
-            var body = new StringBuilder();
-            items.forEach(item -> rowWriter.accept(body, item));
-            byte[] payload = body.toString().getBytes(StandardCharsets.UTF_8);
-
             var settings = new InsertSettings()
                     .logComment(logComment)
                     // best_effort so the client-side formatted DateTime64 literals parse, and
@@ -93,9 +86,16 @@ public class JsonEachRowBulkInsert {
                     // which would make correctness depend on an unrelated server-side setting.
                     .serverSetting("input_format_json_read_numbers_as_strings", "1");
 
-            try (InsertResponse response = clickHouseClient
-                    .insert(table, new ByteArrayInputStream(payload), ClickHouseFormat.JSONEachRow, settings)
-                    .get()) {
+            // Serializes from items on every invocation, so the client's own retry (DataStreamWriter
+            // onRetry) replays an identical body rather than resuming a half-written stream.
+            try (InsertResponse response = clickHouseClient.insert(table, out -> {
+                var buffered = new BufferedOutputStream(out);
+                for (T item : items) {
+                    buffered.write(rowMapper.apply(item).toString().getBytes(StandardCharsets.UTF_8));
+                    buffered.write('\n');
+                }
+                buffered.flush();
+            }, ClickHouseFormat.JSONEachRow, settings).get()) {
                 return response.getMetrics().getMetric(ServerMetrics.NUM_ROWS_WRITTEN).getLong();
             }
         })

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -11,12 +11,14 @@ import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.io.BufferedOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 
 /**
@@ -43,7 +45,8 @@ import java.util.function.Function;
  * which matters because trace {@code input}/{@code output} can be hundreds of KiB each, and a
  * 1000-row batch of those would otherwise be held in full (twice over, converting chars to UTF-8)
  * per concurrent request. Rows are built with Jackson, not string concatenation: the payload carries
- * user-supplied trace content, so escaping has to be correct by construction.
+ * user-supplied trace content, so escaping has to be correct by construction, and failures are
+ * logged as a bounded summary rather than a full message or stack.
  *
  * <p>The client is the shared Dropwizard-managed singleton from
  * {@link DatabaseAnalyticsModule#getClickHouseClient()}; this class never closes it.
@@ -97,12 +100,21 @@ public class JsonEachRowBulkInsert {
                 buffered.flush();
             }, ClickHouseFormat.JSONEachRow, settings).get()) {
                 return response.getMetrics().getMetric(ServerMetrics.NUM_ROWS_WRITTEN).getLong();
+            } catch (ExecutionException e) {
+                // Future.get() wraps the client's failure in ExecutionException. The resource-layer
+                // retry filter (RetryUtils.handleConnectionError) matches on the throwable's own class,
+                // so a wrapped SocketException would not be retried here even though the same failure
+                // is retried on the R2DBC path. Surface the cause so both paths retry alike.
+                throw e.getCause() instanceof Exception cause ? cause : e;
             }
         })
                 // The v2 client call is blocking; keep it off the reactive event loop.
                 .subscribeOn(Schedulers.boundedElastic())
-                // Log the count only — never the payload, which holds customer trace data.
-                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}'", table, items.size(),
-                        err));
+                // Bounded on purpose. A ClickHouse parse error quotes the offending value, and the
+                // payload is customer trace content, so neither the stack nor the full message is
+                // safe to emit here: log the type and an abbreviated message, never the rows.
+                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}', error='{} {}'",
+                        table, items.size(), err.getClass().getSimpleName(),
+                        StringUtils.abbreviate(err.getMessage(), 200)));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -5,6 +5,11 @@ import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.data.ClickHouseFormat;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.io.SerializedString;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
@@ -16,7 +21,6 @@ import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
 import java.io.BufferedOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -56,6 +60,12 @@ import java.util.function.Function;
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class JsonEachRowBulkInsert {
 
+    private static final SerializedString EMPTY_ROOT_SEPARATOR = new SerializedString("");
+
+    private static final ObjectWriter ROW_WRITER = JsonUtils.getMapper()
+            .writer()
+            .without(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
+
     private final @NonNull Client clickHouseClient;
 
     /**
@@ -93,13 +103,30 @@ public class JsonEachRowBulkInsert {
             // onRetry) replays an identical body rather than resuming a half-written stream.
             try (InsertResponse response = clickHouseClient.insert(table, out -> {
                 var buffered = new BufferedOutputStream(out);
-                for (T item : items) {
-                    buffered.write(rowMapper.apply(item).toString().getBytes(StandardCharsets.UTF_8));
-                    buffered.write('\n');
+                // Straight from the node into the stream: an intermediate toString() plus getBytes()
+                // would hold each row twice more, which for trace input/output of hundreds of KiB is
+                // the allocation cost this streaming path exists to avoid.
+                try (JsonGenerator generator = JsonUtils.getMapper().getFactory().createGenerator(buffered)) {
+                    // The generator writes into, but does not own, the client's stream.
+                    generator.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+                    // JSONEachRow rows are newline-separated; Jackson's default root separator is a
+                    // space, which would prepend one to every row after the first.
+                    generator.setRootValueSeparator(EMPTY_ROOT_SEPARATOR);
+                    for (T item : items) {
+                        // A writer without FLUSH_AFTER_WRITE_VALUE, or the BufferedOutputStream would
+                        // be flushed once per row and buffer nothing.
+                        ROW_WRITER.writeValue(generator, rowMapper.apply(item));
+                        generator.writeRaw('\n');
+                    }
                 }
                 buffered.flush();
             }, ClickHouseFormat.JSONEachRow, settings).get()) {
                 return response.getMetrics().getMetric(ServerMetrics.NUM_ROWS_WRITTEN).getLong();
+            } catch (InterruptedException e) {
+                // get() clears the flag when it throws; restore it so the shutdown that interrupted
+                // this worker is not swallowed and reported as an insert failure.
+                Thread.currentThread().interrupt();
+                throw e;
             } catch (ExecutionException e) {
                 // Future.get() wraps the client's failure in ExecutionException. The resource-layer
                 // retry filter (RetryUtils.handleConnectionError) matches on the throwable's own class,

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -68,11 +68,20 @@ public class JsonEachRowBulkInsert {
      * The row writer is built here, in the constructor, rather than in a static initializer.
      *
      * <p>{@code JsonUtils.configure} <em>replaces</em> the static mapper during startup — the hazard
-     * {@code JsonUtilsConfigurationBundle}'s javadoc warns about — so anything that captures the mapper
-     * at class-load freezes the pre-bundle instance and silently ignores the configured
-     * {@code jacksonConfig} limits, {@code maxStringLength} included, which is exactly the setting that
-     * matters for large trace payloads. Guice constructs this singleton after that bundle has run, so
-     * binding it here picks up the configured mapper.
+     * {@code JsonUtilsConfigurationBundle}'s javadoc warns about — so anything capturing it at class-load
+     * holds the pre-bundle instance. What that instance carries is the mapper's <b>serialization</b>
+     * configuration: {@code NON_NULL} inclusion, snake_case naming, the date/duration handling and the
+     * {@code JavaTimeModule}. Deriving the writer from whatever mapper the application configured is the
+     * point; Guice builds this singleton after the bundle has run.
+     *
+     * <p>Note what this does <b>not</b> buy, because it would be easy to assume otherwise: the
+     * {@code jacksonConfig} limits ({@code maxStringLength} / {@code maxDocumentLength}) are
+     * {@link com.fasterxml.jackson.core.StreamReadConstraints} — parser-side only, as
+     * {@code JsonUtils#applyStreamReadConstraints}' own javadoc states. They bound what is read, e.g. an
+     * inbound request body, and place no bound whatsoever on what this class writes. The outbound
+     * payload here is as large as the batch it is given: {@code ExperimentItemBulkUpload} caps a bulk
+     * request at 4MB, but {@code TraceBatch} and {@code SpanBatch} carry no such annotation, so an
+     * outbound guard would be a new behaviour rather than one inherited from the mapper.
      *
      * <p>{@code FLUSH_AFTER_WRITE_VALUE} is disabled deliberately: otherwise the
      * {@link BufferedOutputStream} the rows are written through is flushed once per row and buffers

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -167,7 +167,7 @@ public class JsonEachRowBulkInsert {
                 // the row COUNT are logged alongside it — never the rows themselves. Note a ClickHouse
                 // parse error quotes the offending value in its own message, so this log can carry a
                 // fragment of customer content by way of the exception.
-                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}'",
+                .doOnError(err -> log.error("Failed JSONEachRow insert: table='{}' rows='{}'",
                         table, items.size(), err));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -15,7 +15,6 @@ import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -48,8 +47,8 @@ import java.util.function.Function;
  * which matters because trace {@code input}/{@code output} can be hundreds of KiB each, and a
  * 1000-row batch of those would otherwise be held in full (twice over, converting chars to UTF-8)
  * per concurrent request. Rows are built with Jackson, not string concatenation: the payload carries
- * user-supplied trace content, so escaping has to be correct by construction, and failures are
- * logged as a bounded summary rather than a full message or stack.
+ * user-supplied trace content, so escaping has to be correct by construction. A failure logs the
+ * table, the row count and the exception as its cause — never the rows.
  *
  * <p>The client is the shared Dropwizard-managed singleton from
  * {@link DatabaseAnalyticsModule#getClickHouseClient()}; this class never closes it.
@@ -162,11 +161,13 @@ public class JsonEachRowBulkInsert {
         })
                 // The v2 client call is blocking; keep it off the reactive event loop.
                 .subscribeOn(Schedulers.boundedElastic())
-                // Bounded on purpose. A ClickHouse parse error quotes the offending value, and the
-                // payload is customer trace content, so neither the stack nor the full message is
-                // safe to emit here: log the type and an abbreviated message, never the rows.
-                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}', error='{} {}'",
-                        table, items.size(), err.getClass().getSimpleName(),
-                        StringUtils.abbreviate(err.getMessage(), 200)));
+                // The throwable is passed as the cause, not formatted into the message: a failed bulk
+                // insert is diagnosable only from the stack and the cause chain, which say whether it
+                // was serialization, a connection reset or a server-side rejection. Only the table and
+                // the row COUNT are logged alongside it — never the rows themselves. Note a ClickHouse
+                // parse error quotes the offending value in its own message, so this log can carry a
+                // fragment of customer content by way of the exception.
+                .doOnError(err -> log.error("Failed JSONEachRow insert into '{}': rows='{}'",
+                        table, items.size(), err));
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -62,11 +62,22 @@ public class JsonEachRowBulkInsert {
 
     private static final SerializedString EMPTY_ROOT_SEPARATOR = new SerializedString("");
 
-    private static final ObjectWriter ROW_WRITER = JsonUtils.getMapper()
+    private final @NonNull Client clickHouseClient;
+
+    /**
+     * Built at construction, not in a static initializer.
+     *
+     * <p>{@code JsonUtils.configure} <em>replaces</em> the static mapper during startup — see
+     * {@code JsonUtilsConfigurationBundle}, which warns about holders that capture the previous instance
+     * — so a {@code static final} writer would freeze the pre-bundle mapper and miss the configured
+     * {@code jacksonConfig} limits. Guice builds this singleton after that bundle has run.
+     *
+     * <p>{@code FLUSH_AFTER_WRITE_VALUE} is off deliberately: otherwise the underlying
+     * {@link BufferedOutputStream} is flushed once per row and buffers nothing.
+     */
+    private final ObjectWriter rowWriter = JsonUtils.getMapper()
             .writer()
             .without(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
-
-    private final @NonNull Client clickHouseClient;
 
     /**
      * Inserts {@code items} into {@code table}, mapping each to one JSON row, and returns the row count
@@ -113,9 +124,7 @@ public class JsonEachRowBulkInsert {
                     // space, which would prepend one to every row after the first.
                     generator.setRootValueSeparator(EMPTY_ROOT_SEPARATOR);
                     for (T item : items) {
-                        // A writer without FLUSH_AFTER_WRITE_VALUE, or the BufferedOutputStream would
-                        // be flushed once per row and buffer nothing.
-                        ROW_WRITER.writeValue(generator, rowMapper.apply(item));
+                        rowWriter.writeValue(generator, rowMapper.apply(item));
                         generator.writeRaw('\n');
                     }
                 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsert.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
@@ -57,27 +56,35 @@ import java.util.function.Function;
  */
 @Singleton
 @Slf4j
-@RequiredArgsConstructor(onConstructor_ = @Inject)
 public class JsonEachRowBulkInsert {
 
     private static final SerializedString EMPTY_ROOT_SEPARATOR = new SerializedString("");
 
-    private final @NonNull Client clickHouseClient;
+    private final Client clickHouseClient;
+
+    private final ObjectWriter rowWriter;
 
     /**
-     * Built at construction, not in a static initializer.
+     * The row writer is built here, in the constructor, rather than in a static initializer.
      *
-     * <p>{@code JsonUtils.configure} <em>replaces</em> the static mapper during startup — see
-     * {@code JsonUtilsConfigurationBundle}, which warns about holders that capture the previous instance
-     * — so a {@code static final} writer would freeze the pre-bundle mapper and miss the configured
-     * {@code jacksonConfig} limits. Guice builds this singleton after that bundle has run.
+     * <p>{@code JsonUtils.configure} <em>replaces</em> the static mapper during startup — the hazard
+     * {@code JsonUtilsConfigurationBundle}'s javadoc warns about — so anything that captures the mapper
+     * at class-load freezes the pre-bundle instance and silently ignores the configured
+     * {@code jacksonConfig} limits, {@code maxStringLength} included, which is exactly the setting that
+     * matters for large trace payloads. Guice constructs this singleton after that bundle has run, so
+     * binding it here picks up the configured mapper.
      *
-     * <p>{@code FLUSH_AFTER_WRITE_VALUE} is off deliberately: otherwise the underlying
-     * {@link BufferedOutputStream} is flushed once per row and buffers nothing.
+     * <p>{@code FLUSH_AFTER_WRITE_VALUE} is disabled deliberately: otherwise the
+     * {@link BufferedOutputStream} the rows are written through is flushed once per row and buffers
+     * nothing.
      */
-    private final ObjectWriter rowWriter = JsonUtils.getMapper()
-            .writer()
-            .without(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
+    @Inject
+    public JsonEachRowBulkInsert(@NonNull Client clickHouseClient) {
+        this.clickHouseClient = clickHouseClient;
+        this.rowWriter = JsonUtils.getMapper()
+                .writer()
+                .without(SerializationFeature.FLUSH_AFTER_WRITE_VALUE);
+    }
 
     /**
      * Inserts {@code items} into {@code table}, mapping each to one JSON row, and returns the row count

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
@@ -348,8 +348,8 @@ class BulkInsertV2ClientIntegrationTest {
     }
 
     @Test
-    @DisplayName("a dataset item batch writes each row exactly once and server-stamps created_at")
-    void datasetItemBatchWritesEachRowOnceAndStampsCreatedAt() {
+    @DisplayName("a dataset item batch writes each row exactly once and server-stamps created_at and last_updated_at")
+    void datasetItemBatchWritesEachRowOnceAndServerStampsCreatedAndLastUpdatedAt() {
         var datasetId = newDataset();
         var items = List.of(
                 newDatasetItem(Map.of("input", JsonUtils.getJsonNodeFromString("\"one\""))),

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.comet.opik.api.FeedbackScoreItem.FeedbackScoreBatchItem;
 import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -382,5 +383,97 @@ class BulkInsertV2ClientIntegrationTest {
                         .formatted(WORKSPACE_ID, ids),
                 row -> row.get("row_count", Long.class));
         assertThat(stampedRows).isEqualTo(items.size());
+    }
+
+    // --------------------------------------------------------------- feedback scores ---
+    // FeedbackScoreService#getAuthor takes the author from the request context, so anything arriving
+    // over HTTP has one and lands in authored_feedback_scores -- the 10-column form of the row. The
+    // author-less feedback_scores form is only reachable from a context with no USER_NAME.
+
+    private FeedbackScoreBatchItem newScore(UUID traceId, String projectName, String name) {
+        return factory.manufacturePojo(FeedbackScoreBatchItem.class).toBuilder()
+                .id(traceId)
+                .projectName(projectName)
+                .name(name)
+                // Not "suite_assertion": that category routes to assertion_results instead
+                // (ScoreDestination#fromCategoryName) and never reaches this write path.
+                .categoryName("quality")
+                .sourceQueueId(null)
+                .build();
+    }
+
+    @Test
+    @DisplayName("feedback scores round-trip their decimal value, reason, author and source queue id")
+    void feedbackScoresRoundTrip() {
+        // Decimal(18, 9) at full scale, written as a quoted plain string; and a reason carrying a
+        // newline and quotes, which would end the JSONEachRow line early if it were not escaped.
+        var trace = newTraceBuilder().build();
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+        var value = new BigDecimal("0.123456789");
+        var reason = "line one\nline \"two\"\ttabbed 日本語";
+        // A podam-generated trace id, which is a valid UUIDv7 -- ingestion rejects anything else.
+        var sourceQueueId = factory.manufacturePojo(Trace.class).id();
+        var score = newScore(trace.id(), trace.projectName(), "relevance").toBuilder()
+                .value(value)
+                .reason(reason)
+                .sourceQueueId(sourceQueueId)
+                .build();
+
+        traceResourceClient.feedbackScores(List.of(score), API_KEY, WORKSPACE_NAME);
+
+        var actual = traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY);
+        assertThat(actual.feedbackScores()).hasSize(1);
+        var stored = actual.feedbackScores().getFirst();
+        assertThat(stored.name()).isEqualTo("relevance");
+        assertThat(stored.value()).isEqualByComparingTo(value);
+        assertThat(stored.categoryName()).isEqualTo("quality");
+        assertThat(stored.reason()).isEqualTo(reason);
+        assertThat(stored.source()).isEqualTo(score.source());
+        // The author and source_queue_id cells only surface through value_by_author. source_queue_id is
+        // a FixedString(36) with no DEFAULT: the other test covers the absent case, written as "" and
+        // read back as null, and this is the populated one.
+        assertThat(stored.valueByAuthor()).hasSize(1);
+        var entry = stored.valueByAuthor().values().iterator().next();
+        assertThat(entry.author()).isEqualTo(USER);
+        assertThat(entry.sourceQueueId()).isEqualTo(sourceQueueId.toString());
+    }
+
+    @Test
+    @DisplayName("a feedback score batch writes each row once and server-stamps created_at and last_updated_at")
+    void feedbackScoreBatchWritesEachRowOnceAndServerStampsTimestamps() {
+        var trace = newTraceBuilder().build();
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+        // Distinct names, so each is its own row under the table's ORDER BY key rather than a dedup
+        // candidate.
+        var scores = List.of(
+                newScore(trace.id(), trace.projectName(), "relevance"),
+                newScore(trace.id(), trace.projectName(), "coherence"),
+                newScore(trace.id(), trace.projectName(), "fluency"));
+
+        traceResourceClient.feedbackScores(scores, API_KEY, WORKSPACE_NAME);
+
+        // Raw rows, no FINAL: reads collapse duplicates, so cardinality is the only assertion that sees
+        // a writer emitting every row twice.
+        Long storedRows = queryOne(
+                ("SELECT count() AS row_count FROM authored_feedback_scores WHERE workspace_id = '%s' "
+                        + "AND entity_id = '%s'").formatted(WORKSPACE_ID, trace.id()),
+                row -> row.get("row_count", Long.class));
+        assertThat(storedRows).isEqualTo(scores.size());
+
+        // Both timestamps are omitted from the JSON row so their DEFAULT now64(9) stamps them.
+        // last_updated_at is the ReplacingMergeTree version, so a zero there would make every later
+        // score for the same key lose to the original row.
+        Long stampedRows = queryOne(
+                ("SELECT count() AS row_count FROM authored_feedback_scores WHERE workspace_id = '%s' "
+                        + "AND entity_id = '%s' AND created_at > toDateTime64('2000-01-01 00:00:00', 9) "
+                        + "AND last_updated_at > toDateTime64('2000-01-01 00:00:00', 9)")
+                        .formatted(WORKSPACE_ID, trace.id()),
+                row -> row.get("row_count", Long.class));
+        assertThat(stampedRows).isEqualTo(scores.size());
+
+        assertThat(traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY).feedbackScores())
+                .hasSize(scores.size());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
@@ -19,6 +19,9 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.redis.testcontainers.RedisContainer;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.Row;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -30,6 +33,7 @@ import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.mysql.MySQLContainer;
+import reactor.core.publisher.Mono;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import uk.co.jemos.podam.api.PodamFactory;
@@ -115,6 +119,7 @@ class BulkInsertV2ClientIntegrationTest {
 
     private TraceResourceClient traceResourceClient;
     private SpanResourceClient spanResourceClient;
+    private ConnectionFactory clickHouseConnectionFactory;
 
     @BeforeAll
     void beforeAll(ClientSupport clientSupport) {
@@ -123,6 +128,17 @@ class BulkInsertV2ClientIntegrationTest {
         mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
         traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
         spanResourceClient = new SpanResourceClient(clientSupport, baseUrl);
+        clickHouseConnectionFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME).build();
+    }
+
+    private <T> T queryOne(String sql, java.util.function.Function<Row, T> mapper) {
+        return Mono.usingWhen(
+                clickHouseConnectionFactory.create(),
+                connection -> Mono.from(connection.createStatement(sql).execute())
+                        .flatMap(result -> Mono.from(result.map((row, ignored) -> mapper.apply(row)))),
+                Connection::close)
+                .block();
     }
 
     @AfterAll
@@ -192,7 +208,8 @@ class BulkInsertV2ClientIntegrationTest {
 
         var actual = spanResourceClient.getById(span.id(), WORKSPACE_NAME, API_KEY);
         assertThat(actual.totalEstimatedCost()).isEqualByComparingTo(cost);
-        assertThat(actual.usage()).containsAllEntriesOf(Map.of("prompt_tokens", 12, "completion_tokens", 8));
+        assertThat(actual.usage()).containsExactlyInAnyOrderEntriesOf(
+                Map.of("prompt_tokens", 12, "completion_tokens", 8));
         assertThat(actual.tags()).containsExactlyInAnyOrder("alpha", "beta");
     }
 
@@ -226,12 +243,23 @@ class BulkInsertV2ClientIntegrationTest {
     }
 
     @Test
-    @DisplayName("a multi-row batch writes every row exactly once")
-    void multiRowBatchWritesEveryRow() {
+    @DisplayName("a multi-row batch writes each row exactly once")
+    void multiRowBatchWritesEachRowExactlyOnce() {
         var traces = List.of(newTraceBuilder().build(), newTraceBuilder().build(), newTraceBuilder().build());
 
         traceResourceClient.batchCreateTraces(traces, API_KEY, WORKSPACE_NAME);
 
+        // Read the RAW rows, no FINAL and no LIMIT 1 BY id: getById collapses duplicates, so a writer
+        // that emitted every row twice would satisfy a per-id existence check. Cardinality is the only
+        // assertion that can see it.
+        var ids = traces.stream().map(trace -> "'" + trace.id() + "'")
+                .collect(java.util.stream.Collectors.joining(","));
+        Long storedRows = queryOne(
+                "SELECT count() AS row_count FROM traces WHERE workspace_id = '%s' AND id IN (%s)"
+                        .formatted(WORKSPACE_ID, ids),
+                row -> row.get("row_count", Long.class));
+
+        assertThat(storedRows).isEqualTo(traces.size());
         traces.forEach(trace -> assertThat(
                 traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY).id()).isEqualTo(trace.id()));
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
@@ -1,0 +1,251 @@
+package com.comet.opik.infrastructure;
+
+import com.comet.opik.api.Span;
+import com.comet.opik.api.Trace;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.ClientSupportUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.comet.opik.utils.JsonUtils;
+import com.redis.testcontainers.RedisContainer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static com.comet.opik.api.resources.utils.AuthTestUtils.mockTargetWorkspace;
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the {@code bulkInsert.v2ClientEnabled} write path — traces and spans streamed to ClickHouse
+ * as JSONEachRow through the v2 client instead of bound as named R2DBC parameters.
+ *
+ * <p>Why a separate class rather than a flag on the existing suites: the flag defaults to {@code false},
+ * so every other test — including {@code TraceSentinelIntegrationTest} and
+ * {@code SpanSentinelIntegrationTest} — exercises the R2DBC path. Flipping it there would buy coverage
+ * of this path by removing coverage of that one, and the R2DBC path is what the traces cutover depends
+ * on. This class runs the v2 path alongside them instead.
+ *
+ * <p>It deliberately asserts only what a real server can settle, since the framing and the settings are
+ * already unit-tested in {@code JsonEachRowBulkInsertTest}:
+ *
+ * <ul>
+ *   <li><b>Type encodings</b> that JSONEachRow is stricter about than {@code FORMAT Values} — a
+ *       {@code Decimal128(12)} cost written as a quoted string, {@code Map(String, Int)} usage,
+ *       {@code Array(String)} tags.</li>
+ *   <li><b>The sentinels.</b> Both non-nullable flags are on, so an absent {@code end_time}/{@code ttft}
+ *       is written as the epoch/NaN sentinel. {@code NaN} is not valid JSON, so Jackson quotes it and the
+ *       insert relies on {@code input_format_json_read_numbers_as_strings}; nothing but a live server can
+ *       confirm that round-trips.</li>
+ *   <li><b>Escaping.</b> Row content carrying a newline and quotes must not split one JSONEachRow line
+ *       into two, which would be a server-side parse error rather than a client-visible one.</li>
+ *   <li><b>Omitted columns</b> taking their DDL defaults, which is what
+ *       {@code input_format_defaults_for_omitted_fields} buys.</li>
+ * </ul>
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+class BulkInsertV2ClientIntegrationTest {
+
+    private static final String API_KEY = "apiKey-" + UUID.randomUUID();
+    private static final String WORKSPACE_NAME = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    private final RedisContainer redisContainer = RedisContainerUtils.newRedisContainer();
+    private final MySQLContainer mysqlContainer = MySQLContainerUtils.newMySQLContainer();
+    private final GenericContainer<?> zookeeperContainer = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer clickHouseContainer = ClickHouseContainerUtils
+            .newClickHouseContainer(zookeeperContainer);
+
+    private final WireMockUtils.WireMockRuntime wireMock;
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(redisContainer, mysqlContainer, clickHouseContainer, zookeeperContainer).join();
+        wireMock = WireMockUtils.startWireMock();
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
+                clickHouseContainer, DATABASE_NAME);
+        MigrationUtils.runMysqlDbMigration(mysqlContainer);
+        MigrationUtils.runClickhouseDbMigration(clickHouseContainer);
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(mysqlContainer.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(redisContainer.getRedisURI())
+                        .runtimeInfo(wireMock.runtimeInfo())
+                        .customConfigs(List.of(
+                                new CustomConfig("bulkInsert.v2ClientEnabled", "true"),
+                                new CustomConfig("databaseAnalyticsDataModel.traceColumnsNonNullable", "true"),
+                                new CustomConfig("databaseAnalyticsDataModel.spanColumnsNonNullable", "true")))
+                        .build());
+    }
+
+    private TraceResourceClient traceResourceClient;
+    private SpanResourceClient spanResourceClient;
+
+    @BeforeAll
+    void beforeAll(ClientSupport clientSupport) {
+        var baseUrl = TestUtils.getBaseUrl(clientSupport);
+        ClientSupportUtils.config(clientSupport);
+        mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
+        traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        spanResourceClient = new SpanResourceClient(clientSupport, baseUrl);
+    }
+
+    @AfterAll
+    void afterAll() {
+        wireMock.server().stop();
+    }
+
+    // Mirrors the sibling sentinel suites: podam's generated id is kept (the factory produces a valid
+    // UUIDv7, which ingestion validation requires), and only the sub-objects those suites null are nulled.
+    private Trace.TraceBuilder newTraceBuilder() {
+        return factory.manufacturePojo(Trace.class).toBuilder()
+                .feedbackScores(null)
+                .usage(null)
+                .errorInfo(null);
+    }
+
+    private Span.SpanBuilder newSpanBuilder() {
+        return factory.manufacturePojo(Span.class).toBuilder()
+                .feedbackScores(null)
+                .usage(null)
+                .errorInfo(null);
+    }
+
+    @Test
+    @DisplayName("a batch of traces round-trips through JSONEachRow")
+    void tracesRoundTrip() {
+        var trace = newTraceBuilder().build();
+
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+        var actual = traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY);
+        assertThat(actual.id()).isEqualTo(trace.id());
+        assertThat(actual.name()).isEqualTo(trace.name());
+        assertThat(actual.input()).isEqualTo(trace.input());
+        assertThat(actual.output()).isEqualTo(trace.output());
+        assertThat(actual.tags()).isEqualTo(trace.tags());
+    }
+
+    @Test
+    @DisplayName("absent end_time and ttft round-trip as null through the sentinels")
+    void absentSentinelsRoundTrip() {
+        // Both non-nullable flags are on, so these are written as the epoch and NaN sentinels. NaN is
+        // not valid JSON: Jackson quotes it, and the insert sets
+        // input_format_json_read_numbers_as_strings so ClickHouse parses it back.
+        var trace = newTraceBuilder().endTime(null).ttft(null).build();
+
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+        var actual = traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY);
+        assertThat(actual.endTime()).isNull();
+        assertThat(actual.ttft()).isNull();
+    }
+
+    @Test
+    @DisplayName("a batch of spans round-trips its decimal cost, usage map and tags")
+    void spansRoundTripTypedColumns() {
+        // The three encodings JSONEachRow is strictest about: Decimal128(12) written as a quoted plain
+        // string, Map(String, Int), and Array(String).
+        var cost = new BigDecimal("0.000123456789");
+        var span = newSpanBuilder()
+                .totalEstimatedCost(cost)
+                .usage(Map.of("prompt_tokens", 12, "completion_tokens", 8))
+                .tags(java.util.Set.of("alpha", "beta"))
+                .build();
+
+        spanResourceClient.batchCreateSpans(List.of(span), API_KEY, WORKSPACE_NAME);
+
+        var actual = spanResourceClient.getById(span.id(), WORKSPACE_NAME, API_KEY);
+        assertThat(actual.totalEstimatedCost()).isEqualByComparingTo(cost);
+        assertThat(actual.usage()).containsAllEntriesOf(Map.of("prompt_tokens", 12, "completion_tokens", 8));
+        assertThat(actual.tags()).containsExactlyInAnyOrder("alpha", "beta");
+    }
+
+    @Test
+    @DisplayName("absent span end_time and ttft round-trip as null through the sentinels")
+    void absentSpanSentinelsRoundTrip() {
+        var span = newSpanBuilder().endTime(null).ttft(null).build();
+
+        spanResourceClient.batchCreateSpans(List.of(span), API_KEY, WORKSPACE_NAME);
+
+        var actual = spanResourceClient.getById(span.id(), WORKSPACE_NAME, API_KEY);
+        assertThat(actual.endTime()).isNull();
+        assertThat(actual.ttft()).isNull();
+    }
+
+    @Test
+    @DisplayName("row content with newlines and quotes does not split a JSONEachRow line")
+    void contentWithNewlinesAndQuotesSurvives() {
+        // A literal newline in the payload would end the row early and the next row would parse as
+        // garbage — server-side, far from the cause. This is the escaping guarantee, verified end to end.
+        var awkward = JsonUtils.getJsonNodeFromString(
+                "{\"text\": \"line one\\nline \\\"two\\\"\\ttabbed\", \"unicode\": \"日本語 — ok\"}");
+        var first = newTraceBuilder().input(awkward).build();
+        var second = newTraceBuilder().build();
+
+        traceResourceClient.batchCreateTraces(List.of(first, second), API_KEY, WORKSPACE_NAME);
+
+        // Both rows must land: if the first split the line, the second would be lost or corrupt.
+        assertThat(traceResourceClient.getById(first.id(), WORKSPACE_NAME, API_KEY).input()).isEqualTo(awkward);
+        assertThat(traceResourceClient.getById(second.id(), WORKSPACE_NAME, API_KEY).id()).isEqualTo(second.id());
+    }
+
+    @Test
+    @DisplayName("a multi-row batch writes every row exactly once")
+    void multiRowBatchWritesEveryRow() {
+        var traces = List.of(newTraceBuilder().build(), newTraceBuilder().build(), newTraceBuilder().build());
+
+        traceResourceClient.batchCreateTraces(traces, API_KEY, WORKSPACE_NAME);
+
+        traces.forEach(trace -> assertThat(
+                traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY).id()).isEqualTo(trace.id()));
+    }
+
+    @Test
+    @DisplayName("start_time keeps sub-second precision through the client-side formatter")
+    void startTimeKeepsPrecision() {
+        // The rows carry client-formatted DateTime64 literals parsed with date_time_input_format=best_effort.
+        var startTime = Instant.parse("2026-09-07T10:11:12.123456Z");
+        var trace = newTraceBuilder().startTime(startTime).endTime(startTime.plusSeconds(2)).build();
+
+        traceResourceClient.batchCreateTraces(List.of(trace), API_KEY, WORKSPACE_NAME);
+
+        assertThat(traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY).startTime())
+                .isEqualTo(startTime);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/BulkInsertV2ClientIntegrationTest.java
@@ -1,5 +1,8 @@
 package com.comet.opik.infrastructure;
 
+import com.comet.opik.api.DatasetItem;
+import com.comet.opik.api.DatasetItemBatch;
+import com.comet.opik.api.DatasetItemSource;
 import com.comet.opik.api.Span;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
@@ -12,6 +15,7 @@ import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppCon
 import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
 import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
+import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
@@ -118,6 +122,7 @@ class BulkInsertV2ClientIntegrationTest {
     }
 
     private TraceResourceClient traceResourceClient;
+    private DatasetResourceClient datasetResourceClient;
     private SpanResourceClient spanResourceClient;
     private ConnectionFactory clickHouseConnectionFactory;
 
@@ -127,6 +132,7 @@ class BulkInsertV2ClientIntegrationTest {
         ClientSupportUtils.config(clientSupport);
         mockTargetWorkspace(wireMock.server(), API_KEY, WORKSPACE_NAME, WORKSPACE_ID, USER);
         traceResourceClient = new TraceResourceClient(clientSupport, baseUrl);
+        datasetResourceClient = new DatasetResourceClient(clientSupport, baseUrl);
         spanResourceClient = new SpanResourceClient(clientSupport, baseUrl);
         clickHouseConnectionFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(
                 clickHouseContainer, DATABASE_NAME).build();
@@ -275,5 +281,106 @@ class BulkInsertV2ClientIntegrationTest {
 
         assertThat(traceResourceClient.getById(trace.id(), WORKSPACE_NAME, API_KEY).startTime())
                 .isEqualTo(startTime);
+    }
+
+    // ------------------------------------------------------------------ dataset items ---
+    // Dataset versioning defaults to ON (TOGGLE_DATASET_VERSIONING_ENABLED), so PUT /datasets/items
+    // lands in DatasetItemVersionDAO#insertItems -- dataset_item_versions, 23 columns, the widest bulk
+    // write here. DatasetItemDAO#save covers the legacy dataset_items table on the same flag.
+
+    private DatasetItem newDatasetItem(Map<String, com.fasterxml.jackson.databind.JsonNode> data) {
+        return DatasetItem.builder()
+                .id(factory.manufacturePojo(DatasetItem.class).id())
+                .source(DatasetItemSource.MANUAL)
+                .data(data)
+                .build();
+    }
+
+    private UUID newDataset() {
+        return datasetResourceClient.createDataset(
+                DatasetResourceClient.buildDataset(factory), API_KEY, WORKSPACE_NAME);
+    }
+
+    @Test
+    @DisplayName("dataset items round-trip their data map, tags and source through JSONEachRow")
+    void datasetItemsRoundTrip() {
+        // data is Map(String, String) holding each value's serialized JsonNode, and tags is
+        // Array(String) -- the two encodings this row shares with the span path.
+        var datasetId = newDataset();
+        var data = Map.of(
+                "input", JsonUtils.getJsonNodeFromString("\"what is the capital of France?\""),
+                "expected_output", JsonUtils.getJsonNodeFromString("{\"answer\": \"Paris\"}"));
+        var item = newDatasetItem(data).toBuilder()
+                .tags(java.util.Set.of("alpha", "beta"))
+                .description("a description")
+                .build();
+
+        datasetResourceClient.createDatasetItems(
+                DatasetItemBatch.builder().datasetId(datasetId).items(List.of(item)).build(),
+                WORKSPACE_NAME, API_KEY);
+
+        var actual = datasetResourceClient.getDatasetItem(item.id(), API_KEY, WORKSPACE_NAME);
+        assertThat(actual.id()).isEqualTo(item.id());
+        assertThat(actual.source()).isEqualTo(DatasetItemSource.MANUAL);
+        assertThat(actual.data()).containsExactlyInAnyOrderEntriesOf(data);
+        assertThat(actual.tags()).containsExactlyInAnyOrder("alpha", "beta");
+        assertThat(actual.description()).isEqualTo("a description");
+    }
+
+    @Test
+    @DisplayName("dataset item content with newlines and quotes does not split a JSONEachRow line")
+    void datasetItemContentWithNewlinesSurvives() {
+        var datasetId = newDataset();
+        var awkward = JsonUtils.getJsonNodeFromString(
+                "{\"text\": \"line one\\nline \\\"two\\\"\\ttabbed\", \"unicode\": \"\u65e5\u672c\u8a9e \u2014 ok\"}");
+        var first = newDatasetItem(Map.of("input", awkward));
+        var second = newDatasetItem(Map.of("input", JsonUtils.getJsonNodeFromString("\"plain\"")));
+
+        datasetResourceClient.createDatasetItems(
+                DatasetItemBatch.builder().datasetId(datasetId).items(List.of(first, second)).build(),
+                WORKSPACE_NAME, API_KEY);
+
+        // If the first row's newline ended its line early, the second would be lost or corrupt.
+        assertThat(datasetResourceClient.getDatasetItem(first.id(), API_KEY, WORKSPACE_NAME).data())
+                .containsEntry("input", awkward);
+        assertThat(datasetResourceClient.getDatasetItem(second.id(), API_KEY, WORKSPACE_NAME).id())
+                .isEqualTo(second.id());
+    }
+
+    @Test
+    @DisplayName("a dataset item batch writes each row exactly once and server-stamps created_at")
+    void datasetItemBatchWritesEachRowOnceAndStampsCreatedAt() {
+        var datasetId = newDataset();
+        var items = List.of(
+                newDatasetItem(Map.of("input", JsonUtils.getJsonNodeFromString("\"one\""))),
+                newDatasetItem(Map.of("input", JsonUtils.getJsonNodeFromString("\"two\""))),
+                newDatasetItem(Map.of("input", JsonUtils.getJsonNodeFromString("\"three\""))));
+
+        datasetResourceClient.createDatasetItems(
+                DatasetItemBatch.builder().datasetId(datasetId).items(items).build(),
+                WORKSPACE_NAME, API_KEY);
+
+        var ids = items.stream().map(item -> "'" + item.id() + "'")
+                .collect(java.util.stream.Collectors.joining(","));
+
+        // Raw rows, no FINAL: reads collapse duplicates via LIMIT 1 BY, so a writer emitting every row
+        // twice would still satisfy a per-id read. Cardinality is the only assertion that sees it.
+        Long storedRows = queryOne(
+                "SELECT count() AS row_count FROM dataset_item_versions WHERE workspace_id = '%s' AND id IN (%s)"
+                        .formatted(WORKSPACE_ID, ids),
+                row -> row.get("row_count", Long.class));
+        assertThat(storedRows).isEqualTo(items.size());
+
+        // created_at and last_updated_at are omitted from the JSON row so their DEFAULT now64(9)
+        // stamps them. If they were sent as absent/zero instead, this would read back as the epoch --
+        // and last_updated_at is the ReplacingMergeTree version, so a zero there would make every
+        // later update lose to the original row.
+        Long stampedRows = queryOne(
+                ("SELECT count() AS row_count FROM dataset_item_versions WHERE workspace_id = '%s' "
+                        + "AND id IN (%s) AND created_at > toDateTime64('2000-01-01 00:00:00', 9) "
+                        + "AND last_updated_at > toDateTime64('2000-01-01 00:00:00', 9)")
+                        .formatted(WORKSPACE_ID, ids),
+                row -> row.get("row_count", Long.class));
+        assertThat(stampedRows).isEqualTo(items.size());
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
@@ -1,0 +1,203 @@
+package com.comet.opik.infrastructure.db;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.DataStreamWriter;
+import com.clickhouse.client.api.insert.InsertResponse;
+import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.metrics.Metric;
+import com.clickhouse.client.api.metrics.OperationMetrics;
+import com.clickhouse.client.api.metrics.ServerMetrics;
+import com.clickhouse.data.ClickHouseFormat;
+import com.comet.opik.utils.JsonUtils;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the JSONEachRow body this insert streams, with no ClickHouse in the loop.
+ *
+ * <p>What is worth testing here is the framing, because JSONEachRow is newline-delimited and a
+ * missing separator or an unflushed buffer would merge two rows into one malformed document — a
+ * failure that shows up as a server-side parse error far from its cause. The row content itself is
+ * the caller's business, and the type-level questions (quoted decimals, NaN, omitted defaults) can
+ * only be answered by a real server, so they live in the integration tests instead.
+ */
+class JsonEachRowBulkInsertTest {
+
+    private static final Function<String, ObjectNode> ROW_MAPPER = value -> {
+        ObjectNode node = JsonUtils.createObjectNode();
+        node.put("name", value);
+        return node;
+    };
+
+    private record Captured(String body, InsertSettings settings) {
+    }
+
+    private Captured insertAndCapture(Client client, List<String> items) {
+        var writerCaptor = ArgumentCaptor.forClass(DataStreamWriter.class);
+        var settingsCaptor = ArgumentCaptor.forClass(InsertSettings.class);
+
+        Long rows = new JsonEachRowBulkInsert(client)
+                .insert("traces", "log-comment", items, ROW_MAPPER)
+                .block();
+
+        assertThat(rows).isEqualTo(items.size());
+
+        verify(client).insert(eq("traces"), writerCaptor.capture(), eq(ClickHouseFormat.JSONEachRow),
+                settingsCaptor.capture());
+
+        var out = new ByteArrayOutputStream();
+        try {
+            writerCaptor.getValue().onOutput(out);
+        } catch (Exception e) {
+            throw new AssertionError("writer threw", e);
+        }
+
+        return new Captured(out.toString(StandardCharsets.UTF_8), settingsCaptor.getValue());
+    }
+
+    private static String settingValue(InsertSettings settings, String name) {
+        return settings.getAllSettings().entrySet().stream()
+                .filter(entry -> entry.getKey().equals(name) || entry.getKey().endsWith("." + name)
+                        || entry.getKey().endsWith("_" + name))
+                .map(entry -> String.valueOf(entry.getValue()))
+                .findFirst()
+                .orElseGet(() -> "ABSENT, settings were " + settings.getAllSettings().keySet());
+    }
+
+    private Client clientReturning(long rowsWritten) {
+        var metric = mock(Metric.class);
+        when(metric.getLong()).thenReturn(rowsWritten);
+
+        var metrics = mock(OperationMetrics.class);
+        when(metrics.getMetric(ServerMetrics.NUM_ROWS_WRITTEN)).thenReturn(metric);
+
+        var response = mock(InsertResponse.class);
+        when(response.getMetrics()).thenReturn(metrics);
+
+        var client = mock(Client.class);
+        when(client.insert(any(String.class), any(DataStreamWriter.class), any(ClickHouseFormat.class),
+                any(InsertSettings.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        return client;
+    }
+
+    @Test
+    @DisplayName("one row per item, newline delimited, no trailing separator issues")
+    void writesOneNewlineDelimitedRowPerItem() {
+        var captured = insertAndCapture(clientReturning(3L), List.of("a", "b", "c"));
+
+        assertThat(captured.body()).isEqualTo("""
+                {"name":"a"}
+                {"name":"b"}
+                {"name":"c"}
+                """);
+        assertThat(captured.body().lines()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("a single row still terminates with a newline")
+    void singleRowIsNewlineTerminated() {
+        var captured = insertAndCapture(clientReturning(1L), List.of("only"));
+
+        assertThat(captured.body()).isEqualTo("{\"name\":\"only\"}\n");
+    }
+
+    @Test
+    @DisplayName("the writer is replayable, so a client retry sends an identical body")
+    void writerIsReplayable() {
+        var client = clientReturning(2L);
+        var writerCaptor = ArgumentCaptor.forClass(DataStreamWriter.class);
+
+        new JsonEachRowBulkInsert(client).insert("spans", "log-comment", List.of("x", "y"), ROW_MAPPER).block();
+
+        verify(client).insert(eq("spans"), writerCaptor.capture(), any(ClickHouseFormat.class),
+                any(InsertSettings.class));
+
+        DataStreamWriter writer = writerCaptor.getValue();
+
+        var first = new ByteArrayOutputStream();
+        var second = new ByteArrayOutputStream();
+        try {
+            writer.onOutput(first);
+            writer.onRetry();
+            writer.onOutput(second);
+        } catch (Exception e) {
+            throw new AssertionError("writer threw", e);
+        }
+
+        assertThat(second.toString(StandardCharsets.UTF_8))
+                .isEqualTo(first.toString(StandardCharsets.UTF_8))
+                .isEqualTo("{\"name\":\"x\"}\n{\"name\":\"y\"}\n");
+    }
+
+    @Test
+    @DisplayName("multi-byte content is written as UTF-8, so the byte count is not the char count")
+    void writesUtf8() {
+        var captured = insertAndCapture(clientReturning(1L), List.of("日本語"));
+
+        assertThat(captured.body()).isEqualTo("{\"name\":\"日本語\"}\n");
+    }
+
+    @Test
+    @DisplayName("content that would break a hand-built body is escaped by Jackson")
+    void escapesContentThatWouldBreakTheBody() {
+        var captured = insertAndCapture(clientReturning(1L), List.of("a\"b\nc"));
+
+        // The newline inside the value must be escaped, not emitted literally — a literal one would
+        // split a single row into two malformed JSONEachRow lines.
+        assertThat(captured.body()).isEqualTo("{\"name\":\"a\\\"b\\nc\"}\n");
+        assertThat(captured.body().lines()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("the per-request server settings the row encoding depends on are set")
+    void setsTheServerSettingsTheEncodingDependsOn() {
+        var captured = insertAndCapture(clientReturning(1L), List.of("a"));
+
+        // Matched by key suffix: the client may namespace server settings internally, and this test is
+        // about the settings being applied, not about that internal key shape.
+        assertThat(settingValue(captured.settings(), "date_time_input_format")).isEqualTo("best_effort");
+        assertThat(settingValue(captured.settings(), "input_format_defaults_for_omitted_fields")).isEqualTo("1");
+        assertThat(settingValue(captured.settings(), "input_format_json_read_numbers_as_strings")).isEqualTo("1");
+    }
+
+    @Test
+    @DisplayName("an empty batch is a no-op rather than an empty insert")
+    void emptyBatchDoesNotCallTheClient() {
+        var client = mock(Client.class);
+
+        Long rows = new JsonEachRowBulkInsert(client).insert("traces", "log-comment", List.of(), ROW_MAPPER).block();
+
+        assertThat(rows).isZero();
+        verify(client, never()).insert(any(String.class), any(DataStreamWriter.class), any(ClickHouseFormat.class),
+                any(InsertSettings.class));
+    }
+
+    @Test
+    @DisplayName("the row count comes from the server, not from items.size()")
+    void returnsTheServerRowCount() {
+        // Deduplication or truncation would make these differ; the caller must see the server's number.
+        Long rows = new JsonEachRowBulkInsert(clientReturning(2L))
+                .insert("traces", "log-comment", List.of("a", "b", "c"), ROW_MAPPER)
+                .block();
+
+        assertThat(rows).isEqualTo(2L);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
@@ -15,12 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.ByteArrayOutputStream;
+import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -188,6 +190,42 @@ class JsonEachRowBulkInsertTest {
         assertThat(rows).isZero();
         verify(client, never()).insert(any(String.class), any(DataStreamWriter.class), any(ClickHouseFormat.class),
                 any(InsertSettings.class));
+    }
+
+    @Test
+    @DisplayName("the InsertResponse is closed on success")
+    void closesTheResponse() throws Exception {
+        var metric = mock(Metric.class);
+        when(metric.getLong()).thenReturn(1L);
+        var metrics = mock(OperationMetrics.class);
+        when(metrics.getMetric(ServerMetrics.NUM_ROWS_WRITTEN)).thenReturn(metric);
+        var response = mock(InsertResponse.class);
+        when(response.getMetrics()).thenReturn(metrics);
+        var client = mock(Client.class);
+        when(client.insert(any(String.class), any(DataStreamWriter.class), any(ClickHouseFormat.class),
+                any(InsertSettings.class))).thenReturn(CompletableFuture.completedFuture(response));
+
+        new JsonEachRowBulkInsert(client).insert("traces", "log-comment", List.of("a"), ROW_MAPPER).block();
+
+        // try-with-resources should release it; an unclosed response holds its stream, which over a
+        // few hundred batches per run would accumulate rather than fail loudly.
+        verify(response).close();
+    }
+
+    @Test
+    @DisplayName("a client failure surfaces its cause, not the ExecutionException wrapper")
+    void unwrapsTheClientFailure() {
+        var client = mock(Client.class);
+        when(client.insert(any(String.class), any(DataStreamWriter.class), any(ClickHouseFormat.class),
+                any(InsertSettings.class)))
+                .thenReturn(CompletableFuture.failedFuture(new SocketException("connection reset")));
+
+        // RetryUtils.handleConnectionError matches on the throwable's own class, so a SocketException
+        // still wrapped in ExecutionException would silently bypass the retry the R2DBC path gets.
+        assertThatThrownBy(() -> new JsonEachRowBulkInsert(client)
+                .insert("traces", "log-comment", List.of("a"), ROW_MAPPER)
+                .block())
+                .hasRootCauseInstanceOf(SocketException.class);
     }
 
     @Test

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/db/JsonEachRowBulkInsertTest.java
@@ -193,6 +193,38 @@ class JsonEachRowBulkInsertTest {
     }
 
     @Test
+    @DisplayName("an explicit null is written, not dropped by NON_NULL inclusion")
+    void writesExplicitNulls() {
+        // The configured mapper sets serialization inclusion to NON_NULL, and the DAOs call putNull() for
+        // columns that must receive SQL NULL rather than a column default (experiment_items.project_id,
+        // and end_time/ttft while those columns are still Nullable). If inclusion dropped the field the
+        // row would take the DDL default instead, which is a different cell.
+        Function<String, ObjectNode> nullMapper = value -> {
+            ObjectNode node = JsonUtils.createObjectNode();
+            node.put("name", value);
+            node.putNull("project_id");
+            return node;
+        };
+
+        var client = clientReturning(1L);
+        var writerCaptor = ArgumentCaptor.forClass(DataStreamWriter.class);
+
+        new JsonEachRowBulkInsert(client).insert("traces", "log-comment", List.of("a"), nullMapper).block();
+
+        verify(client).insert(eq("traces"), writerCaptor.capture(), any(ClickHouseFormat.class),
+                any(InsertSettings.class));
+
+        var out = new ByteArrayOutputStream();
+        try {
+            writerCaptor.getValue().onOutput(out);
+        } catch (Exception e) {
+            throw new AssertionError("writer threw", e);
+        }
+
+        assertThat(out.toString(StandardCharsets.UTF_8)).isEqualTo("{\"name\":\"a\",\"project_id\":null}\n");
+    }
+
+    @Test
     @DisplayName("the InsertResponse is closed on success")
     void closesTheResponse() throws Exception {
         var metric = mock(Metric.class);

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -139,6 +139,13 @@ databaseAnalyticsDataModel:
 
 # Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
 #   window, protecting data quality.
+bulkInsert:
+  # false: the R2DBC bulk path (one named parameter per column per row). true: rows streamed as
+  # JSONEachRow through the ClickHouse Java client v2, with no parameter binding. Both write identical
+  # cells, so this is safe to flip either way on a running install. Default false so an upgrade does not
+  # silently change the write path.
+  v2ClientEnabled: ${ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED:-false}
+
 uuidValidation:
   #  Default: true for tests
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -137,15 +137,15 @@ databaseAnalyticsDataModel:
   tracesDistributedWrapEnabled: false
   #  Default: false
 
-# Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
-#   window, protecting data quality.
 bulkInsert:
   # false: the R2DBC bulk path (one named parameter per column per row). true: rows streamed as
   # JSONEachRow through the ClickHouse Java client v2, with no parameter binding. Both write identical
   # cells, so this is safe to flip either way on a running install. Default false so an upgrade does not
   # silently change the write path.
-  v2ClientEnabled: ${ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED:-false}
+  v2ClientEnabled: false
 
+# Description: UUIDv7 ingestion validation. Rejects writes whose `id` embeds a timestamp outside the
+#   window, protecting data quality.
 uuidValidation:
   #  Default: true for tests
   #  Description: Operational kill-switch. When false, ids are not checked against the window (the


### PR DESCRIPTION
## Details

An alternative to #8177 on the same ticket, for A/B/C measurement against it.

The ClickHouse R2DBC driver resolves every `bind(name, value)` with a linear scan over the statement's parameter names. Bulk inserts render one placeholder per column per row, so a 1000-row span batch carries ~26k names and binding is O(n²). #8177 makes that scan cheap by binding positionally. This removes parameter binding from the bulk write paths altogether: rows are serialized to JSONEachRow and streamed through the ClickHouse Java client v2 — one HTTP body, compressed once by the client, parsed server-side in ClickHouse's fast path.

`ExperimentAggregatesDAOImpl` already does exactly this for `experiment_item_aggregates`, and its javadoc measured ~500× end-to-end on large batches. `JsonEachRowBulkInsert` factors that plumbing out so the three write paths the `experiment_items_bulk` benchmark drives can share it:

- `ExperimentItemDAO#insert` — 9 columns
- `TraceDAO#batchInsert` — 22 columns
- `SpanDAO#batchInsert` — 28 columns, the widest and so the worst case for the per-name scan

**Both paths stay in the image**, behind `bulkInsert.v2ClientEnabled` (`BulkInsertConfig`, read through `OpikConfiguration`; `ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED` in `config.yml` and `config-test.yml`). It **defaults to `false`**, so an upgrade does not silently change the write path and CI keeps covering the R2DBC path. Keeping both in the image is deliberate for the benchmark: the A/B then varies one setting rather than the build, which removes image-build differences as a confounder — one image can produce both arms.

### Cell-level parity

Every value comes from the same helper the R2DBC binder uses, so both paths write identical cells:

- The batch-wide `nowForBatch` fallback is preserved — one timestamp per batch, so downstream `MAX(last_updated_at)` aggregations stay stable.
- `created_at` / `last_updated_at` stay **absent** from the row so their column DEFAULTs stamp them server-side, matching the R2DBC column lists. This is load-bearing: `created_at` is the stalled-run reaper's item-level liveness signal (OPIK-7459). Hence `input_format_defaults_for_omitted_fields`.
- Epoch and NaN sentinels key off `traceColumnsNonNullable()` / `spanColumnsNonNullable()`, mirroring `bindEpochSentinel` / `bindNanSentinel` branch for branch.
- `total_estimated_cost` is written as a quoted plain string into `Decimal128(12)`, as `ExperimentAggregatesDAOImpl` does — no exponent notation, no float round-tripping.
- Where the R2DBC binder writes SQL `NULL` into a **non-nullable** column that has a DDL default (`source`, `truncation_threshold`), the JSON row **omits the field** instead. Same resulting cell, without depending on `input_format_null_as_default` the way the current `bindNull` silently does.
- Rows are built with Jackson, not string concatenation: the payload carries user trace input/output, so escaping is correct by construction. Errors log the row count only, never the payload.

### Streaming and compression

Rows are streamed through the client's `DataStreamWriter` overload, one row at a time into a `BufferedOutputStream`, so peak memory is a single row rather than the whole batch. An earlier revision of this branch assembled each batch into a `StringBuilder` and then a `byte[]`, holding the payload two to three times over — harmless for small rows, but trace `input`/`output` can be hundreds of KiB, so a 1000-row batch on concurrent requests was a real heap risk. Re-serializing from the source collection on each invocation also means the client's `onRetry` replays an identical body rather than resuming a half-written stream.

The body is deliberately **not** compressed here: the shared client is built with `compressClientRequest(true)` in `DatabaseAnalyticsFactory`, so it compresses the request body itself, and doing it again would only burn CPU.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8274

<!-- Alternative approach to the parameter-binding component of OPIK-8274; #8177 addresses the same cost by binding positionally. These are not meant to merge together. -->

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: implementation, this description. The commit carries a `Co-Authored-By: Claude Opus 5` trailer.
- Human verification: unit tests plus the sentinel and bulk integration suites run locally with the v2 flag on (see Testing); the full backend suite passed in CI on an earlier default-on revision. Benchmark numbers still outstanding.

## Testing

**Unit** — `JsonEachRowBulkInsertTest`, **8 tests, 0 failures**, no containers:

```
mvn -o test -Dtest=JsonEachRowBulkInsertTest
```

Covers the framing, where the streaming writer can break and where a fault surfaces far from its cause (a missing separator or unflushed buffer merges two rows into one malformed document): one row per item, newline-delimited and terminated; the writer replayable so a retry sends an identical body; UTF-8; and Jackson escaping an embedded newline that would otherwise split a row in two. Plus the three per-request server settings, the empty-batch no-op, and the count coming from the server rather than `items.size()`.

**Integration, with `bulkInsert.v2ClientEnabled=true`** — run locally against real ClickHouse/MySQL/Redis/ZooKeeper containers by adding `new CustomConfig("bulkInsert.v2ClientEnabled", "true")` to each class's `AppContextConfig`:

| Suite | Result |
|---|---|
| `TraceSentinelIntegrationTest` + `SpanSentinelIntegrationTest` | **24 tests, 0 failures, 0 errors** |
| `ExperimentsResourceTest$BulkUpload` | **25 tests, 0 failures, 0 errors** |

The sentinel suites are the ones that matter: they run with the non-nullable flags on and group cases by write path, so `BatchCreateTraces` / `BatchCreateSpans` exercise these JSON rows. They are what confirms the **NaN sentinel** encoding — Jackson quotes non-numeric doubles, so an absent `ttft` arrives as the string `"NaN"`, hence `input_format_json_read_numbers_as_strings=1`. `absentSentinelsArePhysicallyWritten` reads the raw column back, so this is verified against the server rather than assumed.

**Whole-suite evidence.** Commit `d2e3278915` — an earlier revision whose toggle defaulted **on** — passed the full **Backend Tests** workflow in CI, so every backend integration test ran through the JSONEachRow path on a real ClickHouse. That is the broadest signal available for this change.

**Coverage caveat, stated plainly.** With the flag now defaulting to `false`, CI exercises the **R2DBC** path; the v2 numbers above come from local runs with the override, and the CI evidence comes from the earlier default-on revision. There is no *permanent* CI coverage of the v2 path. Committing the overrides would buy that at the cost of removing R2DBC sentinel coverage — the cutover-critical path — so the right follow-up is a small dedicated IT covering the batch sentinel cases with the flag on, leaving the existing suites on R2DBC. Happy to add it here if reviewers prefer it in this PR.

**Not run:** the frontend and SDK suites (no changes to either).

Note for review: an earlier revision of this branch put `${ANALYTICS_DB_BULK_INSERT_V2_CLIENT_ENABLED:-false}` in `config-test.yml`. That file is not run through the environment-variable substitutor, so the boolean field received a literal String and app startup failed for every extension-based test. Fixed by using a literal `false` there. Worth knowing generally: the existing `${PYTHON_EVALUATOR_URL:-...}` in the same file is a **String** field and so swallows the same mistake silently.

## Documentation

None. `bulkInsert.v2ClientEnabled` defaults to `false` and is an operator/benchmark switch rather than a user-facing setting; it is documented in `BulkInsertConfig`'s javadoc and in `config.yml`.
