### PR TITLE
[OPIK-8319] [BE] fix: reject a wholly unusable evaluator response and stop storing failed scorings as zero

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -1548,7 +1548,7 @@ public class OnlineScoringEngine {
 
     /**
      * Splits Python evaluator results into the ones that can be stored and the names of the ones that
-     * carry no value. Shared by the trace, span and thread Python scorers.
+     * cannot, by reason. Shared by the trace, span and thread Python scorers.
      *
      * <p>A user metric is free to return a score with no value — {@code ScoreResult(value=None)} for a
      * check that did not apply, or a scoring attempt the metric itself gave up on. Such a score cannot
@@ -1557,6 +1557,11 @@ public class OnlineScoringEngine {
      * whole batch — every other score for the same entity was lost with it, and the rule's user saw only
      * a generic "Unexpected error" naming neither the metric nor the reason. Dropped per score instead,
      * mirroring how the judge path treats a null judge score.
+     *
+     * <p>A result the metric itself flagged with {@code scoring_failed} is dropped for a different
+     * reason: the SDK pairs that flag with a placeholder {@code 0.0}, so the score is storable but
+     * storing it would record a failed evaluation as a genuine zero, indistinguishable in the UI from a
+     * metric that deliberately scored zero.
      */
     public StorablePythonScores toStorablePythonScores(List<PythonScoreResult> scoreResults) {
         if (CollectionUtils.isEmpty(scoreResults)) {
@@ -1566,36 +1571,47 @@ public class OnlineScoringEngine {
         var storable = new ArrayList<PythonScoreResult>(scoreResults.size());
         var valuelessNames = new ArrayList<String>();
 
+        var failedNames = new ArrayList<String>();
+
         scoreResults.forEach(scoreResult -> {
             // A null entry is what a JSON `null` inside the evaluator's array deserializes to. It carries no
             // value either, so it joins the dropped scores rather than being dereferenced — one unusable
-            // entry must not cost the batch, which is the whole point of this split.
-            if (scoreResult != null && scoreResult.value() != null) {
+            // entry must not cost the batch, which is the whole point of this split. An unnamed score keeps
+            // its missing name here; the record normalizes it, and it is reported as <unnamed>.
+            if (scoreResult == null || scoreResult.value() == null) {
+                valuelessNames.add(scoreResult == null ? null : scoreResult.name());
+            } else if (BooleanUtils.isTrue(scoreResult.scoringFailed())) {
+                failedNames.add(scoreResult.name());
+            } else {
                 storable.add(scoreResult);
-                return;
             }
-
-            // Normalized on collection, because a metric may leave a score unnamed and List.copyOf rejects a
-            // null element — that would fail the batch from inside the code meant to save it. Rendered as
-            // <unnamed> when the name is reported.
-            var name = scoreResult == null ? null : scoreResult.name();
-            valuelessNames.add(StringUtils.defaultString(name));
         });
 
         return StorablePythonScores.builder()
                 .storable(storable)
                 .valuelessNames(valuelessNames)
+                .failedNames(failedNames)
                 .build();
     }
 
     @Builder(toBuilder = true)
-    public record StorablePythonScores(List<PythonScoreResult> storable, List<String> valuelessNames) {
+    public record StorablePythonScores(List<PythonScoreResult> storable, List<String> valuelessNames,
+            List<String> failedNames) {
 
-        // Snapshotted and defaulted here rather than at the call site: this record hands both lists to its
-        // callers, so it is the one place that has to guarantee they are immutable and never null.
+        // Snapshotted, defaulted and normalized here rather than at the call sites: this record hands its
+        // lists to its callers, so it is the one place that has to guarantee they are immutable, never null,
+        // and free of null elements — a metric may leave a score unnamed, and List.copyOf rejects a null
+        // element, which would throw from inside the type meant to make an unusable score harmless.
         public StorablePythonScores {
             storable = storable == null ? List.of() : List.copyOf(storable);
-            valuelessNames = valuelessNames == null ? List.of() : List.copyOf(valuelessNames);
+            valuelessNames = copyOfNames(valuelessNames);
+            failedNames = copyOfNames(failedNames);
+        }
+
+        private static List<String> copyOfNames(List<String> names) {
+            return names == null
+                    ? List.of()
+                    : names.stream().map(StringUtils::defaultString).toList();
         }
     }
 
@@ -1612,28 +1628,40 @@ public class OnlineScoringEngine {
      * paths but the caller-supplied thread id on the thread one — a CR/LF in it would forge entries in the
      * log, and an oversized one would flood a single entry.
      */
-    public void logValuelessPythonScores(
+    public void logDroppedPythonScores(
             @NonNull Logger userFacingLogger,
             @NonNull Map<String, String> mdc,
-            List<String> valuelessNames,
+            @NonNull StorablePythonScores scores,
             @NonNull String entityLabel,
             @NonNull Object entityId) {
-        if (CollectionUtils.isEmpty(valuelessNames)) {
+        if (CollectionUtils.isEmpty(scores.valuelessNames()) && CollectionUtils.isEmpty(scores.failedNames())) {
+            return;
+        }
+
+        try (var logContext = LogContextAware.wrapWithMdc(mdc)) {
+            var safeEntityId = sanitize(String.valueOf(entityId));
+            logDropped(userFacingLogger, scores.valuelessNames(), entityLabel, safeEntityId,
+                    "Skipped {} for {} '{}' because the metric returned no value");
+            logDropped(userFacingLogger, scores.failedNames(), entityLabel, safeEntityId,
+                    "Skipped {} for {} '{}' because the metric reported the scoring as failed");
+        }
+    }
+
+    private void logDropped(Logger userFacingLogger, List<String> names, String entityLabel, String safeEntityId,
+            String message) {
+        if (names.isEmpty()) {
             return;
         }
 
         // A metric is free to leave a score unnamed; rendered rather than dropped, so the count a user sees
         // still matches the scores their rule ran.
-        var reported = valuelessNames.stream()
+        var reported = names.stream()
                 .map(name -> StringUtils.isBlank(name) ? "<unnamed>" : name)
                 .limit(MAX_REPORTED_FIELD_NAMES)
                 .toList();
-        var omitted = valuelessNames.size() - reported.size();
 
-        try (var logContext = LogContextAware.wrapWithMdc(mdc)) {
-            userFacingLogger.warn("Skipped {} for {} '{}' because the metric returned no value",
-                    renderNames(reported, omitted), entityLabel, sanitize(String.valueOf(entityId)));
-        }
+        userFacingLogger.warn(message, renderNames(reported, names.size() - reported.size()), entityLabel,
+                safeEntityId);
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -1578,10 +1578,14 @@ public class OnlineScoringEngine {
             // value either, so it joins the dropped scores rather than being dereferenced — one unusable
             // entry must not cost the batch, which is the whole point of this split. An unnamed score keeps
             // its missing name here; the record normalizes it, and it is reported as <unnamed>.
-            if (scoreResult == null || scoreResult.value() == null) {
-                valuelessNames.add(scoreResult == null ? null : scoreResult.name());
+            if (scoreResult == null) {
+                valuelessNames.add(null);
             } else if (BooleanUtils.isTrue(scoreResult.scoringFailed())) {
+                // Checked before the value, so a metric that both failed and returned nothing is reported by
+                // its cause rather than the symptom. Either way the score is dropped.
                 failedNames.add(scoreResult.name());
+            } else if (scoreResult.value() == null) {
+                valuelessNames.add(scoreResult.name());
             } else {
                 storable.add(scoreResult);
             }

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngine.java
@@ -1547,8 +1547,8 @@ public class OnlineScoringEngine {
     }
 
     /**
-     * Splits Python evaluator results into the ones that can be stored and the names of the ones that
-     * cannot, by reason. Shared by the trace, span and thread Python scorers.
+     * Splits Python evaluator results three ways: the ones that can be stored, and the names of the ones
+     * that cannot, by reason. Shared by the trace, span and thread Python scorers.
      *
      * <p>A user metric is free to return a score with no value — {@code ScoreResult(value=None)} for a
      * check that did not apply, or a scoring attempt the metric itself gave up on. Such a score cannot
@@ -1563,9 +1563,9 @@ public class OnlineScoringEngine {
      * storing it would record a failed evaluation as a genuine zero, indistinguishable in the UI from a
      * metric that deliberately scored zero.
      */
-    public StorablePythonScores toStorablePythonScores(List<PythonScoreResult> scoreResults) {
+    public PythonScoreSplit splitPythonScores(List<PythonScoreResult> scoreResults) {
         if (CollectionUtils.isEmpty(scoreResults)) {
-            return StorablePythonScores.builder().build();
+            return PythonScoreSplit.builder().build();
         }
 
         var storable = new ArrayList<PythonScoreResult>(scoreResults.size());
@@ -1587,7 +1587,7 @@ public class OnlineScoringEngine {
             }
         });
 
-        return StorablePythonScores.builder()
+        return PythonScoreSplit.builder()
                 .storable(storable)
                 .valuelessNames(valuelessNames)
                 .failedNames(failedNames)
@@ -1595,14 +1595,14 @@ public class OnlineScoringEngine {
     }
 
     @Builder(toBuilder = true)
-    public record StorablePythonScores(List<PythonScoreResult> storable, List<String> valuelessNames,
+    public record PythonScoreSplit(List<PythonScoreResult> storable, List<String> valuelessNames,
             List<String> failedNames) {
 
         // Snapshotted, defaulted and normalized here rather than at the call sites: this record hands its
         // lists to its callers, so it is the one place that has to guarantee they are immutable, never null,
         // and free of null elements — a metric may leave a score unnamed, and List.copyOf rejects a null
         // element, which would throw from inside the type meant to make an unusable score harmless.
-        public StorablePythonScores {
+        public PythonScoreSplit {
             storable = storable == null ? List.of() : List.copyOf(storable);
             valuelessNames = copyOfNames(valuelessNames);
             failedNames = copyOfNames(failedNames);
@@ -1631,7 +1631,7 @@ public class OnlineScoringEngine {
     public void logDroppedPythonScores(
             @NonNull Logger userFacingLogger,
             @NonNull Map<String, String> mdc,
-            @NonNull StorablePythonScores scores,
+            @NonNull PythonScoreSplit scores,
             @NonNull String entityLabel,
             @NonNull Object entityId) {
         if (CollectionUtils.isEmpty(scores.valuelessNames()) && CollectionUtils.isEmpty(scores.failedNames())) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -87,8 +87,8 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
                         .info("Received response for spanId '{}':\n\n{}", span.id(), scoreResults)))
                 .flatMap(scoreResults -> {
                     var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
-                    OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc,
-                            pythonScores.valuelessNames(), "spanId", span.id());
+                    OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores,
+                            "spanId", span.id());
                     return storeSpanScores(toFeedbackScores(pythonScores.storable(), span), span,
                             message.userName(), message.workspaceId());
                 })

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringSpanUserDefinedMetricPythonScorer.java
@@ -86,7 +86,7 @@ public class OnlineScoringSpanUserDefinedMetricPythonScorer
                 .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
                         .info("Received response for spanId '{}':\n\n{}", span.id(), scoreResults)))
                 .flatMap(scoreResults -> {
-                    var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
+                    var pythonScores = OnlineScoringEngine.splitPythonScores(scoreResults);
                     OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores,
                             "spanId", span.id());
                     return storeSpanScores(toFeedbackScores(pythonScores.storable(), span), span,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -302,8 +302,8 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
                         .info("Received response for threadId '{}':\n\n{}", threadId, scoreResults)))
                 .flatMap(scoreResults -> {
                     var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
-                    OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc,
-                            pythonScores.valuelessNames(), "threadId", threadId);
+                    OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores, "threadId",
+                            threadId);
                     List<FeedbackScoreBatchItemThread> scores = pythonScores.storable().stream()
                             .map(scoreResult -> FeedbackScoresMapper.INSTANCE.map(
                                     scoreResult,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorer.java
@@ -301,7 +301,7 @@ public class OnlineScoringTraceThreadUserDefinedMetricPythonScorer
                 .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
                         .info("Received response for threadId '{}':\n\n{}", threadId, scoreResults)))
                 .flatMap(scoreResults -> {
-                    var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
+                    var pythonScores = OnlineScoringEngine.splitPythonScores(scoreResults);
                     OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores, "threadId",
                             threadId);
                     List<FeedbackScoreBatchItemThread> scores = pythonScores.storable().stream()

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -100,7 +100,7 @@ public class OnlineScoringUserDefinedMetricPythonScorer
                 .doOnNext(withMdc(mdc, scoreResults -> userFacingLogger
                         .info("Received response for traceId '{}':\n\n{}", trace.id(), scoreResults)))
                 .flatMap(scoreResults -> {
-                    var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
+                    var pythonScores = OnlineScoringEngine.splitPythonScores(scoreResults);
                     OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores,
                             "traceId", trace.id());
                     return storeScores(toFeedbackScores(pythonScores.storable(), trace), trace,

--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorer.java
@@ -101,8 +101,8 @@ public class OnlineScoringUserDefinedMetricPythonScorer
                         .info("Received response for traceId '{}':\n\n{}", trace.id(), scoreResults)))
                 .flatMap(scoreResults -> {
                     var pythonScores = OnlineScoringEngine.toStorablePythonScores(scoreResults);
-                    OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc,
-                            pythonScores.valuelessNames(), "traceId", trace.id());
+                    OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc, pythonScores,
+                            "traceId", trace.id());
                     return storeScores(toFeedbackScores(pythonScores.storable(), trace), trace,
                             message.userName(), message.workspaceId());
                 })

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
@@ -826,6 +826,21 @@ class OnlineScoringEngineParsingTest {
         }
 
         @Test
+        @DisplayName("report a score that both failed and returned no value by its cause")
+        void reportsAScoreThatBothFailedAndReturnedNoValueByItsCause() {
+            var both = PythonScoreResult.builder()
+                    .name(randomScoreName())
+                    .scoringFailed(true)
+                    .build();
+
+            var split = OnlineScoringEngine.splitPythonScores(List.of(both));
+
+            assertThat(split.failedNames()).containsExactly(both.name());
+            assertThat(split.valuelessNames()).isEmpty();
+            assertThat(split.storable()).isEmpty();
+        }
+
+        @Test
         @DisplayName("keep a score whose scoring_failed flag is false or absent")
         void keepsAScoreThatDidNotFail() {
             var explicitlyNotFailed = PythonScoreResult.builder()

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
@@ -729,8 +729,8 @@ class OnlineScoringEngineParsingTest {
         @MethodSource
         @DisplayName("sanitize the score name written to the rule log")
         void sanitizesTheScoreNameWrittenToTheRuleLog(String scenario, String scoreName, String expectedFragment) {
-            OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc(),
-                    Collections.singletonList(scoreName), "traceId", ID_GENERATOR.generateId());
+            OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(),
+                    valueless(Collections.singletonList(scoreName)), "traceId", ID_GENERATOR.generateId());
 
             assertThat(loggedArgument(0)).doesNotContain("\n", "\r").contains(expectedFragment);
         }
@@ -751,8 +751,8 @@ class OnlineScoringEngineParsingTest {
             var forged = "%s\nERROR [2026-01-01 00:00:00,000] forged entry"
                     .formatted(RandomStringUtils.secure().nextAlphanumeric(10));
 
-            OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc(),
-                    List.of(randomScoreName()), "threadId", forged);
+            OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(),
+                    valueless(List.of(randomScoreName())), "threadId", forged);
 
             assertThat(loggedArgument(2)).doesNotContain("\n", "\r").contains("ERROR");
         }
@@ -780,7 +780,7 @@ class OnlineScoringEngineParsingTest {
         void capsTheReportedNamesAndCountsTheRemainder() {
             var names = IntStream.range(0, 25).mapToObj("score_%d"::formatted).toList();
 
-            OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc(), names, "traceId",
+            OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(), valueless(names), "traceId",
                     ID_GENERATOR.generateId());
 
             assertThat(loggedArgument(0))
@@ -794,8 +794,8 @@ class OnlineScoringEngineParsingTest {
         @MethodSource
         @DisplayName("write nothing when no score was dropped")
         void writesNothingWhenNoScoreWasDropped(String scenario, List<String> valuelessNames) {
-            OnlineScoringEngine.logValuelessPythonScores(userFacingLogger, mdc(), valuelessNames, "traceId",
-                    ID_GENERATOR.generateId());
+            OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(), valueless(valuelessNames),
+                    "traceId", ID_GENERATOR.generateId());
 
             Mockito.verifyNoInteractions(userFacingLogger);
         }
@@ -804,6 +804,66 @@ class OnlineScoringEngineParsingTest {
             return Stream.of(
                     arguments("nothing was dropped", List.of()),
                     arguments("the caller passed no list at all", null));
+        }
+
+        @Test
+        @DisplayName("drop a score the metric flagged as failed, rather than storing its placeholder zero")
+        void dropsAScoreTheMetricFlaggedAsFailed() {
+            // The SDK pairs scoring_failed with value=0.0, so the score is storable — but storing it would
+            // record a failed evaluation as a genuine zero.
+            var valued = pythonScore(BigDecimal.valueOf(0.75));
+            var failed = PythonScoreResult.builder()
+                    .name(randomScoreName())
+                    .value(BigDecimal.ZERO)
+                    .scoringFailed(true)
+                    .build();
+
+            var split = OnlineScoringEngine.toStorablePythonScores(List.of(valued, failed));
+
+            assertThat(split.storable()).containsExactly(valued);
+            assertThat(split.failedNames()).containsExactly(failed.name());
+            assertThat(split.valuelessNames()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("keep a score whose scoring_failed flag is false or absent")
+        void keepsAScoreThatDidNotFail() {
+            var explicitlyNotFailed = PythonScoreResult.builder()
+                    .name(randomScoreName())
+                    .value(BigDecimal.ONE)
+                    .scoringFailed(false)
+                    .build();
+            var absent = pythonScore(BigDecimal.ONE);
+
+            var split = OnlineScoringEngine.toStorablePythonScores(List.of(explicitlyNotFailed, absent));
+
+            assertThat(split.storable()).containsExactly(explicitlyNotFailed, absent);
+            assertThat(split.failedNames()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("report each reason on its own line")
+        void reportsEachReasonOnItsOwnLine() {
+            var valuelessName = randomScoreName();
+            var failedName = randomScoreName();
+
+            OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(),
+                    OnlineScoringEngine.StorablePythonScores.builder()
+                            .valuelessNames(List.of(valuelessName))
+                            .failedNames(List.of(failedName))
+                            .build(),
+                    "traceId", ID_GENERATOR.generateId());
+
+            var messages = ArgumentCaptor.forClass(String.class);
+            Mockito.verify(userFacingLogger, Mockito.times(2)).warn(messages.capture(), Mockito.any(),
+                    Mockito.any(), Mockito.any());
+            assertThat(messages.getAllValues())
+                    .anySatisfy(message -> assertThat(message).contains("returned no value"))
+                    .anySatisfy(message -> assertThat(message).contains("reported the scoring as failed"));
+        }
+
+        private static OnlineScoringEngine.StorablePythonScores valueless(List<String> names) {
+            return OnlineScoringEngine.StorablePythonScores.builder().valuelessNames(names).build();
         }
 
         /** The nth interpolated argument of the single warning the helper wrote. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringEngineParsingTest.java
@@ -699,7 +699,7 @@ class OnlineScoringEngineParsingTest {
         @DisplayName("split Python results by whether they can be stored")
         void splitsPythonResultsByWhetherTheyCanBeStored(String scenario, List<PythonScoreResult> results,
                 List<String> expectedStorableNames, List<String> expectedValuelessNames) {
-            var split = OnlineScoringEngine.toStorablePythonScores(results);
+            var split = OnlineScoringEngine.splitPythonScores(results);
 
             assertThat(split.storable()).extracting(PythonScoreResult::name)
                     .containsExactlyElementsOf(expectedStorableNames);
@@ -763,7 +763,7 @@ class OnlineScoringEngineParsingTest {
             var results = new ArrayList<>(List.of(pythonScore(BigDecimal.ONE)));
             var names = new ArrayList<>(List.of(randomScoreName()));
 
-            var split = OnlineScoringEngine.StorablePythonScores.builder()
+            var split = OnlineScoringEngine.PythonScoreSplit.builder()
                     .storable(results)
                     .valuelessNames(names)
                     .build();
@@ -818,7 +818,7 @@ class OnlineScoringEngineParsingTest {
                     .scoringFailed(true)
                     .build();
 
-            var split = OnlineScoringEngine.toStorablePythonScores(List.of(valued, failed));
+            var split = OnlineScoringEngine.splitPythonScores(List.of(valued, failed));
 
             assertThat(split.storable()).containsExactly(valued);
             assertThat(split.failedNames()).containsExactly(failed.name());
@@ -835,7 +835,7 @@ class OnlineScoringEngineParsingTest {
                     .build();
             var absent = pythonScore(BigDecimal.ONE);
 
-            var split = OnlineScoringEngine.toStorablePythonScores(List.of(explicitlyNotFailed, absent));
+            var split = OnlineScoringEngine.splitPythonScores(List.of(explicitlyNotFailed, absent));
 
             assertThat(split.storable()).containsExactly(explicitlyNotFailed, absent);
             assertThat(split.failedNames()).isEmpty();
@@ -848,7 +848,7 @@ class OnlineScoringEngineParsingTest {
             var failedName = randomScoreName();
 
             OnlineScoringEngine.logDroppedPythonScores(userFacingLogger, mdc(),
-                    OnlineScoringEngine.StorablePythonScores.builder()
+                    OnlineScoringEngine.PythonScoreSplit.builder()
                             .valuelessNames(List.of(valuelessName))
                             .failedNames(List.of(failedName))
                             .build(),
@@ -862,8 +862,8 @@ class OnlineScoringEngineParsingTest {
                     .anySatisfy(message -> assertThat(message).contains("reported the scoring as failed"));
         }
 
-        private static OnlineScoringEngine.StorablePythonScores valueless(List<String> names) {
-            return OnlineScoringEngine.StorablePythonScores.builder().valuelessNames(names).build();
+        private static OnlineScoringEngine.PythonScoreSplit valueless(List<String> names) {
+            return OnlineScoringEngine.PythonScoreSplit.builder().valuelessNames(names).build();
         }
 
         /** The nth interpolated argument of the single warning the helper wrote. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest.java
@@ -233,6 +233,36 @@ class OnlineScoringTraceThreadUserDefinedMetricPythonScorerTest {
         }
 
         @Test
+        void dropsAScoreTheMetricFlaggedAsFailedBeforeStoring() {
+            // The thread path maps through FeedbackScoresMapper rather than building items inline, so the
+            // wiring from the split to storage is worth pinning here too.
+            var message = sampleMessage();
+            var trace = sampleTrace();
+            var project = Project.builder().id(projectId).name("test-project").build();
+            stubPythonScoringHappyPath(trace, project);
+            when(pythonEvaluatorService.evaluateThread(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(
+                            PythonScoreResult.builder()
+                                    .name("test_score")
+                                    .value(BigDecimal.valueOf(0.95))
+                                    .reason("test reason")
+                                    .build(),
+                            PythonScoreResult.builder()
+                                    .name("failed_score")
+                                    .value(BigDecimal.ZERO)
+                                    .scoringFailed(true)
+                                    .reason("upstream call failed")
+                                    .build())));
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(feedbackScoreService).scoreBatchOfThreads(captor.capture());
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
+                    threadScore("test_score", BigDecimal.valueOf(0.95), "test reason", project)));
+        }
+
+        @Test
         void dropsScoresWithoutValueAndPersistsTheRest() {
             // A thread metric returning ScoreResult(value=None) cannot be stored — the value column is not
             // nullable — but the score next to it must still land: binding the valueless one used to throw

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/events/OnlineScoringUserDefinedMetricPythonScorerTest.java
@@ -204,6 +204,36 @@ class OnlineScoringUserDefinedMetricPythonScorerTest {
         }
 
         @Test
+        void dropsAScoreTheMetricFlaggedAsFailedBeforeStoring() {
+            // The SDK pairs scoring_failed with a placeholder 0.0, so such a score is storable and would be
+            // recorded as a genuine zero. The split classifies it; this pins that the scorer stores what the
+            // split kept, rather than the list it was handed.
+            var message = sampleMessage();
+            var valued = PythonScoreResult.builder()
+                    .name("answer_relevance")
+                    .value(BigDecimal.valueOf(0.75))
+                    .reason("relevant")
+                    .build();
+            var failed = PythonScoreResult.builder()
+                    .name("hallucination")
+                    .value(BigDecimal.ZERO)
+                    .scoringFailed(true)
+                    .reason("upstream call failed")
+                    .build();
+
+            when(pythonEvaluatorService.evaluate(eq(message.code().metric()), any()))
+                    .thenReturn(Mono.just(List.of(valued, failed)));
+            when(feedbackScoreService.scoreBatchOfTraces(any())).thenReturn(Mono.empty());
+
+            scorer.score(message).block();
+
+            var captor = ArgumentCaptor.forClass(List.class);
+            verify(feedbackScoreService).scoreBatchOfTraces(captor.capture());
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(List.of(
+                    traceScore("answer_relevance", BigDecimal.valueOf(0.75), "relevant", message.trace())));
+        }
+
+        @Test
         void reportsTheDroppedScoreOnTheRuleLog() {
             var message = sampleMessage();
             var valueless = PythonScoreResult.builder().name("hallucination").build();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/AutomationRuleEvaluatorsResourceTest.java
@@ -1625,7 +1625,7 @@ class AutomationRuleEvaluatorsResourceTest {
                             "output", "abc",
                             "reference", "abc"))
                     .build();
-            var pythonEvaluatorResponse = factory.manufacturePojo(PythonEvaluatorResponse.class);
+            var pythonEvaluatorResponse = withUsableScores(factory.manufacturePojo(PythonEvaluatorResponse.class));
             wireMock.server().stubFor(
                     post(urlPathEqualTo("/pythonBackendMock/v1/private/evaluators/python"))
                             .withRequestBody(equalToJson(OBJECT_MAPPER.writeValueAsString(pythonEvaluatorRequest)))
@@ -1680,7 +1680,7 @@ class AutomationRuleEvaluatorsResourceTest {
                                     .build()))
                     .build();
 
-            var pythonEvaluatorResponse = factory.manufacturePojo(PythonEvaluatorResponse.class);
+            var pythonEvaluatorResponse = withUsableScores(factory.manufacturePojo(PythonEvaluatorResponse.class));
 
             // When
             wireMock.server().stubFor(
@@ -2161,6 +2161,21 @@ class AutomationRuleEvaluatorsResourceTest {
             AutomationRuleEvaluator<?, ?> expectedRuleEvaluator) {
         assertThat(actualRuleEvaluator.getCreatedAt()).isAfter(expectedRuleEvaluator.getCreatedAt());
         assertThat(actualRuleEvaluator.getLastUpdatedAt()).isAfter(expectedRuleEvaluator.getLastUpdatedAt());
+    }
+
+    /**
+     * Podam randomizes {@code scoring_failed}, and a score carrying that flag is dropped with a warning on
+     * the rule's log rather than stored — the SDK pairs the flag with a placeholder zero, which would
+     * otherwise be recorded as a genuine score. These log assertions are about a normal scoring run
+     * (four INFO entries, one of them "stored successfully"), so the flag is pinned off here; leaving it
+     * random would make them pass or fail on the roll.
+     */
+    private PythonEvaluatorResponse withUsableScores(PythonEvaluatorResponse response) {
+        return response.toBuilder()
+                .scores(response.scores().stream()
+                        .map(score -> score.toBuilder().scoringFailed(false).build())
+                        .toList())
+                .build();
     }
 
     private void assertTraceLogResponse(LogPage logPage, UUID id, Trace trace) {

--- a/apps/opik-python-backend/src/opik_backend/evaluator.py
+++ b/apps/opik-python-backend/src/opik_backend/evaluator.py
@@ -6,7 +6,7 @@ from werkzeug.exceptions import HTTPException
 
 from opik_backend.executor import CodeExecutorBase
 from opik_backend.http_utils import build_error_response
-from opik_backend.score_validation import describe_unusable, unusable_scores
+from opik_backend.score_validation import has_usable_score
 
 # Environment variable to control execution strategy
 EXECUTION_STRATEGY = os.getenv("PYTHON_CODE_EXECUTOR_STRATEGY", "process")
@@ -72,10 +72,9 @@ def execute_evaluator_python():
     # A mixed list is passed through on purpose: the usable scores still reach the backend, which drops
     # the rest and names them on the rule's log stream. Only a wholly unusable response is rejected,
     # which is the same class of user error as returning no ScoreResult at all, just above.
-    unusable = unusable_scores(scores)
-    if len(unusable) == len(scores):
+    if not has_usable_score(scores):
         current_app.logger.info("No usable ScoreResult in code '%s'", code)
         abort(400, "The provided 'code' field didn't return any usable "
-                   "'opik.evaluation.metrics.ScoreResult': %s" % describe_unusable(unusable))
+                   "'opik.evaluation.metrics.ScoreResult'")
 
     return jsonify({"scores": scores})

--- a/apps/opik-python-backend/src/opik_backend/evaluator.py
+++ b/apps/opik-python-backend/src/opik_backend/evaluator.py
@@ -6,6 +6,7 @@ from werkzeug.exceptions import HTTPException
 
 from opik_backend.executor import CodeExecutorBase
 from opik_backend.http_utils import build_error_response
+from opik_backend.score_validation import describe_unusable, unusable_scores
 
 # Environment variable to control execution strategy
 EXECUTION_STRATEGY = os.getenv("PYTHON_CODE_EXECUTOR_STRATEGY", "process")
@@ -67,5 +68,14 @@ def execute_evaluator_python():
     if len(scores) == 0:
         current_app.logger.info("Missing ScoreResult in code '%s'", code)
         abort(400, "The provided 'code' field didn't return any 'opik.evaluation.metrics.ScoreResult'")
+
+    # A mixed list is passed through on purpose: the usable scores still reach the backend, which drops
+    # the rest and names them on the rule's log stream. Only a wholly unusable response is rejected,
+    # which is the same class of user error as returning no ScoreResult at all, just above.
+    unusable = unusable_scores(scores)
+    if len(unusable) == len(scores):
+        current_app.logger.info("No usable ScoreResult in code '%s'", code)
+        abort(400, "The provided 'code' field didn't return any usable "
+                   "'opik.evaluation.metrics.ScoreResult': %s" % describe_unusable(unusable))
 
     return jsonify({"scores": scores})

--- a/apps/opik-python-backend/src/opik_backend/score_validation.py
+++ b/apps/opik-python-backend/src/opik_backend/score_validation.py
@@ -1,4 +1,4 @@
-"""Validation of the score results a user metric returned, before they are handed to the backend.
+"""Whether the score results a user metric returned can be stored by the backend.
 
 ``ScoreResult.value`` is declared ``float`` in the SDK, so a metric returning ``None`` for it already
 breaks that contract; nothing enforces it at runtime. A score with no value cannot be stored — the
@@ -15,47 +15,17 @@ have stored quite happily. Erring the other way costs nothing: the backend deser
 and drops what it considers failed.
 """
 
-import re
-from typing import Any, Dict, List, Tuple
-
-# Score names come from user code and land in an error message that the backend writes to the rule's
-# user-facing log, so a newline must not be able to forge an entry there, nor a huge name flood one.
-_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
-_MAX_NAME_CHARS = 100
-_MAX_REPORTED_NAMES = 10
-
-NO_VALUE = "returned no value"
-SCORING_FAILED = "reported the scoring as failed"
+from typing import Any, Dict, List
 
 
-def unusable_scores(scores: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
-    """Return ``(name, reason)`` for every score that cannot be stored, in the order given."""
-    unusable = []
-    for score in scores:
-        if not isinstance(score, dict):
-            unusable.append(("", NO_VALUE))
-        elif score.get("scoring_failed") is True:
-            # Checked before the value, so a metric that both failed and returned nothing is reported by
-            # its cause rather than the symptom. One reason per score keeps the message readable.
-            unusable.append((score.get("name"), SCORING_FAILED))
-        elif score.get("value") is None:
-            unusable.append((score.get("name"), NO_VALUE))
-    return unusable
+def has_usable_score(scores: List[Dict[str, Any]]) -> bool:
+    """Whether at least one of these score results is one the backend can store."""
+    return any(_is_usable(score) for score in scores)
 
 
-def describe_unusable(unusable: List[Tuple[str, str]]) -> str:
-    """Render the offending scores for an error message: name plus why, capped and sanitized."""
-    shown = [
-        f"'{_sanitize(name)}' {reason}"
-        for name, reason in unusable[:_MAX_REPORTED_NAMES]
-    ]
-    omitted = len(unusable) - len(shown)
-    rendered = ", ".join(shown)
-    return rendered if omitted == 0 else f"{rendered} and {omitted:,} more"
-
-
-def _sanitize(name: Any) -> str:
-    if name is None or name == "":
-        return "<unnamed>"
-    stripped = _CONTROL_CHARS.sub(" ", str(name))
-    return stripped if len(stripped) <= _MAX_NAME_CHARS else f"{stripped[:_MAX_NAME_CHARS]}…"
+def _is_usable(score: Any) -> bool:
+    if not isinstance(score, dict):
+        return False
+    if score.get("scoring_failed") is True:
+        return False
+    return score.get("value") is not None

--- a/apps/opik-python-backend/src/opik_backend/score_validation.py
+++ b/apps/opik-python-backend/src/opik_backend/score_validation.py
@@ -34,10 +34,12 @@ def unusable_scores(scores: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
     for score in scores:
         if not isinstance(score, dict):
             unusable.append(("", NO_VALUE))
+        elif score.get("scoring_failed") is True:
+            # Checked before the value, so a metric that both failed and returned nothing is reported by
+            # its cause rather than the symptom. One reason per score keeps the message readable.
+            unusable.append((score.get("name"), SCORING_FAILED))
         elif score.get("value") is None:
             unusable.append((score.get("name"), NO_VALUE))
-        elif score.get("scoring_failed") is True:
-            unusable.append((score.get("name"), SCORING_FAILED))
     return unusable
 
 

--- a/apps/opik-python-backend/src/opik_backend/score_validation.py
+++ b/apps/opik-python-backend/src/opik_backend/score_validation.py
@@ -1,0 +1,53 @@
+"""Validation of the score results a user metric returned, before they are handed to the backend.
+
+``ScoreResult.value`` is declared ``float`` in the SDK, so a metric returning ``None`` for it already
+breaks that contract; nothing enforces it at runtime. A score with no value cannot be stored — the
+backend's ``feedback_scores.value`` column is not nullable — and a score the metric itself flagged as
+failed carries a placeholder ``0.0`` that would otherwise be stored as if it were a real zero.
+
+The endpoint rejects a response only when *no* score is usable: a mixed list is passed through, so the
+usable scores still reach the backend, which drops the rest and reports them on the rule's log stream.
+"""
+
+import re
+from typing import Any, Dict, List, Tuple
+
+# Score names come from user code and land in an error message that the backend writes to the rule's
+# user-facing log, so a newline must not be able to forge an entry there, nor a huge name flood one.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+_MAX_NAME_CHARS = 100
+_MAX_REPORTED_NAMES = 10
+
+NO_VALUE = "returned no value"
+SCORING_FAILED = "reported the scoring as failed"
+
+
+def unusable_scores(scores: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
+    """Return ``(name, reason)`` for every score that cannot be stored, in the order given."""
+    unusable = []
+    for score in scores:
+        if not isinstance(score, dict):
+            unusable.append(("", NO_VALUE))
+        elif score.get("value") is None:
+            unusable.append((score.get("name"), NO_VALUE))
+        elif score.get("scoring_failed"):
+            unusable.append((score.get("name"), SCORING_FAILED))
+    return unusable
+
+
+def describe_unusable(unusable: List[Tuple[str, str]]) -> str:
+    """Render the offending scores for an error message: name plus why, capped and sanitized."""
+    shown = [
+        f"'{_sanitize(name)}' {reason}"
+        for name, reason in unusable[:_MAX_REPORTED_NAMES]
+    ]
+    omitted = len(unusable) - len(shown)
+    rendered = ", ".join(shown)
+    return rendered if omitted == 0 else f"{rendered} and {omitted:,} more"
+
+
+def _sanitize(name: Any) -> str:
+    if name is None or name == "":
+        return "<unnamed>"
+    stripped = _CONTROL_CHARS.sub(" ", str(name))
+    return stripped if len(stripped) <= _MAX_NAME_CHARS else f"{stripped[:_MAX_NAME_CHARS]}…"

--- a/apps/opik-python-backend/src/opik_backend/score_validation.py
+++ b/apps/opik-python-backend/src/opik_backend/score_validation.py
@@ -7,6 +7,12 @@ failed carries a placeholder ``0.0`` that would otherwise be stored as if it wer
 
 The endpoint rejects a response only when *no* score is usable: a mixed list is passed through, so the
 usable scores still reach the backend, which drops the rest and reports them on the rule's log stream.
+
+``scoring_failed`` is matched strictly against ``True`` rather than by truthiness, because this side only
+decides whether to reject the whole response while the backend decides what is stored. A truthy
+non-boolean (``"false"`` is a truthy string in Python) would otherwise reject a score the backend would
+have stored quite happily. Erring the other way costs nothing: the backend deserializes the flag itself
+and drops what it considers failed.
 """
 
 import re
@@ -30,7 +36,7 @@ def unusable_scores(scores: List[Dict[str, Any]]) -> List[Tuple[str, str]]:
             unusable.append(("", NO_VALUE))
         elif score.get("value") is None:
             unusable.append((score.get("name"), NO_VALUE))
-        elif score.get("scoring_failed"):
+        elif score.get("scoring_failed") is True:
             unusable.append((score.get("name"), SCORING_FAILED))
     return unusable
 

--- a/apps/opik-python-backend/tests/unit/test_evaluator_python.py
+++ b/apps/opik-python-backend/tests/unit/test_evaluator_python.py
@@ -429,20 +429,15 @@ class ScoringFailedMetric(base_metric.BaseMetric):
 """
 
 
-@pytest.mark.parametrize("code, expected_detail", [
-    (VALUELESS_SCORE_METRIC, "'valueless_metric' returned no value"),
-    (SCORING_FAILED_METRIC, "'scoring_failed_metric' reported the scoring as failed"),
-])
-def test_wholly_unusable_scores_return_bad_request(client, code, expected_detail):
+@pytest.mark.parametrize("code", [VALUELESS_SCORE_METRIC, SCORING_FAILED_METRIC])
+def test_wholly_unusable_scores_return_bad_request(client, code):
     """Nothing usable came back, so the evaluation is a user error — reported like an empty result."""
     response = client.post(EVALUATORS_URL, json={
         "data": DATA,
         "code": code
     })
     assert response.status_code == 400
-    error = str(response.json["error"])
-    assert "didn't return any usable 'opik.evaluation.metrics.ScoreResult'" in error
-    assert expected_detail in error
+    assert "didn't return any usable 'opik.evaluation.metrics.ScoreResult'" in str(response.json["error"])
 
 
 def test_mixed_scores_are_passed_through(client):

--- a/apps/opik-python-backend/tests/unit/test_evaluator_python.py
+++ b/apps/opik-python-backend/tests/unit/test_evaluator_python.py
@@ -381,6 +381,85 @@ def test_evaluation_exception_returns_bad_request(client, code, stacktrace):
     assert stacktrace in error_message
 
 
+VALUELESS_SCORE_METRIC = """
+from typing import Any
+
+from opik.evaluation.metrics import base_metric, score_result
+
+
+class ValuelessMetric(base_metric.BaseMetric):
+    def __init__(self, name: str = "valueless_metric"):
+        self.name = name
+
+    def score(self, output: str, reference: str, **ignored_kwargs: Any):
+        return score_result.ScoreResult(value=None, name=self.name, reason="did not apply")
+"""
+
+MIXED_SCORES_METRIC = """
+from typing import Any
+
+from opik.evaluation.metrics import base_metric, score_result
+
+
+class MixedMetric(base_metric.BaseMetric):
+    def __init__(self, name: str = "mixed_metric"):
+        self.name = name
+
+    def score(self, output: str, reference: str, **ignored_kwargs: Any):
+        return [
+            score_result.ScoreResult(value=1.0, name="usable_score", reason="applied"),
+            score_result.ScoreResult(value=None, name="valueless_score", reason="did not apply"),
+        ]
+"""
+
+SCORING_FAILED_METRIC = """
+from typing import Any
+
+from opik.evaluation.metrics import base_metric, score_result
+
+
+class ScoringFailedMetric(base_metric.BaseMetric):
+    def __init__(self, name: str = "scoring_failed_metric"):
+        self.name = name
+
+    def score(self, output: str, reference: str, **ignored_kwargs: Any):
+        return score_result.ScoreResult(
+            value=0.0, name=self.name, reason="upstream call failed", scoring_failed=True
+        )
+"""
+
+
+@pytest.mark.parametrize("code, expected_detail", [
+    (VALUELESS_SCORE_METRIC, "'valueless_metric' returned no value"),
+    (SCORING_FAILED_METRIC, "'scoring_failed_metric' reported the scoring as failed"),
+])
+def test_wholly_unusable_scores_return_bad_request(client, code, expected_detail):
+    """Nothing usable came back, so the evaluation is a user error — reported like an empty result."""
+    response = client.post(EVALUATORS_URL, json={
+        "data": DATA,
+        "code": code
+    })
+    assert response.status_code == 400
+    error = str(response.json["error"])
+    assert "didn't return any usable 'opik.evaluation.metrics.ScoreResult'" in error
+    assert expected_detail in error
+
+
+def test_mixed_scores_are_passed_through(client):
+    """A mixed list must not fail the evaluation: the backend stores the usable score and reports the rest."""
+    response = client.post(EVALUATORS_URL, json={
+        "data": DATA,
+        "code": MIXED_SCORES_METRIC
+    })
+    assert response.status_code == 200
+
+    scores = response.json["scores"]
+    assert len(scores) == 2
+    by_name = {score["name"]: score for score in scores}
+    assert by_name["usable_score"]["value"] == 1.0
+    assert by_name["valueless_score"]["value"] is None
+
+
 def test_no_scores_returns_bad_request(client):
     response = client.post(EVALUATORS_URL, json={
         "data": DATA,

--- a/apps/opik-python-backend/tests/unit/test_score_validation.py
+++ b/apps/opik-python-backend/tests/unit/test_score_validation.py
@@ -1,0 +1,69 @@
+import pytest
+
+from opik_backend.score_validation import (
+    NO_VALUE,
+    SCORING_FAILED,
+    describe_unusable,
+    unusable_scores,
+)
+
+
+def score(name="metric", value=1.0, scoring_failed=False):
+    return {"name": name, "value": value, "scoring_failed": scoring_failed}
+
+
+@pytest.mark.parametrize("scores, expected", [
+    ([score()], []),
+    ([score(value=0.0)], []),
+    ([score(name="a", value=None)], [("a", NO_VALUE)]),
+    ([score(name="a", value=0.0, scoring_failed=True)], [("a", SCORING_FAILED)]),
+    ([score(name="a"), score(name="b", value=None)], [("b", NO_VALUE)]),
+    ([score(name="a", value=None), score(name="b", value=0.0, scoring_failed=True)],
+     [("a", NO_VALUE), ("b", SCORING_FAILED)]),
+    ([{"name": "a"}], [("a", NO_VALUE)]),
+    (["not a score"], [("", NO_VALUE)]),
+    ([], []),
+])
+def test_unusable_scores_classifies_each_result(scores, expected):
+    assert unusable_scores(scores) == expected
+
+
+def test_zero_is_a_value_not_a_missing_one():
+    """A metric answering "no" must reach the backend, so a zero is never unusable on its own."""
+    assert unusable_scores([score(name="is_toxic", value=0.0)]) == []
+
+
+def test_describe_names_each_score_and_its_reason():
+    described = describe_unusable([("a", NO_VALUE), ("b", SCORING_FAILED)])
+
+    assert described == "'a' returned no value, 'b' reported the scoring as failed"
+
+
+def test_describe_renders_an_unnamed_score():
+    assert "'<unnamed>'" in describe_unusable([(None, NO_VALUE)])
+    assert "'<unnamed>'" in describe_unusable([("", NO_VALUE)])
+
+
+def test_describe_collapses_line_breaks_in_a_name():
+    """The message lands in the rule's user-facing log, so a newline must not forge an entry there."""
+    described = describe_unusable([("ok\nERROR [2026-01-01 00:00:00,000] forged entry", NO_VALUE)])
+
+    assert "\n" not in described
+    assert "\r" not in described
+    assert "ok ERROR" in described
+
+
+def test_describe_caps_an_oversized_name():
+    described = describe_unusable([("x" * 500, NO_VALUE)])
+
+    assert len(described) < 150
+    assert "…" in described
+
+
+def test_describe_caps_the_number_of_names_and_counts_the_remainder():
+    described = describe_unusable([(f"score_{i}", NO_VALUE) for i in range(25)])
+
+    assert "'score_0'" in described
+    assert "'score_9'" in described
+    assert "'score_10'" not in described
+    assert "and 15 more" in described

--- a/apps/opik-python-backend/tests/unit/test_score_validation.py
+++ b/apps/opik-python-backend/tests/unit/test_score_validation.py
@@ -39,6 +39,11 @@ def test_only_a_real_true_counts_as_a_failed_scoring(flag):
     assert unusable_scores([score(name="a", value=1.0, scoring_failed=flag)]) == []
 
 
+def test_a_failed_scoring_with_no_value_is_reported_by_its_cause():
+    """Both conditions hold, so the reason a user can act on is the failure, not its symptom."""
+    assert unusable_scores([score(name="a", value=None, scoring_failed=True)]) == [("a", SCORING_FAILED)]
+
+
 def test_a_real_true_counts_as_a_failed_scoring():
     assert unusable_scores([score(name="a", value=1.0, scoring_failed=True)]) == [("a", SCORING_FAILED)]
 

--- a/apps/opik-python-backend/tests/unit/test_score_validation.py
+++ b/apps/opik-python-backend/tests/unit/test_score_validation.py
@@ -1,11 +1,6 @@
 import pytest
 
-from opik_backend.score_validation import (
-    NO_VALUE,
-    SCORING_FAILED,
-    describe_unusable,
-    unusable_scores,
-)
+from opik_backend.score_validation import has_usable_score
 
 
 def score(name="metric", value=1.0, scoring_failed=False):
@@ -13,72 +8,30 @@ def score(name="metric", value=1.0, scoring_failed=False):
 
 
 @pytest.mark.parametrize("scores, expected", [
-    ([score()], []),
-    ([score(value=0.0)], []),
-    ([score(name="a", value=None)], [("a", NO_VALUE)]),
-    ([score(name="a", value=0.0, scoring_failed=True)], [("a", SCORING_FAILED)]),
-    ([score(name="a"), score(name="b", value=None)], [("b", NO_VALUE)]),
-    ([score(name="a", value=None), score(name="b", value=0.0, scoring_failed=True)],
-     [("a", NO_VALUE), ("b", SCORING_FAILED)]),
-    ([{"name": "a"}], [("a", NO_VALUE)]),
-    (["not a score"], [("", NO_VALUE)]),
-    ([], []),
+    ([score()], True),
+    ([score(value=0.0)], True),
+    ([score(name="a", value=None)], False),
+    ([score(name="a", value=0.0, scoring_failed=True)], False),
+    ([score(name="a"), score(name="b", value=None)], True),
+    ([score(name="a", value=None), score(name="b", value=0.0, scoring_failed=True)], False),
+    ([{"name": "a"}], False),
+    (["not a score"], False),
+    ([], False),
 ])
-def test_unusable_scores_classifies_each_result(scores, expected):
-    assert unusable_scores(scores) == expected
+def test_has_usable_score(scores, expected):
+    assert has_usable_score(scores) is expected
 
 
 def test_zero_is_a_value_not_a_missing_one():
     """A metric answering "no" must reach the backend, so a zero is never unusable on its own."""
-    assert unusable_scores([score(name="is_toxic", value=0.0)]) == []
+    assert has_usable_score([score(name="is_toxic", value=0.0)]) is True
 
 
 @pytest.mark.parametrize("flag", ["false", "true", 1, 0, "", None])
 def test_only_a_real_true_counts_as_a_failed_scoring(flag):
     """Rejection here is all-or-nothing, so a truthy non-boolean must not reject what the backend stores."""
-    assert unusable_scores([score(name="a", value=1.0, scoring_failed=flag)]) == []
-
-
-def test_a_failed_scoring_with_no_value_is_reported_by_its_cause():
-    """Both conditions hold, so the reason a user can act on is the failure, not its symptom."""
-    assert unusable_scores([score(name="a", value=None, scoring_failed=True)]) == [("a", SCORING_FAILED)]
+    assert has_usable_score([score(name="a", value=1.0, scoring_failed=flag)]) is True
 
 
 def test_a_real_true_counts_as_a_failed_scoring():
-    assert unusable_scores([score(name="a", value=1.0, scoring_failed=True)]) == [("a", SCORING_FAILED)]
-
-
-def test_describe_names_each_score_and_its_reason():
-    described = describe_unusable([("a", NO_VALUE), ("b", SCORING_FAILED)])
-
-    assert described == "'a' returned no value, 'b' reported the scoring as failed"
-
-
-def test_describe_renders_an_unnamed_score():
-    assert "'<unnamed>'" in describe_unusable([(None, NO_VALUE)])
-    assert "'<unnamed>'" in describe_unusable([("", NO_VALUE)])
-
-
-def test_describe_collapses_line_breaks_in_a_name():
-    """The message lands in the rule's user-facing log, so a newline must not forge an entry there."""
-    described = describe_unusable([("ok\nERROR [2026-01-01 00:00:00,000] forged entry", NO_VALUE)])
-
-    assert "\n" not in described
-    assert "\r" not in described
-    assert "ok ERROR" in described
-
-
-def test_describe_caps_an_oversized_name():
-    described = describe_unusable([("x" * 500, NO_VALUE)])
-
-    assert len(described) < 150
-    assert "…" in described
-
-
-def test_describe_caps_the_number_of_names_and_counts_the_remainder():
-    described = describe_unusable([(f"score_{i}", NO_VALUE) for i in range(25)])
-
-    assert "'score_0'" in described
-    assert "'score_9'" in described
-    assert "'score_10'" not in described
-    assert "and 15 more" in described
+    assert has_usable_score([score(name="a", value=1.0, scoring_failed=True)]) is False

--- a/apps/opik-python-backend/tests/unit/test_score_validation.py
+++ b/apps/opik-python-backend/tests/unit/test_score_validation.py
@@ -33,6 +33,16 @@ def test_zero_is_a_value_not_a_missing_one():
     assert unusable_scores([score(name="is_toxic", value=0.0)]) == []
 
 
+@pytest.mark.parametrize("flag", ["false", "true", 1, 0, "", None])
+def test_only_a_real_true_counts_as_a_failed_scoring(flag):
+    """Rejection here is all-or-nothing, so a truthy non-boolean must not reject what the backend stores."""
+    assert unusable_scores([score(name="a", value=1.0, scoring_failed=flag)]) == []
+
+
+def test_a_real_true_counts_as_a_failed_scoring():
+    assert unusable_scores([score(name="a", value=1.0, scoring_failed=True)]) == [("a", SCORING_FAILED)]
+
+
 def test_describe_names_each_score_and_its_reason():
     described = describe_unusable([("a", NO_VALUE), ("b", SCORING_FAILED)])
 


### PR DESCRIPTION
## Details

Follow-up to OPIK-8301 (#8208), which made the backend *tolerate* a Python metric score with no value. This stops such a score reaching storage at all, and closes a second way a score becomes meaningless once stored.

**Python evaluator** (`POST /v1/private/evaluators/python`)

A score result is unusable when its value is missing — `ScoreResult.value` is declared `float` in the SDK dataclass, so `None` already breaks that contract and nothing enforces it at runtime — or when the metric flagged it with `scoring_failed`. The endpoint now rejects a response in which **no** score is usable, with a `400` naming each offending score and why. That is the same class of user error as the empty-result `400` already sitting just above it.

A mixed list is deliberately passed through: the usable scores still reach the backend, which drops the rest and names them on the rule's log stream. Rejecting the whole payload would lose the usable scores too — the exact loss #8208 fixed, moved one layer up. So `[ScoreResult("a", 1.0), ScoreResult("b", None)]` still stores `a`.

Score names come from user code and land in an error message the backend writes to the rule's user-facing log, so they are sanitized and capped here. The backend's error path does not sanitize what it logs, so this has to happen upstream.

**Backend**

`scoring_failed` was deserialized into `PythonScoreResult` and then never read anywhere. The SDK always pairs that flag with a placeholder `0.0` (`suite_evaluators/llm_judge/parsers.py:137`, `threads/evaluation_engine.py:181`, `conversation/llm_judges/g_eval_wrappers.py:117`), so such a score is storable — and was being stored, recording a failed evaluation as a genuine zero that nothing distinguishes from a metric that deliberately scored zero. Those scores are now dropped alongside valueless ones, under their own reason.

`toStorablePythonScores` therefore splits three ways, and `logValuelessPythonScores` becomes `logDroppedPythonScores`, taking the split and writing one capped line per reason ("returned no value" / "reported the scoring as failed").

Name normalization also moved into `StorablePythonScores`. The record already owed its callers immutable, non-null lists, and `List.copyOf` rejects a null element — so an unnamed score could throw from inside the very type meant to make an unusable score harmless. That is the original bug's shape, resurfaced by the immutability snapshot added late in #8208.

**User-visible change worth a reviewer's veto**

A rule whose metric returns *only* unusable scores now reports an error on its log naming the metric, where before it logged a skip and `stored {}`. `HttpStatusRetryability` classifies `400` as permanent, so `BaseRedisSubscriber` acks the entry rather than redelivering it — this does not cause retries.

This does contradict one scenario in draft #8209, whose fourth case expects an all-valueless rule to "report no failure and not be re-attempted". The second half still holds; the first no longer does, and that spec needs updating alongside this.

## Change checklist
- [x] User facing

## Issues

- OPIK-8319

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: whole change — Python evaluator validation, backend scoring_failed handling, unit tests on both sides
- Human verification: pending review by the author

## Testing

Python, from `apps/opik-python-backend` (deps installed in a venv; the pinned `requirements.txt` additionally pulls litellm and opik-optimizer, which these tests do not import):

- `pytest tests/unit/test_score_validation.py` — 15 tests, 0 failures. Covers classification per reason, that a zero is a value and not a missing one, an unnamed score, CR/LF collapsing so a score name cannot forge a log entry, oversized-name truncation, and the cap-with-remainder rendering.
- `pytest tests/unit/test_evaluator_python.py` — 36 passed, 2 skipped (both skips pre-existing). The 8 new cases cover a wholly valueless response, a wholly `scoring_failed` response, and a mixed list passing through with its `null` intact, each across both the Docker and Process executors.

Backend, from `apps/opik-backend`:

- `mvn test -Dtest='OnlineScoring*Test,FeedbackScore*Test,Assertion*Test'` — 386 tests, 0 failures, including the testcontainers-backed suites.
- `mvn spotless:apply` then `mvn spotless:check` — clean.

Not run: the backend E2E suites and the Python backend's own e2e/guardrails suites.

## Documentation

No documentation change. The rule-log wording is the user-facing surface and rule logs are not enumerated in the docs; the new `400` follows the shape of the existing empty-result one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
