### PR TITLE
[OPIK-8141] [BE] fix: record trace deletion events before the delete

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -29,6 +29,14 @@ The **deletion-events bridge** closes it: with `traceDeletionEventsCaptureEnable
 `(workspace_id, project_id, id)` in `deletion_events_local`; the cutover **replays** those keys as deletes against the
 new table before the EXCHANGE. The replay matches the **full key**, not `id` alone — see "Delta and replay correctness".
 
+> **Capture goes first (OPIK-8141).** The bridge insert is issued **before** the lightweight delete, not after. A delete
+> can fail its client while the server-side mutation still applies — the observed case being a client timeout on a
+> mutation that then completed — and capturing afterwards let exactly those deletes go unrecorded, which neither replay
+> direction can then re-apply. Capturing first over-records instead when the delete does fail, and the forward replay
+> already handles that: its resurrection guard skips any id still live on the source. Capture remains **best-effort** —
+> a failed insert is logged and swallowed, never failing a user's delete — so the bridge can still miss a delete, but
+> only when the capture itself fails, no longer when the delete does.
+
 > **All user-facing trace deletes route through one captured path.** Single delete, batch delete-by-project, and thread
 > deletion all funnel through `TraceService.delete(...)`, which calls `captureDeletions` for every resolved-project
 > delete — since OPIK-7483 there is no project-less branch (ids that resolve to no project are absent and skipped) — so
@@ -1196,12 +1204,16 @@ Use stage B/C while the parked original still exists.
 > shadow, never the live `traces`, so it has no live-read skew and needs no maintenance window.
 
 **What the reverse replay can and cannot re-apply.** It re-applies the deletes the bridge **recorded**. Capture runs
-after the delete succeeds and is best-effort by design — an auxiliary insert must never fail a user's delete — so a
-delete whose bridge row has not landed yet, or whose capture errored, is invisible to the replay *and* to its
-postcondition check, which reads the same bridge: that trace is live again on the restored original while the check still
-reports `0`. No query here can detect it, so the bound is operational — **quiesce trace deletes before the promote**, not
-just reads, and let in-flight ones land. It takes a delete concurrent with the promote, or a capture failure (which the
-backend logs), so the exposure is small — but `0` means "every recorded delete is masked", not "no delete escaped".
+before the delete but is best-effort by design — an auxiliary insert must never fail a user's delete — so a delete still
+in flight when this runs, or one whose capture errored, is invisible to the replay *and* to its postcondition check,
+which reads the same bridge: that trace is live again on the restored original while the check still reports `0`. No
+query here can detect it, so the bound is operational — **quiesce trace deletes before the promote**, not just reads,
+and let in-flight ones land. It takes a delete concurrent with the promote, or a capture failure (which the backend
+logs), so the exposure is small — but `0` means "every recorded delete is masked", not "no delete escaped". A delete
+that merely *errored* stopped being one of those cases in OPIK-8141: capture goes first, so it is recorded regardless.
+
+The reverse case is a recorded delete that never applied, which this replay masks anyway — it carries no liveness guard,
+by design (see `000004_rollback_reverse_replay.sql`). Accepted: the user did ask for that delete.
 
 **Recovering from an interrupted rollback.** Each promote stage runs its table-swap and then the reverse-replay as two
 statements. Note what that means even when both succeed: from the moment the promote lands until the replay finishes,

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1213,7 +1213,9 @@ logs), so the exposure is small — but `0` means "every recorded delete is mask
 that merely *errored* stopped being one of those cases in OPIK-8141: capture goes first, so it is recorded regardless.
 
 The reverse case is a recorded delete that never applied, which this replay masks anyway — it carries no liveness guard,
-by design (see `000004_rollback_reverse_replay.sql`). Accepted: the user did ask for that delete.
+by design (see `000004_rollback_reverse_replay.sql`). Accepted: the user did ask for that delete. It also stays
+recoverable while the window is open, since the replay touches only `traces` and the row is still live on the parked
+`traces_post_rollback_backup` until `finalize.sh` drops it.
 
 **Recovering from an interrupted rollback.** Each promote stage runs its table-swap and then the reverse-replay as two
 statements. Note what that means even when both succeed: from the moment the promote lands until the replay finishes,

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -132,7 +132,9 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- during the window (client-supplied ids; the delete is a mask, a newer insert wins under FINAL). Such an id is bridged
 -- as deleted but is LIVE again on the source, and the backfill/delta already copied its live version. Deleting it by key
 -- would drop a row that is live on the source — silent data loss. So the replay deletes only ids that are NOT currently
--- live on the source (mask-honored). The `id IN (deleted_ids since anchor)` bound keeps the deleted-id set tiny
+-- live on the source (mask-honored). The guard covers a second case since OPIK-8141: capture runs before the delete, so
+-- the bridge can name an id whose delete then errored and is still live on the source. Same arm, same reason.
+-- The `id IN (deleted_ids since anchor)` bound keeps the deleted-id set tiny
 -- (retention is off, so these are user-scale deletes); `traces` has no id skip index (000088 indexes only
 -- created_at/last_updated_at — id minmax/bloom indexes exist only on traces_local_v2), so this source lookup is a
 -- bounded id-filtered read of that tiny set, not a value-indexed prune of the full `traces` table.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
@@ -14,6 +14,11 @@
 -- post-cutover deletes. `traces` here is the RESTORED ORIGINAL, so a bridged id is present as its pre-cutover version; a
 -- liveness guard would spare it and thereby UNDO the user's post-cutover delete (resurrecting stale content). Masking it
 -- unconditionally is the correct rollback semantics.
+--
+-- One consequence, given the capture ordering (OPIK-8141): capture runs before the lightweight delete, so the bridge can
+-- name an id whose delete then errored and never applied. Having no liveness guard, this replay masks it on the restored
+-- original anyway. Accepted — the user did ask for that delete — and the alternative ordering instead loses genuine
+-- deletes, which resurrect here with the postcondition check reading the same bridge and so reporting 0.
 DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
 WHERE (workspace_id, project_id, id) IN (
     SELECT

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_reverse_replay.sql
@@ -13,12 +13,15 @@
 -- one here: rollback abandons all post-cutover writes on the successor (they are being discarded) while still honoring
 -- post-cutover deletes. `traces` here is the RESTORED ORIGINAL, so a bridged id is present as its pre-cutover version; a
 -- liveness guard would spare it and thereby UNDO the user's post-cutover delete (resurrecting stale content). Masking it
--- unconditionally is the correct rollback semantics.
+-- unconditionally is the correct rollback semantics. Nor a guard reading the parked successor as a proxy for "the delete
+-- applied": an id deleted and then RE-CREATED post-cutover is live there too, so that one would spare it just the same.
 --
 -- One consequence, given the capture ordering (OPIK-8141): capture runs before the lightweight delete, so the bridge can
 -- name an id whose delete then errored and never applied. Having no liveness guard, this replay masks it on the restored
 -- original anyway. Accepted — the user did ask for that delete — and the alternative ordering instead loses genuine
--- deletes, which resurrect here with the postcondition check reading the same bridge and so reporting 0.
+-- deletes, which resurrect here with the postcondition check reading the same bridge and so reporting 0. Such an id is
+-- recoverable while the rollback window is open: this statement touches only `traces`, so the row is still live on the
+-- parked successor (`traces_post_rollback_backup`) until finalize.sh drops it — the point of no return.
 DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.traces
 WHERE (workspace_id, project_id, id) IN (
     SELECT

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_verify_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_verify_replay.sql
@@ -9,10 +9,11 @@
 -- `created_at` with the post-rollback compare bounded below the cutover window — so a row created *inside* that window
 -- and deleted after it falls outside every window the compare looks at.
 --
--- What 0 proves: every delete the bridge RECORDED in the window is masked. What it does not: capture runs after the
--- delete and is best-effort by design (an auxiliary insert must never fail a user's delete), so a delete still in flight
--- when this runs, or one whose capture errored, is invisible to the replay and to this check alike. Quiescing trace
--- deletes before the promote is what bounds that — see the runbook — not this query.
+-- What 0 proves: every delete the bridge RECORDED in the window is masked. What it does not: capture runs before the
+-- delete but is best-effort by design (an auxiliary insert must never fail a user's delete), so a delete still in flight
+-- when this runs, or one whose capture errored, is invisible to the replay and to this check alike. A delete that merely
+-- errored is no longer such a case (OPIK-8141): capture goes first, so it is recorded regardless. Quiescing trace
+-- deletes before the promote is what bounds the rest — see the runbook — not this query.
 --
 -- KEEP IN STEP WITH 000004_rollback_reverse_replay.sql: same (workspace_id, project_id, id) key, same toFixedString(36)
 -- casts onto the bridge's String columns, same length guards. A check filtered differently from the replay would either

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanService.java
@@ -545,11 +545,13 @@ public class SpanService {
                         return commentService.deleteByEntityIds(CommentDAO.EntityType.SPAN, spanIds, projectId)
                                 .then(Mono.defer(() -> feedbackScoreService.deleteBySpanIds(spanIds, projectId)))
                                 .then(Mono.defer(() -> attachmentService.deleteByEntityIds(SPAN, spanIds, projectId)))
-                                .then(spanDAO.deleteByIds(spanIds, projectId)
+                                .then(captureDeletions(spanIds, projectId, workspaceId, userName))
+                                // Deferred like the steps above it, so the delete is assembled after the capture
+                                // rather than alongside it.
+                                .then(Mono.defer(() -> spanDAO.deleteByIds(spanIds, projectId)
                                         .doOnSuccess(__ -> log.info(
                                                 "Deleted '{}' spans for workspace '{}', project '{}'",
-                                                spanIds.size(), workspaceId, projectId)))
-                                .then(captureDeletions(spanIds, projectId, workspaceId, userName))
+                                                spanIds.size(), workspaceId, projectId))))
                                 .thenReturn(spanIds);
                     })
                     .doOnSuccess(spanIds -> {
@@ -562,11 +564,12 @@ public class SpanService {
     }
 
     /**
-     * Records the span ids removed by the trace-delete cascade in the {@code deletion_events_local} bridge so they
-     * survive the {@code spans} table copy during the Slice 3 migration window. Best-effort and deferred: gated by
-     * {@code spanDeletionEventsCaptureEnabled} and run only after the delete succeeds, and any capture failure is
-     * logged and swallowed so it can never disrupt the delete. Spans have no standalone delete, so this cascade is the
-     * only capture path. Mirrors {@code TraceService.captureDeletions}.
+     * Records the span ids the trace-delete cascade is about to remove in the {@code deletion_events_local} bridge so
+     * they survive the {@code spans} table copy during its migration window. Runs <b>before</b> the span lightweight
+     * delete and is best-effort, for the reasons in {@code TraceServiceImpl.captureDeletions}. Sits immediately before
+     * {@code SpanDAO.deleteByIds} rather than at the top of the cascade: the bridge records rows of the {@code spans}
+     * table, and a child-entity delete failing upstream leaves those rows untouched, so there is nothing to record.
+     * No-op unless capture is enabled. Spans have no standalone delete, so this cascade is the only capture path.
      */
     private Mono<Void> captureDeletions(Set<UUID> ids, UUID projectId, String workspaceId, String userName) {
         return Mono.defer(() -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -567,16 +567,19 @@ class TraceServiceImpl implements TraceService {
     }
 
     /**
-     * All-or-nothing over the batch: an error anywhere skips {@code TracesDeleted} and the deletion-events capture for
-     * every pair, not just the failed one. OPIK-8230 widens the window — the DAO can now emit several statements per
-     * batch, so earlier partitions' rows may already be gone. Deletes are idempotent; restructuring this coupling is
-     * out of that ticket's scope.
+     * All-or-nothing over the batch: an error anywhere skips {@code TracesDeleted} for every pair, not just the failed
+     * one. OPIK-8230 widens the window — the DAO can now emit several statements per batch, so earlier partitions' rows
+     * may already be gone. Deletes are idempotent; restructuring this coupling is out of that ticket's scope. The
+     * deletion-events capture is outside it: it runs first, so a failed or partially-applied delete is still recorded.
      */
     private Mono<Void> delete(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, Connection connection) {
         return Mono.deferContextual(ctx -> {
             String workspaceId = ctx.get(RequestContext.WORKSPACE_ID);
             String userName = ctx.get(RequestContext.USER_NAME);
-            return dao.delete(projectIdTraceIdPairs, connection)
+            // Deferred so the delete is assembled after the capture rather than alongside it: TraceDAO.delete
+            // validates and logs eagerly.
+            return captureDeletions(projectIdTraceIdPairs, workspaceId, userName)
+                    .then(Mono.defer(() -> dao.delete(projectIdTraceIdPairs, connection)))
                     .doOnSuccess(_ -> projectIdTraceIdPairs.stream()
                             .collect(Collectors.groupingBy(Pair::getLeft,
                                     Collectors.mapping(Pair::getRight, Collectors.toUnmodifiableSet())))
@@ -590,17 +593,27 @@ class TraceServiceImpl implements TraceService {
                                 log.info(
                                         "Published TracesDeleted event, trace ids count '{}', project id '{}', workspace '{}'",
                                         traceIds.size(), projectId, workspaceId);
-                            }))
-                    .then(captureDeletions(projectIdTraceIdPairs, workspaceId, userName));
+                            }));
         });
     }
 
     /**
-     * Records the deleted (project_id, trace_id) pairs in the deletion-events bridge so deletes issued while the table
-     * is being migrated survive the copy. Runs after the delete and is best-effort: capture is auxiliary and must never
-     * disrupt the delete, so failures are logged and swallowed. Running after the delete also avoids recording a delete
-     * that did not happen. No-op unless capture is enabled. Deferred so that nothing is built or run until subscribed,
-     * i.e. only after the delete succeeds.
+     * Records the (project_id, trace_id) pairs about to be deleted in the deletion-events bridge, so deletes issued
+     * while the table is being migrated survive the copy, and so a rollback re-applies them instead of resurrecting the
+     * rows.
+     * <p>
+     * Runs <b>before</b> the delete (OPIK-8141). The bridge is the only record of a lightweight delete, and a delete can
+     * fail its client while the server-side mutation still applies — the observed case being a client timeout on a
+     * mutation that then completed — so capturing afterwards let exactly those deletes go unrecorded, unrecoverably:
+     * neither replay direction can re-apply what the bridge does not name. Capturing first over-records instead when
+     * the delete does fail, which is the recoverable direction: the forward replay skips any id still live on the
+     * source, and a rollback re-applies a delete the user did ask for. The ordering is only worth something because the
+     * analytics connection carries {@code wait_for_async_insert = 1}: the insert completing means the rows are in the
+     * table, not merely queued in the async-insert buffer.
+     * <p>
+     * Still best-effort: a capture failure is logged and swallowed, never propagated. A lost event risks a resurrected
+     * row at the next copy or rollback, whereas failing the delete would impact live traffic — the worse trade for an
+     * auxiliary insert. No-op unless capture is enabled. Deferred so nothing is built or run until subscribed.
      */
     private Mono<Void> captureDeletions(Set<Pair<UUID, UUID>> projectIdTraceIdPairs, String workspaceId,
             String userName) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanDeletionEventArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanDeletionEventArchTest.java
@@ -13,7 +13,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 /**
  * Architectural guard for the span deletion event capturing. Spans have no standalone user delete
  * ({@code DELETE /spans/{id}} returns 501); the only span-deletion path is the trace-delete cascade in
- * {@link SpanService}, which records the deleted ids in {@code deletion_events_local} after the delete so they
+ * {@link SpanService}, which records the ids in {@code deletion_events_local} before the delete so they
  * survive the data-model migration's table copy. A new caller of {@code SpanDAO.deleteByIds(Set, UUID)} would issue
  * the lightweight delete without that capture, silently bypassing the bridge, so this rule fails the build if one
  * appears. Retention paths ({@code deleteForRetention*}) are intentionally not captured and are separate methods, so

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/SpanServiceImplTest.java
@@ -19,12 +19,14 @@ import reactor.core.publisher.Mono;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.comet.opik.domain.ProjectService.DEFAULT_USER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -120,7 +122,7 @@ class SpanServiceImplTest {
             var workspaceId = UUID.randomUUID().toString();
             mockSpanDeleteFlow(traceIds, spanIds, projectId);
             when(spanDAO.deleteByIds(spanIds, projectId)).thenReturn(Mono.just((long) spanIds.size()));
-            when(deletionEventDAO.insert(any(), eq(DEFAULT_USER)))
+            when(deletionEventDAO.insert(deletionEvents(projectId, spanIds, workspaceId), DEFAULT_USER))
                     .thenReturn(Mono.error(new RuntimeException("Error inserting deletion events")));
 
             spanService = newSpanService(DatabaseAnalyticsDataModelConfig.builder()
@@ -135,12 +137,12 @@ class SpanServiceImplTest {
 
             verify(spanDAO).deleteByIds(spanIds, projectId);
             verify(eventBus).post(any(SpansDeleted.class));
-            verify(deletionEventDAO).insert(any(), eq(DEFAULT_USER));
+            verify(deletionEventDAO).insert(deletionEvents(projectId, spanIds, workspaceId), DEFAULT_USER);
         }
 
         @Test
-        @DisplayName("when the delete fails, then no deletion events are recorded and the error propagates")
-        void delete__whenDeleteFails__thenRecordsNoDeletionEventsAndPropagates() {
+        @DisplayName("when the delete fails, then the deletion events are still recorded and the error propagates")
+        void delete__whenDeleteFails__thenStillRecordsDeletionEventsAndPropagates() {
             var traceIds = Set.of(idGenerator.generateId());
             var spanIds = Set.of(idGenerator.generateId(), idGenerator.generateId());
             var projectId = idGenerator.generateId();
@@ -148,11 +150,13 @@ class SpanServiceImplTest {
             mockSpanDeleteFlow(traceIds, spanIds, projectId);
             when(spanDAO.deleteByIds(spanIds, projectId))
                     .thenReturn(Mono.error(new RuntimeException("Error deleting spans")));
+            when(deletionEventDAO.insert(deletionEvents(projectId, spanIds, workspaceId), DEFAULT_USER))
+                    .thenReturn(Mono.empty());
 
             spanService = newSpanService(DatabaseAnalyticsDataModelConfig.builder()
                     .spanDeletionEventsCaptureEnabled(true)
                     .build());
-            // Capture runs only after a successful delete, so a failed delete records nothing and surfaces the error.
+            // OPIK-8141, cascade side: capture runs before the delete, so a failed delete is recorded anyway.
             assertThatThrownBy(() -> spanService
                     .deleteByTraceIds(traceIds, projectId)
                     .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
@@ -161,8 +165,11 @@ class SpanServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Error deleting spans");
 
-            verify(spanDAO).deleteByIds(spanIds, projectId);
-            verifyNoInteractions(deletionEventDAO, eventBus);
+            // The ordering is the fix, so assert it rather than infer it from both having happened.
+            var inOrder = inOrder(deletionEventDAO, spanDAO);
+            inOrder.verify(deletionEventDAO).insert(deletionEvents(projectId, spanIds, workspaceId), DEFAULT_USER);
+            inOrder.verify(spanDAO).deleteByIds(spanIds, projectId);
+            verifyNoInteractions(eventBus);
         }
 
         @Test
@@ -186,6 +193,23 @@ class SpanServiceImplTest {
             verify(spanDAO).getSpanIdsForTraces(traceIds, projectId);
             verify(spanDAO, never()).deleteByIds(any(), any());
             verifyNoInteractions(deletionEventDAO, eventBus);
+        }
+
+        /**
+         * The bridge rows the cascade is expected to record: one {@code spans} / {@code cascade} event per span id,
+         * with {@code eventTime} left null for ClickHouse to stamp. Matching the insert on this rather than on
+         * {@code any()} is what pins the recorded contents, so a wrong source table, reason or id fails the test.
+         */
+        private Set<DeletionEvent> deletionEvents(UUID projectId, Set<UUID> spanIds, String workspaceId) {
+            return spanIds.stream()
+                    .map(id -> DeletionEvent.builder()
+                            .sourceTable(SourceTable.SPANS)
+                            .workspaceId(workspaceId)
+                            .projectId(projectId)
+                            .deletedId(id.toString())
+                            .deletionReason(DeletionReason.CASCADE)
+                            .build())
+                    .collect(Collectors.toUnmodifiableSet());
         }
 
         // Stubs the cascade steps that run before the span lightweight delete: id resolution and the

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDeletionEventArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceDeletionEventArchTest.java
@@ -12,7 +12,7 @@ import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
 /**
  * Architectural guard for the trace deletion event capturing. User-initiated trace deletes must flow through
- * {@link TraceServiceImpl}, which records the deleted ids in {@code deletion_events_local} after the delete so
+ * {@link TraceServiceImpl}, which records the ids in {@code deletion_events_local} before the delete so
  * they survive the data-model migration's table copy. A new caller of
  * {@code TraceDAO.delete(Set, Connection)} would issue the lightweight delete without that capture,
  * silently bypassing the capturing, so this rule fails the build if one appears. Retention paths

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -45,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -251,7 +252,7 @@ class TraceServiceImplTest {
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
             when(traceDao.delete(pairs(projectId, ids), connection)).thenReturn(Mono.empty());
-            when(deletionEventDAO.insert(any(), eq(DEFAULT_USER)))
+            when(deletionEventDAO.insert(deletionEvents(projectId, ids, workspaceId), DEFAULT_USER))
                     .thenReturn(Mono.error(new RuntimeException("Error inserting deletion events")));
 
             var traceService = newTraceService(DatabaseAnalyticsDataModelConfig.builder()
@@ -266,23 +267,26 @@ class TraceServiceImplTest {
 
             verify(traceDao).delete(pairs(projectId, ids), connection);
             verifyTracesDeletedPosted(ids, projectId, workspaceId);
-            verify(deletionEventDAO).insert(any(), eq(DEFAULT_USER));
+            verify(deletionEventDAO).insert(deletionEvents(projectId, ids, workspaceId), DEFAULT_USER);
         }
 
         @Test
-        @DisplayName("when the delete fails, then no deletion events are recorded and the error propagates")
-        void delete__whenDeleteFails__thenRecordsNoDeletionEventsAndPropagates() {
+        @DisplayName("when the delete fails, then the deletion events are still recorded and the error propagates")
+        void delete__whenDeleteFails__thenStillRecordsDeletionEventsAndPropagates() {
             var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
             var projectId = idGenerator.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
             when(traceDao.delete(pairs(projectId, ids), connection))
                     .thenReturn(Mono.error(new RuntimeException("Error deleting traces")));
+            when(deletionEventDAO.insert(deletionEvents(projectId, ids, workspaceId), DEFAULT_USER))
+                    .thenReturn(Mono.empty());
 
             var traceService = newTraceService(DatabaseAnalyticsDataModelConfig.builder()
                     .traceDeletionEventsCaptureEnabled(true)
                     .build());
-            // Capture runs only after a successful delete, so a failed delete records nothing and surfaces the error.
+            // OPIK-8141: capture runs before the delete, so a failed delete is recorded anyway - including one whose
+            // statement errored on the client while its server-side mutation applied, the case that lost the event.
             assertThatThrownBy(() -> traceService
                     .delete(ids, projectId)
                     .contextWrite(ctx -> ctx.put(RequestContext.USER_NAME, DEFAULT_USER)
@@ -291,8 +295,12 @@ class TraceServiceImplTest {
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("Error deleting traces");
 
-            verify(traceDao).delete(pairs(projectId, ids), connection);
-            verifyNoInteractions(deletionEventDAO, eventBus);
+            // The ordering is the fix, so assert it rather than infer it from both having happened.
+            var inOrder = inOrder(deletionEventDAO, traceDao);
+            inOrder.verify(deletionEventDAO).insert(deletionEvents(projectId, ids, workspaceId), DEFAULT_USER);
+            inOrder.verify(traceDao).delete(pairs(projectId, ids), connection);
+            // A failed delete still skips the cascade: its children belong to traces that may well be live.
+            verifyNoInteractions(eventBus);
         }
 
         @Test
@@ -341,6 +349,23 @@ class TraceServiceImplTest {
          */
         private Set<Pair<UUID, UUID>> pairs(UUID projectId, Set<UUID> ids) {
             return ids.stream().map(id -> Pair.of(projectId, id)).collect(Collectors.toUnmodifiableSet());
+        }
+
+        /**
+         * The bridge rows the delete is expected to record: one {@code traces} / {@code user_request} event per pair,
+         * with {@code eventTime} left null for ClickHouse to stamp. Matching the insert on this rather than on
+         * {@code any()} is what pins the recorded contents, so a wrong source table, reason or id fails the test.
+         */
+        private Set<DeletionEvent> deletionEvents(UUID projectId, Set<UUID> ids, String workspaceId) {
+            return ids.stream()
+                    .map(id -> DeletionEvent.builder()
+                            .sourceTable(SourceTable.TRACES)
+                            .workspaceId(workspaceId)
+                            .projectId(projectId)
+                            .deletedId(id.toString())
+                            .deletionReason(DeletionReason.USER_REQUEST)
+                            .build())
+                    .collect(Collectors.toUnmodifiableSet());
         }
 
         private Connection mockDeleteFlow() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -101,7 +101,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * bridge-capture helpers mirror the production write shapes ({@code TraceDAO}, {@code TraceService} delete,
  * {@code DeletionEventDAO}) and reproduce the two version-stamp regimes the delta relies on (fresh server
  * {@code created_at} vs client {@code last_updated_at}); the DAOs' own semantics are covered by their dedicated suites
- * (e.g. {@code TraceDeletionEventTest}).
+ * (e.g. {@code DeletionEventTest}).
  *
  * <p><b>Scope: this gate validates the cutover SQL logic, not the driver scripts.</b> The safety guards in the runbook's
  * bash drivers — {@code backfill.sh}'s reconciliation abort, {@code rollback.sh}'s wrong-stage topology assertions,


### PR DESCRIPTION
## Details

The deletion-events bridge is the only record of a lightweight delete — LWD does not bump `last_updated_at`, so neither the version-based delta-insert nor the rollback's reverse replay can see one otherwise. Capture ran **after** the delete, which made that record conditional on the delete succeeding, and a delete can fail its client while the server-side mutation still applies (the observed case: a client timeout on a statement that then completes). The rows went, the bridge row did not, and the delete became invisible to both replay directions.

Capture now runs **before** the lightweight delete, in the trace delete and in the span cascade alike, so a delete that fails is recorded anyway.

- **Still best-effort.** A failed bridge insert is logged and swallowed exactly as before, never propagated, so this cannot make a delete fail that would previously have succeeded — one failure mode closed, none opened. Losing an event risks a resurrected row at the next copy or rollback; failing the delete would impact live traffic, the worse trade for an auxiliary insert.
- **Also covers partially-applied batches.** The DAO can emit one statement per partition per batch, so a mid-batch failure leaves earlier partitions' rows already deleted — previously unbridged, now recorded up front.
- **The bridge is neither a subset nor a superset** of the deletes that actually applied: it can miss one when the capture itself fails (unchanged), and name one whose delete then errored (new). Over-recording is the recoverable direction — the forward replay's resurrection guard already skips any id still live on the source, while the rollback's reverse replay deliberately carries no such guard and so will mask an over-recorded id on the restored original. That is correct: the user did ask for that delete.
- **Both deletes are wrapped in `Mono.defer`** so they are assembled after the capture rather than alongside it; without it the DAO call is invoked during chain assembly.
- **The ordering means something** because the analytics connection carries `wait_for_async_insert = 1`, so the insert completing is the rows being in the table rather than queued in the async-insert buffer. That dependency is now recorded in the javadoc.
- `DeletionEventDAO` is untouched. The capture flags stay the operator switch and stay `false` by default; the span half is inert until the spans cutover and is included so the two capture sites, which cross-reference each other and are guarded by a matched pair of ArchUnit rules, do not diverge.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-8141

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation, tests and documentation, iterated over several review rounds with the author
- Human verification: author-directed design decisions (best-effort over gating, scope, test level), code review, and three negative controls run against the suite

## Testing

Run from `apps/opik-backend`:

```
mvn test -Dtest='TraceServiceImplTest,SpanServiceImplTest,DeletionEventTest,TraceDeletionEventArchTest,SpanDeletionEventArchTest'
mvn test -Dtest='TracesPartitionPruningMutationTest,TracesDistributedWrapMutationTest,TracesLegacyTablePruningMutationTest,TraceMutationRoutingArchTest,WeeklyPartitionsTest'
mvn spotless:check
```

All green (18 and 35 respectively; spotless clean).

**Scenarios validated**

- Capture disabled → nothing recorded, delete and `TracesDeleted` still happen (both services, unit).
- Capture fails → delete still runs and succeeds (both services, unit). This pre-existing test already asserted the behavior the change keeps, so it is unchanged.
- Delete fails → events recorded anyway, `InOrder` assertions pinning capture-before-delete, error propagates, cascade suppressed (both services, unit).
- Success path across every trace-delete entry point — delete-by-id, batch delete with and without a project scope, thread delete, and an id reused across two projects — plus the cascaded span capture, against a real ClickHouse with a deliberately small insert batch size so the chunked-insert path is exercised (`DeletionEventTest`, integration).
- A new caller bypassing the capturing service fails the build (ArchUnit, both source tables).

**Negative controls** — each of these fails the suite, so the guards are load-bearing rather than decorative:

1. Reverting the capture ordering in `TraceServiceImpl`.
2. Removing `Mono.defer` from either service.
3. Perturbing the recorded `deletion_reason`.

**Not covered, with reason:** a failing ClickHouse mutation and a failing bridge insert cannot be induced through the API, so the two failure paths are unit-tested rather than black-box. The capture→replay seam end-to-end (capture through the API, then the replay SQL over those exact rows) spans two suites with incompatible container requirements and is assigned to the QA gate against a full-volume clone, per the cutover runbook.

## Documentation

- `apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md` — a note on the bridge write order where the design is introduced, and a rewrite of "What the reverse replay can and cannot re-apply" (the old text asserted the previous ordering and the escape routes that came with it). The deletion-capture monitoring guidance is deliberately unchanged: capture-failure behavior is exactly as it was.
- `000002_delta_and_deletion_replay.sql` — the resurrection guard now covers a second case.
- `000004_rollback_reverse_replay.sql` — the consequence of the ordering for a guard-less replay.
- `000004_rollback_verify_replay.sql` — what a `0` result does and does not prove, under the new ordering.
- Javadoc on both `captureDeletions` methods and on `TraceServiceImpl.delete`, plus the two ArchUnit guards.
- Repoints a stale reference in `TracesLocalV2CutoverTest` to a test class that was consolidated into `DeletionEventTest`.
