### PR TITLE
[OPIK-8280] [QA] fix: a brace in a taxonomy note stopped reconcile seeing the entry

### DIFF
--- a/tests_end_to_end/coverage/reconcile.py
+++ b/tests_end_to_end/coverage/reconcile.py
@@ -71,7 +71,12 @@ TIER_ORDER = ("t1-smoke", "t2-cuj", "t3-nightly")
 
 # `  key:   { covered: true,  tier: t1-smoke }` — captures indent, key, and the
 # inside of the braces so we can rewrite values without touching alignment.
-FLOW_ENTRY = re.compile(r"^(?P<indent>\s+)(?P<key>[\w.-]+):(?P<pad>\s*)\{(?P<body>[^}]*)\}\s*$")
+# Greedy body, anchored on the LAST closing brace: a `note:` legitimately
+# contains one, e.g. "PATCH /traces/{id} merges ...". With `[^}]*` the match
+# stopped at that inner brace and failed the `\}\s*$` anchor, so the whole
+# entry was skipped -- the capability never entered `seen`, was reported as
+# "tagged in a spec but absent from the taxonomy", and the nightly exited 1.
+FLOW_ENTRY = re.compile(r"^(?P<indent>\s+)(?P<key>[\w.-]+):(?P<pad>\s*)\{(?P<body>.*)\}\s*$")
 SECTION = re.compile(r"^(?P<indent>\s+)(?P<name>[\w.-]+):\s*$")
 
 


### PR DESCRIPTION
## Details

The nightly `qa_coverage_reconcile` job has failed **every run since ~2026-08-27**
— 27 consecutive failures, scheduled and on push — on two warnings:

```
@cap:dashboards.configure-widget is tagged in a spec but absent from the taxonomy
@cap:traces.update-trace-api    is tagged in a spec but absent from the taxonomy
```

**Both capabilities are present**, correctly, under exactly those areas
(`taxonomy.yaml:392` and `:285`). The parse was wrong, not the taxonomy.

### Root cause

`FLOW_ENTRY` matched a flow mapping's body with `[^}]*`, so it stopped at the
first closing brace. Both entries' notes cite an API path:

```yaml
update-trace-api: { covered: true, tier: t2-cuj, note: "PATCH /traces/{id} merges into …" }
configure-widget: { covered: true, tier: t2-cuj, note: "… (POST /projects/{id}/metrics …)" }
```

That literal `}` ended the body early, leaving the trailing `\}\s*$` anchor
unmatched — so the line matched **nothing**, the capability never entered `seen`,
and the absent-from-taxonomy check fired on an entry sitting in the file.

### The worse consequence

The failing job is the visible half. Any capability whose note contains a brace
was **invisible to reconcile entirely**, so its `covered:`/`tier:` could never be
corrected — the drift this job exists to catch was silently unfixable for those
entries, for two weeks.

## Change checklist

- [x] Root cause traced to the regex, not assumed from the message
- [x] Confirmed both capabilities are correctly defined under the right areas
- [x] Confirmed the failures predate any recent change to this file
- [x] Greedy body verified not to mangle any entry — applying it writes a byte-identical file
- [x] Verified reconcile can now *correct* an entry whose note contains a brace
- [x] `tag_lint` green (72 specs, 0 problems); taxonomy still valid YAML
- [ ] First green nightly observed (needs merge)

## Issues

OPIK-8280

## Testing

Before — 27 failures in a row, most recently run `34304350308`:

```
warning: @cap:dashboards.configure-widget is tagged in a spec but absent…
warning: @cap:traces.update-trace-api is tagged in a spec but absent…
##[error]Process completed with exit code 1
```

After:

```
$ reconcile.py --check --summary
taxonomy already agrees with the spec tags — nothing to do.     exit=0

$ reconcile.py            # apply
reconcile: no changes
$ diff before.yaml taxonomy.yaml
BYTE-IDENTICAL — greedy match did not mangle any entry

$ tag_lint.py
tag-lint: 72 specs checked, 1 exempt, 0 problem(s)
```

And the capability that mattered — flipping `update-trace-api` to
`covered: false`, which the old regex could never see:

```
1 derived field(s) drifted from the tags:
  traces.update-trace-api: covered False -> True
reconcile: updated taxonomy.yaml (1 field(s))
→ corrected back byte-identical
```

That last case is the one the old regex could not do at all, so it is the real
proof rather than the absence of a warning.

## Documentation

The regex now carries a comment naming the failure: a `note:` legitimately
contains a brace, `[^}]*` stops there, and the entry is skipped. Worth stating
inline because the symptom ("absent from the taxonomy") points at the taxonomy
rather than at the parser, which is what made this take two weeks to look at.
