### PR TITLE
[OPIK-8280] [QA] chore: keep taxonomy specs lists sorted so concurrent additions stop colliding

### DIFF
--- a/tests_end_to_end/coverage/tag_lint.py
+++ b/tests_end_to_end/coverage/tag_lint.py
@@ -181,10 +181,22 @@ def lint_spec(path: Path, rel: str, idx, retired: dict, *, visual: bool) -> list
 
 
 def lint_taxonomy(tax: dict, idx) -> list[Finding]:
-    """Rule 3: visual state values must be in the enum."""
+    """Rule 3: visual state values must be in the enum.
+    Rule 4: `specs:` lists stay sorted, so concurrent additions do not collide.
+    """
     _, _, _, states, _ = idx
     out = []
     for area, body in (tax.get("areas") or {}).items():
+        specs = (body or {}).get("specs") or []
+        if specs != sorted(specs):
+            # Appending puts every concurrent addition on the same last line, so
+            # two open spec PRs in one area always conflict here. Sorted
+            # insertion lands them on different lines and git merges them.
+            out.append(Finding(
+                "taxonomy.yaml", 1,
+                f"{area}.specs is not sorted — insert new specs in sorted "
+                f"position, not at the end (see the header)",
+            ))
         for vcap, spec in (body.get("visual") or {}).items():
             st = (spec or {}).get("state")
             if st is None:

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -14,6 +14,13 @@
 #
 # SCOPE: tests_end_to_end/ only — e2e (Playwright) + visual-tests. Nothing else.
 #
+# Every `specs:` list is kept in sorted order, and a new spec goes in its sorted
+# position rather than at the end. Appending put every concurrent addition on the
+# same last line, so two open spec PRs in one area always conflicted here — this
+# file was the single most-conflicted in the QA queue, touched by 4 of 4 open spec
+# PRs at one point. Sorted insertion lands them on different lines, which git
+# merges without a conflict. Nothing reads the order, so it costs nothing.
+#
 # Verified against main @ c54a6a99d7 (2026-07-29):
 #   24 e2e specs across 13 dirs, 3 visual specs.
 #
@@ -244,13 +251,13 @@ areas:
     routes: ["/projects/$projectId/logs?type=traces", "/logs?type=spans"]
     spec_dir: trace-explore   # NOTE: dir name != product vocabulary ("Logs")
     specs:
-      - trace-explore/trace-explore-smoke.spec.ts
-      - trace-explore/trace-spans-depth.spec.ts
-      - trace-explore/trace-delete.spec.ts
-      - trace-explore/trace-filters.spec.ts
       - trace-explore/trace-attachments.spec.ts
+      - trace-explore/trace-delete.spec.ts
+      - trace-explore/trace-explore-smoke.spec.ts
+      - trace-explore/trace-filters.spec.ts
       - trace-explore/trace-id-time-window.spec.ts
       - trace-explore/trace-partial-update-merge.spec.ts
+      - trace-explore/trace-spans-depth.spec.ts
 
     # ---- functional dimension ----
     capabilities:
@@ -321,9 +328,9 @@ areas:
     routes: ["/projects/$projectId/logs?type=threads"]
     spec_dir: trace-explore
     specs:
-      - trace-explore/thread-logging-smoke.spec.ts
-      - trace-explore/thread-id-prefilter.spec.ts
       - trace-explore/thread-evaluation.spec.ts
+      - trace-explore/thread-id-prefilter.spec.ts
+      - trace-explore/thread-logging-smoke.spec.ts
     capabilities:
       list-threads:            { covered: true,  tier: t1-smoke }
       thread-message-count:    { covered: true,  tier: t1-smoke }
@@ -371,9 +378,9 @@ areas:
     routes: ["/$workspaceName/dashboards", "/dashboards/$dashboardId", "/projects/$projectId/dashboards"]
     spec_dir: dashboards
     specs:
-      - dashboards/workspace-span-metrics.spec.ts
-      - dashboards/project-span-metrics.spec.ts
       - dashboards/dashboards-list-filters.spec.ts
+      - dashboards/project-span-metrics.spec.ts
+      - dashboards/workspace-span-metrics.spec.ts
     capabilities:
       list-dashboards:      { covered: true,  tier: t2-cuj, note: "the list is filtered by the Description column; the other operators and columns are uncovered" }
       create-dashboard:     { covered: true,  tier: t2-cuj, note: "created via the Create dashboard dialog as the UI test's setup; rename/delete/duplicate uncovered" }
@@ -397,8 +404,8 @@ areas:
     routes: ["/projects/$projectId/prompts", "/prompts/$promptId"]
     spec_dir: prompts
     specs:
-      - prompts/prompt-library-smoke.spec.ts
       - prompts/prompt-delete.spec.ts
+      - prompts/prompt-library-smoke.spec.ts
     capabilities:
       list-prompts:            { covered: true,  tier: t1-smoke }
       create-text-prompt-ui:   { covered: true,  tier: t1-smoke }
@@ -422,8 +429,8 @@ areas:
     routes: ["/projects/$projectId/playground"]
     spec_dir: playground
     specs:
-      - playground/playground-smoke.spec.ts
       - playground/playground-providers.spec.ts
+      - playground/playground-smoke.spec.ts
       - prompts/prompt-playground-new-prompt.spec.ts
       - prompts/prompt-playground-save.spec.ts
       - prompts/prompt-playground-traces.spec.ts
@@ -505,14 +512,14 @@ areas:
     spec_dir: datasets
     specs:
       - datasets/dataset-crud-smoke.spec.ts
-      - datasets/dataset-items.spec.ts
-      - datasets/dataset-items-filter-scope.spec.ts
-      - datasets/dataset-version-counters.spec.ts
-      - datasets/dataset-version-repeated-item-id.spec.ts
-      - datasets/dataset-version-concurrent-writes.spec.ts
       - datasets/dataset-item-count.spec.ts
+      - datasets/dataset-items-filter-scope.spec.ts
+      - datasets/dataset-items.spec.ts
       - datasets/dataset-parallel-item-read.spec.ts
       - datasets/dataset-read-version-pinning.spec.ts
+      - datasets/dataset-version-concurrent-writes.spec.ts
+      - datasets/dataset-version-counters.spec.ts
+      - datasets/dataset-version-repeated-item-id.spec.ts
     capabilities:
       list-datasets:          { covered: true,  tier: t1-smoke, note: "row is listed (t1); t2 also asserts the Item count column against the items endpoint on a page mixing a versioned dataset (items_total) with a version-less one (legacy count scan), and follows it through an item delete" }
       create-dataset-ui:      { covered: true,  tier: t1-smoke }
@@ -547,8 +554,8 @@ areas:
     routes: ["/projects/$projectId/test-suites", "/test-suites/$suiteId/items"]
     spec_dir: test-suites
     specs:
-      - test-suites/test-suites-smoke.spec.ts
       - test-suites/test-suite-delete.spec.ts
+      - test-suites/test-suites-smoke.spec.ts
     capabilities:
       list-suites:           { covered: true,  tier: t1-smoke }
       create-suite-ui:       { covered: true,  tier: t1-smoke }
@@ -571,11 +578,11 @@ areas:
     routes: ["/projects/$projectId/experiments", "/experiments/$datasetId/compare"]
     spec_dir: experiments
     specs:
-      - experiments/experiments-smoke.spec.ts
-      - experiments/experiments-compare.spec.ts
-      - experiments/experiment-logs-date-window.spec.ts
       - experiments/compare-json-key-sorting.spec.ts
       - experiments/experiment-delete.spec.ts
+      - experiments/experiment-logs-date-window.spec.ts
+      - experiments/experiments-compare.spec.ts
+      - experiments/experiments-smoke.spec.ts
     capabilities:
       list-experiments:        { covered: true,  tier: t1-smoke }
       per-item-scores:         { covered: true,  tier: t1-smoke }
@@ -614,8 +621,8 @@ areas:
     # 7-day window spanning the merge reports a false gap.
     tag_aliases: [annotation-queue]
     specs:
-      - annotation-queues/annotation-queue-scoring.spec.ts
       - annotation-queues/annotation-queue-delete.spec.ts
+      - annotation-queues/annotation-queue-scoring.spec.ts
     capabilities:
       score-queue-item:        { covered: true,  tier: t2-cuj }
       score-with-reason:       { covered: true,  tier: t2-cuj }
@@ -646,14 +653,14 @@ areas:
     routes: ["/projects/$projectId/online-evaluation", "/$workspaceName/automation-logs"]
     spec_dir: online-evaluation
     specs:
-      - online-evaluation/online-evaluation-smoke.spec.ts
       - online-evaluation/online-evaluation-delete-rule.spec.ts
       - online-evaluation/online-evaluation-enable-disable-rule.spec.ts
-      - online-evaluation/online-evaluation-sampling-rate.spec.ts
-      - online-evaluation/online-evaluation-python-metric-errors.spec.ts
-      - online-evaluation/online-evaluation-non-object-sections.spec.ts
       - online-evaluation/online-evaluation-json-looking-judge-prompts.spec.ts
       - online-evaluation/online-evaluation-judge-prompt-round-trip.spec.ts
+      - online-evaluation/online-evaluation-non-object-sections.spec.ts
+      - online-evaluation/online-evaluation-python-metric-errors.spec.ts
+      - online-evaluation/online-evaluation-sampling-rate.spec.ts
+      - online-evaluation/online-evaluation-smoke.spec.ts
     capabilities:
       create-llm-judge-rule:   { covered: true,  tier: t1-smoke }
       llm-judge-scores:        { covered: true,  tier: t1-smoke, note: "bimodal safe/unsafe" }
@@ -737,10 +744,10 @@ areas:
     spec_dir: ollie
     cloud_only: true   # requires AssistantSidebar plugin + OLLIE_ENABLED
     specs:
-      - ollie/ollie-smoke.spec.ts
       - ollie/ollie-agentic.spec.ts
       - ollie/ollie-connect.spec.ts
       - ollie/ollie-explain.spec.ts
+      - ollie/ollie-smoke.spec.ts
     capabilities:
       surface-mounts:          { covered: true,  tier: t1-smoke }
       sidebar-persists-nav:    { covered: true,  tier: t1-smoke }


### PR DESCRIPTION
## Details

`taxonomy.yaml` has been the most-conflicted file in the QA queue — touched by
**4 of 4** open generated spec PRs at one point, against 3 for `client.ts` and 3
for `fixtures/index.ts`.

The reason is mechanical, not conceptual: every spec was **appended**, so every
concurrent addition landed on the same last line of the same list. Any two open
spec PRs in one area therefore conflicted *by construction*.

Sorted insertion puts them on different lines, which git merges with no conflict
at all — including the **same-area** case, which is the half a per-area file split
could not fix.

### What changed

- **11 of 14** multi-spec areas were unsorted; they are now sorted.
- `tag_lint` gains a rule for it, so the convention can't silently decay back to
  appending.
- The header documents *why*, where an editor will actually see it.

### Why not split the file per area instead

That was the original plan. The survey killed it: **21 files load this taxonomy
across three repos** (opik, comet-automation-tests, qa-plugin), including
`tag_lint.py` (a required check), the Notion dashboard, bug discovery, coverage
map/history, PR triage and release coverage — and `reconcile.py` **rewrites the
file line-by-line** rather than via `yaml.dump`, to preserve formatting and
comments. Splitting means rewriting that round-trip for N files, in a script that
runs nightly against the real coverage denominator.

A split also only *halves* the problem: `online-evaluation` alone accounts for 5
of 11 PRs, and same-area additions would still collide. Sorted insertion fixes
that case for a fraction of the risk.

## Change checklist

- [x] Spec sets provably unchanged — only ordering moved
- [x] `tag_lint` passes on the sorted file (64 specs, 0 problems)
- [x] The new rule verified to **fire** on a simulated append, not just pass when clean
- [x] Confirmed no consumer depends on list order — all iterate or build sets; `release_surface.py` already sorts
- [x] Confirmed `reconcile.py` only *reads* `specs` (it rewrites `covered:`/`tier:`), so this cannot fight the nightly

## Issues

OPIK-8280

## Testing

```
tag-lint: 64 specs checked, 1 exempt, 0 problem(s)
```

Content equivalence, old vs new parsed and normalised:

```
identical after normalising specs order: True
areas whose spec SET changed: none
```

The rule is not inert — simulating an out-of-order append:

```
taxonomy.yaml:1: datasets.specs is not sorted — insert new specs in sorted
                 position, not at the end (see the header)
tag-lint: 64 specs checked, 1 exempt, 1 problem(s)
```

and silent again once restored.

## Documentation

The taxonomy header carries the convention and the reason. Paired with
comet-automation-tests#(pending), which tells both generator prompts to insert in
sorted position and makes the conflict auto-union emit sorted output — otherwise
it would resolve a conflict and fail this new rule in the same breath.
