### PR TITLE
[OPIK-8200] [OPIK-7931] [FE] fix: keep playground sampling params across a model round trip

### DIFF
--- a/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
+++ b/apps/opik-frontend/src/api/playground/createLogPlaygroundProcessor.ts
@@ -29,6 +29,7 @@ import {
 import { ProviderMessageType } from "@/types/llm";
 import { parseCompletionOutput } from "@/lib/playground";
 import { PLAYGROUND_PROJECT_NAME } from "@/constants/shared";
+import { sanitizeConfigForRequest } from "@/lib/modelUtils";
 
 export interface LogQueueParams extends RunStreamingReturn {
   promptId: string;
@@ -219,13 +220,29 @@ const getSpanFromRun = (
       created_from: spanProvider,
       usage: run.usage,
       model: spanModel,
-      parameters: run.configs,
+      parameters: getLoggedParameters(run),
       ...(run.provider === PROVIDER_TYPE.OPIK_FREE && {
         opik_free_model: true,
       }),
     },
   };
 };
+
+/**
+ * What the request actually carried, for the trace to record.
+ *
+ * The stored config deliberately keeps a parameter the selected model rejects so that switching
+ * back to one that accepts it restores the value, and sanitizeConfigForRequest is what decides
+ * which of those reach the provider. Logging the raw config instead would report a temperature the
+ * call never ran at.
+ */
+export const getLoggedParameters = (
+  run: Pick<LogQueueParams, "model" | "configs">,
+): Record<string, unknown> =>
+  sanitizeConfigForRequest(
+    run.model,
+    run.configs as unknown as Record<string, unknown>,
+  );
 
 const getExperimentFromRun = (run: LogQueueParams): LogExperiment => {
   // Use the actual model from the response headers if available
@@ -234,7 +251,7 @@ const getExperimentFromRun = (run: LogQueueParams): LogExperiment => {
   const experimentMetadata: Record<string, unknown> = {
     model: experimentModel,
     messages: JSON.stringify(run.providerMessages),
-    model_config: run.configs,
+    model_config: getLoggedParameters(run),
   };
 
   // Add selected_rule_ids to experiment metadata if provided

--- a/apps/opik-frontend/src/api/playground/loggedParameters.test.ts
+++ b/apps/opik-frontend/src/api/playground/loggedParameters.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { getLoggedParameters } from "./createLogPlaygroundProcessor";
+import { LLMPromptConfigsType, PROVIDER_MODEL_TYPE } from "@/types/providers";
+
+const configs = (c: Record<string, unknown>) =>
+  c as unknown as LLMPromptConfigsType;
+
+// The config deliberately keeps a parameter the selected model rejects, so that switching back to
+// one that accepts it restores the value. The trace must still record what was sent, or it reports
+// a temperature the call never ran at — which is the one thing a trace is for.
+describe("getLoggedParameters", () => {
+  it("omits the sampling params an OpenAI reasoning model never received", () => {
+    const parameters = getLoggedParameters({
+      model: PROVIDER_MODEL_TYPE.GPT_5_5,
+      configs: configs({
+        temperature: 0.3,
+        topP: 0.85,
+        maxCompletionTokens: 4000,
+      }),
+    });
+
+    expect(parameters.temperature).toBeUndefined();
+    expect(parameters.topP).toBeUndefined();
+    expect(parameters.maxCompletionTokens).toBe(4000);
+  });
+
+  it("omits the sampling params an Anthropic model without them never received", () => {
+    const parameters = getLoggedParameters({
+      model: PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5,
+      configs: configs({ temperature: 0.3, maxCompletionTokens: 4000 }),
+    });
+
+    expect(parameters.temperature).toBeUndefined();
+  });
+
+  it("records what a model that accepts them was sent", () => {
+    const parameters = getLoggedParameters({
+      model: PROVIDER_MODEL_TYPE.GPT_4O,
+      configs: configs({ temperature: 0.3, topP: 0.85 }),
+    });
+
+    expect(parameters.temperature).toBe(0.3);
+    expect(parameters.topP).toBe(0.85);
+  });
+});

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -252,7 +252,10 @@ describe("getOpenAIReasoningEffortOptions", () => {
 });
 
 describe("updateProviderConfig — OpenAI", () => {
-  it("bumps temperature to 1 when switching into a reasoning model with temp < 1", () => {
+  it("keeps temperature when switching into a reasoning model, which does not take one", () => {
+    // o3 accepts only its own default temperature, so there is nothing to legalise here: the panel
+    // offers no slider and the request omits the field. Rewriting the value would lose the user's
+    // choice for whenever they pick a model that does take one.
     const config: LLMOpenAIConfigsType = {
       temperature: 0,
       maxCompletionTokens: 4000,
@@ -264,7 +267,13 @@ describe("updateProviderConfig — OpenAI", () => {
       model: PROVIDER_MODEL_TYPE.GPT_O3,
       provider: OPEN_AI,
     });
-    expect(result?.temperature).toBe(1);
+    expect(result?.temperature).toBe(0);
+    expect(
+      sanitizeConfigForRequest(
+        PROVIDER_MODEL_TYPE.GPT_O3,
+        result as unknown as Record<string, unknown>,
+      ).temperature,
+    ).toBeUndefined();
   });
 
   it("leaves the config untouched on a reasoning model that already has temperature 1", () => {
@@ -386,10 +395,9 @@ describe("updateProviderConfig — OpenAI", () => {
     expect(result).toBe(config);
   });
 
-  it("retains topP when switching into a reasoning OpenAI model, and pins temperature", () => {
-    // topP is kept so gpt-4o -> gpt-5.5 -> gpt-4o gives the slider back with the user's own value;
-    // the request builder is what keeps top_p off a gpt-5.5 call. Temperature is still coerced
-    // here, because nothing downstream makes a sub-1 value legal for a reasoning model.
+  it("retains both sampling params when switching into a reasoning OpenAI model", () => {
+    // Both are kept so gpt-4o -> gpt-5.5 -> gpt-4o gives the sliders back with the user's own
+    // values; the request builder is what keeps them off a gpt-5.5 call.
     const config: LLMOpenAIConfigsType = {
       temperature: 0.7,
       maxCompletionTokens: 4000,
@@ -401,14 +409,14 @@ describe("updateProviderConfig — OpenAI", () => {
       model: PROVIDER_MODEL_TYPE.GPT_5_5,
       provider: OPEN_AI,
     });
-    expect(result?.topP).toBe(0.9);
-    expect(result?.temperature).toBe(1.0);
-    expect(
-      sanitizeConfigForRequest(
-        PROVIDER_MODEL_TYPE.GPT_5_5,
-        result as unknown as Record<string, unknown>,
-      ).topP,
-    ).toBeUndefined();
+    expect(result).toBe(config);
+
+    const request = sanitizeConfigForRequest(
+      PROVIDER_MODEL_TYPE.GPT_5_5,
+      result as unknown as Record<string, unknown>,
+    );
+    expect(request.topP).toBeUndefined();
+    expect(request.temperature).toBeUndefined();
   });
 
   it("keeps topP when switching to a non-reasoning OpenAI model", () => {
@@ -545,14 +553,14 @@ describe("sanitizeConfigForRequest", () => {
     expect(result.reasoningEffort).toBe("high");
   });
 
-  it("strips topP for OpenAI reasoning models", () => {
-    // gpt-5.5 is a reasoning model; OpenAI returns 400 if top_p is in the request.
+  it("strips both sampling params for OpenAI reasoning models", () => {
+    // gpt-5.5 returns 400 if top_p is in the request, and accepts only its own default temperature.
     const result = sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5_5, {
-      temperature: 1,
+      temperature: 0.3,
       topP: 0.9,
     });
     expect(result.topP).toBeUndefined();
-    expect(result.temperature).toBe(1);
+    expect(result.temperature).toBeUndefined();
   });
 
   it("keeps topP for non-reasoning OpenAI models", () => {
@@ -1109,6 +1117,27 @@ describe("sampling params survive a model round trip", () => {
     expect(back?.temperature).toBe(0.7);
   });
 
+  it("keeps temperature across gpt-4o-mini -> gpt-5.5 -> gpt-4o-mini", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 0.3,
+      maxCompletionTokens: 4000,
+      topP: 1,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+
+    const onReasoning = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_5_5,
+      provider: OPEN_AI,
+    });
+    const back = updateProviderConfig(onReasoning, {
+      model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      provider: OPEN_AI,
+    });
+
+    expect(back?.temperature).toBe(0.3);
+  });
+
   it("still omits the retained value from the wire while the model rejects it", () => {
     expect(
       sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5, {
@@ -1117,12 +1146,12 @@ describe("sampling params survive a model round trip", () => {
       }).temperature,
     ).toBeUndefined();
 
-    expect(
-      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5_5, {
-        temperature: 1,
-        topP: 0.9,
-      }).topP,
-    ).toBeUndefined();
+    const onReasoningModel = sanitizeConfigForRequest(
+      PROVIDER_MODEL_TYPE.GPT_5_5,
+      { temperature: 0.3, topP: 0.9 },
+    );
+    expect(onReasoningModel.topP).toBeUndefined();
+    expect(onReasoningModel.temperature).toBeUndefined();
   });
 });
 
@@ -1169,13 +1198,15 @@ describe("resolveSamplingParams", () => {
     ).toBeUndefined();
   });
 
-  it("omits topP for OpenAI reasoning models", () => {
+  it("omits both for OpenAI reasoning models, which take neither", () => {
+    // top_p is rejected outright and temperature accepts only the provider's own default, so
+    // neither is tunable and the panel offers no slider for either.
     expect(
       resolveSamplingParams(PROVIDER_MODEL_TYPE.GPT_5_5, {
-        temperature: 1,
+        temperature: 0.3,
         topP: 0.9,
-      }).topP,
-    ).toBeUndefined();
+      }),
+    ).toEqual({});
   });
 
   it("passes other providers' values through untouched", () => {

--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -4,6 +4,7 @@ import {
   getRoutableProviderModelValue,
   getOpenAIReasoningEffortOptions,
   getThinkingLevelOptions,
+  resolveSamplingParams,
   sanitizeConfigForRequest,
   supportsGeminiThinkingLevel,
   supportsOpenAIReasoningEffort,
@@ -19,6 +20,8 @@ import {
   PROVIDER_MODEL_TYPE,
   PROVIDER_TYPE,
 } from "@/types/providers";
+import { ANTHROPIC_MODEL_CAPABILITIES } from "@/constants/llm";
+import { getProviderFromModel } from "@/lib/provider";
 
 const ANTHROPIC = PROVIDER_TYPE.ANTHROPIC as COMPOSED_PROVIDER_TYPE;
 const OPEN_AI = PROVIDER_TYPE.OPEN_AI as COMPOSED_PROVIDER_TYPE;
@@ -93,7 +96,9 @@ describe("supportsSamplingParams", () => {
 });
 
 describe("updateProviderConfig — Anthropic", () => {
-  it("strips temperature and topP when switching into Opus 4.7", () => {
+  it("retains temperature and topP when switching into Opus 4.7, which rejects them", () => {
+    // Kept in the config, omitted from the request: Opus 4.7 hides both sliders, and dropping the
+    // values here is what used to lose them for good once the user picked a model that takes them.
     const config: LLMAnthropicConfigsType = {
       temperature: 0.5,
       topP: 0.9,
@@ -103,9 +108,16 @@ describe("updateProviderConfig — Anthropic", () => {
       model: PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_7,
       provider: ANTHROPIC,
     });
-    expect(result?.temperature).toBeUndefined();
-    expect(result?.topP).toBeUndefined();
+    expect(result?.temperature).toBe(0.5);
+    expect(result?.topP).toBe(0.9);
     expect(result?.maxCompletionTokens).toBe(4000);
+
+    const request = sanitizeConfigForRequest(
+      PROVIDER_MODEL_TYPE.CLAUDE_OPUS_4_7,
+      result as unknown as Record<string, unknown>,
+    );
+    expect(request.temperature).toBeUndefined();
+    expect(request.topP).toBeUndefined();
   });
 
   it("keeps temperature when switching into Opus 4.6", () => {
@@ -255,10 +267,10 @@ describe("updateProviderConfig — OpenAI", () => {
     expect(result?.temperature).toBe(1);
   });
 
-  it("does not change temperature when already 1, but still strips topP on a reasoning model", () => {
-    // topP=1 is the slider default and "harmless" in spirit, but OpenAI rejects any topP value
-    // on reasoning models (the constraint is the parameter's presence, not its value). The
-    // reconciler strips it; that's a real change so reference equality no longer holds.
+  it("leaves the config untouched on a reasoning model that already has temperature 1", () => {
+    // OpenAI rejects any topP value on reasoning models — the constraint is the parameter's
+    // presence, not its value — but that is the request builder's job to enforce, so nothing here
+    // needs changing and the reference survives.
     const config: LLMOpenAIConfigsType = {
       temperature: 1,
       maxCompletionTokens: 4000,
@@ -270,8 +282,13 @@ describe("updateProviderConfig — OpenAI", () => {
       model: PROVIDER_MODEL_TYPE.GPT_O3,
       provider: OPEN_AI,
     });
-    expect(result?.temperature).toBe(1);
-    expect(result?.topP).toBeUndefined();
+    expect(result).toBe(config);
+    expect(
+      sanitizeConfigForRequest(
+        PROVIDER_MODEL_TYPE.GPT_O3,
+        result as unknown as Record<string, unknown>,
+      ).topP,
+    ).toBeUndefined();
   });
 
   it("coerces invalid reasoningEffort to high when switching into a model that doesn't support it", () => {
@@ -369,9 +386,10 @@ describe("updateProviderConfig — OpenAI", () => {
     expect(result).toBe(config);
   });
 
-  it("drops topP when switching into a reasoning OpenAI model", () => {
-    // OpenAI rejects top_p with 400 on reasoning models. The reconciler must clear stale
-    // values when the user switches from gpt-4o (where top_p is valid) to gpt-5.5.
+  it("retains topP when switching into a reasoning OpenAI model, and pins temperature", () => {
+    // topP is kept so gpt-4o -> gpt-5.5 -> gpt-4o gives the slider back with the user's own value;
+    // the request builder is what keeps top_p off a gpt-5.5 call. Temperature is still coerced
+    // here, because nothing downstream makes a sub-1 value legal for a reasoning model.
     const config: LLMOpenAIConfigsType = {
       temperature: 0.7,
       maxCompletionTokens: 4000,
@@ -383,9 +401,14 @@ describe("updateProviderConfig — OpenAI", () => {
       model: PROVIDER_MODEL_TYPE.GPT_5_5,
       provider: OPEN_AI,
     });
-    expect(result?.topP).toBeUndefined();
-    // Temperature should also be coerced to 1.0 in the same call.
+    expect(result?.topP).toBe(0.9);
     expect(result?.temperature).toBe(1.0);
+    expect(
+      sanitizeConfigForRequest(
+        PROVIDER_MODEL_TYPE.GPT_5_5,
+        result as unknown as Record<string, unknown>,
+      ).topP,
+    ).toBeUndefined();
   });
 
   it("keeps topP when switching to a non-reasoning OpenAI model", () => {
@@ -1043,5 +1066,177 @@ describe("updateProviderConfig — Gemini thinking level", () => {
     });
 
     expect(next).toBe(config);
+  });
+});
+
+describe("sampling params survive a model round trip", () => {
+  it("keeps topP across gpt-4o-mini -> gpt-5.5 -> gpt-4o-mini", () => {
+    const config: LLMOpenAIConfigsType = {
+      temperature: 0,
+      maxCompletionTokens: 4000,
+      topP: 0.9,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+
+    const onReasoning = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.GPT_5_5,
+      provider: OPEN_AI,
+    });
+    const back = updateProviderConfig(onReasoning, {
+      model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      provider: OPEN_AI,
+    });
+
+    expect(back?.topP).toBe(0.9);
+  });
+
+  it("keeps temperature across sonnet-4.6 -> sonnet-5 -> sonnet-4.6", () => {
+    const config: LLMAnthropicConfigsType = {
+      temperature: 0.7,
+      maxCompletionTokens: 4000,
+    };
+
+    const onSonnet5 = updateProviderConfig(config, {
+      model: PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5,
+      provider: ANTHROPIC,
+    });
+    const back = updateProviderConfig(onSonnet5, {
+      model: PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6,
+      provider: ANTHROPIC,
+    });
+
+    expect(back?.temperature).toBe(0.7);
+  });
+
+  it("still omits the retained value from the wire while the model rejects it", () => {
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5, {
+        temperature: 0.7,
+        maxCompletionTokens: 4000,
+      }).temperature,
+    ).toBeUndefined();
+
+    expect(
+      sanitizeConfigForRequest(PROVIDER_MODEL_TYPE.GPT_5_5, {
+        temperature: 1,
+        topP: 0.9,
+      }).topP,
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveSamplingParams", () => {
+  it("re-establishes the temperature/topP pair for an Anthropic config that has neither", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, {}),
+    ).toEqual({ temperature: 0 });
+  });
+
+  it("omits both for an Anthropic model that rejects sampling params", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5, {
+        temperature: 0.7,
+        topP: 0.9,
+      }),
+    ).toEqual({});
+  });
+
+  it("keeps temperature and drops topP when an Anthropic config carries both", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, {
+        temperature: 0.7,
+        topP: 0.9,
+      }),
+    ).toEqual({ temperature: 0.7 });
+  });
+
+  it("keeps topP alone when the user cleared temperature", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, {
+        topP: 0.9,
+      }),
+    ).toEqual({ topP: 0.9 });
+  });
+
+  it("does not invent a topP the config has no value for", () => {
+    // The same panels serve the LLM judge, whose rule stores no topP. Putting a parameter back for
+    // a surface that owns it is that surface's job — restoreMissingConfigKeys for the playground.
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.GPT_4O_MINI, {
+        temperature: 0,
+      }).topP,
+    ).toBeUndefined();
+  });
+
+  it("omits topP for OpenAI reasoning models", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.GPT_5_5, {
+        temperature: 1,
+        topP: 0.9,
+      }).topP,
+    ).toBeUndefined();
+  });
+
+  it("passes other providers' values through untouched", () => {
+    expect(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.GEMINI_2_5_PRO, {
+        temperature: 0.3,
+        topP: 0.8,
+      }),
+    ).toEqual({ temperature: 0.3, topP: 0.8 });
+  });
+});
+
+describe("resolveSamplingParams provider routing", () => {
+  it("routes every model with an Anthropic capability row to the Anthropic rules", () => {
+    // getProviderFromModel falls back to OpenAI for a model it cannot place, and the OpenAI branch
+    // fills in a default topP. An Anthropic model missing from the registry would therefore be sent
+    // temperature and top_p together, which Anthropic rejects.
+    for (const model of Object.keys(
+      ANTHROPIC_MODEL_CAPABILITIES,
+    ) as PROVIDER_MODEL_TYPE[]) {
+      expect(getProviderFromModel(model)).toBe(PROVIDER_TYPE.ANTHROPIC);
+      expect(
+        resolveSamplingParams(model, { temperature: 0 }).topP,
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("the settings panel and the request agree on sampling params", () => {
+  // Both shapes are what an earlier model switch left behind in PLAYGROUND_STATE. The panel reads
+  // them through resolveSamplingParams, so the request has to resolve to the same values.
+  it("sends the temperature the panel resolves for an Anthropic config that lost both", () => {
+    const configs: LLMAnthropicConfigsType = { maxCompletionTokens: 4000 };
+
+    expect(
+      sanitizeConfigForRequest(
+        PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6,
+        configs as unknown as Record<string, unknown>,
+      ).temperature,
+    ).toBe(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, configs)
+        .temperature,
+    );
+  });
+
+  it("sends the topP the panel resolves for an OpenAI config that carries one", () => {
+    const configs: LLMOpenAIConfigsType = {
+      temperature: 0,
+      maxCompletionTokens: 4000,
+      topP: 0.75,
+      frequencyPenalty: 0,
+      presencePenalty: 0,
+    };
+
+    expect(
+      sanitizeConfigForRequest(
+        PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+        configs as unknown as Record<string, unknown>,
+      ).topP,
+    ).toBe(
+      resolveSamplingParams(PROVIDER_MODEL_TYPE.GPT_4O_MINI, configs).topP,
+    );
   });
 });

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -356,16 +356,6 @@ export const updateProviderConfig = <
     const next: T = { ...currentConfig };
     let changed = false;
 
-    // Reasoning models reject temperature < 1; coerce.
-    if (
-      isReasoningModel(params.model) &&
-      typeof next.temperature === "number" &&
-      next.temperature < 1
-    ) {
-      next.temperature = 1.0;
-      changed = true;
-    }
-
     // reasoningEffort: drop it for models without an effort option list,
     // coerce stale values to "high" otherwise. Mirrors the Anthropic
     // thinkingEffort handling below.
@@ -480,10 +470,11 @@ export const resolveSamplingParams = (
     return { temperature: DEFAULT_ANTHROPIC_CONFIGS.TEMPERATURE };
   }
 
-  // Reasoning models reject top_p outright: OpenAI returns 400 "Unsupported parameter: 'top_p' is
-  // not supported with this model."
+  // Reasoning models take neither: top_p is rejected outright ("Unsupported parameter: 'top_p' is
+  // not supported with this model.") and temperature accepts only the provider's own default, so
+  // there is nothing to tune and omitting both is the one payload that always works.
   if (provider === PROVIDER_TYPE.OPEN_AI && isReasoningModel(model)) {
-    return { temperature };
+    return {};
   }
 
   return { temperature, topP };

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -366,14 +366,6 @@ export const updateProviderConfig = <
       changed = true;
     }
 
-    // Reasoning models reject top_p outright (OpenAI returns 400 "Unsupported parameter:
-    // 'top_p' is not supported with this model."). Drop any stale value so the next request
-    // omits the field entirely. The Top P slider is hidden for these models in the UI.
-    if (isReasoningModel(params.model) && next.topP !== undefined) {
-      next.topP = undefined;
-      changed = true;
-    }
-
     // reasoningEffort: drop it for models without an effort option list,
     // coerce stale values to "high" otherwise. Mirrors the Anthropic
     // thinkingEffort handling below.
@@ -397,17 +389,6 @@ export const updateProviderConfig = <
   if (providerType === PROVIDER_TYPE.ANTHROPIC) {
     const next: T = { ...currentConfig };
     let changed = false;
-
-    if (!supportsSamplingParams(params.model)) {
-      if (next.temperature !== undefined) {
-        next.temperature = undefined;
-        changed = true;
-      }
-      if (next.topP !== undefined) {
-        next.topP = undefined;
-        changed = true;
-      }
-    }
 
     const effortOptions = getAnthropicThinkingEffortOptions(params.model);
     if (effortOptions.length === 0) {
@@ -455,6 +436,59 @@ export const updateProviderConfig = <
   return currentConfig;
 };
 
+export type SamplingParams = { temperature?: number; topP?: number };
+
+/**
+ * The single interpreter of temperature/topP for a model: capability gating plus Anthropic's
+ * temperature-XOR-topP rule.
+ *
+ * The settings panel and the request builder both read through it, so a slider can never show a
+ * value the request leaves out. That lets the stored config keep whatever the user last chose even
+ * while a model that rejects it is selected — switching back restores the value instead of losing
+ * it.
+ *
+ * It gates and disambiguates; it does not invent. A parameter the config does not carry stays
+ * absent, because the same panels serve surfaces with narrower configs — the LLM judge rule stores
+ * no topP, so offering one there would show a control its save path drops. Filling in a parameter a
+ * surface genuinely owns belongs to that surface (see restoreMissingConfigKeys for the playground).
+ */
+export const resolveSamplingParams = (
+  model: PROVIDER_MODEL_TYPE | "",
+  configs: { temperature?: number | null; topP?: number | null },
+): SamplingParams => {
+  const temperature = configs.temperature ?? undefined;
+  const topP = configs.topP ?? undefined;
+
+  if (!model) {
+    return { temperature, topP };
+  }
+
+  const provider = getProviderFromModel(model as PROVIDER_MODEL_TYPE);
+
+  if (provider === PROVIDER_TYPE.ANTHROPIC) {
+    if (!supportsSamplingParams(model)) {
+      return {};
+    }
+    // Anthropic takes one of the pair, never both: temperature wins a config carrying both, and
+    // takes over when neither is set so the panel can't offer two live sliders.
+    if (temperature !== undefined) {
+      return { temperature };
+    }
+    if (topP !== undefined) {
+      return { topP };
+    }
+    return { temperature: DEFAULT_ANTHROPIC_CONFIGS.TEMPERATURE };
+  }
+
+  // Reasoning models reject top_p outright: OpenAI returns 400 "Unsupported parameter: 'top_p' is
+  // not supported with this model."
+  if (provider === PROVIDER_TYPE.OPEN_AI && isReasoningModel(model)) {
+    return { temperature };
+  }
+
+  return { temperature, topP };
+};
+
 // Last-mile request hardening, complementary to updateProviderConfig: this
 // layer doesn't trust upstream and keeps the payload valid for stale state
 // (e.g. older persisted prompts missing maxCompletionTokens).
@@ -467,17 +501,26 @@ export const sanitizeConfigForRequest = (
   const sanitized: Record<string, unknown> = { ...configs };
   const provider = getProviderFromModel(model as PROVIDER_MODEL_TYPE);
 
-  if (provider === PROVIDER_TYPE.ANTHROPIC) {
-    if (!supportsSamplingParams(model)) {
-      delete sanitized.temperature;
-      delete sanitized.topP;
-    } else if (sanitized.topP != null && sanitized.temperature != null) {
-      delete sanitized.topP;
+  if (
+    provider === PROVIDER_TYPE.ANTHROPIC ||
+    provider === PROVIDER_TYPE.OPEN_AI
+  ) {
+    const sampling = resolveSamplingParams(model, configs as SamplingParams);
+    for (const key of ["temperature", "topP"] as const) {
+      if (sampling[key] === undefined) {
+        delete sanitized[key];
+      } else {
+        sanitized[key] = sampling[key];
+      }
     }
-    if (sanitized.maxCompletionTokens == null) {
-      sanitized.maxCompletionTokens =
-        DEFAULT_ANTHROPIC_CONFIGS.MAX_COMPLETION_TOKENS;
-    }
+  }
+
+  if (
+    provider === PROVIDER_TYPE.ANTHROPIC &&
+    sanitized.maxCompletionTokens == null
+  ) {
+    sanitized.maxCompletionTokens =
+      DEFAULT_ANTHROPIC_CONFIGS.MAX_COMPLETION_TOKENS;
   }
 
   if (provider === PROVIDER_TYPE.OPEN_AI && sanitized.reasoningEffort != null) {
@@ -491,18 +534,6 @@ export const sanitizeConfigForRequest = (
         delete sanitized.reasoningEffort;
       }
     }
-  }
-
-  // Strip top_p for OpenAI reasoning models — OpenAI rejects it with 400 "Unsupported
-  // parameter: 'top_p' is not supported with this model." Belt-and-braces with the slider
-  // gating and updateProviderConfig: stale persisted prompts that bypass the reconciler
-  // still produce a valid wire payload.
-  if (
-    provider === PROVIDER_TYPE.OPEN_AI &&
-    isReasoningModel(model) &&
-    sanitized.topP != null
-  ) {
-    delete sanitized.topP;
   }
 
   // The request body is a flat spread of the config, and the backend deserializes it into

--- a/apps/opik-frontend/src/lib/playground.test.ts
+++ b/apps/opik-frontend/src/lib/playground.test.ts
@@ -104,6 +104,31 @@ describe("restoreMissingConfigKeys", () => {
     expect(restoreMissingConfigKeys(complete)).toBe(complete);
   });
 
+  it("does not throw on a prompt persisted without a config", () => {
+    // It runs over every persisted prompt during store hydration, so a throw here costs the whole
+    // playground state, not one prompt.
+    const restored = restoreMissingConfigKeys({
+      name: "p",
+      id: "p1",
+      messages: [],
+      model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      provider: PROVIDER_TYPE.OPEN_AI as COMPOSED_PROVIDER_TYPE,
+    } as unknown as PlaygroundPromptType);
+
+    expect((restored.configs as LLMOpenAIConfigsType).topP).toBe(1);
+  });
+
+  it("treats a null value as missing", () => {
+    const restored = restoreMissingConfigKeys(
+      prompt(PROVIDER_TYPE.OPEN_AI, PROVIDER_MODEL_TYPE.GPT_4O_MINI, {
+        temperature: 0.4,
+        topP: null,
+      }),
+    );
+
+    expect((restored.configs as LLMOpenAIConfigsType).topP).toBe(1);
+  });
+
   it("leaves a prompt with no provider alone", () => {
     const noProvider = {
       name: "p",

--- a/apps/opik-frontend/src/lib/playground.test.ts
+++ b/apps/opik-frontend/src/lib/playground.test.ts
@@ -129,6 +129,15 @@ describe("restoreMissingConfigKeys", () => {
     expect((restored.configs as LLMOpenAIConfigsType).topP).toBe(1);
   });
 
+  it("does not throw on a malformed prompt entry", () => {
+    expect(
+      restoreMissingConfigKeys(null as unknown as PlaygroundPromptType),
+    ).toBeNull();
+    expect(
+      restoreMissingConfigKeys("nonsense" as unknown as PlaygroundPromptType),
+    ).toBe("nonsense");
+  });
+
   it("does not throw on a prompt whose stored provider is not a string", () => {
     // parseComposedProviderType calls provider.startsWith, so a corrupted entry would throw inside
     // the hydration map and take every sibling prompt's state with it.

--- a/apps/opik-frontend/src/lib/playground.test.ts
+++ b/apps/opik-frontend/src/lib/playground.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { getDefaultConfigByProvider } from "@/lib/playground";
+import {
+  getDefaultConfigByProvider,
+  restoreMissingConfigKeys,
+} from "@/lib/playground";
 import {
   COMPOSED_PROVIDER_TYPE,
   LLMAnthropicConfigsType,
+  LLMOpenAIConfigsType,
   PROVIDER_MODEL_TYPE,
   PROVIDER_TYPE,
 } from "@/types/providers";
+import { PlaygroundPromptType } from "@/types/playground";
 
 describe("getDefaultConfigByProvider — Anthropic", () => {
   it("seeds temperature default for models that accept sampling params", () => {
@@ -26,5 +31,89 @@ describe("getDefaultConfigByProvider — Anthropic", () => {
     expect(config.temperature).toBeUndefined();
     expect(config.topP).toBeUndefined();
     expect(config.maxCompletionTokens).toBe(4000);
+  });
+});
+
+describe("restoreMissingConfigKeys", () => {
+  const prompt = (
+    provider: PROVIDER_TYPE,
+    model: PROVIDER_MODEL_TYPE,
+    configs: Record<string, unknown>,
+  ) =>
+    ({
+      name: "p",
+      id: "p1",
+      messages: [],
+      model,
+      provider: provider as COMPOSED_PROVIDER_TYPE,
+      configs,
+    }) as unknown as PlaygroundPromptType;
+
+  it("puts back a topP the old model-change reconciler dropped", () => {
+    const restored = restoreMissingConfigKeys(
+      prompt(PROVIDER_TYPE.OPEN_AI, PROVIDER_MODEL_TYPE.GPT_4O_MINI, {
+        temperature: 0.4,
+        maxCompletionTokens: 4000,
+        frequencyPenalty: 0,
+        presencePenalty: 0,
+      }),
+    );
+
+    expect((restored.configs as LLMOpenAIConfigsType).topP).toBe(1);
+    expect((restored.configs as LLMOpenAIConfigsType).temperature).toBe(0.4);
+  });
+
+  it("puts back parameters added after the prompt was persisted", () => {
+    const restored = restoreMissingConfigKeys(
+      prompt(PROVIDER_TYPE.OPEN_ROUTER, PROVIDER_MODEL_TYPE.OPENAI_GPT_4O, {
+        temperature: 1,
+        topP: 1,
+        maxTokens: 0,
+      }),
+    );
+
+    expect(restored.configs).toMatchObject({ minP: 0, topA: 0 });
+  });
+
+  it("leaves a cleared Anthropic temperature cleared when Top P is the live half", () => {
+    // Restoring temperature here would silently override the user's Top P: with both set the
+    // request drops Top P. Which half is live stays resolveSamplingParams' call.
+    const restored = restoreMissingConfigKeys(
+      prompt(PROVIDER_TYPE.ANTHROPIC, PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, {
+        topP: 0.9,
+        maxCompletionTokens: 4000,
+      }),
+    );
+
+    expect(
+      (restored.configs as LLMAnthropicConfigsType).temperature,
+    ).toBeUndefined();
+    expect((restored.configs as LLMAnthropicConfigsType).topP).toBe(0.9);
+  });
+
+  it("returns the same prompt when nothing is missing", () => {
+    const complete = prompt(
+      PROVIDER_TYPE.OPEN_AI,
+      PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      getDefaultConfigByProvider(
+        PROVIDER_TYPE.OPEN_AI as COMPOSED_PROVIDER_TYPE,
+        PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      ) as unknown as Record<string, unknown>,
+    );
+
+    expect(restoreMissingConfigKeys(complete)).toBe(complete);
+  });
+
+  it("leaves a prompt with no provider alone", () => {
+    const noProvider = {
+      name: "p",
+      id: "p1",
+      messages: [],
+      model: "",
+      provider: "",
+      configs: {},
+    } as unknown as PlaygroundPromptType;
+
+    expect(restoreMissingConfigKeys(noProvider)).toBe(noProvider);
   });
 });

--- a/apps/opik-frontend/src/lib/playground.test.ts
+++ b/apps/opik-frontend/src/lib/playground.test.ts
@@ -129,6 +129,21 @@ describe("restoreMissingConfigKeys", () => {
     expect((restored.configs as LLMOpenAIConfigsType).topP).toBe(1);
   });
 
+  it("does not throw on a prompt whose stored provider is not a string", () => {
+    // parseComposedProviderType calls provider.startsWith, so a corrupted entry would throw inside
+    // the hydration map and take every sibling prompt's state with it.
+    const malformed = {
+      name: "p",
+      id: "p1",
+      messages: [],
+      model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+      provider: { openai: true },
+      configs: {},
+    } as unknown as PlaygroundPromptType;
+
+    expect(restoreMissingConfigKeys(malformed)).toBe(malformed);
+  });
+
   it("leaves a prompt with no provider alone", () => {
     const noProvider = {
       name: "p",

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -37,6 +37,56 @@ import {
 import { RunStreamingReturn } from "@/api/playground/useCompletionProxyStreaming";
 import { parseComposedProviderType } from "@/lib/provider";
 
+/**
+ * Fills in config parameters a stored prompt has no value for, from the provider defaults.
+ *
+ * Two ways a prompt ends up short of one. It was persisted before the parameter existed, or an
+ * earlier model change cleared it: the reconciler used to overwrite a parameter the newly picked
+ * model rejected, and the panels render one control per parameter the config carries, so the
+ * control stayed gone for good (a playground reset was the only way back).
+ *
+ * Only absent parameters are filled; a value the user chose is never overwritten. The
+ * temperature/topP pair is skipped where the provider takes one or the other — restoring
+ * temperature next to a live Top P would make the request drop the Top P. resolveSamplingParams
+ * settles which half is live for those.
+ */
+export const restoreMissingConfigKeys = (
+  prompt: PlaygroundPromptType,
+): PlaygroundPromptType => {
+  if (!prompt.provider) {
+    return prompt;
+  }
+
+  const defaults = getDefaultConfigByProvider(prompt.provider, prompt.model) as
+    | Record<string, unknown>
+    | undefined;
+
+  if (!defaults) {
+    return prompt;
+  }
+
+  const exclusiveSamplingPair =
+    parseComposedProviderType(prompt.provider) === PROVIDER_TYPE.ANTHROPIC;
+  const configs = prompt.configs as unknown as Record<string, unknown>;
+  const restored: Record<string, unknown> = { ...configs };
+  let changed = false;
+
+  for (const [key, value] of Object.entries(defaults)) {
+    if (value === undefined || configs[key] !== undefined) {
+      continue;
+    }
+    if (exclusiveSamplingPair && (key === "temperature" || key === "topP")) {
+      continue;
+    }
+    restored[key] = value;
+    changed = true;
+  }
+
+  return changed
+    ? { ...prompt, configs: restored as unknown as LLMPromptConfigsType }
+    : prompt;
+};
+
 export const getDefaultConfigByProvider = (
   provider: COMPOSED_PROVIDER_TYPE,
   model?: PROVIDER_MODEL_TYPE | "",

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -54,7 +54,13 @@ export const restoreMissingConfigKeys = (
   prompt: PlaygroundPromptType,
 ): PlaygroundPromptType => {
   // Runs over every stored prompt during hydration, so anything this touches has to tolerate a
-  // corrupted entry: throwing costs every sibling prompt's state, not just this one's.
+  // corrupted entry: throwing costs every sibling prompt's state, not just this one's. The
+  // parameter type is a claim about persisted JSON, not a guarantee, so the shape is checked
+  // rather than trusted — an entry it cannot read is returned untouched.
+  if (!prompt || typeof prompt !== "object") {
+    return prompt;
+  }
+
   // parseComposedProviderType calls provider.startsWith.
   if (!prompt.provider || typeof prompt.provider !== "string") {
     return prompt;

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -53,7 +53,10 @@ import { parseComposedProviderType } from "@/lib/provider";
 export const restoreMissingConfigKeys = (
   prompt: PlaygroundPromptType,
 ): PlaygroundPromptType => {
-  if (!prompt.provider) {
+  // Runs over every stored prompt during hydration, so anything this touches has to tolerate a
+  // corrupted entry: throwing costs every sibling prompt's state, not just this one's.
+  // parseComposedProviderType calls provider.startsWith.
+  if (!prompt.provider || typeof prompt.provider !== "string") {
     return prompt;
   }
 
@@ -67,8 +70,6 @@ export const restoreMissingConfigKeys = (
 
   const exclusiveSamplingPair =
     parseComposedProviderType(prompt.provider) === PROVIDER_TYPE.ANTHROPIC;
-  // A prompt persisted without a config at all has to survive this: it runs over every stored
-  // prompt during hydration, so throwing here would cost the whole playground state.
   const stored = prompt.configs as Record<string, unknown> | undefined | null;
   const configs = stored ?? {};
   const restored: Record<string, unknown> = { ...configs };

--- a/apps/opik-frontend/src/lib/playground.ts
+++ b/apps/opik-frontend/src/lib/playground.ts
@@ -67,12 +67,17 @@ export const restoreMissingConfigKeys = (
 
   const exclusiveSamplingPair =
     parseComposedProviderType(prompt.provider) === PROVIDER_TYPE.ANTHROPIC;
-  const configs = prompt.configs as unknown as Record<string, unknown>;
+  // A prompt persisted without a config at all has to survive this: it runs over every stored
+  // prompt during hydration, so throwing here would cost the whole playground state.
+  const stored = prompt.configs as Record<string, unknown> | undefined | null;
+  const configs = stored ?? {};
   const restored: Record<string, unknown> = { ...configs };
-  let changed = false;
+  let changed = stored == null;
 
   for (const [key, value] of Object.entries(defaults)) {
-    if (value === undefined || configs[key] !== undefined) {
+    // A stored null is as absent as a missing key, and a default that is itself nullish (Custom's
+    // custom_parameters) has nothing to restore.
+    if (value == null || configs[key] != null) {
       continue;
     }
     if (exclusiveSamplingPair && (key === "temperature" || key === "topP")) {

--- a/apps/opik-frontend/src/store/PlaygroundStore.hydration.test.ts
+++ b/apps/opik-frontend/src/store/PlaygroundStore.hydration.test.ts
@@ -54,6 +54,26 @@ describe("PLAYGROUND_STATE hydration", () => {
     expect(configs.temperature).toBe(0.4);
   });
 
+  it("hydrates a prompt stored without a config instead of failing the whole state", async () => {
+    seed({
+      promptIds: ["p1"],
+      promptMap: {
+        p1: {
+          name: "Prompt 1",
+          id: "p1",
+          messages: [],
+          model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+          provider: PROVIDER_TYPE.OPEN_AI,
+        },
+      },
+    });
+
+    const configs = (await loadPromptMap()).p1.configs as LLMOpenAIConfigsType;
+
+    expect(configs.topP).toBe(1);
+    expect(configs.maxCompletionTokens).toBe(4000);
+  });
+
   it("never overwrites a value the user chose", async () => {
     seed({
       promptIds: ["p1"],

--- a/apps/opik-frontend/src/store/PlaygroundStore.hydration.test.ts
+++ b/apps/opik-frontend/src/store/PlaygroundStore.hydration.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LLMOpenAIConfigsType,
+  PROVIDER_MODEL_TYPE,
+  PROVIDER_TYPE,
+} from "@/types/providers";
+
+const seed = (state: unknown, version?: number) =>
+  localStorage.setItem(
+    "PLAYGROUND_STATE",
+    JSON.stringify(version === undefined ? { state } : { state, version }),
+  );
+
+// The store is a module singleton that hydrates on import, so each case needs a fresh module.
+const loadPromptMap = async () => {
+  vi.resetModules();
+  const { default: usePlaygroundStore } = await import(
+    "@/store/PlaygroundStore"
+  );
+  return usePlaygroundStore.getState().promptMap;
+};
+
+describe("PLAYGROUND_STATE hydration", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("puts back a config parameter a stored prompt is missing", async () => {
+    // What a workspace has stored after switching to an OpenAI reasoning model and back: the old
+    // reconciler cleared topP, and the panel renders Top P only for a config that carries it.
+    seed({
+      promptIds: ["p1"],
+      promptMap: {
+        p1: {
+          name: "Prompt 1",
+          id: "p1",
+          messages: [],
+          model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+          provider: PROVIDER_TYPE.OPEN_AI,
+          configs: {
+            temperature: 0.4,
+            maxCompletionTokens: 4000,
+            frequencyPenalty: 0,
+            presencePenalty: 0,
+          },
+        },
+      },
+    });
+
+    const configs = (await loadPromptMap()).p1.configs as LLMOpenAIConfigsType;
+
+    expect(configs.topP).toBe(1);
+    expect(configs.temperature).toBe(0.4);
+  });
+
+  it("never overwrites a value the user chose", async () => {
+    seed({
+      promptIds: ["p1"],
+      promptMap: {
+        p1: {
+          name: "Prompt 1",
+          id: "p1",
+          messages: [],
+          model: PROVIDER_MODEL_TYPE.GPT_4O_MINI,
+          provider: PROVIDER_TYPE.OPEN_AI,
+          configs: { temperature: 0.4, topP: 0.75 },
+        },
+      },
+    });
+
+    const configs = (await loadPromptMap()).p1.configs as LLMOpenAIConfigsType;
+
+    expect(configs.topP).toBe(0.75);
+    expect(configs.temperature).toBe(0.4);
+    expect(configs.maxCompletionTokens).toBe(4000);
+  });
+});

--- a/apps/opik-frontend/src/store/PlaygroundStore.ts
+++ b/apps/opik-frontend/src/store/PlaygroundStore.ts
@@ -1,8 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import pick from "lodash/pick";
+import mapValues from "lodash/mapValues";
 
 import { LogExperiment, PlaygroundPromptType } from "@/types/playground";
+import { restoreMissingConfigKeys } from "@/lib/playground";
 import { JsonObject } from "@/types/shared";
 import { Filters } from "@/types/filters";
 import { DATASET_TYPE } from "@/types/datasets";
@@ -467,6 +469,25 @@ const usePlaygroundStore = create<PlaygroundStore>()(
     }),
     {
       name: "PLAYGROUND_STATE",
+      // Normalizes on every load rather than through `migrate`: persisted blobs carry no version
+      // (this store never set one), and zustand only migrates a blob whose stored version is a
+      // number — so a migrate hook would skip exactly the states that need repairing. Cheap and
+      // idempotent, since restoreMissingConfigKeys returns the prompt untouched when it is complete.
+      merge: (persisted, current) => {
+        const state = {
+          ...current,
+          ...(persisted as Partial<PlaygroundStore>),
+        };
+
+        if (!state.promptMap) {
+          return state;
+        }
+
+        return {
+          ...state,
+          promptMap: mapValues(state.promptMap, restoreMissingConfigKeys),
+        };
+      },
       partialize: (state) => {
         /* eslint-disable @typescript-eslint/no-unused-vars */
         const {

--- a/apps/opik-frontend/src/types/playground.ts
+++ b/apps/opik-frontend/src/types/playground.ts
@@ -111,7 +111,9 @@ export interface LogSpan {
     created_from: string;
     usage: UsageType | null;
     model: string;
-    parameters: LLMPromptConfigsType;
+    // The parameters the request carried, not the stored config: the two differ wherever the
+    // selected model rejects something the config keeps.
+    parameters: Record<string, unknown>;
   };
 }
 

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.temperature.test.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.temperature.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { convertLLMJudgeDataToLLMJudgeObject } from "./schema";
+import { PROVIDER_MODEL_TYPE } from "@/types/providers";
+import { LLM_JUDGE } from "@/types/llm";
+
+const asFormData = (model: PROVIDER_MODEL_TYPE, temperature?: number) =>
+  ({
+    model,
+    config: { temperature, seed: null, custom_parameters: null },
+    template: LLM_JUDGE.custom,
+    messages: [],
+    variables: {},
+    schema: [],
+    maxCostUsd: null,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+// This save path never reaches sanitizeConfigForRequest, so it is the only thing standing between
+// the form's temperature and a rule the provider rejects at scoring time.
+describe("LLM judge temperature on save", () => {
+  it("keeps the temperature for a model that takes one", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.GPT_4O, 0.3),
+    );
+
+    expect(object.model.temperature).toBe(0.3);
+  });
+
+  it("drops it for an Anthropic model that takes no sampling params", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5, 0.3),
+    );
+
+    expect(object.model.temperature).toBeUndefined();
+  });
+
+  it("drops it for an OpenAI reasoning model, which only accepts its own default", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.GPT_5_5, 0.3),
+    );
+
+    expect(object.model.temperature).toBeUndefined();
+  });
+
+  it("does not invent a temperature for a rule that has none", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6, undefined),
+    );
+
+    expect(object.model.temperature).toBeUndefined();
+  });
+
+  it("keeps the temperature for a Gemini thinking model, which does take one", () => {
+    const object = convertLLMJudgeDataToLLMJudgeObject(
+      asFormData(PROVIDER_MODEL_TYPE.GEMINI_2_5_PRO, 0.3),
+    );
+
+    expect(object.model.temperature).toBe(0.3);
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -15,6 +15,7 @@ import {
 } from "@/types/providers";
 import {
   getThinkingLevelOptions,
+  supportsSamplingParams,
   updateProviderConfig,
 } from "@/lib/modelUtils";
 import { getProviderFromModel } from "@/lib/provider";
@@ -575,7 +576,13 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
     name: data.model as PROVIDER_MODEL_TYPE,
   };
 
-  if (temperature != null) {
+  // This path never reaches sanitizeConfigForRequest, so the capability check belongs here: the
+  // form keeps a temperature the user set on another model, and Anthropic 400s on the models that
+  // take no sampling params.
+  if (
+    temperature != null &&
+    supportsSamplingParams(data.model as PROVIDER_MODEL_TYPE)
+  ) {
     model.temperature = temperature;
   }
 

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -580,12 +580,12 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
   // keeps a temperature the user set on another model, and the providers that take none reject it at
   // scoring time. The resolver answers whether this model takes one; the value stays the user's, so
   // a rule that never had a temperature does not gain the resolver's default.
-  const { temperature: modelTakesTemperature } = resolveSamplingParams(
+  const { temperature: resolvedTemperature } = resolveSamplingParams(
     data.model as PROVIDER_MODEL_TYPE,
     data.config,
   );
 
-  if (temperature != null && modelTakesTemperature != null) {
+  if (temperature != null && resolvedTemperature != null) {
     model.temperature = temperature;
   }
 

--- a/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
+++ b/apps/opik-frontend/src/v2/pages-shared/automations/AddEditRuleDialog/schema.ts
@@ -15,7 +15,7 @@ import {
 } from "@/types/providers";
 import {
   getThinkingLevelOptions,
-  supportsSamplingParams,
+  resolveSamplingParams,
   updateProviderConfig,
 } from "@/lib/modelUtils";
 import { getProviderFromModel } from "@/lib/provider";
@@ -576,13 +576,16 @@ export const convertLLMJudgeDataToLLMJudgeObject = (
     name: data.model as PROVIDER_MODEL_TYPE,
   };
 
-  // This path never reaches sanitizeConfigForRequest, so the capability check belongs here: the
-  // form keeps a temperature the user set on another model, and Anthropic 400s on the models that
-  // take no sampling params.
-  if (
-    temperature != null &&
-    supportsSamplingParams(data.model as PROVIDER_MODEL_TYPE)
-  ) {
+  // This path never reaches sanitizeConfigForRequest, so the capability check belongs here: the form
+  // keeps a temperature the user set on another model, and the providers that take none reject it at
+  // scoring time. The resolver answers whether this model takes one; the value stays the user's, so
+  // a rule that never had a temperature does not gain the resolver's default.
+  const { temperature: modelTakesTemperature } = resolveSamplingParams(
+    data.model as PROVIDER_MODEL_TYPE,
+    data.config,
+  );
+
+  if (temperature != null && modelTakesTemperature != null) {
     model.temperature = temperature;
   }
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/AnthropicModelConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/AnthropicModelConfigs.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/ui/button";
 import { X } from "lucide-react";
 import {
   getAnthropicThinkingEffortOptions,
+  resolveSamplingParams,
   supportsAnthropicThinkingEffort,
   supportsSamplingParams,
 } from "@/lib/modelUtils";
@@ -34,8 +35,11 @@ const AnthropicModelConfigs = ({
   const showThinkingEffort = supportsAnthropicThinkingEffort(model);
   const showSamplingParams = supportsSamplingParams(model);
   const thinkingEffortOptions = getAnthropicThinkingEffortOptions(model);
-  const hasTemperatureValue = !isNil(configs.temperature);
-  const hasTopPValue = !isNil(configs.topP);
+  // Read the pair through the resolver rather than off the config: it is what the request will
+  // carry, and it guarantees exactly one half is live, so the two sliders can't both look editable.
+  const { temperature, topP } = resolveSamplingParams(model ?? "", configs);
+  const hasTemperatureValue = !isNil(temperature);
+  const hasTopPValue = !isNil(topP);
   const temperatureDisabled = hasTopPValue && !hasTemperatureValue;
   const topPDisabled = hasTemperatureValue && !hasTopPValue;
 
@@ -77,12 +81,7 @@ const AnthropicModelConfigs = ({
             }
           >
             <SliderInputControl
-              value={
-                configs.temperature ??
-                (temperatureDisabled
-                  ? undefined
-                  : DEFAULT_ANTHROPIC_CONFIGS.TEMPERATURE)
-              }
+              value={temperature}
               onChange={handleTemperatureChange}
               id="temperature"
               min={0}
@@ -132,10 +131,7 @@ const AnthropicModelConfigs = ({
         <div className="space-y-2">
           <div className={topPDisabled ? "pointer-events-none opacity-50" : ""}>
             <SliderInputControl
-              value={
-                configs.topP ??
-                (topPDisabled ? undefined : DEFAULT_ANTHROPIC_CONFIGS.TOP_P)
-              }
+              value={topP}
               onChange={handleTopPChange}
               id="topP"
               min={0}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
@@ -10,7 +10,6 @@ import {
 import { DEFAULT_OPEN_AI_CONFIGS } from "@/constants/llm";
 import {
   getOpenAIReasoningEffortOptions,
-  isReasoningModel,
   resolveSamplingParams,
   supportsOpenAIReasoningEffort,
 } from "@/lib/modelUtils";
@@ -36,32 +35,24 @@ const OpenAIModelConfigs = ({
   model,
   onChange,
 }: OpenAIModelSettingsProps) => {
-  // Reasoning models (GPT-5.2, GPT-5.1, GPT-5, O1, O3, O4-mini) require temperature = 1.0
-  const isReasoning = isReasoningModel(model);
   // The resolver owns which sampling params this model accepts and what the request will carry, so
-  // Top P follows it rather than the config's own key — a config that lost the key still offers it.
-  const { topP } = resolveSamplingParams(model ?? "", configs);
+  // both sliders follow it rather than the config's own keys. Reasoning models tune neither.
+  const { temperature, topP } = resolveSamplingParams(model ?? "", configs);
 
   return (
     <div className="flex w-72 flex-col gap-6">
-      {!isUndefined(configs.temperature) && (
+      {!isUndefined(temperature) && (
         <SliderInputControl
-          value={configs.temperature}
+          value={temperature}
           onChange={(v) => onChange({ temperature: v })}
           id="temperature"
-          min={isReasoning ? 1 : 0}
+          min={0}
           max={1}
           step={0.01}
-          defaultValue={isReasoning ? 1 : DEFAULT_OPEN_AI_CONFIGS.TEMPERATURE}
+          defaultValue={DEFAULT_OPEN_AI_CONFIGS.TEMPERATURE}
           label="Temperature"
           tooltip={
-            <PromptModelSettingsTooltipContent
-              text={
-                isReasoning
-                  ? "Reasoning models require temperature = 1.0. This setting controls randomness in completions."
-                  : "Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive."
-              }
-            />
+            <PromptModelSettingsTooltipContent text="Controls randomness: Lowering results in less random completions. As the temperature approaches zero, the model will become deterministic and repetitive." />
           }
         />
       )}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/OpenAIModelConfigs.tsx
@@ -11,6 +11,7 @@ import { DEFAULT_OPEN_AI_CONFIGS } from "@/constants/llm";
 import {
   getOpenAIReasoningEffortOptions,
   isReasoningModel,
+  resolveSamplingParams,
   supportsOpenAIReasoningEffort,
 } from "@/lib/modelUtils";
 import isUndefined from "lodash/isUndefined";
@@ -37,6 +38,9 @@ const OpenAIModelConfigs = ({
 }: OpenAIModelSettingsProps) => {
   // Reasoning models (GPT-5.2, GPT-5.1, GPT-5, O1, O3, O4-mini) require temperature = 1.0
   const isReasoning = isReasoningModel(model);
+  // The resolver owns which sampling params this model accepts and what the request will carry, so
+  // Top P follows it rather than the config's own key — a config that lost the key still offers it.
+  const { topP } = resolveSamplingParams(model ?? "", configs);
 
   return (
     <div className="flex w-72 flex-col gap-6">
@@ -78,12 +82,9 @@ const OpenAIModelConfigs = ({
         />
       )}
 
-      {!isUndefined(configs.topP) && !isReasoning && (
-        // OpenAI rejects top_p with "Unsupported parameter: 'top_p' is not supported with this
-        // model." on reasoning models (gpt-5.x, o-series). Hide the slider rather than send a
-        // value the backend will surface as a 400. Mirrors the temperature pinning above.
+      {!isUndefined(topP) && (
         <SliderInputControl
-          value={configs.topP}
+          value={topP}
           onChange={(v) => onChange({ topP: v })}
           id="topP"
           min={0}

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/samplingParams.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/samplingParams.test.tsx
@@ -38,7 +38,9 @@ describe("OpenAI sampling params", () => {
     expect(screen.getByTestId("topP-input")).toHaveValue("0.75");
   });
 
-  it("hides Top P for a reasoning model, which rejects the parameter", () => {
+  it("hides both sliders for a reasoning model, which takes neither", () => {
+    // top_p is rejected outright and temperature accepts only the provider's own default, so a
+    // temperature slider here could only ever be a control clamped to a single value.
     renderPanel(
       <OpenAIModelConfigs
         configs={OPEN_AI_CONFIG}
@@ -48,6 +50,7 @@ describe("OpenAI sampling params", () => {
     );
 
     expect(screen.queryByTestId("topP-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("temperature-input")).not.toBeInTheDocument();
   });
 });
 

--- a/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/samplingParams.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/llm/PromptModelSettings/providerConfigs/samplingParams.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import AnthropicModelConfigs from "./AnthropicModelConfigs";
+import OpenAIModelConfigs from "./OpenAIModelConfigs";
+import {
+  LLMAnthropicConfigsType,
+  LLMOpenAIConfigsType,
+  PROVIDER_MODEL_TYPE,
+} from "@/types/providers";
+import { TooltipProvider } from "@/ui/tooltip";
+
+const OPEN_AI_CONFIG: LLMOpenAIConfigsType = {
+  temperature: 0,
+  maxCompletionTokens: 4000,
+  topP: 0.75,
+  frequencyPenalty: 0,
+  presencePenalty: 0,
+};
+
+const ANTHROPIC_WITHOUT_SAMPLING = {
+  maxCompletionTokens: 4000,
+} as LLMAnthropicConfigsType;
+
+const renderPanel = (ui: React.ReactElement) =>
+  render(<TooltipProvider delayDuration={700}>{ui}</TooltipProvider>);
+
+describe("OpenAI sampling params", () => {
+  it("offers Top P for a non-reasoning model", () => {
+    renderPanel(
+      <OpenAIModelConfigs
+        configs={OPEN_AI_CONFIG}
+        model={PROVIDER_MODEL_TYPE.GPT_4O_MINI}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("topP-input")).toHaveValue("0.75");
+  });
+
+  it("hides Top P for a reasoning model, which rejects the parameter", () => {
+    renderPanel(
+      <OpenAIModelConfigs
+        configs={OPEN_AI_CONFIG}
+        model={PROVIDER_MODEL_TYPE.GPT_5_5}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("topP-input")).not.toBeInTheDocument();
+  });
+});
+
+describe("surfaces whose config has no topP", () => {
+  it("does not offer Top P to the LLM judge, whose rule cannot store it", () => {
+    // The judge dialog renders this same panel over its own four-field config. Offering a slider
+    // that convertLLMJudgeDataToLLMJudgeObject drops on save is the defect this file is about,
+    // pointed the other way.
+    renderPanel(
+      <OpenAIModelConfigs
+        configs={
+          {
+            temperature: 0,
+            seed: null,
+            custom_parameters: null,
+          } as unknown as LLMOpenAIConfigsType
+        }
+        model={PROVIDER_MODEL_TYPE.GPT_4O_MINI}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("topP-input")).not.toBeInTheDocument();
+  });
+});
+
+describe("Anthropic sampling params", () => {
+  it("shows temperature as the active half of the pair when a config lost both", () => {
+    // Anthropic takes temperature or topP, never both. With neither set the panel used to enable
+    // both sliders and send neither, so the displayed Temperature was not the one the model ran at.
+    renderPanel(
+      <AnthropicModelConfigs
+        configs={ANTHROPIC_WITHOUT_SAMPLING}
+        model={PROVIDER_MODEL_TYPE.CLAUDE_SONNET_4_6}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("temperature-input")).toHaveValue("0");
+    expect(
+      screen.getByLabelText("Clear temperature to use Top P"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Clear Top P to use temperature"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still hides both for a model that rejects sampling params", () => {
+    renderPanel(
+      <AnthropicModelConfigs
+        configs={{ ...ANTHROPIC_WITHOUT_SAMPLING, temperature: 0.7 }}
+        model={PROVIDER_MODEL_TYPE.CLAUDE_SONNET_5}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("temperature-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("topP-input")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Details

OPIK-8200 and OPIK-7931 are one defect. `updateProviderConfig` wrote `undefined` over `temperature`/`topP` whenever the newly picked model rejected them, and nothing ever put the value back — so the config stayed damaged after switching to a model that accepts them. The two panels then disagreed about what `undefined` means, which is why one ticket reports a missing control and the other a wrong value.

- **OpenAI panel** — a missing key means "render no control", so Top P was gone for good and only a playground reset brought it back (OPIK-7931).
- **Anthropic panel** — a missing key means "the other half of the temperature/topP pair is live", and it falls back to the default for display. With *both* missing it showed Temperature 0 while the request carried no temperature at all, and enabled both sliders at once — a state its own mutual-exclusion controls can never produce (OPIK-8200).
- `resolveSamplingParams` is now the only interpreter of the pair (capability gating + Anthropic's temperature-XOR-topP rule). The panel and the request builder both read through it, so a slider cannot show a value the request omits. It gates and disambiguates but never invents a parameter the config has no value for — the same panels serve the LLM judge, whose rule stores no `topP`.
- With display and wire both resolved, the reconciler no longer has to strip, so the config keeps whatever the user last chose while an incompatible model is selected and switching back restores it.
- Configs already damaged are repaired on load by `restoreMissingConfigKeys`, off the store's `merge` rather than `migrate`: persisted blobs carry no version and zustand only migrates a blob whose stored version is a number, so a `migrate` hook would have skipped exactly the states needing repair.
- OpenAI reasoning models accept only their own default temperature, so the panel clamped that slider to `min=1/max=1` and the reconciler rewrote the user's value to keep the request legal. The slider is gone and the field is omitted, which is the one payload those models always accept.
- The LLM judge save path never reaches `sanitizeConfigForRequest`, so it gains the capability check the reconciler's stripping used to provide there.

**Added during review** (Baz findings, each with a regression test):

- `restoreMissingConfigKeys` runs over every stored prompt during hydration, so anything it dereferences has to tolerate a corrupted entry — a throw costs the whole `PLAYGROUND_STATE`, not one prompt. The entry's shape, the provider's type and the config's presence are all now checked; a stored `null` counts as absent. Three separate reports of the same failure mode, so the third fix guards the shape rather than the next field.
- Playground logging recorded the raw config into the span's `metadata.parameters` and the experiment's `model_config`. Keeping a rejected parameter in the config is what makes the round trip non-destructive, but it also means the raw config is no longer what was sent — so a gpt-5.5 or claude-sonnet-5 trace reported a temperature the call never ran at. Both sites now log `sanitizeConfigForRequest`'s output, and the span metadata's `parameters` is retyped to match what it holds.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-8200
- OPIK-7931

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Root-cause investigation, the implementation, and all tests in this PR were AI-authored.
- Human verification: The reporter reproduced both tickets manually before this work and reviewed the root-cause analysis, the evidence below, and the two behaviour decisions in it (repairing already-damaged state on load; dropping the un-tunable temperature slider rather than pinning it). **Line-by-line code review and a visual check of the panel in a running app are still outstanding** — hence draft.

## Testing

Commands run from `apps/opik-frontend`, all by exit code:

- `npm run typecheck` — 0
- `npx eslint src --max-warnings=0` — 0
- `npx vitest run` — 0, 2365 tests
- `npm run deps:validate` — 0
- `make precommit` (repo root) — 0

Both tickets were driven test-first: a failing unit test and a failing component test per ticket before any fix. Three existing tests asserted the destructive stripping and were restated, each with a comment saying why.

Scenarios covered by new tests: sampling params surviving a round trip through a model that rejects them (both providers); panel and request resolving to the same value; the Anthropic temperature-XOR-topP invariant re-established for a config that lost both; a config that lost a parameter being repaired on store hydration without overwriting a chosen value; the judge save path dropping a temperature for a model that takes none while never inventing one; and a guard that every model with an Anthropic capability row resolves to the Anthropic rules — a row for a model missing from the registry would otherwise route to the OpenAI branch and send `temperature` and `top_p` together.

Replaying the tickets' own repro steps through the real code path:

```
OPIK-8200   run 1: {"model":"claude-sonnet-4-6","temperature":0.35,"maxCompletionTokens":4000,...}
            run 2: {"model":"claude-sonnet-4-6","temperature":0.35,"maxCompletionTokens":4000,...}
            -> byte-identical; on claude-sonnet-5 the panel offers neither and the body carries neither

OPIK-7931    run 1: topP 0.85 sent
             gpt-5.5: panel offers neither slider, body carries neither
             back:   panel offers Top P 0.85, body sends 0.85

already-damaged state, on load
  openai:     panel {"temperature":0,"topP":1}   body carries topP 1
  anthropic:  panel {"temperature":0}            body carries temperature 0
```

Not run: the Playwright e2e suite. `playground.configure-model-settings` is still `covered: false` in `tests_end_to_end/coverage/taxonomy.yaml` and I have not flipped it — that ledger tracks Playwright specs, this coverage is unit/component, and an e2e for the model-parameters panel needs a provider key so it would skip in the default pipeline.

No video: the change is state/request behaviour behind an existing panel; the request bodies above are the evidence.

## Documentation

None. No user-facing documentation describes the model-parameters panel's persistence behaviour.

