### PR TITLE
[OPIK-8280] [QA] chore: let reconcile own the taxonomy specs lists instead of generated PRs

### DIFF
--- a/tests_end_to_end/coverage/reconcile.py
+++ b/tests_end_to_end/coverage/reconcile.py
@@ -7,9 +7,20 @@ fact, and this job refreshes the cache. Nobody edits those flags by hand.
 
   covered:   derived — does any spec tag this capability
   tier:      derived — the shallowest tier among the tagging tests
+  specs:     derived — every spec carrying that area's `@area:` tag, sorted
   (everything else)  authored — areas, capability keys, notes, cloud_only,
                      state, axes. Never touched here. Those change via the
                      discovery job (OPIK-7632) or a human PR.
+
+`specs:` became derived because maintaining it by hand made this the
+most-conflicted file in the QA queue: every generated spec PR appended to the
+same list, so 4 of 4 open ones collided here at once. Every entry was already
+knowable from the `@area:` tags, and the only consumer that reads the list
+(bug_discovery's "Already covered by" line) wants exactly what the tags say.
+Generated PRs no longer write it.
+
+A `specs:` block containing a comment or a blank line is left alone: something is
+annotated there, and replacing the block would drop the annotation silently.
 
 Run nightly after merges land.
 
@@ -68,8 +79,10 @@ SECTION = re.compile(r"^(?P<indent>\s+)(?P<name>[\w.-]+):\s*$")
 # read the estate
 # --------------------------------------------------------------------------- #
 
-def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]:
-    """-> (functional cap -> tiers covering it, visual cap -> tiers).
+def scan_estate(
+    estate: Path,
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, set[str]]]:
+    """-> (functional cap -> tiers, visual cap -> tiers, area -> spec paths).
 
     Asks Playwright, not a regex. Tags union from describe to test, so the tier
     that applies to a given `@cap:` is only knowable after describe-inheritance
@@ -82,6 +95,8 @@ def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]
     """
     caps: dict[str, set[str]] = {}
     vcaps: dict[str, set[str]] = {}
+    # area -> spec paths, derived from the @area: tags rather than authored.
+    area_specs: dict[str, set[str]] = {}
 
     for sub, sink, prefix in (
         ("e2e", caps, "@cap:"),
@@ -99,16 +114,18 @@ def scan_estate(estate: Path) -> tuple[dict[str, set[str]], dict[str, set[str]]]
                 "reconcile refuses to run against an incomplete estate — it would "
                 "mark every capability in this dimension as uncovered."
             )
-        for tags in playwright_test_tags(root):
+        for tags, path in playwright_test_tags(root):
             tiers = {t.lstrip("@") for t in tags if t.lstrip("@") in TIER_ORDER}
             for t in tags:
                 if t.startswith(prefix):
                     sink.setdefault(t.split(":", 1)[1], set()).update(tiers)
-    return caps, vcaps
+                if t.startswith("@area:") and path:
+                    area_specs.setdefault(t.split(":", 1)[1], set()).add(path)
+    return caps, vcaps, area_specs
 
 
-def playwright_test_tags(project_root: Path) -> list[set[str]]:
-    """Every test's fully-resolved tag set, via `playwright test --list`.
+def playwright_test_tags(project_root: Path) -> list[tuple[set[str], str]]:
+    """Every test's (fully-resolved tag set, spec path), via `--list`.
 
     Raises rather than returning a partial list. This matters more than it looks:
     a single spec with a syntax error makes `--list` exit 1 while still printing
@@ -167,16 +184,22 @@ def playwright_test_tags(project_root: Path) -> list[set[str]]:
     if report.get("errors"):
         raise fail(f"playwright --list reported {len(report['errors'])} collection error(s)")
 
-    out: list[set[str]] = []
+    out: list[tuple[set[str], str]] = []
 
     def walk(suite: dict) -> None:
         for spec in suite.get("specs") or []:
+            # Relative to the project's `tests/` dir, which is the form the
+            # taxonomy's `specs:` entries use.
+            path = spec.get("file") or ""
             for test in spec.get("tests") or []:
                 tags = set(test.get("tags") or [])
                 # Older reporter shapes hang tags off the spec, not the test.
                 tags.update(spec.get("tags") or [])
                 # Normalise: the reporter may or may not keep the leading '@'.
-                out.append({t if t.startswith("@") else f"@{t}" for t in tags})
+                out.append((
+                    {t if t.startswith("@") else f"@{t}" for t in tags},
+                    path,
+                ))
         for child in suite.get("suites") or []:
             walk(child)
 
@@ -275,7 +298,7 @@ def reconcile(taxonomy: Path, estate: Path) -> tuple[list[str], list[Change], li
         raise RuntimeError(f"{taxonomy} is not valid YAML: {e}") from None
     if not isinstance(tax, dict):
         raise RuntimeError(f"{taxonomy} did not parse to a mapping (got {type(tax).__name__})")
-    caps, vcaps = scan_estate(estate)
+    caps, vcaps, area_specs = scan_estate(estate)
 
     # The load dimension is `status: planned` and reports to JUnit, not Allure.
     # Its specs are also outside the agreed estate, so it has no tags to read —
@@ -362,7 +385,75 @@ def reconcile(taxonomy: Path, estate: Path) -> tuple[list[str], list[Change], li
     for fq in sorted(set(vcaps) - seen["visual"]):
         warnings.append(f"@vcap:{fq} is tagged in a spec but absent from the taxonomy")
 
+    lines, spec_changes = rewrite_spec_lists(lines, known_areas, area_specs)
+    changes += spec_changes
+
     return lines, changes, warnings
+
+
+def rewrite_spec_lists(
+    lines: list[str], known_areas: set[str], area_specs: dict[str, set[str]]
+) -> tuple[list[str], list[Change]]:
+    """Replace each area's `specs:` list with the one derived from @area: tags.
+
+    The list is a cache, like `covered:` and `tier:` — every entry is knowable
+    from the tags, and the only consumer that reads it (bug_discovery's
+    "Already covered by" line) wants exactly what the tags say. Maintaining it by
+    hand made it the most-conflicted file in the QA queue: 4 of 4 open spec PRs
+    touched it, because every one appended to the same list.
+
+    So generated PRs no longer write it and this job owns it, the same way it
+    owns the derived flags.
+
+    Sorted, to match tag_lint's rule 4. Splices whole lines rather than
+    round-tripping the YAML, for the reason in this module's header: a load/dump
+    would flatten 175 comments and 242 aligned flow mappings into an
+    unreviewable diff.
+    """
+    out: list[str] = []
+    changes: list[Change] = []
+    i = 0
+    area: str | None = None
+
+    while i < len(lines):
+        m_sec = SECTION.match(lines[i])
+        if m_sec and m_sec.group("name") in known_areas and len(m_sec.group("indent")) <= 4:
+            area = m_sec.group("name")
+            out.append(lines[i]); i += 1
+            continue
+
+        if m_sec and m_sec.group("name") == "specs" and area:
+            indent = m_sec.group("indent")
+            out.append(lines[i])
+            j = i + 1
+            existing: list[str] = []
+            # Only a contiguous run of plain list items. A comment or a blank
+            # line inside it means something is annotated here, so leave the
+            # whole block alone rather than silently dropping the annotation.
+            annotated = False
+            while j < len(lines):
+                stripped = lines[j].strip()
+                if lines[j].startswith(indent + "  - "):
+                    existing.append(stripped[2:]); j += 1
+                elif stripped.startswith("#") or not stripped:
+                    annotated = True; break
+                else:
+                    break
+            derived = sorted(area_specs.get(area) or [])
+            if annotated or not derived:
+                out.extend(lines[i + 1:j])
+            else:
+                out.extend(f"{indent}  - {sp}" for sp in derived)
+                if derived != existing:
+                    changes.append(Change(i + 1, area, "specs", "list",
+                                          f"{len(existing)} entries",
+                                          f"{len(derived)} entries"))
+            i = j
+            continue
+
+        out.append(lines[i]); i += 1
+
+    return out, changes
 
 
 def main() -> int:


### PR DESCRIPTION
## Details

`taxonomy.yaml` has been the most-conflicted file in the QA queue — **4 of 4**
open generated spec PRs touched it at once, and it *still* caused 2 of 3
conflicts after the sort landed. The cause is that every spec PR hand-edited the
same `specs:` list.

**None of that editing was necessary.** What I verified:

- **`tag_lint` never required** a spec to appear in the list — nothing enforced it
- **`coverage_map.py` already derives its own** spec list from tags
  (`claims[key]["specs"].add(rel)`), not from the taxonomy
- **The only consumer that reads it** is `bug_discovery.py`, for its
  *"Already covered by: …"* line — which wants exactly what the tags say
- Every entry is derivable from the spec's own `@area:` tag

So `specs:` joins `covered:` and `tier:` as a **derived** field owned by this job.
Generated PRs stop touching the file, which *removes* the collision rather than
resolving it.

### How

`scan_estate` now also returns `area -> spec paths`, taken from the same
`playwright test --list --reporter=json` walk that already resolves tags (each
spec carries a `file`). A new pass splices each area's list, sorted, satisfying
`tag_lint`'s rule 4.

Spliced line-by-line rather than via `yaml.safe_load`/`dump`, for the reason in
this module's header: a round-trip flattens 175 comments and 242 column-aligned
flow mappings into an unreviewable diff.

**A block containing a comment or blank line is left untouched** — something is
annotated there, and replacing it would drop the annotation silently.

## Change checklist

- [x] Derived lists reproduce the hand-maintained ones exactly
- [x] Nightly gains **no** spurious diff — output byte-identical on a clean estate
- [x] A missing entry is detected and restored; result round-trips byte-identical
- [x] `tag_lint` green (69 specs, 0 problems)
- [x] Comment/blank-line blocks skipped rather than rewritten
- [ ] First real nightly run observed (needs merge)

## Issues

OPIK-8280

## Testing

Against the live estate, with the existing hand-maintained lists in place:

```
$ reconcile.py --check --summary
taxonomy already agrees with the spec tags — nothing to do.

$ reconcile.py            # apply
reconcile: no changes
$ diff before.yaml taxonomy.yaml
BYTE-IDENTICAL — no spurious nightly diff
```

That is the load-bearing result: the derived lists match what humans maintained,
so this is a change of *ownership*, not of content.

Simulating a generated PR that skipped the list — removing one entry:

```
1 derived field(s) drifted from the tags:
  datasets.specs: list 9 entries -> 10 entries
reconcile: updated taxonomy.yaml (1 field(s))
```

and the result diffs byte-identical against the original.

Two pre-existing warnings are unchanged by this PR
(`@cap:dashboards.configure-widget` and `@cap:traces.update-trace-api` tagged but
absent from the taxonomy).

**Not yet exercised:** a real nightly run. Note it needs `npm ci` in **both**
`e2e/` and `visual-tests/` — the job already does this, but my first local run
failed on the missing `visual-tests` install, which is worth knowing if the
nightly ever reports a MODULE_NOT_FOUND.

## Documentation

The module docstring records `specs:` as derived and why — including the
comment/blank-line exception, which is the one case a future reader would
otherwise "fix". Paired with comet-automation-tests#(pending), which stops both
propose prompts writing the field.
