### PR TITLE
[OPIK-8255] [BE] fix: batch the Distributed async-insert forwarding queue

### DIFF
--- a/apps/opik-backend/src/test/resources/users.xml
+++ b/apps/opik-backend/src/test/resources/users.xml
@@ -26,6 +26,20 @@
             <optimize_skip_unused_shards>1</optimize_skip_unused_shards>
             <do_not_merge_across_partitions_select_final>1</do_not_merge_across_partitions_select_final>
             <distributed_product_mode>local</distributed_product_mode>
+            <!-- Distributed async-insert forwarding queue (OPIK-8255). Batching ships many
+                 queued files per network round trip instead of one; split_batch_on_failure
+                 retries a failed batch file-by-file rather than wedging the queue. Both seed
+                 the engine's background_insert_* table settings at attach time.
+
+                 Harmless here, but not because there is no Distributed table — several tests
+                 create real ones against this profile (TracesDistributedWrapMutationTest,
+                 TracesLocalV2CutoverTest, TracesSchemaParityPostCutoverTest). It is that a
+                 single node with prefer_localhost_replica at its default of 1 writes
+                 in-process, so no queue file is produced. Hence prefer_localhost_replica is
+                 deliberately not set to 0 here: it would route those writes through the queue
+                 and the tests' read-backs would stop seeing them. -->
+            <distributed_background_insert_batch>1</distributed_background_insert_batch>
+            <distributed_background_insert_split_batch_on_failure>1</distributed_background_insert_split_batch_on_failure>
         </default>
         <comet_llm_readonly_freeform_sql_profile>
             <readonly>1</readonly>

--- a/deployment/docker-compose/clickhouse_config/users.d/distributed_insert_queue.xml
+++ b/deployment/docker-compose/clickhouse_config/users.d/distributed_insert_queue.xml
@@ -1,0 +1,24 @@
+<clickhouse>
+    <!-- Distributed async-insert forwarding queue (OPIK-8255). An INSERT into a Distributed
+         table that does not land on a local replica is serialised to a file on disk, and a
+         single background sender per node ships those files one per network round trip unless
+         batching is on — each round trip paying the receiving node's async-insert flush, which
+         caps forwarding throughput. split_batch_on_failure retries a failed batch file-by-file
+         rather than wedging the queue behind one bad file.
+
+         Inert in this stack: a single node with prefer_localhost_replica at its default of 1
+         writes in-process, so no queue file is produced. Set anyway to keep the local stack
+         identical to Kubernetes, the same reason additional_config.xml pins
+         internal_replication on a single-replica cluster. Note this does not depend on there
+         being no Distributed table — enabling the wrap locally creates one, and these apply.
+
+         Must be a profile (users.d) setting, not a server (config.d) one: ClickHouse reads
+         <profiles> only from users.d. clickhouse-init copies clickhouse_config into config.d,
+         so this file also needs its own mount in docker-compose.yaml to reach users.d. -->
+    <profiles>
+        <default>
+            <distributed_background_insert_batch>1</distributed_background_insert_batch>
+            <distributed_background_insert_split_batch_on_failure>1</distributed_background_insert_split_batch_on_failure>
+        </default>
+    </profiles>
+</clickhouse>

--- a/deployment/docker-compose/docker-compose.yaml
+++ b/deployment/docker-compose/docker-compose.yaml
@@ -58,6 +58,7 @@ services:
       - clickhouse-server:/var/log/clickhouse-server/:type=volume,source=~/opik/clickhouse/logs
       - clickhouse-config:/etc/clickhouse-server/config.d
       - ./clickhouse_config/users.d/enable_time_type.xml:/etc/clickhouse-server/users.d/enable_time_type.xml
+      - ./clickhouse_config/users.d/distributed_insert_queue.xml:/etc/clickhouse-server/users.d/distributed_insert_queue.xml
     healthcheck:
       test: [ "CMD", "wget", "--spider", "-q", "http://127.0.0.1:8123/ping" ]
       interval: 1s

--- a/deployment/helm_chart/opik/README.md
+++ b/deployment/helm_chart/opik/README.md
@@ -108,6 +108,7 @@ Call opik api on http://localhost:5173/api
 | chartMigration.nodeSelector | object | `{}` |  |
 | chartMigration.serviceAccountName | string | `""` |  |
 | chartMigration.tolerations | list | `[]` |  |
+| clickhouse.additionalProfiles | list | `[{"name":"default","settings":{"distributed_background_insert_batch":1,"distributed_background_insert_split_batch_on_failure":1}}]` | Extra ClickHouse settings profiles. Wins over the operator's own defaults; carries the Distributed insert-queue baseline on `default`. A values file declaring its own list must repeat that entry — Helm replaces lists rather than merging them. |
 | clickhouse.adminUser.password | string | `"opik"` |  |
 | clickhouse.adminUser.useSecret.enabled | bool | `false` |  |
 | clickhouse.adminUser.username | string | `"opik"` |  |

--- a/deployment/helm_chart/opik/tests/clickhouse_profiles_test.yaml
+++ b/deployment/helm_chart/opik/tests/clickhouse_profiles_test.yaml
@@ -1,0 +1,102 @@
+suite: clickhouse default settings profile (Distributed insert-queue settings)
+
+# The Distributed forwarding queue ships one file per network round trip unless
+# `distributed_background_insert_batch` is on, each trip paying the receiving node's
+# async-insert flush. That caps forwarding throughput, and once arrivals exceed it the queue
+# and the ingestion visibility lag grow without bound, with no errors and no MergeTree
+# throttling (OPIK-8255). So these settings are an installation-wide baseline, not an opt-in.
+#
+# `clickhouse.additionalProfiles` is what makes that stick: the operator renders it into
+# `users.d/chop-generated-profiles.xml`, the last file the server reads, so it wins over both
+# the chart's `conf.d/profiles.xml` and the operator's own default profile.
+#
+# The cost is that Helm replaces lists wholesale rather than merging them, so any values file
+# declaring its own list drops the `default` entry unless it repeats it. This suite pins the
+# chart's default and asserts the drop, so a consumer's obligation is visible here rather than
+# only in a comment.
+
+templates:
+  - templates/clickhouseinstallation.yaml
+
+tests:
+  - it: sets the Distributed insert-queue settings on the default profile out of the box
+    asserts:
+      - equal:
+          path: spec.configuration.profiles["default/distributed_background_insert_batch"]
+          value: 1
+      - equal:
+          path: spec.configuration.profiles["default/distributed_background_insert_split_batch_on_failure"]
+          value: 1
+
+  # The settings have to reach the *default* profile specifically: that is the profile the
+  # backend's ClickHouse user inherits, and so the one the insert path runs under.
+  - it: renders the settings under the default profile, not a profile of their own
+    asserts:
+      - equal:
+          path: spec.configuration.profiles
+          value:
+            default/distributed_background_insert_batch: 1
+            default/distributed_background_insert_split_batch_on_failure: 1
+
+  # The rendered key shape is `<profile>/<setting>`, which is what the Altinity operator
+  # flattens into the users.d XML. Asserted separately so a template refactor that changed the
+  # separator would fail loudly rather than silently emitting a profile nobody inherits.
+  - it: keeps the operator's profile/setting key shape
+    asserts:
+      - exists:
+          path: spec.configuration.profiles["default/distributed_background_insert_batch"]
+      - notExists:
+          path: spec.configuration.profiles.default
+
+  # Extra profiles are additive: a consumer adding a read-only profile must not have to think
+  # about the queue settings, so the `default` entry has to survive alongside its own entries.
+  - it: keeps the default entry alongside additional profiles
+    set:
+      clickhouse.additionalProfiles:
+        - name: default
+          settings:
+            distributed_background_insert_batch: 1
+            distributed_background_insert_split_batch_on_failure: 1
+        - name: readonly_profile
+          settings:
+            readonly: 1
+            max_execution_time: 60
+    asserts:
+      - equal:
+          path: spec.configuration.profiles["default/distributed_background_insert_batch"]
+          value: 1
+      - equal:
+          path: spec.configuration.profiles["default/distributed_background_insert_split_batch_on_failure"]
+          value: 1
+      - equal:
+          path: spec.configuration.profiles["readonly_profile/readonly"]
+          value: 1
+
+  # The trap, asserted rather than only commented: a values file that declares its own list and
+  # omits `default` loses the queue settings entirely. Any consumer that overrides the list must
+  # repeat the `default` entry — which is what the test above covers.
+  - it: loses the settings when a consumer replaces the list without the default entry
+    set:
+      clickhouse.additionalProfiles:
+        - name: readonly_profile
+          settings:
+            readonly: 1
+    asserts:
+      - notExists:
+          path: spec.configuration.profiles["default/distributed_background_insert_batch"]
+      - notExists:
+          path: spec.configuration.profiles["default/distributed_background_insert_split_batch_on_failure"]
+
+  # The monitoring user's readonly flag shares the profiles block with these settings; it is
+  # gated separately, so check the two coexist rather than one gate shadowing the other.
+  - it: coexists with the monitoring profile
+    set:
+      clickhouse.monitoring.enabled: true
+      clickhouse.monitoring.username: monitor
+    asserts:
+      - equal:
+          path: spec.configuration.profiles["monitor/readonly"]
+          value: 1
+      - equal:
+          path: spec.configuration.profiles["default/distributed_background_insert_batch"]
+          value: 1

--- a/deployment/helm_chart/opik/values.yaml
+++ b/deployment/helm_chart/opik/values.yaml
@@ -840,6 +840,42 @@ clickhouse:
   # shardsCount is.
   sharding:
     enabled: false
+  # Rendered into the ClickHouseInstallation's `spec.configuration.profiles`. The Altinity
+  # operator turns these into `users.d/chop-generated-profiles.xml`, the last file the server
+  # reads, so a value here wins over both the chart's `conf.d/profiles.xml` below and the
+  # operator's own `users.d/02-clickhouse-default-profile.xml`. That precedence is why the
+  # Distributed insert-queue settings live here rather than in `configuration.files`.
+  #
+  # WARNING: this is a Helm list, and Helm replaces lists wholesale rather than merging them. A
+  # values file declaring its own `additionalProfiles` must repeat the `default` entry below or
+  # silently lose these settings. `tests/clickhouse_profiles_test.yaml` asserts both.
+  #
+  # -- (list) Extra ClickHouse settings profiles. Wins over the operator's own defaults; carries
+  # the Distributed insert-queue baseline on `default`. A values file declaring its own list must
+  # repeat that entry — Helm replaces lists rather than merging them.
+  additionalProfiles:
+    # An INSERT into a Distributed table that does not land on a local replica is serialised to a
+    # file on disk, and a single background sender per node ships those files one per network
+    # round trip unless batching is on — each trip paying the receiving node's async-insert
+    # flush. That caps forwarding throughput hard, and once arrivals exceed it the queue and the
+    # ingestion visibility lag grow without bound, with no errors and no MergeTree throttling.
+    # Batching packs many files into each round trip; split_batch_on_failure retries a failed
+    # batch file-by-file rather than wedging the queue behind one bad file.
+    #
+    # These session-setting spellings are what belongs in a profile: they seed the Distributed
+    # engine's own background_insert_* table settings for tables created without a SETTINGS
+    # clause, which is all of ours.
+    #
+    # IMPORTANT: that seeding happens when the table is ATTACHED — on CREATE and on every server
+    # start — and is read from the server-wide context, so setting them per session has no
+    # effect. Landing these needs a rolling ClickHouse restart. No table recreate is required and
+    # the table definition is untouched; `ALTER TABLE ... MODIFY SETTING` is rejected on a
+    # Distributed table (Code 48, NOT_IMPLEMENTED).
+    #
+    - name: default
+      settings:
+        distributed_background_insert_batch: 1
+        distributed_background_insert_split_batch_on_failure: 1
   # For a FRESH High-Availability install, use the two-phase flow: install with replicasCount 1, let
   # opik-backend finish all migrations, THEN raise replicasCount and upgrade so the ClickHouse operator
   # clones the schema to the new replicas. Installing directly on >= 2 replicas prevents the analytics


### PR DESCRIPTION
## Details

Sets the Distributed async-insert queue settings on the ClickHouse `default` profile, on every installation surface — Helm chart, docker-compose and testcontainers — so the insert path no longer depends on which ClickHouse flavour a deployment runs.

```yaml
clickhouse:
  additionalProfiles:
    - name: default
      settings:
        distributed_background_insert_batch: 1
        distributed_background_insert_split_batch_on_failure: 1
```

An INSERT into a Distributed table that does not land on a local replica is serialised to a file on disk, and a single background sender per node ships those files **one per network round trip** unless batching is on — each trip paying the receiving node's async-insert flush. That caps forwarding throughput hard, and once arrivals exceed the cap the queue and the ingestion visibility lag grow without bound, with no errors, no failed inserts and no MergeTree throttling. Everything succeeds, slowly.

Batching packs many files into each round trip. `split_batch_on_failure` makes a failed batch retry file-by-file instead of wedging the queue behind one bad file.

Measurements and the incident timeline are on OPIK-8255; they are deliberately not restated here.

### Why these spellings, in a profile

Both spellings exist and are different settings at different layers:

| Name | Kind | Where it belongs |
|---|---|---|
| `distributed_background_insert_batch` | session setting (the documented one) | a `<profiles>` block |
| `background_insert_batch` | Distributed table-engine setting | server `<distributed>` section, or a table `SETTINGS` clause |

The session setting seeds the table setting for tables created without a `SETTINGS` clause, which is all of ours. It is resolved from the **server-wide context at attach time**, so setting it per session has no effect.

### Needs a rolling restart, not a table recreate

Attach happens on `CREATE` and on **every server start**, and `ALTER TABLE ... MODIFY SETTING` is rejected on a `Distributed` table (Code 48, `NOT_IMPLEMENTED`). So a rolling ClickHouse restart is both necessary and sufficient — no table recreate, and the table definition is untouched.

### Placement, and what it costs

`clickhouse.additionalProfiles` is rendered by the Altinity operator into `users.d/chop-generated-profiles.xml`, the last file the server reads, so it wins over both the chart's `conf.d/profiles.xml` and the operator's own `users.d/02-clickhouse-default-profile.xml`.

The cheaper route — the chart's existing `conf.d/profiles.xml` map key — would work today only *because* the value happens to agree with what the operator sets; `conf.d` loses whenever it disagrees. `additionalProfiles` wins by construction rather than by coincidence.

**The cost:** it is a Helm **list**, and Helm replaces lists wholesale. Any values file declaring its own list drops the `default` entry unless it repeats it.

Note the direction, because it is easy to read backwards: the **consumer's list wins**. A consumer's own profiles are never dropped. What is lost is the *new* `default` entry, i.e. a benefit that consumer never had — so no existing deployment regresses; some just do not gain until updated. Consumers that declare their own list are tracked on the ticket; the enterprise chart declares none and inherits this default.

A map-merged key would be immune to the drop and was considered, but the affected consumers are internal and re-declaring is cheap, and the list keeps the mechanism identical to the one that was verified. The new suite asserts both the default and the drop, so the obligation is visible in the chart rather than only in a comment.

### Surfaces

| Surface | File |
|---|---|
| Opik chart | `deployment/helm_chart/opik/values.yaml` |
| Render assertion | `deployment/helm_chart/opik/tests/clickhouse_profiles_test.yaml` (new, 6 tests) |
| Local Docker | `deployment/docker-compose/clickhouse_config/users.d/distributed_insert_queue.xml` (new) + mount |
| Testcontainers | `apps/opik-backend/src/test/resources/users.xml` |

Inert on the two single-node surfaces — **but not for the reason the ticket assumed.** It scoped them on the grounds that they have no Distributed table; they do. `ClickHouseContainerUtils.java:94` mounts `users.xml` into `users.d/`, and `TracesDistributedWrapMutationTest.java:244` runs `ENGINE = Distributed(...)` against that profile, while `TracesLocalV2CutoverTest` and `TracesSchemaParityPostCutoverTest` wrap `traces` and read their own writes back.

The real reason is that both are a **single node with `prefer_localhost_replica` at its default of 1**, so `DistributedSink` writes in-process and no queue file is produced. That distinction bounds the change: it is why `prefer_localhost_replica` cannot be set to 0 there, which the stacked #8230 confirmed the hard way.

`clickhouse-init` copies `clickhouse_config` into `config.d`, and ClickHouse reads `<profiles>` only from `users.d`, hence the explicit per-file mount. A whole-directory mount is not an option — the image entrypoint writes `users.d/default-user.xml` from `CLICKHOUSE_USER`, which a directory mount would shadow.

`prefer_localhost_replica` is left out entirely; it lands in #8230, resolved from the cluster topology.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-8255

Related, not resolved here: OPIK_7686, OPIK_6875.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: values/XML/test authoring and PR description.
- Human verification: renders and lint run locally and reviewed; every suite assertion re-checked mechanically against a real render; CI green.

## Testing

The helm-unittest plugin was not available locally, so every assertion was validated against a real `helm template` render — by script, parsing the suite, applying each test's `set:` block and comparing every asserted path and value:

```
6 tests, 12 assertions — ALL MATCH THE REAL RENDER
```

CI then runs the suite itself (`unittest-helm-chart` — pass).

```bash
cd deployment/helm_chart/opik && helm dependency build
helm lint --values values.yaml .      # clean
```

Scenarios covered: default render (both keys on `default`); monitoring enabled (`monitor/readonly` renders alongside, neither gate shadowing the other); consumer replaces the list without `default` (both keys gone — the documented drop); consumer replaces it *with* `default` plus a readonly profile (all keys present); key shape `<profile>/<setting>` with no nested `profiles.default`.

Also: both XML files parse; the testcontainers `default` profile carries all five settings in order; `docker compose config` clean; README regenerated with `jnorwood/helm-docs:v1.14.2`, the version the pre-commit hook pins.

Full backend suite green — 16 integration groups plus unit tests, which exercise the testcontainers profile change including the tests that build real Distributed tables.

Not run: no production verification. This lands ahead of the rolling ClickHouse restart and is inert until then; runtime evidence is gathered separately and recorded on the ticket.

## Documentation

No user-facing docs change. `deployment/helm_chart/opik/README.md` is regenerated by helm-docs for the new values key. Reasoning is captured in-tree where an operator will hit it: the `additionalProfiles` comment in `values.yaml` (including the list-replacement warning), the suite header, and the new `distributed_insert_queue.xml`.
