### PR TITLE
[OPIK-7791] [QA] Proposed e2e specs from the 2.2.54 → 2.2.55 release exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -266,7 +266,7 @@ areas:
       trace-ordering:         { covered: true,  tier: t1-smoke }
       open-trace-panel:       { covered: true,  tier: t1-smoke }
       span-tree-expand:       { covered: true,  tier: t2-cuj }
-      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls" }
+      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls; also reasoning-token billing on perplexity/sonar-deep-research (the only shipped-price-table model that can observe it) — the reasoning rate applied and subtracted from the standard-output bucket, the bare OTel usage key as a fallback for the original_usage. one, and both clamps" }
       trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
@@ -280,8 +280,8 @@ areas:
       attachments-media:      { covered: true,  tier: t2-cuj, note: "presigned multipart upload with mime_type omitted, asserting the type tika derives from each file name (incl. the octet-stream fallback), plus every attachment rendering as a thumbnail in the trace panel" }
       set-guardrail:          { covered: false, note: "SetGuardrailDialog — GUARDRAILS_ENABLED flag" }
       guardrail-results:      { covered: false, note: "GuardrailsCell column + Guardrails tree block — GUARDRAILS_ENABLED flag" }
-      delete-traces:          { covered: true,  tier: t2-cuj }
-      delete-traces-api:      { covered: true,  tier: t2-cuj, note: "SDK/API delete reflected in the Logs table" }
+      delete-traces:          { covered: true,  tier: t2-cuj, note: "Logs bulk delete; also the span cascade behind it — a 5-deep span chain, asserted gone project-wide rather than only through a filter on the deleted trace_id, against a bystander trace that keeps its own spans, scores and comments" }
+      delete-traces-api:      { covered: true,  tier: t2-cuj, note: "SDK/API delete reflected in the Logs table; also the span cascade behind DELETE /v1/private/traces/{id}, same shape as delete-traces" }
       update-trace-api:       { covered: true,  tier: t2-cuj, note: "PATCH /traces/{id} merges into the existing row rather than replacing it with a partial; asserted at the epoch-week, present and ~2201 id ages" }
       export-traces:          { covered: false, note: "EXPORT_ENABLED flag" }
 

--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -192,6 +192,14 @@ export interface SpanCostRef {
   totalEstimatedCost: number | null;
 }
 
+/** A span reduced to the fields a cascade assertion needs: who it is, and whose it is. */
+export interface SpanRef {
+  id: string;
+  name: string;
+  traceId: string;
+  parentSpanId: string | null;
+}
+
 export interface TraceDetail {
   id: string;
   name: string;
@@ -1945,6 +1953,119 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
     },
 
     /**
+     * Spans in a project, optionally narrowed to one trace.
+     *
+     * The `traceId`-less form is what makes a cascade assertion mean anything.
+     * `GET /spans?trace_id=<deleted>` answering "0 spans" is not evidence the
+     * cascade ran: a filter on a trace that no longer exists matches nothing
+     * either way, so a delete that removed the trace and orphaned every span
+     * would produce that same zero. Listing the whole project and naming the
+     * spans that survived tells the two apart.
+     *
+     * `projectId` is mandatory for the same reason it is on `listSpanCosts`:
+     * without it the backend falls back to the Default Project and answers with
+     * an empty page, which again reads identically to "everything was deleted".
+     */
+    async listSpanRefs(args: { projectId: string; traceId?: string }): Promise<SpanRef[]> {
+      const content = await fetchAllPages(
+        (page) =>
+          opik.api.spans.getSpansByProject({
+            projectId: args.projectId,
+            ...(args.traceId ? { traceId: args.traceId } : {}),
+            page,
+            size: 100,
+          }),
+        100,
+      );
+      return content.map((s) => ({
+        id: String(s.id ?? ''),
+        name: s.name ?? '',
+        traceId: String(s.traceId ?? ''),
+        parentSpanId: s.parentSpanId ? String(s.parentSpanId) : null,
+      }));
+    },
+
+    /**
+     * Attach a feedback score to a trace, so a delete has a dependent row to
+     * cascade to. `source: 'sdk'` matches how a logged score arrives.
+     */
+    async addTraceFeedbackScore(args: {
+      traceId: string;
+      name: string;
+      value: number;
+    }): Promise<void> {
+      await opik.api.traces.addTraceFeedbackScore(args.traceId, {
+        body: { name: args.name, value: args.value, source: 'sdk' },
+      });
+    },
+
+    /** The span-level counterpart of `addTraceFeedbackScore`. */
+    async addSpanFeedbackScore(args: {
+      spanId: string;
+      name: string;
+      value: number;
+    }): Promise<void> {
+      await opik.api.spans.addSpanFeedbackScore(args.spanId, {
+        body: { name: args.name, value: args.value, source: 'sdk' },
+      });
+    },
+
+    /**
+     * Comment on a trace or a span, returning the comment's id.
+     *
+     * Through `rawFetch` rather than the pinned SDK because the id has to come
+     * back. `CommentServiceImpl.create` mints its own id and IGNORES any the
+     * caller sends, answering 201 with the real one in `Location` — which the
+     * SDK's `void` return discards. Sending an id and then reading it back
+     * would 404 every time, against a comment that was created perfectly well.
+     */
+    async addComment(args: {
+      entity: 'traces' | 'spans';
+      entityId: string;
+      text: string;
+    }): Promise<string> {
+      const { status, message, location } = await rawFetch(
+        'POST',
+        `/v1/private/${args.entity}/${args.entityId}/comments`,
+        { body: { text: args.text } },
+      );
+      if (status !== 201) {
+        throw new Error(
+          `addComment on ${args.entity}/${args.entityId}: expected 201, got ${status}: ${message}`,
+        );
+      }
+      const id = location?.split('/').filter(Boolean).pop();
+      if (!id) {
+        throw new Error(
+          `addComment on ${args.entity}/${args.entityId}: 201 carried no usable Location header (got ${location ?? '<none>'})`,
+        );
+      }
+      return id;
+    },
+
+    /** One trace comment by id, or null once it is no longer readable. */
+    async getTraceComment(traceId: string, commentId: string): Promise<string | null> {
+      try {
+        const comment = await opik.api.traces.getTraceComment(traceId, commentId);
+        return comment.text ?? '';
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    /** One span comment by id, or null once it is no longer readable. */
+    async getSpanComment(spanId: string, commentId: string): Promise<string | null> {
+      try {
+        const comment = await opik.api.spans.getSpanComment(spanId, commentId);
+        return comment.text ?? '';
+      } catch (err) {
+        if (isNotFoundError(err)) return null;
+        throw err;
+      }
+    },
+
+    /**
      * A trace's rolled-up estimated cost — the number the trace panel's stats
      * row renders, aggregated server-side over the trace's spans.
      *
@@ -2668,6 +2789,9 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
      * keeps only spans whose source `isLoggingSource`, so a span written without
      * it is dropped before any rule sees it — silently, which is exactly how a
      * scoring spec ends up asserting nothing.
+     *
+     * The `id` must be a UUIDv7 (`uuid7()`); the backend rejects a v4 outright
+     * with "Span id must be a version 7 UUID".
      */
     async createSpan(args: {
       id: string;
@@ -2680,6 +2804,26 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       output?: TraceJsonSection;
       startTime?: Date;
       endTime?: Date;
+      model?: string;
+      provider?: string;
+      /**
+       * The span's `usage` map, written through to the backend VERBATIM.
+       *
+       * This is the whole reason an LLM span is ever seeded here rather than
+       * through `sdkClient.python.createNestedTrace`. The Python SDK normalises
+       * whatever it is handed: a bare OTel usage key such as
+       * `completion_tokens_details.reasoning_tokens` is re-emitted as
+       * `original_usage.completion_tokens_details.reasoning_tokens`, so the
+       * backend's bare-key fallback can never be reached through the bridge —
+       * a seed aimed at the fallback would silently exercise the primary key
+       * and pass for the wrong reason. Spans that really arrive with bare OTel
+       * keys come from OTel ingestion, not from the SDK, and this raw write is
+       * the faithful stand-in for that producer.
+       *
+       * Deliberately not `total_cost`: a caller that supplies a cost is not
+       * exercising server-side pricing at all.
+       */
+      usage?: Record<string, number>;
     }): Promise<string> {
       const now = new Date();
       await postSeedWrite('/v1/private/spans', `createSpan '${args.name}'`, {
@@ -2693,6 +2837,9 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         end_time: (args.endTime ?? now).toISOString(),
         ...(args.input === undefined ? {} : { input: args.input }),
         ...(args.output === undefined ? {} : { output: args.output }),
+        ...(args.model === undefined ? {} : { model: args.model }),
+        ...(args.provider === undefined ? {} : { provider: args.provider }),
+        ...(args.usage === undefined ? {} : { usage: args.usage }),
       });
       return args.id;
     },

--- a/tests_end_to_end/e2e/core/backend/index.ts
+++ b/tests_end_to_end/e2e/core/backend/index.ts
@@ -24,6 +24,7 @@ export {
   type FeedbackScoreRef,
   type PromptVersionRef,
   type SpanCostRef,
+  type SpanRef,
   type TraceDetail,
   type TracePayload,
   type SpanDetail,

--- a/tests_end_to_end/e2e/core/sdk/index.ts
+++ b/tests_end_to_end/e2e/core/sdk/index.ts
@@ -16,3 +16,4 @@ export function makeSdkClient(env: EnvConfig): SdkClient {
 
 export { PythonSdkBridgeError } from './python-sdk-client';
 export type { PythonSdkClient, TypescriptSdk };
+export type { SpanSeedUsage } from './python-sdk-client';

--- a/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
+++ b/tests_end_to_end/e2e/core/sdk/python-sdk-client.ts
@@ -1,3 +1,22 @@
+/**
+ * A seeded span's `usage` map: the three counts every LLM span reports, plus
+ * whatever else the scenario needs.
+ *
+ * Open-ended because the backend's cost calculators read far more than the
+ * trio — audio, cache and reasoning token counts all arrive as extra keys on
+ * this same flat map (`original_usage.completion_tokens_details.reasoning_tokens`
+ * and friends), and the bridge types the field as a plain `dict[str, int]`.
+ *
+ * Note the Python SDK normalises what it is given: a bare OTel key is re-emitted
+ * under the `original_usage.` prefix. A seed that must arrive with the bare key
+ * cannot go through the bridge at all — see `backendClient.createSpan`.
+ */
+export type SpanSeedUsage = {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+} & Record<string, number>;
+
 export interface PythonSdkClient {
   createProject(args: { name: string; workspace?: string }): Promise<{ id: string; name: string }>;
   createTrace(args: {
@@ -34,7 +53,7 @@ export interface PythonSdkClient {
       metadata?: Record<string, unknown>;
       model?: string;
       provider?: string;
-      usage?: { prompt_tokens: number; completion_tokens: number; total_tokens: number };
+      usage?: SpanSeedUsage;
       total_cost?: number;
       parent_index?: number;
     }>;

--- a/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
@@ -1,7 +1,27 @@
 import { test as baseTest } from './alert.fixture';
 import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7 } from '../core/backend';
+import type { SpanSeedUsage } from '../core/sdk';
+
+/**
+ * How a seed has to reach the backend.
+ *
+ * `python-sdk` is the default and what almost every span in the estate is:
+ * written through the bridge with `sdkClient.python.createNestedTrace`.
+ *
+ * `otel-rest` exists for one reason — the Python SDK normalises usage keys.
+ * A bare OTel key such as `completion_tokens_details.reasoning_tokens` is
+ * re-emitted by the SDK under the `original_usage.` prefix, so a seed aimed at
+ * the backend's BARE-key fallback would silently arrive on the primary key and
+ * the assertion would pass for the wrong reason. Spans that genuinely carry
+ * bare OTel keys arrive via OTel ingestion rather than the SDK, so those seeds
+ * are written straight to `POST /v1/private/spans` instead.
+ */
+export type ModelCostSpanWriter = 'python-sdk' | 'otel-rest';
 
 export interface ModelCostSpanSeed {
+  /** Stable, namespace-free handle a spec can look a vector up by. */
+  key: string;
   name: string;
   model: string;
   provider: string;
@@ -14,6 +34,12 @@ export interface ModelCostSpanSeed {
    * answer and this is only what the test compares it against.
    */
   expectedCost: number;
+  /**
+   * Usage keys this span carries on top of the shared prompt/completion counts,
+   * spelled exactly as they must reach the backend.
+   */
+  usageExtras?: Record<string, number>;
+  writer: ModelCostSpanWriter;
 }
 
 export interface ModelCostSpansRef {
@@ -38,9 +64,99 @@ export interface ModelCostSpansFixtures {
 const PROMPT_TOKENS = 1_000_000;
 const COMPLETION_TOKENS = 1_000_000;
 
+/** The `usage` key SDK 1.6.0+ logs reasoning/thinking tokens under. */
+const SDK_REASONING_KEY = 'original_usage.completion_tokens_details.reasoning_tokens';
+/** The bare OTel GenAI key the backend falls back to when the prefixed one is absent. */
+const OTEL_REASONING_KEY = 'completion_tokens_details.reasoning_tokens';
+
 /**
- * Five LLM spans whose model ids each exercise one step of server-side price
- * resolution, with the two ways it could go wrong.
+ * Five vectors over one model, covering reasoning-token billing
+ * (`SpanCostCalculator.textGenerationCost`).
+ *
+ * Reasoning tokens are a SUBSET of `completion_tokens`, so the calculator bills
+ * them at `output_cost_per_reasoning_token` and subtracts them from the
+ * standard-output bucket rather than billing them at both rates. Two clamps
+ * guard the arithmetic: a reported count above `completion_tokens` must not
+ * bill more reasoning than there are completion tokens (nor drive the standard
+ * bucket negative), and a negative count must floor at zero.
+ *
+ * `perplexity/sonar-deep-research` is not an arbitrary pick — it is the only
+ * model in the shipped price table that can observe this behaviour at all. The
+ * vector needs a model that publishes `output_cost_per_reasoning_token`, has no
+ * cache price (a cache price routes to `textGenerationWithCacheCost*`, which
+ * does not read the reasoning rate), belongs to a provider in
+ * `CostService.PROVIDERS_MAPPING` (an unmapped provider never enters the price
+ * map, so its cost reads null), AND publishes a reasoning rate that DIFFERS
+ * from its output rate — otherwise the split is arithmetically invisible and
+ * the spec would pass with the feature removed. Of the 72 entries publishing a
+ * reasoning rate, exactly one satisfies all four.
+ *
+ *   perplexity/sonar-deep-research  $2/M in, $8/M out, $3/M reasoning
+ *
+ * At 1M prompt + 1M completion tokens that gives, per vector:
+ *
+ *   no reasoning key   2.00 + 1.0M x 8/M                    -> $10.00
+ *   400k reasoning     2.00 + 600k x 8/M + 400k x 3/M       ->  $8.00
+ *   1.5M reasoning     2.00 +    0 x 8/M + 1.0M x 3/M       ->  $5.00  (clamped down)
+ *   -100k reasoning    2.00 + 1.0M x 8/M                    -> $10.00  (clamped up to 0)
+ *
+ * The absent-key vector is the control the other four are read against: without
+ * it, "reasoning tokens were billed at the reasoning rate" and "the price table
+ * moved" are the same observation.
+ */
+const REASONING_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
+  {
+    key: 'reasoning-absent',
+    model: 'perplexity/sonar-deep-research',
+    provider: 'perplexity',
+    expectedCost: 10,
+    writer: 'python-sdk',
+  },
+  {
+    key: 'reasoning-sdk-key',
+    model: 'perplexity/sonar-deep-research',
+    provider: 'perplexity',
+    usageExtras: { [SDK_REASONING_KEY]: 400_000 },
+    expectedCost: 8,
+    writer: 'python-sdk',
+  },
+  {
+    key: 'reasoning-otel-key',
+    model: 'perplexity/sonar-deep-research',
+    provider: 'perplexity',
+    usageExtras: { [OTEL_REASONING_KEY]: 400_000 },
+    expectedCost: 8,
+    // Not `python-sdk`, and it cannot be: the SDK rewrites this bare key onto
+    // the `original_usage.` one, which would make this vector a duplicate of
+    // `reasoning-sdk-key` that reads as fallback coverage. See ModelCostSpanWriter.
+    writer: 'otel-rest',
+  },
+  {
+    key: 'reasoning-over-reported',
+    model: 'perplexity/sonar-deep-research',
+    provider: 'perplexity',
+    // More reasoning tokens than there are completion tokens. Clamps to
+    // completion_tokens: the whole output bills at the reasoning rate and the
+    // standard bucket floors at zero rather than going negative.
+    usageExtras: { [SDK_REASONING_KEY]: 1_500_000 },
+    expectedCost: 5,
+    writer: 'python-sdk',
+  },
+  {
+    key: 'reasoning-negative',
+    model: 'perplexity/sonar-deep-research',
+    provider: 'perplexity',
+    // Clamps up to zero, so this must bill exactly what `reasoning-absent` does.
+    usageExtras: { [SDK_REASONING_KEY]: -100_000 },
+    expectedCost: 10,
+    writer: 'python-sdk',
+  },
+];
+
+/**
+ * Ten LLM spans: five whose model ids each exercise one step of server-side
+ * price resolution (with the two ways it could go wrong), and five that cover
+ * reasoning-token billing over a single model.
  *
  * Costs are the shipped price table's own numbers at 1M prompt + 1M completion
  * tokens (`model_prices_and_context_window.json` / `model_prices_overrides.json`):
@@ -53,47 +169,55 @@ const COMPLETION_TOKENS = 1_000_000;
  * eight trailing digits that are not a date; a stripper eager enough to remove
  * them would silently bill another model's rate, and the failure would look
  * exactly like an ordinary cost.
+ *
+ * See REASONING_SEEDS above for the reasoning half.
  */
-const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'> & { suffix: string }> = [
+const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
   {
-    suffix: 'opus-prefixed',
+    key: 'opus-prefixed',
     // Prefix strip + dot-normalise + compact-date strip + the claude-4-6-opus alias.
     model: 'anthropic/claude-4.6-opus-20260205',
     provider: 'anthropic',
     expectedCost: 30,
+    writer: 'python-sdk',
   },
   {
-    suffix: 'haiku-dotted',
+    key: 'haiku-dotted',
     // Dot-normalise only: claude-haiku-4-5-20251001 is a price-table key as-is.
     model: 'claude-haiku-4.5-20251001',
     provider: 'anthropic',
     expectedCost: 6,
+    writer: 'python-sdk',
   },
   {
-    suffix: 'gpt-dated',
+    key: 'gpt-dated',
     // Compact-date strip; the old regex could not do this and read $0.
     model: 'gpt-5.2-20251217',
     provider: 'openai',
     expectedCost: 15.75,
+    writer: 'python-sdk',
   },
   {
-    suffix: 'gpt-build-number',
+    key: 'gpt-build-number',
     // Negative control: 8 digits, but a build number, not a date.
     model: 'gpt-5.2-99999999',
     provider: 'openai',
     expectedCost: 0,
+    writer: 'python-sdk',
   },
   {
-    suffix: 'gpt-impossible-date',
+    key: 'gpt-impossible-date',
     // Negative control: 8 digits shaped like a date, but month 13 / day 45.
     model: 'gpt-5.2-20251345',
     provider: 'openai',
     expectedCost: 0,
+    writer: 'python-sdk',
   },
+  ...REASONING_SEEDS,
 ];
 
 /**
- * One trace carrying five LLM spans that report token `usage` and **no**
+ * One trace carrying ten LLM spans that report token `usage` and **no**
  * `total_cost`, so the backend has to price them itself.
  *
  * Every other cost fixture in the estate (`tracedAgent`, the thread seeds)
@@ -101,40 +225,65 @@ const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'> & { suffix: string }> = 
  * resolution path has never been exercised end to end — a wrong price there is
  * invisible, because the number still renders as a perfectly ordinary cost.
  *
+ * Most spans go through the bridge; the ones carrying bare OTel usage keys are
+ * written straight to `POST /v1/private/spans` afterwards, because the SDK
+ * would normalise exactly the key they exist to test. Both land on the same
+ * trace, so the rolled-up total covers all ten either way.
+ *
  * Teardown deletes the trace (and with it its spans) here rather than in the
  * test: an assertion failure must not leave priced spans behind, since the
  * project's own rolled-up cost is one of the things asserted.
  */
 export const test = baseTest.extend<ModelCostSpansFixtures>({
   modelCostSpans: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
-    const spans: ModelCostSpanSeed[] = SPAN_SEEDS.map(({ suffix, ...seed }) => ({
+    const spans: ModelCostSpanSeed[] = SPAN_SEEDS.map((seed) => ({
       ...seed,
-      name: `${testNamespace}-${suffix}`,
+      name: `${testNamespace}-${seed.key}`,
     }));
+
+    const usageFor = (span: ModelCostSpanSeed): SpanSeedUsage => ({
+      prompt_tokens: PROMPT_TOKENS,
+      completion_tokens: COMPLETION_TOKENS,
+      total_tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
+      ...(span.usageExtras ?? {}),
+      // No `total_cost` — deliberately. See the doc comment above.
+    });
+
+    const sdkSpans = spans.filter((s) => s.writer === 'python-sdk');
+    const otelSpans = spans.filter((s) => s.writer === 'otel-rest');
 
     const created = await sdkClient.python.createNestedTrace({
       project_name: project.name,
       name: `${testNamespace}-cost-trace`,
       input: { question: 'seeded model cost resolution' },
       output: { answer: 'seeded model cost resolution' },
-      spans: spans.map((span) => ({
+      spans: sdkSpans.map((span) => ({
         name: span.name,
         type: 'llm' as const,
         model: span.model,
         provider: span.provider,
-        usage: {
-          prompt_tokens: PROMPT_TOKENS,
-          completion_tokens: COMPLETION_TOKENS,
-          total_tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
-        },
-        // No `total_cost` — deliberately. See the doc comment above.
+        usage: usageFor(span),
       })),
     });
 
-    if (created.span_count !== spans.length) {
+    if (created.span_count !== sdkSpans.length) {
       throw new Error(
-        `[modelCostSpans fixture] expected ${spans.length} spans, bridge reported ${created.span_count}`,
+        `[modelCostSpans fixture] expected ${sdkSpans.length} spans, bridge reported ${created.span_count}`,
       );
+    }
+
+    for (const span of otelSpans) {
+      await backendClient.createSpan({
+        id: uuid7(),
+        traceId: created.id,
+        projectName: project.name,
+        name: span.name,
+        source: 'sdk',
+        type: 'llm',
+        model: span.model,
+        provider: span.provider,
+        usage: usageFor(span),
+      });
     }
 
     const ref: ModelCostSpansRef = {

--- a/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
@@ -239,7 +239,7 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
     backendClient,
     page,
   }) => {
-    await test.step('The server really resolved the prices the panel is about to be read for', async () => {
+    const byName = await test.step('The server really resolved the prices the panel is about to be read for', async () => {
       // A UI assertion over a seed that never got priced is a test that cannot
       // fail: the amounts below would simply never appear, and any wait for
       // them would be indistinguishable from a rendering bug.
@@ -256,6 +256,10 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
           { timeout: 60_000, intervals: [500, 1_000, 2_000] },
         )
         .toBe(priced(modelCostSpans.spans).length);
+
+      // Read back for the ids, which are what pin each panel assertion below to
+      // the span it is supposed to be about.
+      return readSeededSpans(backendClient, project.id, modelCostSpans);
     });
 
     const logs = new LogsPage(page);
@@ -278,6 +282,16 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
       // API, where "no cost was attributed" is unambiguous.
       for (const seed of priced(modelCostSpans.spans)) {
         await panel.selectSpan(seed.name);
+        // Pin the two assertions below to the span that is actually selected.
+        // `selectSpan` only waits for SOME span to be in the URL, and five of
+        // these vectors share one model while two pairs share an expected
+        // amount — so a click that left the viewer on the previous span would
+        // still satisfy both, giving an iteration that cannot fail.
+        await expect
+          .poll(() => new URL(page.url()).searchParams.get('span'), {
+            message: `the panel must be showing '${seed.name}' itself, not whichever span was selected before it`,
+          })
+          .toBe(byName.get(seed.name)!.id);
         await expect(panel.spanModelChip).toContainText(seed.model);
         await expect(panel.estimatedCost(asDisplayed(seed.expectedCost))).toBeVisible();
       }

--- a/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from '@e2e/fixtures';
-import type { ModelCostSpanSeed } from '@e2e/fixtures';
+import type { ModelCostSpanSeed, ModelCostSpansRef } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
-import type { SpanCostRef } from '@e2e/core/backend';
+import type { BackendClient, SpanCostRef } from '@e2e/core/backend';
 
 /**
- * Server-side LLM cost resolution for dated model ids (OPIK-8242).
+ * Server-side LLM cost resolution: dated model ids (OPIK-8242) and
+ * reasoning-token billing (OPIK-7791).
  *
  * Every other cost assertion in the estate seeds `total_cost` from the client,
  * so the backend never has to look a price up — which means the resolution path
@@ -13,10 +14,14 @@ import type { SpanCostRef } from '@e2e/core/backend';
  * too eagerly reads as some other model's price. Both render as a perfectly
  * ordinary number on a page people read to decide what their LLM spend is.
  *
- * The fixture logs five LLM spans with `usage` and **no** `total_cost`. Three
- * exercise a normalisation step each (provider-prefix strip, dot-normalising,
- * compact-date strip, and an alias); two are controls whose eight trailing
- * digits are not dates and must not be stripped onto another model's row.
+ * The fixture logs ten LLM spans with `usage` and **no** `total_cost`:
+ *
+ *  - Five for id normalisation. Three exercise a step each (provider-prefix
+ *    strip, dot-normalising, compact-date strip, and an alias); two are controls
+ *    whose eight trailing digits are not dates and must not be stripped onto
+ *    another model's row.
+ *  - Five for reasoning tokens, all on one model, differing only in the
+ *    reasoning count and the usage key it arrives under.
  *
  * The expected amounts are the shipped price table's own numbers — see the
  * fixture. They are asserted at both surfaces because that is where the two can
@@ -48,37 +53,61 @@ const asDisplayed = (cost: number): string => `$${Number(cost.toFixed(2))}`;
  */
 const attributedCost = (span: SpanCostRef): number => span.totalEstimatedCost ?? 0;
 
+/**
+ * Every seeded span, by name, once all of them are queryable.
+ *
+ * The count is asserted, not just the lookup: a read that also returned spans
+ * from another trace would still find every seeded one and pass.
+ */
+async function readSeededSpans(
+  backendClient: BackendClient,
+  projectId: string,
+  seed: ModelCostSpansRef,
+): Promise<Map<string, SpanCostRef>> {
+  await expect
+    .poll(
+      async () =>
+        (await backendClient.listSpanCosts({ projectId, traceId: seed.traceId })).length,
+      { timeout: 60_000, intervals: [500, 1_000, 2_000] },
+    )
+    .toBe(seed.spans.length);
+
+  const spans = await backendClient.listSpanCosts({ projectId, traceId: seed.traceId });
+  expect(spans, 'the trace carries exactly the seeded spans').toHaveLength(seed.spans.length);
+  return new Map(spans.map((s) => [s.name, s]));
+}
+
+/**
+ * The cost the server attributed to the vector seeded under `key`.
+ *
+ * Asserts the span was read back and carries a cost before returning it, so a
+ * seed that never landed fails here rather than turning into a `null` that the
+ * arithmetic below would have to code around.
+ */
+function costOf(
+  byName: Map<string, SpanCostRef>,
+  seed: ModelCostSpansRef,
+  key: string,
+): number {
+  const vector = seed.spans.find((s) => s.key === key);
+  expect(vector, `the fixture must seed a '${key}' vector`).toBeDefined();
+  const span = byName.get(vector!.name);
+  expect(span, `span ${vector!.name} was seeded`).toBeDefined();
+  expect(
+    span!.totalEstimatedCost,
+    `${key} must be priced server-side — an absent cost is a failure, not a zero`,
+  ).not.toBeNull();
+  return span!.totalEstimatedCost!;
+}
+
 test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '@area:traces'] }, () => {
   test('LLM spans logged without a cost are priced from their model id, and undated look-alikes are not', { tag: ['@cap:traces.span-model-cost-tokens'] }, async ({
     modelCostSpans,
     project,
     backendClient,
   }) => {
-    const byName = await test.step('Read the seeded spans back once all five are queryable', async () => {
-      await expect
-        .poll(
-          async () => {
-            const spans = await backendClient.listSpanCosts({
-              projectId: project.id,
-              traceId: modelCostSpans.traceId,
-            });
-            return spans.length;
-          },
-          { timeout: 60_000, intervals: [500, 1_000, 2_000] },
-        )
-        .toBe(modelCostSpans.spans.length);
-
-      const spans = await backendClient.listSpanCosts({
-        projectId: project.id,
-        traceId: modelCostSpans.traceId,
-      });
-      // The count, not just the lookup: a read that also returned spans from
-      // another trace would still find every seeded one and pass.
-      expect(spans, 'the trace carries exactly the seeded spans').toHaveLength(
-        modelCostSpans.spans.length,
-      );
-      return new Map(spans.map((s) => [s.name, s]));
-    });
+    const byName = await test.step('Read the seeded spans back once all of them are queryable', async () =>
+      readSeededSpans(backendClient, project.id, modelCostSpans));
 
     await test.step('Each span really carries the model id under test (seed shape)', async () => {
       // Without this the cost assertions below could pass over a seed that
@@ -91,7 +120,7 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
       }
     });
 
-    await test.step('The three resolvable model ids are priced at the table rate', async () => {
+    await test.step('Every resolvable model id is priced at the table rate', async () => {
       for (const seed of priced(modelCostSpans.spans)) {
         const span = byName.get(seed.name)!;
         expect(
@@ -117,10 +146,90 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
     await test.step("The trace's rolled-up cost is the sum of its spans", async () => {
       const traceCost = await backendClient.getTraceCost(modelCostSpans.traceId);
       expect(traceCost, 'the trace must report a rolled-up cost').not.toBeNull();
-      expect(traceCost!, 'trace total across the five seeded spans').toBeCloseTo(
+      expect(traceCost!, 'trace total across every seeded span').toBeCloseTo(
         modelCostSpans.expectedTraceCost,
         6,
       );
+    });
+  });
+
+  test('Reasoning tokens bill at the reasoning rate and come out of the standard-output bucket', { tag: ['@cap:traces.span-model-cost-tokens'] }, async ({
+    modelCostSpans,
+    project,
+    backendClient,
+  }) => {
+    // No page: the subject is an arithmetic decision the backend makes while
+    // pricing a span. The panel renders whatever number came out of it, so
+    // reading it through a browser would add a rendering failure mode to an
+    // assertion about arithmetic. The panel's rendering of these same spans is
+    // covered by the UI test below, which walks every priced span.
+
+    const byName = await test.step('Read the seeded spans back once all of them are queryable', async () =>
+      readSeededSpans(backendClient, project.id, modelCostSpans));
+
+    const cost = (key: string) => costOf(byName, modelCostSpans, key);
+
+    await test.step('Each vector is priced at the hand-computed table amount', async () => {
+      // Absolute amounts first: they are what pins the arithmetic to the
+      // shipped rates rather than merely to itself. Every one is 1M prompt +
+      // 1M completion tokens on perplexity/sonar-deep-research
+      // ($2/M in, $8/M out, $3/M reasoning) — see the fixture.
+      const expected: Array<[string, number, string]> = [
+        ['reasoning-absent', 10, '2.00 in + 1.0M x $8/M out'],
+        ['reasoning-sdk-key', 8, '2.00 in + 600k x $8/M out + 400k x $3/M reasoning'],
+        ['reasoning-otel-key', 8, 'same as the SDK key, reached through the bare OTel key'],
+        ['reasoning-over-reported', 5, '2.00 in + 0 x $8/M out + 1.0M x $3/M reasoning'],
+        ['reasoning-negative', 10, 'negative reasoning count floors at 0, so identical to absent'],
+      ];
+      for (const [key, amount, workings] of expected) {
+        expect(cost(key), `${key}: ${workings}`).toBeCloseTo(amount, 6);
+      }
+    });
+
+    await test.step('Reasoning tokens are billed at their own rate, not the output rate', async () => {
+      // The discriminating comparison, and the reason the absent-key control is
+      // seeded. Both spans report identical prompt and completion totals, so if
+      // reasoning tokens were still billed at the plain output rate — the
+      // behaviour before the split — these two would be equal. An absolute
+      // assertion alone could not tell that apart from the price table moving.
+      expect(
+        cost('reasoning-sdk-key'),
+        'a span reporting reasoning tokens must cost less than an identical one that reports none, because $3/M reasoning is cheaper than $8/M output',
+      ).toBeLessThan(cost('reasoning-absent'));
+    });
+
+    await test.step('The bare OTel usage key is an equal-standing fallback', async () => {
+      // completion_tokens_details.reasoning_tokens (OTel ingestion) must price
+      // exactly as original_usage.completion_tokens_details.reasoning_tokens
+      // (Python SDK 1.6.0+) does. The fixture writes this vector straight to
+      // the REST API precisely so the SDK cannot normalise the two into one.
+      expect(
+        cost('reasoning-otel-key'),
+        'the bare OTel key must resolve the same price as the original_usage. key',
+      ).toBeCloseTo(cost('reasoning-sdk-key'), 6);
+    });
+
+    await test.step('Both clamps hold', async () => {
+      // Over-report: reasoning tokens are a subset of completion tokens, so a
+      // count above the completion total bills the whole output at the
+      // reasoning rate and no more — never more reasoning than there are
+      // completion tokens, and never a negative standard-output bucket, which
+      // would show up as a cost below the $2.00 input floor.
+      expect(
+        cost('reasoning-over-reported'),
+        'an over-reported reasoning count must clamp to completion_tokens, not bill beyond it',
+      ).toBeLessThan(cost('reasoning-sdk-key'));
+      expect(
+        cost('reasoning-over-reported'),
+        'the standard-output bucket must floor at zero rather than go negative',
+      ).toBeGreaterThan(0);
+
+      // Under-report: a negative count floors at zero, leaving the span priced
+      // exactly as one that reported no reasoning tokens at all.
+      expect(
+        cost('reasoning-negative'),
+        'a negative reasoning count must floor at 0, pricing identically to the absent-key control',
+      ).toBeCloseTo(cost('reasoning-absent'), 6);
     });
   });
 

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
@@ -316,6 +316,18 @@ test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces
           { timeout: 60_000, intervals: [500, 1_000, 2_000] },
         )
         .toBe(0);
+
+      // And the rows hung off it. The seed attaches a comment at both levels
+      // precisely so the cascade has dependents to reach; leaving them
+      // unasserted would make seeding them prove nothing.
+      expect(
+        await backendClient.getTraceComment(traces.api.id, traces.api.traceCommentId),
+        'the deleted trace must not still serve its own comment',
+      ).toBeNull();
+      expect(
+        await backendClient.getSpanComment(traces.api.deepestSpanId, traces.api.spanCommentId),
+        "the deleted trace's span comment must go with the span",
+      ).toBeNull();
     });
 
     const logs = new LogsPage(page);
@@ -351,6 +363,15 @@ test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces
           { timeout: 60_000, intervals: [500, 1_000, 2_000] },
         )
         .toBe(0);
+
+      expect(
+        await backendClient.getTraceComment(traces.ui.id, traces.ui.traceCommentId),
+        'the bulk-deleted trace must not still serve its own comment',
+      ).toBeNull();
+      expect(
+        await backendClient.getSpanComment(traces.ui.deepestSpanId, traces.ui.spanCommentId),
+        "the bulk-deleted trace's span comment must go with the span",
+      ).toBeNull();
     });
 
     await test.step('Project-wide, exactly the control survives — trace, spans and its own rows', async () => {

--- a/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/trace-delete.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@e2e/fixtures';
 import { LogsPage } from '@e2e/pom/logs.page';
 import type { SdkClient } from '@e2e/core/sdk';
+import type { BackendClient } from '@e2e/core/backend';
 
 interface SeededTrace {
   id: string;
@@ -25,6 +26,67 @@ async function seedTraces(
     traces.push({ id: created.id, name: created.name });
   }
   return traces;
+}
+
+/** A trace seeded with a chain of nested spans, plus the decoration hung off it. */
+interface NestedTrace {
+  id: string;
+  name: string;
+  spanNames: string[];
+  scoreName: string;
+  traceCommentId: string;
+  spanCommentId: string;
+  /** Id of the deepest span in the chain — the one carrying the span-level rows. */
+  deepestSpanId: string;
+}
+
+/**
+ * Seed one trace whose spans form a CHAIN — each parented to the previous —
+ * rather than a flat fan-out.
+ *
+ * Depth is the point. A cascade that only reached the trace's direct children
+ * would leave the rest behind, and a flat seed could not tell the two apart.
+ */
+async function seedNestedTrace(
+  sdkClient: SdkClient,
+  projectName: string,
+  namespace: string,
+  label: string,
+  depth: number,
+): Promise<{ id: string; name: string; spanNames: string[] }> {
+  const spanNames = Array.from({ length: depth }, (_, i) => `${namespace}-${label}-span-${i}`);
+  const created = await sdkClient.python.createNestedTrace({
+    project_name: projectName,
+    name: `${namespace}-${label}`,
+    input: { question: label },
+    output: { answer: label },
+    spans: spanNames.map((name, i) => ({
+      name,
+      ...(i === 0 ? {} : { parent_index: i - 1 }),
+    })),
+  });
+  if (created.span_count !== depth) {
+    throw new Error(
+      `[seedNestedTrace] expected ${depth} spans on '${label}', bridge reported ${created.span_count}`,
+    );
+  }
+  return { id: created.id, name: created.name, spanNames };
+}
+
+/** Spans of one trace, once every one of them is queryable. */
+async function awaitSpans(
+  backendClient: BackendClient,
+  projectId: string,
+  traceId: string,
+  expected: number,
+) {
+  await expect
+    .poll(async () => (await backendClient.listSpanRefs({ projectId, traceId })).length, {
+      timeout: 60_000,
+      intervals: [500, 1_000, 2_000],
+    })
+    .toBe(expected);
+  return backendClient.listSpanRefs({ projectId, traceId });
 }
 
 test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces'] }, () => {
@@ -102,6 +164,231 @@ test.describe('Trace deletion — multi-trace', { tag: ['@t2-cuj', '@area:traces
       await expect(logs.traceRow(survivor.id)).toBeVisible();
       await expect(logs.traceRows).toHaveCount(1);
       await expect.poll(() => logs.countTraces()).toBe(1);
+    });
+  });
+
+  /**
+   * Deleting a trace has to take its spans with it (OPIK-7791).
+   *
+   * Both tests above seed SPAN-LESS traces, so the span cascade has never been
+   * asserted anywhere in the estate — it runs only in fixture teardowns, where
+   * nothing reads the result. That makes it exactly the kind of regression that
+   * stays invisible: the trace disappears from the table either way, and
+   * orphaned spans are only visible to whoever later wonders why the project's
+   * storage never shrinks.
+   *
+   * Driven at both surfaces because the delete has two entry points that reach
+   * the same service — `DELETE /v1/private/traces/{id}` and the Logs table's
+   * bulk delete — and a cascade that broke on one of them would still look
+   * healthy on the other.
+   */
+  test('Deleting a trace cascades to its nested spans, through the API and through the Logs table', { tag: ['@cap:traces.delete-traces-api', '@cap:traces.delete-traces'] }, async ({
+    project,
+    sdkClient,
+    backendClient,
+    testNamespace,
+    page,
+  }) => {
+    test.setTimeout(180_000);
+
+    const DOOMED_DEPTH = 5;
+    const CONTROL_DEPTH = 4;
+
+    const seeded = await test.step('Seed two 5-span traces to delete and a 4-span control that must survive', async () => {
+      // The control is a bystander in the strict sense: nothing in this test
+      // ever touches it. Without one, "the target's spans are gone" would be
+      // satisfied just as well by a delete that took the whole project.
+      const [api, ui, control] = await Promise.all([
+        seedNestedTrace(sdkClient, project.name, testNamespace, 'doomed-api', DOOMED_DEPTH),
+        seedNestedTrace(sdkClient, project.name, testNamespace, 'doomed-ui', DOOMED_DEPTH),
+        seedNestedTrace(sdkClient, project.name, testNamespace, 'control', CONTROL_DEPTH),
+      ]);
+      return { api, ui, control };
+    });
+
+    const decorate = async (
+      base: { id: string; name: string; spanNames: string[] },
+      depth: number,
+    ): Promise<NestedTrace> => {
+      const spans = await awaitSpans(backendClient, project.id, base.id, depth);
+      const deepest = spans.find((s) => s.name === base.spanNames[depth - 1]);
+      expect(deepest, `the deepest span of '${base.name}' must be readable`).toBeDefined();
+
+      const scoreName = `${base.name}-score`;
+      const deepestSpanId = deepest!.id;
+
+      // Feedback scores and comments on BOTH the trace and a span, so the
+      // delete has dependent rows at both levels to clean up rather than just
+      // the span rows themselves.
+      await backendClient.addTraceFeedbackScore({ traceId: base.id, name: scoreName, value: 1 });
+      await backendClient.addSpanFeedbackScore({ spanId: deepestSpanId, name: scoreName, value: 1 });
+
+      return {
+        ...base,
+        deepestSpanId,
+        scoreName,
+        traceCommentId: await backendClient.addComment({
+          entity: 'traces',
+          entityId: base.id,
+          text: `comment on ${base.name}`,
+        }),
+        spanCommentId: await backendClient.addComment({
+          entity: 'spans',
+          entityId: deepestSpanId,
+          text: `comment on the deepest span of ${base.name}`,
+        }),
+      };
+    };
+
+    const traces = await test.step('Attach a feedback score and a comment to each trace and to its deepest span', async () => ({
+      api: await decorate(seeded.api, DOOMED_DEPTH),
+      ui: await decorate(seeded.ui, DOOMED_DEPTH),
+      control: await decorate(seeded.control, CONTROL_DEPTH),
+    }));
+
+    await test.step('The seed really holds before anything is deleted', async () => {
+      // A cascade assertion over a seed that never landed is a test that cannot
+      // fail: every "it is gone" check would pass against state that was never
+      // there. Assert the whole shape first, then delete.
+      const all = await backendClient.listSpanRefs({ projectId: project.id });
+      expect(all, 'the project holds every seeded span and nothing else').toHaveLength(
+        DOOMED_DEPTH * 2 + CONTROL_DEPTH,
+      );
+
+      for (const [depth, trace] of [
+        [DOOMED_DEPTH, traces.api],
+        [DOOMED_DEPTH, traces.ui],
+        [CONTROL_DEPTH, traces.control],
+      ] as const) {
+        const own = all.filter((s) => s.traceId === trace.id);
+        expect(own.map((s) => s.name).sort(), `spans of '${trace.name}'`).toEqual(
+          [...trace.spanNames].sort(),
+        );
+        // The chain, not just the count: one span hangs off the trace and every
+        // other hangs off a span, which is what gives the cascade depth to lose.
+        expect(
+          own.filter((s) => s.parentSpanId === null),
+          `'${trace.name}' must have exactly one root span`,
+        ).toHaveLength(1);
+        expect(
+          own.filter((s) => s.parentSpanId !== null),
+          `'${trace.name}' must nest its remaining ${depth - 1} spans`,
+        ).toHaveLength(depth - 1);
+
+        const detail = await backendClient.getTrace(trace.id);
+        expect(detail, `'${trace.name}' must exist`).not.toBeNull();
+        expect(
+          detail!.feedbackScores.map((s) => s.name),
+          `'${trace.name}' carries its trace-level score`,
+        ).toContain(trace.scoreName);
+
+        const span = await backendClient.getSpan(trace.deepestSpanId);
+        expect(span, `the deepest span of '${trace.name}' must exist`).not.toBeNull();
+        expect(
+          span!.feedbackScores.map((s) => s.name),
+          `the deepest span of '${trace.name}' carries its span-level score`,
+        ).toContain(trace.scoreName);
+
+        expect(
+          await backendClient.getTraceComment(trace.id, trace.traceCommentId),
+          `'${trace.name}' carries its trace comment`,
+        ).not.toBeNull();
+        expect(
+          await backendClient.getSpanComment(trace.deepestSpanId, trace.spanCommentId),
+          `the deepest span of '${trace.name}' carries its span comment`,
+        ).not.toBeNull();
+      }
+    });
+
+    await test.step('Deleting through the REST API removes the trace and every span under it', async () => {
+      await backendClient.deleteTraces([traces.api.id]);
+      await expect
+        .poll(() => backendClient.getTrace(traces.api.id), {
+          timeout: 60_000,
+          intervals: [500, 1_000, 2_000],
+        })
+        .toBeNull();
+      await expect
+        .poll(
+          async () =>
+            (await backendClient.listSpanRefs({ projectId: project.id, traceId: traces.api.id }))
+              .length,
+          { timeout: 60_000, intervals: [500, 1_000, 2_000] },
+        )
+        .toBe(0);
+    });
+
+    const logs = new LogsPage(page);
+
+    await test.step('Open Logs: the second doomed trace and the control are listed', async () => {
+      await logs.goto(project.id);
+      await logs.waitForReady();
+      await expect(logs.traceRows).toHaveCount(2);
+      await expect(logs.traceRow(traces.ui.id)).toBeVisible();
+      await expect(logs.traceRow(traces.control.id)).toBeVisible();
+    });
+
+    await test.step('Bulk-delete the second doomed trace from the table', async () => {
+      await logs.selectTrace(traces.ui.id);
+      await expect(logs.bulkDeleteButton).toBeEnabled();
+      await logs.bulkDeleteSelected();
+    });
+
+    await test.step('Its row leaves the table without a reload and the control stays', async () => {
+      // No page.reload() on purpose: the table has to drop the row on its own.
+      await expect(logs.traceRow(traces.ui.id)).toHaveCount(0);
+      await expect(logs.traceRow(traces.control.id)).toBeVisible();
+      await expect(logs.traceRows).toHaveCount(1);
+      await expect.poll(() => logs.countTraces()).toBe(1);
+    });
+
+    await test.step('The bulk delete cascaded to that trace\'s spans too', async () => {
+      await expect
+        .poll(
+          async () =>
+            (await backendClient.listSpanRefs({ projectId: project.id, traceId: traces.ui.id }))
+              .length,
+          { timeout: 60_000, intervals: [500, 1_000, 2_000] },
+        )
+        .toBe(0);
+    });
+
+    await test.step('Project-wide, exactly the control survives — trace, spans and its own rows', async () => {
+      // The assertion the per-trace zeros cannot make on their own. Filtering
+      // on a deleted trace_id matches nothing whether the cascade ran or merely
+      // orphaned the spans, so the surviving set has to be named.
+      const remaining = await backendClient.listSpanRefs({ projectId: project.id });
+      expect(
+        remaining.map((s) => s.name).sort(),
+        'only the control trace may still own spans in this project',
+      ).toEqual([...traces.control.spanNames].sort());
+      expect(remaining, 'and no others').toHaveLength(CONTROL_DEPTH);
+
+      expect(
+        await backendClient.listTraceIds({ projectId: project.id }),
+        'the control is the only trace left',
+      ).toEqual([traces.control.id]);
+
+      // The bystander is intact in substance, not just present: a delete that
+      // over-reached could have taken its dependent rows while leaving the row
+      // that renders in the table.
+      const detail = await backendClient.getTrace(traces.control.id);
+      expect(detail, 'the control trace must still exist').not.toBeNull();
+      expect(
+        detail!.feedbackScores.map((s) => s.name),
+        'the control keeps its trace-level score',
+      ).toContain(traces.control.scoreName);
+      expect(
+        await backendClient.getTraceComment(traces.control.id, traces.control.traceCommentId),
+        'the control keeps its trace comment',
+      ).not.toBeNull();
+      expect(
+        await backendClient.getSpanComment(
+          traces.control.deepestSpanId,
+          traces.control.spanCommentId,
+        ),
+        'the control keeps its span comment',
+      ).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
> **Generated by the release QA side flow** (release exploration → test proposal).
> Nothing here has been reviewed by a human. It is a **draft**: please read the
> assertions before promoting it, and do not merge it on a green CI run alone.

## Details

Two behaviours that a QA exploration pass verified by hand on staging during the
**2.2.54 → 2.2.55** release, turned into permanent assertions.

**Written and run against the `2.2.55` release ref** (commit `07ef0c6`), which is
what the specs were verified on. They are based on `main` because that is where
they have to merge — `2.2.55` is a tag, not a branch — so `main` will have moved
on since. `2.2.55` is an ancestor of `main`, so the diff here is only these
commits.

Both candidates **extend an existing spec in `trace-explore`** rather than adding
a parallel one for the same capability, because in both cases the capability was
already nominally covered and the gap was in the seed matrix, not in the spec.

### 1. Reasoning tokens bill at their own rate — `traces.span-model-cost-tokens`

Extends `tests/trace-explore/span-cost-resolution.spec.ts` and its fixture.

[PR 7777](https://github.com/comet-ml/opik/pull/7777) changed
`SpanCostCalculator.textGenerationCost` so reasoning/thinking tokens bill at
`output_cost_per_reasoning_token` and are subtracted from the standard-output
bucket instead of being billed at both rates. `span-cost-resolution.spec.ts`
nominally covers this capability, but **all five of its seed models carry a cache
price**, so they route to `textGenerationWithCacheCost*` — the function 7777
changed never executed in it.

The fixture gains five vectors on **`perplexity/sonar-deep-research`**. That model
is not an arbitrary pick: it is the only entry in the shipped price table that can
observe the change at all. The vector needs a model that publishes a reasoning
rate, has **no** cache price, belongs to a provider in
`CostService.PROVIDERS_MAPPING`, **and** whose reasoning rate differs from its
output rate — otherwise the split is arithmetically invisible and the spec would
pass with the feature removed. Of the 72 entries publishing
`output_cost_per_reasoning_token`, exactly one satisfies all four. (The release
report's own suggested models — `gemini/gemini-omni-flash-preview` and
`dashscope/qwen-turbo` — were checked on staging and **cannot** detect this: the
first prices identically with and without reasoning tokens, the second prices
`null` because `dashscope` is unmapped.)

The new test asserts, at 1M prompt + 1M completion tokens:

| Vector | Reasoning tokens | Expected |
|---|---|---|
| no reasoning key (control) | — | $10.00 |
| `original_usage.completion_tokens_details.reasoning_tokens` | 400,000 | $8.00 |
| bare OTel `completion_tokens_details.reasoning_tokens` | 400,000 | $8.00 |
| over-report (clamps to `completion_tokens`) | 1,500,000 | $5.00 |
| negative (clamps to 0) | −100,000 | $10.00 |

…plus the relationships that encode the behaviour independently of the table:
the reasoning vector costs **strictly less** than the identical control (this is
what an absolute assertion alone could not tell apart from the price table
moving), the OTel key resolves the same price as the SDK key, and both clamps
hold.

**One thing worth a reviewer's attention.** The bare-OTel-key vector cannot be
seeded through the SDK bridge. The Python SDK normalises usage keys, re-emitting
`completion_tokens_details.reasoning_tokens` under the `original_usage.` prefix
(verified against `validation_helpers.validate_and_parse_usage`), so a seed aimed
at the backend's **fallback** key would silently arrive on the **primary** one and
pass for the wrong reason. That vector is therefore written straight to
`POST /v1/private/spans` via `backendClient.createSpan`, which is also how such a
span really arrives in production — from OTel ingestion, not from the SDK. The
fixture documents this; the alternative was a vector that looked like fallback
coverage and was not.

### 2. Deleting a trace cascades to its spans — `traces.delete-traces-api`, `traces.delete-traces`

Extends `tests/trace-explore/trace-delete.spec.ts`.

[PR 8201](https://github.com/comet-ml/opik/pull/8201) reorders the deletion-events
capture ahead of the lightweight delete and wraps both the trace delete and the
`SpanService` cascade in `Mono.defer`. The reorder is unconditional and ships on
every deployment regardless of the capture flags. Both existing tests in that file
seed **span-less** traces, so the cascade ran only in fixture teardowns, where
nothing read the result.

The new test seeds two 5-span traces and a 4-span control, with the spans **chained**
(each parented to the previous) so the cascade has depth to lose, and a feedback
score and a comment on both the trace and its deepest span so the delete has
dependent rows at both levels. It then deletes through **both** entry points —
`DELETE /v1/private/traces/{id}` and the Logs table's bulk delete — because a
cascade that broke on one would still look healthy on the other.

Two details that are the point of the test rather than incidental:

- **The project-wide cross-check.** `GET /spans?trace_id=<deleted>` answering
  "0 spans" is *not* evidence the cascade ran: a filter on a trace that no longer
  exists matches nothing either way, so a delete that removed the trace and
  orphaned every span produces that same zero. The test names the surviving set
  project-wide instead.
- **The bystander.** The control trace is never touched, and is asserted intact in
  substance — its spans, its trace-level score, its trace and span comments — not
  merely present, since an over-reaching delete could take the dependent rows and
  leave the row that renders in the table.

The UI half asserts the row leaves the table **without a reload**.

### What was deliberately not written

- **A permanent provider error in the automation log** (`online-evaluation.automation-logs`,
  [PR 8169](https://github.com/comet-ml/opik/pull/8169)) — **dropped, unrunnable
  here.** The candidate's flow needs a `custom-llm` provider pointed at the
  estate's own mock gateway (`services/mock-token-auth`) to force a 401. That mock
  binds to the test runner, and this run targeted a **cloud** deployment
  (`staging.dev.comet.com`) whose backend cannot reach it — the estate already
  codifies exactly this in `core/mock-auth.ts`, where `mockAuthSkipReason()`
  refuses outright for any non-`oss` deployment rather than even probing. (The
  runner confirms it: its only addresses are private, `10.4.104.165` and
  `172.17.0.1`, behind NAT.) The alternative — pointing a provider at a real
  third-party endpoint that 401s — would put an external network dependency inside
  an e2e assertion, which is the thing the mock gateway exists to avoid. Rather
  than ship a spec that could only ever `.skip` on the environment it was proposed
  from, it is left out and `online-evaluation.automation-logs` stays
  `covered: false`. It is worth writing against a local OSS backend, where the
  mock is reachable.

  Worth flagging separately: the exploration report this came from records item 3's
  verdict as *pending*, and its own environment notes say a read at +3 min could
  not tell the permanent and retryable cases apart. So this candidate was marked
  `verified_on_staging: true` without a recorded verification.
- **A transient provider error being retried** — not automatable at e2e level.
  `onlineScoring.pendingMessageDuration` defaults to 10m, so no e2e can wait for a
  redelivery. Belongs in the backend's own tests.
- **Deletion-events rows in `deletion_events_local`** — needs a deployment flag
  change and direct ClickHouse access, both out of reach from the e2e estate.
- **An attachment on a deleted trace.** The cascade test covers comments and
  feedback scores on trace and span, not attachments. The exploration did not
  exercise that either.

### Known trade-off

The reasoning-token amounts hardcode the shipped price table's rates, which are
synced daily from LiteLLM. That coupling is real, but it is the estate's existing
trade-off — `span-cost-resolution.spec.ts` already hardcodes table prices — not a
new one introduced here. The relational assertions are there partly so a table
move produces a legible failure rather than a mysterious one.

## Change checklist

- [x] Specs live in the area's own `spec_dir` (`trace-explore`) and extend the
      existing spec for the capability instead of duplicating it
- [x] Imports come from `@e2e/fixtures`; interaction goes through `@e2e/pom`
      (`LogsPage`) — no raw selectors in the specs
- [x] Seeding is through the SDK bridge, except the one vector the SDK provably
      cannot express, which is documented at its call site
- [x] Teardown is owned by fixtures, not by the test body
- [x] Every `@area:`/`@cap:` value already existed in `coverage/taxonomy.yaml`;
      no new keys invented, and no capability flipped to `covered: true` on the
      strength of a surface it does not exercise
- [x] `taxonomy.yaml` notes updated to state what is now asserted. **The area's
      `specs:` list is deliberately untouched** — the nightly reconcile job
      derives it from the `@area:` tag, and hand-editing it is what made this file
      the most-conflicted in the queue
- [x] No fixed sleeps; async state is awaited with `expect.poll`
- [x] No `.skip`, and no spec included that was not run green
- [x] Only spec, fixture, POM-support and taxonomy files committed — no
      exploration report, candidate list, screenshots or run artifacts

## Issues

OPIK-7791

Related product changes the specs are aimed at: #7777 (reasoning-token cost),
#8201 (trace delete / span cascade). Candidate dropped from this PR: #8169
(provider-error automation logs) — see *What was deliberately not written*.

## Testing

Run against `$OPIK_BASE_URL = https://staging.dev.comet.com/opik` (serving
`2.2.55`), `OPIK_DEPLOYMENT=cloud`, workspace `opik-testing`, from the `2.2.55`
ref with these changes applied.

```
npx playwright test tests/trace-explore/span-cost-resolution.spec.ts --reporter=line
  3 passed (22.3s)

npx playwright test tests/trace-explore/trace-delete.spec.ts --reporter=line
  3 passed (32.4s)
```

| Spec | Result |
|---|---|
| `span-cost-resolution.spec.ts` — reasoning tokens bill at the reasoning rate (new) | **passed** |
| `span-cost-resolution.spec.ts` — id normalisation, widened to the new seeds (existing) | **passed** |
| `span-cost-resolution.spec.ts` — trace panel renders each resolved cost, now over 8 priced spans (existing) | **passed** |
| `trace-delete.spec.ts` — delete cascades to nested spans, API + Logs (new) | **passed** |
| `trace-delete.spec.ts` — the two existing delete tests | **passed** |

Also run, since this change touches shared `core/` helpers rather than only spec
files:

```
python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
  tag-lint: 72 specs checked, 1 exempt, 0 problem(s)

npx playwright test tests/trace-explore/ --reporter=line     # full feature directory
  4 flaky
  22 passed (8.3m)
```

The whole feature directory is green, with **4 flaky and 0 failed**. All four
flakes are **pre-existing tests, not the new ones** — `thread-logging-smoke`,
`trace-attachments`, `trace-explore-smoke`, and the *existing* bulk-delete test at
`trace-delete.spec.ts:93` (the new cascade test is at `:185` and passed first
time, as did the new reasoning test). All four failed with the same
`PythonSdkBridgeError: POST /traces aborted after 30000ms` and passed on retry,
alongside a run-long stream of `HTTP 429 … for 'search_traces'` — i.e. shared
staging throttling a 26-test parallel load, not a code fault. Worth knowing that
this directory cannot currently be run at full parallelism against shared
staging without retries.

**One honest failure along the way, and what it was.** The cascade test failed on
its first run asserting a seeded trace comment could be read back. The cause was
the spec, not the app: `CommentServiceImpl.create` mints its own comment id and
ignores any the caller sends, returning the real one in `Location`. The helper now
reads the id from the header (the same way `createAutomationRule` does) and the
test passes. No app defect was found by either spec on its first green run.

**A pre-existing issue noticed but not touched.** `npx tsc --noEmit` fails at this
ref before any of these changes, with `TS5102: Option 'baseUrl' has been removed`
— the pinned `typescript: ^7.0.2` no longer accepts the `baseUrl` in
`tests_end_to_end/e2e/tsconfig.json`. `main` has the same tsconfig. Typechecking
here was done with an equivalent config that expresses the path alias without
`baseUrl` (not committed); it reports only two pre-existing duplicate
`deleteDashboard` identifiers in `core/backend/client.ts:899,1554`, both untouched
by this change. Separately, `tests/ai-providers/token-auth-refetch.spec.ts` fails
to load at this ref (`test.describe() in a configuration file`), also pre-existing
and unrelated. Both look worth a follow-up ticket; neither is in scope here.

## Documentation

No documentation change is needed. This adds test coverage only — no user-facing
behaviour, API, SDK surface or configuration changes. The `coverage/taxonomy.yaml`
notes, which are the estate's own record of what each capability's coverage
actually claims, are updated in this PR.
