### PR TITLE
[NA] [FE] chore: rename "Opik Connect" to "Ollie" in the sidebar

### DIFF
--- a/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
+++ b/apps/opik-frontend/src/v2/layout/SideBar/helpers/getMenuItems.ts
@@ -82,7 +82,7 @@ const getMenuItems = ({
                 path: projectPath("/ollie"),
                 type: MENU_ITEM_TYPE.router as const,
                 icon: OllieOwl,
-                label: "Opik Connect",
+                label: "Ollie",
                 disabled: !projectPrefix,
               },
             ]


### PR DESCRIPTION
## Details

- The sidebar item under **Home** now reads **Ollie** instead of **Opik Connect**.
- Nothing else changes: same route (`/projects/$projectId/ollie`), same owl icon, same feature flag.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- N/A

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Single string literal change in `getMenuItems.ts`, plus this PR description.
- Human verification: Pending author review of the rendered sidebar.

## Testing

- No automated tests run. `apps/opik-frontend/node_modules` is not installed in this
  worktree, and `pre-commit` is not available on this machine.
- The change replaces one string literal inside an existing menu item object. It does
  not alter types, routes or control flow.
- Verified by inspection that no test or snapshot asserts the old label. The only other
  matches for "Opik Connect" are an unrelated upgrade message in
  `PairingStatusScreen.tsx` and a descriptive entry in
  `tests_end_to_end/coverage/taxonomy.yaml`. Both are left unchanged, as requested.

## Documentation

N/A
