### PR TITLE
[issue-6147] [BE] fix: replace FINAL with LIMIT 1 BY on thread-by-id span aggregation

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ThreadDAO.java
@@ -781,7 +781,8 @@ class ThreadDAOImpl implements ThreadDAO {
      *  - The creator of the thread, which is the created_by of the first trace in the list.
      *  - The creation time of the thread, which is the created_at of the first trace in the list.
      ***/
-    private static final String SELECT_TRACES_THREAD_BY_ID = """
+    @VisibleForTesting
+    static final String SELECT_TRACES_THREAD_BY_ID = """
             WITH traces_ids AS (
                 SELECT
                     id
@@ -803,16 +804,29 @@ class ThreadDAOImpl implements ThreadDAO {
                 AND id IN (SELECT id FROM traces_ids)
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 LIMIT 1 BY id
+            ), spans_deduped AS (
+                SELECT
+                    workspace_id,
+                    project_id,
+                    trace_id,
+                    id,
+                    last_updated_at,
+                    usage,
+                    total_estimated_cost,
+                    provider
+                FROM spans
+                WHERE workspace_id = :workspace_id
+                  AND project_id = :project_id
+                  AND trace_id IN (SELECT DISTINCT id FROM traces_ids)
+                ORDER BY (workspace_id, project_id, trace_id, id) DESC, last_updated_at DESC
+                LIMIT 1 BY id
             ), spans_agg AS (
                 SELECT
                     trace_id,
                     sumMap(usage) as usage,
                     sum(total_estimated_cost) as total_estimated_cost,
                     arraySort(groupUniqArrayIf(provider, provider != '')) as providers
-                FROM spans final
-                WHERE workspace_id = :workspace_id
-                  AND project_id = :project_id
-                  AND trace_id IN (SELECT DISTINCT id FROM traces_ids)
+                FROM spans_deduped
                 GROUP BY workspace_id, project_id, trace_id
             ), trace_threads_ids AS (
                 SELECT

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ThreadDAOImplTest.java
@@ -213,4 +213,36 @@ class ThreadDAOImplTest {
             return sql.substring(start, end);
         }
     }
+
+    @Nested
+    @DisplayName("thread-by-id spans aggregation")
+    class ThreadByIdSpansDedup {
+
+        @Test
+        @DisplayName("SELECT_TRACES_THREAD_BY_ID dedups spans with LIMIT 1 BY id instead of FINAL")
+        void threadByIdDoesNotUseSpansFinal() {
+            String sql = ThreadDAOImpl.SELECT_TRACES_THREAD_BY_ID;
+
+            assertThat(sql).doesNotContain("FROM spans final");
+
+            String spansDeduped = cte(sql, "spans_deduped AS (", "), spans_agg AS (");
+            assertThat(spansDeduped).contains("FROM spans");
+            assertThat(spansDeduped).contains("AND trace_id IN (SELECT DISTINCT id FROM traces_ids)");
+            assertThat(spansDeduped)
+                    .contains("ORDER BY (workspace_id, project_id, trace_id, id) DESC, last_updated_at DESC");
+            assertThat(spansDeduped).contains("LIMIT 1 BY id");
+
+            String spansAgg = cte(sql, "spans_agg AS (", "), trace_threads_ids AS (");
+            assertThat(spansAgg).contains("FROM spans_deduped");
+            assertThat(spansAgg).doesNotContain("FROM spans final");
+        }
+
+        private static String cte(String sql, String startMarker, String endMarker) {
+            int start = sql.indexOf(startMarker);
+            assertThat(start).isNotNegative();
+            int end = sql.indexOf(endMarker, start);
+            assertThat(end).isGreaterThan(start);
+            return sql.substring(start, end);
+        }
+    }
 }


### PR DESCRIPTION
## Details

Clicking a thread still times out on large `spans` tables because `SELECT_TRACES_THREAD_BY_ID` was the one remaining ThreadDAO query that aggregated with `FROM spans final`. List/count/stats already switched to a `spans_deduped` CTE (`ORDER BY ... LIMIT 1 BY id`) so ClickHouse can apply `workspace_id` / `project_id` / `trace_id` filters before ReplacingMergeTree dedup. This change uses that same shape on the retrieve-by-id path, which is what `POST /traces/threads/retrieve` runs.

PR #6358 fixed the listing queries. PR #6295 tried to convert all four `spans_agg` CTEs, including this one, but was closed after those listing changes landed. The by-id query was left on `FINAL`.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #6147

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Cursor
  - Model(s): Cursor Grok 4.6
  - Scope: root-cause investigation of #6147, ThreadDAO SQL change, and ThreadDAOImplTest regression
  - Human verification: confirmed the leftover `FROM spans final` is only in `SELECT_TRACES_THREAD_BY_ID`; matched the existing list-query `spans_deduped` pattern; ran `ThreadDAOImplTest` (12 tests, 0 failures)

## Testing

- Command: `mvn -B test -Dtest=ThreadDAOImplTest` in `apps/opik-backend` (JDK 25 Maven container)
- Result: Tests run: 12, Failures: 0, Errors: 0, Skipped: 0; BUILD SUCCESS
- Scenarios: new regression asserts the by-id query no longer contains `FROM spans final`, dedups via `LIMIT 1 BY id`, and keeps the `trace_id IN (SELECT DISTINCT id FROM traces_ids)` filter
- Existing ThreadDAOImplTest cases (firstThreadOrEmpty, traces_final_ids prefilter gate, thread_id pushdown) still pass
- ClickHouse integration tests / FindTraceThreadsResourceTest were not run locally (no Java/Maven on the host besides Docker; no live ClickHouse for resource tests)

## Documentation

No documentation update. Behavior is unchanged for callers; only the ClickHouse scan for thread-by-id retrieve is aligned with the existing list/count/stats queries.
