### PR TITLE
[OPIK-8314] [SDK] fix: forward the LiteLLM proxy's own cost to ADK spans

### DIFF
--- a/sdks/python/src/opik/api_objects/validation_helpers.py
+++ b/sdks/python/src/opik/api_objects/validation_helpers.py
@@ -37,7 +37,7 @@ def validate_and_parse_usage(
     unknown_provider = (provider is None) or (not LLMProvider.has_value(provider))
 
     if unknown_provider:
-        return _parse_usage_of_unknown_provider(usage)
+        return _parse_usage_of_unknown_provider(usage, logger)
 
     provider = LLMProvider(provider)
 
@@ -45,15 +45,30 @@ def validate_and_parse_usage(
         opik_usage = llm_usage.build_opik_usage(provider=provider, usage=usage)
         return opik_usage.to_backend_compatible_full_usage_dict()
     except Exception:
-        return _parse_usage_of_unknown_provider(usage)
+        return _parse_usage_of_unknown_provider(usage, logger)
 
 
-def _parse_usage_of_unknown_provider(usage: Any) -> Optional[Dict[str, int]]:
+def _parse_usage_of_unknown_provider(
+    usage: Any, logger: logging.Logger
+) -> Optional[Dict[str, int]]:
     opik_usage = llm_usage.build_opik_usage_from_unknown_provider(usage)
     if opik_usage is None:
         return None
 
-    return opik_usage.to_backend_compatible_full_usage_dict()
+    try:
+        return opik_usage.to_backend_compatible_full_usage_dict()
+    except Exception:
+        # Flattening walks the provider payload, so pathological input (deep or
+        # cyclic nesting -> RecursionError) can still fail here even though parsing
+        # succeeded. This is the best-effort path and it is reached with arbitrary
+        # caller data from `Opik.span(usage=...)`: the usage is droppable, the span
+        # it rides on is not. Type only, never the value.
+        logger.error(
+            "Failed to serialize token usage of an unknown provider (received %s)",
+            type(usage).__name__,
+            exc_info=True,
+        )
+        return None
 
 
 def validate_feedback_score(

--- a/sdks/python/src/opik/api_objects/validation_helpers.py
+++ b/sdks/python/src/opik/api_objects/validation_helpers.py
@@ -37,9 +37,7 @@ def validate_and_parse_usage(
     unknown_provider = (provider is None) or (not LLMProvider.has_value(provider))
 
     if unknown_provider:
-        return llm_usage.build_opik_usage_from_unknown_provider(
-            usage
-        ).to_backend_compatible_full_usage_dict()
+        return _parse_usage_of_unknown_provider(usage)
 
     provider = LLMProvider(provider)
 
@@ -47,9 +45,15 @@ def validate_and_parse_usage(
         opik_usage = llm_usage.build_opik_usage(provider=provider, usage=usage)
         return opik_usage.to_backend_compatible_full_usage_dict()
     except Exception:
-        return llm_usage.build_opik_usage_from_unknown_provider(
-            usage
-        ).to_backend_compatible_full_usage_dict()
+        return _parse_usage_of_unknown_provider(usage)
+
+
+def _parse_usage_of_unknown_provider(usage: Any) -> Optional[Dict[str, int]]:
+    opik_usage = llm_usage.build_opik_usage_from_unknown_provider(usage)
+    if opik_usage is None:
+        return None
+
+    return opik_usage.to_backend_compatible_full_usage_dict()
 
 
 def validate_feedback_score(

--- a/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/legacy_opik_tracer.py
@@ -265,6 +265,7 @@ class LegacyOpikTracer:
         model = None
         usage = None
         output = None
+        total_cost = None
 
         # Final (non-partial) response for this call: clear any output cached for
         # this invocation up front, so a missing span or failed conversion below
@@ -284,6 +285,9 @@ class LegacyOpikTracer:
                 output = adk_helpers.convert_adk_base_model_to_dict(llm_response)
                 self._last_model_output.set(callback_context.invocation_id, output)
 
+                # Before the usage parsing below, which can raise - the cost must not
+                # be lost to a usage problem it has nothing to do with.
+                total_cost = llm_response_wrapper.pop_response_cost(output)
                 usage_data = llm_response_wrapper.pop_llm_usage_data(
                     output, span_data.provider
                 )
@@ -305,6 +309,7 @@ class LegacyOpikTracer:
                     output=output,
                     usage=usage,
                     model=model,
+                    total_cost=total_cost,
                 )
                 self._end_current_span()
                 self._opik_created_spans.discard(span_data.id)

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -384,9 +384,16 @@ class OpikTracer:
                 self._last_model_output.discard(callback_context.invocation_id)
                 if not is_partial:
                     try:
+                        recovered_output = adk_helpers.convert_adk_base_model_to_dict(
+                            llm_response
+                        )
+                        # There is no span to charge here, but the cost must still be
+                        # taken out of the output: after_agent_callback stamps this
+                        # dict as the trace output, so leaving it in would surface an
+                        # internal marker as ordinary agent output.
+                        llm_response_wrapper.pop_response_cost(recovered_output)
                         self._last_model_output.set(
-                            callback_context.invocation_id,
-                            adk_helpers.convert_adk_base_model_to_dict(llm_response),
+                            callback_context.invocation_id, recovered_output
                         )
                     except Exception:
                         LOGGER.debug(

--- a/sdks/python/src/opik/integrations/adk/opik_tracer.py
+++ b/sdks/python/src/opik/integrations/adk/opik_tracer.py
@@ -328,6 +328,7 @@ class OpikTracer:
             model = None
             usage = None
             output = None
+            total_cost = None
 
             # Resolve the LLM span created in before_model_callback up front, so
             # the ``finally`` can clean up its TTFT and pending-registry entries
@@ -438,6 +439,9 @@ class OpikTracer:
 
             try:
                 output = adk_helpers.convert_adk_base_model_to_dict(llm_response)
+                # Before the usage parsing below, which can raise - the cost must not
+                # be lost to a usage problem it has nothing to do with.
+                total_cost = llm_response_wrapper.pop_response_cost(output)
                 usage_data = llm_response_wrapper.pop_llm_usage_data(
                     output, current_span.provider
                 )
@@ -476,6 +480,7 @@ class OpikTracer:
                 type="llm",
                 model=model,
                 usage=usage,
+                total_cost=total_cost,
                 metadata=current_span.metadata,
                 project_name=self.project_name,
             )

--- a/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from functools import wraps
 from typing import Any, Callable, Optional, Tuple, Union, TYPE_CHECKING
 
@@ -55,10 +56,18 @@ def try_get_response_cost(
         return None
 
     try:
-        return float(raw_cost)
+        cost = float(raw_cost)
     except (TypeError, ValueError):
         LOGGER.debug("Failed to parse LiteLLM response cost from value: %r", raw_cost)
         return None
+
+    # nan/inf serialize to bare NaN/Infinity, which is not valid JSON, so letting one
+    # through would risk the span it rides on rather than just the cost.
+    if not math.isfinite(cost):
+        LOGGER.debug("Ignoring non-finite LiteLLM response cost: %r", raw_cost)
+        return None
+
+    return cost
 
 
 def generate_content_response_decorator(func: Callable) -> Callable:

--- a/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
@@ -27,6 +27,40 @@ def parse_provider_and_model(
     return provider, parts[1]
 
 
+def try_get_response_cost(
+    model_response: "litellm.types.utils.ModelResponse",
+) -> Optional[float]:
+    """Reads the cost LiteLLM computed for this call off the raw response.
+
+    Opik's price table is keyed on (provider, model), which can never resolve a
+    ``litellm_proxy/<alias>`` route: "litellm_proxy" is not an ``opik.LLMProvider``
+    and the alias is not a real model name (the OpenAI-compatible spec requires the
+    response to echo the requested model, so no proxy config can fix that either).
+    LiteLLM does know the real cost for those calls, so we forward it as the span's
+    cost instead of estimating one.
+
+    ``_hidden_params`` is LiteLLM's own documented place for this and the only one:
+    ``litellm.completion_cost()`` recomputes from the price map, which is precisely
+    what fails for a proxy alias. Being a pydantic private attribute it is also
+    absent from ``to_dict()``, so it has to be read off the object - kept to this
+    single guarded access so a LiteLLM-side change degrades to "no cost", not a
+    raise inside ADK's response conversion.
+    """
+    hidden_params = getattr(model_response, "_hidden_params", None)
+    if not isinstance(hidden_params, dict):
+        return None
+
+    raw_cost = hidden_params.get("response_cost", None)
+    if raw_cost is None:
+        return None
+
+    try:
+        return float(raw_cost)
+    except (TypeError, ValueError):
+        LOGGER.debug("Failed to parse LiteLLM response cost from value: %r", raw_cost)
+        return None
+
+
 def generate_content_response_decorator(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> adk_models.LlmResponse:
@@ -38,13 +72,15 @@ def generate_content_response_decorator(func: Callable) -> Callable:
         model_response = args[0]
         model_response_dict = model_response.to_dict()
 
+        response_cost = try_get_response_cost(model_response)
         provider_and_model = model_response_dict.get("provider_and_model", None)
         LOGGER.debug(
-            "generate_content_response_decorator: provider_and_model=%s",
+            "generate_content_response_decorator: provider_and_model=%s, response_cost=%s",
             provider_and_model,
+            response_cost,
         )
 
-        if provider_and_model is None:
+        if provider_and_model is None and response_cost is None:
             return result
 
         if result.custom_metadata is None:
@@ -53,18 +89,23 @@ def generate_content_response_decorator(func: Callable) -> Callable:
             )
             result.custom_metadata = {}
 
-        provider, model = parse_provider_and_model(provider_and_model)
-        LOGGER.debug(
-            "generate_content_response_decorator: provider=%s, model=%s",
-            provider,
-            model,
-        )
+        if response_cost is not None:
+            result.custom_metadata["opik_response_cost"] = response_cost
 
-        result.custom_metadata["opik_usage"] = model_response_dict["usage"]
-        result.custom_metadata["provider"] = provider
-        result.custom_metadata["model_version"] = model_response_dict.get(
-            "model", model
-        )
+        if provider_and_model is not None:
+            provider, model = parse_provider_and_model(provider_and_model)
+            LOGGER.debug(
+                "generate_content_response_decorator: provider=%s, model=%s",
+                provider,
+                model,
+            )
+
+            result.custom_metadata["opik_usage"] = model_response_dict["usage"]
+            result.custom_metadata["provider"] = provider
+            result.custom_metadata["model_version"] = model_response_dict.get(
+                "model", model
+            )
+
         LOGGER.debug(
             "generate_content_response_decorator finished: result.custom_metadata=%s",
             result.custom_metadata,

--- a/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/litellm_wrappers.py
@@ -28,46 +28,55 @@ def parse_provider_and_model(
     return provider, parts[1]
 
 
-def try_get_response_cost(
+def try_get_proxy_response_cost(
     model_response: "litellm.types.utils.ModelResponse",
 ) -> Optional[float]:
-    """Reads the cost LiteLLM computed for this call off the raw response.
+    """The cost a LiteLLM *proxy* reported for this call, or None if not proxied.
 
-    Opik's price table is keyed on (provider, model), which can never resolve a
-    ``litellm_proxy/<alias>`` route: "litellm_proxy" is not an ``opik.LLMProvider``
-    and the alias is not a real model name (the OpenAI-compatible spec requires the
-    response to echo the requested model, so no proxy config can fix that either).
-    LiteLLM does know the real cost for those calls, so we forward it as the span's
-    cost instead of estimating one.
+    Deliberately not ``_hidden_params["response_cost"]``, which LiteLLM's ``@client``
+    wrapper sets on *every* completion, proxied or not. Since the backend prefers a
+    client-supplied cost over its own table, reading that would switch every ADK
+    LiteLLM span from Opik's pricing to LiteLLM's as a side effect - and a LiteLLM
+    cache hit reports an explicit ``0.0``, which would suppress the backend's own
+    calculation rather than fall through to it.
 
-    ``_hidden_params`` is LiteLLM's own documented place for this and the only one:
-    ``litellm.completion_cost()`` recomputes from the price map, which is precisely
-    what fails for a proxy alias. Being a pydantic private attribute it is also
-    absent from ``to_dict()``, so it has to be read off the object - kept to this
-    single guarded access so a LiteLLM-side change degrades to "no cost", not a
-    raise inside ADK's response conversion.
+    The reliable proxy signal is the ``x-litellm-response-cost`` header, which only a
+    LiteLLM proxy sends and which LiteLLM folds into
+    ``_hidden_params["additional_headers"]``. Its own
+    ``get_response_cost_from_hidden_params`` reads exactly that, so the header key and
+    the dict/BaseModel handling stay LiteLLM's business rather than ours.
+
+    Keying on the header rather than on a ``litellm_proxy/`` prefix also covers a
+    proxy addressed as ``openai/<alias>`` with ``api_base`` pointed at it: same
+    unpriceable alias echoed back, same missing cost, and the prefix says "openai".
+    Verified against a real proxy - present for both routings, absent for a direct
+    call.
+
+    Never raises: the conversion this runs inside is ADK's, so a LiteLLM-side change
+    has to degrade to "no cost" rather than cost the whole response.
     """
     hidden_params = getattr(model_response, "_hidden_params", None)
-    if not isinstance(hidden_params, dict):
-        return None
-
-    raw_cost = hidden_params.get("response_cost", None)
-    if raw_cost is None:
+    if hidden_params is None:
         return None
 
     try:
-        cost = float(raw_cost)
-    except (TypeError, ValueError):
-        LOGGER.debug("Failed to parse LiteLLM response cost from value: %r", raw_cost)
+        from litellm import cost_calculator
+
+        raw_cost = cost_calculator.get_response_cost_from_hidden_params(hidden_params)
+    except Exception:
+        LOGGER.debug("Failed to read the LiteLLM proxy response cost", exc_info=True)
+        return None
+
+    if raw_cost is None:
         return None
 
     # nan/inf serialize to bare NaN/Infinity, which is not valid JSON, so letting one
     # through would risk the span it rides on rather than just the cost.
-    if not math.isfinite(cost):
+    if not math.isfinite(raw_cost):
         LOGGER.debug("Ignoring non-finite LiteLLM response cost: %r", raw_cost)
         return None
 
-    return cost
+    return raw_cost
 
 
 def generate_content_response_decorator(func: Callable) -> Callable:
@@ -81,15 +90,13 @@ def generate_content_response_decorator(func: Callable) -> Callable:
         model_response = args[0]
         model_response_dict = model_response.to_dict()
 
-        response_cost = try_get_response_cost(model_response)
         provider_and_model = model_response_dict.get("provider_and_model", None)
         LOGGER.debug(
-            "generate_content_response_decorator: provider_and_model=%s, response_cost=%s",
+            "generate_content_response_decorator: provider_and_model=%s",
             provider_and_model,
-            response_cost,
         )
 
-        if provider_and_model is None and response_cost is None:
+        if provider_and_model is None:
             return result
 
         if result.custom_metadata is None:
@@ -98,22 +105,29 @@ def generate_content_response_decorator(func: Callable) -> Callable:
             )
             result.custom_metadata = {}
 
+        provider, model = parse_provider_and_model(provider_and_model)
+        LOGGER.debug(
+            "generate_content_response_decorator: provider=%s, model=%s",
+            provider,
+            model,
+        )
+
+        result.custom_metadata["opik_usage"] = model_response_dict["usage"]
+        result.custom_metadata["provider"] = provider
+        result.custom_metadata["model_version"] = model_response_dict.get(
+            "model", model
+        )
+
+        # Only a proxied call yields a cost here; a direct one keeps Opik's own
+        # pricing, which this must not quietly take over. See
+        # try_get_proxy_response_cost.
+        response_cost = try_get_proxy_response_cost(model_response)
+        LOGGER.debug(
+            "generate_content_response_decorator: proxy response_cost=%s",
+            response_cost,
+        )
         if response_cost is not None:
             result.custom_metadata["opik_response_cost"] = response_cost
-
-        if provider_and_model is not None:
-            provider, model = parse_provider_and_model(provider_and_model)
-            LOGGER.debug(
-                "generate_content_response_decorator: provider=%s, model=%s",
-                provider,
-                model,
-            )
-
-            result.custom_metadata["opik_usage"] = model_response_dict["usage"]
-            result.custom_metadata["provider"] = provider
-            result.custom_metadata["model_version"] = model_response_dict.get(
-                "model", model
-            )
 
         LOGGER.debug(
             "generate_content_response_decorator finished: result.custom_metadata=%s",

--- a/sdks/python/src/opik/integrations/adk/patchers/llm_response_wrapper.py
+++ b/sdks/python/src/opik/integrations/adk/patchers/llm_response_wrapper.py
@@ -39,6 +39,21 @@ class LLMUsageData:
     provider: Optional[str]
 
 
+def pop_response_cost(result_dict: Dict[str, Any]) -> Optional[float]:
+    """Extracts the LiteLLM-computed cost from ADK output and removes it from the result dict.
+
+    Kept separate from ``pop_llm_usage_data``, and called before it, because that
+    function can both give up on and raise over usage it cannot parse, and the two
+    share one try/except: reading the cost afterwards would forfeit it to a problem
+    it has nothing to do with. The cost is reported by the proxy, not derived from
+    the tokens.
+    """
+    if (custom_metadata := result_dict.get("custom_metadata", None)) is None:
+        return None
+
+    return custom_metadata.pop("opik_response_cost", None)
+
+
 def pop_llm_usage_data(
     result_dict: Dict[str, Any], provider: Optional[str]
 ) -> Optional[LLMUsageData]:

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -4,6 +4,8 @@ from typing import Any, Callable, Dict, List, Optional, Union
 from opik.types import LLMProvider
 from . import opik_usage
 
+LOGGER = logging.getLogger(__name__)
+
 
 # One provider can have multiple formats of usage dicts, so it can have more than 1 build function
 _PROVIDER_TO_OPIK_USAGE_BUILDERS: Dict[
@@ -44,7 +46,16 @@ def build_opik_usage(
 
 def build_opik_usage_from_unknown_provider(
     usage: Dict[str, Any],
-) -> opik_usage.OpikUsage:
+) -> Optional[opik_usage.OpikUsage]:
+    """Best-effort usage parsing for a provider we have no builder for.
+
+    Never raises. This is the last resort behind every provider-specific builder and
+    every caller already treats a failure as "no usage", but the generic fallback was
+    the one unguarded step here: ``from_unknown_usage_dict`` ends in ``cls(**usage)``,
+    so a payload that is not a mapping at all raised straight out of a function whose
+    whole contract is best effort - taking down whatever the caller was doing
+    alongside the usage.
+    """
     for build_functions in _PROVIDER_TO_OPIK_USAGE_BUILDERS.values():
         for build_function in build_functions:
             try:
@@ -53,7 +64,16 @@ def build_opik_usage_from_unknown_provider(
             except Exception:
                 pass
 
-    return opik_usage.OpikUsage.from_unknown_usage_dict(usage)
+    try:
+        return opik_usage.OpikUsage.from_unknown_usage_dict(usage)
+    except Exception:
+        # Not debug: the usage is silently dropped, and nothing else reports it.
+        LOGGER.error(
+            "Failed to parse token usage of an unknown provider from: %r",
+            usage,
+            exc_info=True,
+        )
+        return None
 
 
 def try_build_opik_usage_or_log_error(

--- a/sdks/python/src/opik/llm_usage/opik_usage_factory.py
+++ b/sdks/python/src/opik/llm_usage/opik_usage_factory.py
@@ -68,9 +68,12 @@ def build_opik_usage_from_unknown_provider(
         return opik_usage.OpikUsage.from_unknown_usage_dict(usage)
     except Exception:
         # Not debug: the usage is silently dropped, and nothing else reports it.
+        # Only the type is logged, never the value: this runs on whatever a caller
+        # passed to `Opik.span(usage=...)`, which is arbitrary and unbounded. The
+        # traceback carries the actual diagnosis.
         LOGGER.error(
-            "Failed to parse token usage of an unknown provider from: %r",
-            usage,
+            "Failed to parse token usage of an unknown provider (received %s)",
+            type(usage).__name__,
             exc_info=True,
         )
         return None

--- a/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
+++ b/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
@@ -1,0 +1,257 @@
+"""Cost reporting for LiteLLM-routed ADK calls.
+
+A ``litellm_proxy/<alias>`` route can never be priced from Opik's (provider, model)
+table: "litellm_proxy" is not an ``opik.LLMProvider``, and ``model`` stays the proxy
+alias because the OpenAI-compatible spec requires the response to echo the requested
+model - so no proxy configuration can fix it either. The proxy does compute the real
+cost server-side and LiteLLM hands it back on the response, so the integration has to
+forward that instead of estimating one.
+
+These tests build the same response objects a proxied LiteLLM call produces, which
+keeps them offline. The end-to-end chain (live proxy -> ``x-litellm-response-cost``
+-> ``_hidden_params`` -> span) was verified against a real local LiteLLM proxy when
+this was fixed; what can regress silently afterwards is our side of it, which is what
+is pinned here.
+"""
+
+import asyncio
+from typing import AsyncGenerator
+
+import litellm
+import pytest
+from google.adk import agents as adk_agents
+from google.adk import models as adk_models
+from google.adk import runners as adk_runners
+from google.adk.models import base_llm, lite_llm as adk_lite_llm
+from google.adk.models import llm_request
+from google.adk.sessions import in_memory_session_service
+from google.genai import types as genai_types
+
+import opik
+from opik.integrations.adk import OpikTracer
+from opik.integrations.adk.patchers import (
+    litellm_wrappers,
+    llm_response_wrapper,
+    patchers,
+)
+from . import helpers
+
+PROXY_ALIAS = "gemini-3.5-flash"
+PROXY_ROUTE = f"litellm_proxy/{PROXY_ALIAS}"
+# The value a real proxy returned for one call while investigating the ticket.
+RESPONSE_COST = 0.0009352500000000001
+RESPONSE_TEXT = "It is sunny and 22C."
+
+
+def _build_proxy_model_response() -> "litellm.types.utils.ModelResponse":
+    """The response object a ``litellm_proxy/<alias>`` call produces.
+
+    ``model`` echoes the proxy alias, and the cost the proxy computed arrives in
+    ``_hidden_params`` - LiteLLM folds the ``x-litellm-response-cost`` response
+    header into it. ``provider_and_model`` is what Opik's own ``acompletion``
+    patch attaches upstream of this point.
+    """
+    response = litellm.types.utils.ModelResponse(
+        id="chatcmpl-proxy-1",
+        created=1758000000,
+        model=PROXY_ALIAS,
+        object="chat.completion",
+        choices=[
+            litellm.types.utils.Choices(
+                index=0,
+                finish_reason="stop",
+                message=litellm.types.utils.Message(
+                    role="assistant", content=RESPONSE_TEXT
+                ),
+            )
+        ],
+        usage=litellm.types.utils.Usage(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        ),
+    )
+    response._hidden_params = {"response_cost": RESPONSE_COST}
+    response.provider_and_model = PROXY_ROUTE
+    return response
+
+
+def test_proxy_alias_is_unpriceable_by_the_price_table():
+    """Pins the premise the whole fix rests on.
+
+    If "litellm_proxy" ever became a real provider this forwarding would be
+    redundant, and if the assumption is wrong the tests below would be asserting
+    a workaround for a problem that does not exist.
+    """
+    with pytest.raises(ValueError):
+        opik.LLMProvider("litellm_proxy")
+
+    provider, model = litellm_wrappers.parse_provider_and_model(PROXY_ROUTE)
+    assert provider == "litellm_proxy"
+    assert model == PROXY_ALIAS
+
+
+def test_generate_content_response_decorator__proxy_cost__attached_for_the_tracer():
+    """The cost has to leave the LiteLLM boundary, where the raw response is.
+
+    Asserted through the patched module attribute rather than the decorator
+    directly, so this also covers that ``patch_adk`` still lands on the function
+    ADK uses to convert LiteLLM responses.
+    """
+    patchers.patch_adk()
+
+    llm_response = adk_lite_llm._model_response_to_generate_content_response(
+        _build_proxy_model_response()
+    )
+
+    assert llm_response.custom_metadata["opik_response_cost"] == RESPONSE_COST
+    # The usage/provider handling must keep working alongside it.
+    assert llm_response.custom_metadata["provider"] == "litellm_proxy"
+    assert llm_response.custom_metadata["model_version"] == PROXY_ALIAS
+
+
+def test_generate_content_response_decorator__no_cost_reported__no_cost_key():
+    """A call LiteLLM reported no cost for must not gain a null cost entry.
+
+    ``total_cost=None`` is skipped by the span update, but an ``opik_response_cost``
+    key would still leak into the logged span output.
+    """
+    patchers.patch_adk()
+    model_response = _build_proxy_model_response()
+    model_response._hidden_params = {}
+
+    llm_response = adk_lite_llm._model_response_to_generate_content_response(
+        model_response
+    )
+
+    assert "opik_response_cost" not in llm_response.custom_metadata
+
+
+def test_try_get_response_cost__no_hidden_params__returns_none():
+    """LiteLLM owns ``_hidden_params``; losing it must degrade, not raise.
+
+    The conversion this runs inside is ADK's, so an exception here would cost the
+    response, not just the cost.
+    """
+    assert litellm_wrappers.try_get_response_cost(object()) is None
+
+
+def test_pop_response_cost__reads_and_removes_the_cost():
+    """Popped rather than read, so the cost is reported as the span's cost
+    instead of also being duplicated into the logged output."""
+    result_dict = {"custom_metadata": {"opik_response_cost": RESPONSE_COST}}
+
+    assert llm_response_wrapper.pop_response_cost(result_dict) == RESPONSE_COST
+    assert result_dict["custom_metadata"] == {}
+
+
+def test_pop_response_cost__unusable_usage__cost_still_read():
+    """The cost is reported by the proxy, so unusable usage must not take it down."""
+    result_dict = {
+        "custom_metadata": {
+            "opik_response_cost": RESPONSE_COST,
+            "opik_usage": "not-a-usage-dict",
+        }
+    }
+
+    assert llm_response_wrapper.pop_response_cost(result_dict) == RESPONSE_COST
+    assert llm_response_wrapper.pop_llm_usage_data(result_dict, "litellm_proxy") is None
+
+
+class _FakeLiteLlmProxyModel(base_llm.BaseLlm):
+    """An ADK model that answers with a proxied LiteLLM response, offline.
+
+    Converts through ``lite_llm._model_response_to_generate_content_response`` -
+    the boundary Opik patches - so the run exercises the real conversion instead
+    of a hand-built ``LlmResponse`` that would pass with the patching gone. The
+    model name is the proxy route, which is what makes ``before_model_callback``
+    resolve the unpriceable ("litellm_proxy", alias) pair.
+    """
+
+    model: str = PROXY_ROUTE
+
+    async def generate_content_async(
+        self, request: llm_request.LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[adk_models.LlmResponse, None]:
+        yield adk_lite_llm._model_response_to_generate_content_response(
+            _build_proxy_model_response()
+        )
+
+
+def _run_fake_proxy_agent() -> None:
+    """Drive a real ADK agent through the fake proxied model, offline."""
+    tracer = OpikTracer(project_name="adk-litellm-cost-test")
+    agent = adk_agents.LlmAgent(
+        name="weather_agent",
+        model=_FakeLiteLlmProxyModel(),
+        instruction="Answer the weather question.",
+        before_agent_callback=tracer.before_agent_callback,
+        after_agent_callback=tracer.after_agent_callback,
+        before_model_callback=tracer.before_model_callback,
+        after_model_callback=tracer.after_model_callback,
+    )
+
+    session_service = in_memory_session_service.InMemorySessionService()
+    runner = adk_runners.Runner(
+        agent=agent, app_name="litellm-cost-probe", session_service=session_service
+    )
+
+    async def _run() -> None:
+        await session_service.create_session(
+            app_name="litellm-cost-probe", user_id="u1", session_id="s1"
+        )
+        async for _ in runner.run_async(
+            user_id="u1",
+            session_id="s1",
+            new_message=genai_types.Content(
+                role="user", parts=[genai_types.Part(text="weather?")]
+            ),
+        ):
+            pass
+
+    asyncio.run(_run())
+    tracer.flush()
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_adk_llm_span__litellm_proxy_cost__reaches_the_backend(fake_backend):
+    """The user-facing symptom: the span the backend receives carries the cost.
+
+    Every assertion above stops at one of our own boundaries, which is how a cost
+    that parses correctly can still be dropped on the way to the span - the exact
+    shape of this bug. So this asserts the recorded span.
+    """
+    _run_fake_proxy_agent()
+
+    assert len(fake_backend.trace_trees) == 1
+    llm_span = fake_backend.trace_trees[0].spans[0]
+
+    assert llm_span.total_cost == RESPONSE_COST
+    # Recorded despite the provider/model pair the price table cannot resolve --
+    # a span that had somehow become priceable would not be proving anything.
+    assert llm_span.provider == "litellm_proxy"
+    assert llm_span.model == PROXY_ALIAS
+    # The cost rides in custom_metadata, so it must not also be left in the output.
+    assert "opik_response_cost" not in llm_span.output["custom_metadata"]
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_adk_llm_span__usage_extraction_raises__cost_still_recorded(
+    fake_backend, monkeypatch
+):
+    """Why the cost is read before the usage, not alongside it.
+
+    Both run in one try/except in ``after_model_callback``, and usage extraction
+    does raise on payloads it cannot parse - so reading the cost afterwards would
+    silently forfeit it to a problem it has nothing to do with. The cost comes
+    from the proxy, not from the tokens; it has no reason to go down with them.
+    """
+
+    def _raise(*args, **kwargs):
+        raise ValueError("usage extraction blew up")
+
+    monkeypatch.setattr(llm_response_wrapper, "pop_llm_usage_data", _raise)
+
+    _run_fake_proxy_agent()
+
+    llm_span = fake_backend.trace_trees[0].spans[0]
+    assert llm_span.usage is None
+    assert llm_span.total_cost == RESPONSE_COST

--- a/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
+++ b/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
@@ -125,6 +125,19 @@ def test_generate_content_response_decorator__no_cost_reported__no_cost_key():
     assert "opik_response_cost" not in llm_response.custom_metadata
 
 
+@pytest.mark.parametrize("raw_cost", [float("nan"), float("inf"), float("-inf")])
+def test_try_get_response_cost__non_finite__returns_none(raw_cost):
+    """A nan/inf cost must not reach the span.
+
+    `float()` accepts both, and they serialize to bare NaN/Infinity, which is not
+    valid JSON - so forwarding one risks the span it rides on, not just the cost.
+    """
+    model_response = _build_proxy_model_response()
+    model_response._hidden_params = {"response_cost": raw_cost}
+
+    assert litellm_wrappers.try_get_response_cost(model_response) is None
+
+
 def test_try_get_response_cost__no_hidden_params__returns_none():
     """LiteLLM owns ``_hidden_params``; losing it must degrade, not raise.
 
@@ -255,3 +268,49 @@ def test_adk_llm_span__usage_extraction_raises__cost_still_recorded(
     llm_span = fake_backend.trace_trees[0].spans[0]
     assert llm_span.usage is None
     assert llm_span.total_cost == RESPONSE_COST
+
+
+@helpers.pytest_skip_for_adk_older_than_1_3_0
+def test_adk_trace_output__no_span_to_charge__cost_marker_not_leaked(fake_backend):
+    """The recovery path must not surface the cost marker as agent output.
+
+    With no LLM span registered, after_model_callback can only recover the model
+    output into the per-invocation cache, which after_agent_callback then stamps as
+    the trace output. `opik_response_cost` is ours, not the model's, so leaving it in
+    that dict would publish an internal marker as ordinary output.
+    """
+    tracer = OpikTracer(project_name="adk-litellm-cost-test")
+    # Only the agent callbacks: without before_model_callback there is no span for
+    # after_model_callback to find, which is the path being exercised.
+    agent = adk_agents.LlmAgent(
+        name="weather_agent",
+        model=_FakeLiteLlmProxyModel(),
+        instruction="Answer the weather question.",
+        before_agent_callback=tracer.before_agent_callback,
+        after_agent_callback=tracer.after_agent_callback,
+        after_model_callback=tracer.after_model_callback,
+    )
+
+    session_service = in_memory_session_service.InMemorySessionService()
+    runner = adk_runners.Runner(
+        agent=agent, app_name="litellm-cost-probe", session_service=session_service
+    )
+
+    async def _run() -> None:
+        await session_service.create_session(
+            app_name="litellm-cost-probe", user_id="u1", session_id="s1"
+        )
+        async for _ in runner.run_async(
+            user_id="u1",
+            session_id="s1",
+            new_message=genai_types.Content(
+                role="user", parts=[genai_types.Part(text="weather?")]
+            ),
+        ):
+            pass
+
+    asyncio.run(_run())
+    tracer.flush()
+
+    trace_output = fake_backend.trace_trees[0].output
+    assert "opik_response_cost" not in (trace_output.get("custom_metadata") or {})

--- a/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
+++ b/sdks/python/tests/library_integration/adk/test_litellm_wrappers.py
@@ -7,11 +7,17 @@ model - so no proxy configuration can fix it either. The proxy does compute the 
 cost server-side and LiteLLM hands it back on the response, so the integration has to
 forward that instead of estimating one.
 
-These tests build the same response objects a proxied LiteLLM call produces, which
-keeps them offline. The end-to-end chain (live proxy -> ``x-litellm-response-cost``
--> ``_hidden_params`` -> span) was verified against a real local LiteLLM proxy when
-this was fixed; what can regress silently afterwards is our side of it, which is what
-is pinned here.
+Crucially the cost is taken from the proxy's ``x-litellm-response-cost`` header and
+not from ``_hidden_params["response_cost"]``, which LiteLLM sets on *every*
+completion: since the backend prefers a client-supplied cost, reading the latter
+would move every ADK LiteLLM span off Opik's price table as a side effect. The
+direct-route tests below pin that boundary using real LiteLLM responses.
+
+These tests stay offline: ``mock_response`` runs LiteLLM's full ``@client`` wrapper
+without a network call, so ``_hidden_params`` is populated for real. The end-to-end
+chain (live proxy -> header -> span) was verified against a real local LiteLLM proxy
+in front of real OpenAI; what can regress silently afterwards is our side of it,
+which is what is pinned here.
 """
 
 import asyncio
@@ -43,13 +49,38 @@ RESPONSE_COST = 0.0009352500000000001
 RESPONSE_TEXT = "It is sunny and 22C."
 
 
-def _build_proxy_model_response() -> "litellm.types.utils.ModelResponse":
-    """The response object a ``litellm_proxy/<alias>`` call produces.
+PROXY_COST_HEADER = "llm_provider-x-litellm-response-cost"
 
-    ``model`` echoes the proxy alias, and the cost the proxy computed arrives in
-    ``_hidden_params`` - LiteLLM folds the ``x-litellm-response-cost`` response
-    header into it. ``provider_and_model`` is what Opik's own ``acompletion``
-    patch attaches upstream of this point.
+
+def _real_litellm_response(model: str) -> "litellm.types.utils.ModelResponse":
+    """A real LiteLLM response, produced offline by LiteLLM's own ``@client`` wrapper.
+
+    ``mock_response`` short-circuits the network but still runs the full wrapper, so
+    ``_hidden_params`` is populated exactly as a live call populates it. That matters
+    for the direct-route assertions: hand-setting the dict would pin a state LiteLLM
+    never produces, and the whole point is that LiteLLM *does* compute a cost for
+    unproxied calls.
+    """
+    response = litellm.completion(
+        model=model,
+        messages=[{"role": "user", "content": "weather?"}],
+        mock_response=RESPONSE_TEXT,
+    )
+    # What Opik's own acompletion patch attaches upstream of the conversion.
+    response.provider_and_model = model
+    return response
+
+
+def _build_proxy_model_response() -> "litellm.types.utils.ModelResponse":
+    """The response object a proxied call produces.
+
+    ``model`` echoes the proxy alias, and the cost the proxy computed arrives as the
+    ``x-litellm-response-cost`` response header, which LiteLLM folds into
+    ``_hidden_params["additional_headers"]`` under the ``llm_provider-`` prefix. That
+    exact shape was confirmed against a real local LiteLLM proxy; a live proxy cannot
+    be stood up from a unit test, so the header is set here rather than earned.
+    ``provider_and_model`` is what Opik's own ``acompletion`` patch attaches upstream
+    of this point.
     """
     response = litellm.types.utils.ModelResponse(
         id="chatcmpl-proxy-1",
@@ -69,7 +100,9 @@ def _build_proxy_model_response() -> "litellm.types.utils.ModelResponse":
             prompt_tokens=100, completion_tokens=50, total_tokens=150
         ),
     )
-    response._hidden_params = {"response_cost": RESPONSE_COST}
+    response._hidden_params = {
+        "additional_headers": {PROXY_COST_HEADER: str(RESPONSE_COST)}
+    }
     response.provider_and_model = PROXY_ROUTE
     return response
 
@@ -108,15 +141,42 @@ def test_generate_content_response_decorator__proxy_cost__attached_for_the_trace
     assert llm_response.custom_metadata["model_version"] == PROXY_ALIAS
 
 
-def test_generate_content_response_decorator__no_cost_reported__no_cost_key():
-    """A call LiteLLM reported no cost for must not gain a null cost entry.
+def test_direct_call__litellm_computes_a_cost_that_must_not_be_forwarded():
+    """A non-proxied call must keep Opik's own pricing.
 
-    ``total_cost=None`` is skipped by the span update, but an ``opik_response_cost``
-    key would still leak into the logged span output.
+    LiteLLM's ``@client`` wrapper sets ``_hidden_params["response_cost"]`` on *every*
+    completion, and the backend prefers a client-supplied cost over its own table -
+    so reading that unconditionally would silently move every ADK LiteLLM span onto
+    LiteLLM's price map. Asserted on a real LiteLLM response, since the premise is
+    precisely that LiteLLM really does compute a cost here.
     """
     patchers.patch_adk()
-    model_response = _build_proxy_model_response()
-    model_response._hidden_params = {}
+    model_response = _real_litellm_response("openai/gpt-4o-mini")
+
+    # The premise, stated rather than assumed.
+    assert model_response._hidden_params["response_cost"] is not None
+    assert litellm_wrappers.try_get_proxy_response_cost(model_response) is None
+
+    llm_response = adk_lite_llm._model_response_to_generate_content_response(
+        model_response
+    )
+
+    assert "opik_response_cost" not in llm_response.custom_metadata
+    # The usage/provider handling still has to work on this route.
+    assert llm_response.custom_metadata["provider"] == opik.LLMProvider.OPENAI
+
+
+def test_proxy_route__no_cost_header__no_cost_key():
+    """A proxied route LiteLLM reported no cost header for gains no cost entry.
+
+    Real state, not a contrived one: LiteLLM cannot price an arbitrary proxy alias
+    locally, so a ``litellm_proxy/`` response carries no cost of its own until the
+    proxy's header supplies one.
+    """
+    patchers.patch_adk()
+    model_response = _real_litellm_response(PROXY_ROUTE)
+
+    assert litellm_wrappers.try_get_proxy_response_cost(model_response) is None
 
     llm_response = adk_lite_llm._model_response_to_generate_content_response(
         model_response
@@ -126,25 +186,27 @@ def test_generate_content_response_decorator__no_cost_reported__no_cost_key():
 
 
 @pytest.mark.parametrize("raw_cost", [float("nan"), float("inf"), float("-inf")])
-def test_try_get_response_cost__non_finite__returns_none(raw_cost):
+def test_try_get_proxy_response_cost__non_finite__returns_none(raw_cost):
     """A nan/inf cost must not reach the span.
 
-    `float()` accepts both, and they serialize to bare NaN/Infinity, which is not
-    valid JSON - so forwarding one risks the span it rides on, not just the cost.
+    They serialize to bare NaN/Infinity, which is not valid JSON - so forwarding one
+    risks the span it rides on, not just the cost.
     """
     model_response = _build_proxy_model_response()
-    model_response._hidden_params = {"response_cost": raw_cost}
+    model_response._hidden_params = {
+        "additional_headers": {PROXY_COST_HEADER: raw_cost}
+    }
 
-    assert litellm_wrappers.try_get_response_cost(model_response) is None
+    assert litellm_wrappers.try_get_proxy_response_cost(model_response) is None
 
 
-def test_try_get_response_cost__no_hidden_params__returns_none():
+def test_try_get_proxy_response_cost__no_hidden_params__returns_none():
     """LiteLLM owns ``_hidden_params``; losing it must degrade, not raise.
 
     The conversion this runs inside is ADK's, so an exception here would cost the
     response, not just the cost.
     """
-    assert litellm_wrappers.try_get_response_cost(object()) is None
+    assert litellm_wrappers.try_get_proxy_response_cost(object()) is None
 
 
 def test_pop_response_cost__reads_and_removes_the_cost():

--- a/sdks/python/tests/unit/llm_usage/test_opik_usage_factory.py
+++ b/sdks/python/tests/unit/llm_usage/test_opik_usage_factory.py
@@ -1,5 +1,8 @@
+import logging
+
 import opik
 from opik import llm_usage
+from opik.api_objects import validation_helpers
 
 
 def test_opik_usage_factory__openai_happyflow():
@@ -46,3 +49,39 @@ def test_opik_usage_factory__vertex_ai_none_candidates_token_count__happy_flow()
     assert result.completion_tokens == 0
     assert result.prompt_tokens == 7859
     assert result.total_tokens == 7859
+
+
+def test_opik_usage_factory__unknown_provider__unparseable_usage__returns_none():
+    """The last-resort builder must not raise.
+
+    It sits behind every provider-specific builder and its callers all treat a
+    failure as "no usage", but its own fallback ends in ``UnknownUsage(**usage)`` -
+    so a payload that is not a mapping raised out of a best-effort function and took
+    the caller's surrounding work (span output, cost) down with it.
+    """
+    assert llm_usage.build_opik_usage_from_unknown_provider("not-a-usage-dict") is None
+
+
+def test_opik_usage_factory__unknown_provider__usage_dict__still_parsed():
+    """The guard must not swallow the case the fallback exists for."""
+    result = llm_usage.build_opik_usage_from_unknown_provider(
+        {"prompt_tokens": 20, "completion_tokens": 10, "some_provider_field": 5}
+    )
+
+    assert result is not None
+    assert result.prompt_tokens == 20
+    assert result.completion_tokens == 10
+    assert result.total_tokens == 30
+
+
+def test_validate_and_parse_usage__unknown_provider__unparseable_usage__returns_none():
+    """The public entry point this reaches from ``Opik.span(usage=...)``.
+
+    A user-supplied usage value the SDK cannot parse is a reason to log and drop the
+    usage, not to raise out of a validation helper.
+    """
+    result = validation_helpers.validate_and_parse_usage(
+        usage="not-a-usage-dict", logger=logging.getLogger(__name__), provider=None
+    )
+
+    assert result is None


### PR DESCRIPTION
## Details

An ADK agent routed through a LiteLLM proxy (`LiteLlm(model="litellm_proxy/<alias>")`) never got a cost. Opik prices spans from a `(provider, model)` pair and neither half works here: `"litellm_proxy"` is not an `opik.LLMProvider`, and `model` stays the proxy alias because the OpenAI-compatible spec requires the response to echo the requested model. The proxy already computes the true cost and returns it in `x-litellm-response-cost` — we were discarding it. Now we read that header and forward it as the span's `total_cost`, mirroring what the LangChain integration already does with the same header.

- **Proxied calls only.** The cost comes from the `x-litellm-response-cost` header (via LiteLLM's own `get_response_cost_from_hidden_params`), *not* from `_hidden_params["response_cost"]` — LiteLLM's `@client` wrapper sets the latter on **every** completion, and since the backend prefers a client-supplied cost over its own table (`SpanDAO`), reading it would silently move every ADK LiteLLM span onto LiteLLM's price map. It would also record an explicit `0.0` for a LiteLLM cache hit, suppressing the backend's calculation instead of falling through. Direct calls are therefore untouched: same cost source as before this PR.
- Keying on the header rather than on the `litellm_proxy/` prefix also covers a proxy addressed as `openai/<alias>` with `api_base` pointed at it — same unpriceable alias echoed back, same missing cost, but the prefix says `openai`. Verified against a real proxy: the header is present for both routings and absent for a direct call.
- Popped before the usage parsing, which can both give up on and raise over payloads it cannot parse, so a usage problem cannot take the cost down with it.
- **Also fixed, found while testing:** `build_opik_usage_from_unknown_provider` swallowed every provider-specific builder failure but let its own generic fallback raise, so a payload that was not a mapping raised out of a best-effort function — reaching users through the public `Opik.span(usage=...)` path. It now logs and returns `None`, which every caller already declared and handled. Review follow-up extended this to the serialization step in `validate_and_parse_usage` (an unguarded call that predates this branch), so that helper now genuinely cannot raise; both sites log the payload's type rather than its value, since it is arbitrary caller data.
- **Not covered:** streaming, which ADK converts through the unpatched sync `LiteLLMClient.completion` — the same reason streaming already loses `opik_usage` and `provider`. No feature toggles changed.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves OPIK-8314

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation, tests, and live-proxy verification
- Human verification: code review pending; author directed the verification approach and reviewed the diff before submission

## Testing

Verified end to end against a **real local LiteLLM proxy** fronting a fake OpenAI-compatible upstream, so the proxy prices the call itself from its config — the same code path a production proxy takes, with no API keys and no network.

The same ADK run, with and without the fix:

| | span provider | span model | span `total_cost` |
|---|---|---|---|
| before | `litellm_proxy` | `gemini-3.5-flash` | `None` |
| after | `litellm_proxy` | `gemini-3.5-flash` | `0.00019999999999999998` |

which matches the proxy's `x-litellm-response-cost: 0.00019999999999999998` exactly.

To confirm the recorded number is the **proxy's** price and not a local recomputation, a second scenario used `gpt-4o-mini` — a name LiteLLM *does* price locally — configured on the proxy with a deliberately absurd price:

| source | value |
|---|---|
| proxy `x-litellm-response-cost` header | `2.0` |
| local price-table estimate | `0.000045` |
| **span `total_cost`** | **`2.0`** |

The span carried the proxy's number, ~44,400x the local estimate, so it cannot have come from a price table.

Automated tests:

- `pytest tests/library_integration/adk/test_litellm_wrappers.py` — 13 new offline tests. They cover the premise (`opik.LLMProvider("litellm_proxy")` raises), cost attachment through the patched ADK boundary, **that a direct call's LiteLLM-computed cost is _not_ forwarded** (asserted on a real LiteLLM response via `mock_response`, so the premise that LiteLLM does compute one is stated rather than assumed), a proxy route with no cost header gaining no key, non-finite costs being rejected, graceful behavior when `_hidden_params` is absent, the cost surviving unusable usage, that the cost marker is not leaked as trace output when there is no span to charge, and the user-facing symptom — asserting `total_cost` on the span the backend receives, plus that the cost is not duplicated into the span output.
- `pytest tests/unit/llm_usage/test_opik_usage_factory.py` — 3 new tests for the usage-factory fix, including the public `Opik.span(usage=...)` entry point.
- `pytest tests/unit` — 5282 passed, 3 skipped.
- `pytest tests/library_integration/adk/` (the offline subset: `test_llm_response_wrapper`, `test_adk_graph_builder`, `test_helpers`, `test_adk_otel_delegation`, `test_adk_context_cache_recovery`) — 44 passed, no regressions.
- `make precommit` — passed (ruff, ruff-format, mypy).

Not run: the API-key-gated ADK library-integration tests (live Gemini/OpenAI) and the streaming paths, which this change does not touch.

## Documentation

N/A — no user-facing API or configuration change. The behavior change is that proxied ADK calls now report the cost the proxy already computed, which needs no new documentation.
