### PR TITLE
[OPIK-8239] [BE] fix: drop the traces-cutover async-insert buffer bump

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -383,21 +383,19 @@ toward `--force`, which the Go/No-Go forbids. Hence:
 | unfinished **mutations** on `traces_local_v2` | **Unconditional** — none, within `--settle-timeout` (default 120s). What this catches is a mutation left behind by an earlier step or by manual intervention. It does **not** cover the final deletion replay, which the driver issues *after* this sample: that one is covered by `lightweight_deletes_sync = 2` in its own block, which returns only once every replica has applied the mask, and the driver asserts the setting is still present before running it. |
 | the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** Counts only `GET_PART`/`ATTACH_PART` — the entries that mean a replica lacks data. Merges and mutations also sit in this queue and say nothing about completeness; counting them would fail the gate on the large merges that follow a backfill. It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is busy but not stuck is accepted, with the numbers printed so the operator sees what was accepted. |
 
-The queue verdict is a **snapshot** over the last sample read, in both the polled and the single-sample case — nothing
-compares consecutive samples. Polling buys the queue time to drain, and a genuinely stuck entry time to age past the
-thresholds; that is all, so a shorter `--settle-timeout` is a weaker gate by exactly that much.
+**Budget for the wait.** The queue verdict is a **snapshot** over the last sample read — nothing compares consecutive
+samples, in either the polled or the single-sample case. Polling buys exactly two things: time for the queue to drain,
+and time for a genuinely stuck entry to age past the thresholds. So the gate returns early only on a drained queue;
+otherwise it spends the whole budget before accepting, and because it sits between the final delta and the `EXCHANGE`,
+that wait lands in the tail write-gap. It is not wasted — aging is the only detection this gate has, and accepting the
+first not-stuck sample would make the default no stronger than `--settle-timeout 0`. Restricting the count to
+`GET_PART`/`ATTACH_PART` is what makes the early exit reachable in practice: those entries clear continuously, whereas
+the merge backlog that follows a backfill does not.
 
-**Budget for the wait.** The gate returns early only on a drained queue; the busy-but-not-stuck verdict is reached once
-the poll budget is spent. So a run whose queue never reaches 0 waits the full `--settle-timeout` before passing, and
-that wait lands in the tail write-gap. It is not wasted — the wait is what lets a stuck entry age past the thresholds,
-which is the only detection this gate has, and accepting the first not-stuck sample would make the default no stronger
-than `--settle-timeout 0`. Restricting the count to `GET_PART`/`ATTACH_PART` is what makes the early exit reachable in
-practice: those entries clear continuously, whereas the merge backlog that follows a backfill does not.
-
-`--settle-timeout` accepts 0–3600s; raise it for a slow-but-progressing cluster, at a price — the gate sits between the
-final delta and the `EXCHANGE`, so whatever it waits is added to the tail write-gap. The driver prints the wait
-alongside its elapsed-through-`EXCHANGE`, so the gap can be sized with it included. `--force` skips the gate and is a
-production No-Go: the gate is permissive enough that reaching its failure path means something is genuinely wrong.
+`--settle-timeout` accepts 0–3600s; raise it for a slow-but-progressing cluster, at the price of a longer tail. The
+driver prints the wait alongside its elapsed-through-`EXCHANGE`, so the gap can be sized with it included. `--force`
+skips the gate and is a production No-Go: the gate is permissive enough that reaching its failure path means something
+is genuinely wrong.
 
 ### The final cutover window
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1,13 +1,17 @@
-# Buffered cutover runbook — `traces` → partitioned + sharding-ready
+# Cutover runbook — `traces` → partitioned + sharding-ready
 
-Operator runbook for the buffered cutover of the ClickHouse `traces` table: it migrates the live, unpartitioned
+Operator runbook for the cutover of the ClickHouse `traces` table: it migrates the live, unpartitioned
 `traces` table to `traces_local_v2` (weekly-partitioned, denullified, `is_deleted`-ready) with **near-zero downtime**
 and **near-zero deletion loss** — the deletion bridge replays every captured delete before the swap, leaving only a
 bounded residual micro-window (see "The final cutover window" below, which also gives the mitigation) — then wraps it
 in a sharding-ready `Distributed` table.
 
-The mechanism is **backfill + delta + deletion replay + EXCHANGE**, using the ingestion async-insert buffer to absorb
-the brief cutover window instead of a dual-write path.
+The mechanism is **backfill + delta + deletion replay + EXCHANGE**, with no dual-write path and **no ingestion-path
+config change**. Writes are never held: the `EXCHANGE` is atomic per node, so a concurrent insert always commits to a
+valid table. Writes that land in the *old* one — in the final-delta→`EXCHANGE` gap and during the cross-node
+`ON CLUSTER` skew — stay in the parked backup, which is an open defect tracked as OPIK-8238 rather than a property of
+this procedure. See ["The final cutover window"](#the-final-cutover-window) for what the swap does and does not
+guarantee.
 
 This runbook is the human-facing artifact; its SQL is validated end-to-end by
 [`TracesLocalV2CutoverTest`](../../src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java). Treat
@@ -59,12 +63,12 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 |---|---|---|
 | Before the backfill | Row masked on the source | `INSERT SELECT` honors `apply_deleted_mask=1` → never copied. No replay. |
 | During the backfill, after its row was copied | Delta can't see the mask flip | Captured in the bridge → **replayed** before EXCHANGE. |
-| During the delta / buffer window | Same as above | Same bridge, same replay step. |
+| During the delta and the final cutover window | Same as above | Same bridge, same replay step. |
 
 ## Prerequisites (do not start without these)
 
 1. **24h UUIDv7 ingestion validation** live long enough that no un-validated future-dated ids land in newly ingested
-   weeks. This is not tied to a retention cycle (retention never runs — prereq 8). Pre-validation far-future-timestamp
+   weeks. This is not tied to a retention cycle (retention never runs — prereq 7). Pre-validation far-future-timestamp
    rows already in the table are *not* blocked by this: they are copied by the `created_at` slice and surfaced by the far-future audit
    query below — this prereq only ensures no *new* out-of-range partitions are created mid-cutover.
 2. **`traces_local_v2` exists and is empty** (migration 000101).
@@ -78,21 +82,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    `ANALYTICS_DB_DATA_MODEL_TRACE_DELETION_EVENTS_CAPTURE_ENABLED=true` (the backend service forwards it) and restart the
    backend. `backfill.sh` captures the `backfill_start` anchor (a `now64(6, 'UTC')` taken just before the first INSERT)
    and prints it — the delta and the replay both key off it.
-6. **Cutover buffer knob ready** — `databaseAnalytics.asyncInsertBusyTimeoutMaxMs` (env
-   `ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS`), unset by default so the buffer inherits the
-   `async_insert_busy_timeout_max_ms=250` carried by `queryParameters`. Raise it to ~10000 for the cutover, then unset it
-   again. **Where it is set, the exact value, the rollout and the revert step are in
-   ["Where the buffer bump lives"](#where-the-buffer-bump-lives-and-how-to-revert-it)** — it is a temporary env var on the
-   deployment's own backend config, not a chart value (OPIK-7686). Have that config change written and reviewed *before*
-   the window, so applying it is a merge, not an edit. The ceiling is a backend per-query setting applied on the backend's own
-   ClickHouse client, so the migration scripts' direct `clickhouse-client` session **cannot read or verify it**. It is
-   therefore **operator-asserted**: `exchange_and_wrap.sh` refuses the EXCHANGE without `--confirm-buffer-raised` (a
-   fail-fast acknowledgment gate — it forces the operator to confirm the step, though it cannot prove the value took
-   effect). Confirm it actually took effect on the prod-clone/staging load test (the Go/No-Go "Async-insert ceiling
-   confirmed" item) before production. **Also confirm client/SDK insert timeouts exceed the widened buffer** (~10s) —
-   with `wait_for_async_insert=1` a raised ceiling blocks each insert until it flushes, so a shorter client timeout would
-   surface as ingestion errors during the window.
-7. **Schema-state flag wired, with a rollout plan** — `databaseAnalyticsDataModel.traceColumnsNonNullable` (env
+6. **Schema-state flag wired, with a rollout plan** — `databaseAnalyticsDataModel.traceColumnsNonNullable` (env
    `ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE`, default `false`). The successor's `end_time`/`ttft` are
    **non-nullable sentinel** columns, so the app must represent an absent value as the epoch/NaN sentinel — not `null` —
    once they are live. This flag switches that on **both** sides: the write bind, and the read/filter/sort translation
@@ -111,26 +101,26 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    > EXCHANGE the read-back becomes the discriminator: an absent `end_time` must return `null`, not `1970-01-01`. Assert
    > `ttft` alongside it — same flag, other arm, and one trace written without either covers both. Do both sides of the
    > swap, or a stale instance passes the only check you ran.
-8. **Confirm Data Retention is disabled** (`RETENTION_ENABLED=false`, the default). If it is ever enabled, see the
+7. **Confirm Data Retention is disabled** (`RETENTION_ENABLED=false`, the default). If it is ever enabled, see the
    retention note above first.
-9. **Sufficient free disk** — the backfill writes a full second physical copy of `traces`, so node free space must clear
+8. **Sufficient free disk** — the backfill writes a full second physical copy of `traces`, so node free space must clear
    **≥ 2× the current `traces` on-disk size** (more counting merge scratch). `estimate.sh` reports headroom and
    `backfill.sh` aborts below `--min-free-factor` (default 2.0). On tiered storage this whole-node floor is necessary but
    not sufficient — validate per-volume (hot) headroom too, since new parts land hot before they tier.
-10. **Schema parity of source and successor** — `traces` and `traces_local_v2` must stay equivalent for as long as both
-    exist: the same base (stored) columns (which the cutover must copy) and the same materialized columns (which each
-    table recomputes). Guarded in CI by `TracesLocalV2CutoverTest` — `cutoverCopiesEveryBaseColumn` (a new base column
-    fails the build until it is in the cutover column list) and `successorMaterializedColumnsMatchSource` (a materialized
-    column added to one table but not the other fails the build). Re-confirm both are green on the release being
-    deployed.
-11. **Fresh backup / snapshot** of the ClickHouse data node.
-12. **Freeze concurrent DDL on `traces` for the window — and through the rollback-eligible soak.** Hold any deploy or
+9. **Schema parity of source and successor** — `traces` and `traces_local_v2` must stay equivalent for as long as both
+   exist: the same base (stored) columns (which the cutover must copy) and the same materialized columns (which each
+   table recomputes). Guarded in CI by `TracesLocalV2CutoverTest` — `cutoverCopiesEveryBaseColumn` (a new base column
+   fails the build until it is in the cutover column list) and `successorMaterializedColumnsMatchSource` (a materialized
+   column added to one table but not the other fails the build). Re-confirm both are green on the release being
+   deployed.
+10. **Fresh backup / snapshot** of the ClickHouse data node.
+11. **Freeze concurrent DDL on `traces` for the window — and through the rollback-eligible soak.** Hold any deploy or
     Liquibase changeset that would `ALTER`, `RENAME`, or otherwise touch `traces` / `traces_local_v2` for the whole
     backfill→EXCHANGE window — a schema change landing mid-cutover races the swap and can corrupt it — and keep it frozen
     until `finalize.sh` commits (see "Point of no return"): a `traces` schema change made *after* the EXCHANGE is lost
     from the live table on a rollback + finalize. The revamp's own migrations (000096/000101) are already applied; this
     is about *unrelated* migrations or ad-hoc DDL during the window.
-13. **Deletion bridge holds no empty-`project_id` trace events, and OPIK-7483 is live fleet-wide.** Since OPIK-7483 every
+12. **Deletion bridge holds no empty-`project_id` trace events, and OPIK-7483 is live fleet-wide.** Since OPIK-7483 every
     trace delete carries its `project_id`, so the cutover replay is full-key only (no workspace-scoped branch). Confirm
     OPIK-7483 is deployed across the **whole** backend fleet before the window (a straggler pre-7483 backend could emit an
     empty-`project_id` event the replay would miss), then assert the bridge holds none. `deletion_events_local` is a
@@ -140,7 +130,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
     WHERE source_table = 'traces' AND project_id = '';
     ```
     If non-zero, do NOT proceed: an unexpected row means the replay would miss those deletes — investigate/drain them first.
-14. **Privilege smoke test — run `delta_replay.sh` once BEFORE the backfill, anchored at the current instant.** The
+13. **Privilege smoke test — run `delta_replay.sh` once BEFORE the backfill, anchored at the current instant.** The
     driver takes a literal timestamp carrying the ` UTC` marker, so read the clock first and pass what it printed:
     `SELECT toString(now64(6, 'UTC'))`, then `--backfill-start '<that value> UTC'`. Both statements execute but match
     nothing (no row has `created_at`/`last_updated_at` in the future, and the bridge holds no events after that instant),
@@ -153,7 +143,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
     > `ALTER DELETE`**. The read-only drivers (`estimate.sh`, `verify.sh`) cannot surface this — only executing a
     > mutation can. Grant it **column-scoped** (`ALTER UPDATE(_row_exists)`) so the user can flip the delete mask
     > without being able to modify any real data column.
-15. Schedule during off-peak hours.
+14. Schedule during off-peak hours.
 
 ## The sequence
 
@@ -176,36 +166,36 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    It executes the reference statement in
    [`000001_backfill_traces_local_v2.sql`](scripts/db-app-analytics/000001_backfill_traces_local_v2.sql) — the script
    reads that file and substitutes the window bounds, so the two never drift.
-2. **Raise the buffer ceiling** (config — see
-   ["Where the buffer bump lives"](#where-the-buffer-bump-lives-and-how-to-revert-it) for the key, the value and the
-   restart wait), then **[`scripts/delta_replay.sh`](scripts/delta_replay.sh)**
+2. **[`scripts/delta_replay.sh`](scripts/delta_replay.sh)**
    (reference SQL [`000002_delta_and_deletion_replay.sql`](scripts/db-app-analytics/000002_delta_and_deletion_replay.sql))
    — delta-insert (anchored at `backfill_start`), then **deletion replay**. The replay runs with
    `lightweight_deletes_sync = 2`, so it returns only once the delete mutation has applied on **every** replica.
+   No config change precedes this step — the procedure takes no hold on writes.
    The driver passes `--time`, so clickhouse-client prints each statement's wall time in seconds (delta-insert first,
-   deletion replay second) — **record the second value**: the final-delta→EXCHANGE gap must fit inside the buffer hold
-   (Go/No-Go). Without `--time` a bare `--query` prints no timing at all.
+   deletion replay second) — **record the second value**: it sizes the final-delta→`EXCHANGE` gap, which is where tail
+   writes are left behind. Without `--time` a bare `--query` prints no timing at all.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/delta_replay.sh --database opik --backfill-start '<ts> UTC'
    ```
 3. **QA — run [`scripts/verify.sh`](scripts/verify.sh)** (see "Verifying the migration"): confirm the copy altered no
-   data before committing the swap. Run it after step 2 (and it can be re-run after step 4).
+   data before committing the swap. Run it after step 2; it can be re-run after the swap, bounded as
+   ["Verifying the migration"](#verifying-the-migration-qa) describes.
 4. **[`scripts/exchange_and_wrap.sh`](scripts/exchange_and_wrap.sh)** (reference SQL
    [`000003_exchange_and_wrap.sql`](scripts/db-app-analytics/000003_exchange_and_wrap.sql)) — first **gates on a settled
-   replication state** (empty `replication_queue` on `traces`/`traces_local_v2` and the deletion-replay mutation finished
-   on `traces_local_v2`, across all replicas via `clusterAllReplicas`) so no replica swaps in an incomplete table
-   (`--force` overrides); then records and
+   replication state** (see ["The replication-settle gate"](#the-replication-settle-gate) — it polls rather than
+   demanding an instantaneous zero, so live ingest churn does not abort it while a genuinely lagging replica still
+   does; `--force` overrides, and the Go/No-Go forbids that in production); then records and
    prints `cutover_start`, runs `EXCHANGE TABLES ... ON CLUSTER` and renames the displaced old data to
    `traces_pre_cutover_backup` (see "Naming and the parked backup"). It **stops there by default** (EXCHANGE only,
    leaving `traces` a `MergeTree` where deletes still work); the `RENAME` + `Distributed` wrap runs only with
-   `--with-wrap`. Restore the buffer ceiling and verify.
+   `--with-wrap`. Then reconcile (step 5) and verify.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/exchange_and_wrap.sh --database opik \
-       --backfill-start '<anchor from backfill.sh> UTC' --confirm-buffer-raised --confirm-retention-paused
+       --backfill-start '<anchor from backfill.sh> UTC' --confirm-retention-paused
    ```
-   Every EXCHANGE path requires: `--backfill-start` (for the final deletion replay), `--confirm-buffer-raised` (writes in
-   the final window survive the swap), and `--confirm-retention-paused` (retention deletes bypass the bridge, so a
-   retention sweep in the window would leak across the swap). Add `--with-wrap --confirm-daos-retargeted` only once
+   Every EXCHANGE path requires: `--backfill-start` (for the final deletion replay) and `--confirm-retention-paused`
+   (retention deletes bypass the bridge, so a retention sweep in the window would leak across the swap). Add
+   `--with-wrap --confirm-maintenance --confirm-daos-retargeted` only once
    `databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true` is live across the backend fleet (OPIK-7455), so trace
    mutations target `traces_local`. The wrap is separately reversible at any later point with
    `rollback.sh --unwrap-only` (see "Un-wrap"), which keeps the cutover — so a wrap concern need not become a decision
@@ -259,7 +249,7 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 >   completes, every trace delete targets a `traces_local` that does not exist yet →
 >   `Code: 60 UNKNOWN_TABLE`. Reads and writes are unaffected.
 > - **wrap first**: from the swap until the rolling restart finishes, deletes hit the `Distributed` `traces`
->   → `Code: 36`. Same blast radius, but it also exposes the cross-node `ON CLUSTER` skew with no buffer.
+>   → `Code: 36`. Same blast radius, but it also exposes the cross-node `ON CLUSTER` skew to reads.
 >
 > **Since OPIK-7773 the mismatch window is also a readiness window.** `clickhouse-traces-topology` is a
 > `critical`/`ready` check, so for as long as flag and topology disagree — in **either** order — every instance that
@@ -305,12 +295,10 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > The wrap is **gapless per node**: it pre-builds the `Distributed` wrapper under a temp name, then one atomic
 > multi-target `RENAME` rotates the data to `traces_local` and the wrapper into `traces`, so `traces` is never absent on
 > a node. A brief **cross-node** `ON CLUSTER` propagation skew still exists (as for any `ON CLUSTER` DDL), during which a
-> Distributed query could route to a not-yet-created `traces_local` on a lagging node — so the deferred `--wrap-only`
-> path still **requires `--confirm-maintenance`** (re-raise `asyncInsertBusyTimeoutMaxMs` / quiesce ingestion / take a
-> maintenance window). The same-run `--with-wrap` path **shares that cross-node window** — the still-raised EXCHANGE
-> buffer parks INSERTs (reducing, not eliminating, the exposure to a size-triggered flush routed at a not-yet-created
-> `traces_local`), and SELECTs are not buffered — so the brief skew is an accepted cost of the cutover window either way,
-> not something the buffer fully covers.
+> Distributed query could route to a not-yet-created `traces_local` on a lagging node — so **both** wrap paths
+> **require `--confirm-maintenance`** (quiesce ingestion / take a maintenance window). The exposure is identical on the
+> two paths: the failing query is a `SELECT`, so nothing done on the ingestion side reduces it, and being in the same
+> run as the `EXCHANGE` buys `--with-wrap` nothing here (OPIK-8239).
 >
 > **Wrap flags** (`exchange_and_wrap.sh`, mutually exclusive; default is EXCHANGE-only): omit them (or pass
 > `--skip-wrap`, an explicit alias) to run the EXCHANGE and stop; `--with-wrap` to also apply the wrap in the same run;
@@ -320,78 +308,33 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 delta one). This is normal — `ReplacingMergeTree` collapses them on merge / under `FINAL` / `LIMIT 1 BY id`, highest
 `last_updated_at` winning. Do not "fix" it.
 
-### Where the buffer bump lives (and how to revert it)
+### The one rolling restart (`traceColumnsNonNullable`)
 
-**Decision (OPIK-7686): a temporary env var on the deployed backend's own configuration — not a chart value.** The three
-`ANALYTICS_DB_ASYNC_INSERT_*` knobs are deliberately absent from the chart's `values.yaml` (OPIK-6880, #7675).
-Rationale:
+Getting to the `EXCHANGE` needs **one** rolling restart, and it carries no latency cost: rolling out
+`databaseAnalyticsDataModel.traceColumnsNonNullable = true` (prereq 6) to every backend instance beforehand. Nothing is
+restarted afterwards to undo it. The optional `Distributed` wrap spends a restart of its own for
+`tracesDistributedWrapEnabled` (see the wrap prerequisite) — that one belongs to the wrap, is only paid if you apply
+it, and likewise costs no latency.
 
-- **No chart change is needed.** `component.backend.env` is a free-form map rendered straight into the backend
-  ConfigMap, so a deployment-level entry is already sufficient.
-- **Removal is a clean one-step rollback.** Unset means "leave `queryParameters` alone" (`DatabaseAnalyticsFactory`), so
-  *deleting* the key restores whatever `queryParameters` carries — `async_insert_busy_timeout_max_ms=250` on the shipped
-  `config.yml` default. There is no "set it back to 250" edit, and therefore no pinned value that can later drift from
-  that default. For a time-boxed window that reversibility is the property worth optimising for.
-  > **If your deployment overrides `ANALYTICS_DB_QUERY_PARAMETERS`, `250` is not your baseline.** Deleting the key
-  > restores *that* chain's `async_insert_busy_timeout_max_ms` — or, if the chain omits it, the ClickHouse server value.
-  > Read your effective `queryParameters` before the window and record the number you are reverting to.
-- **The value is deployment- and window-specific** — one environment, for the length of the cutover. Keeping it in that
-  deployment's own config leaves it version-controlled and auditable without turning a temporary state into a permanent
-  chart default that every install inherits.
-- **A chart value would save no work**: you edit the deployment config either way.
-
-> For the record, the reason first given on #7675 for excluding these — that rendering them would send empty strings
-> where the backend expects an integer, so it "would not be inert" — was **wrong**. `config.yml` ships
-> `${ANALYTICS_DB_ASYNC_INSERT_*:-}` as the default for all three, so the empty case is the normal path in every
-> environment today: an empty substitution leaves a bare YAML scalar that parses to `null` on the boxed field behind it
-> (`Integer` for the two busy-timeout knobs, `Long` for `asyncInsertMaxDataSize`), and the `@Min(1)` each of them carries
-> does not fire on null. Exposing them in the chart with empty defaults *would* be safe. The decision above rests on
-> reversibility and scope, not on safety.
-
-> **Never bump it by editing `ANALYTICS_DB_QUERY_PARAMETERS`.** That means re-pasting the entire tuning string
-> (`compress`, `failover`, `async_insert`, `wait_for_async_insert`, the skip-index and shard settings, …), which risks
-> silently dropping one of the others and drifting from the `config.yml` default. The dedicated
-> `ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS` override exists precisely so the cutover states only the one value it
-> is changing.
-
-**What to set.** One key on the backend. The two delivery forms are not interchangeable — under Helm it is a YAML entry
-in the values map, so `KEY=VALUE` shell syntax there renders nothing:
-
-```yaml
-# Helm — under component.backend.env (quote the value; the ConfigMap takes strings)
-component:
-  backend:
-    env:
-      ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS: "10000"
-```
-
-```bash
-# docker-compose — a backend environment variable (the compose file already forwards it)
-ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS=10000
-```
-
-Only the ceiling changes: leave `…_MIN_MS` and `…_MAX_DATA_SIZE` unset, so the floor stays at the
-`async_insert_busy_timeout_min_ms=100` carried by `queryParameters`, and widening the ceiling alone is what parks the
-inserts.
-
-**How to revert: delete the key** — do not set `250` (see the caveat above on what your baseline actually is). The revert
-is owed on **every** exit path, not just the happy one: after a successful EXCHANGE it is sequence step 5, and after a
-**rollback** it is equally required. `rollback.sh` is SQL-only and does not touch backend config, so no stage removes the
-override for you — a rolled-back deployment left with the widened ceiling keeps parking every insert for up to ~10s.
-Treat the revert (and its restart) as part of finishing either outcome.
+> **The async-insert knob is untouched, and OPIK-7686's decision stands.** The three
+> `ANALYTICS_DB_ASYNC_INSERT_*` knobs remain valid production tuning, deliberately absent from the chart's `values.yaml`
+> (OPIK-6880, #7675) and settable as a deployment-level env var — see the
+> [self-host troubleshooting guide](../../../opik-documentation/documentation/fern/docs-v2/self-host/troubleshooting.mdx)
+> for how and when to use them. What ended is only the **cutover's dependence** on raising one of them for the window
+> (OPIK-8239) — a dependence that never delivered what it promised; see "The final cutover window".
 
 **It takes effect only on a backend restart — so confirm the restart finished before continuing.** The backend receives
-this through the container environment (`envFrom.configMapRef` under Helm), which Kubernetes injects at container start
-only: editing the ConfigMap does not reach a running pod. **How that restart is triggered is deployment-specific** — the
-chart ships no automation for it, so some deployments run a ConfigMap watcher that rolls the workload on its own while
-others need an explicit `kubectl rollout restart deployment/opik-backend`. Know which one yours is *before* the window.
-Either way the operator's obligation is identical, because the ceiling has to be live on **every** instance before step
-2 — so verify rather than assume:
+the flag through the container environment (`envFrom.configMapRef` under Helm), which Kubernetes injects at container
+start only: editing the ConfigMap does not reach a running pod. **How that restart is triggered is deployment-specific**
+— the chart ships no automation for it, so some deployments run a ConfigMap watcher that rolls the workload on its own
+while others need an explicit `kubectl rollout restart deployment/opik-backend`. Know which one yours is *before* the
+window. Either way the flag has to be live on **every** instance before the `EXCHANGE` (see "The final cutover window"),
+so verify rather than assume:
 
 ```bash
 kubectl rollout status deployment/opik-backend -n <namespace>
 kubectl get cm opik-backend -n <namespace> \
-    -o jsonpath='{.data.ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS}{"\n"}'
+    -o jsonpath='{.data.ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE}{"\n"}'
 # and confirm no surviving pod predates the roll:
 kubectl get pods -n <namespace> -l component=opik-backend \
     -o custom-columns=NAME:.metadata.name,START:.status.startTime
@@ -399,48 +342,91 @@ kubectl get pods -n <namespace> -l component=opik-backend \
 
 These names are what the chart renders by default — Deployment and ConfigMap `opik-backend`, label
 `component=opik-backend`. They are derived from `opik.name`, so a `nameOverride` (or a parent chart supplying one) moves
-all three; substitute your release's actual names.
+all three; substitute your release's actual names. The ConfigMap read proves the *value* is there; it does not prove
+every pod picked it up, which is what the rollout status and the pod start times are for — and neither proves the
+**behaviour**, which only the positive per-instance check in prereq 6 does.
 
-Three consequences to plan for:
+**The restart itself costs ingestion capacity** (rolling-update `maxUnavailable`, plus any PodDisruptionBudget), so do
+it while there is slack — not between the final delta and the `EXCHANGE`.
 
-- **One restart, not two, before the tail.** `traceColumnsNonNullable = true` (prereq 7) is another entry in the same
-  backend config and the same ConfigMap — and step 1 of "The final cutover window" asks for both. Land them **together**
-  so the fleet restarts once.
-- **Keep the chosen ceiling below the pod's termination grace period.** The revert is delivered by a *second* restart, and
-  at that moment pods are holding inserts parked for up to the widened ceiling. The chart does not set
-  `terminationGracePeriodSeconds`, so it is the Kubernetes default **30s** — comfortably above a ~10000ms ceiling, but a
-  much larger ceiling would let `SIGKILL` land on parked inserts. Check the two numbers against each other before
-  choosing a value.
-- **The restart itself costs ingestion capacity** (rolling-update `maxUnavailable`, plus any PodDisruptionBudget), so do
-  it while there is slack — not between the final delta and the EXCHANGE.
+### The replication-settle gate
 
-### The final cutover window (the zero-loss invariant)
+`exchange_and_wrap.sh` gates the swap on replication having settled, because the `EXCHANGE` is metadata-only and
+near-instant but each replica reads its own local parts afterwards: a replica still fetching backfilled parts, or one
+that has not finished the deletion-replay mutation, would serve an incomplete table. Both signals are read across every
+replica via `clusterAllReplicas`, so one connection sees the whole cluster. The queries are the `settle-sample`,
+`settle-queue-detail` and `settle-mutation-detail` blocks of
+[`000003_exchange_and_wrap.sql`](scripts/db-app-analytics/000003_exchange_and_wrap.sql); the driver renders all three
+before it starts polling, so a mis-marked block fails the run up front rather than while reporting a failure.
 
-The buffer widening (prereq 6) is what makes the flip lossless, but the guarantee rests on a timing invariant worth
-stating precisely. Writes use `async_insert=1, wait_for_async_insert=1`, so a raised `asyncInsertBusyTimeoutMaxMs` parks
-each insert (the client blocks) until it flushes — and after the `EXCHANGE` a parked insert flushes into whatever table
-is now named `traces`, i.e. the successor. **But the adaptive buffer also flushes on size**, so under load a flush can
-still land in the *old* `traces` in the gap between the last delta read and the `EXCHANGE` — and the delta has already
-run. The binding constraint is therefore **not** "replay < buffer window"; it is that the **gap between the final delta
-and the `EXCHANGE` completing must stay within the buffer hold**. So run the tail as tightly as possible:
+**It polls, and it judges the two signals differently.** On a multi-replica cluster under live ingestion the
+`replication_queue` count is intermittently non-zero by construction — a `GET_PART` entry exists for every part a
+replica has not yet fetched — so demanding an instantaneous 0 would abort on ordinary churn and push the operator
+toward `--force`, which the Go/No-Go forbids. Hence:
 
-1. Widen the buffer, and **roll out `traceColumnsNonNullable = true` to every backend instance** (see below). Both are
-   entries in the same backend config and the same ConfigMap, so land them **together** and let the single restart carry
-   both — see ["Where the buffer bump lives"](#where-the-buffer-bump-lives-and-how-to-revert-it).
+| Signal | Judgement |
+|---|---|
+| the deletion-replay **mutation** on `traces_local_v2` | **Unconditional.** It is one bounded statement, not churn, so it must reach `is_done` on every replica within `--settle-timeout` (default 120s) or the gate fails — an unapplied mask means bridged deletes leak live across the swap. |
+| the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is merely moving is accepted, with the numbers printed so the operator sees what was accepted. |
+
+Raise `--settle-timeout` for a slow-but-progressing cluster. `--force` skips the gate entirely and is a production
+No-Go: the gate is permissive enough that reaching its failure path means something is genuinely wrong.
+
+### The final cutover window
+
+**What the swap guarantees.** Nothing in this procedure parks an insert, and it does not need to: the `EXCHANGE` is
+**atomic per node** (it requires an Atomic database, the default), so `traces` is never absent anywhere and every
+concurrent insert commits to a valid table — the old storage if it reaches a node pre-swap, the new one if post-swap.
+Neither errors, and no insert is rejected. **Deletes** are covered up to `cutover_start` by step 4's final replay.
+
+**Writes in the tail are not covered yet.** Two sources leave them in the table that becomes the parked backup:
+
+- the **final-delta→`EXCHANGE` gap** — writes after the last delta read and before the swap;
+- the **cross-node `ON CLUSTER` skew** — `EXCHANGE` is atomic per node but not across nodes, so while it propagates,
+  inserts routed at a not-yet-swapped node still land in the old table.
+
+Those rows are **not destroyed** — they sit in `traces_pre_cutover_backup` and stay recoverable until `finalize.sh`
+retires it. What is missing is a step that carries them into the live table and proves it did: one driven by *version*
+rather than key presence (a trace merely *updated* in the tail is already on the successor at an older
+`last_updated_at`, so a presence check finds nothing to do), and one that does not resurrect a delete that fired after
+the swap. **OPIK-8238 adds exactly that** and supersedes this note. Until it lands, size the gap after the swap and
+decide knowingly — see the Go/No-Go item.
+
+> **This is an open defect, not a regression introduced by dropping the buffer.** The removed setting was believed to
+> hold these writes and largely did not — the rejected alternatives below give the mechanism. Removing it widens the gap
+> by the small fraction the buffer genuinely held, and replaces a false guarantee with a stated one.
+
+The tail is still worth running tightly, because its length is what decides how many writes land in that gap:
+
+1. **Roll out `traceColumnsNonNullable = true` to every backend instance**
+   (["The one rolling restart"](#the-one-rolling-restart-tracecolumnsnonnullable), and the flip's own note below). Do it
+   while there is slack, not between the final delta and the `EXCHANGE`.
 2. Do the QA verify on an **earlier** pass (it can take minutes on a large table — do not let it be the last thing
    before the swap).
-3. Run a **final** `delta_replay.sh` as the last write-facing step.
+3. Run a **final** `delta_replay.sh` as the last write-facing step before the swap.
 4. Run `exchange_and_wrap.sh --backfill-start '<anchor> UTC' …` **immediately** after it (the settle gate + `EXCHANGE` are
    fast and metadata-only). It captures `cutover_start`, then runs a **final deletion replay** from `backfill_start`
    right before the swap — so deletes bridged in the `[final delta_replay, cutover_start)` gap are masked on the
    successor rather than leaking (that gap is covered by neither the earlier forward replay nor the rollback
-   reverse-replay, which starts at `cutover_start`). Deletions only; the buffer carries the writes.
-5. Restore the buffer ceiling; parked inserts flush into the successor.
+   reverse-replay, which starts at `cutover_start`). Deletions only.
 
-Keep step 3→4 short. **Deletes** up to `cutover_start` are covered by step 4's final deletion replay; **writes** in the
-gap are covered by the buffer (which flushes into the successor after the flip). The one residual is a delete whose
-bridge row commits after that final replay's read but with `event_time < cutover_start` — the same inherent micro-window
-as a size-triggered buffer flush; if delete load is high, quiesce user deletes for the final seconds.
+Keep step 3→4 short. **Deletes** up to `cutover_start` are covered by step 4's final deletion replay; **writes** in
+that gap and across the swap skew are the exposure above. The one residual on the delete side is a delete whose
+bridge row commits after that final replay's read but with `event_time < cutover_start` — an inherent micro-window; if
+delete load is high, quiesce user deletes for the final seconds.
+
+*Rejected alternatives, recorded so they are not re-proposed (OPIK-8239).* **Widening the async-insert buffer**
+(`asyncInsertBusyTimeoutMaxMs`) to hold writes across the swap does not work here. The backend serves reads and writes
+through one shared R2DBC `ConnectionFactory` (`DatabaseAnalyticsModule`), and writes run `wait_for_async_insert=1`, so
+a parked insert holds a request thread and a connection for its whole wait and reads contend with it on the same
+transport: the entire ClickHouse-backed surface slows, not just ingestion. It also covers only part of the gap, because
+the adaptive buffer flushes on whichever of the busy timeout, `async_insert_max_data_size` or
+`async_insert_max_query_number` fires first, and at real trace row widths the size and count limits bind well before
+the timeout. And because the ceiling arrives through the container environment, applying
+it and reverting it are two fleet-wide restarts, which brackets the degraded period and puts a floor under its length.
+**`wait_for_async_insert=0`** removes the latency but discards delivery confirmation exactly when it matters most, and
+still needs both restarts. **A smaller ceiling** keeps every one of those costs for proportionally less of an already
+partial benefit.
 
 **The `traceColumnsNonNullable` flip (mandatory, and why it goes first).** The successor stores `end_time`/`ttft` as
 non-nullable epoch/NaN sentinels, and the flag is what makes the app agree with that representation — sentinel binds on
@@ -448,7 +434,7 @@ write, and sentinel→`null` translation on read, filter and sort. It is a **con
 (not atomic), unlike the metadata-only `EXCHANGE`, so it cannot be flipped at the same instant; roll it out to `true` on
 **all** instances **before** the `EXCHANGE`.
 
-*Why before, not after.* Not because writes would break — they would not (see prereq #7: a `null` bind is silently
+*Why before, not after.* Not because writes would break — they would not (see prereq #6: a `null` bind is silently
 converted to the column DEFAULT, which is the sentinel, so writes succeed on either setting). It goes first because the
 **read** side must already speak sentinel the instant the successor is live under the name `traces`: while the flag is
 `false` against the successor, an absent `end_time` reads back as `1970-01-01` rather than `null`, and absent-value
@@ -645,7 +631,7 @@ instead scatter each insert across every weekly partition that workspace spans �
 (litellm [BerriAI/litellm#31294](https://github.com/BerriAI/litellm/issues/31294) mints ~2201). The rows are legitimate
 customer data — a valid UUIDv7 that merely carries a future timestamp — so they are copied and kept like any other.
 `traces_local_v2` partitions by the honest `Date32` weekly Monday of `id_at`
-([OPIK-7456](https://comet-ml.atlassian.net/browse/OPIK-7456): `toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))`),
+(OPIK-7456: `toYYYYMMDD(toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))`),
 and its `id_at` is a `DateTime64` (honest to 2299), so each such row lands in its **own honest ~2201 (`22010601`-shaped)
 weekly partition**, isolated from real recent weeks — a per-week `DROP PARTITION` / retention / tiering operation never
 touches them by accident, and vice versa. Once written, the extra partitions are benign at rest: they never tier to cold
@@ -797,7 +783,7 @@ on a large backfill for no gain.
 `TraceService.delete(ids, projectId)` resolves each id's owning project(s) and deletes per project under the full key.
 Since **OPIK-7483** there is no project-less path: an id that resolves to no owning project is absent (a delete of a
 non-existent row) and is skipped, so **no deletion event is ever bridged with an empty `project_id`** for
-`source_table='traces'` (a pre-cutover check asserts the bridge holds none — Prerequisites #13). The replay therefore
+`source_table='traces'` (a pre-cutover check asserts the bridge holds none — Prerequisites #12). The replay therefore
 carries a single branch: full-key events delete by `(workspace_id, project_id, id)` — exact, prunes on the destination
 primary key, and correct even though trace ids are not globally unique (a reused id deleted in one project leaves its
 copies in other projects untouched). Without this replay, those during-window deletions would **silently leak** across
@@ -832,17 +818,29 @@ They are **complementary, not alternatives**, and there is **no copy-paste drift
   pins this list to the live `traces` base columns (OPIK-7772 extends it to a topology-aware CI check).
 
 **Every SQL operation — happy path and every rollback stage — is run by a driver script; no SQL or `.sql` file is ever
-run by hand.** Each `.sql` file is the single source a driver reads:
+run by hand.** Each `.sql` file is the single source its driver reads those statements from:
 
 | Step | Reference SQL | Driver |
 |------|---------------|--------|
 | plan — backfill ETA | — | `estimate.sh` |
 | 1 — backfill | `000001_backfill_traces_local_v2.sql` | `backfill.sh` |
 | 2 — delta + replay | `000002_delta_and_deletion_replay.sql` | `delta_replay.sh` |
-| 3 — EXCHANGE + wrap | `000003_exchange_and_wrap.sql` | `exchange_and_wrap.sh` |
+| 3 — settle gate, EXCHANGE + wrap | `000003_exchange_and_wrap.sql` | `exchange_and_wrap.sh` |
 | QA — fidelity compare (+ `--drill-down`) | `000005_verify_migration.sql` | `verify.sh` |
 | rollback | `000004_rollback_stage_{a,b,c}_*.sql`, `000004_rollback_unwrap.sql`, `000004_rollback_reverse_replay.sql` + its postcondition `000004_rollback_verify_replay.sql`, `000004_rollback_sentinel_repair.sql` + its postcondition `000004_rollback_verify_sentinels.sql` | `rollback.sh` |
 | finalize — retire the parked backup (drop after cutover / recycle to empty shadow after rollback) | — | `finalize.sh` |
+
+**Where the line falls, for anyone adding SQL here.** Two rows show `—` because not every query a driver issues comes
+from a file, and the split is deliberate:
+
+- **In a versioned `.sql` file, extracted by marker:** every statement that changes data or schema, and every read
+  whose result *is a verdict* the operator acts on. That second half is why `000005`'s `compare` / `confirm-keys` /
+  `version-ties` blocks and `000003`'s three `settle-*` blocks live in files despite being read-only — a fidelity gate
+  or a swap gate deciding wrongly is the failure this procedure exists to prevent, so its SQL is reviewed and versioned
+  like a statement.
+- **Inline in the driver:** the short scalar probes that steer control flow — "what engine is `traces`?", "does this
+  table exist?", "how many replicas?". They are one-liners against `system.*`, they change nothing, and putting them
+  behind a marker would add indirection without adding review value.
 
 Each driver takes the connection from the `clickhouse-client` env vars `CLICKHOUSE_HOST`, `CLICKHOUSE_USER` and
 `CLICKHOUSE_PASSWORD`, plus `--database` and — when the native port is not 9000 — `--port`.
@@ -951,15 +949,14 @@ server's major version, either way:
   official `clickhouse/clickhouse-server` image (set `CLICKHOUSE_CLIENT_IMAGE` to your server version) and dials out to
   `CLICKHOUSE_HOST`; for a ClickHouse on the host's own loopback, add `--network=host` via `CLICKHOUSE_CLIENT_DOCKER_OPTS`.
 
-**In the forward sequence, the only manual actions are not SQL:** (1) raising/restoring the async-insert buffer ceiling
-(`databaseAnalytics.asyncInsertBusyTimeoutMaxMs`) around steps 2–3 — see
-["Where the buffer bump lives"](#where-the-buffer-bump-lives-and-how-to-revert-it); (2) flipping
-`databaseAnalyticsDataModel.traceColumnsNonNullable` to `true` in lockstep with the EXCHANGE (and back on rollback) —
-see "The final cutover window"; (3) flipping `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` around the wrap and
-the un-wrap — see "Un-wrap"; and (4) the go/no-go judgement between steps. All four are *backend config* / judgement
+**In the forward sequence, the only manual actions are not SQL:** (1) flipping
+`databaseAnalyticsDataModel.traceColumnsNonNullable` to `true` before the EXCHANGE (and back on rollback) — see "The
+final cutover window"; (2) flipping `databaseAnalyticsDataModel.tracesDistributedWrapEnabled` around the wrap and the
+un-wrap — see "Un-wrap"; and (3) the go/no-go judgement between steps. All three are *backend config* / judgement
 changes (env + rolling restart, or a config push) that these DB-facing scripts cannot and should not make: the mechanism
 is deployment-specific, so the drivers name the flag and the ordering and leave the rollout to the operator. They are
-deliberately operator-owned, and none of them involves typing SQL.
+deliberately operator-owned, and none of them involves typing SQL. **No ingestion-path config change appears on any
+path** — forward, rollback, wrap or un-wrap.
 
 **Recovery is where hand-run SQL does appear**, so the claim above is about the forward sequence and not about the whole
 runbook. Two kinds, both deliberate and documented where they occur:
@@ -1159,8 +1156,8 @@ choosing its mutation table, so reads and inserts never consult it — which is 
 The **DDL** window is separate and not delete-only. While the `ON CLUSTER` rename propagates, a lagging replica still
 resolves the wrapper's `traces_local` target, which the already-renamed replicas no longer have, so a query routed there
 can fail with `UNKNOWN_TABLE` — the exact mirror of the wrap's own window, where a `Distributed` query reaches a node
-where `traces_local` does not exist *yet*. It is sub-second and fails loudly, but it touches **reads too**, so the
-async-insert buffer alone does not cover it: quiesce traffic or take a maintenance window. That is what
+where `traces_local` does not exist *yet*. It is sub-second and fails loudly, but it touches **reads too**, so no
+ingestion-side setting covers it: quiesce traffic or take a maintenance window. That is what
 `--confirm-maintenance` asserts.
 
 `traceColumnsNonNullable` stays `true`: the live table is still the partitioned, sentinel-schema successor, which is
@@ -1185,7 +1182,7 @@ Use stage B/C while the parked original still exists.
 >
 > | step | order | why |
 > |---|---|---|
-> | forward wrap (`--wrap-only`) | **toggle first**, then DDL | in the gap, deletes target a `traces_local` that does not exist yet → `Code 60`. DDL-first would send them at a `traces` that is already `Distributed` → `Code 36`, plus unbuffered cross-node skew |
+> | forward wrap (`--with-wrap` or `--wrap-only`) | **toggle first**, then DDL | in the gap, deletes target a `traces_local` that does not exist yet → `Code 60`. DDL-first would send them at a `traces` that is already `Distributed` → `Code 36`, and exposes the cross-node skew to reads as well |
 > | un-wrap (`--unwrap-only`) | **DDL first**, then toggle | the mirror image: the gap gives `Code 60` again, which is the cheaper failure |
 > | stage B / C | **DDL first**, then toggle | same reasoning as the un-wrap; the promote must land before the flags describing the new shape |
 >
@@ -1377,9 +1374,10 @@ it revives writes the rollback chose to discard. Run it only with the guards bel
    you to set `traceColumnsNonNullable` back to `false`, so it *is* false now; the retry puts the sentinel-schema
    successor back under `traces`, which needs it `true` and needs every backend instance restarted to pick it up (it
    comes from a startup snapshot). Skipping this is silent, not loud: absent `end_time` reads back as `1970-01-01` while
-   writes keep succeeding. Raise the async-insert buffer for the window too. Nothing else needs flipping: trace-delete
+   writes keep succeeding. Nothing else needs flipping: no ingestion-path config change is involved, and trace-delete
    partition pruning carries no flag, so the retry's `EXCHANGE` needs no pruning step in either direction — see
-   "Trace-delete partition pruning needs no flip at all".
+   "Trace-delete partition pruning needs no flip at all". The retry's own final-delta→`EXCHANGE` gap and swap skew
+   carry the same write exposure as the first run — see "The final cutover window".
 5. Resume the normal sequence: `delta_replay.sh` with the **original** `backfill_start` anchor, marker included (the
    shadow still holds every row copied before it), then `verify.sh` before the `EXCHANGE`. That gate is what makes reuse safe — staleness or
    corruption in the reused shadow is caught exactly as in the first cutover — so do not skip it on the grounds that the
@@ -1421,7 +1419,7 @@ reversible indefinitely via `--unwrap-only`, which needs only `traces` and `trac
 - **Soak duration** — keep the parked backup (`traces_pre_cutover_backup` after a successful cutover;
   `traces_post_rollback_backup` after a rollback) for a defined window (recommend ~2 weeks; it fits well inside the
   bridge's 2-year TTL) so any latent read/query regression surfaces while rollback is still an option.
-- **Freeze `traces` schema DDL through the soak** (extends prereq #12 past the EXCHANGE). Rollback restores the **frozen
+- **Freeze `traces` schema DDL through the soak** (extends prereq #11 past the EXCHANGE). Rollback restores the **frozen
   original** `traces`, which carries no post-cutover DDL, so a column/index added to the successor in-window is **lost
   from the live table** on rollback; finalize's recycle then truncates the parked successor to an empty shadow (its data
   gone — the empty shadow keeps the added column, drift the next cutover's `cutoverCopiesEveryBaseColumn` guard flags).
@@ -1479,10 +1477,10 @@ and disable capture after finalize.
 
 | Variant | Strategy | Notes |
 |---------|----------|-------|
-| Comet SaaS | Buffered cutover (this runbook) | Buffer absorbs the cutover window; bridge active through the soak. |
-| On-premise enterprise | Buffered cutover | Same runbook; ships in the same Helm push. |
+| Comet SaaS | Live cutover (this runbook) | No ingestion-path config change. Tail write-gap per "The final cutover window" (OPIK-8238). Bridge active through the soak. |
+| On-premise enterprise | Live cutover | Same runbook; ships in the same Helm push. |
 | Open-source Docker | Brief read-only window | Little data, downtime acceptable. Bridge still ships; the replay is a no-op when there were no concurrent deletes. If the Liquibase ClickHouse extension cannot run `EXCHANGE ON CLUSTER`, use the fallback `RENAME` sequence. |
-| AWS SageMaker | Buffered cutover | Runs on its own cadence; the bridge ships ahead of the cutover. |
+| AWS SageMaker | Live cutover | Runs on its own cadence; the bridge ships ahead of the cutover. |
 
 ## Verifying the migration (QA)
 
@@ -1629,7 +1627,7 @@ side only is the copy gap, whatever the re-check said. If the sets cannot be est
 and escalate rather than passing it — arbitrary is not the same as benign.
 
 > **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat.** `traces_pre_cutover_backup` is a
-> **frozen** snapshot as of `cutover_start`, but live `traces` keeps taking writes the instant the buffer drains — so
+> **frozen** snapshot as of `cutover_start`, but live `traces` never stops taking writes — so
 > the **current (live) week will legitimately show a mismatch** (the live table is a superset of the frozen backup by
 > exactly the post-cutover writes). That is expected, not a leak. To use the post-EXCHANGE compare as a real check,
 > either run it **immediately after the swap before writes resume**, or bound it to the **sealed historical weeks** with
@@ -1681,14 +1679,25 @@ ones most often worth reading).
   reverse-replays so a post-cutover delete does not resurrect;
 - **wrong-stage rollback guard** — the topology signals `rollback.sh` keys on (the `traces` engine and `end_time`
   nullability) are distinct in each cutover state, so a mis-targeted stage aborts instead of touching the wrong table;
-- the replay wall time is measured and logged (not asserted — it is environment-sensitive; the buffer-window sizing is
-  done in the cutover rehearsal, not in CI).
+- the replay wall time is measured and logged (not asserted — it is environment-sensitive; sizing the tail against a
+  real workload is done in the cutover rehearsal, not in CI).
 
-**What it does not cover.** The suite drives SQL directly, so nothing in the `scripts/` drivers is exercised by it — they
-need a `clickhouse-client` binary the backend test job does not install, and the repo has no bash harness. The cutover
-rehearsal covers them instead: their argument validation, their topology guards, and three `verify.sh` behaviours worth
-separating from the rest, because they decide a *verdict* rather than reject an argument — and a wrong verdict from a
-fidelity gate is the failure this whole procedure exists to avoid:
+**What it does not cover, and why that is a decision rather than a gap.** The suite drives SQL directly, so nothing in
+the `scripts/` drivers is exercised by it. **Unit-testing them is deliberately out of scope, and the reason is lifespan
+rather than feasibility**: the repo does run bash suites elsewhere (`test_rebaseline_db_changelog.sh`,
+`test_precommit_wrappers.sh`) and stubbing `clickhouse-client` would work. But this is migration tooling with a finite
+life — once the cutover and its soak are done it stops changing, `spans` gets its own parallel directory rather than
+reusing these files, and a harness over eight drivers would be permanent maintenance on code heading for the archive.
+
+**The sanctioned validation is performing the procedure** — the forward cutover, the wrap, and the rollback of each
+(stage A/B/C and `--unwrap-only`) — on a local or test environment. That exercises the drivers against a real
+ClickHouse rather than a stub, which is the stronger check, and it suffices because every guard fails *closed*: a
+refused argument, a lagging replica or a mis-marked SQL block aborts before any DDL or mutation is sent, so an untested
+guard costs a re-run, not data. Do not add per-driver suites here without revisiting that trade-off explicitly.
+
+So the cutover rehearsal is what covers the drivers: their argument validation, their topology guards, and three
+`verify.sh` behaviours worth separating from the rest, because they decide a *verdict* rather than reject an argument —
+and a wrong verdict from a fidelity gate is the failure this whole procedure exists to avoid:
 
 - refusing to report `PASSED` when the bounds selected **no** window (an empty range compares nothing, so a pass would be
   vacuous);
@@ -1697,6 +1706,18 @@ fidelity gate is the failure this whole procedure exists to avoid:
 
 Each rests on manual verification. Exercise them in the rehearsal alongside the driver guards, and treat a change to any
 of the three as needing the same.
+
+The **replication-settle gate** belongs in the same category — it decides a verdict rather than reading a single
+number — so it needs the rehearsal too, under **live ingestion**, in both directions:
+
+- it does **not** abort on ordinary ingest churn (a moving `replication_queue` is accepted, with its numbers printed);
+- it **does** abort on a genuinely lagging replica, naming the offending entries — stop or throttle a replica, or hold
+  a mutation, and confirm the gate fails loudly rather than passing;
+- the deletion-replay mutation is judged unconditionally: an unfinished mutation fails the gate however quiet the queue
+  is, and `--settle-timeout` bounds how long it waits to find out.
+
+The **argument guards** fail fast, before touching ClickHouse, so they are cheap to exercise by hand after any change
+here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`.
 
 Run it with: `mvn -o test -Dtest=TracesLocalV2CutoverTest` from `apps/opik-backend`.
 
@@ -1709,8 +1730,6 @@ Watch these for the whole backfill→EXCHANGE window; wire alerts before startin
   means merges are not keeping up; increase `--pause-seconds`.
 - **Replication backlog** (`system.replication_queue`) and **mutations** (`system.mutations` `is_done = 0`) — must trend
   to zero; a growing queue means a replica is falling behind.
-- **Ingestion latency / error rate** — with the widened buffer, insert latency rises by design (up to the buffer window);
-  alert on client-side timeouts or ingestion errors, which mean the client timeout is below the buffer.
 - **Query p99** on the project traces listing — the backfill competes for I/O; a sustained regression is an abort signal.
 - **Deletion-capture health** — capture is best-effort and **swallows** errors (so a bridge hiccup never blocks a user's
   delete), so watch the backend logs for `captureDeletions` failures. A silently-dropped capture would leak a delete.
@@ -1730,11 +1749,19 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
 
 - [ ] **Runbook rehearsed on a production-shape staging snapshot** end-to-end; timings recorded. Staging must match
       production **topology**, not just data shape — same replica count and tiered-storage policy — since the
-      multi-replica settle gates, storage/TTL parity, and buffer-flush timing are otherwise untested until production.
+      multi-replica settle gate and the storage/TTL parity are otherwise untested until production. Rehearse with
+      **parallel traffic still flowing through the swap** — converging by stopping traffic tests an assumption this
+      procedure does not make.
 - [ ] **Deletion test green** — `TracesLocalV2CutoverTest` passes; **0 deletion leaks** confirmed on staging.
-- [ ] **Final-delta→EXCHANGE gap fits inside the buffer hold with margin** — the binding invariant is the gap between
-      the final delta and the EXCHANGE completing (≈ replay wall time + EXCHANGE), staying within the buffer hold and
-      accounting for size-triggered flushes — **not** "replay < buffer window" alone (see "The final cutover window").
+- [ ] **Tail write-gap accepted knowingly, or OPIK-8238 landed** — writes in the final-delta→`EXCHANGE` gap and the
+      cross-node swap skew stay in `traces_pre_cutover_backup` and nothing in this procedure carries them into the live
+      table yet (see "The final cutover window"). Size it straight after the swap with an **unbounded** post-`EXCHANGE`
+      compare plus `--drill-down`: the gap rows sit in the cutover week, which every weekly bound excludes, so a bounded
+      run cannot see them. Keys listed **backup-only** are the gap; live-only keys are post-swap writes, the harmless
+      direction. Then either accept it with whoever authorised the cutover, or recover from the backup before
+      `finalize.sh` retires it. OPIK-8238 replaces this item with its reconciliation postcondition.
+- [ ] **Final-delta→EXCHANGE gap kept short** — record the final replay's wall time. The tail's length is what decides
+      how many writes land in the gap above.
 - [ ] **Far-future partitions quantified — and `max_partitions_per_insert_block` sized from the result.** Run the
       bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
       `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised
@@ -1745,22 +1772,20 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       settings profile too, so it does not depend on the invocation.
 - [ ] **`EXCHANGE TABLES ... ON CLUSTER` works end-to-end** — or the fallback `RENAME` sequence is documented for the
       variant that needs it.
-- [ ] **Async-insert ceiling confirmed** — raising `asyncInsertBusyTimeoutMaxMs` demonstrably widens the adaptive buffer
-      under load, not just the cap. `exchange_and_wrap.sh` enforces the acknowledgment via `--confirm-buffer-raised`, but
-      that is an assertion only — this checklist item is the actual "it took effect under load" verification.
-- [ ] **The buffer-bump and revert changes are pre-written and reviewed** — the config entry raising
-      `ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS` (with `traceColumnsNonNullable = true` alongside it) and the revert
-      that *deletes* the key, both prepared before the window so each is a merge rather than an edit under pressure.
-      Confirm the chosen ceiling is below `terminationGracePeriodSeconds`, and that you know how a backend restart is
-      triggered on the target deployment and that it fits the schedule — see
-      ["Where the buffer bump lives"](#where-the-buffer-bump-lives-and-how-to-revert-it).
+- [ ] **No ingestion-path config change on any path** — forward, rollback, wrap or un-wrap. The procedure requires
+      one rolling restart to reach the `EXCHANGE`, carrying only `traceColumnsNonNullable = true`, with no latency
+      cost — plus the wrap's own restart for `tracesDistributedWrapEnabled` if the wrap is applied. Confirm you know
+      how a backend restart is triggered on the target deployment and that it fits the schedule — see
+      ["The one rolling restart"](#the-one-rolling-restart-tracecolumnsnonnullable).
 - [ ] **Data Retention confirmed disabled** for the cutover window (`RETENTION_ENABLED=false`). Retention deletes bypass
       the deletion bridge, so a sweep in the window would leak/resurrect across the swap; `exchange_and_wrap.sh` and
       `rollback.sh` (stages B/C) enforce `--confirm-retention-paused`, but that is an assertion — this item is the real
       "it is actually paused on every backend" verification.
 - [ ] **Reconciliation clean** — per-window source/dest counts within 0.01% across the whole backfill.
-- [ ] **Replication settled before the EXCHANGE** — `replication_queue` empty and the deletion-replay mutation
-      `is_done` on **all** replicas (`exchange_and_wrap.sh` gates on this; do not `--force` past it in production).
+- [ ] **Replication settled before the EXCHANGE** — the deletion-replay mutation `is_done` on **all** replicas, and the
+      replication queue either drained or demonstrably just busy rather than stuck (`exchange_and_wrap.sh` gates on
+      this — see ["The replication-settle gate"](#the-replication-settle-gate); do **not** `--force` past it in
+      production, and confirm on staging under live ingest that it does not abort on ordinary churn).
 - [ ] **`traceColumnsNonNullable = true` rolled out to every backend instance before the EXCHANGE** — confirmed live on
       the whole fleet by a **positive** check, not by the absence of ingestion errors: write an in-progress trace (no
       `end_time`, and so no `ttft`) through the API and assert the epoch/NaN **sentinel** was stored for both — then
@@ -1777,8 +1802,10 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       for a single-row deletion leak — an unexpected empty-`project_id` bridge event the single-branch replay would miss,
       or any other single-key divergence — and any sampling (`--sample-mod > 1`), week stride, or week narrowing can hash
       that one row out and still report `ok=1`. Reserve sampling/ranged runs for follow-up confidence *after* the full gate
-      passes. Re-run `delta_replay.sh` then `verify.sh` until it PASSES: while the buffer holds writes (or, on a rehearsal
-      without it, once traffic is quiescent) the last delta must catch every in-flight write.
+      passes. Re-run `delta_replay.sh` then `verify.sh` until it PASSES. Read that PASS for what it is: writes never
+      stop, so it certifies the copy **as of the last delta**, not that nothing arrived after it. The writes that
+      arrive after it land in the tail gap described in "The final cutover window" — do not quiesce traffic to force a
+      cleaner PASS.
 - [ ] **`Distributed` wrap gated on the DAO toggle** — apply the wrap (step 4, part 2) only once
       `databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true` is live across the backend fleet (OPIK-7455), set in
       lockstep with the wrap so trace mutations target `traces_local`; otherwise stop after the `EXCHANGE`, since a
@@ -1786,6 +1813,11 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       is unsupported and breaks the trace-delete path.
 - [ ] **No query-semantics regression** — FINAL / `LIMIT 1 BY` dedup verified; p99 on the project traces listing page within
       ±10% of the pre-migration baseline.
-- [ ] **Rollback rehearsed at every stage** (before EXCHANGE, after EXCHANGE/before wrap, after wrap) — deletes during
+- [ ] **Rollback rehearsed at every stage** (before EXCHANGE, after EXCHANGE/before wrap, after wrap) — **with traffic
+      running**, the same way the forward direction is rehearsed. Deletes during
       the post-cutover window do not resurrect after the reverse-replay; the parked table is retained for the soak.
+- [ ] **`--with-wrap` refuses without `--confirm-maintenance`** — verified. Both wrap paths carry the same unmitigated
+      cross-node `UNKNOWN_TABLE` exposure, and it hits reads either way.
+- [ ] **No ingestion-latency regression, and query p99 within the agreed budget**, measured on the prod-clone
+      environment across the whole tail.
 - [ ] **Go/No-Go decision recorded** with the staging evidence attached.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -355,12 +355,12 @@ it while there is slack — not between the final delta and the `EXCHANGE`.
 ### The replication-settle gate
 
 `exchange_and_wrap.sh` gates the swap on replication having settled, because the `EXCHANGE` is metadata-only and
-near-instant but each replica reads its own local parts afterwards: a replica still fetching backfilled parts, or one
-that has not finished the deletion-replay mutation, would serve an incomplete table. Both signals are read across every
-replica via `clusterAllReplicas`, so one connection sees the whole cluster. The queries are the `settle-sample`,
-`settle-queue-detail` and `settle-mutation-detail` blocks of
+near-instant but each replica reads its own local parts afterwards: a replica that does not yet hold every part would
+serve an incomplete table. Both signals are read across every replica via `clusterAllReplicas`, so one connection sees
+the whole cluster. The queries are the `settle-sample`, `settle-queue-detail` and `settle-mutation-detail` blocks of
 [`000003_exchange_and_wrap.sql`](scripts/db-app-analytics/000003_exchange_and_wrap.sql); the driver renders all three
-before it starts polling, so a mis-marked block fails the run up front rather than while reporting a failure.
+before it starts polling, so a mis-marked block fails the run up front rather than while reporting a failure. The gate
+does not run for `--wrap-only`, which performs no swap.
 
 **It polls, and it judges the two signals differently.** On a multi-replica cluster under live ingestion the
 `replication_queue` count is intermittently non-zero by construction — a `GET_PART` entry exists for every part a
@@ -369,12 +369,19 @@ toward `--force`, which the Go/No-Go forbids. Hence:
 
 | Signal | Judgement |
 |---|---|
-| the deletion-replay **mutation** on `traces_local_v2` | **Unconditional.** It is one bounded statement, not churn, so it must reach `is_done` on every replica within `--settle-timeout` (default 120s) or the gate fails — an unapplied mask means bridged deletes leak live across the swap. |
-| the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is busy but not stuck is accepted, with the numbers printed so the operator sees what was accepted. |
+| unfinished **mutations** on `traces_local_v2` | **Unconditional** — none, within `--settle-timeout` (default 120s). What this catches is a mutation left behind by an earlier step or by manual intervention. It does **not** cover the final deletion replay, which the driver issues *after* this sample: that one is covered by `lightweight_deletes_sync = 2` in its own block, which returns only once every replica has applied the mask, and the driver asserts the setting is still present before running it. |
+| the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** Counts only `GET_PART`/`ATTACH_PART` — the entries that mean a replica lacks data. Merges and mutations also sit in this queue and say nothing about completeness; counting them would fail the gate on the large merges that follow a backfill. It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is busy but not stuck is accepted, with the numbers printed so the operator sees what was accepted. |
 
 The queue verdict is a **snapshot** over the last sample read, in both the polled and the single-sample case — nothing
 compares consecutive samples. Polling buys the queue time to drain, and a genuinely stuck entry time to age past the
 thresholds; that is all, so a shorter `--settle-timeout` is a weaker gate by exactly that much.
+
+**Budget for the wait.** The gate returns early only on a drained queue; the busy-but-not-stuck verdict is reached once
+the poll budget is spent. So a run whose queue never reaches 0 waits the full `--settle-timeout` before passing, and
+that wait lands in the tail write-gap. It is not wasted — the wait is what lets a stuck entry age past the thresholds,
+which is the only detection this gate has, and accepting the first not-stuck sample would make the default no stronger
+than `--settle-timeout 0`. Restricting the count to `GET_PART`/`ATTACH_PART` is what makes the early exit reachable in
+practice: those entries clear continuously, whereas the merge backlog that follows a backfill does not.
 
 `--settle-timeout` accepts 0–3600s; raise it for a slow-but-progressing cluster, at a price — the gate sits between the
 final delta and the `EXCHANGE`, so whatever it waits is added to the tail write-gap. The driver prints the wait

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -1742,8 +1742,9 @@ number — so it needs the rehearsal too, under **live ingestion**, in both dire
   numbers printed);
 - it **does** abort on a genuinely lagging replica, naming the offending entries — stop or throttle a replica, or hold
   a mutation, and confirm the gate fails loudly rather than passing;
-- the deletion-replay mutation is judged unconditionally: an unfinished mutation fails the gate however quiet the queue
-  is, and `--settle-timeout` bounds how long it waits to find out.
+- unfinished mutations on the shadow are judged unconditionally: one fails the gate however quiet the queue is, and
+  `--settle-timeout` bounds how long it waits to find out. Hold a mutation deliberately to see it — but note the gate
+  samples before the final deletion replay is issued, so that replay is not what this rehearses.
 
 The **argument guards** fail fast, before touching ClickHouse, so they are cheap to exercise by hand after any change
 here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`, and `--settle-timeout` must
@@ -1827,10 +1828,12 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       `rollback.sh` (stages B/C) enforce `--confirm-retention-paused`, but that is an assertion — this item is the real
       "it is actually paused on every backend" verification.
 - [ ] **Reconciliation clean** — per-window source/dest counts within 0.01% across the whole backfill.
-- [ ] **Replication settled before the EXCHANGE** — the deletion-replay mutation `is_done` on **all** replicas, and the
+- [ ] **Replication settled before the EXCHANGE** — no unfinished mutation on the shadow on **any** replica, and the
       replication queue either drained or demonstrably just busy rather than stuck (`exchange_and_wrap.sh` gates on
       this — see ["The replication-settle gate"](#the-replication-settle-gate); do **not** `--force` past it in
-      production, and confirm on staging under live ingest that it does not abort on ordinary churn).
+      production, and confirm on staging under live ingest that it does not abort on ordinary churn). The **final**
+      deletion replay is not covered by this gate, which samples before that statement is issued; what covers it is
+      `lightweight_deletes_sync = 2` in its own block, asserted by the driver.
 - [ ] **`traceColumnsNonNullable = true` rolled out to every backend instance before the EXCHANGE** — confirmed live on
       the whole fleet by a **positive** check, not by the absence of ingestion errors: write an in-progress trace (no
       `end_time`, and so no `ttft`) through the API and assert the epoch/NaN **sentinel** was stored for both — then

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -172,8 +172,9 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    `lightweight_deletes_sync = 2`, so it returns only once the delete mutation has applied on **every** replica.
    No config change precedes this step — the procedure takes no hold on writes.
    The driver passes `--time`, so clickhouse-client prints each statement's wall time in seconds (delta-insert first,
-   deletion replay second) — **record the second value**: it sizes the final-delta→`EXCHANGE` gap, which is where tail
-   writes are left behind. Without `--time` a bare `--query` prints no timing at all.
+   deletion replay second) — **record the second value**: it is the *first half* of the final-delta→`EXCHANGE` gap,
+   which is where tail writes are left behind. The second half is `exchange_and_wrap.sh`'s own run through the swap,
+   which that driver reports (step 4). Without `--time` a bare `--query` prints no timing at all.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/delta_replay.sh --database opik --backfill-start '<ts> UTC'
    ```
@@ -310,11 +311,12 @@ delta one). This is normal — `ReplacingMergeTree` collapses them on merge / un
 
 ### The one rolling restart (`traceColumnsNonNullable`)
 
-Getting to the `EXCHANGE` needs **one** rolling restart, and it carries no latency cost: rolling out
+Getting to the `EXCHANGE` needs **one** rolling restart, and it carries no *steady-state* latency cost: rolling out
 `databaseAnalyticsDataModel.traceColumnsNonNullable = true` (prereq 6) to every backend instance beforehand. Nothing is
 restarted afterwards to undo it. The optional `Distributed` wrap spends a restart of its own for
 `tracesDistributedWrapEnabled` (see the wrap prerequisite) — that one belongs to the wrap, is only paid if you apply
-it, and likewise costs no latency.
+it, and likewise leaves no standing latency behind. What each roll *does* cost while it is in flight is ingestion
+capacity, so plan for that (see the end of this section).
 
 > **The async-insert knob is untouched, and OPIK-7686's decision stands.** The three
 > `ANALYTICS_DB_ASYNC_INSERT_*` knobs remain valid production tuning, deliberately absent from the chart's `values.yaml`
@@ -367,10 +369,16 @@ toward `--force`, which the Go/No-Go forbids. Hence:
 | Signal | Judgement |
 |---|---|
 | the deletion-replay **mutation** on `traces_local_v2` | **Unconditional.** It is one bounded statement, not churn, so it must reach `is_done` on every replica within `--settle-timeout` (default 120s) or the gate fails — an unapplied mask means bridged deletes leak live across the swap. |
-| the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is merely moving is accepted, with the numbers printed so the operator sees what was accepted. |
+| the **replication queue** on `traces` / `traces_local_v2` | **Stuck-ness, not depth.** It passes the moment the queue drains to 0. If it has not drained by the deadline, the gate reports the oldest entry's age, the highest `num_tries` and whether any entry carries a `last_exception` — an entry older than 60s, more than 3 retries, or any recorded exception means a replica is genuinely lagging and the gate **fails loudly, printing the offending entries per replica**. A queue that is busy but not stuck is accepted, with the numbers printed so the operator sees what was accepted. |
 
-Raise `--settle-timeout` for a slow-but-progressing cluster. `--force` skips the gate entirely and is a production
-No-Go: the gate is permissive enough that reaching its failure path means something is genuinely wrong.
+The queue verdict is a **snapshot** over the last sample read, in both the polled and the single-sample case — nothing
+compares consecutive samples. Polling buys the queue time to drain, and a genuinely stuck entry time to age past the
+thresholds; that is all, so a shorter `--settle-timeout` is a weaker gate by exactly that much.
+
+Raise `--settle-timeout` (0–3600s) for a slow-but-progressing cluster, at a price: the gate sits between the final
+delta and the `EXCHANGE`, so whatever it waits is added to the tail write-gap. The driver prints the wait alongside its
+elapsed-through-`EXCHANGE` so the gap can be sized with it included. `--force` skips the gate entirely and is a
+production No-Go: the gate is permissive enough that reaching its failure path means something is genuinely wrong.
 
 ### The final cutover window
 
@@ -404,11 +412,13 @@ The tail is still worth running tightly, because its length is what decides how 
 2. Do the QA verify on an **earlier** pass (it can take minutes on a large table — do not let it be the last thing
    before the swap).
 3. Run a **final** `delta_replay.sh` as the last write-facing step before the swap.
-4. Run `exchange_and_wrap.sh --backfill-start '<anchor> UTC' …` **immediately** after it (the settle gate + `EXCHANGE` are
-   fast and metadata-only). It captures `cutover_start`, then runs a **final deletion replay** from `backfill_start`
-   right before the swap — so deletes bridged in the `[final delta_replay, cutover_start)` gap are masked on the
-   successor rather than leaking (that gap is covered by neither the earlier forward replay nor the rollback
-   reverse-replay, which starts at `cutover_start`). Deletions only.
+4. Run `exchange_and_wrap.sh --backfill-start '<anchor> UTC' …` **immediately** after it. It captures `cutover_start`,
+   then runs a **final deletion replay** from `backfill_start` right before the swap — so deletes bridged in the
+   `[final delta_replay, cutover_start)` gap are masked on the successor rather than leaking (that gap is covered by
+   neither the earlier forward replay nor the rollback reverse-replay, which starts at `cutover_start`). Deletions only.
+   The `EXCHANGE` itself is metadata-only, but this driver is **not** instantaneous: the settle gate ahead of it polls
+   for as long as the cluster needs, to `--settle-timeout`, and every second of that is tail. The driver prints its
+   elapsed-through-`EXCHANGE` with the gate wait itemised — that figure plus step 3's replay time is the gap.
 
 Keep step 3→4 short. **Deletes** up to `cutover_start` are covered by step 4's final deletion replay; **writes** in
 that gap and across the swap skew are the exposure above. The one residual on the delete side is a delete whose
@@ -1710,14 +1720,18 @@ of the three as needing the same.
 The **replication-settle gate** belongs in the same category — it decides a verdict rather than reading a single
 number — so it needs the rehearsal too, under **live ingestion**, in both directions:
 
-- it does **not** abort on ordinary ingest churn (a moving `replication_queue` is accepted, with its numbers printed);
+- it does **not** abort on ordinary ingest churn (a busy-but-not-stuck `replication_queue` is accepted, with its
+  numbers printed);
 - it **does** abort on a genuinely lagging replica, naming the offending entries — stop or throttle a replica, or hold
   a mutation, and confirm the gate fails loudly rather than passing;
 - the deletion-replay mutation is judged unconditionally: an unfinished mutation fails the gate however quiet the queue
   is, and `--settle-timeout` bounds how long it waits to find out.
 
 The **argument guards** fail fast, before touching ClickHouse, so they are cheap to exercise by hand after any change
-here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`.
+here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`, and `--settle-timeout` must
+refuse anything outside 0–3600 as well as a leading zero. That last one is not cosmetic: bash arithmetic wraps silently
+past 2^63 instead of erroring, and an out-of-range value used to leave the gate's poll count negative, which skipped
+every sample and passed the gate without reading replication at all.
 
 Run it with: `mvn -o test -Dtest=TracesLocalV2CutoverTest` from `apps/opik-backend`.
 
@@ -1757,11 +1771,22 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       cross-node swap skew stay in `traces_pre_cutover_backup` and nothing in this procedure carries them into the live
       table yet (see "The final cutover window"). Size it straight after the swap with an **unbounded** post-`EXCHANGE`
       compare plus `--drill-down`: the gap rows sit in the cutover week, which every weekly bound excludes, so a bounded
-      run cannot see them. Keys listed **backup-only** are the gap; live-only keys are post-swap writes, the harmless
-      direction. Then either accept it with whoever authorised the cutover, or recover from the backup before
-      `finalize.sh` retires it. OPIK-8238 replaces this item with its reconciliation postcondition.
-- [ ] **Final-delta→EXCHANGE gap kept short** — record the final replay's wall time. The tail's length is what decides
-      how many writes land in the gap above.
+      run cannot see them. The drill-down reports keys in three shapes and **two of them can be gap rows**, so do not
+      size this by key presence alone:
+      - **backup-only** (`dst_hash` NULL) — traces *created* in the tail. Gap.
+      - **both sides, hashes differ** — gap when the newer `last_updated_at` is **in the backup**: a trace *updated* in
+        the tail, whose successor row is an older version. A presence check finds nothing to do here and would report
+        the gap as clean. When the newer version is the **live** one, it is an ordinary post-swap update instead.
+      - **live-only** (`src_hash` NULL) — traces created after the swap. Harmless.
+
+      The drill-down prints hashes, not versions, so the middle shape needs a `last_updated_at` comparison per key
+      across the two tables to settle which way it points. Then either accept the total with whoever authorised the
+      cutover, or recover from the backup before `finalize.sh` retires it. OPIK-8238 replaces this item with its
+      reconciliation postcondition.
+- [ ] **Final-delta→EXCHANGE gap kept short** — record the **whole** interval, not just the final replay's wall time:
+      the replay's own `--time` output *plus* the elapsed-through-`EXCHANGE` figure `exchange_and_wrap.sh` prints in its
+      tail summary, which itemises the settle-gate wait. The tail's length is what decides how many writes land in the
+      gap above, and on a busy cluster the gate is the part of it that varies.
 - [ ] **Far-future partitions quantified — and `max_partitions_per_insert_block` sized from the result.** Run the
       bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
       `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised
@@ -1773,8 +1798,9 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
 - [ ] **`EXCHANGE TABLES ... ON CLUSTER` works end-to-end** — or the fallback `RENAME` sequence is documented for the
       variant that needs it.
 - [ ] **No ingestion-path config change on any path** — forward, rollback, wrap or un-wrap. The procedure requires
-      one rolling restart to reach the `EXCHANGE`, carrying only `traceColumnsNonNullable = true`, with no latency
-      cost — plus the wrap's own restart for `tracesDistributedWrapEnabled` if the wrap is applied. Confirm you know
+      one rolling restart to reach the `EXCHANGE`, carrying only `traceColumnsNonNullable = true`, with no
+      steady-state latency cost though it does consume ingestion capacity while it rolls — plus the wrap's own
+      restart for `tracesDistributedWrapEnabled` if the wrap is applied. Confirm you know
       how a backend restart is triggered on the target deployment and that it fits the schedule — see
       ["The one rolling restart"](#the-one-rolling-restart-tracecolumnsnonnullable).
 - [ ] **Data Retention confirmed disabled** for the cutover window (`RETENTION_ENABLED=false`). Retention deletes bypass

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -191,6 +191,13 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    leaving `traces` a `MergeTree` where deletes still work); the `RENAME` + `Distributed` wrap runs only with
    `--with-wrap`. Afterwards, size the tail write-gap (["The final cutover window"](#the-final-cutover-window)) and
    verify (["Verifying the migration"](#verifying-the-migration-qa)).
+
+   **Check the per-host `ON CLUSTER` rows before you go further.** Each `ON CLUSTER` DDL prints one row per host
+   (`host, port, status, error, hosts_remaining, hosts_active`); status 0 with an empty error means that host applied
+   it. This is the only place a *partial* application surfaces: the driver's topology guards read `system.tables` on
+   the **connected node only**, so a host that missed the swap is invisible to every later step, and both the deferred
+   wrap and `finalize.sh` assume the cluster is uniform. If any host reports non-zero, stop and reconcile it before
+   running anything else.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/exchange_and_wrap.sh --database opik \
        --backfill-start '<anchor from backfill.sh> UTC' --confirm-retention-paused
@@ -289,7 +296,9 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it validates the
 > post-EXCHANGE topology and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new
 > `cutover_start`, and no replication-settle gate — neither of its signals describes this path, see
-> ["The replication-settle gate"](#the-replication-settle-gate)).
+> ["The replication-settle gate"](#the-replication-settle-gate)). Its topology guard reads the **connected node**, as
+> the EXCHANGE path's does, so it assumes the earlier `EXCHANGE` applied on every host — which is what the per-host
+> rows in step 4 are for. Confirm those before deferring the wrap, not after.
 > `--confirm-daos-retargeted` is required for **any** wrap (same-run or deferred), since the wrap makes `traces`
 > `Distributed` and breaks the delete/mutation DAOs until `tracesDistributedWrapEnabled=true` routes them at `traces_local`. To roll the wrap back, use
 > `rollback.sh --stage C`, then set `tracesDistributedWrapEnabled` back to `false` with the same rolling restart so

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -286,8 +286,10 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 >
 > **Applying the deferred wrap later:** once the retarget flag (`tracesDistributedWrapEnabled=true`) is live across the
 > backend fleet, run
-> `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it runs the settle
-> gate and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new `cutover_start`).
+> `exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted` — it validates the
+> post-EXCHANGE topology and applies **only** the wrap on the already-swapped `traces` (no second EXCHANGE, no new
+> `cutover_start`, and no replication-settle gate — neither of its signals describes this path, see
+> ["The replication-settle gate"](#the-replication-settle-gate)).
 > `--confirm-daos-retargeted` is required for **any** wrap (same-run or deferred), since the wrap makes `traces`
 > `Distributed` and breaks the delete/mutation DAOs until `tracesDistributedWrapEnabled=true` routes them at `traces_local`. To roll the wrap back, use
 > `rollback.sh --stage C`, then set `tracesDistributedWrapEnabled` back to `false` with the same rolling restart so

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -189,7 +189,8 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    prints `cutover_start`, runs `EXCHANGE TABLES ... ON CLUSTER` and renames the displaced old data to
    `traces_pre_cutover_backup` (see "Naming and the parked backup"). It **stops there by default** (EXCHANGE only,
    leaving `traces` a `MergeTree` where deletes still work); the `RENAME` + `Distributed` wrap runs only with
-   `--with-wrap`. Then reconcile (step 5) and verify.
+   `--with-wrap`. Afterwards, size the tail write-gap (["The final cutover window"](#the-final-cutover-window)) and
+   verify (["Verifying the migration"](#verifying-the-migration-qa)).
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/exchange_and_wrap.sh --database opik \
        --backfill-start '<anchor from backfill.sh> UTC' --confirm-retention-paused

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -375,9 +375,9 @@ The queue verdict is a **snapshot** over the last sample read, in both the polle
 compares consecutive samples. Polling buys the queue time to drain, and a genuinely stuck entry time to age past the
 thresholds; that is all, so a shorter `--settle-timeout` is a weaker gate by exactly that much.
 
-Raise `--settle-timeout` (0–3600s) for a slow-but-progressing cluster, at a price: the gate sits between the final
-delta and the `EXCHANGE`, so whatever it waits is added to the tail write-gap. The driver prints the wait alongside its
-elapsed-through-`EXCHANGE` so the gap can be sized with it included. `--force` skips the gate entirely and is a
+`--settle-timeout` accepts 0–3600s; raise it for a slow-but-progressing cluster, at a price — the gate sits between the
+final delta and the `EXCHANGE`, so whatever it waits is added to the tail write-gap. The driver prints the wait
+alongside its elapsed-through-`EXCHANGE`, so the gap can be sized with it included. `--force` skips the gate and is a
 production No-Go: the gate is permissive enough that reaching its failure path means something is genuinely wrong.
 
 ### The final cutover window
@@ -1697,7 +1697,8 @@ the `scripts/` drivers is exercised by it. **Unit-testing them is deliberately o
 rather than feasibility**: the repo does run bash suites elsewhere (`test_rebaseline_db_changelog.sh`,
 `test_precommit_wrappers.sh`) and stubbing `clickhouse-client` would work. But this is migration tooling with a finite
 life — once the cutover and its soak are done it stops changing, `spans` gets its own parallel directory rather than
-reusing these files, and a harness over eight drivers would be permanent maintenance on code heading for the archive.
+reusing these files, and a harness over every driver in `scripts/` would be permanent maintenance on code heading for
+the archive.
 
 **The sanctioned validation is performing the procedure** — the forward cutover, the wrap, and the rollback of each
 (stage A/B/C and `--unwrap-only`) — on a local or test environment. That exercises the drivers against a real
@@ -1729,9 +1730,10 @@ number — so it needs the rehearsal too, under **live ingestion**, in both dire
 
 The **argument guards** fail fast, before touching ClickHouse, so they are cheap to exercise by hand after any change
 here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`, and `--settle-timeout` must
-refuse anything outside 0–3600 as well as a leading zero. That last one is not cosmetic: bash arithmetic wraps silently
-past 2^63 instead of erroring, and an out-of-range value used to leave the gate's poll count negative, which skipped
-every sample and passed the gate without reading replication at all.
+refuse a leading zero as well as anything outside 0–3600. Keep that last check **lexical**, on the digit count, rather
+than turning it into a numeric comparison: bash arithmetic wraps silently past 2^63 instead of erroring, and a wrapped
+value is negative, so it both passes a `<=` test and leaves the gate's poll count negative — which skips every sample
+and passes the gate without reading replication at all.
 
 Run it with: `mvn -o test -Dtest=TracesLocalV2CutoverTest` from `apps/opik-backend`.
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/backfill.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Backfill driver for the buffered traces cutover (runbook: ../README.md, step 1).
+# Backfill driver for the traces cutover (runbook: ../README.md, step 1).
 #
 # Copies traces -> traces_local_v2 oldest to newest, reconciling and aborting on divergence. It iterates by week (for
 # progress and --from-week resume), but each week is further split, adaptively, into time sub-windows so that no single

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -181,8 +181,9 @@ SETTINGS allow_nondeterministic_mutations = 1,
          log_comment = 'traces_local_v2_cutover:deletion_replay';
 -- >>> END deletion-replay
 
--- Step 4: Measure the replay. Its wall time sizes the tail — it is part of the final-delta -> EXCHANGE gap, and that
--- gap is where tail writes are left behind (OPIK-8238), so keeping it short keeps that set small. Re-run
+-- Step 4: Measure the replay. Its wall time is the first half of the final-delta -> EXCHANGE gap (exchange_and_wrap.sh
+-- reports the second half, its own run through the swap), and that gap is where tail writes are left behind
+-- (OPIK-8238), so keeping it short keeps that set small. Re-run
 -- steps 2-3 if new rows/deletes accumulated during the replay itself. Note the anchor is fixed, so a re-run re-copies
 -- the WHOLE window rather than only what is new — the statement does not get cheaper, and ReplacingMergeTree dedups the
 -- re-copies. What shrinks is the residual: after each pass, only the writes that arrived during that pass are uncaught.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000002_delta_and_deletion_replay.sql
@@ -11,28 +11,22 @@
 --   ../delta_replay.sh --database opik --backfill-start '2025-06-01 12:00:00.000000 UTC'
 -- The ' UTC' marker is mandatory: the driver refuses an anchor without it, because the bounds below parse the
 -- value as UTC and one captured elsewhere would shift them silently.
--- The surrounding config operations (buffer raise/restore) and the go/no-go checkpoint stay with the operator, where
--- situational awareness matters most — those are config/judgement, not SQL. The driver invokes clickhouse-client with
--- --time, so it prints each statement's elapsed seconds to stderr (delta-insert first, deletion replay second); the
--- second value is the replay measurement in step 5. A bare --query prints no timing, hence the flag.
+-- The go/no-go checkpoint between the steps stays with the operator, where situational awareness matters most — that is
+-- judgement, not SQL. The driver invokes clickhouse-client with --time, so it prints each statement's elapsed seconds
+-- to stderr (delta-insert first, deletion replay second); the second value is the replay measurement in step 4. A bare
+-- --query prints no timing, hence the flag.
 
 -- Step 1: BACKFILL_START is the timestamp captured BEFORE the backfill began. backfill.sh prints it at startup
 -- ("RECORD backfill_start=..."); if you ran the backfill manually, use the now64(6, 'UTC') you captured before the first
 -- INSERT. The delta and the replay both key off this single anchor, so writes during the whole backfill window are
 -- covered.
 
--- Step 2: Raise the async-insert buffer ceiling so the buffer can absorb the cutover window. Set
--- databaseAnalytics.asyncInsertBusyTimeoutMaxMs ~= 10000 (env ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS) and roll
--- it out (config push + rolling restart, OR a session-level SET on a dedicated cutover connection). Because
--- async_insert_use_adaptive_busy_timeout=1, this only widens the buffer while rows are queued. VERIFY the widening
--- took effect before proceeding — see README.
-
--- Step 3: Delta-insert — re-copy every row written during the backfill window. Anchored on
+-- Step 2: Delta-insert — re-copy every row written during the backfill window. Anchored on
 -- created_at OR last_updated_at >= backfill_start (NOT last_updated_at alone): last_updated_at is client-supplied on the
 -- batch-ingest path, so it is not a reliable "changed since" signal by itself. Every trace write sets EITHER a fresh
 -- server created_at (batch-ingest path) OR a fresh server last_updated_at (create/update merge paths), so the union is
 -- complete. ReplacingMergeTree dedups the re-copied rows against the backfilled ones (newest last_updated_at wins).
--- Uses ${BACKFILL_START}. SETTINGS max_insert_block_size bounds per-block memory as in step 1, and
+-- Uses ${BACKFILL_START}. SETTINGS max_insert_block_size bounds per-block memory as in the backfill (000001), and
 -- max_partitions_per_insert_block bounds how many partitions one block may span — a CORRECTNESS gate here, not a
 -- tuning knob, and it is NOT optional just because the delta is smaller than the backfill. This INSERT writes into the
 -- same weekly-partitioned shadow, and the last_updated_at arm re-copies UPDATES TO OLD ROWS, so a far-future-id row
@@ -122,7 +116,7 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
          log_comment = 'traces_local_v2_cutover:delta_insert';
 -- >>> END delta-insert
 
--- Step 4: Deletion replay — remove from the destination every row that was deleted on the source since backfill_start
+-- Step 3: Deletion replay — remove from the destination every row that was deleted on the source since backfill_start
 -- AND is still deleted there. Single FULL-KEY branch: since OPIK-7483 every trace delete resolves its owning project(s)
 -- and deletes each under the full (workspace_id, project_id, id) key — there is no project-less delete path, so no
 -- deletion event is ever bridged with an empty project_id for source_table='traces' (a pre-cutover prereq asserts the
@@ -144,7 +138,7 @@ SETTINGS max_insert_block_size = ${MAX_INSERT_BLOCK_SIZE},
 -- lightweight_deletes_sync = 2: block until the delete mutation has completed on EVERY replica, not just the one that
 -- accepted it. The mutation is otherwise asynchronous, so without this the verify step (and the EXCHANGE) could run
 -- against a replica where the mask is not yet applied — a false mismatch, or worse an incomplete cutover.
--- Uses ${BACKFILL_START}. Retention is disabled everywhere (see step 6), so this is user-scale volume — a single
+-- Uses ${BACKFILL_START}. Retention is disabled everywhere (see step 5), so this is user-scale volume — a single
 -- mutation. If it is ever large (e.g. retention enabled), bound each mutation by a created_at week (the non-wrapping,
 -- minmax-indexed slice backfill.sh uses) and loop the weeks — NOT toMonday(id_at), which wraps far-future/epoch ids
 -- (OPIK-7456) and no longer matches the successor's honest-Date32 partition expression.
@@ -187,14 +181,17 @@ SETTINGS allow_nondeterministic_mutations = 1,
          log_comment = 'traces_local_v2_cutover:deletion_replay';
 -- >>> END deletion-replay
 
--- Step 5: Measure the replay. Compare its wall time against the buffer window (must fit with margin — acceptance
--- criterion). Re-run steps 3-4 if new rows/deletes accumulated during the replay itself; convergence is fast because
--- the buffer is holding new writes.
+-- Step 4: Measure the replay. Its wall time sizes the tail — it is part of the final-delta -> EXCHANGE gap, and that
+-- gap is where tail writes are left behind (OPIK-8238), so keeping it short keeps that set small. Re-run
+-- steps 2-3 if new rows/deletes accumulated during the replay itself. Note the anchor is fixed, so a re-run re-copies
+-- the WHOLE window rather than only what is new — the statement does not get cheaper, and ReplacingMergeTree dedups the
+-- re-copies. What shrinks is the residual: after each pass, only the writes that arrived during that pass are uncaught.
 
--- Step 6 (retention — see README): Data Retention is disabled in every deployment (RETENTION_ENABLED=false), so the
+-- Step 5 (retention — see README): Data Retention is disabled in every deployment (RETENTION_ENABLED=false), so the
 -- retention delete path does not fire during the cutover. The only deletes in this window are user-initiated, and those
 -- ARE captured by the bridge. If retention is ever enabled, pause it for the window (or land retention-path capture).
 
 -- rollback: none for the delta-insert (it only adds newest versions that ReplacingMergeTree dedups); the replay is
---           idempotent. If aborting the cutover here, TRUNCATE traces_local_v2 (step 1 rollback) and restore the buffer
---           ceiling (step 2, reverse). The live `traces` table is still untouched until the EXCHANGE in step 3.
+--           idempotent. If aborting the cutover here, TRUNCATE traces_local_v2 (rollback.sh --stage A) and see the
+--           README on the traceColumnsNonNullable revert and sentinel repair that an abandoned run still owes. The
+--           live `traces` table is untouched until the EXCHANGE in 000003.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -1,13 +1,84 @@
--- runbook traces-local-v2-cutover — step 3 of 3: EXCHANGE + Distributed wrap (reference statements)
--- The gate test TracesLocalV2CutoverTest reimplements these statements inline; keep the two in step (see its Javadoc).
+-- runbook traces-local-v2-cutover — step 3 of 3: replication-settle gate + EXCHANGE + Distributed wrap
+-- The gate test TracesLocalV2CutoverTest reimplements the EXCHANGE and wrap statements inline; keep the two in step
+-- (see its Javadoc). The settle-gate blocks are read-only and are exercised in the cutover rehearsal instead.
 --
--- ../exchange_and_wrap.sh drives this: it records cutover_start, runs the `exchange` block, and (unless --skip-wrap)
--- the `wrap` block. Run it right after step 2's delta + replay, while the async-insert buffer is still holding writes.
--- Do NOT run this whole file wholesale — the driver runs one marked block at a time. Buffer knob: raise
--- databaseAnalytics.asyncInsertBusyTimeoutMaxMs before the cutover and unset it after (a backend-config action, not SQL).
+-- ../exchange_and_wrap.sh drives this: it runs the settle gate, records cutover_start, runs the `exchange` block, and
+-- (unless --skip-wrap) the `wrap` block. Run it right after step 2's delta + replay, so the final-delta -> EXCHANGE gap
+-- stays small. Do NOT run this whole file wholesale — the driver runs one marked block at a time. Nothing here needs an
+-- ingestion-side config change: the EXCHANGE is atomic per node, so a concurrent insert always commits to a valid
+-- table. Writes that land in the old one — in that gap or during the cross-node skew — stay in the parked backup: the
+-- open tail write-gap tracked as OPIK-8238, stated in the runbook's "The final cutover window".
 --
 -- cutover_start is a now64(6) captured RIGHT BEFORE the EXCHANGE; a rollback after this point replays deletes that fired
 -- on the new live table since then. exchange_and_wrap.sh captures and prints it; record it for the rollback.
+
+-- Blocks, in the order the driver runs them: settle-sample, then settle-queue-detail / settle-mutation-detail only when
+-- the gate refuses, then `exchange`, then `wrap`. The first three are read-only. '{cluster}' is the macro, resolved
+-- server-side, as in the 000004 postcondition files.
+
+-- The gate's one sample, as seven numbers on a single row so the driver can read it as TSV: the replication queue's
+-- depth, its oldest entry's age in seconds, its highest num_tries and how many of its entries carry a last_exception;
+-- then the count of unfinished mutations on the shadow, their oldest age and how many carry a latest_fail_reason. Every
+-- column is numeric on purpose — the free-text exception columns would need quoting to survive TSV, and the two detail
+-- blocks below print them instead. max()/countIf() over an empty set yield 0, so a drained queue and an idle mutation
+-- list need no special casing. Each side is a single-row aggregate, so the CROSS JOIN is 1x1.
+-- >>> BEGIN settle-sample
+SELECT q.cnt, q.age, q.tries, q.exc, m.cnt, m.age, m.fails
+FROM (
+    SELECT count()                                     AS cnt,
+           max(dateDiff('second', create_time, now())) AS age,
+           max(num_tries)                              AS tries,
+           countIf(last_exception != '')               AS exc
+    FROM clusterAllReplicas('{cluster}', system.replication_queue)
+    WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
+      AND table IN ('traces', 'traces_local_v2')
+) AS q
+CROSS JOIN (
+    SELECT count()                                     AS cnt,
+           max(dateDiff('second', create_time, now())) AS age,
+           countIf(latest_fail_reason != '')           AS fails
+    FROM clusterAllReplicas('{cluster}', system.mutations)
+    WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
+      AND table = 'traces_local_v2'
+      AND is_done = 0
+) AS m;
+-- >>> END settle-sample
+
+-- Printed when the gate judges a replica to be lagging rather than merely busy: the oldest and most-retried queue
+-- entries, per replica, with the free text the sample above deliberately omits.
+-- >>> BEGIN settle-queue-detail
+SELECT hostName()                             AS replica,
+       table,
+       type,
+       create_time,
+       dateDiff('second', create_time, now()) AS age_seconds,
+       num_tries,
+       num_postponed,
+       postpone_reason,
+       last_exception
+FROM clusterAllReplicas('{cluster}', system.replication_queue)
+WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
+  AND table IN ('traces', 'traces_local_v2')
+ORDER BY num_tries DESC, create_time ASC
+LIMIT 10;
+-- >>> END settle-queue-detail
+
+-- Printed when the deletion-replay mutation has not finished on every replica by the gate's deadline.
+-- >>> BEGIN settle-mutation-detail
+SELECT hostName() AS replica,
+       mutation_id,
+       command,
+       create_time,
+       parts_to_do,
+       latest_failed_part,
+       latest_fail_reason
+FROM clusterAllReplicas('{cluster}', system.mutations)
+WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
+  AND table = 'traces_local_v2'
+  AND is_done = 0
+ORDER BY create_time
+LIMIT 10;
+-- >>> END settle-mutation-detail
 
 -- >>> BEGIN exchange
 -- The atomic swap: `traces` now refers to the partitioned data. The displaced old data lands under `traces_local_v2`
@@ -53,6 +124,6 @@ RENAME TABLE
     ON CLUSTER '{cluster}';
 -- >>> END wrap
 
--- After the wrap: restore the buffer ceiling (unset asyncInsertBusyTimeoutMaxMs), verify (README "Verifying the
--- migration"), and keep `traces_pre_cutover_backup` (the parked old data) until the soak completes. Rollback: the
--- 000004_rollback_* files via ../rollback.sh.
+-- After the wrap: size the tail write-gap (README "The final cutover window"), verify (README "Verifying the
+-- migration"), and keep `traces_pre_cutover_backup` (the parked old data) until the soak completes — it is the only
+-- copy of the gap rows. Rollback: the 000004_rollback_* files via ../rollback.sh.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -54,6 +54,10 @@ CROSS JOIN (
 -- Printed when the gate judges a replica to be lagging rather than merely busy: the oldest and most-retried queue
 -- entries, per replica, with the free text the sample above deliberately omits. Same type filter as the sample, so the
 -- rows shown are the population the verdict was reached on.
+--
+-- LIMIT n BY replica, not a global LIMIT: the cluster is ordered as one result set, so a single replica holding many
+-- retried entries would fill a global cap and hide every other replica that contributed to the verdict — which is the
+-- opposite of what this block is for. The row count is bounded by the replica count instead.
 -- >>> BEGIN settle-queue-detail
 SELECT hostName()                             AS replica,
        table,
@@ -69,10 +73,12 @@ WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
   AND table IN ('traces', 'traces_local_v2')
   AND type IN ('GET_PART', 'ATTACH_PART')
 ORDER BY num_tries DESC, create_time ASC
-LIMIT 10;
+LIMIT 3 BY replica;
 -- >>> END settle-queue-detail
 
--- Printed when the deletion-replay mutation has not finished on every replica by the gate's deadline.
+-- Printed when a mutation on the shadow has not finished on every replica by the gate's deadline. Bounded per replica
+-- for the same reason as the queue detail above: the point is to name which replicas are behind, and a global cap
+-- would hide them behind whichever replica sorted first.
 -- >>> BEGIN settle-mutation-detail
 SELECT hostName() AS replica,
        mutation_id,
@@ -86,7 +92,7 @@ WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
   AND table = 'traces_local_v2'
   AND is_done = 0
 ORDER BY create_time
-LIMIT 10;
+LIMIT 2 BY replica;
 -- >>> END settle-mutation-detail
 
 -- >>> BEGIN exchange

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -22,6 +22,12 @@
 -- column is numeric on purpose — the free-text exception columns would need quoting to survive TSV, and the two detail
 -- blocks below print them instead. max()/countIf() over an empty set yield 0, so a drained queue and an idle mutation
 -- list need no special casing. Each side is a single-row aggregate, so the CROSS JOIN is 1x1.
+--
+-- The queue side counts only GET_PART / ATTACH_PART, the entry types that mean a replica does not yet hold a part —
+-- which is the one queue condition that would make it serve an incomplete table after the swap. The queue also carries
+-- MERGE_PARTS and MUTATE_PART entries, and those say nothing about completeness: a pending merge is an optimisation,
+-- and an unfinished mutation is the other half of this sample. Counting them would fail the gate on ordinary post-
+-- backfill merge activity, where one legitimate large merge easily outlives the driver's stuck threshold.
 -- >>> BEGIN settle-sample
 SELECT q.cnt, q.age, q.tries, q.exc, m.cnt, m.age, m.fails
 FROM (
@@ -32,6 +38,7 @@ FROM (
     FROM clusterAllReplicas('{cluster}', system.replication_queue)
     WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
       AND table IN ('traces', 'traces_local_v2')
+      AND type IN ('GET_PART', 'ATTACH_PART')
 ) AS q
 CROSS JOIN (
     SELECT count()                                     AS cnt,
@@ -45,7 +52,8 @@ CROSS JOIN (
 -- >>> END settle-sample
 
 -- Printed when the gate judges a replica to be lagging rather than merely busy: the oldest and most-retried queue
--- entries, per replica, with the free text the sample above deliberately omits.
+-- entries, per replica, with the free text the sample above deliberately omits. Same type filter as the sample, so the
+-- rows shown are the population the verdict was reached on.
 -- >>> BEGIN settle-queue-detail
 SELECT hostName()                             AS replica,
        table,
@@ -59,6 +67,7 @@ SELECT hostName()                             AS replica,
 FROM clusterAllReplicas('{cluster}', system.replication_queue)
 WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
   AND table IN ('traces', 'traces_local_v2')
+  AND type IN ('GET_PART', 'ATTACH_PART')
 ORDER BY num_tries DESC, create_time ASC
 LIMIT 10;
 -- >>> END settle-queue-detail

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -51,34 +51,54 @@ CROSS JOIN (
 ) AS m;
 -- >>> END settle-sample
 
--- Printed when the gate judges a replica to be lagging rather than merely busy: the oldest and most-retried queue
--- entries, per replica, with the free text the sample above deliberately omits. Same type filter as the sample, so the
--- rows shown are the population the verdict was reached on.
+-- Printed when the gate judges a replica to be lagging rather than merely busy, with the free text the sample above
+-- deliberately omits. Same type filter as the sample, so the rows shown are the population the verdict was reached on.
 --
--- LIMIT n BY replica, not a global LIMIT: the cluster is ordered as one result set, so a single replica holding many
--- retried entries would fill a global cap and hide every other replica that contributed to the verdict — which is the
--- opposite of what this block is for. The row count is bounded by the replica count instead.
+-- Selected by RANK PER TRIGGER rather than a top-N, because the driver fails on any of three independent conditions —
+-- an entry older than its age threshold, one past its retry threshold, or any entry carrying a last_exception — and a
+-- single ordering cannot surface all three. Sorting by num_tries hides an old-but-rarely-retried entry behind busier
+-- ones, which is precisely the entry an age verdict is about. So each replica contributes its oldest entry, its
+-- most-retried entry, and up to two carrying an exception: at most four rows, always including whichever tripped the
+-- verdict. Ranking per replica also keeps one noisy replica from crowding the others out of the report.
 -- >>> BEGIN settle-queue-detail
-SELECT hostName()                             AS replica,
+SELECT replica,
        table,
        type,
        create_time,
-       dateDiff('second', create_time, now()) AS age_seconds,
+       age_seconds,
        num_tries,
        num_postponed,
        postpone_reason,
        last_exception
-FROM clusterAllReplicas('{cluster}', system.replication_queue)
-WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
-  AND table IN ('traces', 'traces_local_v2')
-  AND type IN ('GET_PART', 'ATTACH_PART')
-ORDER BY num_tries DESC, create_time ASC
-LIMIT 3 BY replica;
+FROM (
+    SELECT hostName()                             AS replica,
+           table,
+           type,
+           create_time,
+           dateDiff('second', create_time, now()) AS age_seconds,
+           num_tries,
+           num_postponed,
+           postpone_reason,
+           last_exception,
+           row_number() OVER (PARTITION BY hostName() ORDER BY create_time ASC)                          AS oldest_rank,
+           row_number() OVER (PARTITION BY hostName() ORDER BY num_tries DESC)                           AS retried_rank,
+           row_number() OVER (PARTITION BY hostName() ORDER BY (last_exception != '') DESC, create_time) AS failing_rank
+    FROM clusterAllReplicas('{cluster}', system.replication_queue)
+    WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
+      AND table IN ('traces', 'traces_local_v2')
+      AND type IN ('GET_PART', 'ATTACH_PART')
+)
+WHERE oldest_rank = 1
+   OR retried_rank = 1
+   OR (last_exception != '' AND failing_rank <= 2)
+ORDER BY replica, age_seconds DESC;
 -- >>> END settle-queue-detail
 
 -- Printed when a mutation on the shadow has not finished on every replica by the gate's deadline. Bounded per replica
 -- for the same reason as the queue detail above: the point is to name which replicas are behind, and a global cap
--- would hide them behind whichever replica sorted first.
+-- would hide them behind whichever replica sorted first. Every row here is unfinished, so there is no equivalent of
+-- that block's decoy problem — only the ordering matters, and one carrying a latest_fail_reason explains more than an
+-- older one that is merely still running, so those come first.
 -- >>> BEGIN settle-mutation-detail
 SELECT hostName() AS replica,
        mutation_id,
@@ -91,7 +111,7 @@ FROM clusterAllReplicas('{cluster}', system.mutations)
 WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
   AND table = 'traces_local_v2'
   AND is_done = 0
-ORDER BY create_time
+ORDER BY (latest_fail_reason != '') DESC, create_time
 LIMIT 2 BY replica;
 -- >>> END settle-mutation-detail
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -3,8 +3,8 @@
 -- (see its Javadoc). The settle-gate blocks are read-only and are exercised in the cutover rehearsal instead.
 --
 -- ../exchange_and_wrap.sh drives this: it runs the settle gate, records cutover_start, runs the `exchange` block, and
--- (unless --skip-wrap) the `wrap` block. Run it right after step 2's delta + replay, so the final-delta -> EXCHANGE gap
--- stays small. Do NOT run this whole file wholesale — the driver runs one marked block at a time. Nothing here needs an
+-- runs the `wrap` block only with --with-wrap (or --wrap-only, which runs that block alone). Run it right after step 2's
+-- delta + replay, so the final-delta -> EXCHANGE gap stays small. Do NOT run this whole file wholesale — the driver runs one marked block at a time. Nothing here needs an
 -- ingestion-side config change: the EXCHANGE is atomic per node, so a concurrent insert always commits to a valid
 -- table. Writes that land in the old one — in that gap or during the cross-node skew — stay in the parked backup: the
 -- open tail write-gap tracked as OPIK-8238, stated in the runbook's "The final cutover window".

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_unwrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000004_rollback_unwrap.sql
@@ -29,8 +29,8 @@
 -- replica still has the wrapper, that wrapper resolves `traces_local`, which the already-renamed replicas no longer
 -- have, so a query routed there can fail with UNKNOWN_TABLE (the wrap's own window is the same thing in reverse — a
 -- Distributed query reaching a node where `traces_local` does not exist YET). It is brief and fails loudly rather than
--- silently, and ../rollback.sh gates it behind --confirm-maintenance; quiescing reads, not just buffering writes, is
--- what actually covers it.
+-- silently, and ../rollback.sh gates it behind --confirm-maintenance; only quiescing reads as well as writes actually
+-- covers it — nothing on the ingestion side can.
 --
 -- Partial-failure recovery: if the RENAME succeeds and the DROP does not, the estate is already correct (`traces` is the
 -- successor) and only the data-less ex-wrapper lingers under `traces_dist_old`. Nothing needs re-running — --unwrap-only

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Driver for step 2 of the buffered traces cutover: delta-insert + deletion replay (runbook: ../README.md).
+# Driver for step 2 of the traces cutover: delta-insert + deletion replay (runbook: ../README.md).
 #
 # Reads db-app-analytics/000002_delta_and_deletion_replay.sql (the single source), substitutes the placeholders and runs
 # it. Run it after backfill.sh, then verify.sh, then exchange_and_wrap.sh.
@@ -117,9 +117,6 @@ esac
 [[ -z "$MAX_INSERT_THREADS" || "$MAX_INSERT_THREADS" =~ ^(0|[1-9][0-9]?)$ ]] || { echo "ERROR: --max-insert-threads must be 0 (force no parallel INSERT SELECT execution) or 1..99; omit it entirely to inherit the server's setting." >&2; exit 2; }
 [[ -f "$SQL_FILE" ]] || { echo "ERROR: cannot find $SQL_FILE" >&2; exit 2; }
 
-echo "Reminder: raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs before this step (backend config, not SQL) and"
-echo "restore it after the EXCHANGE."
-
 sql="$(cat "$SQL_FILE")"
 sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
 sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
@@ -217,10 +214,11 @@ if grep -qF '${MAX_INSERT_THREADS}' <<<"$mit_masked"; then
 fi
 # <<< END max_insert_threads rendering
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
-# --query). The SECOND number is the deletion replay's wall time — a Go/No-Go acceptance criterion (it must fit inside
-# the buffer hold with margin), so without this the operator has no way to record it short of digging in query_log.
+# --query). The SECOND number is the deletion replay's wall time, which is how the operator sizes the tail: it sits
+# inside the final-delta -> EXCHANGE gap, which is where tail writes are left behind (see the runbook's "The final
+# cutover window"; OPIK-8238). Without this flag there is no way to record it short of digging in query_log.
 echo "Statement wall times (seconds, in order: delta-insert, deletion-replay):"
 clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
 
-echo "Delta + deletion replay complete. RECORD the deletion-replay wall time above (the second value) — the"
-echo "final-delta -> EXCHANGE gap must fit inside the buffer hold. Run verify.sh before the EXCHANGE."
+echo "Delta + deletion replay complete. RECORD the deletion-replay wall time above (the second value) — it sizes the"
+echo "final-delta -> EXCHANGE gap where tail writes are left behind. Run verify.sh before the EXCHANGE."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -100,7 +100,7 @@ WITH_WRAP=0
 WRAP_ONLY=0
 FORCE=0
 SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
-SETTLE_TIMEOUT_MAX=3600   # accepted ceiling for it, enforced lexically at validation. See there for why.
+SETTLE_TIMEOUT_MAX=3600   # its accepted ceiling; the validation below explains why the check is lexical.
 CONFIRM_MAINTENANCE=0
 CONFIRM_DAOS_RETARGETED=0
 CONFIRM_RETENTION_PAUSED=0
@@ -137,14 +137,12 @@ done
 [[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
 [[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ "$RECEIVE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --receive-timeout must be a positive integer (seconds)." >&2; exit 2; }
-# 0 is meaningful (a single sample), so unlike the bound above this accepts it — but not a leading zero, which bash
-# arithmetic reads as octal and rejects ("value too great for base") once the gate divides by the poll interval.
-#
-# The four-digit cap is what keeps the gate honest, and it has to be LEXICAL. Past 2^63 bash arithmetic wraps silently
-# rather than erroring, so `polls` in the gate below goes negative, its `for` loop runs zero times, and the verdict then
-# reads unset sample variables as 0 and passes — a mistyped argument would swap without ever having looked at
-# replication. A numeric `<= SETTLE_TIMEOUT_MAX` test cannot catch that either, because the wrapped value is negative
-# and so compares as in-range; the digit count must be bounded before any arithmetic touches it.
+# Both halves matter, and the digit cap has to come first, before any arithmetic sees the value. A leading zero would be
+# read as octal ("value too great for base" once the gate divides by the poll interval). Past 2^63 bash arithmetic wraps
+# silently instead of erroring: `polls` in the gate below goes negative, its `for` loop runs zero times, and the verdict
+# then reads the unset sample variables as 0 and passes — so an out-of-range value would reach the EXCHANGE without
+# having read replication at all. A numeric `<= SETTLE_TIMEOUT_MAX` test cannot catch that, because the wrapped value is
+# negative and compares as in-range. 0 is accepted, and means a single sample.
 [[ "$SETTLE_TIMEOUT" =~ ^(0|[1-9][0-9]{0,3})$ ]] && (( SETTLE_TIMEOUT <= SETTLE_TIMEOUT_MAX )) || { echo "ERROR: --settle-timeout must be an integer between 0 and $SETTLE_TIMEOUT_MAX seconds, with no leading zero; 0 takes a single sample. An hour of pre-swap polling is already past the point of aborting and resolving the lag." >&2; exit 2; }
 
 # One place for the connection and client-side options, so every call site below carries the same host, port,
@@ -445,10 +443,9 @@ assert_replication_settled() {
         exit 1
     fi
 
-    # "Not stuck", not "moving": the verdict is a snapshot predicate over the last sample read. Neither this path nor
-    # the polled one compares consecutive samples — polling exists to give the queue time to drain (the queue == 0 exit
-    # above) or to give a genuinely stuck entry time to age past the thresholds. So a shorter --settle-timeout is a
-    # weaker gate by exactly that much, which is what the flag means.
+    # "Not stuck" rather than "moving": this is a snapshot predicate over the last sample read, and no path here
+    # compares consecutive samples. Polling only gives the queue time to drain (the queue == 0 exit above) or a stuck
+    # entry time to age past the thresholds, so a shorter --settle-timeout is a weaker gate by exactly that much.
     echo "Replication settled enough across cluster '$cluster': the deletion-replay mutation is done on every replica and"
     echo "no queue entry is stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a last_exception."
     echo "That is ordinary ingest churn on a live table."
@@ -461,9 +458,9 @@ else
     assert_pre_exchange_topology
 fi
 
-# Timed, because this driver's own run is the second half of the final-delta -> EXCHANGE gap and the gate is the part
-# of it that varies: it can poll to --settle-timeout on a busy cluster, so calling it "fast and metadata-only" and
-# sizing the tail from the delta replay alone would understate the gap by up to that much.
+# Timed, because this driver's run is the second half of the final-delta -> EXCHANGE gap and the settle gate is the
+# part of it that varies: on a busy cluster it polls up to --settle-timeout, so the delta replay's wall time on its own
+# understates the gap by that much.
 SETTLE_SECONDS=0
 if [[ "$FORCE" == "1" ]]; then
     echo "WARNING: --force set; skipping the replication-settle gate."
@@ -555,13 +552,12 @@ echo
 echo "TAIL WRITE-GAP: traces written between the last delta and this swap — and any routed at a not-yet-swapped node"
 echo "during it — are in traces_pre_cutover_backup, NOT in live traces. Nothing in this procedure carries them across"
 echo "yet (OPIK-8238)."
-echo "  Length: ${EXCHANGE_SECONDS}s in this driver from start through the EXCHANGE, of which ${SETTLE_SECONDS}s was the settle"
-echo "  gate. Add the final delta_replay's replay time (its own --time output) for the whole final-delta -> EXCHANGE gap."
-echo "  Size it now with the post-EXCHANGE compare and --drill-down. TWO categories are gap rows, not one: keys the"
-echo "  drill-down shows backup-only (created in the tail), and keys present on BOTH sides whose hashes differ with the"
-echo "  newer last_updated_at in the backup (updated in the tail — the successor holds an older version, so a"
-echo "  presence-only check misses these). Differing hashes with the newer version live are post-swap writes and are"
-echo "  harmless, so compare last_updated_at per key to tell the two apart."
-echo "  Then either accept the gap or recover from the backup BEFORE finalize.sh retires it."
+echo "  Length: ${EXCHANGE_SECONDS}s from this driver's start through the EXCHANGE, of which ${SETTLE_SECONDS}s was the"
+echo "  settle gate. Add the final delta_replay's replay time (its --time output) for the whole gap."
+echo "  Size it now with the post-EXCHANGE compare and --drill-down. TWO of its three key shapes are gap rows: keys"
+echo "  shown backup-only (created in the tail), and keys on BOTH sides whose hashes differ with the newer"
+echo "  last_updated_at in the backup (updated in the tail — sizing by key presence alone misses these). Differing"
+echo "  hashes whose newer version is live are ordinary post-swap writes. The drill-down prints hashes, not versions,"
+echo "  so compare last_updated_at per key. Then accept the gap, or recover from the backup BEFORE finalize.sh retires it."
 echo "Then verify, and keep traces_pre_cutover_backup for the soak. No ingestion-side config was changed, so there is"
 echo "nothing to restore."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -252,14 +252,27 @@ extract() {
 # RETURN, not exit: `render` calls this inside a command substitution, where an exit would end only that subshell and
 # hand the caller partial SQL. Every caller assigns first and adds `|| exit 2`, so a refusal still stops the run.
 require_rendered() {
-    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends
-    # Exactly one pair, checked on the file rather than the extraction: the awk stops at the first END and otherwise
-    # runs to EOF, so a missing or renamed END sweeps every later block into this one and --multiquery executes them
-    # all. The content checks below cannot see that -- a run-on capture still contains this block's own statement.
+    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
+    # Both structural checks read the FILE, not the extraction, because the content checks below cannot see a run-on
+    # capture: extract()'s awk clears its flag only on a line equal to the END marker, so with no such line after the
+    # BEGIN it captures to end of file and --multiquery executes every later block too. Such a capture is neither empty
+    # nor missing this block's own statement, and its must_contain token can be satisfied by the swept-in neighbour --
+    # so identity does not localize to the intended block either.
+    #
+    # First: exactly one of each marker. Catches a missing or renamed END.
     begins="$(grep -cxF -e "-- >>> BEGIN $what" "$file" || true)"
     ends="$(grep -cxF -e "-- >>> END $what" "$file" || true)"
     if (( begins != 1 || ends != 1 )); then
         echo "ERROR: $file holds $begins '-- >>> BEGIN $what' and $ends '-- >>> END $what'; expected one of each." >&2
+        return 2
+    fi
+    # Second: the END must sit after its BEGIN. Counting alone misses a reordered END, which still counts 1 and 1 while
+    # producing that same run-on capture. One pass, since the counts above establish there is exactly one of each.
+    read -r begin_line end_line <<<"$(awk -v b="-- >>> BEGIN $what" -v e="-- >>> END $what" \
+        '$0 == b {bl = NR} $0 == e {el = NR} END {print bl, el}' "$file")"
+    if (( end_line <= begin_line )); then
+        echo "ERROR: $file has the '$what' markers out of order (BEGIN at line $begin_line, END at line $end_line)," >&2
+        echo "       so the block would capture to end of file and sweep every later block into it. Refusing to run it." >&2
         return 2
     fi
     masked="$(sed 's/--.*$//' <<<"$sql")"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -62,11 +62,11 @@
 #                             slow-but-progressing cluster — it delays the EXCHANGE and so lengthens the tail write-gap
 #                             by the wait, which the driver reports. See assert_replication_settled for the two
 #                             judgements it makes.
-#   --force           skip the replication-settle gate entirely. By default the swap aborts when the deletion-replay
-#                     mutation has not finished on every replica, or when the replication queue is not merely busy but
+#   --force           skip the replication-settle gate entirely. By default the swap aborts when a mutation on the
+#                     shadow has not finished on every replica, or when the replication queue is not merely busy but
 #                     stuck (an aged entry, retries, or a last_exception) — either way a behind replica would swap in an
 #                     incomplete table. Use only if settlement is confirmed out of band; the runbook's Go/No-Go forbids
-#                     it in production.
+#                     it in production. Irrelevant to --wrap-only, which does not run the gate at all.
 #   --confirm-maintenance  REQUIRED whenever the wrap is applied (--with-wrap or --wrap-only). The wrap is gapless per
 #                     node (atomic rotate), but a brief cross-node ON CLUSTER propagation skew remains, during which a
 #                     Distributed query can hit a not-yet-created `traces_local` on a lagging node and fail. The failing
@@ -379,20 +379,23 @@ assert_pre_wrap_topology() {
 }
 
 # Pre-EXCHANGE gate: the swap is metadata-only and near-instant, but each replica reads its own local parts afterwards,
-# so a replica still fetching backfilled parts (replication_queue) or still applying the deletion-replay mutation
-# (system.mutations) would serve an incomplete table. Both are read across every replica via clusterAllReplicas, so one
-# connection sees the whole cluster. Aborts unless --force.
+# so a replica that does not yet hold every part would serve an incomplete table. Both signals are read across every
+# replica via clusterAllReplicas, so one connection sees the whole cluster. Aborts unless --force, and does not run for
+# --wrap-only, which performs no swap.
 #
 # The two signals are judged differently, because only one of them is quiet on a healthy cluster:
 #
-#   * The deletion-replay MUTATION is one bounded statement. It must reach is_done on every replica within
-#     --settle-timeout or the gate fails: an unapplied mask means bridged deletes leak live across the swap.
+#   * Unfinished MUTATIONS on the shadow must be none, within --settle-timeout. What this catches is a mutation left
+#     behind by an earlier step or by manual intervention -- NOT the final deletion replay below, which has not been
+#     issued yet when this samples. That one is covered by lightweight_deletes_sync = 2 in its own block, which returns
+#     only once every replica has applied the mask; run_final_deletion_replay asserts the setting is still there.
 #   * The replication QUEUE is expected to be busy under live ingestion — a GET_PART entry exists for every part a
 #     replica has not yet fetched — so requiring an instantaneous 0 would abort on ordinary churn and push the operator
 #     toward --force, which the Go/No-Go forbids. It passes as soon as the queue drains; failing that, the verdict is
 #     stuck-ness rather than depth: an entry aged past SETTLE_STUCK_AGE_SECONDS, more retries than
 #     SETTLE_STUCK_NUM_TRIES, or any last_exception means a replica is genuinely lagging, and the gate fails naming the
-#     offending entries per replica.
+#     offending entries per replica. The sample counts only the entry types that mean a replica lacks data, so ordinary
+#     merge activity neither holds the gate open nor trips it (see the settle-sample block for why).
 assert_replication_settled() {
     local cluster deadline polls poll row
     local sample_sql queue_detail_sql mutation_detail_sql
@@ -475,7 +478,14 @@ fi
 # part of it that varies: on a busy cluster it polls up to --settle-timeout, so the delta replay's wall time on its own
 # understates the gap by that much.
 SETTLE_SECONDS=0
-if [[ "$FORCE" == "1" ]]; then
+if [[ "$WRAP_ONLY" == "1" ]]; then
+    # Not skipped as a shortcut: neither signal describes this path. --wrap-only runs no EXCHANGE, and
+    # assert_pre_wrap_topology has already required traces_local_v2 to be gone, so the mutation half queries a table
+    # that no longer exists while the queue half judges the ingest churn of the live successor. Both would only ever
+    # block the wrap for a reason that has nothing to do with it. The wrap's own exposure is the cross-node DDL window,
+    # which --confirm-maintenance covers.
+    echo "Replication-settle gate not applicable to --wrap-only (no EXCHANGE); proceeding to the wrap."
+elif [[ "$FORCE" == "1" ]]; then
     echo "WARNING: --force set; skipping the replication-settle gate."
 else
     SETTLE_STARTED_AT=$SECONDS
@@ -522,6 +532,16 @@ run_final_deletion_replay() {
         exit 2
     }
     sql="${sql//"$from"/"$to"}"
+    # lightweight_deletes_sync = 2 is what actually protects the swap: it makes this statement return only once every
+    # replica has applied the mask, so the EXCHANGE below cannot run ahead of it. The settle gate cannot stand in for
+    # that -- it samples system.mutations before this statement is issued, so this mutation does not exist yet when it
+    # looks. Asserted for the same reason as the tag above: if the setting were dropped from 000002 the replay would go
+    # async and the swap could then serve a replica whose mask is not applied, with nothing downstream to notice.
+    grep -qF 'lightweight_deletes_sync = 2' <<<"$sql" || {
+        echo "ERROR: the deletion-replay block no longer sets lightweight_deletes_sync = 2, so this replay would not" >&2
+        echo "       wait for every replica to apply the delete mask before the EXCHANGE. Restore it in $DELTA_SQL_FILE." >&2
+        exit 2
+    }
     # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). This replay sits inside
     # the final-delta -> EXCHANGE gap where tail writes are left behind, so its wall time is the number to record.
     clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -55,11 +55,13 @@
 #   --skip-wrap       explicit alias for the default (EXCHANGE only); accepted for clarity and back-compat.
 #   --wrap-only       run ONLY the Distributed wrap on the already-swapped `traces` (no EXCHANGE, no new cutover_start)
 #                     — the deferred second half of a prior EXCHANGE-only run. Mutually exclusive with the above.
-#   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120. The gate
-#                             does not demand an instantaneous zero: under live ingestion the replication_queue is
-#                             intermittently non-zero by construction (a GET_PART entry per not-yet-fetched part), so a
-#                             single sample would abort on ordinary churn. Raise it for a slow-but-progressing cluster.
-#                             See assert_replication_settled for the two judgements it makes.
+#   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120, capped at
+#                             3600. The gate does not demand an instantaneous zero: under live ingestion the
+#                             replication_queue is intermittently non-zero by construction (a GET_PART entry per
+#                             not-yet-fetched part), so a single sample would abort on ordinary churn. Raise it for a
+#                             slow-but-progressing cluster — it delays the EXCHANGE and so lengthens the tail write-gap
+#                             by the wait, which the driver reports. See assert_replication_settled for the two
+#                             judgements it makes.
 #   --force           skip the replication-settle gate entirely. By default the swap aborts when the deletion-replay
 #                     mutation has not finished on every replica, or when the replication queue is not merely busy but
 #                     stuck (an aged entry, retries, or a last_exception) — either way a behind replica would swap in an
@@ -98,6 +100,7 @@ WITH_WRAP=0
 WRAP_ONLY=0
 FORCE=0
 SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
+SETTLE_TIMEOUT_MAX=3600   # accepted ceiling for it, enforced lexically at validation. See there for why.
 CONFIRM_MAINTENANCE=0
 CONFIRM_DAOS_RETARGETED=0
 CONFIRM_RETENTION_PAUSED=0
@@ -136,7 +139,13 @@ done
 [[ "$RECEIVE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --receive-timeout must be a positive integer (seconds)." >&2; exit 2; }
 # 0 is meaningful (a single sample), so unlike the bound above this accepts it — but not a leading zero, which bash
 # arithmetic reads as octal and rejects ("value too great for base") once the gate divides by the poll interval.
-[[ "$SETTLE_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] || { echo "ERROR: --settle-timeout must be a non-negative integer (seconds) with no leading zero; 0 takes a single sample." >&2; exit 2; }
+#
+# The four-digit cap is what keeps the gate honest, and it has to be LEXICAL. Past 2^63 bash arithmetic wraps silently
+# rather than erroring, so `polls` in the gate below goes negative, its `for` loop runs zero times, and the verdict then
+# reads unset sample variables as 0 and passes — a mistyped argument would swap without ever having looked at
+# replication. A numeric `<= SETTLE_TIMEOUT_MAX` test cannot catch that either, because the wrapped value is negative
+# and so compares as in-range; the digit count must be bounded before any arithmetic touches it.
+[[ "$SETTLE_TIMEOUT" =~ ^(0|[1-9][0-9]{0,3})$ ]] && (( SETTLE_TIMEOUT <= SETTLE_TIMEOUT_MAX )) || { echo "ERROR: --settle-timeout must be an integer between 0 and $SETTLE_TIMEOUT_MAX seconds, with no leading zero; 0 takes a single sample. An hour of pre-swap polling is already past the point of aborting and resolving the lag." >&2; exit 2; }
 
 # One place for the connection and client-side options, so every call site below carries the same host, port,
 # database and the two timeouts. log_comment is NOT here, because clickhouse-client rejects a setting passed twice and
@@ -394,7 +403,8 @@ assert_replication_settled() {
     # Bounded two ways on purpose: the loop header caps the iteration count, so the gate cannot spin whatever the clock
     # does, and the deadline check keeps a slow-reading cluster from overrunning the seconds --settle-timeout promises.
     # --settle-timeout 0 collapses this to a single sample. The last iteration always breaks (poll == polls fails the
-    # guard), so the verdict below always runs against a sample that was actually read.
+    # guard), so the verdict below always runs against a sample that was actually read — which holds because the
+    # validated --settle-timeout bound keeps polls in [1, SETTLE_TIMEOUT_MAX / SETTLE_POLL_SECONDS + 1].
     polls=$(( SETTLE_TIMEOUT / SETTLE_POLL_SECONDS + 1 ))
     deadline=$(( SECONDS + SETTLE_TIMEOUT ))
     for (( poll = 1; poll <= polls; poll++ )); do
@@ -435,9 +445,13 @@ assert_replication_settled() {
         exit 1
     fi
 
+    # "Not stuck", not "moving": the verdict is a snapshot predicate over the last sample read. Neither this path nor
+    # the polled one compares consecutive samples — polling exists to give the queue time to drain (the queue == 0 exit
+    # above) or to give a genuinely stuck entry time to age past the thresholds. So a shorter --settle-timeout is a
+    # weaker gate by exactly that much, which is what the flag means.
     echo "Replication settled enough across cluster '$cluster': the deletion-replay mutation is done on every replica and"
-    echo "the queue is moving, not stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a"
-    echo "last_exception. That is ordinary ingest churn on a live table."
+    echo "no queue entry is stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a last_exception."
+    echo "That is ordinary ingest churn on a live table."
 }
 
 # Topology precondition first (independent of --force, which only bypasses the replication-settle gate).
@@ -447,10 +461,16 @@ else
     assert_pre_exchange_topology
 fi
 
+# Timed, because this driver's own run is the second half of the final-delta -> EXCHANGE gap and the gate is the part
+# of it that varies: it can poll to --settle-timeout on a busy cluster, so calling it "fast and metadata-only" and
+# sizing the tail from the delta replay alone would understate the gap by up to that much.
+SETTLE_SECONDS=0
 if [[ "$FORCE" == "1" ]]; then
     echo "WARNING: --force set; skipping the replication-settle gate."
 else
+    SETTLE_STARTED_AT=$SECONDS
     assert_replication_settled
+    SETTLE_SECONDS=$(( SECONDS - SETTLE_STARTED_AT ))
 fi
 
 run_block() {
@@ -518,6 +538,9 @@ echo "Final deletion replay: masking deletes bridged since the last delta_replay
 run_final_deletion_replay
 
 run_block exchange
+# Stamped here, not in the tail summary below: the tail ends at the EXCHANGE, so an optional wrap running in between
+# must not be counted into it.
+EXCHANGE_SECONDS=$SECONDS
 echo "EXCHANGE done: 'traces' is now the partitioned data; the old data is parked as 'traces_pre_cutover_backup'."
 
 if [[ "$WITH_WRAP" == "1" ]]; then
@@ -531,7 +554,14 @@ fi
 echo
 echo "TAIL WRITE-GAP: traces written between the last delta and this swap — and any routed at a not-yet-swapped node"
 echo "during it — are in traces_pre_cutover_backup, NOT in live traces. Nothing in this procedure carries them across"
-echo "yet (OPIK-8238). Size it now with the post-EXCHANGE compare (--drill-down lists keys present on one side only;"
-echo "backup-only keys are the gap) and either accept it or recover from the backup BEFORE finalize.sh retires it."
+echo "yet (OPIK-8238)."
+echo "  Length: ${EXCHANGE_SECONDS}s in this driver from start through the EXCHANGE, of which ${SETTLE_SECONDS}s was the settle"
+echo "  gate. Add the final delta_replay's replay time (its own --time output) for the whole final-delta -> EXCHANGE gap."
+echo "  Size it now with the post-EXCHANGE compare and --drill-down. TWO categories are gap rows, not one: keys the"
+echo "  drill-down shows backup-only (created in the tail), and keys present on BOTH sides whose hashes differ with the"
+echo "  newer last_updated_at in the backup (updated in the tail — the successor holds an older version, so a"
+echo "  presence-only check misses these). Differing hashes with the newer version live are post-swap writes and are"
+echo "  harmless, so compare last_updated_at per key to tell the two apart."
+echo "  Then either accept the gap or recover from the backup BEFORE finalize.sh retires it."
 echo "Then verify, and keep traces_pre_cutover_backup for the soak. No ingestion-side config was changed, so there is"
 echo "nothing to restore."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -425,7 +425,7 @@ assert_replication_settled() {
         read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
 
         if (( queue == 0 && mutations == 0 )); then
-            echo "Replication settled across cluster '$cluster': queue drained, deletion-replay mutation done on every replica."
+            echo "Replication settled across cluster '$cluster': queue drained, no unfinished mutations on the shadow."
             return 0
         fi
         (( poll < polls && SECONDS < deadline )) || break
@@ -461,8 +461,8 @@ assert_replication_settled() {
     # "Not stuck" rather than "moving": this is a snapshot predicate over the last sample read, and no path here
     # compares consecutive samples. Polling only gives the queue time to drain (the queue == 0 exit above) or a stuck
     # entry time to age past the thresholds, so a shorter --settle-timeout is a weaker gate by exactly that much.
-    echo "Replication settled enough across cluster '$cluster': the deletion-replay mutation is done on every replica and"
-    echo "no queue entry is stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a last_exception."
+    echo "Replication settled enough across cluster '$cluster': no unfinished mutations on the shadow, and no queue"
+    echo "entry is stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a last_exception."
     echo "That is ordinary ingest churn on a live table."
 }
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 #
-# Driver for step 3 of the buffered traces cutover: EXCHANGE + Distributed wrap (runbook: ../README.md).
+# Driver for step 3 of the traces cutover: settle gate + EXCHANGE + Distributed wrap (runbook: ../README.md).
 #
-# Captures and prints cutover_start (needed by rollback.sh if you roll back after this), then runs the `exchange` block
-# of db-app-analytics/000003_exchange_and_wrap.sql. By default it stops there (EXCHANGE only) — the Distributed `wrap`
-# block runs only with --with-wrap. Run it right after the delta + replay + verify, while the async-insert buffer is
-# still holding writes.
+# Runs the replication-settle gate, captures and prints cutover_start (needed by rollback.sh if you roll back after
+# this), then runs the `exchange` block of db-app-analytics/000003_exchange_and_wrap.sql. By default it stops there
+# (EXCHANGE only) — the Distributed `wrap` block runs only with --with-wrap. Every statement it sends comes from a
+# marked block of that file (the final deletion replay from 000002's, so the two runs share one source); only the short
+# topology probes below are inline. Run it right after the delta + replay + verify, so the final-delta -> EXCHANGE gap
+# stays small. Nothing here needs an ingestion-side config change: the EXCHANGE is atomic per node, so a concurrent
+# insert always commits to a valid table. Writes that land in the old one — in that gap, or during the cross-node
+# ON CLUSTER skew — stay in the parked backup; that is the open tail write-gap tracked as OPIK-8238, and the runbook's
+# "The final cutover window" states the exposure.
 #
 # The wrap is OPT-IN on purpose: a lightweight DELETE against a Distributed table is unsupported, so wrapping `traces`
 # breaks the product's trace-delete / retention paths unless tracesDistributedWrapEnabled=true (OPIK-7455) routes those
@@ -50,27 +55,28 @@
 #   --skip-wrap       explicit alias for the default (EXCHANGE only); accepted for clarity and back-compat.
 #   --wrap-only       run ONLY the Distributed wrap on the already-swapped `traces` (no EXCHANGE, no new cutover_start)
 #                     — the deferred second half of a prior EXCHANGE-only run. Mutually exclusive with the above.
-#   --force           skip the replication-settle gate. By default the swap aborts while any replica still
-#                     has replication-queue backlog or an unfinished mutation on traces / traces_local_v2, since a
-#                     behind replica would swap in an incomplete table. Use only if settlement is confirmed out of band.
-#   --confirm-maintenance  REQUIRED with --wrap-only. The wrap is gapless per node (atomic rotate), but a brief cross-node
-#                     ON CLUSTER propagation skew remains, during which a Distributed query can hit a not-yet-created
-#                     `traces_local` on a lagging node and fail. That is a READ exposure as much as a write one, so
-#                     re-raising the async-insert buffer does NOT by itself discharge this flag — the buffer parks
-#                     writes and does nothing for reads. Unlike the same-run --with-wrap path (still buffered from the
-#                     EXCHANGE), --wrap-only runs later against live traffic. Assert that traffic is quiesced or a
-#                     maintenance window is in effect. Mirrored by rollback.sh --unwrap-only, which reverses this.
+#   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120. The gate
+#                             does not demand an instantaneous zero: under live ingestion the replication_queue is
+#                             intermittently non-zero by construction (a GET_PART entry per not-yet-fetched part), so a
+#                             single sample would abort on ordinary churn. Raise it for a slow-but-progressing cluster.
+#                             See assert_replication_settled for the two judgements it makes.
+#   --force           skip the replication-settle gate entirely. By default the swap aborts when the deletion-replay
+#                     mutation has not finished on every replica, or when the replication queue is not merely busy but
+#                     stuck (an aged entry, retries, or a last_exception) — either way a behind replica would swap in an
+#                     incomplete table. Use only if settlement is confirmed out of band; the runbook's Go/No-Go forbids
+#                     it in production.
+#   --confirm-maintenance  REQUIRED whenever the wrap is applied (--with-wrap or --wrap-only). The wrap is gapless per
+#                     node (atomic rotate), but a brief cross-node ON CLUSTER propagation skew remains, during which a
+#                     Distributed query can hit a not-yet-created `traces_local` on a lagging node and fail. The failing
+#                     query is a SELECT, so no ingestion-side setting reduces it and both wrap paths carry it equally.
+#                     Assert that traffic is quiesced or a maintenance window is in effect. Mirrored by
+#                     rollback.sh --unwrap-only, which reverses this.
 #   --confirm-daos-retargeted  REQUIRED whenever the wrap is applied (--with-wrap or --wrap-only). Asserts the trace
 #                     delete/mutation DAOs already target `traces_local`: set backend config
 #                     databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true (OPIK-7455) in lockstep with the wrap.
 #                     A Distributed `traces` rejects mutations, so without the flag delete-by-id and retention deletes
 #                     return 500 the moment the wrap lands. The script cannot inspect backend config, so the operator
 #                     must assert it.
-#   --confirm-buffer-raised  REQUIRED for every EXCHANGE path (the default and --with-wrap; not --wrap-only). Asserts the
-#                     async-insert buffer (asyncInsertBusyTimeoutMaxMs) is raised on every backend instance — it holds
-#                     writes across the swap so they land on the new table; at the default, a write in the final window
-#                     can commit to the old table and be lost after the EXCHANGE. It's a backend setting the script can't
-#                     read, so the operator must assert it.
 #   --confirm-retention-paused  REQUIRED for every EXCHANGE path. Retention deletes (deleteForRetention*) bypass the
 #                     deletion bridge and are never replayed onto the successor, so a retention sweep during the cutover
 #                     window leaks live across the swap. Asserts retention is paused (RETENTION_ENABLED=false on every
@@ -91,10 +97,17 @@ SKIP_WRAP=0
 WITH_WRAP=0
 WRAP_ONLY=0
 FORCE=0
+SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
 CONFIRM_MAINTENANCE=0
 CONFIRM_DAOS_RETARGETED=0
-CONFIRM_BUFFER_RAISED=0
 CONFIRM_RETENTION_PAUSED=0
+
+# Stuck-ness thresholds for the replication queue, deliberately not flags: they describe what "a replica is genuinely
+# lagging" means, not a per-run choice. An entry that has sat this long, or retried this many times, is not the
+# ordinary GET_PART churn of a busy table.
+SETTLE_POLL_SECONDS=5
+SETTLE_STUCK_AGE_SECONDS=60
+SETTLE_STUCK_NUM_TRIES=3
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -104,9 +117,9 @@ while [[ $# -gt 0 ]]; do
         --with-wrap) WITH_WRAP=1; shift ;;
         --wrap-only) WRAP_ONLY=1; shift ;;
         --force) FORCE=1; shift ;;
+        --settle-timeout) SETTLE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
         --confirm-maintenance) CONFIRM_MAINTENANCE=1; shift ;;
         --confirm-daos-retargeted) CONFIRM_DAOS_RETARGETED=1; shift ;;
-        --confirm-buffer-raised) CONFIRM_BUFFER_RAISED=1; shift ;;
         --confirm-retention-paused) CONFIRM_RETENTION_PAUSED=1; shift ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -121,6 +134,9 @@ done
 [[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
 [[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
 [[ "$RECEIVE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --receive-timeout must be a positive integer (seconds)." >&2; exit 2; }
+# 0 is meaningful (a single sample), so unlike the bound above this accepts it — but not a leading zero, which bash
+# arithmetic reads as octal and rejects ("value too great for base") once the gate divides by the poll interval.
+[[ "$SETTLE_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] || { echo "ERROR: --settle-timeout must be a non-negative integer (seconds) with no leading zero; 0 takes a single sample." >&2; exit 2; }
 
 # One place for the connection and client-side options, so every call site below carries the same host, port,
 # database and the two timeouts. log_comment is NOT here, because clickhouse-client rejects a setting passed twice and
@@ -164,15 +180,16 @@ esac
 if (( SKIP_WRAP + WITH_WRAP + WRAP_ONLY > 1 )); then
     echo "ERROR: --skip-wrap, --with-wrap and --wrap-only are mutually exclusive" >&2; exit 2
 fi
-# The deferred wrap is gapless per node but has a brief cross-node ON CLUSTER propagation skew, and --wrap-only runs
-# against live, unbuffered ingestion — unlike the same-run --with-wrap path, still buffered from the EXCHANGE. Refuse
-# (fail fast, before touching ClickHouse) unless the operator asserts the buffer is re-raised / ingestion quiesced / a
-# maintenance window is in effect.
-if [[ "$WRAP_ONLY" == "1" && "$CONFIRM_MAINTENANCE" != "1" ]]; then
-    echo "ERROR: --wrap-only requires --confirm-maintenance. The wrap has a brief cross-node ON CLUSTER window in which a" >&2
-    echo "       Distributed query can reach a node where 'traces_local' does not exist yet and fail — a READ exposure as" >&2
-    echo "       much as a write one, so re-raising asyncInsertBusyTimeoutMaxMs is not sufficient on its own (it parks" >&2
-    echo "       writes and does nothing for reads). Quiesce traffic or take a maintenance window, then re-run with it." >&2
+# The wrap is gapless per node but has a brief cross-node ON CLUSTER propagation skew, in which a Distributed query can
+# reach a node where `traces_local` does not exist yet. The failing query is a SELECT, so nothing done on the ingestion
+# side reduces it, and running in the same session as the EXCHANGE does not either: --with-wrap and --wrap-only carry
+# the same exposure and the same requirement. Refuse (fail fast, before touching ClickHouse) unless the operator asserts
+# ingestion is quiesced / a maintenance window is in effect.
+if [[ ( "$WITH_WRAP" == "1" || "$WRAP_ONLY" == "1" ) && "$CONFIRM_MAINTENANCE" != "1" ]]; then
+    echo "ERROR: applying the wrap requires --confirm-maintenance (both --with-wrap and --wrap-only). The wrap has a brief" >&2
+    echo "       cross-node ON CLUSTER window in which a Distributed query can reach a node where 'traces_local' does not" >&2
+    echo "       exist yet and fail — a READ exposure as much as a write one, which no ingestion-side setting covers." >&2
+    echo "       Quiesce traffic or take a maintenance window, then re-run with it." >&2
     exit 2
 fi
 # HARD PREREQUISITE (OPIK-7455): a Distributed table rejects mutations, so once the wrap is applied the product's
@@ -182,17 +199,6 @@ if [[ ( "$WITH_WRAP" == "1" || "$WRAP_ONLY" == "1" ) && "$CONFIRM_DAOS_RETARGETE
     echo "ERROR: applying the wrap requires --confirm-daos-retargeted. Set backend config" >&2
     echo "       databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true (OPIK-7455) so the trace delete/mutation" >&2
     echo "       DAOs target 'traces_local' before 'traces' becomes Distributed, or deletes/retention break at runtime." >&2
-    exit 2
-fi
-# The EXCHANGE is the zero-loss step: writes in the final-delta -> EXCHANGE gap must be held by the raised async-insert
-# buffer (asyncInsertBusyTimeoutMaxMs) so they flush onto the new table after the swap; if the buffer is at its default,
-# such a write can commit to the old table just before the swap and be silently lost. The buffer is a backend per-query
-# setting the script can't read, so require the operator to assert it. Applies to every EXCHANGE path (not --wrap-only,
-# which does no EXCHANGE). Fail fast, before touching ClickHouse.
-if [[ "$WRAP_ONLY" != "1" && "$CONFIRM_BUFFER_RAISED" != "1" ]]; then
-    echo "ERROR: the EXCHANGE requires --confirm-buffer-raised. Raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs on" >&2
-    echo "       every backend instance first — it holds writes across the swap; at the default, writes in the final" >&2
-    echo "       window can commit to the old table and be lost after the EXCHANGE — then re-run with the flag." >&2
     exit 2
 fi
 # The EXCHANGE runs a final deletion replay first (see below), to mask deletes bridged since the last delta_replay so
@@ -214,6 +220,71 @@ fi
 
 ch() {
     clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "$1"
+}
+
+# Same connection, but rendered for a human — used only for the settle gate's detail blocks, whose interesting columns
+# are free text (last_exception, postpone_reason, latest_fail_reason) that must not be parsed.
+ch_vertical() {
+    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' \
+        --format Vertical --query "$1"
+}
+
+# Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block (exact-line markers) from a reference SQL file.
+extract() {
+    awk -v begin="-- >>> BEGIN $1" -v end="-- >>> END $1" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$2"
+}
+
+# Refuse rendered SQL that is not what the caller asked for. A marker renamed, moved, indented or split yields text
+# that is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and
+# the step prints its success line having done nothing.
+#
+# Masking comes first because every check needs the executable text: comments are not whitespace, and a block's prose
+# can contain the very phrase that identifies it. The identity check is not redundant with the emptiness one -- markers
+# can match around the wrong statement, which is plenty of text.
+#
+# RETURN, not exit: `render` calls this inside a command substitution, where an exit would end only that subshell and
+# hand the caller partial SQL. Every caller assigns first and adds `|| exit 2`, so a refusal still stops the run.
+require_rendered() {
+    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends
+    # Exactly one pair, checked on the file rather than the extraction: the awk stops at the first END and otherwise
+    # runs to EOF, so a missing or renamed END sweeps every later block into this one and --multiquery executes them
+    # all. The content checks below cannot see that -- a run-on capture still contains this block's own statement.
+    begins="$(grep -cxF -e "-- >>> BEGIN $what" "$file" || true)"
+    ends="$(grep -cxF -e "-- >>> END $what" "$file" || true)"
+    if (( begins != 1 || ends != 1 )); then
+        echo "ERROR: $file holds $begins '-- >>> BEGIN $what' and $ends '-- >>> END $what'; expected one of each." >&2
+        return 2
+    fi
+    masked="$(sed 's/--.*$//' <<<"$sql")"
+    if [[ -z "${masked//[[:space:]]/}" ]]; then
+        echo "ERROR: the '$what' block from $file rendered no executable SQL (empty, or comments only)." >&2
+        echo "       Expected the exact marker lines '-- >>> BEGIN $what' and '-- >>> END $what'." >&2
+        return 2
+    fi
+    if ! grep -qF "$must_contain" <<<"$masked"; then
+        echo "ERROR: the '$what' block from $file has no '$must_contain' outside its comments, so the markers are" >&2
+        echo "       around the wrong statement. Refusing to run it." >&2
+        return 2
+    fi
+    if grep -qF '${' <<<"$masked"; then
+        echo "ERROR: the '$what' block from $file still holds an unsubstituted \${...} placeholder after rendering." >&2
+        echo "       Refusing to send SQL containing a literal placeholder." >&2
+        return 2
+    fi
+}
+
+# render <block> <file> <must-contain-token> -> the block's SQL, substituted and validated.
+#
+# BACKFILL_START is substituted only when set, so a block that needs it and runs without it keeps the literal
+# placeholder and is refused by require_rendered — rather than being sent with an empty timestamp, which parses and
+# silently matches the wrong window. '{cluster}' is NOT a placeholder: it is the ClickHouse macro, resolved server-side.
+render() {
+    local sql
+    sql="$(extract "$1" "$2")"
+    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    [[ -z "$BACKFILL_START" ]] || sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
+    require_rendered "$sql" "$1" "$3" "$2" || return 2
+    printf '%s' "$sql"
 }
 
 # Single scalar (empty string if the object does not exist).
@@ -287,31 +358,86 @@ assert_pre_wrap_topology() {
     fi
 }
 
-# Pre-EXCHANGE gate: the swap is metadata-only and near-instant, but each replica reads its own local parts afterwards.
-# If a replica is still fetching backfilled parts (replication_queue) or has not finished the deletion-replay mutation
-# (system.mutations), swapping now would make that replica serve an incomplete table. Both are checked across ALL
-# replicas via clusterAllReplicas, so a single connection sees the whole cluster's backlog. Aborts unless --force.
+# Pre-EXCHANGE gate: the swap is metadata-only and near-instant, but each replica reads its own local parts afterwards,
+# so a replica still fetching backfilled parts (replication_queue) or still applying the deletion-replay mutation
+# (system.mutations) would serve an incomplete table. Both are read across every replica via clusterAllReplicas, so one
+# connection sees the whole cluster. Aborts unless --force.
+#
+# The two signals are judged differently, because only one of them is quiet on a healthy cluster:
+#
+#   * The deletion-replay MUTATION is one bounded statement. It must reach is_done on every replica within
+#     --settle-timeout or the gate fails: an unapplied mask means bridged deletes leak live across the swap.
+#   * The replication QUEUE is expected to be busy under live ingestion — a GET_PART entry exists for every part a
+#     replica has not yet fetched — so requiring an instantaneous 0 would abort on ordinary churn and push the operator
+#     toward --force, which the Go/No-Go forbids. It passes as soon as the queue drains; failing that, the verdict is
+#     stuck-ness rather than depth: an entry aged past SETTLE_STUCK_AGE_SECONDS, more retries than
+#     SETTLE_STUCK_NUM_TRIES, or any last_exception means a replica is genuinely lagging, and the gate fails naming the
+#     offending entries per replica.
 assert_replication_settled() {
-    local cluster queue mutations
+    local cluster deadline polls poll row
+    local sample_sql queue_detail_sql mutation_detail_sql
+    local queue age tries failures mutations mut_age mut_failed
+
+    # The macro is resolved here only to fail fast with a clear message and to name the cluster in what follows; the
+    # blocks below reach it through '{cluster}' themselves.
     cluster="$(ch "SELECT getMacro('cluster')")"
     [[ -n "$cluster" ]] || { echo "ERROR: could not resolve the '{cluster}' macro (getMacro('cluster') was empty). Pass --force only if you have confirmed replication settlement out of band." >&2; exit 1; }
 
-    queue="$(ch "SELECT count()
-        FROM clusterAllReplicas('$cluster', system.replication_queue)
-        WHERE database = '$DATABASE'
-          AND table IN ('traces', 'traces_local_v2')")"
-    mutations="$(ch "SELECT count()
-        FROM clusterAllReplicas('$cluster', system.mutations)
-        WHERE database = '$DATABASE'
-          AND table = 'traces_local_v2'
-          AND is_done = 0")"
+    # All three blocks are rendered up front: a malformed marker then aborts before the first poll rather than midway
+    # through a failure report, and the loop reuses one rendered string instead of rebuilding it every pass.
+    # Each token identifies exactly one block in 000003, so a marker wrapped around the wrong statement is caught:
+    # clusterAllReplicas or system.mutations would match two or three of them and prove nothing.
+    sample_sql="$(render settle-sample "$SQL_FILE" "CROSS JOIN")" || exit 2
+    queue_detail_sql="$(render settle-queue-detail "$SQL_FILE" postpone_reason)" || exit 2
+    mutation_detail_sql="$(render settle-mutation-detail "$SQL_FILE" latest_failed_part)" || exit 2
 
-    if [[ "$queue" != "0" || "$mutations" != "0" ]]; then
-        echo "ERROR: replication not settled across cluster '$cluster' — replication_queue=$queue, unfinished mutations=$mutations." >&2
-        echo "       Wait for both to reach 0 (parts fetched, deletion replay applied everywhere) before the EXCHANGE, or pass --force to override." >&2
+    # Bounded two ways on purpose: the loop header caps the iteration count, so the gate cannot spin whatever the clock
+    # does, and the deadline check keeps a slow-reading cluster from overrunning the seconds --settle-timeout promises.
+    # --settle-timeout 0 collapses this to a single sample. The last iteration always breaks (poll == polls fails the
+    # guard), so the verdict below always runs against a sample that was actually read.
+    polls=$(( SETTLE_TIMEOUT / SETTLE_POLL_SECONDS + 1 ))
+    deadline=$(( SECONDS + SETTLE_TIMEOUT ))
+    for (( poll = 1; poll <= polls; poll++ )); do
+        row="$(ch "$sample_sql")" || row=""
+        [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
+        read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
+
+        if (( queue == 0 && mutations == 0 )); then
+            echo "Replication settled across cluster '$cluster': queue drained, deletion-replay mutation done on every replica."
+            return 0
+        fi
+        (( poll < polls && SECONDS < deadline )) || break
+        echo "  settling: replication_queue=$queue (oldest ${age}s, max num_tries=$tries, with last_exception=$failures)," \
+             "unfinished mutations=$mutations — polling up to ${SETTLE_TIMEOUT}s..."
+        sleep "$SETTLE_POLL_SECONDS"
+    done
+
+    # Out of time and still not clean. The mutation is unconditional; the queue is judged on stuck-ness, not depth.
+    if (( mutations != 0 )); then
+        echo "ERROR: the deletion-replay mutation on 'traces_local_v2' has not finished on every replica after ${SETTLE_TIMEOUT}s" >&2
+        echo "       ($mutations unfinished, oldest ${mut_age}s, $mut_failed carrying a latest_fail_reason). Swapping now would" >&2
+        echo "       serve a replica where the delete mask is not applied, so bridged deletes would leak live across the swap." >&2
+        echo "       Unfinished mutations:" >&2
+        ch_vertical "$mutation_detail_sql" >&2 || true
+        echo "       Let it finish (or fix the cause), then re-run. Raise --settle-timeout for a slow-but-progressing" >&2
+        echo "       cluster; --force skips the gate entirely and the runbook's Go/No-Go forbids it in production." >&2
         exit 1
     fi
-    echo "Replication settled across cluster '$cluster' (replication_queue=0, mutations done)."
+
+    if (( age > SETTLE_STUCK_AGE_SECONDS || tries > SETTLE_STUCK_NUM_TRIES || failures > 0 )); then
+        echo "ERROR: a replica is lagging, not merely busy — after ${SETTLE_TIMEOUT}s the replication queue for" >&2
+        echo "       traces / traces_local_v2 still holds $queue entries: oldest ${age}s (stuck above ${SETTLE_STUCK_AGE_SECONDS}s)," >&2
+        echo "       max num_tries=$tries (stuck above ${SETTLE_STUCK_NUM_TRIES}), $failures carrying a last_exception." >&2
+        echo "       A behind replica would swap in an incomplete table. Oldest / most-retried entries:" >&2
+        ch_vertical "$queue_detail_sql" >&2 || true
+        echo "       Resolve the lag, then re-run. Raise --settle-timeout for a slow-but-progressing cluster; --force" >&2
+        echo "       skips the gate entirely and the runbook's Go/No-Go forbids it in production." >&2
+        exit 1
+    fi
+
+    echo "Replication settled enough across cluster '$cluster': the deletion-replay mutation is done on every replica and"
+    echo "the queue is moving, not stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a"
+    echo "last_exception. That is ordinary ingest churn on a live table."
 }
 
 # Topology precondition first (independent of --force, which only bypasses the replication-settle gate).
@@ -327,54 +453,11 @@ else
     assert_replication_settled
 fi
 
-# Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block from the reference SQL (exact-line markers).
-extract() {
-    awk -v begin="-- >>> BEGIN $1" -v end="-- >>> END $1" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$SQL_FILE"
-}
-
-# Refuse rendered SQL that is not what the caller asked for. A marker renamed, moved, indented or split yields text
-# that is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and
-# the step prints its success line having done nothing.
-#
-# Masking comes first because every check needs the executable text: comments are not whitespace, and a block's prose
-# can contain the very phrase that identifies it. The identity check is not redundant with the emptiness one -- markers
-# can match around the wrong statement, which is plenty of text.
-require_rendered() {
-    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends
-    # Exactly one pair, checked on the file rather than the extraction: the awk stops at the first END and otherwise
-    # runs to EOF, so a missing or renamed END sweeps every later block into this one and --multiquery executes them
-    # all. The content checks below cannot see that -- a run-on capture still contains this block's own statement.
-    begins="$(grep -cxF -e "-- >>> BEGIN $what" "$file" || true)"
-    ends="$(grep -cxF -e "-- >>> END $what" "$file" || true)"
-    if (( begins != 1 || ends != 1 )); then
-        echo "ERROR: $file holds $begins '-- >>> BEGIN $what' and $ends '-- >>> END $what'; expected one of each." >&2
-        exit 2
-    fi
-    masked="$(sed 's/--.*$//' <<<"$sql")"
-    if [[ -z "${masked//[[:space:]]/}" ]]; then
-        echo "ERROR: the '$what' block from $file rendered no executable SQL (empty, or comments only)." >&2
-        echo "       Expected the exact marker lines '-- >>> BEGIN $what' and '-- >>> END $what'." >&2
-        exit 2
-    fi
-    if ! grep -qF "$must_contain" <<<"$masked"; then
-        echo "ERROR: the '$what' block from $file has no '$must_contain' outside its comments, so the markers are" >&2
-        echo "       around the wrong statement. Refusing to run it." >&2
-        exit 2
-    fi
-    if grep -qF '${' <<<"$masked"; then
-        echo "ERROR: the '$what' block from $file still holds an unsubstituted \${...} placeholder after rendering." >&2
-        echo "       Refusing to send SQL containing a literal placeholder." >&2
-        exit 2
-    fi
-}
-
 run_block() {
     local sql
-    sql="$(extract "$1")"
-    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
     case "$1" in
-        exchange) require_rendered "$sql" exchange "EXCHANGE TABLES" "$SQL_FILE" ;;
-        wrap)     require_rendered "$sql" wrap     "Distributed"     "$SQL_FILE" ;;
+        exchange) sql="$(render exchange "$SQL_FILE" "EXCHANGE TABLES")" || exit 2 ;;
+        wrap)     sql="$(render wrap     "$SQL_FILE" "Distributed")"     || exit 2 ;;
         *)        echo "ERROR: unknown block '$1'." >&2; exit 2 ;;
     esac
     # Each ON CLUSTER DDL in the block emits one row per host (host, port, status, error, hosts_remaining,
@@ -388,17 +471,15 @@ run_block() {
 # is captured HERE, so a delete bridged in that final gap would be covered by neither the forward replay nor the rollback
 # reverse-replay (which starts at cutover_start) and would leak live across the swap. Re-running the deletion-replay block
 # (from the single-source 000002) right after capturing cutover_start extends forward coverage to it — the arm is
-# idempotent and user-scale (retention off), so it is cheap. Deletions only: writes in the gap are held by the async
-# buffer and flush onto the successor after the swap.
+# idempotent and user-scale (retention off), so it is cheap. Deletions only: the writes in that gap, and those that land
+# in the old table during the cross-node EXCHANGE skew, are the open tail write-gap (OPIK-8238), not this step's job.
 run_final_deletion_replay() {
     local sql
-    sql="$(awk -v begin="-- >>> BEGIN deletion-replay" -v end="-- >>> END deletion-replay" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$DELTA_SQL_FILE")"
-    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
-    sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
     # A silent no-op here is the worst failure in this script: the deletes it masks are covered by neither the forward
     # replay (bounded by when delta_replay.sh ran) nor the rollback reverse-replay (bounded by cutover_start), and
     # verify.sh has already run, so nothing downstream would notice them going live again on `traces` after the swap.
-    require_rendered "$sql" deletion-replay "DELETE FROM" "$DELTA_SQL_FILE"
+    # Hence `render`, which refuses an empty, mis-marked or still-templated block rather than sending it.
+    sql="$(render deletion-replay "$DELTA_SQL_FILE" "DELETE FROM")" || exit 2
     # Retag so this run is separable from delta_replay.sh's in query_log. The block sets log_comment in its own trailing
     # SETTINGS, and a per-statement value beats the client's --log_comment, so substituting the value is the only way to
     # distinguish them; the runbook asks for this replay's wall time specifically. Asserted, because a rename of the tag
@@ -412,7 +493,7 @@ run_final_deletion_replay() {
     }
     sql="${sql//"$from"/"$to"}"
     # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). This replay sits inside
-    # the final-delta -> EXCHANGE gap the buffer hold has to cover, so its wall time is the number to record.
+    # the final-delta -> EXCHANGE gap where tail writes are left behind, so its wall time is the number to record.
     clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
 }
 
@@ -421,12 +502,8 @@ if [[ "$WRAP_ONLY" == "1" ]]; then
     # partitioned data. Do not re-EXCHANGE (that would swap the parked original back in) and do not capture a new
     # cutover_start (the data cutover is already done). Just apply the Distributed wrap.
     #
-    # The wrap is two non-atomic statements (RENAME traces -> traces_local, then CREATE Distributed traces); between them
-    # `traces` does not exist, so concurrent INSERT/SELECT fails with "Table traces doesn't exist" (ON CLUSTER widens the
-    # window per-node). The same-run path is covered by the still-raised EXCHANGE buffer, but --wrap-only runs later
-    # against live, unbuffered ingestion. PRECONDITION: re-raise databaseAnalytics.asyncInsertBusyTimeoutMaxMs (or quiesce
-    # ingestion / assert a maintenance window) so the wrap runs under the same buffered conditions as the EXCHANGE.
-    # --confirm-maintenance was already enforced up front (gapless per node, but a brief cross-node ON CLUSTER window).
+    # Gapless per node — the wrapper is built under a temp name and one atomic RENAME rotates it in — but the cross-node
+    # ON CLUSTER skew remains, which is what --confirm-maintenance (enforced up front, for both wrap paths) covers.
     run_block wrap
     echo "Distributed wrap done: 'traces' fronts 'traces_local' via sipHash64(project_id). (EXCHANGE was a prior step.)"
     exit 0
@@ -451,4 +528,10 @@ else
     echo "'--wrap-only --confirm-maintenance --confirm-daos-retargeted' once tracesDistributedWrapEnabled=true is live."
 fi
 
-echo "Restore databaseAnalytics.asyncInsertBusyTimeoutMaxMs to default, verify, and keep traces_pre_cutover_backup for the soak."
+echo
+echo "TAIL WRITE-GAP: traces written between the last delta and this swap — and any routed at a not-yet-swapped node"
+echo "during it — are in traces_pre_cutover_backup, NOT in live traces. Nothing in this procedure carries them across"
+echo "yet (OPIK-8238). Size it now with the post-EXCHANGE compare (--drill-down lists keys present on one side only;"
+echo "backup-only keys are the gap) and either accept it or recover from the backup BEFORE finalize.sh retires it."
+echo "Then verify, and keep traces_pre_cutover_backup for the soak. No ingestion-side config was changed, so there is"
+echo "nothing to restore."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -187,11 +187,9 @@ esac
 if (( SKIP_WRAP + WITH_WRAP + WRAP_ONLY > 1 )); then
     echo "ERROR: --skip-wrap, --with-wrap and --wrap-only are mutually exclusive" >&2; exit 2
 fi
-# The wrap is gapless per node but has a brief cross-node ON CLUSTER propagation skew, in which a Distributed query can
-# reach a node where `traces_local` does not exist yet. The failing query is a SELECT, so nothing done on the ingestion
-# side reduces it, and running in the same session as the EXCHANGE does not either: --with-wrap and --wrap-only carry
-# the same exposure and the same requirement. Refuse (fail fast, before touching ClickHouse) unless the operator asserts
-# ingestion is quiesced / a maintenance window is in effect.
+# Both wrap paths, not just the deferred one: being in the same run as the EXCHANGE buys --with-wrap nothing here,
+# because the exposure is a READ reaching a not-yet-created `traces_local` (mechanism in the --confirm-maintenance help
+# above, and restated in the refusal below). Fail fast, before touching ClickHouse.
 if [[ ( "$WITH_WRAP" == "1" || "$WRAP_ONLY" == "1" ) && "$CONFIRM_MAINTENANCE" != "1" ]]; then
     echo "ERROR: applying the wrap requires --confirm-maintenance (both --with-wrap and --wrap-only). The wrap has a brief" >&2
     echo "       cross-node ON CLUSTER window in which a Distributed query can reach a node where 'traces_local' does not" >&2
@@ -438,9 +436,10 @@ assert_replication_settled() {
 
     # Out of time and still not clean. The mutation is unconditional; the queue is judged on stuck-ness, not depth.
     if (( mutations != 0 )); then
-        echo "ERROR: the deletion-replay mutation on 'traces_local_v2' has not finished on every replica after ${SETTLE_TIMEOUT}s" >&2
+        echo "ERROR: a mutation on 'traces_local_v2' has not finished on every replica after ${SETTLE_TIMEOUT}s" >&2
         echo "       ($mutations unfinished, oldest ${mut_age}s, $mut_failed carrying a latest_fail_reason). Swapping now would" >&2
-        echo "       serve a replica where the delete mask is not applied, so bridged deletes would leak live across the swap." >&2
+        echo "       serve a replica mid-mutation; if it is a deletion replay left by an earlier step, its delete mask is" >&2
+        echo "       not applied there and bridged deletes would leak live across the swap." >&2
         echo "       Unfinished mutations:" >&2
         ch_vertical "$mutation_detail_sql" >&2 || true
         echo "       Let it finish (or fix the cause), then re-run. Raise --settle-timeout for a slow-but-progressing" >&2
@@ -474,9 +473,9 @@ else
     assert_pre_exchange_topology
 fi
 
-# Timed, because this driver's run is the second half of the final-delta -> EXCHANGE gap and the settle gate is the
-# part of it that varies: on a busy cluster it polls up to --settle-timeout, so the delta replay's wall time on its own
-# understates the gap by that much.
+# Timed, because everything from here to the EXCHANGE is part of the final-delta -> EXCHANGE gap, and the settle gate
+# is the part of it that varies: on a busy cluster it polls up to --settle-timeout, so the delta replay's wall time on
+# its own understates the gap by that much.
 SETTLE_SECONDS=0
 if [[ "$WRAP_ONLY" == "1" ]]; then
     # Not skipped as a shortcut: neither signal describes this path. --wrap-only runs no EXCHANGE, and

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Driver for rolling the buffered traces cutover back (runbook: ../README.md).
+# Driver for rolling the traces cutover back (runbook: ../README.md).
 #
 # Runs the db-app-analytics/000004_rollback_* file(s) that match how far the cutover got. Pick the stage by the last
 # step that completed:
@@ -108,9 +108,9 @@
 #   --confirm-maintenance     REQUIRED with --unwrap-only. The un-wrap is gapless per node (atomic rotate), but renaming
 #                             the live `traces` has a brief cross-node ON CLUSTER propagation skew during which a query
 #                             routed at a lagging replica's wrapper can fail with UNKNOWN_TABLE. That hits READS, not
-#                             only writes, so raising the async-insert buffer does NOT discharge this flag: it asserts
-#                             traffic is quiesced or a maintenance window is in effect. Same gate, and the same
-#                             read exposure, as the --wrap-only in exchange_and_wrap.sh that this reverses.
+#                             only writes, so no ingestion-side setting can discharge this flag: it asserts traffic is
+#                             quiesced or a maintenance window is in effect. Same gate, and the same read exposure, as
+#                             the wrap in exchange_and_wrap.sh that this reverses.
 
 set -euo pipefail
 
@@ -278,9 +278,9 @@ if [[ "$UNWRAP_ONLY" == "1" ]]; then
         echo "ERROR: --unwrap-only requires --confirm-maintenance. It renames the live 'traces': gapless per node, but with" >&2
         echo "       a brief cross-node ON CLUSTER skew during which a lagging replica still resolves the wrapper's" >&2
         echo "       'traces_local' target, which the already-renamed replicas no longer have — so a query routed there can" >&2
-        echo "       fail with UNKNOWN_TABLE. That hits READS as well as writes, so the async-insert buffer alone does not" >&2
-        echo "       cover it: quiesce traffic or take a maintenance window (the mirror of the window exchange_and_wrap.sh" >&2
-        echo "       gates for the --wrap-only this reverses), then re-run with the flag." >&2
+        echo "       fail with UNKNOWN_TABLE. That hits READS as well as writes, so no ingestion-side setting covers it:" >&2
+        echo "       quiesce traffic or take a maintenance window (the mirror of the window exchange_and_wrap.sh gates for" >&2
+        echo "       the wrap this reverses), then re-run with the flag." >&2
         exit 2
     fi
 fi
@@ -635,7 +635,7 @@ if [[ "$UNWRAP_ONLY" == "1" ]]; then
     echo "     Do it in THIS order (DDL first, flag second), which is the inverse of the forward wrap and keeps the failure"
     echo "     on the same side: until the restart completes, trace DELETES target the now-absent 'traces_local' and fail"
     echo "     with Code 60 UNKNOWN_TABLE. Reverting the flag first instead would point them at a 'traces' that is still"
-    echo "     Distributed, which rejects mutations (Code 36) AND exposes the cross-node skew unbuffered. Either window is"
+    echo "     Distributed, which rejects mutations (Code 36) AND exposes the cross-node skew to reads too. Either window is"
     echo "     delete-path-only — reads and inserts never consult the flag — so keep it short and fail loud."
     echo "  2. Leave databaseAnalyticsDataModel.traceColumnsNonNullable=true: the live table keeps the successor's sentinel"
     echo "     schema. Step 1's wrap flag is the only one this stage reverts, and trace-delete partition pruning is not a"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -142,28 +142,31 @@ render_block() {
     sql="${sql//'${WINDOW_HI}'/$hi}"
     sql="${sql//'${SAMPLE_MOD}'/$SAMPLE_MOD}"
     # A renamed, moved or split marker yields text that is empty or only the block's own comments, and clickhouse-client
-    # exits 0 on either, so the caller would read "no output" as a verdict rather than as a failure to ask. Tested on
-    # comment-masked text because comments are not whitespace.
+    # exits 0 on either, so the caller would read "no output" as a verdict rather than as a failure to ask.
     #
     # RETURN, not exit: every caller invokes this inside a command substitution, where an exit ends only the subshell
     # and would leave the outer clickhouse-client running with an empty --query. The callers assign first, so a
     # non-zero return trips `set -e` there.
+    #
+    # Masked first because every check below needs the executable text: comments are not whitespace, and a block's own
+    # prose can contain the token that identifies it.
     masked="$(sed 's/--.*$//' <<<"$sql")"
     if [[ -z "${masked//[[:space:]]/}" ]]; then
         log "ERROR: the '$block' block from $VERIFY_SQL rendered no executable SQL (empty, or comments only)." >&2
         log "       Expected the exact marker lines '-- >>> BEGIN $block' and '-- >>> END $block'." >&2
         return 1
     fi
-    # A block whose markers moved around the wrong statement is plenty of text, so emptiness cannot catch it, and an
-    # unsubstituted placeholder would reach ClickHouse as a literal. Both would turn a mis-marked file into a wrong
-    # verdict rather than a refusal — which is worse here than in a driver that only executes, because this driver's
-    # output IS the go/no-go. Checked on the comment-masked text: comments are not whitespace and a block's own prose
-    # can contain the phrase that identifies it.
+    # Markers that slipped onto prose or a non-statement leave plenty of text, so emptiness cannot catch that; every
+    # block here is a read, so requiring a SELECT does. Note the limit: this cannot tell one block's SELECT from
+    # another's, which would need a per-block token. It does not have to — the callers validate the shape of what comes
+    # back (`ok` must be 1, confirm-keys must be a count), so a block swapped for another read fails closed there.
     if ! grep -qF 'SELECT' <<<"$masked"; then
-        log "ERROR: the '$block' block from $VERIFY_SQL has no SELECT outside its comments, so the markers are around" >&2
-        log "       the wrong statement. Refusing to run it." >&2
+        log "ERROR: the '$block' block from $VERIFY_SQL has no SELECT outside its comments, so the markers are not" >&2
+        log "       around a statement. Refusing to run it." >&2
         return 1
     fi
+    # A surviving placeholder means a substitution was missed — a moved marker, or one added to the block and not to the
+    # list above. ClickHouse would reject the literal anyway; refusing here names the actual cause instead.
     if grep -qF '${' <<<"$masked"; then
         log "ERROR: the '$block' block from $VERIFY_SQL still holds an unsubstituted \${...} placeholder after" >&2
         log "       rendering. Refusing to send SQL containing a literal placeholder." >&2

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -125,12 +125,23 @@ log() {
 # Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block from the reference SQL (exact-line markers), and
 # substitute this window's placeholders.
 render_block() {
-    local block="$1" lo="$2" hi="$3" sql begins ends masked
+    local block="$1" lo="$2" hi="$3" sql begins ends masked begin_line end_line
     # Exactly one pair: the awk otherwise runs to EOF on a missing END and sweeps the later blocks in with this one.
     begins="$(grep -cxF -e "-- >>> BEGIN $block" "$VERIFY_SQL" || true)"
     ends="$(grep -cxF -e "-- >>> END $block" "$VERIFY_SQL" || true)"
     if (( begins != 1 || ends != 1 )); then
         log "ERROR: $VERIFY_SQL holds $begins '-- >>> BEGIN $block' and $ends '-- >>> END $block'; expected one of each." >&2
+        return 1
+    fi
+    # Counting alone misses an END moved ABOVE its BEGIN, which still counts 1 and 1 and gives the same run-on capture.
+    # Here that costs queries rather than correctness: every block is a read, and each caller parses the first row,
+    # which still comes from the intended statement. Refused anyway -- drill-down and the two re-checks are not cheap
+    # to run per window by accident, and "the caller happens to parse the right row" is not a property to depend on.
+    read -r begin_line end_line <<<"$(awk -v b="-- >>> BEGIN $block" -v e="-- >>> END $block" \
+        '$0 == b {bl = NR} $0 == e {el = NR} END {print bl, el}' "$VERIFY_SQL")"
+    if (( end_line <= begin_line )); then
+        log "ERROR: $VERIFY_SQL has the '$block' markers out of order (BEGIN at line $begin_line, END at line" >&2
+        log "       $end_line), so the block would capture to end of file. Refusing to run it." >&2
         return 1
     fi
     sql="$(awk -v begin="-- >>> BEGIN $block" -v end="-- >>> END $block" \

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -125,7 +125,7 @@ log() {
 # Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block from the reference SQL (exact-line markers), and
 # substitute this window's placeholders.
 render_block() {
-    local block="$1" lo="$2" hi="$3" sql begins ends
+    local block="$1" lo="$2" hi="$3" sql begins ends masked
     # Exactly one pair: the awk otherwise runs to EOF on a missing END and sweeps the later blocks in with this one.
     begins="$(grep -cxF -e "-- >>> BEGIN $block" "$VERIFY_SQL" || true)"
     ends="$(grep -cxF -e "-- >>> END $block" "$VERIFY_SQL" || true)"
@@ -148,9 +148,25 @@ render_block() {
     # RETURN, not exit: every caller invokes this inside a command substitution, where an exit ends only the subshell
     # and would leave the outer clickhouse-client running with an empty --query. The callers assign first, so a
     # non-zero return trips `set -e` there.
-    if [[ -z "$(sed 's/--.*$//' <<<"$sql" | tr -d '[:space:]')" ]]; then
+    masked="$(sed 's/--.*$//' <<<"$sql")"
+    if [[ -z "${masked//[[:space:]]/}" ]]; then
         log "ERROR: the '$block' block from $VERIFY_SQL rendered no executable SQL (empty, or comments only)." >&2
         log "       Expected the exact marker lines '-- >>> BEGIN $block' and '-- >>> END $block'." >&2
+        return 1
+    fi
+    # A block whose markers moved around the wrong statement is plenty of text, so emptiness cannot catch it, and an
+    # unsubstituted placeholder would reach ClickHouse as a literal. Both would turn a mis-marked file into a wrong
+    # verdict rather than a refusal — which is worse here than in a driver that only executes, because this driver's
+    # output IS the go/no-go. Checked on the comment-masked text: comments are not whitespace and a block's own prose
+    # can contain the phrase that identifies it.
+    if ! grep -qF 'SELECT' <<<"$masked"; then
+        log "ERROR: the '$block' block from $VERIFY_SQL has no SELECT outside its comments, so the markers are around" >&2
+        log "       the wrong statement. Refusing to run it." >&2
+        return 1
+    fi
+    if grep -qF '${' <<<"$masked"; then
+        log "ERROR: the '$block' block from $VERIFY_SQL still holds an unsubstituted \${...} placeholder after" >&2
+        log "       rendering. Refusing to send SQL containing a literal placeholder." >&2
         return 1
     fi
     printf '%s' "$sql"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Fidelity QA driver for the buffered traces cutover (runbook: ../README.md, "Verifying the migration").
+# Fidelity QA driver for the traces cutover (runbook: ../README.md, "Verifying the migration").
 #
 # Compares the migrated data on the old-schema and new-schema tables, week by week (created_at), using a NORMALIZED
 # fingerprint so sentinel/precision differences (end_time NULL<->epoch, ttft NULL<->NaN, ns<->us) do not count as

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -41,7 +41,7 @@ import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABA
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * End-to-end validation of the buffered cutover that migrates {@code traces} to its partitioned, sharding-ready
+ * End-to-end validation of the cutover that migrates {@code traces} to its partitioned, sharding-ready
  * successor {@code traces_local_v2}. It rehearses the full sequence against a fresh ClickHouse in raw SQL — the same
  * steps an operator runs from the {@code data-migrations/traces-local-v2-cutover} runbook — and pins the properties
  * the cutover's correctness depends on.
@@ -83,7 +83,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>It also confirms {@code EXCHANGE TABLES ... ON CLUSTER} on the single-shard cluster, the sharding-ready
  * {@code Distributed} wrapper reading transparently on one shard, newest-version-wins for concurrent upserts, and it
- * measures the replay wall time so the runbook can size it against the ingestion buffer window. Finally it proves the
+ * measures the replay wall time so the runbook can size the cutover tail against a real workload. Finally it proves the
  * cutover is reversible: the post-wrap rollback drops the wrapper, promotes the parked old data back to {@code traces},
  * and reverse-replays so a post-cutover delete does not resurrect — and, separately, that the wrap alone can be
  * reversed ({@code --unwrap-only}) leaving the partitioned successor and its post-cutover writes live, with no parked
@@ -339,7 +339,7 @@ class TracesLocalV2CutoverTest {
     }
 
     @Test
-    void bufferedCutoverPreservesEveryDeletionAcrossExchange() {
+    void cutoverPreservesEveryDeletionAcrossExchange() {
         var workspaceId = UUID.randomUUID().toString();
         var projectId = ID_GENERATOR.generateId();
         var otherProjectId = ID_GENERATOR.generateId();
@@ -425,8 +425,8 @@ class TracesLocalV2CutoverTest {
         // Deletion replay: read the bridge for the window and re-issue the deletes against the destination, matched on
         // the full key so a reused id in another project is untouched.
         // Measured and logged (not asserted): replay wall time is environment-sensitive (container startup, CI
-        // contention), so a hard bound here would be a flaky gate on a non-correctness property. The runbook sizes it
-        // against the buffer window during the cutover rehearsal; correctness is asserted below (the mask is applied).
+        // contention), so a hard bound here would be a flaky gate on a non-correctness property. The runbook sizes the
+        // cutover tail from it during the rehearsal; correctness is asserted below (the mask is applied).
         var replayMillis = replayDeletions(backfillStart);
         log.info("Deletion replay covered {} ids in {} ms", leakedIds.size() + 1, replayMillis);
 
@@ -1758,7 +1758,7 @@ class TracesLocalV2CutoverTest {
      * events match the full key {@code (workspace_id, project_id, id)} (exact; a reused id in another project is
      * untouched) — without this replay those deletions silently leak across the swap. The branch also requires the id is
      * NOT currently live on the source (the resurrection guard), so a deleted-then-recreated id is not dropped. Returns
-     * the wall time so the runbook can size it against the buffer window.
+     * the wall time so the runbook can size the cutover tail from it.
      */
     private long replayDeletions(String backfillStart) {
         var start = System.nanoTime();

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -83,7 +83,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>It also confirms {@code EXCHANGE TABLES ... ON CLUSTER} on the single-shard cluster, the sharding-ready
  * {@code Distributed} wrapper reading transparently on one shard, newest-version-wins for concurrent upserts, and it
- * measures the replay wall time so the runbook can size the cutover tail against a real workload. Finally it proves the
+ * measures the replay wall time, which the runbook counts toward the cutover tail. Finally it proves the
  * cutover is reversible: the post-wrap rollback drops the wrapper, promotes the parked old data back to {@code traces},
  * and reverse-replays so a post-cutover delete does not resurrect — and, separately, that the wrap alone can be
  * reversed ({@code --unwrap-only}) leaving the partitioned successor and its post-cutover writes live, with no parked
@@ -425,8 +425,8 @@ class TracesLocalV2CutoverTest {
         // Deletion replay: read the bridge for the window and re-issue the deletes against the destination, matched on
         // the full key so a reused id in another project is untouched.
         // Measured and logged (not asserted): replay wall time is environment-sensitive (container startup, CI
-        // contention), so a hard bound here would be a flaky gate on a non-correctness property. The runbook sizes the
-        // cutover tail from it during the rehearsal; correctness is asserted below (the mask is applied).
+        // contention), so a hard bound here would be a flaky gate on a non-correctness property. The runbook counts it
+        // toward the cutover tail during the rehearsal; correctness is asserted below (the mask is applied).
         var replayMillis = replayDeletions(backfillStart);
         log.info("Deletion replay covered {} ids in {} ms", leakedIds.size() + 1, replayMillis);
 
@@ -1758,7 +1758,7 @@ class TracesLocalV2CutoverTest {
      * events match the full key {@code (workspace_id, project_id, id)} (exact; a reused id in another project is
      * untouched) — without this replay those deletions silently leak across the swap. The branch also requires the id is
      * NOT currently live on the source (the resurrection guard), so a deleted-then-recreated id is not dropped. Returns
-     * the wall time so the runbook can size the cutover tail from it.
+     * the wall time, which the runbook counts toward the cutover tail.
      */
     private long replayDeletions(String backfillStart) {
         var start = System.nanoTime();

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -1,8 +1,13 @@
 # Traces cutover — local simulation tooling
 
-Ad-hoc CLI scripts to stand up a representative dataset and live traffic on a **local** Opik, so the traces
-buffered-cutover runbook (`apps/opik-backend/data-migrations/traces-local-v2-cutover`) can be rehearsed end to end and
-iterated on quickly.
+Ad-hoc CLI scripts to stand up a representative dataset and live traffic on a **local** Opik, so the traces cutover
+runbook (`apps/opik-backend/data-migrations/traces-local-v2-cutover`) can be rehearsed end to end and iterated on
+quickly.
+
+**Rehearse with traffic still flowing through the swap.** The cutover holds writes nowhere, so convergence has to come
+from the procedure rather than from stopping traffic: keep the write and delete generators below running across the
+delta and the `EXCHANGE`. Quiescing traffic to make the compare converge rehearses an assumption the procedure does
+not make.
 
 | Script | What it does | Talks to |
 |---|---|---|
@@ -45,8 +50,8 @@ ClickHouse connection defaults (user/password/db all `opik`, host `localhost:812
 
 ### Changing backend config mid-rehearsal
 
-The runbook's operator-owned steps are **backend config plus a restart** (raise/restore the async-insert buffer, flip
-`traceColumnsNonNullable`, flip `tracesDistributedWrapEnabled`). These flags are read from a startup snapshot, so a
+The runbook's operator-owned steps are **backend config plus a restart** (flip `traceColumnsNonNullable`, flip
+`tracesDistributedWrapEnabled`). These flags are read from a startup snapshot, so a
 restart is required — `opik.sh` has no flag for them. Recreate just the backend, keeping the rest of the stack up. Note
 `opik.sh` runs under compose project **`opik-opik`** (containers are `opik-opik-*`), so pass `-p opik-opik` or you will
 silently create a second, parallel project:
@@ -58,12 +63,12 @@ recreate_backend() {   # exports must be set by the caller; unset a var to retur
     -f deployment/docker-compose/docker-compose.override.yaml \
     --profile opik up -d --no-deps backend
   until [ "$(docker inspect -f '{{.State.Health.Status}}' opik-opik-backend-1)" = healthy ]; do sleep 3; done
-  docker exec opik-opik-backend-1 env | grep -E 'ANALYTICS_DB_DATA_MODEL_TRACE|ASYNC_INSERT_BUSY_TIMEOUT_MAX' | sort
+  docker exec opik-opik-backend-1 env | grep -E 'ANALYTICS_DB_DATA_MODEL_TRACE' | sort
 }
 ```
 
 Always re-read the env out of the container afterwards (as above) to confirm the flag actually took — that is the only
-check available for `traceColumnsNonNullable`, whose failure mode is silent (see the runbook's prereq #7).
+check available for `traceColumnsNonNullable`, whose failure mode is silent (see the runbook's prereq #6).
 
 ## End-to-end rehearsal
 
@@ -79,10 +84,13 @@ export CLICKHOUSE_HOST=localhost CLICKHOUSE_USER=opik CLICKHOUSE_PASSWORD=opik
 # 2. (Optional) Estimate the backfill ETA for a given config.
 $RUNBOOK/scripts/estimate.sh --database opik --max-rows-per-insert 400 --pause-seconds 1
 
-# 3. Generate concurrent write + delete traffic for the duration of the cutover (two more terminals).
+# 3. Generate concurrent write + delete traffic for the duration of the cutover (two more terminals). Size --duration
+#    to cover the WHOLE sequence through the EXCHANGE, not just the backfill: the procedure takes no hold on writes, so
+#    traffic flowing across the swap is the condition being rehearsed. Stopping traffic to make verify.sh converge
+#    tests an assumption the runbook does not make.
 #    --resurrect-ratio is REQUIRED to exercise the replay's resurrection guard (delete then re-create under the same
 #    id). Do NOT expect the write/delete overlap to produce that by chance: live_traffic.py only updates ids from its
-#    own recent-creates buffer, and a 5-minute 5-tps/3-tps run has been observed to yield ZERO resurrections — leaving
+#    own recent-creates list, and a 5-minute 5-tps/3-tps run was measured yielding ZERO resurrections — leaving
 #    the one silent-data-loss path in the replay completely unexercised. delete_traffic.py warns if it resurrected none.
 #    Let the delete traffic run PAST the end of the backfill: a delete of an already-copied row is the leak the bridge
 #    exists to close, whereas a delete before its row is copied is simply never copied (mask-honored INSERT).
@@ -93,8 +101,10 @@ $RUNBOOK/scripts/estimate.sh --database opik --max-rows-per-insert 400 --pause-s
 #    --in-progress-ratio is likewise REQUIRED to exercise the pre-swap window's sentinel / negative-duration caveat:
 #    without it every trace is ended, so no trace is ever written with an absent end_time and the caveat (plus its
 #    rollback repair) produces ZERO affected rows. live_traffic.py warns if it left none in progress.
-python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 5 --duration 150 --update-ratio 0.4 --in-progress-ratio 0.15
-python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 3 --duration 150 --resurrect-ratio 0.05
+#    --duration 900 is a starting point, not a recommendation: it has to outlast steps 4-8. Extend it (or re-launch
+#    both generators) rather than letting them expire before the EXCHANGE.
+python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 10 --duration 900 --update-ratio 0.2 --in-progress-ratio 0.15
+python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 3  --duration 900 --resurrect-ratio 0.05
 
 # 4. Backfill (small --max-rows-per-insert exercises the adaptive sub-window splitting on modest data). Record the
 #    backfill_start it prints.
@@ -105,9 +115,10 @@ $RUNBOOK/scripts/delta_replay.sh --database opik --backfill-start '<backfill_sta
 
 # 6. QA the copy BEFORE the swap: normalized fidelity compare of source vs destination.
 $RUNBOOK/scripts/verify.sh --database opik            # --drill-down lists the differing keys of ANY differing window
-#    Locally there is no async-insert buffer, so in-flight writes may still be settling: once traffic has stopped,
-#    re-run delta_replay.sh then verify.sh until it reports "PASSED" (convergence). In production the buffer holds
-#    writes during the cutover window instead.
+#    Writes keep arriving throughout, so the current week converges only as far as the last delta reached: re-run
+#    delta_replay.sh then verify.sh, and read a PASS as "the copy is faithful as of the last delta", not "nothing can
+#    arrive after it". Whatever arrives after it lands in the tail write-gap (runbook "The final cutover window"), not
+#    in this compare. Do NOT stop the traffic to force a clean PASS.
 #
 #    Re-running only converges a MISMATCH. The other two non-zero verdicts do not resolve by re-copying, so do not
 #    loop on them:
@@ -119,13 +130,13 @@ $RUNBOOK/scripts/verify.sh --database opik            # --drill-down lists the d
 #    "OK -- superseded-version artifact" is a PASS that differs, so it needs no action.
 
 # 7. MANDATORY CONFIG STEP, and the one most easily skipped in a rehearsal: roll out traceColumnsNonNullable=true
-#    BEFORE the EXCHANGE (runbook "The final cutover window"), and raise the buffer ceiling so the --confirm-buffer-raised
-#    assertion is truthful rather than vacuous. Use recreate_backend() from "Changing backend config mid-rehearsal" above.
+#    BEFORE the EXCHANGE (runbook "The final cutover window"). This is the only restart the cutover itself needs, and
+#    it carries no latency cost; step 10's optional wrap has its own. Use recreate_backend() from "Changing backend
+#    config mid-rehearsal" above.
 #    Skipping this leaves the whole read-side half of the flag unexercised — and its failure mode is SILENT (writes still
 #    succeed either way; absent end_time just reads back as 1970-01-01 instead of null).
 export ANALYTICS_DB_DATA_MODEL_TRACE_DELETION_EVENTS_CAPTURE_ENABLED=true \
-       ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE=true \
-       ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS=10000
+       ANALYTICS_DB_DATA_MODEL_TRACE_COLUMNS_NON_NULLABLE=true
 recreate_backend
 #    Positive check (the only real one): an in-progress trace must read back end_time = None. Writing one now, while
 #    `traces` is still the Nullable original, is also what exercises the pre-swap window's two documented caveats.
@@ -136,30 +147,40 @@ recreate_backend
 #    --confirm-retention-paused holds trivially here (retention is disabled by default).
 $RUNBOOK/scripts/delta_replay.sh --database opik --backfill-start '<backfill_start> UTC'
 $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfill_start> UTC' \
-    --confirm-buffer-raised --confirm-retention-paused --skip-wrap
-#    Record the cutover_start it prints. Run the post-swap compare NOW, while writes are still held — and UNBOUNDED,
-#    because the current week is where the delta and the final deletion replay just landed, making it the week most worth
-#    comparing. Once writes resume, live legitimately outgrows the frozen backup and that week diverges for good; from
-#    then on the compare only means anything bounded, which skips exactly that week:
-#      $RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --to-week last-sealed
-#    ('last-sealed' excludes the current calendar week, so it covers the cutover week only in a same-week rehearsal —
-#     which a local run always is. Elsewhere, bound below cutover_start's week explicitly.)
-$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces
+    --confirm-retention-paused --skip-wrap
+#    The settle gate polls (default 120s) instead of demanding an instantaneous replication_queue of 0, so with the
+#    traffic from step 3 still flowing it should pass on ordinary churn rather than abort. Watch what it prints: it
+#    reports the queue depth, the oldest entry's age and max num_tries, and says which of the two verdicts it reached.
+#    Record the cutover_start it prints. With traffic running there WILL be traces left in the tail write-gap — in
+#    traces_pre_cutover_backup but not in live traces (runbook "The final cutover window"; OPIK-8238 adds the sweep
+#    that carries them). Seeing that gap is part of the point of rehearsing with traffic, and it takes TWO different
+#    compares, because the gap and a fidelity defect live in different weeks:
+#
+#    (a) SIZE THE GAP — unbounded, straight after the swap, with --drill-down. The gap rows are in the cutover week,
+#        which every weekly bound excludes, so a bounded run cannot see them. Read the keys listed for the
+#        backup-only side: those are the tail writes. (Keys live-only are post-swap writes — the harmless direction.)
+$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --drill-down
+#
+#    (b) CHECK FIDELITY — bounded below the cutover week, where any mismatch IS a defect rather than the known gap.
+#        The parked backup is frozen at cutover_start while live `traces` keeps taking writes, so the current week
+#        diverges for good. ('last-sealed' excludes the current calendar week, which in a same-week local rehearsal is
+#        the cutover week; elsewhere bound below cutover_start's week explicitly.)
+$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --to-week last-sealed
 
-# 9. Restore the buffer ceiling (unset the env var and recreate_backend), keeping traceColumnsNonNullable=true and
-#    deletion capture ON — capture must stay live through the soak, since the rollback reverse-replay reads the bridge.
-unset ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS; recreate_backend
+# 9. Leave the config as it is: keep traceColumnsNonNullable=true and deletion capture ON — capture must stay live
+#    through the soak, since the rollback reverse-replay reads the bridge.
 
 # 10. OPTIONAL — the deferred Distributed wrap. Flip tracesDistributedWrapEnabled=true FIRST (it retargets trace
-#     mutations at traces_local) and re-raise the buffer for --confirm-maintenance. A mismatch here IS fail-loud: with
-#     the flag true before the wrap exists, deletes 500 with "Code: 60 ... Table opik.traces_local does not exist" —
-#     worth triggering once, to see it. After the wrap, `DELETE FROM opik.traces` returns "Code: 36 DELETE query is not
-#     supported", and system.parts relabels from traces to traces_local.
-export ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=true \
-       ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS=10000
+#     mutations at traces_local). --confirm-maintenance is a SEPARATE, unrelated concern: it asserts traffic is
+#     quiesced or a maintenance window is in effect for the wrap's cross-node ON CLUSTER skew, which hits reads and
+#     which no ingestion-side setting covers. Both wrap paths (--with-wrap and --wrap-only) require it.
+#     A mismatch on the toggle IS fail-loud: with the flag true before the wrap exists, deletes 500 with
+#     "Code: 60 ... Table opik.traces_local does not exist" — worth triggering once, to see it. After the wrap,
+#     `DELETE FROM opik.traces` returns "Code: 36 DELETE query is not supported", and system.parts relabels from
+#     traces to traces_local.
+export ANALYTICS_DB_DATA_MODEL_TRACES_DISTRIBUTED_WRAP_ENABLED=true
 recreate_backend
 $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --wrap-only --confirm-maintenance --confirm-daos-retargeted
-unset ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS; recreate_backend
 ```
 
 **Resetting between iterations depends on how far the last run got.** If you have **not** completed the `EXCHANGE`
@@ -193,6 +214,11 @@ Rollback is driven by `rollback.sh`; pick the stage by how far the forward run g
 deletion replay**, so to exercise it, delete some traces *after* the EXCHANGE — they are bridged with
 `event_time >= cutover_start`, and the rollback must re-apply them so they do **not** resurrect on the restored `traces`.
 Pass the `cutover_start` that `exchange_and_wrap.sh` printed.
+
+**Rehearse the rollback direction with traffic running too**, for the same reason as the forward direction: no path in
+either direction holds writes, so the promote and the reverse replay have to be correct against a table that is still
+being written to. The generators below are the post-cutover activity the rollback discards or replays; leave them
+running across the promote.
 
 ```bash
 # Stage A — forward run stopped before the EXCHANGE: discards the shadow; live `traces` is untouched.

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -157,14 +157,11 @@ $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfil
 #    compares, because the gap and a fidelity defect live in different weeks:
 #
 #    (a) SIZE THE GAP — unbounded, straight after the swap, with --drill-down. The gap rows are in the cutover week,
-#        which every weekly bound excludes, so a bounded run cannot see them. TWO of the drill-down's categories are
-#        gap rows: keys listed backup-only (traces created in the tail), AND keys on both sides whose hashes differ
-#        with the newer last_updated_at in the backup (traces updated in the tail — the successor holds an older
-#        version, so counting only backup-only keys would report this gap as clean). Keys live-only, and differing
-#        hashes whose newer version is live, are post-swap writes — the harmless direction. The drill-down prints
-#        hashes, not versions, so compare last_updated_at per key to separate the two. live_traffic.py's --update-ratio
-#        is what makes the both-sides category reachable at all — it updates traces created earlier in the run, so some
-#        of those updates land in the tail against a trace the backfill already copied. Rehearse with it non-zero.
+#        which every weekly bound excludes, so a bounded run cannot see them. Classify the output by the runbook's
+#        Go/No-Go item, which owns the taxonomy: backup-only keys AND both-sides keys whose newer last_updated_at is
+#        in the backup are both gap rows, so counting backup-only alone under-reports it. live_traffic.py's
+#        --update-ratio is what makes that second shape reachable here — it updates traces created earlier in the run,
+#        so some of those updates land in the tail against a trace the backfill already copied. Keep it non-zero.
 $RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --drill-down
 #
 #    (b) CHECK FIDELITY — bounded below the cutover week, where any mismatch IS a defect rather than the known gap.

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -157,8 +157,14 @@ $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfil
 #    compares, because the gap and a fidelity defect live in different weeks:
 #
 #    (a) SIZE THE GAP — unbounded, straight after the swap, with --drill-down. The gap rows are in the cutover week,
-#        which every weekly bound excludes, so a bounded run cannot see them. Read the keys listed for the
-#        backup-only side: those are the tail writes. (Keys live-only are post-swap writes — the harmless direction.)
+#        which every weekly bound excludes, so a bounded run cannot see them. TWO of the drill-down's categories are
+#        gap rows: keys listed backup-only (traces created in the tail), AND keys on both sides whose hashes differ
+#        with the newer last_updated_at in the backup (traces updated in the tail — the successor holds an older
+#        version, so counting only backup-only keys would report this gap as clean). Keys live-only, and differing
+#        hashes whose newer version is live, are post-swap writes — the harmless direction. The drill-down prints
+#        hashes, not versions, so compare last_updated_at per key to separate the two. live_traffic.py's --update-ratio
+#        is what makes the both-sides category reachable at all — it updates traces created earlier in the run, so some
+#        of those updates land in the tail against a trace the backfill already copied. Rehearse with it non-zero.
 $RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --drill-down
 #
 #    (b) CHECK FIDELITY — bounded below the cutover week, where any mismatch IS a defect rather than the known gap.

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -177,6 +177,8 @@ $RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup
 #     mutations at traces_local). --confirm-maintenance is a SEPARATE, unrelated concern: it asserts traffic is
 #     quiesced or a maintenance window is in effect for the wrap's cross-node ON CLUSTER skew, which hits reads and
 #     which no ingestion-side setting covers. Both wrap paths (--with-wrap and --wrap-only) require it.
+#     Unlike step 8, this run prints no settle-gate output: --wrap-only performs topology validation and the wrap only,
+#     with no EXCHANGE and no replication-settle gate (neither of its signals describes this path).
 #     A mismatch on the toggle IS fail-loud: with the flag true before the wrap exists, deletes 500 with
 #     "Code: 60 ... Table opik.traces_local does not exist" — worth triggering once, to see it. After the wrap,
 #     `DELETE FROM opik.traces` returns "Code: 36 DELETE query is not supported", and system.parts relabels from

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -131,8 +131,8 @@ $RUNBOOK/scripts/verify.sh --database opik            # --drill-down lists the d
 
 # 7. MANDATORY CONFIG STEP, and the one most easily skipped in a rehearsal: roll out traceColumnsNonNullable=true
 #    BEFORE the EXCHANGE (runbook "The final cutover window"). This is the only restart the cutover itself needs, and
-#    it carries no latency cost; step 10's optional wrap has its own. Use recreate_backend() from "Changing backend
-#    config mid-rehearsal" above.
+#    it carries no steady-state latency cost, though the roll itself consumes ingestion capacity; step 10's optional
+#    wrap has its own. Use recreate_backend() from "Changing backend config mid-rehearsal" above.
 #    Skipping this leaves the whole read-side half of the flag unexercised — and its failure mode is SILENT (writes still
 #    succeed either way; absent end_time just reads back as 1970-01-01 instead of null).
 export ANALYTICS_DB_DATA_MODEL_TRACE_DELETION_EVENTS_CAPTURE_ENABLED=true \

--- a/tests_load/tests/traces-local-v2-cutover/_common.py
+++ b/tests_load/tests/traces-local-v2-cutover/_common.py
@@ -1,6 +1,6 @@
 """Shared helpers for the local traces-cutover simulation scripts.
 
-These scripts stand up a representative dataset and live traffic on a *local* Opik so the traces buffered-cutover runbook
+These scripts stand up a representative dataset and live traffic on a *local* Opik so the traces cutover runbook
 (apps/opik-backend/data-migrations/traces-local-v2-cutover) can be rehearsed end to end. They are ad-hoc CLI tools, not
 pytest suites.
 


### PR DESCRIPTION
## Details

The traces cutover runbook required raising `ANALYTICS_DB_ASYNC_INSERT_BUSY_TIMEOUT_MAX_MS` for the duration of the window, to hold in-flight ingestion across the swap. That step slows every ClickHouse-backed surface while it is in effect and does not deliver what it promises, so the procedure no longer uses it.

Why it cannot work here:

- The backend serves reads and writes through one shared R2DBC `ConnectionFactory` (`DatabaseAnalyticsModule`) and writes run `wait_for_async_insert=1`, so a parked insert holds a request thread and a connection for its whole wait while reads contend with it on the same transport. The slowdown is not confined to ingestion.
- It covers only part of the window it was raised for: the adaptive buffer flushes on whichever of the busy timeout, `async_insert_max_data_size` or `async_insert_max_query_number` fires first, and at real trace row widths the size and count limits bind well before the timeout.
- The ceiling arrives through the container environment, so applying it and reverting it are two fleet-wide rolling restarts. That brackets the degraded period and puts a floor under its length.

**What is removed.** The prerequisite and the "Where the buffer bump lives" section, the raise/restore steps in the sequence and the tail, the revert obligation on the rollback exit paths, the ingestion-latency monitoring line, two Go/No-Go items, and `--confirm-buffer-raised` from `exchange_and_wrap.sh` — which now rejects it as an unknown argument rather than accepting it silently. Also swept from `delta_replay.sh`, `backfill.sh`, `verify.sh`, `rollback.sh`, the two reference SQL files, the gate-test Javadoc and the load-test README, verified by a repo-wide grep. Reaching the `EXCHANGE` now needs one rolling restart (`traceColumnsNonNullable`) rather than two, and that one carries no latency cost.

**What is kept.** The knob itself is untouched — `DatabaseAnalyticsFactory`, `config.yml`, `config-test.yml`, the docker-compose passthrough, their tests and the self-host troubleshooting guide are unchanged. The runbook states that OPIK_7686's decision stands for it as production tuning (deliberately absent from the chart per OPIK_6880); only the cutover's dependence on it ends, so the removal does not read as a reversal.

**Two companion changes the removal requires.**

- The replication-settle gate no longer demands an instantaneous `replication_queue` of 0. Under live ingestion that count is non-zero by construction — a `GET_PART` entry exists for every part a replica has not yet fetched — so an instantaneous check would abort on ordinary churn and push the operator toward `--force`, which the Go/No-Go forbids. It now polls to `--settle-timeout` (default 120s, capped at 3600) and judges the two signals differently: the deletion-replay mutation must reach `is_done` on every replica, while the queue passes when it drains or when it is busy but not stuck, and fails loudly — reporting the oldest entry's age, `num_tries` and `last_exception` per replica — when it is genuinely lagging. The queue verdict is a snapshot over the last sample in both the polled and single-sample paths; polling buys time to drain or to age past the thresholds, and nothing compares consecutive samples. Because the gate sits between the final delta and the swap, the driver reports its wait as part of the tail.
- `--with-wrap` now requires `--confirm-maintenance`, as `--wrap-only` already did. The asymmetry rested on the same-run path inheriting the swap's ingestion-side hold, and that hold never covered reads — which is the half that matters for the wrap's cross-node `UNKNOWN_TABLE` window.

**From PR review.** `--settle-timeout` is now bounded lexically (at most four digits, then `<= 3600`): past 2^63 bash arithmetic wraps silently rather than erroring, which left the gate's poll count negative, its sampling loop running zero times, and the verdict reading never-assigned variables as 0 — so an out-of-range value passed the gate without reading replication at all. A numeric range test cannot catch that, since the wrapped value is negative and compares as in-range. Alongside it, the tail is now sized by version rather than key presence (above), its length includes the settle wait, and `verify.sh`'s block renderer gained the statement-identity and placeholder checks `exchange_and_wrap.sh` already had, so a mis-marked file cannot become a wrong verdict there either.

**Also in scope.** The settle gate's three queries moved into `000003_exchange_and_wrap.sql` as marked blocks, so every statement the driver sends comes from a versioned file; only three one-line topology probes remain inline. `exchange_and_wrap.sh` gained a shared block loader, which removed a hand-rolled duplicate in the final deletion replay.

**The tail write-gap is now stated rather than papered over.** Writes in the final-delta to `EXCHANGE` gap and the cross-node swap skew stay in `traces_pre_cutover_backup`, recoverable until `finalize.sh` retires it. That gap predates this change — the removed setting never held those writes — and is tracked separately as OPIK_8238. Until that lands, the Go/No-Go item asks the operator to size the gap with an unbounded post-`EXCHANGE` compare plus `--drill-down` and accept it knowingly. **Two** of the drill-down's three key shapes are gap rows: backup-only keys (created in the tail) and keys on both sides whose hashes differ with the newer `last_updated_at` in the backup (updated in the tail — the successor holds an older version, so sizing by key presence alone reports that half as clean). The two changes are independently shippable: nothing here executes on merge.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-8239

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation — driver changes, reference SQL and runbook prose
- Human verification: author-directed across several review iterations, each reviewed and corrected before commit; the procedure itself is validated by rehearsing it (see Testing)

## Testing

Automated, run locally:

- `mvn -o test -Dtest=TracesLocalV2CutoverTest` from `apps/opik-backend` — 20/20 passing. This is the gate that pins the cutover SQL's correctness and is listed in the ticket's acceptance criteria.
- `bash -n` over all eight scripts in `scripts/`, and `spotless:check` for the backend.
- `verify.sh`'s four rendered blocks (`compare`, `drill-down`, `confirm-keys`, `version-ties`) each pass the three guards its renderer now applies — non-empty, a `SELECT` outside comments, no surviving `${...}` — so the added checks refuse nothing they should accept.
- `pre-commit` on the changed files (`spotless` for the backend; the remaining hooks are scoped to `sdks/*` and skip).

Manual, against ClickHouse 26.3 in a container:

- The three new `settle-*` blocks of `000003` executed end to end through the driver's own `render()`, confirming they are valid on the target engine and that `settle-sample` returns the single row of seven numeric columns the driver parses with one `read -r`.
- `render()`'s refusal paths: a missing `END` marker, markers around the wrong statement, and a surviving `${...}` placeholder are each refused without sending the `EXCHANGE`.
- Driver argument gates by invocation: `--with-wrap` and `--wrap-only` both refuse without `--confirm-maintenance`; `--confirm-buffer-raised` is rejected as an unknown argument; `--settle-timeout` accepts `0`, `120` and `3600` and rejects `3601`, `9999`, `08`, `0120`, `abc`, `-5`, `1e3` and values past 2^63, each before any connection is attempted.
- The settle gate's verdict matrix — clean, busy-but-young, stuck by age / retries / exception, both threshold boundaries, an unfinished mutation, a draining queue over two polls, and `--settle-timeout 0` — driven against a stubbed `clickhouse-client`, confirming a refused gate sends no `EXCHANGE` and an accepted one does.

Not run here, by design: the drivers have no committed harness. Per the runbook's stated strategy, driver validation is performing the procedure — the forward cutover, the wrap, and the rollback of each — on a local or test environment, which exercises them against a real ClickHouse rather than a stub. The rehearsal instructions in `tests_load/tests/traces-local-v2-cutover/README.md` are updated to keep write and delete traffic running across the swap, since converging by stopping traffic rehearses an assumption this procedure does not make.

## Documentation

- `apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md` — the operator runbook: prerequisite and buffer section removed, sequence and tail rewritten, the settle gate and the one rolling restart documented, Go/No-Go items replaced, and a note recording why the async-insert knob itself is unchanged.
- `tests_load/tests/traces-local-v2-cutover/README.md` — rehearsal updated to run traffic through the swap and to size the tail write-gap with two distinct compares.
- Reference SQL comments in `000002`, `000003` and `000004_rollback_unwrap.sql`, and the driver header/option docs.
- Public documentation is deliberately unchanged: `apps/opik-documentation/.../self-host/troubleshooting.mdx` keeps its async-insert tuning guidance, which remains valid and carries no cutover-specific framing.


