### PR TITLE
feat(opik-frontend): bulk annotate traces/spans from the table actions panel

### DIFF
--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
@@ -201,9 +201,7 @@ describe("AnnotateTracesDialog", () => {
     fireEvent.click(
       screen.getByTestId("annotate-bulk-score-select-option-satisfaction"),
     );
-    fireEvent.click(
-      screen.getByTestId("annotate-bulk-category-select-option-good"),
-    );
+    fireEvent.click(screen.getByTestId("annotate-bulk-category-toggle-good"));
 
     await waitFor(() => {
       expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-
 import AnnotateTracesDialog from "./AnnotateTracesDialog";
-import { Trace } from "@/types/traces";
+import { Span, Trace } from "@/types/traces";
 import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import { FEEDBACK_DEFINITION_TYPE } from "@/types/feedback-definitions";
 
 const mockSetFeedbackScore = vi.fn();
+const mockToast = vi.fn();
+const mockSetOpen = vi.fn();
 
 vi.mock("@/api/feedback-definitions/useFeedbackDefinitionsList", () => ({
   default: vi.fn(() => ({
@@ -55,11 +56,11 @@ vi.mock("@/shared/SelectBox/SelectBox", () => ({
   default: ({
     options,
     onChange,
-    "data-testid": testId,
+    testId,
   }: {
     options: Array<{ label: string; value: string }>;
     onChange: (value?: string) => void;
-    "data-testid"?: string;
+    testId?: string;
   }) => (
     <div data-testid={testId}>
       {options.map((option) => (
@@ -77,7 +78,7 @@ vi.mock("@/shared/SelectBox/SelectBox", () => ({
 }));
 
 vi.mock("@/ui/use-toast", () => ({
-  useToast: vi.fn(() => ({ toast: vi.fn() })),
+  useToast: vi.fn(() => ({ toast: mockToast })),
 }));
 
 const mockTraces: Trace[] = [
@@ -85,17 +86,30 @@ const mockTraces: Trace[] = [
   { id: "trace-2" } as Trace,
 ];
 
-const renderDialog = () => {
-  const setOpen = vi.fn();
+const renderDialog = (
+  rows: Array<Trace | Span> = mockTraces,
+  type: TRACE_DATA_TYPE = TRACE_DATA_TYPE.traces,
+) => {
   render(
     <AnnotateTracesDialog
-      rows={mockTraces}
+      rows={rows}
       open={true}
-      setOpen={setOpen}
-      type={TRACE_DATA_TYPE.traces}
+      setOpen={mockSetOpen}
+      type={type}
     />,
   );
-  return setOpen;
+};
+
+const selectNumericalScore = async () => {
+  fireEvent.click(
+    screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+  );
+  fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
+    target: { value: "7" },
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+  });
 };
 
 describe("AnnotateTracesDialog", () => {
@@ -114,33 +128,13 @@ describe("AnnotateTracesDialog", () => {
 
   it("enables apply after selecting a score and entering a valid value", async () => {
     renderDialog();
-
-    fireEvent.click(
-      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
-    );
-
-    const input = screen.getByTestId("annotate-bulk-score-input");
-    fireEvent.change(input, { target: { value: "7" } });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
-    });
+    await selectNumericalScore();
   });
 
   it("submits an annotation for every selected row", async () => {
     mockSetFeedbackScore.mockResolvedValue({});
     renderDialog();
-
-    fireEvent.click(
-      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
-    );
-    fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
-      target: { value: "7" },
-    });
-
-    await waitFor(() => {
-      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
-    });
+    await selectNumericalScore();
 
     fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
 
@@ -162,6 +156,42 @@ describe("AnnotateTracesDialog", () => {
         traceId: "trace-2",
       }),
     );
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Annotations applied" }),
+    );
+  });
+
+  it("preserves the entered reason when switching scores", async () => {
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.change(screen.getByTestId("annotate-bulk-reason-input"), {
+      target: { value: "looks good" },
+    });
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-satisfaction"),
+    );
+
+    expect(screen.getByTestId("annotate-bulk-reason-input")).toHaveValue(
+      "looks good",
+    );
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeDisabled();
+  });
+
+  it("disables apply and skips submission for out-of-range values", async () => {
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+    );
+    fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
+      target: { value: "99" },
+    });
+
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+    expect(mockSetFeedbackScore).not.toHaveBeenCalled();
   });
 
   it("supports categorical scores via category selection", async () => {
@@ -190,5 +220,98 @@ describe("AnnotateTracesDialog", () => {
         }),
       );
     });
+  });
+
+  it("maps boolean scores to their labels and numeric values", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-thumbs"),
+    );
+    fireEvent.click(screen.getByText("up"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "thumbs",
+          value: 1,
+          categoryName: "up",
+        }),
+      );
+    });
+  });
+
+  it("fans out span annotations with spanId and parent traceId", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    const spans: Span[] = [
+      { id: "span-1", trace_id: "trace-1" } as Span,
+      { id: "span-2", trace_id: "trace-1" } as Span,
+    ];
+    renderDialog(spans, TRACE_DATA_TYPE.spans);
+
+    expect(screen.getByText("Annotate spans")).toBeInTheDocument();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-1",
+        spanId: "span-1",
+      }),
+    );
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-1",
+        spanId: "span-2",
+      }),
+    );
+  });
+
+  it("toasts a full failure when every mutation is rejected", async () => {
+    mockSetFeedbackScore.mockRejectedValue(new Error("boom"));
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Error" }),
+      );
+    });
+    expect(mockSetOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("toasts a partial failure with the success count", async () => {
+    mockSetFeedbackScore
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("boom"));
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Partially applied" }),
+      );
+    });
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "1 of 2 traces annotated successfully.",
+      }),
+    );
   });
 });

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import AnnotateTracesDialog from "./AnnotateTracesDialog";
+import { Trace } from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { FEEDBACK_DEFINITION_TYPE } from "@/types/feedback-definitions";
+
+const mockSetFeedbackScore = vi.fn();
+
+vi.mock("@/api/feedback-definitions/useFeedbackDefinitionsList", () => ({
+  default: vi.fn(() => ({
+    data: {
+      content: [
+        {
+          name: "helpfulness",
+          type: FEEDBACK_DEFINITION_TYPE.numerical,
+          details: { min: 0, max: 10 },
+        },
+        {
+          name: "satisfaction",
+          type: FEEDBACK_DEFINITION_TYPE.categorical,
+          details: { categories: { good: 1, bad: 0 } },
+        },
+        {
+          name: "thumbs",
+          type: FEEDBACK_DEFINITION_TYPE.boolean,
+          details: { true_label: "up", false_label: "down" },
+        },
+      ],
+      total: 3,
+    },
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/api/traces/useTraceFeedbackScoreSetMutation", () => ({
+  default: vi.fn(() => ({
+    mutateAsync: mockSetFeedbackScore,
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/store/AppStore", () => ({
+  default: vi.fn((selector) =>
+    selector({
+      activeWorkspaceName: "test-workspace",
+      activeProjectId: "test-project-id",
+      loggedInUserName: "tester",
+    }),
+  ),
+}));
+
+vi.mock("@/shared/SelectBox/SelectBox", () => ({
+  default: ({
+    options,
+    onChange,
+    "data-testid": testId,
+  }: {
+    options: Array<{ label: string; value: string }>;
+    onChange: (value?: string) => void;
+    "data-testid"?: string;
+  }) => (
+    <div data-testid={testId}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`${testId}-option-${option.value}`}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: vi.fn(() => ({ toast: vi.fn() })),
+}));
+
+const mockTraces: Trace[] = [
+  { id: "trace-1" } as Trace,
+  { id: "trace-2" } as Trace,
+];
+
+const renderDialog = () => {
+  const setOpen = vi.fn();
+  render(
+    <AnnotateTracesDialog
+      rows={mockTraces}
+      open={true}
+      setOpen={setOpen}
+      type={TRACE_DATA_TYPE.traces}
+    />,
+  );
+  return setOpen;
+};
+
+describe("AnnotateTracesDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the dialog with selection count and disabled apply button", () => {
+    renderDialog();
+
+    expect(screen.getByText("Annotate traces")).toBeInTheDocument();
+    expect(screen.getByText(/2 selected/)).toBeInTheDocument();
+    const applyButton = screen.getByTestId("annotate-bulk-apply-button");
+    expect(applyButton).toBeDisabled();
+  });
+
+  it("enables apply after selecting a score and entering a valid value", async () => {
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+    );
+
+    const input = screen.getByTestId("annotate-bulk-score-input");
+    fireEvent.change(input, { target: { value: "7" } });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+  });
+
+  it("submits an annotation for every selected row", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+    );
+    fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
+      target: { value: "7" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "helpfulness",
+        value: 7,
+        traceId: "trace-1",
+      }),
+    );
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "helpfulness",
+        value: 7,
+        traceId: "trace-2",
+      }),
+    );
+  });
+
+  it("supports categorical scores via category selection", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-satisfaction"),
+    );
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-category-select-option-good"),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "satisfaction",
+          categoryName: "good",
+          value: 1,
+        }),
+      );
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -1,0 +1,357 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { useToast } from "@/ui/use-toast";
+import { Loader2 } from "lucide-react";
+import { Span, Trace } from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import useTraceFeedbackScoreSetMutation from "@/api/traces/useTraceFeedbackScoreSetMutation";
+import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
+import useAppStore from "@/store/AppStore";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
+import DebounceInput from "@/shared/DebounceInput/DebounceInput";
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
+import SelectBox from "@/shared/SelectBox/SelectBox";
+import { SelectItem } from "@/ui/select";
+import { DropdownOption } from "@/types/shared";
+import { Textarea } from "@/ui/textarea";
+
+type AnnotateTracesDialogProps = {
+  rows: Array<Trace | Span>;
+  open: boolean | number;
+  setOpen: (open: boolean | number) => void;
+  type: TRACE_DATA_TYPE;
+};
+
+type DraftScore = {
+  name?: string;
+  value?: number;
+  categoryName?: string;
+  reason?: string;
+};
+
+const AnnotateTracesDialog: React.FunctionComponent<
+  AnnotateTracesDialogProps
+> = ({ rows, open, setOpen, type }) => {
+  const { toast } = useToast();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const { data: feedbackDefinitionsData } = useFeedbackDefinitionsList({
+    workspaceName,
+    page: 1,
+    size: 1000,
+  });
+  const { mutateAsync: setFeedbackScore } = useTraceFeedbackScoreSetMutation();
+
+  const [draft, setDraft] = useState<DraftScore>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isSpanType = type === TRACE_DATA_TYPE.spans;
+  const entityCopy = isSpanType ? "spans" : "traces";
+
+  const feedbackDefinitions: FeedbackDefinition[] = useMemo(
+    () => feedbackDefinitionsData?.content || [],
+    [feedbackDefinitionsData?.content],
+  );
+
+  const selectedDefinition = useMemo(
+    () =>
+      feedbackDefinitions.find((definition) => definition.name === draft.name),
+    [feedbackDefinitions, draft.name],
+  );
+
+  const isValueValid = useMemo(() => {
+    if (!selectedDefinition || draft.value === undefined) {
+      return false;
+    }
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+      return isNumericFeedbackScoreValid(
+        selectedDefinition.details as { min: number; max: number },
+        draft.value,
+      );
+    }
+    return true;
+  }, [selectedDefinition, draft.value]);
+
+  const handleScoreNameChange = useCallback((name: string) => {
+    setDraft({ name });
+  }, []);
+
+  const handleNumericValueChange = useCallback(
+    (value: string | number | readonly string[] | undefined) => {
+      const num =
+        typeof value === "string" && value !== "" ? Number(value) : value;
+      if (typeof num !== "number" || Number.isNaN(num) || !selectedDefinition) {
+        setDraft((d) => ({ ...d, value: undefined }));
+        return;
+      }
+      if (
+        isNumericFeedbackScoreValid(
+          selectedDefinition.details as { min: number; max: number },
+          num,
+        )
+      ) {
+        setDraft((d) => ({ ...d, value: num }));
+      }
+    },
+    [selectedDefinition],
+  );
+
+  const handleApply = useCallback(async () => {
+    if (!isValueValid || !draft.name || draft.value === undefined) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const results = await Promise.allSettled(
+      rows.map((row) => {
+        const isSpan = isSpanType;
+        return setFeedbackScore({
+          name: draft.name!,
+          value: draft.value!,
+          categoryName: draft.categoryName,
+          reason: draft.reason || undefined,
+          traceId: isSpan ? (row as Span).trace_id : (row as Trace).id,
+          spanId: isSpan ? (row as Span).id : undefined,
+        });
+      }),
+    );
+
+    const failed = results.filter(
+      (result) => result.status === "rejected",
+    ).length;
+
+    setIsSubmitting(false);
+
+    if (failed === 0) {
+      toast({
+        title: "Annotations applied",
+        description: `Successfully annotated ${rows.length} ${entityCopy}.`,
+      });
+      setDraft({});
+      setOpen(false);
+    } else if (failed === rows.length) {
+      toast({
+        title: "Error",
+        description: `Failed to annotate all selected ${entityCopy}.`,
+        variant: "destructive",
+      });
+    } else {
+      toast({
+        title: "Partially applied",
+        description: `${rows.length - failed} of ${
+          rows.length
+        } ${entityCopy} annotated successfully.`,
+        variant: "destructive",
+      });
+      setDraft({});
+      setOpen(false);
+    }
+  }, [
+    isValueValid,
+    draft,
+    rows,
+    isSpanType,
+    entityCopy,
+    setFeedbackScore,
+    setOpen,
+    toast,
+  ]);
+
+  const renderValueInput = () => {
+    if (!selectedDefinition) {
+      return null;
+    }
+
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+      return (
+        <DebounceInput
+          className="my-0.5 h-8 min-w-[120px] py-1"
+          max={selectedDefinition.details.max}
+          min={selectedDefinition.details.min}
+          step="any"
+          dimension="sm"
+          delay={300}
+          onValueChange={handleNumericValueChange}
+          placeholder="Score"
+          type="number"
+          value={draft.value ?? ""}
+          data-testid="annotate-bulk-score-input"
+        />
+      );
+    }
+
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
+      return (
+        <ToggleGroup
+          className="min-w-fit p-0.5"
+          onValueChange={(value?: string) => {
+            if (!value) {
+              return;
+            }
+            setDraft((d) => ({
+              ...d,
+              value: value === selectedDefinition.details.true_label ? 1 : 0,
+              categoryName: value,
+            }));
+          }}
+          variant="outline"
+          type="single"
+          size="md"
+          value={draft.categoryName ?? ""}
+        >
+          <ToggleGroupItem
+            className="w-full"
+            key="true"
+            value={selectedDefinition.details.true_label}
+          >
+            {selectedDefinition.details.true_label}
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            className="w-full"
+            key="false"
+            value={selectedDefinition.details.false_label}
+          >
+            {selectedDefinition.details.false_label}
+          </ToggleGroupItem>
+        </ToggleGroup>
+      );
+    }
+
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
+      const categoricalOptionList = Object.entries(
+        selectedDefinition.details.categories,
+      ).map(([name, value]) => ({
+        label: name,
+        value: name,
+        description: String(value),
+      }));
+
+      return (
+        <SelectBox
+          value={draft.categoryName ?? ""}
+          options={categoricalOptionList}
+          onChange={(value?: string) => {
+            if (!value) {
+              return;
+            }
+            const categoryValue = Object.entries(
+              selectedDefinition.details.categories,
+            ).find(([categoryName]) => categoryName === value)?.[1];
+
+            setDraft((d) => ({
+              ...d,
+              categoryName: value,
+              value: categoryValue,
+            }));
+          }}
+          className="my-0.5 h-8 min-w-[160px] py-1"
+          renderTrigger={(value) => {
+            if (!value) {
+              return <div className="truncate">Select a category</div>;
+            }
+            return <span className="text-nowrap">{value}</span>;
+          }}
+          renderOption={(option: DropdownOption<string>) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.value} ({option.description})
+            </SelectItem>
+          )}
+          data-testid="annotate-bulk-category-select"
+        />
+      );
+    }
+
+    return null;
+  };
+
+  return (
+    <Dialog open={Boolean(open)} onOpenChange={setOpen}>
+      <DialogContent className="max-w-lg" data-testid="annotate-bulk-dialog">
+        <DialogHeader>
+          <DialogTitle>Annotate {entityCopy}</DialogTitle>
+        </DialogHeader>
+        <p className="comet-body-s text-light-slate">
+          Apply the same feedback score to {rows.length} selected {entityCopy}.
+        </p>
+        <div className="flex flex-col gap-3 py-2">
+          <div>
+            <div className="comet-body-s-accented pb-1">Score</div>
+            <SelectBox
+              value={draft.name ?? ""}
+              options={feedbackDefinitions.map((definition) => ({
+                label: definition.name,
+                value: definition.name,
+              }))}
+              onChange={handleScoreNameChange}
+              className="h-8 min-w-[200px] py-1"
+              renderTrigger={(value) => {
+                if (!value) {
+                  return <div className="truncate">Select a score</div>;
+                }
+                return <span className="text-nowrap">{value}</span>;
+              }}
+              renderOption={(option: DropdownOption<string>) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              )}
+              data-testid="annotate-bulk-score-select"
+            />
+          </div>
+          {selectedDefinition && (
+            <div>
+              <div className="comet-body-s-accented pb-1">Value</div>
+              {renderValueInput()}
+            </div>
+          )}
+          {selectedDefinition && (
+            <div>
+              <div className="comet-body-s-accented pb-1">
+                Reason (optional)
+              </div>
+              <Textarea
+                placeholder="Add a reason..."
+                value={draft.reason ?? ""}
+                onChange={(event) =>
+                  setDraft((d) => ({ ...d, reason: event.target.value }))
+                }
+                className="min-h-8 resize-none py-1"
+                data-testid="annotate-bulk-reason-input"
+              />
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleApply}
+            disabled={!isValueValid || isSubmitting}
+            data-testid="annotate-bulk-apply-button"
+          >
+            {isSubmitting && <Loader2 className="mr-1 size-3 animate-spin" />}
+            Apply to {rows.length} {entityCopy}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AnnotateTracesDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -48,11 +48,19 @@ const AnnotateTracesDialog: React.FunctionComponent<
 > = ({ rows, open, setOpen, type }) => {
   const { toast } = useToast();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
-  const { data: feedbackDefinitionsData } = useFeedbackDefinitionsList({
-    workspaceName,
-    page: 1,
-    size: 1000,
-  });
+  const {
+    data: feedbackDefinitionsData,
+    isLoading: isDefinitionsLoading,
+    isError: isDefinitionsError,
+    refetch: refetchDefinitions,
+  } = useFeedbackDefinitionsList(
+    {
+      workspaceName,
+      page: 1,
+      size: 1000,
+    },
+    { enabled: Boolean(open) },
+  );
   const { mutateAsync: setFeedbackScore } = useTraceFeedbackScoreSetMutation();
 
   const [draft, setDraft] = useState<DraftScore>({});
@@ -323,51 +331,73 @@ const AnnotateTracesDialog: React.FunctionComponent<
           Apply the same feedback score to {rows.length} selected {entityCopy}.
         </p>
         <div className="flex flex-col gap-3 py-2">
-          <div>
-            <div className="comet-body-s-accented pb-1">Score</div>
-            <SelectBox
-              value={draft.name ?? ""}
-              options={feedbackDefinitions.map((definition) => ({
-                label: definition.name,
-                value: definition.name,
-              }))}
-              onChange={handleScoreNameChange}
-              className="h-8 min-w-[200px] py-1"
-              testId="annotate-bulk-score-select"
-              renderTrigger={(value) => {
-                if (!value) {
-                  return <div className="truncate">Select a score</div>;
-                }
-                return <span className="text-nowrap">{value}</span>;
-              }}
-              renderOption={(option: DropdownOption<string>) => (
-                <SelectItem key={option.value} value={option.value}>
-                  {option.label}
-                </SelectItem>
-              )}
-            />
-          </div>
-          {selectedDefinition && (
-            <div>
-              <div className="comet-body-s-accented pb-1">Value</div>
-              {renderValueInput()}
+          {isDefinitionsError ? (
+            <div
+              className="comet-body-s text-red-600"
+              data-testid="annotate-bulk-error"
+            >
+              Failed to load feedback definitions.
+              <Button
+                variant="link"
+                size="sm"
+                onClick={() => refetchDefinitions()}
+              >
+                Retry
+              </Button>
             </div>
-          )}
-          {selectedDefinition && (
-            <div>
-              <div className="comet-body-s-accented pb-1">
-                Reason (optional)
+          ) : isDefinitionsLoading ? (
+            <div className="comet-body-s text-light-slate">
+              Loading feedback definitions…
+            </div>
+          ) : (
+            <>
+              <div>
+                <div className="comet-body-s-accented pb-1">Score</div>
+                <SelectBox
+                  value={draft.name ?? ""}
+                  options={feedbackDefinitions.map((definition) => ({
+                    label: definition.name,
+                    value: definition.name,
+                  }))}
+                  onChange={handleScoreNameChange}
+                  className="h-8 min-w-[200px] py-1"
+                  testId="annotate-bulk-score-select"
+                  renderTrigger={(value) => {
+                    if (!value) {
+                      return <div className="truncate">Select a score</div>;
+                    }
+                    return <span className="text-nowrap">{value}</span>;
+                  }}
+                  renderOption={(option: DropdownOption<string>) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  )}
+                />
               </div>
-              <Textarea
-                placeholder="Add a reason..."
-                value={draft.reason ?? ""}
-                onChange={(event) =>
-                  setDraft((d) => ({ ...d, reason: event.target.value }))
-                }
-                className="min-h-8 resize-none py-1"
-                data-testid="annotate-bulk-reason-input"
-              />
-            </div>
+              {selectedDefinition && (
+                <div>
+                  <div className="comet-body-s-accented pb-1">Value</div>
+                  {renderValueInput()}
+                </div>
+              )}
+              {selectedDefinition && (
+                <div>
+                  <div className="comet-body-s-accented pb-1">
+                    Reason (optional)
+                  </div>
+                  <Textarea
+                    placeholder="Add a reason..."
+                    value={draft.reason ?? ""}
+                    onChange={(event) =>
+                      setDraft((d) => ({ ...d, reason: event.target.value }))
+                    }
+                    className="min-h-8 resize-none py-1"
+                    data-testid="annotate-bulk-reason-input"
+                  />
+                </div>
+              )}
+            </>
           )}
         </div>
         <DialogFooter>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -25,6 +25,9 @@ import SelectBox from "@/shared/SelectBox/SelectBox";
 import { SelectItem } from "@/ui/select";
 import { DropdownOption } from "@/types/shared";
 import { Textarea } from "@/ui/textarea";
+
+const MAX_ANNOTATE_ROWS = 500;
+const MAX_CONCURRENT_ANNOTATIONS = 5;
 
 type AnnotateTracesDialogProps = {
   rows: Array<Trace | Span>;
@@ -82,26 +85,43 @@ const AnnotateTracesDialog: React.FunctionComponent<
     return true;
   }, [selectedDefinition, draft.value]);
 
+  useEffect(() => {
+    if (open && rows.length > MAX_ANNOTATE_ROWS) {
+      toast({
+        title: "Error",
+        description: `You can only annotate up to ${MAX_ANNOTATE_ROWS} ${entityCopy} at a time. Please select fewer items.`,
+        variant: "destructive",
+      });
+      setOpen(false);
+    }
+  }, [open, rows.length, entityCopy, setOpen, toast]);
+
   const handleScoreNameChange = useCallback((name: string) => {
-    setDraft({ name });
+    setDraft((d) => ({
+      name,
+      value: undefined,
+      categoryName: undefined,
+      reason: d.reason,
+    }));
   }, []);
 
   const handleNumericValueChange = useCallback(
     (value: string | number | readonly string[] | undefined) => {
       const num =
         typeof value === "string" && value !== "" ? Number(value) : value;
-      if (typeof num !== "number" || Number.isNaN(num) || !selectedDefinition) {
-        setDraft((d) => ({ ...d, value: undefined }));
-        return;
-      }
       if (
-        isNumericFeedbackScoreValid(
+        typeof num !== "number" ||
+        Number.isNaN(num) ||
+        !selectedDefinition ||
+        !isNumericFeedbackScoreValid(
           selectedDefinition.details as { min: number; max: number },
           num,
         )
       ) {
-        setDraft((d) => ({ ...d, value: num }));
+        setDraft((d) => ({ ...d, value: undefined }));
+        return;
       }
+      setDraft((d) => ({ ...d, value: num }));
     },
     [selectedDefinition],
   );
@@ -113,18 +133,36 @@ const AnnotateTracesDialog: React.FunctionComponent<
 
     setIsSubmitting(true);
 
-    const results = await Promise.allSettled(
-      rows.map((row) => {
-        const isSpan = isSpanType;
-        return setFeedbackScore({
+    const results: Array<PromiseSettledResult<void>> = [];
+    const queue = [...rows];
+    const submitOne = async (row: Trace | Span) => {
+      try {
+        await setFeedbackScore({
           name: draft.name!,
           value: draft.value!,
           categoryName: draft.categoryName,
           reason: draft.reason || undefined,
-          traceId: isSpan ? (row as Span).trace_id : (row as Trace).id,
-          spanId: isSpan ? (row as Span).id : undefined,
+          traceId: isSpanType ? (row as Span).trace_id : (row as Trace).id,
+          spanId: isSpanType ? (row as Span).id : undefined,
         });
-      }),
+        results.push({ status: "fulfilled", value: undefined });
+      } catch (error) {
+        results.push({ status: "rejected", reason: error });
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(MAX_CONCURRENT_ANNOTATIONS, queue.length) },
+        async () => {
+          while (queue.length > 0) {
+            const row = queue.shift();
+            if (!row) {
+              break;
+            }
+            await submitOne(row);
+          }
+        },
+      ),
     );
 
     const failed = results.filter(
@@ -256,6 +294,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
             }));
           }}
           className="my-0.5 h-8 min-w-[160px] py-1"
+          testId="annotate-bulk-category-select"
           renderTrigger={(value) => {
             if (!value) {
               return <div className="truncate">Select a category</div>;
@@ -267,7 +306,6 @@ const AnnotateTracesDialog: React.FunctionComponent<
               {option.value} ({option.description})
             </SelectItem>
           )}
-          data-testid="annotate-bulk-category-select"
         />
       );
     }
@@ -295,6 +333,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
               }))}
               onChange={handleScoreNameChange}
               className="h-8 min-w-[200px] py-1"
+              testId="annotate-bulk-score-select"
               renderTrigger={(value) => {
                 if (!value) {
                   return <div className="truncate">Select a score</div>;
@@ -306,7 +345,6 @@ const AnnotateTracesDialog: React.FunctionComponent<
                   {option.label}
                 </SelectItem>
               )}
-              data-testid="annotate-bulk-score-select"
             />
           </div>
           {selectedDefinition && (

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -18,13 +18,12 @@ import {
   FEEDBACK_DEFINITION_TYPE,
   FeedbackDefinition,
 } from "@/types/feedback-definitions";
-import { isNumericFeedbackScoreValid } from "@/lib/traces";
-import DebounceInput from "@/shared/DebounceInput/DebounceInput";
-import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
 import SelectBox from "@/shared/SelectBox/SelectBox";
 import { SelectItem } from "@/ui/select";
 import { DropdownOption } from "@/types/shared";
 import { Textarea } from "@/ui/textarea";
+import FeedbackScoreValueInput from "@/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
 
 const MAX_ANNOTATE_ROWS = 500;
 const MAX_CONCURRENT_ANNOTATIONS = 5;
@@ -113,27 +112,6 @@ const AnnotateTracesDialog: React.FunctionComponent<
     }));
   }, []);
 
-  const handleNumericValueChange = useCallback(
-    (value: string | number | readonly string[] | undefined) => {
-      const num =
-        typeof value === "string" && value !== "" ? Number(value) : value;
-      if (
-        typeof num !== "number" ||
-        Number.isNaN(num) ||
-        !selectedDefinition ||
-        !isNumericFeedbackScoreValid(
-          selectedDefinition.details as { min: number; max: number },
-          num,
-        )
-      ) {
-        setDraft((d) => ({ ...d, value: undefined }));
-        return;
-      }
-      setDraft((d) => ({ ...d, value: num }));
-    },
-    [selectedDefinition],
-  );
-
   const handleApply = useCallback(async () => {
     if (!isValueValid || !draft.name || draft.value === undefined) {
       return;
@@ -214,113 +192,6 @@ const AnnotateTracesDialog: React.FunctionComponent<
     toast,
   ]);
 
-  const renderValueInput = () => {
-    if (!selectedDefinition) {
-      return null;
-    }
-
-    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
-      return (
-        <DebounceInput
-          className="my-0.5 h-8 min-w-[120px] py-1"
-          max={selectedDefinition.details.max}
-          min={selectedDefinition.details.min}
-          step="any"
-          dimension="sm"
-          delay={300}
-          onValueChange={handleNumericValueChange}
-          placeholder="Score"
-          type="number"
-          value={draft.value ?? ""}
-          data-testid="annotate-bulk-score-input"
-        />
-      );
-    }
-
-    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
-      return (
-        <ToggleGroup
-          className="min-w-fit p-0.5"
-          onValueChange={(value?: string) => {
-            if (!value) {
-              return;
-            }
-            setDraft((d) => ({
-              ...d,
-              value: value === selectedDefinition.details.true_label ? 1 : 0,
-              categoryName: value,
-            }));
-          }}
-          variant="outline"
-          type="single"
-          size="md"
-          value={draft.categoryName ?? ""}
-        >
-          <ToggleGroupItem
-            className="w-full"
-            key="true"
-            value={selectedDefinition.details.true_label}
-          >
-            {selectedDefinition.details.true_label}
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            className="w-full"
-            key="false"
-            value={selectedDefinition.details.false_label}
-          >
-            {selectedDefinition.details.false_label}
-          </ToggleGroupItem>
-        </ToggleGroup>
-      );
-    }
-
-    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
-      const categoricalOptionList = Object.entries(
-        selectedDefinition.details.categories,
-      ).map(([name, value]) => ({
-        label: name,
-        value: name,
-        description: String(value),
-      }));
-
-      return (
-        <SelectBox
-          value={draft.categoryName ?? ""}
-          options={categoricalOptionList}
-          onChange={(value?: string) => {
-            if (!value) {
-              return;
-            }
-            const categoryValue = Object.entries(
-              selectedDefinition.details.categories,
-            ).find(([categoryName]) => categoryName === value)?.[1];
-
-            setDraft((d) => ({
-              ...d,
-              categoryName: value,
-              value: categoryValue,
-            }));
-          }}
-          className="my-0.5 h-8 min-w-[160px] py-1"
-          testId="annotate-bulk-category-select"
-          renderTrigger={(value) => {
-            if (!value) {
-              return <div className="truncate">Select a category</div>;
-            }
-            return <span className="text-nowrap">{value}</span>;
-          }}
-          renderOption={(option: DropdownOption<string>) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.value} ({option.description})
-            </SelectItem>
-          )}
-        />
-      );
-    }
-
-    return null;
-  };
-
   return (
     <Dialog open={Boolean(open)} onOpenChange={setOpen}>
       <DialogContent className="max-w-lg" data-testid="annotate-bulk-dialog">
@@ -378,7 +249,22 @@ const AnnotateTracesDialog: React.FunctionComponent<
               {selectedDefinition && (
                 <div>
                   <div className="comet-body-s-accented pb-1">Value</div>
-                  {renderValueInput()}
+                  <FeedbackScoreValueInput
+                    feedbackDefinition={selectedDefinition}
+                    value={draft.value ?? ""}
+                    categoryName={draft.categoryName}
+                    onChange={({
+                      value: newValue,
+                      categoryName: newCategory,
+                    }) =>
+                      setDraft((d) => ({
+                        ...d,
+                        value: newValue,
+                        categoryName: newCategory,
+                      }))
+                    }
+                    testIdPrefix="annotate-bulk"
+                  />
                 </div>
               )}
               {selectedDefinition && (

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import FeedbackScoreValueInput, {
+  FeedbackScoreValue,
+} from "./FeedbackScoreValueInput";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+
+vi.mock("@/shared/SelectBox/SelectBox", () => ({
+  default: ({
+    options,
+    onChange,
+    testId,
+  }: {
+    options: Array<{ label: string; value: string }>;
+    onChange: (value?: string) => void;
+    testId?: string;
+  }) => (
+    <div data-testid={testId}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`${testId}-option-${option.value}`}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const numericalDef = {
+  name: "helpfulness",
+  type: FEEDBACK_DEFINITION_TYPE.numerical,
+  details: { min: 0, max: 10 },
+};
+const booleanDef = {
+  name: "thumbs",
+  type: FEEDBACK_DEFINITION_TYPE.boolean,
+  details: { true_label: "up", false_label: "down" },
+};
+const categoricalDef = {
+  name: "satisfaction",
+  type: FEEDBACK_DEFINITION_TYPE.categorical,
+  details: { categories: { good: 1, bad: 0 } },
+};
+const categoricalLongDef = {
+  name: "satisfaction",
+  type: FEEDBACK_DEFINITION_TYPE.categorical,
+  details: { categories: { excellent: 3, average: 2, poor: 1 } },
+};
+
+const renderInput = (
+  feedbackDefinition: FeedbackDefinition,
+  onChange: (update: FeedbackScoreValue) => void,
+  props?: { value?: number | ""; categoryName?: string },
+) => {
+  render(
+    <FeedbackScoreValueInput
+      feedbackDefinition={feedbackDefinition}
+      value={props?.value ?? ""}
+      categoryName={props?.categoryName}
+      onChange={onChange}
+      testIdPrefix="fsvi"
+    />,
+  );
+};
+
+describe("FeedbackScoreValueInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits valid numeric values", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "7" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: 7,
+        status: "valid",
+      });
+    });
+  });
+
+  it("marks out-of-range numeric input as invalid without clearing it", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange, {
+      value: 7,
+    });
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "99" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: undefined,
+        status: "invalid",
+      });
+    });
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "empty" }),
+    );
+  });
+
+  it("marks empty numeric input as an explicit clear", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange, {
+      value: 7,
+    });
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: undefined,
+        status: "empty",
+      });
+    });
+  });
+
+  it("exposes an accessible name on the numeric input", () => {
+    renderInput(numericalDef as unknown as FeedbackDefinition, vi.fn());
+    expect(screen.getByLabelText("helpfulness")).toBeInTheDocument();
+  });
+
+  it("maps boolean labels to values", () => {
+    const onChange = vi.fn();
+    renderInput(booleanDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-boolean-toggle-up"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 1,
+      categoryName: "up",
+    });
+  });
+
+  it("maps short categorical lists to toggle items", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-toggle-good"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 1,
+      categoryName: "good",
+    });
+  });
+
+  it("uses a select for long categorical lists", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalLongDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-select-option-average"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 2,
+      categoryName: "average",
+    });
+  });
+
+  it("treats empty-string selection as a clear only when no empty key exists", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalLongDef as unknown as FeedbackDefinition, onChange);
+
+    // SelectBox mock only fires real option values; simulate a clear
+    // selection through the same onChange contract used by SelectBox.
+    const select = screen.getByTestId("fsvi-category-select");
+    fireEvent.click(select); // no-op click; ensure no clear event was emitted
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ value: undefined }),
+    );
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
@@ -29,6 +29,13 @@ vi.mock("@/shared/SelectBox/SelectBox", () => ({
           {option.label}
         </button>
       ))}
+      <button
+        type="button"
+        data-testid={`${testId}-clear`}
+        onClick={() => onChange("")}
+      >
+        Clear selection
+      </button>
     </div>
   ),
 }));
@@ -171,16 +178,32 @@ describe("FeedbackScoreValueInput", () => {
     });
   });
 
-  it("treats empty-string selection as a clear only when no empty key exists", () => {
+  it("emits a clear event when no empty-string key exists", () => {
     const onChange = vi.fn();
     renderInput(categoricalLongDef as unknown as FeedbackDefinition, onChange);
 
-    // SelectBox mock only fires real option values; simulate a clear
-    // selection through the same onChange contract used by SelectBox.
-    const select = screen.getByTestId("fsvi-category-select");
-    fireEvent.click(select); // no-op click; ensure no clear event was emitted
-    expect(onChange).not.toHaveBeenCalledWith(
-      expect.objectContaining({ value: undefined }),
-    );
+    fireEvent.click(screen.getByTestId("fsvi-category-select-clear"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: undefined,
+      categoryName: undefined,
+    });
+  });
+
+  it("treats an empty-string key as a selectable category when defined", () => {
+    const onChange = vi.fn();
+    const emptyKeyDef = {
+      name: "satisfaction",
+      type: FEEDBACK_DEFINITION_TYPE.categorical,
+      details: { categories: { "": 0, good: 1, great: 2 } },
+    };
+    renderInput(emptyKeyDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-select-clear"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 0,
+      categoryName: "",
+    });
   });
 });

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
@@ -1,0 +1,225 @@
+import React, { useCallback } from "react";
+import sortBy from "lodash/sortBy";
+import DebounceInput from "@/shared/DebounceInput/DebounceInput";
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
+import SelectBox from "@/shared/SelectBox/SelectBox";
+import { SelectItem } from "@/ui/select";
+import { DropdownOption } from "@/types/shared";
+import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
+
+const SET_VALUE_DEBOUNCE_DELAY = 500;
+
+export type FeedbackScoreValue = {
+  value?: number;
+  categoryName?: string;
+};
+
+type FeedbackScoreValueInputProps = {
+  feedbackDefinition: FeedbackDefinition;
+  value: number | "";
+  categoryName?: string;
+  onChange: (update: FeedbackScoreValue) => void;
+  testIdPrefix?: string;
+};
+
+/**
+ * Controlled input for a feedback definition value.
+ *
+ * Encodes the shared domain rules for numerical (range validation), boolean
+ * (label/value mapping) and categorical (category/value mapping) feedback
+ * scores. Callers keep their own draft state and persistence callbacks; a
+ * change with `value: undefined` means "clear the score".
+ */
+const FeedbackScoreValueInput: React.FunctionComponent<
+  FeedbackScoreValueInputProps
+> = ({ feedbackDefinition, value, categoryName, onChange, testIdPrefix }) => {
+  const prefix = testIdPrefix ?? "feedback-score-value";
+
+  const handleNumericChange = useCallback(
+    (inputValue: string | number | readonly string[] | undefined) => {
+      const num =
+        typeof inputValue === "string" && inputValue !== ""
+          ? Number(inputValue)
+          : inputValue;
+      if (
+        typeof num !== "number" ||
+        Number.isNaN(num) ||
+        !isNumericFeedbackScoreValid(
+          feedbackDefinition.details as { min: number; max: number },
+          num,
+        )
+      ) {
+        onChange({ value: undefined });
+        return;
+      }
+      onChange({ value: num });
+    },
+    [feedbackDefinition, onChange],
+  );
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+    return (
+      <DebounceInput
+        className="my-0.5 h-7 min-w-[100px] py-1"
+        max={feedbackDefinition.details.max}
+        min={feedbackDefinition.details.min}
+        step="any"
+        dimension="sm"
+        delay={SET_VALUE_DEBOUNCE_DELAY}
+        onValueChange={handleNumericChange}
+        placeholder="Score"
+        type="number"
+        value={value}
+        data-testid={`${prefix}-score-input`}
+      />
+    );
+  }
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
+    const onBooleanValueChange = (label?: string) => {
+      if (!label) {
+        return;
+      }
+      onChange({
+        value: label === feedbackDefinition.details.true_label ? 1 : 0,
+        categoryName: label,
+      });
+    };
+
+    return (
+      <ToggleGroup
+        className="min-w-fit p-0.5"
+        onValueChange={onBooleanValueChange}
+        variant="outline"
+        type="single"
+        size="md"
+        value={categoryName}
+      >
+        <ToggleGroupItem
+          className="w-full"
+          key="true"
+          value={feedbackDefinition.details.true_label}
+          data-testid={`${prefix}-boolean-toggle-${feedbackDefinition.details.true_label}`}
+        >
+          <div className="text-nowrap">
+            {feedbackDefinition.details.true_label}
+          </div>
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          className="w-full"
+          key="false"
+          value={feedbackDefinition.details.false_label}
+          data-testid={`${prefix}-boolean-toggle-${feedbackDefinition.details.false_label}`}
+        >
+          <div className="text-nowrap">
+            {feedbackDefinition.details.false_label}
+          </div>
+        </ToggleGroupItem>
+      </ToggleGroup>
+    );
+  }
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
+    const onCategoricalValueChange = (label?: string) => {
+      if (!label || label === "") {
+        onChange({ value: undefined, categoryName: undefined });
+        return;
+      }
+      const categoryEntry = Object.entries(
+        feedbackDefinition.details.categories,
+      ).find(([name]) => name === label);
+
+      if (categoryEntry) {
+        onChange({ value: categoryEntry[1], categoryName: label });
+      }
+    };
+
+    const categoricalOptionList = sortBy(
+      Object.entries(feedbackDefinition.details.categories).map(
+        ([name, val]) => ({
+          name,
+          value: val,
+        }),
+      ),
+      "value",
+    );
+
+    const hasLongNames = categoricalOptionList.some((item) => {
+      const label = categoryOptionLabelRenderer(item.name, item.value);
+      return label.length > 10;
+    });
+    const hasMultipleOptions = categoricalOptionList.length > 2;
+
+    if (hasLongNames || hasMultipleOptions) {
+      const categoricalSelectOptionList = categoricalOptionList.map((item) => ({
+        label: item.name,
+        value: item.name,
+        description: String(item.value),
+      }));
+      return (
+        <SelectBox
+          value={categoryName || ""}
+          options={categoricalSelectOptionList}
+          onChange={onCategoricalValueChange}
+          className="my-0.5 h-7 min-w-[100px] py-1"
+          testId={`${prefix}-category-select`}
+          renderTrigger={(val) => {
+            const selectedOption = categoricalOptionList.find(
+              (item) => item.name.trim() === (val || "").trim(),
+            );
+
+            if (!selectedOption) {
+              return <div className="truncate">Select a category</div>;
+            }
+
+            return (
+              <span className="text-nowrap">
+                {categoryOptionLabelRenderer(val, selectedOption.value)}
+              </span>
+            );
+          }}
+          renderOption={(option: DropdownOption<string>) => (
+            <SelectItem key={option.value} value={option.value}>
+              {categoryOptionLabelRenderer(option.value, option.description)}
+            </SelectItem>
+          )}
+        />
+      );
+    }
+
+    return (
+      <ToggleGroup
+        className="min-w-fit p-0.5"
+        onValueChange={onCategoricalValueChange}
+        variant="outline"
+        type="single"
+        size="md"
+        value={String(categoryName)}
+      >
+        {categoricalOptionList.map(({ name, value: categoryValue }) => {
+          return (
+            <ToggleGroupItem
+              className="w-full"
+              key={name}
+              value={name}
+              data-testid={`${prefix}-category-toggle-${name}`}
+            >
+              <div className="text-nowrap">
+                {categoryOptionLabelRenderer(name, categoryValue)}
+              </div>
+            </ToggleGroupItem>
+          );
+        })}
+      </ToggleGroup>
+    );
+  }
+
+  return null;
+};
+
+export default FeedbackScoreValueInput;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
@@ -12,11 +12,18 @@ import { SelectItem } from "@/ui/select";
 import { DropdownOption } from "@/types/shared";
 import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
 
-const SET_VALUE_DEBOUNCE_DELAY = 500;
+export const SET_VALUE_DEBOUNCE_DELAY = 500;
 
 export type FeedbackScoreValue = {
   value?: number;
   categoryName?: string;
+  /**
+   * Why the numeric value changed: "empty" = the user cleared the input,
+   * "invalid" = out-of-range/non-numeric input was rejected, "valid" = a
+   * usable value was entered. Callers use this to distinguish clearing a
+   * score (delete) from merely ignoring bad input.
+   */
+  status?: "empty" | "invalid" | "valid";
 };
 
 type FeedbackScoreValueInputProps = {
@@ -42,10 +49,11 @@ const FeedbackScoreValueInput: React.FunctionComponent<
 
   const handleNumericChange = useCallback(
     (inputValue: string | number | readonly string[] | undefined) => {
-      const num =
-        typeof inputValue === "string" && inputValue !== ""
-          ? Number(inputValue)
-          : inputValue;
+      if (inputValue === undefined || inputValue === "") {
+        onChange({ value: undefined, status: "empty" });
+        return;
+      }
+      const num = Number(inputValue);
       if (
         typeof num !== "number" ||
         Number.isNaN(num) ||
@@ -54,10 +62,10 @@ const FeedbackScoreValueInput: React.FunctionComponent<
           num,
         )
       ) {
-        onChange({ value: undefined });
+        onChange({ value: undefined, status: "invalid" });
         return;
       }
-      onChange({ value: num });
+      onChange({ value: num, status: "valid" });
     },
     [feedbackDefinition, onChange],
   );
@@ -75,6 +83,7 @@ const FeedbackScoreValueInput: React.FunctionComponent<
         placeholder="Score"
         type="number"
         value={value}
+        aria-label={feedbackDefinition.name}
         data-testid={`${prefix}-score-input`}
       />
     );
@@ -126,7 +135,13 @@ const FeedbackScoreValueInput: React.FunctionComponent<
 
   if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
     const onCategoricalValueChange = (label?: string) => {
-      if (!label || label === "") {
+      // An empty-string category can be a legitimate key; only treat "" as
+      // "clear" when no such key exists in the definition.
+      const hasEmptyKey = Object.prototype.hasOwnProperty.call(
+        feedbackDefinition.details.categories,
+        "",
+      );
+      if (!label && !hasEmptyKey) {
         onChange({ value: undefined, categoryName: undefined });
         return;
       }

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -6,34 +6,23 @@ import React, {
   useState,
 } from "react";
 import isNumber from "lodash/isNumber";
-import sortBy from "lodash/sortBy";
 import { Copy, Trash, X } from "lucide-react";
-import DebounceInput from "@/shared/DebounceInput/DebounceInput";
-import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
-import {
-  FEEDBACK_DEFINITION_TYPE,
-  FeedbackDefinition,
-} from "@/types/feedback-definitions";
+import { FeedbackDefinition } from "@/types/feedback-definitions";
 import { TraceFeedbackScore } from "@/types/traces";
 import { Button } from "@/ui/button";
-import { isNumericFeedbackScoreValid } from "@/lib/traces";
 import ColoredTagNew from "@/shared/ColoredTag/ColoredTagNew";
-import SelectBox from "@/shared/SelectBox/SelectBox";
-import { SelectItem } from "@/ui/select";
-import { DropdownOption } from "@/types/shared";
 import { updateTextAreaHeight } from "@/lib/utils";
 import { Textarea } from "@/ui/textarea";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import {
-  categoryOptionLabelRenderer,
-  findValueByAuthor,
-  hasValuesByAuthor,
-} from "@/lib/feedback-scores";
+import { findValueByAuthor, hasValuesByAuthor } from "@/lib/feedback-scores";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import copy from "clipboard-copy";
 import { useToast } from "@/ui/use-toast";
-import { UpdateFeedbackScoreData } from "./types";
+import FeedbackScoreValueInput, {
+  FeedbackScoreValue,
+} from "../../FeedbackScoreValueInput/FeedbackScoreValueInput";
 import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
+import { UpdateFeedbackScoreData } from "./types";
 
 const SET_VALUE_DEBOUNCE_DELAY = 500;
 
@@ -96,14 +85,6 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
   }, [feedbackScoreData.category_name]);
 
   const [value, setValue] = useState<number | "">(feedbackScoreData.value);
-  useEffect(() => {
-    setValue(feedbackScoreData.value);
-
-    if (feedbackScoreData.value === "") {
-      setReasonValue("");
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feedbackScoreData.value]);
 
   const onChangeTextAreaTriggered = useCallback(() => {
     updateTextAreaHeight(textAreaRef.current);
@@ -135,12 +116,21 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     onChange: onChangeTextAreaTriggered,
   });
 
+  useEffect(() => {
+    setValue(feedbackScoreData.value);
+
+    if (feedbackScoreData.value === "") {
+      setReasonValue("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [feedbackScoreData.value]);
+
   const handleChangeValue = useCallback(
-    (value: number, categoryName?: string) => {
+    (newValue: number, newCategoryName?: string) => {
       onUpdateFeedbackScore({
-        categoryName,
+        categoryName: newCategoryName,
         name,
-        value,
+        value: newValue,
         reason: reasonValue,
       });
     },
@@ -153,185 +143,26 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, setReasonValue]);
 
+  const handleValueChange = useCallback(
+    (update: FeedbackScoreValue) => {
+      if (update.value === undefined) {
+        setValue("");
+        deleteFeedbackScore();
+        return;
+      }
+      setCategoryName(update.categoryName);
+      setValue(update.value);
+      handleChangeValue(update.value, update.categoryName);
+    },
+    [deleteFeedbackScore, handleChangeValue],
+  );
+
   const handleCopyReasonClick = async (v: string) => {
     await copy(v);
 
     toast({
       description: "Reason successfully copied to clipboard",
     });
-  };
-
-  const renderOptions = (feedbackDefinition: FeedbackDefinition) => {
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
-      return (
-        <DebounceInput
-          className="my-0.5 h-7 min-w-[100px] py-1"
-          max={feedbackDefinition.details.max}
-          min={feedbackDefinition.details.min}
-          step="any"
-          dimension="sm"
-          delay={SET_VALUE_DEBOUNCE_DELAY}
-          onValueChange={(value) => {
-            const newValue = value === "" ? "" : Number(value);
-
-            setValue(newValue);
-
-            if (newValue === "") {
-              deleteFeedbackScore();
-              return;
-            }
-
-            if (
-              isNumericFeedbackScoreValid(feedbackDefinition.details, newValue)
-            ) {
-              handleChangeValue(newValue as number);
-            }
-          }}
-          placeholder="Score"
-          type="number"
-          value={value}
-          data-testid="annotate-score-input"
-        />
-      );
-    }
-
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
-      const onBooleanValueChange = (value?: string) => {
-        const boolValue =
-          value === feedbackDefinition.details.true_label ? 1 : 0;
-        const categoryName = value;
-
-        setCategoryName(categoryName);
-        setValue(boolValue);
-        handleChangeValue(boolValue, categoryName);
-      };
-
-      return (
-        <ToggleGroup
-          className="min-w-fit p-0.5"
-          onValueChange={onBooleanValueChange}
-          variant="outline"
-          type="single"
-          size="md"
-          value={categoryName}
-        >
-          <ToggleGroupItem
-            className="w-full"
-            key="true"
-            value={feedbackDefinition.details.true_label}
-          >
-            <div className="text-nowrap">
-              {feedbackDefinition.details.true_label}
-            </div>
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            className="w-full"
-            key="false"
-            value={feedbackDefinition.details.false_label}
-          >
-            <div className="text-nowrap">
-              {feedbackDefinition.details.false_label}
-            </div>
-          </ToggleGroupItem>
-        </ToggleGroup>
-      );
-    }
-
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
-      const onCategoricalValueChange = (value?: string) => {
-        if (value === "") {
-          deleteFeedbackScore();
-          return;
-        }
-
-        const categoryEntry = Object.entries(
-          feedbackDefinition.details.categories,
-        ).find(([categoryName]) => categoryName === value);
-
-        if (categoryEntry) {
-          const categoryValue = categoryEntry[1];
-
-          setCategoryName(value);
-          setValue(categoryValue);
-          handleChangeValue(categoryValue, value);
-        }
-      };
-      const categoricalOptionList = sortBy(
-        Object.entries(feedbackDefinition.details.categories).map(
-          ([name, value]) => ({
-            name,
-            value,
-          }),
-        ),
-        "value",
-      );
-
-      const hasLongNames = categoricalOptionList.some((item) => {
-        const label = categoryOptionLabelRenderer(item.name, item.value);
-        return label.length > 10;
-      });
-      const hasMultipleOptions = categoricalOptionList.length > 2;
-
-      if (hasLongNames || hasMultipleOptions) {
-        const categoricalSelectOptionList = categoricalOptionList.map(
-          (item) => ({
-            label: item.name,
-            value: item.name,
-            description: String(item.value),
-          }),
-        );
-        return (
-          <SelectBox
-            value={categoryName || ""}
-            options={categoricalSelectOptionList}
-            onChange={onCategoricalValueChange}
-            className="my-0.5 h-7 min-w-[100px] py-1"
-            renderTrigger={(value) => {
-              const selectedOption = categoricalOptionList.find(
-                (item) => item.name.trim() === value.trim(),
-              );
-
-              if (!selectedOption) {
-                return <div className="truncate">Select a category</div>;
-              }
-
-              return (
-                <span className="text-nowrap">
-                  {categoryOptionLabelRenderer(value, selectedOption.value)}
-                </span>
-              );
-            }}
-            renderOption={(option: DropdownOption<string>) => (
-              <SelectItem key={option.value} value={option.value}>
-                {categoryOptionLabelRenderer(option.value, option.description)}
-              </SelectItem>
-            )}
-          ></SelectBox>
-        );
-      }
-      return (
-        <ToggleGroup
-          className="min-w-fit p-0.5"
-          onValueChange={onCategoricalValueChange}
-          variant="outline"
-          type="single"
-          size="md"
-          value={String(categoryName)}
-        >
-          {categoricalOptionList.map(({ name, value }) => {
-            return (
-              <ToggleGroupItem className="w-full" key={name} value={name}>
-                <div className="text-nowrap">
-                  {name} ({value})
-                </div>
-              </ToggleGroupItem>
-            );
-          })}
-        </ToggleGroup>
-      );
-    }
-
-    return null;
   };
 
   return (
@@ -346,7 +177,13 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
       >
         {feedbackDefinition ? (
           <div className="min-w-0 flex-1 overflow-auto">
-            {renderOptions(feedbackDefinition)}
+            <FeedbackScoreValueInput
+              feedbackDefinition={feedbackDefinition}
+              value={value}
+              categoryName={categoryName}
+              onChange={handleValueChange}
+              testIdPrefix="annotate"
+            />
           </div>
         ) : (
           <div>{feedbackScoreData?.value}</div>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -71,7 +71,11 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
   const {
-    permissions: { canDeleteTraces, canLogTraceSpanThread },
+    permissions: {
+      canDeleteTraces,
+      canLogTraceSpanThread,
+      canAnnotateTraceSpanThread,
+    },
   } = usePermissions();
 
   const showEvaluate =
@@ -122,7 +126,7 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           confirmButtonVariant="destructive"
         />
       )}
-      {canLogTraceSpanThread && (
+      {canAnnotateTraceSpanThread && (
         <AnnotateTracesDialog
           key={`annotate-${resetKeyRef.current}`}
           rows={selectedRows}
@@ -161,7 +165,7 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         buttonVariant={buttonVariant}
         buttonSize={buttonSize}
       />
-      {canLogTraceSpanThread && (
+      {canAnnotateTraceSpanThread && (
         <TooltipWrapper content="Annotate">
           <Button
             variant={buttonVariant}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash } from "lucide-react";
+import { PenLine, Tag, Trash } from "lucide-react";
 import slugify from "slugify";
 import { cn } from "@/lib/utils";
 import { Button, ButtonProps } from "@/ui/button";
@@ -12,6 +12,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/v2/pages-shared/traces/AddTagDialog/AddTagDialog";
+import AnnotateTracesDialog from "@/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog";
 import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
 import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
@@ -122,6 +123,15 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         />
       )}
       {canLogTraceSpanThread && (
+        <AnnotateTracesDialog
+          key={`annotate-${resetKeyRef.current}`}
+          rows={selectedRows}
+          open={open === 5}
+          setOpen={setOpen}
+          type={type}
+        />
+      )}
+      {canLogTraceSpanThread && (
         <AddTagDialog
           key={`tag-${resetKeyRef.current}`}
           rows={selectedRows}
@@ -151,6 +161,23 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         buttonVariant={buttonVariant}
         buttonSize={buttonSize}
       />
+      {canLogTraceSpanThread && (
+        <TooltipWrapper content="Annotate">
+          <Button
+            variant={buttonVariant}
+            size={buttonSize}
+            onClick={() => {
+              setOpen(5);
+              resetKeyRef.current = resetKeyRef.current + 1;
+            }}
+            disabled={disabled}
+            data-testid="traces-bulk-annotate-button"
+          >
+            <PenLine className={leadIconClassName} />
+            <span>Annotate</span>
+          </Button>
+        </TooltipWrapper>
+      )}
       {canLogTraceSpanThread && (
         <TooltipWrapper content="Manage tags">
           <Button


### PR DESCRIPTION
Fixes #1010
/claim #1010

## What
Adds an **Annotate** bulk action to the traces/spans table actions panel, letting users apply one feedback score (numerical, boolean, or categorical) with an optional reason to all selected rows at once.

## Why
When tracking LLM apps in production, users filter traces down to a cohort (e.g. failures, low-scored samples) and annotate the whole set. Today that requires opening each trace individually and repeating the same annotation - slow and error-prone for large cohorts.

## How
- New `AnnotateTracesDialog` (`v2/pages-shared/traces/`): score picker backed by feedback definitions, type-aware value input (numeric with min/max validation via `isNumericFeedbackScoreValid`, boolean toggle, categorical select), optional reason, then fans out `useTraceFeedbackScoreSetMutation` per selected row (spans pass `spanId` + parent `trace_id`).
- Existing mutation hook reused so all optimistic cache updates, invalidations and per-row error toasts behave exactly like single-trace annotation.
- Wired into `TracesActionsPanel` behind the same `canLogTraceSpanThread` permission as the existing annotate/tags actions, with `traces-bulk-annotate-button` test id.
- Outcome toasts: success / partial / full-failure summary.

## Verification
- `bun run typecheck` passes
- `eslint` on changed files passes (0 warnings)
- New tests `AnnotateTracesDialog.test.tsx` (4/4 green): render, enable-flow, fan-out submission per row, categorical mapping

## Screenshot
UI flow: select rows → Annotate → pick score + value + reason → Apply to N traces (dashboard-driven dialog consistent with Manage tags).