### PR TITLE
[OPIK-8058] [FE] fix: keep experiment item panel sizes stable when navigating dataset items

### DIFF
--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/CompareExperimentsPanel.tsx
@@ -83,7 +83,7 @@ const CompareExperimentsPanel: React.FunctionComponent<
 
   const experimentItems = useMemo(() => {
     return sortBy(activeExperimentsCompare?.experiment_items || [], (e) =>
-      findIndex(experimentsIds, (id) => e.id === id),
+      findIndex(experimentsIds, (id) => e.experiment_id === id),
     );
   }, [activeExperimentsCompare?.experiment_items, experimentsIds]);
 

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
@@ -24,9 +24,6 @@ const DataTab = ({
   datasetItemId,
 }: DataTabProps) => {
   const renderExperimentsSection = () => {
-    // One panel per slot: the index is stable across dataset items, unlike the
-    // experiment item id, and unique, unlike the experiment id when an
-    // experiment run contributes several items per dataset item.
     return experimentItems.map((experimentItem, idx) => (
       <React.Fragment key={idx}>
         <ResizablePanel

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
@@ -24,8 +24,11 @@ const DataTab = ({
   datasetItemId,
 }: DataTabProps) => {
   const renderExperimentsSection = () => {
+    // One panel per slot: the index is stable across dataset items, unlike the
+    // experiment item id, and unique, unlike the experiment id when an
+    // experiment run contributes several items per dataset item.
     return experimentItems.map((experimentItem, idx) => (
-      <React.Fragment key={experimentItem.experiment_id}>
+      <React.Fragment key={idx}>
         <ResizablePanel
           order={idx + 1}
           className="min-w-72"

--- a/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
+++ b/apps/opik-frontend/src/v2/pages/CompareExperimentsPage/CompareExperimentsPanel/DataTab/DataTab.tsx
@@ -25,8 +25,12 @@ const DataTab = ({
 }: DataTabProps) => {
   const renderExperimentsSection = () => {
     return experimentItems.map((experimentItem, idx) => (
-      <React.Fragment key={experimentItem.id}>
-        <ResizablePanel className="min-w-72" style={{ overflow: "unset" }}>
+      <React.Fragment key={experimentItem.experiment_id}>
+        <ResizablePanel
+          order={idx + 1}
+          className="min-w-72"
+          style={{ overflow: "unset" }}
+        >
           <CompareExperimentsViewer
             experimentItem={experimentItem}
             openTrace={openTrace}
@@ -46,7 +50,7 @@ const DataTab = ({
       style={{ height: "unset", overflow: "unset" }}
       className="min-h-full"
     >
-      <ResizablePanel defaultSize={30} className="min-w-72">
+      <ResizablePanel order={0} defaultSize={30} className="min-w-72">
         <ExperimentDataset data={data} datasetItemId={datasetItemId} />
       </ResizablePanel>
       <ResizableHandle />


### PR DESCRIPTION
## Details

Clicking `Next` in the experiment item side panel blew up the dataset item column and collapsed the result column to its min width. The result panels were keyed by experiment **item** id, which changes with the dataset item, so navigating remounted them — and `react-resizable-panels` cannot recover from that remount: the fresh panel renders before it registers (so it falls back to `flex-grow: 1`), and the group's layout recompute then sees an unchanged layout and never re-renders it.

- Key the result panels by their slot index and give both panels an explicit `order`, which is what the library recommends for dynamically rendered panels (it keeps the registered panel array in DOM order when an experiment has no item for a row). The index is stable across dataset items, unlike the item id; panels are positional slots already, since `order` and the viewer's preserved state are both index-based.
- Compare `experiment_id` in the `sortBy` comparator — it compared the item id against experiment ids, so it always returned `-1`, the sort did nothing, and result columns followed API response order instead of the compared-experiments order.

Two notes for reviewers:

- The `order` props change the `react-resizable-panels` autosave key, so anyone who had dragged this divider gets the 30/70 default once, then it persists again as before.
- Keying by `experiment_id` was the first attempt and review caught it: an experiment run with `trial_count > 1` contributes several items per dataset item, so sibling panels collided and React logged `Encountered two children with the same key`. Verified on a 4-trial experiment — three warnings before, none after; no visual difference either way, since React reconciles same-order duplicates positionally.
- No automated test guards this. `react-resizable-panels` never resolves its layout under happy-dom (a plain freshly-mounted group also reports `30.0 / 1.0` there), so a size assertion would pass on the broken code too. Verified in a real browser instead — measurements below.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-8058

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: root-cause investigation, the two-file fix, and the verification runs below
- Human verification: author reviewed the full diff and the before/after measurements, and decided against keeping a proposed regression test

## Testing

Automated, from `apps/opik-frontend`:

- `npx vitest run` — 155 files, 2326 tests passed
- `npx tsc -p tsconfig.json --noEmit` — clean
- `pre-commit run --files <the two changed files>` — eslint and typecheck passed

Manual, against a local stack with the vite dev server, measuring the panel group's `flex-grow` and rendered widths inside the side panel:

| scenario | before | after |
| --- | --- | --- |
| single experiment, 6x `Next` | 342 / 288px (result column pinned at its `min-w-72`), panel id churned on every click | 342 / 798px held, panel ids stable |
| divider dragged to 55/45, then `Next` | — | 55/45 held (627 / 513px) |
| 2-experiment compare, `Next` | — | 30/35/35 held, columns stayed in baseline order |

## Documentation

No documentation changes. This is a bug fix in existing UI behaviour — no new or changed feature to document, and no user-facing docs describe the side panel's column widths.
