### PR TITLE
[OPIK-7315] time the rollback statements, so the reverse replay's duration is recordable

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1006,6 +1006,10 @@ other feature: a slow query to tune, a dashboard label, a metric gone quiet, a b
 not the safer default — it discards post-cutover writes, runs the guard-less reverse replay, and returns the estate to
 the unpartitioned original, so it costs more than most faults are worth.
 
+`rollback.sh` passes `--time`, so every statement it runs prints its elapsed seconds. Record the **reverse replay's**:
+it is the step that scales with the number of bridged deletions, so it is the one to compare against the window below.
+The promotes and the un-wrap are single `RENAME`s and are effectively constant.
+
 Two things bound the decision rather than a stopwatch. The **window** is open only while the parked original exists —
 `finalize.sh` closes it, and nothing reopens it (see "Point of no return"). And in practice the decision is made in the
 hours after the cutover, while the soak is still fresh: the longer the successor serves traffic well, the less a rollback

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1006,9 +1006,9 @@ other feature: a slow query to tune, a dashboard label, a metric gone quiet, a b
 not the safer default — it discards post-cutover writes, runs the guard-less reverse replay, and returns the estate to
 the unpartitioned original, so it costs more than most faults are worth.
 
-`rollback.sh` passes `--time`, so every statement it runs prints its elapsed seconds. Record the **reverse replay's**:
-it is the step that scales with the number of bridged deletions, so it is the one to compare against the window below.
-The promotes and the un-wrap are single `RENAME`s and are effectively constant.
+`rollback.sh` passes `--time`, so every statement it runs prints its elapsed seconds. Record the figure for the
+**reverse replay**: it scales with the number of bridged deletions, so that is the number to compare against the window
+below. The promotes and the un-wrap are single `RENAME`s and are effectively constant.
 
 Two things bound the decision rather than a stopwatch. The **window** is open only while the parked original exists —
 `finalize.sh` closes it, and nothing reopens it (see "Point of no return"). And in practice the decision is made in the

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -581,7 +581,10 @@ run_file() {
     sql="${sql//'${CUTOVER_START}'/$CUTOVER_START}"
     sql="${sql//'${SENTINEL_WINDOW_FROM}'/$SENTINEL_WINDOW_FROM}"
     sql="${sql//'${SENTINEL_WINDOW_TO}'/$SENTINEL_WINDOW_TO}"
-    clickhouse-client "${CH_ARGS[@]}" --multiquery --query "$sql"
+    # --time prints each statement's elapsed seconds to stderr. Every mutating rollback statement runs through here,
+    # and the reverse replay's duration is the one that scales with the bridge window -- the figure to record against
+    # the parked-table window, as delta_replay.sh already prints for the forward replay.
+    clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
 }
 
 # Un-wrap mode: reverse the Distributed wrap and stop, leaving the partitioned successor live (see


### PR DESCRIPTION
## Details

The rollback runbook asks the operator to size a rollback against the window the parked original stays available for, but `rollback.sh` printed no durations, so that figure could not be recorded. `run_file` now passes `--time`, which covers every mutating rollback statement.

- The reverse deletion replay is the step whose duration scales with the number of bridged deletions; the stage promotes and the un-wrap are single `RENAME`s and are effectively constant.
- The forward replay was already timed in `delta_replay.sh` and in `exchange_and_wrap.sh`'s final deletion replay, so this makes the reverse path consistent with it.
- Timings go to stderr, so no statement output changes. `run_file`'s stdout is never captured; the one caller that inspects it reads the exit status, and the two helpers that do capture output (`sentinel_counts` and the postcondition read) do not go through `run_file`.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves OPIK-7315

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: the `--time` flag on `run_file`, the runbook paragraph naming the figure to record, and the commit and PR text. Reviewed line by line by the author before pushing.
- Human verification: author read the full diff; the ClickHouse behaviour below was checked against a real server rather than assumed, and the "stdout is never captured" claim was verified by inspecting every `run_file` call site.

## Testing

Environment: local Docker, `clickhouse/clickhouse-server:26.3.16.16-alpine` (the version production runs).

Commands run:

- `bash -n apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh` — clean.
- `clickhouse-client --time --multiquery --query "SELECT sleep(0.4) FORMAT Null; SELECT sleep(0.2) FORMAT Null;"` — printed `0.403` and `0.204`, confirming per-statement elapsed seconds rather than one total.
- `clickhouse-client --time --multiquery --query "SELECT 42" 2>/dev/null` — printed `42`, confirming the timings go to stderr and stdout stays clean.

Scenarios validated:

- Every `run_file` call site inspected: the reverse replay (three sites), the stage A/B/C promotes, the un-wrap and the sentinel repair all gain timing, and none of them captures stdout.
- The two output-capturing helpers were confirmed not to route through `run_file`, so their parsing is unaffected.

Not run, with reason:

- The drivers themselves were not executed against any live estate. They mutate, and this touches the rollback path, which is deliberately not being exercised on the Comet production cutover. The behaviour that this change depends on is the client flag, which is covered above.
- The Java suite was not re-run: this PR changes no Java and no SQL, only a client flag and a runbook paragraph.

## Documentation

`README.md` in the same directory now states that `rollback.sh` passes `--time`, and names the reverse replay as the figure to record against the parked-table window, with the reason the promotes and the un-wrap are not the interesting numbers. No other documentation is affected.
