### PR TITLE
[OPIK-8304] [CI] fix: wait for the whole stack concurrently with a deadline

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
@@ -15,12 +15,21 @@ To run Opik locally we recommend using [Docker Compose](https://docs.docker.com/
 Before running the installation, make sure you have Docker and Docker Compose installed:
 
 - [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker Compose](https://docs.docker.com/compose/install/) **v2.17.0 or newer**
+
+You can confirm your Compose version with `docker compose version --short`.
 
 <Note>
   If you are using Mac or Windows, both `docker` and `docker compose` are included in the [Docker
   Desktop](https://docs.docker.com/desktop/) installation.
 </Note>
+
+<Warning>
+  `opik.sh` checks the Compose version before starting any container and exits with an upgrade message if it is older
+  than v2.17.0, which is where the `--wait-timeout` flag it uses was introduced. On Linux, a `docker-compose` v1 binary
+  installed from a distro package is usually too old — install the [Compose v2
+  plugin](https://docs.docker.com/compose/install/linux/) instead.
+</Warning>
 
 ## Installation
 
@@ -109,14 +118,20 @@ Run `./opik.sh --help` (or `powershell -ExecutionPolicy ByPass -c ".\opik.ps1 --
 
 ### Startup timeout
 
-`opik.sh` waits up to 300 seconds for every container to start and report healthy, then fails with the container
-status and recent logs. A first-time start that has to pull or build images, or a host under heavy load, can
+`opik.sh` waits up to 300 seconds for the long-running services to start and report healthy, then fails with the
+container status and recent logs. A first-time start that has to pull or build images, or a host under heavy load, can
 legitimately take longer than that. Raise the deadline with `OPIK_STARTUP_TIMEOUT` (in seconds, between 1 and 86400)
 rather than retrying:
 
 ```bash
 OPIK_STARTUP_TIMEOUT=600 ./opik.sh
 ```
+
+The deadline covers the long-running services — the ones with a health check, such as the databases, the backend and
+the frontend. Short-lived setup jobs that run once and exit, such as the MinIO bucket provisioning and the demo-data
+generator, are started but are not part of the readiness check, so they do not count towards startup success or
+failure. If one of those jobs fails, Opik still reports a successful start; check `docker compose ps -a` for their exit
+codes.
 
 <Note>
   `OPIK_STARTUP_TIMEOUT` is read by `opik.sh`. On Windows, `opik.ps1` applies its own fixed per-container wait and does

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
@@ -15,7 +15,7 @@ To run Opik locally we recommend using [Docker Compose](https://docs.docker.com/
 Before running the installation, make sure you have Docker and Docker Compose installed:
 
 - [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/) **v2.17.0 or newer**
+- [Docker Compose](https://docs.docker.com/compose/install/) **v2.24.4 or newer**
 
 You can confirm your Compose version with `docker compose version --short`.
 
@@ -26,7 +26,8 @@ You can confirm your Compose version with `docker compose version --short`.
 
 <Warning>
   `opik.sh` checks the Compose version before starting any container and exits with an upgrade message if it is older
-  than v2.17.0, which is where the `--wait-timeout` flag it uses was introduced. On Linux, a `docker-compose` v1 binary
+  than v2.24.4. Two features set that floor: the `--wait-timeout` flag used for the readiness check, and the
+  `!override` tag used by the port-mapping and local-development overlay files. On Linux, a `docker-compose` v1 binary
   installed from a distro package is usually too old — install the [Compose v2
   plugin](https://docs.docker.com/compose/install/linux/) instead.
 </Warning>

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/local_deployment.mdx
@@ -107,6 +107,22 @@ The `opik.sh` and `opik.ps1` scripts support the following options:
 
 Run `./opik.sh --help` (or `powershell -ExecutionPolicy ByPass -c ".\opik.ps1 --help"` on Windows) to see the full list of options.
 
+### Startup timeout
+
+`opik.sh` waits up to 300 seconds for every container to start and report healthy, then fails with the container
+status and recent logs. A first-time start that has to pull or build images, or a host under heavy load, can
+legitimately take longer than that. Raise the deadline with `OPIK_STARTUP_TIMEOUT` (in seconds, between 1 and 86400)
+rather than retrying:
+
+```bash
+OPIK_STARTUP_TIMEOUT=600 ./opik.sh
+```
+
+<Note>
+  `OPIK_STARTUP_TIMEOUT` is read by `opik.sh`. On Windows, `opik.ps1` applies its own fixed per-container wait and does
+  not honour this variable.
+</Note>
+
 ## Stopping the Opik platform
 
 You can stop the Opik server by running the following commands:

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -3,7 +3,17 @@
 ## Installation pre-requirements for local installation
 
 - Docker: https://docs.docker.com/engine/install/
-- Docker Compose: https://docs.docker.com/compose/install/
+- Docker Compose **v2.17.0 or newer**: https://docs.docker.com/compose/install/
+
+`opik.sh` checks the Compose version before starting anything and exits with an upgrade message if it is older, since
+it relies on `docker compose up --wait --wait-timeout` for the startup readiness check. Confirm your version with:
+
+```bash
+docker compose version --short
+```
+
+Docker Desktop bundles a recent Compose; on Linux, a `docker-compose` v1 binary installed from a distro package is
+usually too old and should be replaced with the Compose v2 plugin.
 
 ## Service Profiles for Development
 
@@ -72,7 +82,7 @@ Run `./opik.sh --help` to see the full list of options.
 
 | Variable                | Default | Description                                                                                              |
 | ----------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
-| `OPIK_STARTUP_TIMEOUT`  | `300`   | Seconds `opik.sh` waits for the containers to start and become healthy. Accepts `1`-`86400`.              |
+| `OPIK_STARTUP_TIMEOUT`  | `300`   | Seconds `opik.sh` waits for the long-running services to start and become healthy. Accepts `1`-`86400`.   |
 
 The default suits a warm machine. A first-time start that has to pull or build images, or a host under heavy load, can
 legitimately take longer — raise the deadline rather than retrying:
@@ -80,6 +90,11 @@ legitimately take longer — raise the deadline rather than retrying:
 ```bash
 OPIK_STARTUP_TIMEOUT=600 ./opik.sh
 ```
+
+The deadline covers the services that have a health check. Run-once setup jobs — the `mc` bucket provisioning and the
+`demo-data-generator` — are started but excluded from the wait, because `compose up --wait` treats any service exit as
+a failure even when it exits 0. They therefore do not affect startup success; check `docker compose ps -a` for their
+exit codes if something they provision is missing.
 
 This variable is read by `opik.sh` only; `opik.ps1` on Windows still applies its own fixed per-container wait.
 

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -3,10 +3,11 @@
 ## Installation pre-requirements for local installation
 
 - Docker: https://docs.docker.com/engine/install/
-- Docker Compose **v2.17.0 or newer**: https://docs.docker.com/compose/install/
+- Docker Compose **v2.24.4 or newer**: https://docs.docker.com/compose/install/
 
-`opik.sh` checks the Compose version before starting anything and exits with an upgrade message if it is older, since
-it relies on `docker compose up --wait --wait-timeout` for the startup readiness check. Confirm your version with:
+`opik.sh` checks the Compose version before starting anything and exits with an upgrade message if it is older. Two
+features set that floor: `docker compose up --wait --wait-timeout`, used for the startup readiness check, and the
+`!override` tag used by the port-mapping and local-development overlay files. Confirm your version with:
 
 ```bash
 docker compose version --short

--- a/deployment/docker-compose/README.md
+++ b/deployment/docker-compose/README.md
@@ -68,6 +68,21 @@ Instead of running `docker compose` directly, you can use the `opik.sh` script (
 
 Run `./opik.sh --help` to see the full list of options.
 
+### Environment variables
+
+| Variable                | Default | Description                                                                                              |
+| ----------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `OPIK_STARTUP_TIMEOUT`  | `300`   | Seconds `opik.sh` waits for the containers to start and become healthy. Accepts `1`-`86400`.              |
+
+The default suits a warm machine. A first-time start that has to pull or build images, or a host under heavy load, can
+legitimately take longer — raise the deadline rather than retrying:
+
+```bash
+OPIK_STARTUP_TIMEOUT=600 ./opik.sh
+```
+
+This variable is read by `opik.sh` only; `opik.ps1` on Windows still applies its own fixed per-container wait.
+
 ## Run `docker compose` using the images
 
 If you want to use a specific version, set Opik version like:

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -255,10 +255,6 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      # mc provisions the `public` bucket the backend writes attachments to, and is a run-once job.
-      # Declaring the completion dependency also tells `compose up --wait` that its exit is expected.
-      mc:
-        condition: service_completed_successfully
     tmpfs:
       - /tmp
 

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -255,6 +255,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      # mc provisions the `public` bucket the backend writes attachments to, and is a run-once job.
+      # Declaring the completion dependency also tells `compose up --wait` that its exit is expected.
+      mc:
+        condition: service_completed_successfully
     tmpfs:
       - /tmp
 

--- a/opik.sh
+++ b/opik.sh
@@ -105,7 +105,9 @@ generate_uuid() {
 }
 
 debugLog() {
+  # The trailing `true` keeps a no-op debug line from becoming the caller's non-zero return value.
   [[ "$DEBUG_MODE" == true ]] && echo "$@"
+  true
 }
 
 # Log worktree configuration (called after DEBUG_MODE is set)
@@ -230,7 +232,7 @@ create_opik_config_if_missing() {
   
   if [[ -f "$config_file" ]]; then
     debugLog "[DEBUG] .opik.config file already exists, skipping creation"
-    return
+    return 0
   fi
   
   debugLog "[DEBUG] Creating .opik.config file at $config_file"
@@ -348,7 +350,6 @@ start_missing_containers() {
   debugLog "OPIK_ANONYMOUS_ID=$uuid"
 
   debugLog "🔍 Checking required containers..."
-  all_running=true
 
   local containers=("${CONTAINERS[@]}")
   for container in "${containers[@]}"; do
@@ -356,7 +357,6 @@ start_missing_containers() {
 
     if [[ "$status" != "running" ]]; then
       debugLog "🔴 $container is not running (status: ${status:-not found})"
-      all_running=false
     else
       debugLog "✅ $container is already running"
     fi
@@ -368,50 +368,26 @@ start_missing_containers() {
 
   local cmd
   cmd=$(get_docker_compose_cmd)
-  $cmd up -d ${BUILD_MODE:+--build}
 
-  echo "⏳ Waiting for all containers to be running and healthy..."
-  max_retries=60
-  interval=1
-  all_running=true
+  local startup_timeout="${OPIK_STARTUP_TIMEOUT:-300}"
+  echo "⏳ Waiting for all containers to be running and healthy (timeout: ${startup_timeout}s)..."
 
-  for container in "${containers[@]}"; do
-    retries=0
-    debugLog "⏳ Waiting for $container..."
-
-    while true; do
-      status=$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)
-      health=$(docker inspect -f '{{.State.Health.Status}}' "$container" 2>/dev/null)
-
-      if [[ "$status" != "running" ]]; then
-        echo "❌ $container failed to start (status: $status)"
-        break
-      fi
-
-      if [[ "$health" == "healthy" ]]; then
-        debugLog "✅ $container is now running and healthy!"
-        break
-      elif [[ "$health" == "starting" ]]; then
-        debugLog "⏳ $container is starting... retrying (${retries}s)"
-        sleep "$interval"
-        retries=$((retries + 1))
-        if [[ $retries -ge $max_retries ]]; then
-          echo "⚠️  $container is still not healthy after ${max_retries}s"
-          all_running=false
-          break
-        fi
-      else
-        echo "❌ $container health state is '$health'"
-        all_running=false
-        break
-      fi
-    done
-  done
-
-  if $all_running; then
-    send_install_report "$uuid" "true" "$start_time"
-    create_opik_config_if_missing
+  # --wait waits on every service concurrently and honours each service's own healthcheck plus the
+  # depends_on graph, so a slow service can't be starved by the time spent on the ones before it.
+  if ! $cmd up -d ${BUILD_MODE:+--build} --wait --wait-timeout "$startup_timeout"; then
+    echo "❌ Containers did not become healthy within ${startup_timeout}s"
+    echo "   Set OPIK_STARTUP_TIMEOUT to allow more time, e.g. OPIK_STARTUP_TIMEOUT=600 $(get_start_cmd)"
+    echo ""
+    echo "📋 Container status:"
+    $cmd ps
+    echo ""
+    echo "📜 Recent container logs:"
+    $cmd logs --tail=200
+    return 1
   fi
+
+  send_install_report "$uuid" "true" "$start_time"
+  create_opik_config_if_missing
 }
 
 stop_containers() {
@@ -778,15 +754,11 @@ case "$1" in
     ;;
   "")
     echo "🔍 Checking container status and starting missing ones..."
-    start_missing_containers
-    sleep 2
-    echo "🔄 Re-checking container status..."
-    if check_containers_status; then
-      print_banner
-    else
+    if ! start_missing_containers; then
       echo "⚠️  Some containers are still not healthy. Please check manually using '$(get_verify_cmd)'"
       exit 1
     fi
+    print_banner
     ;;
   *)
     echo "❌ Unknown option: $1"

--- a/opik.sh
+++ b/opik.sh
@@ -53,8 +53,10 @@ set_containers_for_profile() {
 
 }
 
-# `compose up --wait --wait-timeout` is only available from this version on.
-COMPOSE_MIN_VERSION="2.17.0"
+# Minimum Docker Compose version. `up --wait --wait-timeout` needs v2.17.0, but the `!override` tag
+# used by the port-mapping and local-development overlays arrived with compose-go/v2 in v2.24.x, so
+# the higher floor is the binding one for anything that loads those files.
+COMPOSE_MIN_VERSION="2.24.4"
 
 # Upper bound for OPIK_STARTUP_TIMEOUT (24h). Compose parses --wait-timeout as an int64 and rejects
 # anything larger, so the value is range-checked here rather than by a failed flag parse later.
@@ -64,13 +66,32 @@ compose_version() {
   docker compose version --short 2>/dev/null
 }
 
+# True when the first argument is a version greater than or equal to the second. Compares the
+# numeric major/minor/patch components in bash rather than with `sort -V`, which is a GNU/BSD
+# extension and absent on busybox hosts — where a missing comparison would reject a valid version.
+version_at_least() {
+  local have="${1#v}" want="$2" i have_part want_part
+  # Trailing qualifiers such as -desktop.1 or -rc.2 are not part of the precedence we care about.
+  have="${have%%-*}"
+  local -a have_parts want_parts
+  IFS=. read -r -a have_parts <<< "$have"
+  IFS=. read -r -a want_parts <<< "$want"
+  for i in 0 1 2; do
+    have_part="${have_parts[i]:-0}"
+    want_part="${want_parts[i]:-0}"
+    # Any non-numeric component makes the comparison meaningless; treat the version as unusable.
+    [[ "$have_part" =~ ^[0-9]+$ ]] || return 1
+    (( 10#$have_part > 10#$want_part )) && return 0
+    (( 10#$have_part < 10#$want_part )) && return 1
+  done
+  return 0
+}
+
 compose_supports_wait() {
   local version
   version=$(compose_version)
   [[ -z "$version" ]] && return 1
-  # Sort the detected and minimum versions together; support is present unless the detected one
-  # sorts first, which keeps this correct across multi-digit components (e.g. 2.9 vs 2.17).
-  [[ "$(printf '%s\n%s\n' "$COMPOSE_MIN_VERSION" "${version#v}" | sort -V | head -1)" == "$COMPOSE_MIN_VERSION" ]]
+  version_at_least "$version" "$COMPOSE_MIN_VERSION"
 }
 
 # The compose service names to wait on, derived from the profile's container list so the two can't

--- a/opik.sh
+++ b/opik.sh
@@ -405,13 +405,20 @@ start_missing_containers() {
   cmd=$(get_docker_compose_cmd)
 
   local startup_timeout="${OPIK_STARTUP_TIMEOUT:-300}"
-  # Bounded on both ends: an out-of-range value is rejected by compose only once it parses the flag,
-  # which would be after the stack had already been started below. The digit-count check keeps an
-  # absurdly long value from overflowing the arithmetic comparison that follows it.
-  if ! [[ "$startup_timeout" =~ ^[0-9]{1,7}$ ]] || (( startup_timeout > STARTUP_TIMEOUT_MAX )); then
-    echo "❌ OPIK_STARTUP_TIMEOUT must be an integer between 0 and ${STARTUP_TIMEOUT_MAX} seconds, got '$startup_timeout'"
+  # Range-checked here because compose only rejects an out-of-range --wait-timeout once it parses
+  # the flag, which is after the stack would already have been started below. The digit-count bound
+  # keeps an absurdly long value out of the arithmetic comparison, and `10#` forces base 10 so a
+  # zero-padded value is neither read as octal (0100000 -> 32768, under the bound) nor fatal to the
+  # arithmetic (08 -> "value too great for base"). Zero is excluded: compose reads --wait-timeout 0
+  # as "no timeout", which would silently remove the deadline instead of setting one.
+  if ! [[ "$startup_timeout" =~ ^[0-9]{1,7}$ ]] \
+    || (( 10#$startup_timeout < 1 )) \
+    || (( 10#$startup_timeout > STARTUP_TIMEOUT_MAX )); then
+    echo "❌ OPIK_STARTUP_TIMEOUT must be an integer between 1 and ${STARTUP_TIMEOUT_MAX} seconds, got '$startup_timeout'"
     return 1
   fi
+  # Normalized so the value handed to compose matches the one that was validated.
+  startup_timeout=$(( 10#$startup_timeout ))
 
   if ! compose_supports_wait; then
     echo "❌ Docker Compose $(compose_version) is too old: starting Opik requires v${COMPOSE_MIN_VERSION}+"

--- a/opik.sh
+++ b/opik.sh
@@ -53,6 +53,33 @@ set_containers_for_profile() {
 
 }
 
+# `compose up --wait --wait-timeout` is only available from this version on.
+COMPOSE_MIN_VERSION="2.17.0"
+
+compose_version() {
+  docker compose version --short 2>/dev/null
+}
+
+compose_supports_wait() {
+  local version
+  version=$(compose_version)
+  [[ -z "$version" ]] && return 1
+  # Sort the detected and minimum versions together; support is present unless the detected one
+  # sorts first, which keeps this correct across multi-digit components (e.g. 2.9 vs 2.17).
+  [[ "$(printf '%s\n%s\n' "$COMPOSE_MIN_VERSION" "${version#v}" | sort -V | head -1)" == "$COMPOSE_MIN_VERSION" ]]
+}
+
+# The compose service names to wait on, derived from the profile's container list so the two can't
+# drift. Run-once jobs are absent from that list by design and so are never waited on.
+wait_services() {
+  local container
+  for container in "${CONTAINERS[@]}"; do
+    # "<project>-<service>-1" -> "<service>"
+    container="${container#"${COMPOSE_PROJECT_NAME}"-}"
+    echo "${container%-1}"
+  done
+}
+
 get_verify_cmd() {
   local cmd="./opik.sh"
   if [[ "$INFRA" == "true" ]]; then
@@ -239,11 +266,15 @@ create_opik_config_if_missing() {
   
   local ui_url=$(get_ui_url)
   
-  cat > "$config_file" << EOF
+  if ! cat > "$config_file" << EOF
 [opik]
 url_override = ${ui_url}/api/
 workspace = default
 EOF
+  then
+    echo "❌ Failed to write $config_file"
+    return 1
+  fi
   debugLog "[DEBUG] .opik.config file created successfully with URL: ${ui_url}/api/"
 }
 
@@ -370,11 +401,34 @@ start_missing_containers() {
   cmd=$(get_docker_compose_cmd)
 
   local startup_timeout="${OPIK_STARTUP_TIMEOUT:-300}"
+  if ! [[ "$startup_timeout" =~ ^[0-9]+$ ]]; then
+    echo "❌ OPIK_STARTUP_TIMEOUT must be a non-negative integer number of seconds, got '$startup_timeout'"
+    return 1
+  fi
+
+  if ! compose_supports_wait; then
+    echo "❌ Docker Compose $(compose_version) is too old: starting Opik requires v${COMPOSE_MIN_VERSION}+"
+    echo "   (the startup readiness check relies on 'compose up --wait --wait-timeout')."
+    echo "   Please upgrade Docker Compose and retry."
+    return 1
+  fi
+
+  # Start everything in the profile, including the run-once jobs (mc, demo-data-generator) that
+  # nothing declares a dependency on — passing a service list to the waiting command below would
+  # otherwise silently skip them.
+  if ! $cmd up -d ${BUILD_MODE:+--build}; then
+    echo "❌ Failed to start containers"
+    $cmd ps
+    return 1
+  fi
+
   echo "⏳ Waiting for all containers to be running and healthy (timeout: ${startup_timeout}s)..."
 
-  # --wait waits on every service concurrently and honours each service's own healthcheck plus the
-  # depends_on graph, so a slow service can't be starved by the time spent on the ones before it.
-  if ! $cmd up -d ${BUILD_MODE:+--build} --wait --wait-timeout "$startup_timeout"; then
+  # Wait only on the long-running services for this profile. --wait waits on them concurrently and
+  # honours each healthcheck plus the depends_on graph, so a slow service can't be starved by the
+  # time spent on the ones before it. The run-once jobs are deliberately excluded here: --wait
+  # treats any service exit as a failure, even a successful exit 0.
+  if ! $cmd up -d --wait --wait-timeout "$startup_timeout" $(wait_services); then
     echo "❌ Containers did not become healthy within ${startup_timeout}s"
     echo "   Set OPIK_STARTUP_TIMEOUT to allow more time, e.g. OPIK_STARTUP_TIMEOUT=600 $(get_start_cmd)"
     echo ""

--- a/opik.sh
+++ b/opik.sh
@@ -56,6 +56,10 @@ set_containers_for_profile() {
 # `compose up --wait --wait-timeout` is only available from this version on.
 COMPOSE_MIN_VERSION="2.17.0"
 
+# Upper bound for OPIK_STARTUP_TIMEOUT (24h). Compose parses --wait-timeout as an int64 and rejects
+# anything larger, so the value is range-checked here rather than by a failed flag parse later.
+STARTUP_TIMEOUT_MAX=86400
+
 compose_version() {
   docker compose version --short 2>/dev/null
 }
@@ -401,8 +405,11 @@ start_missing_containers() {
   cmd=$(get_docker_compose_cmd)
 
   local startup_timeout="${OPIK_STARTUP_TIMEOUT:-300}"
-  if ! [[ "$startup_timeout" =~ ^[0-9]+$ ]]; then
-    echo "❌ OPIK_STARTUP_TIMEOUT must be a non-negative integer number of seconds, got '$startup_timeout'"
+  # Bounded on both ends: an out-of-range value is rejected by compose only once it parses the flag,
+  # which would be after the stack had already been started below. The digit-count check keeps an
+  # absurdly long value from overflowing the arithmetic comparison that follows it.
+  if ! [[ "$startup_timeout" =~ ^[0-9]{1,7}$ ]] || (( startup_timeout > STARTUP_TIMEOUT_MAX )); then
+    echo "❌ OPIK_STARTUP_TIMEOUT must be an integer between 0 and ${STARTUP_TIMEOUT_MAX} seconds, got '$startup_timeout'"
     return 1
   fi
 
@@ -413,23 +420,24 @@ start_missing_containers() {
     return 1
   fi
 
-  # Start everything in the profile, including the run-once jobs (mc, demo-data-generator) that
-  # nothing declares a dependency on — passing a service list to the waiting command below would
-  # otherwise silently skip them.
-  if ! $cmd up -d ${BUILD_MODE:+--build}; then
-    echo "❌ Failed to start containers"
-    $cmd ps
-    return 1
+  echo "⏳ Starting containers and waiting for them to be healthy (timeout: ${startup_timeout}s)..."
+
+  local start_failed=false
+
+  # Start and wait in one call, scoped to the long-running services: --wait treats any service exit
+  # as a failure, even a successful exit 0, so the run-once jobs must be left out of it. Carrying
+  # the deadline here bounds pulls, builds and container creation as well as readiness, and --wait
+  # is concurrent across services, so a slow one is never starved by the services ahead of it.
+  if ! $cmd up -d ${BUILD_MODE:+--build} --wait --wait-timeout "$startup_timeout" $(wait_services); then
+    start_failed=true
+  # The scoped call above starts only those services and their dependencies, so the run-once jobs
+  # (mc, demo-data-generator) that nothing depends on need a second, unwaited call to launch.
+  elif ! $cmd up -d ${BUILD_MODE:+--build}; then
+    start_failed=true
   fi
 
-  echo "⏳ Waiting for all containers to be running and healthy (timeout: ${startup_timeout}s)..."
-
-  # Wait only on the long-running services for this profile. --wait waits on them concurrently and
-  # honours each healthcheck plus the depends_on graph, so a slow service can't be starved by the
-  # time spent on the ones before it. The run-once jobs are deliberately excluded here: --wait
-  # treats any service exit as a failure, even a successful exit 0.
-  if ! $cmd up -d --wait --wait-timeout "$startup_timeout" $(wait_services); then
-    echo "❌ Containers did not become healthy within ${startup_timeout}s"
+  if [[ "$start_failed" == "true" ]]; then
+    echo "❌ Containers did not start and become healthy within ${startup_timeout}s"
     echo "   Set OPIK_STARTUP_TIMEOUT to allow more time, e.g. OPIK_STARTUP_TIMEOUT=600 $(get_start_cmd)"
     echo ""
     echo "📋 Container status:"


### PR DESCRIPTION
## Details

`opik.sh` waited for containers in a per-container loop that gave each container its own 60-iteration budget, walked in list order with infrastructure first and the backend last. Because all services actually start in parallel, infrastructure burned 30-40s of wall clock before the loop even reached the backend, which then had to finish Liquibase migrations against both MySQL and ClickHouse inside whatever remained. A passing CI run measured 45.6s of the 60s budget — roughly 14s of margin — so ordinary runner variance tipped it over several times a day with `backend is still not healthy after 60s`.

The loop was also stricter than Docker itself: the backend healthcheck allows ~10 minutes, and CI's own `check_backend.sh` retries the ready endpoint for 60s in the very next step, but `opik.sh` exited 1 before either could apply.

- Start the profile in full, then wait on only its long-running services with `compose up --wait --wait-timeout`, under a single 300s deadline overridable via `OPIK_STARTUP_TIMEOUT`. Waiting concurrently removes the starvation problem on its own; the higher ceiling gives ~6x headroom over the observed 46s instead of 1.3x.
- The wait set is derived from the existing per-profile `CONTAINERS` list so the two cannot drift, and run-once jobs (`mc`, `demo-data-generator`) are excluded automatically — `--wait` treats any service exit as a failure, even a successful exit 0. Starting and waiting are separate calls on purpose: passing a service list to a single `up --wait` starts only those services plus their dependencies, which silently skips `mc` and leaves the attachments bucket uncreated.
- On timeout, dump `compose ps` and recent `compose logs` so a failure reports *why* rather than only that it happened.
- Require Compose v2.24.4+ with a clear prerequisite error, checked before any container starts. Two features set that floor: `--wait-timeout` (v2.17.0) and the `!override` tag used by the port-mapping and local-development overlays, which arrived with compose-go/v2 in v2.24.x. `opik.sh` is the public self-hosted install path, and without the gate an older Compose surfaces a flag-parse or overlay-parse error as a health timeout. The comparison is pure bash rather than `sort -V`, which is a GNU/BSD extension that would silently reject a valid version on a busybox host.
- Validate `OPIK_STARTUP_TIMEOUT` before invoking compose, so a bad value fails with an input error rather than a bogus timeout: an integer from 1 to 86400, parsed with `10#` so a zero-padded value is neither read as octal nor fatal to the arithmetic. Zero is rejected because compose reads `--wait-timeout 0` as "no timeout", which would silently remove the deadline. The deadline rides on the call that starts *and* waits, so pulls, builds and container creation are bounded too.
- Propagate the `$HOME/.opik.config` write status instead of masking it with the trailing `debugLog`, and make `debugLog` status-neutral so a no-op debug line cannot become a caller's return value.

`scripts/dev-runner.sh` delegates to `opik.sh` and gates on its exit code, so local development gets the same fix. No compose-file changes: an earlier revision added an `mc` completion dependency, which review correctly flagged as letting one transient MinIO failure block the backend permanently; scoping the wait removed the need for it and it was reverted.

**Out of scope:** `opik.ps1` carries the identical 60s per-container loop, so Windows users keep the flake. Porting a second launcher in a different language roughly doubles the review surface of a fix whose purpose is to stop a daily CI failure, and the Bash version needed several non-obvious corrections (the Compose version gate, the run-once exclusion, base-10 timeout parsing) that would each have to be re-derived and verified on a Windows host. Tracked separately; the divergence is now documented so it is at least explicit for users.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-8304

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation (investigation, change, local verification, review response)
- Human verification: code review + local runs of the affected `opik.sh` paths

## Testing

Verified locally on macOS with Docker Compose v2.36.0, running the real stack from this branch:

- `./opik.sh --infra` — exit 0; `mc` runs and creates the `public` bucket (`Bucket created successfully s3/public`), confirming run-once jobs are still started even though they are excluded from the wait
- `./opik.sh --backend` — exit 0; earlier full cold run took 46s including backend migrations, matching the 45.6s figure measured in CI and now well inside the 300s deadline
- `./opik.sh --backend --verify` — all 7 containers reported running and healthy
- Backend readiness confirmed directly: `curl -sf "http://localhost:8080/health-check?name=all&type=ready"` returned HTTP 200 (the same check CI's `check_backend.sh` performs)
- Run-once regression reproduced and fixed: before the fix, a `local-be-fe` profile wait returned 1 with all five long-running services `Healthy` and `demo-data-generator exited (0)`; a scoped wait on the same profile exits 0
- Re-ran `./opik.sh --backend` on an already-healthy stack — exit 0, idempotent
- `./opik.sh --infra --debug` — exit 0 with verbose output intact, covering the `debugLog` change
- `./opik.sh --stop` — clean teardown
- Invalid timeouts: `OPIK_STARTUP_TIMEOUT=abc` and `=-1` both exit 1 with the input error, without invoking compose
- Induced timeout from clean volumes: `OPIK_STARTUP_TIMEOUT=1 ./opik.sh --infra` exits 1 and emits the timeout message, `compose ps`, and `compose logs --tail=200`
- Compose version comparison exercised across 16 cases: the multi-digit trap in both directions (2.9.0 < 2.17.0, 2.17.0 > 2.9.0), the 2.24.3 / 2.24.4 / 2.24.5 boundary, a `v` prefix, a `-desktop.1` suffix, a major bump, a two-component version, a non-numeric component, and an empty string
- `bash -n opik.sh` clean; `docker compose config` validated for every profile as `opik.sh` actually invokes it (infra, backend, guardrails, guardrails-cpu, and local-be / local-be-fe with their overlay files); `pre-commit` run on the changed file

Not run: `--port-mapping` combinations were not exercised end-to-end because an unrelated local process held port 3333 on the test machine. The health-wait logic under test is identical with and without that flag, and CI exercises the `--backend --port-mapping` path directly. The `--guardrails` profiles were config-validated but not started (large images).

Note on CI coverage: no E2E workflow path-filters on `opik.sh` or `deployment/**`, so none ran automatically on this PR. `Installation Tests` is the suite that actually exercises `./opik.sh` and it is cron-only. Widening those filters is worth doing separately.

## Documentation

`OPIK_STARTUP_TIMEOUT` is documented in both places that describe the installation script, since it was otherwise only discoverable by hitting the failure:

- `deployment/docker-compose/README.md` — a new "Environment variables" subsection under the `opik.sh` options table
- `apps/opik-documentation/.../self-host/local_deployment.mdx` — a "Startup timeout" subsection after the options table

Both state the 300s default, the accepted 1-86400 range, and the same worked example, and both note that `opik.ps1` does not honour the variable (it keeps its own fixed per-container wait — see Out of scope). Both also clarify that the deadline covers the services with a health check, not the run-once setup jobs, so a failed `mc` does not fail the startup.

The **Compose v2.24.4 prerequisite** is documented in the prerequisites list of both guides — it is an install requirement rather than a tuning knob, and the check exits before any container starts — with the verification command (`docker compose version --short`) and a note that a distro-packaged `docker-compose` v1 binary is the usual culprit on Linux.

Documented values were cross-checked against the script (`COMPOSE_MIN_VERSION`, the validation bounds) and the documented example verified to behave as written.


