### PR TITLE
[OPIK-8238] [BE] fix: reconcile the traces cutover gap after the swap, in both directions

### DIFF
--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -531,7 +531,10 @@ The tail is still worth running tightly, because its length is what decides how 
    recording `exchange_done` and printing the **CUTOVER INCOMPLETE** banner.
 5. Run `reconcile.sh --gap-start '<delta_start> UTC' --swap-done '<exchange_done> UTC'`, **immediately** again. It
    sweeps the parked writes into the live successor, re-applies the deletes bridged across the swap, and does not exit 0
-   until its four-count postcondition says the gap is closed.
+   until its four-count postcondition says the gap is closed. Pass the **recorded** `exchange_done`, never an estimate:
+   the sweep and the gate apply the same `--swap-done` exclusion, so a value earlier than the real swap drops a key
+   deleted and re-created in between from *both*, leaving that trace missing under a clean gate. `--help` states both
+   directions of error; only `--gap-start` is free to widen.
 
 Keep step 3→4 short, and step 4→5 shorter:
 
@@ -541,7 +544,7 @@ Keep step 3→4 short, and step 4→5 shorter:
 | **Writes** — all of them, since nothing holds any of them across the swap | **step 5's sweep** |
 | **Deletes** bridged after step 4's replay read but before the swap | **step 5's post-swap replay**, whose resurrection guard reads the frozen backup and is therefore race-free |
 
-**Four residuals remain, all narrow. The first three are on the delete side and share one mitigation — so state it
+**Five residuals remain, all narrow. The first three are on the delete side and share one mitigation — so state it
 once: quiesce user DELETES across the swap, not merely reads.**
 
 - A delete whose bridge row lands *after* step 5's read is invisible to it.
@@ -571,6 +574,14 @@ once: quiesce user DELETES across the swap, not merely reads.**
   the backup, and a lightweight `DELETE` **accepts `apply_deleted_mask = 0` and then ignores it**, so folding the check
   into the replay would produce a statement that reports success having masked nothing. Clamping future client
   timestamps at ingestion is the durable fix and is not this procedure's to make.
+- **A post-swap write that REGRESSES `last_updated_at` is overwritten by the sweep, and the gate reports it clean.**
+  The same writable column as above, in the other direction. The sweep re-inserts the parked payload,
+  `ReplacingMergeTree` keeps the higher version, and a client-supplied value below the parked row's loses the live
+  write; the postcondition then compares the parked payload against itself and returns zeros, so `newer_keys` does not
+  see it either. It needs a gap-window key *and* a post-swap write that moves `last_updated_at` backwards. Nothing in
+  the reconciliation can fix it: skipping keys already live would abandon exactly the stale and partial rows the sweep
+  exists to repair, and re-stamping the version would clobber legitimate newer writes. Clamping client timestamps at
+  ingestion is the durable fix here too.
 - Between the `EXCHANGE` and the sweep, gap-window traces are briefly absent from live reads — and `TraceDAO`'s merge
   path reads the old row to preserve `created_at`, so an update landing in that hole re-stamps it.
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -2,16 +2,21 @@
 
 Operator runbook for the cutover of the ClickHouse `traces` table: it migrates the live, unpartitioned
 `traces` table to `traces_local_v2` (weekly-partitioned, denullified, `is_deleted`-ready) with **near-zero downtime**
-and **near-zero deletion loss** — the deletion bridge replays every captured delete before the swap, leaving only a
-bounded residual micro-window (see "The final cutover window" below, which also gives the mitigation) — then wraps it
-in a sharding-ready `Distributed` table.
+and **no write or deletion loss** — the deletion bridge replays every captured delete before the swap, and the
+post-swap reconciliation sweeps back every write that landed in the gap between the last delta and the `EXCHANGE` and
+proves it did — then wraps it in a sharding-ready `Distributed` table.
 
-The mechanism is **backfill + delta + deletion replay + EXCHANGE**, with no dual-write path and **no ingestion-path
-config change**. Writes are never held: the `EXCHANGE` is atomic per node, so a concurrent insert always commits to a
-valid table. Writes that land in the *old* one — in the final-delta→`EXCHANGE` gap and during the cross-node
-`ON CLUSTER` skew — stay in the parked backup, which is an open defect tracked as OPIK-8238 rather than a property of
-this procedure. See ["The final cutover window"](#the-final-cutover-window) for what the swap does and does not
-guarantee.
+The mechanism is **backfill + delta + deletion replay + EXCHANGE + post-swap reconciliation**, with no dual-write path
+and **no ingestion-path config change**. Writes are never held: the `EXCHANGE` is atomic per node, so a concurrent
+insert always commits to a valid table. Writes that land in the *old* one — in the final-delta→`EXCHANGE` gap and
+during the cross-node `ON CLUSTER` skew — stay in the parked backup until step 5 sweeps them into the live table. See
+["The final cutover window"](#the-final-cutover-window) for what the swap does and does not guarantee.
+
+> **The cutover is not complete when the `EXCHANGE` returns.** Those parked writes stay orphaned until `reconcile.sh`
+> sweeps them back and proves it did. `exchange_and_wrap.sh` ends with a **CUTOVER INCOMPLETE** banner naming the exact
+> command, and `finalize.sh` refuses to retire the backup without `--confirm-gap-reconciled`. This is not a theoretical
+> residual — it has been observed on a real cutover (OPIK-8238), with traces left in `traces_pre_cutover_backup` and
+> absent from the live table.
 
 This runbook is the human-facing artifact; its SQL is validated end-to-end by
 [`TracesLocalV2CutoverTest`](../../src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java). Treat
@@ -143,6 +148,12 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
     > `ALTER DELETE`**. The read-only drivers (`estimate.sh`, `verify.sh`) cannot surface this — only executing a
     > mutation can. Grant it **column-scoped** (`ALTER UPDATE(_row_exists)`) so the user can flip the delete mask
     > without being able to modify any real data column.
+    >
+    > **The smoke test covers the pre-swap shape only.** The post-swap reconciliation mutates the LIVE name, so it also
+    > needs `ALTER UPDATE(_row_exists)` and `INSERT` on `traces` (or `traces_local` on a wrapped estate) plus `SELECT` on
+    > `traces_pre_cutover_backup` — grants this no-op run cannot exercise, because those objects do not hold those roles
+    > yet. Provision them from the privileges table before the window and confirm them on the prod-clone rehearsal: a
+    > grant gap found there lands with the cutover already committed and the write gap still open.
 14. Schedule during off-peak hours.
 
 ## The sequence
@@ -173,11 +184,17 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    No config change precedes this step — the procedure takes no hold on writes.
    The driver passes `--time`, so clickhouse-client prints each statement's wall time in seconds (delta-insert first,
    deletion replay second) — **record the second value**: it is the *first half* of the final-delta→`EXCHANGE` gap,
-   which is where tail writes are left behind. The second half is `exchange_and_wrap.sh`'s own run through the swap,
-   which that driver reports (step 4). Without `--time` a bare `--query` prints no timing at all.
+   which is the window step 5 sweeps back. The second half is `exchange_and_wrap.sh`'s own run through the swap, which
+   that driver reports (step 4). Without `--time` a bare `--query` prints no timing at all.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/delta_replay.sh --database opik --backfill-start '<ts> UTC'
    ```
+   It prints two things step 5 needs. **`RECORD delta_start=`** is the instant the pass began reading, and it is the
+   gap anchor `reconcile.sh` sweeps from — record it with the ` UTC` marker, exactly like `backfill_start`. **The
+   pending-delta size** is how many rows the source took *while the pass ran*, i.e. what an `EXCHANGE` issued now would
+   strand in the parked backup. Re-run the driver to watch it shrink; it will **not reach 0** while the source is live,
+   which is precisely why reconciliation happens after the swap and not before it. Losing `delta_start` is not an
+   escalation — widening the gap window is free, so `backfill_start` is always a valid fallback.
 3. **QA — run [`scripts/verify.sh`](scripts/verify.sh)** (see "Verifying the migration"): confirm the copy altered no
    data before committing the swap. Run it after step 2; it can be re-run after the swap, bounded as
    ["Verifying the migration"](#verifying-the-migration-qa) describes.
@@ -186,10 +203,11 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    replication state** (see ["The replication-settle gate"](#the-replication-settle-gate) — it polls rather than
    demanding an instantaneous zero, so live ingest churn does not abort it while a genuinely lagging replica still
    does; `--force` overrides, and the Go/No-Go forbids that in production); then records and
-   prints `cutover_start`, runs `EXCHANGE TABLES ... ON CLUSTER` and renames the displaced old data to
-   `traces_pre_cutover_backup` (see "Naming and the parked backup"). It **stops there by default** (EXCHANGE only,
-   leaving `traces` a `MergeTree` where deletes still work); the `RENAME` + `Distributed` wrap runs only with
-   `--with-wrap`. Afterwards, size the tail write-gap (["The final cutover window"](#the-final-cutover-window)) and
+   prints `cutover_start`, runs `EXCHANGE TABLES ... ON CLUSTER`, renames the displaced old data to
+   `traces_pre_cutover_backup` (see "Naming and the parked backup") and prints `RECORD exchange_done=`. It **stops there
+   by default** (EXCHANGE only, leaving `traces` a `MergeTree` where deletes still work); the `RENAME` + `Distributed`
+   wrap runs only with `--with-wrap`. It ends with a **CUTOVER INCOMPLETE** banner naming the step-5 command, because
+   the swap leaves the tail writes parked (["The final cutover window"](#the-final-cutover-window)); reconcile, then
    verify (["Verifying the migration"](#verifying-the-migration-qa)).
 
    **Check the per-host `ON CLUSTER` rows before you go further.** Each `ON CLUSTER` DDL prints one row per host
@@ -317,6 +335,34 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > `--skip-wrap`, an explicit alias) to run the EXCHANGE and stop; `--with-wrap` to also apply the wrap in the same run;
 > `--wrap-only` to apply just the deferred wrap later.
 
+5. **Reconcile the gap — run [`scripts/reconcile.sh`](scripts/reconcile.sh) immediately after step 4** (reference SQL
+   [`000006_post_swap_reconciliation.sql`](scripts/db-app-analytics/000006_post_swap_reconciliation.sql) and its
+   postcondition [`000006_verify_reconciliation.sql`](scripts/db-app-analytics/000006_verify_reconciliation.sql)).
+   **This step is not optional and it is not a check** — it is the second half of the data cutover. Everything written
+   to the old table between step 2's last delta pass and the `EXCHANGE` is sitting in `traces_pre_cutover_backup`,
+   absent from live `traces`.
+   ```bash
+   CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/reconcile.sh --database opik \
+       --gap-start '<delta_start from step 2> UTC' --swap-done '<exchange_done from step 4> UTC'
+   ```
+   It derives the direction from the live topology (no `--direction` flag to get wrong), gates on the cluster-wide
+   settle (the same gate as step 4, with a post-swap scope — see
+   ["The replication-settle gate"](#the-replication-settle-gate)), then **sweeps → replays deletes → asserts a
+   four-count postcondition**, repeating up to `--max-passes` (default 3) and failing loudly rather than reporting
+   progress. `--report-only` returns the counts and issues no mutation. It reads the postcondition before mutating
+   anything, so a second run on a reconciled estate is a no-op that exits 0.
+   > **Why this cannot be done before the swap.** The source is live, so every pre-swap pass opens a new gap — iterating
+   > the delta shrinks it and then stops improving, which is what was observed on the cutover that motivated this step.
+   > After the swap the parked table is **frozen**, so the sweep converges by construction and its postcondition is a
+   > gate rather than a snapshot.
+6. **QA over the reconciled range — `verify.sh --window-from/--window-to`** for the payload-level picture over exactly
+   what step 5 swept, alongside the usual bounded weekly compare (see "Verifying the migration"):
+   ```bash
+   ./scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces \
+       --window-from '<delta_start>' --window-to '<now, UTC>'
+   ```
+   Then work the ["When the cutover is done"](#when-the-cutover-is-done) checklist before the soak.
+
 **Dedup note.** After the delta, a row can have two physical versions on `traces_local_v2` (the backfilled one and the
 delta one). This is normal — `ReplacingMergeTree` collapses them on merge / under `FINAL` / `LIMIT 1 BY id`, highest
 `last_updated_at` winning. Do not "fix" it.
@@ -397,6 +443,22 @@ driver prints the wait alongside its elapsed-through-`EXCHANGE`, so the gap can 
 skips the gate and is a production No-Go: the gate is permissive enough that reaching its failure path means something
 is genuinely wrong.
 
+**`reconcile.sh` runs the same gate with a post-swap scope.** It reads the same three blocks — the table sets are
+placeholders, so each driver renders its own scope — and needs the settle for two reasons of its own: its sweep reads
+the parked table **mask-honored**, and its postcondition joins two tables and so reads **one** replica (`clusterAllReplicas`
+would return a copy of each side per replica and multiply both). What the swap changes is *which* table is quiet:
+
+| Signal | Scope after the swap | Judgement |
+|---|---|---|
+| unfinished **mutations** | the **parked backup** only | **Unconditional.** That table is frozen, so anything still applying to it is a user delete that fired before the swap and has not landed on this replica yet — and the mask-honored sweep would read the row as live and copy a deleted trace back. It drains rather than recurring, so demanding zero is reachable. |
+| unfinished **mutations** | the **live** table — **deliberately not gated** | After the swap the live table takes user deletes continuously, each an ordinary asynchronous mutation, so requiring zero would abort on healthy traffic. Nor is it a hazard: a delete still applying leaves the row visible, which the postcondition reads as *present*, never as missing; and deletes bridged across the swap are re-applied by the sweep's own replay, which carries `lightweight_deletes_sync = 2`. |
+| the **replication queue** | **both** tables | **Stuck-ness, not depth** — same thresholds, same reasoning as above. Either table short of a part on this replica skews the postcondition's join. |
+
+The wait costs no cutover tail here, since the swap has already committed — but every second of it is a second the
+gap-window traces are still absent from live reads, so it is not free either. And it is spent **per gate**: once before
+the first postcondition read and once per pass, so on a queue that stays busy-but-not-stuck the worst case is
+`(1 + --max-passes) × --settle-timeout`. A drained queue returns immediately, which is the normal case off-peak.
+
 ### The final cutover window
 
 **What the swap guarantees.** Nothing in this procedure parks an insert, and it does not need to: the `EXCHANGE` is
@@ -404,43 +466,68 @@ is genuinely wrong.
 concurrent insert commits to a valid table — the old storage if it reaches a node pre-swap, the new one if post-swap.
 Neither errors, and no insert is rejected. **Deletes** are covered up to `cutover_start` by step 4's final replay.
 
-**Writes in the tail are not covered yet.** Two sources leave them in the table that becomes the parked backup:
+**Writes in the tail are not held by the swap.** Two sources leave them in the table that becomes the parked backup:
 
 - the **final-delta→`EXCHANGE` gap** — writes after the last delta read and before the swap;
 - the **cross-node `ON CLUSTER` skew** — `EXCHANGE` is atomic per node but not across nodes, so while it propagates,
   inserts routed at a not-yet-swapped node still land in the old table.
 
 Those rows are **not destroyed** — they sit in `traces_pre_cutover_backup` and stay recoverable until `finalize.sh`
-retires it. What is missing is a step that carries them into the live table and proves it did: one driven by *version*
-rather than key presence (a trace merely *updated* in the tail is already on the successor at an older
-`last_updated_at`, so a presence check finds nothing to do), and one that does not resurrect a delete that fired after
-the swap. **OPIK-8238 adds exactly that** and supersedes this note. Until it lands, size the gap after the swap and
-decide knowingly — see the Go/No-Go item.
+retires it. **Step 5, `reconcile.sh`, is what carries them into the live table and proves it did** (OPIK-8238). Two
+properties make it more than a copy: it is driven by *version* rather than key presence — a trace merely *updated* in
+the tail is already on the successor at an older `last_updated_at`, so a presence check would find nothing to do — and
+it does not resurrect a delete that fired after the swap.
 
-> **This is an open defect, not a regression introduced by dropping the buffer.** The removed setting was believed to
-> hold these writes and largely did not — the rejected alternatives below give the mechanism. Removing it widens the gap
-> by the small fraction the buffer genuinely held, and replaces a false guarantee with a stated one.
+**Nothing before the swap can do that job.** Pre-swap reconciliation cannot converge, because the source is live: every
+pass reads a snapshot and opens a new gap behind itself. Iterating the delta shrinks the gap and then stops improving —
+that floor is what the pending-delta count in step 3 shows you. **Post-swap it converges by construction**, because the
+parked table is frozen. That is the whole reason the reconciliation step sits after the `EXCHANGE` rather than before
+it.
 
-The tail is still worth running tightly, because its length is what decides how many writes land in that gap:
+The tail is still worth running tightly, because its length is what decides how many writes the sweep has to carry:
 
 1. **Roll out `traceColumnsNonNullable = true` to every backend instance**
    (["The one rolling restart"](#the-one-rolling-restart-tracecolumnsnonnullable), and the flip's own note below). Do it
    while there is slack, not between the final delta and the `EXCHANGE`.
 2. Do the QA verify on an **earlier** pass (it can take minutes on a large table — do not let it be the last thing
    before the swap).
-3. Run a **final** `delta_replay.sh` as the last write-facing step before the swap.
+3. Run a **final** `delta_replay.sh` as the last write-facing step before the swap, and **record the
+   `RECORD delta_start=` it prints**: that is the gap anchor step 5 sweeps from. The pending-delta size printed
+   alongside is how large the gap is right now — re-run to shrink it, and stop when it stops improving rather than
+   chasing a zero that cannot exist while the source is live.
 4. Run `exchange_and_wrap.sh --backfill-start '<anchor> UTC' …` **immediately** after it. It captures `cutover_start`,
    then runs a **final deletion replay** from `backfill_start` right before the swap — so deletes bridged in the
    `[final delta_replay, cutover_start)` gap are masked on the successor rather than leaking (that gap is covered by
    neither the earlier forward replay nor the rollback reverse-replay, which starts at `cutover_start`). Deletions only.
    The `EXCHANGE` itself is metadata-only, but this driver is **not** instantaneous: the settle gate ahead of it polls
    for as long as the cluster needs, to `--settle-timeout`, and every second of that is tail. The driver prints its
-   elapsed-through-`EXCHANGE` with the gate wait itemised — that figure plus step 3's replay time is the gap.
+   elapsed-through-`EXCHANGE` with the gate wait itemised — that figure plus step 3's replay time is the gap. It ends by
+   recording `exchange_done` and printing the **CUTOVER INCOMPLETE** banner.
+5. Run `reconcile.sh --gap-start '<delta_start> UTC' --swap-done '<exchange_done> UTC'`, **immediately** again. It
+   sweeps the parked writes into the live successor, re-applies the deletes bridged across the swap, and does not exit 0
+   until its four-count postcondition says the gap is closed.
 
-Keep step 3→4 short. **Deletes** up to `cutover_start` are covered by step 4's final deletion replay; **writes** in
-that gap and across the swap skew are the exposure above. The one residual on the delete side is a delete whose
-bridge row commits after that final replay's read but with `event_time < cutover_start` — an inherent micro-window; if
-delete load is high, quiesce user deletes for the final seconds.
+Keep step 3→4 short, and step 4→5 shorter:
+
+| In the `[last delta, EXCHANGE]` gap | Covered by |
+|---|---|
+| **Deletes** bridged before `cutover_start` | step 4's final deletion replay |
+| **Writes** — all of them, since nothing holds any of them across the swap | **step 5's sweep** |
+| **Deletes** bridged after step 4's replay read but before the swap | **step 5's post-swap replay**, whose resurrection guard reads the frozen backup and is therefore race-free |
+
+**Three residuals remain, all narrow, all on the delete side, and all bounded by the same mitigation — so state it once:
+quiesce user DELETES across the swap, not merely reads.**
+
+- A delete whose bridge row lands *after* step 5's read is invisible to it.
+- Capture writes the bridge row *before* the delete executes, so for the width of the `EXCHANGE` a delete can be bridged
+  before `exchange_done` while its `DELETE` lands on the successor after the swap. That key is live in the frozen backup
+  and bridged before the bound, so **step 5's sweep brings it back**. It needs the trace to be written *and* deleted
+  inside the gap window, with the swap falling between its capture and its delete.
+- Between the `EXCHANGE` and the sweep, gap-window traces are briefly absent from live reads — and `TraceDAO`'s merge
+  path reads the old row to preserve `created_at`, so an update landing in that hole re-stamps it.
+
+The first and third are reasons to run step 5 *immediately*; the second is a reason to quiesce deletes rather than to
+skip the sweep, since skipping it loses every write in the gap instead.
 
 *Rejected alternatives, recorded so they are not re-proposed (OPIK-8239).* **Widening the async-insert buffer**
 (`asyncInsertBusyTimeoutMaxMs`) to hold writes across the swap does not work here. The backend serves reads and writes
@@ -841,8 +928,15 @@ They are **complementary, not alternatives**, and there is **no copy-paste drift
 - **Keep the explicit column list in sync.** `000001`'s `INSERT` names each copied column explicitly (parallel `SELECT`,
   no `SELECT *`), so a column added to `traces` before a cutover is carried across **only if it is also added to this
   list and to the `traces_local_v2` shadow** (migration 000101, recreated by 000114). This is an incidental per-column
-  edit that rides with the feature DDL; omissions are caught in CI by the schema-parity guard — `cutoverCopiesEveryBaseColumn`
-  pins this list to the live `traces` base columns (OPIK-7772 extends it to a topology-aware CI check).
+  edit that rides with the feature DDL; a missing column is caught in CI by the schema-parity guard —
+  `cutoverCopiesEveryBaseColumn` pins the cutover's column list to the live `traces` base columns (OPIK-7772 extends it
+  to a topology-aware CI check).
+  > **That guard fails on the test's copy of the list, not on the reference files — treat it as the prompt to update
+  > them.** Four statements spell the list out independently: `000001`'s backfill, `000002`'s delta and both `000006`
+  > sweeps. They are duplicated rather than shared because the drivers read whole statements, so each file has to stay
+  > readable and runnable on its own. Keeping them in step is a manual step, and an `INSERT ... SELECT` is positional,
+  > so each must **list and project** the same columns in the same order. The same applies to the fidelity fingerprint
+  > repeated across `000005`/`000006`.
 
 **Every SQL operation — happy path and every rollback stage — is run by a driver script; no SQL or `.sql` file is ever
 run by hand.** Each `.sql` file is the single source its driver reads those statements from:
@@ -852,8 +946,9 @@ run by hand.** Each `.sql` file is the single source its driver reads those stat
 | plan — backfill ETA | — | `estimate.sh` |
 | 1 — backfill | `000001_backfill_traces_local_v2.sql` | `backfill.sh` |
 | 2 — delta + replay | `000002_delta_and_deletion_replay.sql` | `delta_replay.sh` |
-| 3 — settle gate, EXCHANGE + wrap | `000003_exchange_and_wrap.sql` | `exchange_and_wrap.sh` |
-| QA — fidelity compare (+ `--drill-down`) | `000005_verify_migration.sql` | `verify.sh` |
+| 3 — settle gate, EXCHANGE + wrap (+ the final pre-swap replay, from `000002`'s `deletion-replay` block) | `000003_exchange_and_wrap.sql` | `exchange_and_wrap.sh` |
+| 4 — **post-swap reconciliation**, forward and reverse | `000006_post_swap_reconciliation.sql` (`forward-sweep` + `forward-deletion-replay`, or `reverse-sweep` followed by the unchanged `000004_rollback_reverse_replay.sql` + `000004_rollback_verify_replay.sql`) + its postcondition `000006_verify_reconciliation.sql`, and `000003`'s three `settle-*` blocks for its own gate | `reconcile.sh` |
+| QA — fidelity compare, weekly or over one window (+ `--drill-down`) | `000005_verify_migration.sql` | `verify.sh` |
 | rollback | `000004_rollback_stage_{a,b,c}_*.sql`, `000004_rollback_unwrap.sql`, `000004_rollback_reverse_replay.sql` + its postcondition `000004_rollback_verify_replay.sql`, `000004_rollback_sentinel_repair.sql` + its postcondition `000004_rollback_verify_sentinels.sql` | `rollback.sh` |
 | finalize — retire the parked backup (drop after cutover / recycle to empty shadow after rollback) | — | `finalize.sh` |
 
@@ -862,12 +957,23 @@ from a file, and the split is deliberate:
 
 - **In a versioned `.sql` file, extracted by marker:** every statement that changes data or schema, and every read
   whose result *is a verdict* the operator acts on. That second half is why `000005`'s `compare` / `confirm-keys` /
-  `version-ties` blocks and `000003`'s three `settle-*` blocks live in files despite being read-only — a fidelity gate
-  or a swap gate deciding wrongly is the failure this procedure exists to prevent, so its SQL is reviewed and versioned
-  like a statement.
+  `version-ties` blocks, `000006`'s `verify-forward` / `verify-reverse` blocks and `000003`'s three `settle-*` blocks
+  live in files despite being read-only — a fidelity gate, a reconciliation gate or a swap gate deciding wrongly is the
+  failure this procedure exists to prevent, so its SQL is reviewed and versioned like a statement. The `settle-*` blocks
+  are read by **two** drivers: `exchange_and_wrap.sh` before the swap and `reconcile.sh` after it, each rendering its own
+  table scope into the blocks' `${SETTLE_QUEUE_TABLES}` / `${SETTLE_MUTATION_TABLES}` placeholders. Same hazard, same
+  SQL, different scope — which is why these are parameterised where the two deletion replays are duplicated (below).
 - **Inline in the driver:** the short scalar probes that steer control flow — "what engine is `traces`?", "does this
   table exist?", "how many replicas?". They are one-liners against `system.*`, they change nothing, and putting them
   behind a marker would add indirection without adding review value.
+
+> **There are two deletion replays, and they are separate files on purpose.** `000002`'s runs **pre-swap** against a
+> **live** source (`delta_replay.sh`, and again inside `exchange_and_wrap.sh`); `000006`'s `forward-deletion-replay`
+> runs **post-swap** against the **frozen** backup. They share a shape — the full-key bridge match, the length guards,
+> the resurrection guard — but not their semantics, and the post-swap one carries a third arm the pre-swap one has no
+> counterpart for. Parameterising one block to serve both would mean a placeholder whose only job is to switch that arm
+> off, inside the statement whose silent failure leaks deletions; `000004_rollback_reverse_replay.sql` is a separate
+> file for the same reason. Each carries a `KEEP IN STEP WITH` header naming the other.
 
 Each driver takes the connection from the `clickhouse-client` env vars `CLICKHOUSE_HOST`, `CLICKHOUSE_USER` and
 `CLICKHOUSE_PASSWORD`, plus `--database` and — when the native port is not 9000 — `--port`.
@@ -941,6 +1047,8 @@ read-only drivers cannot surface a mutation-privilege gap by construction.
 | deletion replay | lightweight `DELETE FROM <shadow>` | **`ALTER UPDATE(_row_exists)`** on the shadow — *not* `ALTER DELETE`. A lightweight delete is implemented as `ALTER UPDATE _row_exists = 0`. Grant it **column-scoped** so the user can flip the delete mask without being able to rewrite any real column. |
 | `EXCHANGE` | `EXCHANGE TABLES <source> AND <shadow> ON CLUSTER` | **`INSERT` + `CREATE TABLE` + `DROP TABLE` on BOTH names** — `INSERT` is required even though the swap is metadata-only and moves no rows. |
 | post-swap `RENAME` | `RENAME TABLE <shadow> TO <backup>` | `CREATE TABLE` + `DROP TABLE` (grant `INSERT` on the backup name too, so the rename cannot trip the same check) |
+| **post-swap reconciliation** (`reconcile.sh`, forward — **required on every cutover**) | `INSERT INTO traces SELECT … FROM traces_pre_cutover_backup`, then the lightweight `DELETE FROM traces` | **`INSERT` and `ALTER UPDATE(_row_exists)` on `traces`** (or `traces_local` on a wrapped estate), plus **`SELECT` on `traces_pre_cutover_backup`**. This is the grant set that widens the forward path's blast radius — see the boundary note below, which it deliberately rewrites. `INSERT` on `traces` is already required by the `EXCHANGE`; the mutation grant is new. Column-scoped `ALTER UPDATE(_row_exists)`, as for the shadow, so the user can flip the delete mask without rewriting any real column. |
+| **post-swap reconciliation** (`reconcile.sh`, reverse — only after a rollback) | `INSERT INTO traces SELECT … FROM traces_post_rollback_backup`, then the reverse replay | `INSERT` and `ALTER UPDATE(_row_exists)` on `traces` (the latter already in the rollback set), plus `SELECT` on `traces_post_rollback_backup`. |
 | **wrap** (sharding) | `CREATE TABLE traces_dist … ENGINE = Distributed(…)`, then `RENAME traces → traces_local, traces_dist → traces` | `CREATE TABLE` + `DROP TABLE` on **`traces_dist`** and **`traces_local`** — two names that **do not exist yet**, so a grant set scoped to the cutover's three names will NOT cover the wrap. Plus `SELECT` on `traces_local` (post-wrap reads route through the wrapper to it) and `REMOTE` for the `Distributed` engine. |
 | rollback stage A/B (if in scope) | stage A `TRUNCATE`; stage B 2-way `RENAME` + reverse replay | `TRUNCATE` on the shadow, and `ALTER UPDATE(_row_exists)` on the **source** (the reverse replay masks rows on the restored original). **Stage B also renames**, so it needs **`INSERT` + `CREATE TABLE`** on **`traces_post_rollback_backup`** — a destination that **does not exist yet**, so a set without `INSERT` fails `Code: 497` at the rename (see the four-privileges note below) — and **`SELECT` + `DROP TABLE`** on **`traces_pre_cutover_backup`**, its source. Note stage B is the *likelier* rollback, not the exotic one: the wrap is deferred by default, so the post-`EXCHANGE` resting state is the one stage B reverses, and reaching it needs no extra step. Withhold unless a rollback is actually planned. |
 | rollback stage C (if the wrap is applied) | 3-way `RENAME` + `DROP` of the ex-wrapper | **`INSERT` + `CREATE TABLE`** on **`traces_dist_old`** and **`traces_post_rollback_backup`** — both `RENAME` destinations, so a set without `INSERT` fails `Code: 497` at the rename (see the four-privileges note below) — plus `DROP TABLE` on `traces_dist_old`, which is dropped after the rotation. `DROP TABLE` on `traces_local`, plus `ALTER UPDATE(_row_exists)` on the restored `traces`. **Decide this before applying the wrap:** without these grants there is no way back to the pre-cutover table until another grant change lands. (The *wrap itself* stays reversible via the un-wrap row below, which needs no extra grants — but that returns to the successor, not to the original.) |
@@ -956,11 +1064,23 @@ read-only drivers cannot surface a mutation-privilege gap by construction.
 > *source* and never on the shadow. When provisioning, take each `RENAME`/`EXCHANGE` row as "all four on every name it
 > touches", and confirm with a dry run rather than at the cutover moment.
 
-**The boundary worth preserving.** For a *forward-only* cutover the user needs `INSERT` on the live source
-(forced by `EXCHANGE`) but needs **no `ALTER DELETE`/`ALTER UPDATE` on it and no `TRUNCATE` anywhere** — so
-it cannot delete or modify existing live rows, nor empty a table. The worst it can do to live data is add
-rows. Keep it that way: grant rollback/finalize privileges only when those steps are in scope, as a separate
-reviewed change.
+**The boundary worth preserving — and how the post-swap reconciliation widened it (OPIK-8238).** The forward path ends
+with `reconcile.sh`, which mutates the live name: it re-applies bridged deletes onto `traces` with a lightweight
+`DELETE`. So the forward-only grant set now includes **`ALTER UPDATE(_row_exists)` on `traces`**, where it previously
+needed no mutation grant on the live table at all and the worst it could do to live data was add rows. That widening is
+deliberate — the delete side of the cutover cannot be completed without it — and is called out here so it is reviewed as
+such rather than inherited silently.
+
+What still holds, and is worth keeping:
+
+- **No `ALTER UPDATE` on any real data column** anywhere in the forward path. The grant is column-scoped to the hidden
+  `_row_exists`, so the user can flip the delete mask but cannot rewrite a value. (`--sentinel-repair-only` is the only
+  step that needs real-column grants, and it is a rollback-tail step, granted and revoked around itself.)
+- **No `TRUNCATE` anywhere** in the forward path, so it cannot empty a table.
+- So the worst it can do to live data is **add rows, or mask them** — and the masking is bounded by the replay's two
+  guards, which delete only keys the frozen backup shows as deleted and only rows written before the swap.
+
+Keep the rest: grant rollback/finalize privileges only when those steps are in scope, as a separate reviewed change.
 
 **`clickhouse-client` is an operator prerequisite on the machine that runs these scripts.** Every driver invokes it and
 reads the env above. It is a **client tool on the operator's host**, separate from ClickHouse itself, which the scripts
@@ -1022,6 +1142,33 @@ The two `*_backup` names are the only retained backups and never co-exist. The o
 **recycling** `traces_post_rollback_backup` back into an empty `traces_local_v2` after a rollback (it is physically the
 000101 shadow object, renamed) — and never touches the live `traces`/`traces_local`.
 
+## When the cutover is done
+
+The mirror of ["When the rollback is done"](#rollback) below, and it exists for the same reason: the `EXCHANGE` reports
+that it swapped two names, not that the estate is correct — and the step that makes it correct comes *after* it. Treat a
+cutover as complete only when all of these hold.
+
+- [ ] **The gap is reconciled** — `reconcile.sh` ran and printed `RECONCILED`, with `missing_keys`, `stale_keys` and
+      `payload_mismatch_keys` all `0`. A non-zero `newer_keys` beside them is expected, not a failure: it is the count of
+      gap-window traces that were written again after the swap, which the sweep deliberately leaves alone.
+      **`exchange_and_wrap.sh` ends with a CUTOVER INCOMPLETE banner naming this command**; the banner is the reason this
+      box is first.
+- [ ] **Fidelity over the reconciled range** — `verify.sh --window-from '<delta_start>' --window-to '<now>'` PASSED on
+      the `traces_pre_cutover_backup` / `traces` pair. The four counts already cover presence, version and payload, so
+      this is the payload-level *picture* rather than a second gate; run it because a `PASSED` line stating the exact
+      window is what an incident review will ask for.
+- [ ] **Fidelity over sealed history** — the bounded weekly compare passed (see "Verifying the migration" for the bound
+      and for which mismatches inside it are benign).
+- [ ] **`traceColumnsNonNullable = true` confirmed live on every instance by a POSITIVE read-back** — an absent
+      `end_time`/`ttft` must return `null`, not `1970-01-01`/`NaN`. Do it **after** the swap: before it the Nullable
+      original answers `null` either way, so a pre-swap check proves nothing.
+- [ ] **`traces_pre_cutover_backup` still parked** for the soak. It is the only copy of anything reconciliation did not
+      recover, and `finalize.sh` refuses to retire it without `--confirm-gap-reconciled` — which is you asserting the
+      first box, not something it can check.
+
+Until the first box is ticked the cutover has lost writes, whether or not anything has noticed: they are in the parked
+backup, not in the live table. `finalize.sh` is the point at which that stops being recoverable.
+
 ## Rollback
 
 The full, ready-to-run rollback — including the **reverse deletion replay** so deletes don't resurrect — is pre-written
@@ -1064,14 +1211,23 @@ restoring the pre-cutover, Liquibase-consistent estate. Stage A instead discards
 and leaves the untouched live `traces` — there is no backup to soak or finalize. No leftover
 `*_new` names.
 
-> **Stages B/C make post-cutover writes non-live — an accepted, acknowledged trade-off.** Promoting the frozen
-> `traces_pre_cutover_backup` means traces the successor accepted **after** `cutover_start` stop being served by the live
-> table (the reverse-replay carries post-cutover *deletes* forward, but not *writes*). They are **not destroyed**: the
-> successor is parked as `traces_post_rollback_backup` and retained until `finalize.sh`, so recover them from there during
-> the soak if the rollback is later judged unnecessary. This is inherent to promoting a point-in-time backup and is *not* auto-repaired
-> — merging the successor's post-cutover writes back would re-import the very data the rollback exists to discard. Because
-> it is irreversible in the moment, stages B/C require `--accept-post-cutover-write-loss`, and `rollback.sh` prints the
-> recovery pointer before the promote.
+> **Stages B/C make post-cutover writes non-live — acknowledged at the promote, and then a CHOICE, not a verdict.**
+> Promoting the frozen `traces_pre_cutover_backup` means traces the successor accepted **after** `cutover_start` stop
+> being served by the live table (the reverse-replay carries post-cutover *deletes* forward, but not *writes*). They are
+> **not destroyed**: the successor is parked as `traces_post_rollback_backup` and retained until `finalize.sh`.
+>
+> Stages B/C require `--accept-post-cutover-write-loss` to acknowledge that the promote makes them non-live. What that
+> flag no longer means is that nothing can be done about it. After the promote, `rollback.sh` prints **how many rows are
+> in that set** and the two options, and the decision is yours to make before `finalize.sh` forecloses it:
+>
+> - **Accept the loss.** Correct when the successor's *content* is what is suspect — merging its writes back would
+>   re-import the very data the rollback existed to discard. This is the historical default, and it stays the default.
+> - **Recover them** with `reconcile.sh --confirm-reimport-successor-writes` (see "Recovering the post-cutover writes"
+>   below). Correct when the rollback was motivated by **latency, merge load or a wrap regression** rather than by
+>   fidelity — there the discarded writes are good data, and throwing them away was never the point of the rollback.
+>
+> The flag's name is about the promote's immediate effect. It is not a judgement that the data is unrecoverable, which
+> would only ever have been true of the fidelity-motivated case.
 
 **Use exactly the `cutover_start` that `exchange_and_wrap.sh` printed** (`RECORD cutover_start=…`), and record it with
 the run: it is an artifact *of* the forward run, not a value to derive afterwards. The driver captures it deliberately
@@ -1142,6 +1298,39 @@ Pick the stage by how far the cutover got:
   the only ordering that binds** — repairing while any instance still has the flag `true` lets it mint fresh sentinels
   behind the mutation. Stage A may run before or after, because it `TRUNCATE`s the shadow rather than dropping it, so
   the evidence the guard looks for survives. See step 2 of "Rolling back the `traceColumnsNonNullable` flip".
+
+### Recovering the post-cutover writes after a stage B/C rollback
+
+The reverse direction of `reconcile.sh`. It re-imports into the restored original the traces the successor accepted after
+`cutover_start`, which the promote made non-live:
+
+```bash
+./scripts/reconcile.sh --database opik --report-only \
+    --cutover-start '<ts> UTC' --swap-done '<promote_done from rollback.sh> UTC'   # size it first
+./scripts/reconcile.sh --database opik \
+    --cutover-start '<ts> UTC' --swap-done '<promote_done> UTC' --confirm-reimport-successor-writes
+```
+
+Three things make it safe to run and worth understanding before you do:
+
+- **`--confirm-reimport-successor-writes` is required**, because this re-imports exactly what
+  `--accept-post-cutover-write-loss` acknowledged discarding. Reach for it on a latency / merge-load / wrap rollback; not
+  on one where the successor's content is suspect.
+- **Sentinels are denormalized back to `NULL`** (`nullIf(end_time, epoch)`, `if(isNaN(ttft), NULL, ttft)`). This is not
+  cosmetic: the original's MATERIALIZED `duration` guards `end_time IS NOT NULL` and knows nothing of the epoch, so
+  importing the sentinel verbatim would give every unfinished trace a duration of about **-1.79e12 ms**. Restoring
+  `NULL` is what makes the recomputed duration `NULL`. It is the same damage the sentinel repair fixes, so re-importing
+  raw would be undoing that repair one row at a time.
+- **Deletes still win.** The driver re-runs `000004_rollback_reverse_replay.sql` *after* the sweep, so a trace deleted
+  since `cutover_start` is re-imported and then masked, and `000004_rollback_verify_replay.sql` still reports `0`. The
+  one case that does not come back is an id **deleted and then re-created** after `cutover_start`: the reverse replay is
+  deliberately guard-less, so the delete is honoured and the re-creation is lost with the other discarded writes — the
+  same semantics the retry section already documents.
+
+**It changes the post-rollback fidelity compare.** Once the writes are back, the cutover window's week no longer
+legitimately mismatches *by writes*, so **drop the `--to-week` bound** and compare unbounded; what remains expected is
+post-cutover deletes (masked on the original, still live in the parked successor) and anything written after the promote.
+Running the bounded form afterwards is not wrong, only weaker — it stops short of the week the recovery was about.
 
 ### Un-wrap: reversing sharding without reversing the cutover
 
@@ -1365,8 +1554,13 @@ Treat a stage B/C rollback as complete only when all of these hold:
       ran with the right window. This checklist is the only control standing between a wrong-window no-op and
       `TRUNCATE TABLE traces_post_rollback_backup`, which retires the last reference copy. Treat the box as a human
       gate, because that is all it is.
+- [ ] **The post-cutover writes decided** — either recovered with
+      `reconcile.sh --confirm-reimport-successor-writes` (see "Recovering the post-cutover writes"), or knowingly left
+      discarded. `rollback.sh` prints the row count and both commands after the promote, so this is a decision with a
+      number attached rather than a shrug. **`finalize.sh` refuses without `--confirm-gap-reconciled`, which asserts the
+      decision was MADE** — not that a recovery ran.
 - [ ] **The parked successor still parked** — `traces_post_rollback_backup` retained, not finalized. It is the only copy
-      of the post-cutover writes the rollback discarded, and the only thing that makes a retry cheap.
+      of the post-cutover writes, and the only thing that makes a retry cheap.
 
 Until the last box is ticked, do not run `finalize.sh`: it is what forecloses both going back and retrying cheaply.
 `rollback.sh` prints that instruction last, after the steps it depends on, for the same reason.
@@ -1453,11 +1647,16 @@ reversible indefinitely via `--unwrap-only`, which needs only `traces` and `trac
   Do not deploy `traces` schema migrations until the soak ends (finalize committed). Post-finalize the general rule
   resumes: apply `ADD`/`DROP`/`MODIFY COLUMN` to **both** `traces_local` and the `Distributed` `traces` (see the wrap
   prerequisite).
-- **Finalize exit criteria** — before retiring the backup: `verify.sh` clean, query p99 within budget over the soak, no
-  cutover-related incidents open, and (if the wrap was applied) the retarget flag (`tracesDistributedWrapEnabled`) live
-  and healthy across the backend fleet.
+- **Finalize exit criteria** — before retiring the backup: the ["When the cutover is done"](#when-the-cutover-is-done)
+  checklist complete (or, after a rollback, "When the rollback is done"), `verify.sh` clean, query p99 within budget over
+  the soak, no cutover-related incidents open, and (if the wrap was applied) the retarget flag
+  (`tracesDistributedWrapEnabled`) live and healthy across the backend fleet.
 
-Once those hold, run [`scripts/finalize.sh`](scripts/finalize.sh) — it auto-detects whichever parked table is present
+Once those hold, run [`scripts/finalize.sh`](scripts/finalize.sh) **with `--confirm --confirm-gap-reconciled`** — the
+second flag is required on both branches and is refused by neither dry run, which name it so its first appearance is
+never a surprise. It asserts what no query can see: after a cutover, that `reconcile.sh` ran and returned `0`; after a
+rollback, that the accept-or-recover decision on the post-cutover writes has been made. The script auto-detects whichever
+parked table is present
 (`traces_pre_cutover_backup` or `traces_post_rollback_backup`), never the live `traces`/`traces_local` or the working
 `traces_local_v2` shadow, and picks the action by case: after a **successful cutover** it **drops**
 `traces_pre_cutover_backup` (committing to the new layout); after a **rollback** it **recycles**
@@ -1599,6 +1798,12 @@ Expect the **cutover window's own week to mismatch**, by exactly the post-cutove
 parked successor holds them; the restored original never did) — so stop before it. Note the divergence is the
 **opposite** direction from the post-EXCHANGE case: here the *new-table* side is the superset.
 
+> **This bound is for the ACCEPT option.** If you took the recover option
+> (`reconcile.sh --confirm-reimport-successor-writes`, see "Recovering the post-cutover writes"), those writes are back
+> on the restored original, so the week no longer legitimately mismatches by writes: **drop `--to-week` and compare
+> unbounded.** What is still expected there is post-cutover *deletes* — masked on the original by the reverse replay,
+> still live in the parked successor — plus anything written after the promote. `rollback.sh` prints both readings.
+
 **Bound this one by `cutover_start`, not by the calendar.** `--to-week last-sealed` drops the current calendar week,
 which is the window's week only while the verify runs promptly; run it in a later week and the window's week counts as
 sealed, so its discarded writes read as a fidelity failure. `rollback.sh` prints the offset of the last week wholly
@@ -1653,17 +1858,25 @@ two version sets: identical sets mean the copy is faithful and only the tie-brea
 side only is the copy gap, whatever the re-check said. If the sets cannot be established, treat the week as unresolved
 and escalate rather than passing it — arbitrary is not the same as benign.
 
-> **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat.** `traces_pre_cutover_backup` is a
-> **frozen** snapshot as of `cutover_start`, but live `traces` never stops taking writes — so
-> the **current (live) week will legitimately show a mismatch** (the live table is a superset of the frozen backup by
-> exactly the post-cutover writes). That is expected, not a leak. To use the post-EXCHANGE compare as a real check,
-> either run it **immediately after the swap before writes resume**, or bound it to the **sealed historical weeks** with
+> **The pre-EXCHANGE compare is the gate; the post-EXCHANGE compare has a caveat — and a direction that is NOT benign.**
+> `traces_pre_cutover_backup` is a **frozen** snapshot as of `cutover_start`, but live `traces` never stops taking
+> writes — so the **current (live) week will legitimately show a mismatch** (the live table is a superset of the frozen
+> backup by exactly the post-cutover writes). That is expected, not a leak.
+>
+> **The opposite direction — rows present in the backup and absent from live — is the write loss OPIK-8238 fixed**, and
+> the bounded weekly compare is a poor instrument for it: the loss sits in the gap window, i.e. in the *current* week,
+> which is exactly the week the bound excludes. The instrument for it is `reconcile.sh`'s postcondition, which is scoped
+> to the gap and gates on `missing_keys` directly; **run that, not a weekly compare, to decide whether the swap lost
+> writes.** Use `verify.sh --window-from/--window-to` over the same range afterwards for the payload-level picture the
+> four counts summarise.
+>
+> To use the post-EXCHANGE weekly compare as a real check, either run it **immediately after the swap before writes
+> resume**, or bound it to the **sealed historical weeks** with
 > `--to-week N` (a **0-based week offset** from the anchor Monday, not a date — e.g. `--to-week 3` to stop before the
 > current partial week), where a mismatch is worth investigating — with one exception in the same class as the
 > post-cutover writes: a write touching a **pre-existing** trace after `cutover_start` diverges it in that row's own
 > week, sealed or not (see "Verifying after a rollback" for the two shapes and the triage). Check
-> `last_updated_at >= cutover_start` on the differing ids before calling it a defect. A leak shows up as rows present in
-> the backup but absent from `traces` *and* absent from it entirely; post-cutover writes are the harmless direction.
+> `last_updated_at >= cutover_start` on the differing ids before calling it a defect.
 
 **Feasibility at scale.** A full pass reads every week in the range (heavy but bounded per week — run off-peak). When
 that is infeasible, sample and still get high confidence:
@@ -1675,6 +1888,20 @@ that is infeasible, sample and still get high confidence:
   post-mismatch confirm-keys re-check can stall past the stock value and abort the compare at the first mismatch.
 - `--from-week` / `--to-week` bound the range by **0-based week offset** (integers from the anchor Monday, not dates;
   `--to-week` is inclusive) — e.g. verify the most recent weeks fully, older weeks sampled.
+- `--window-from` / `--window-to` compare **one arbitrary `created_at` window** instead of walking the week grid —
+  half-open `[from, to)`, `'YYYY-MM-DD HH:MM:SS[.ffffff]'`, interpreted as UTC (an optional ` UTC` marker is accepted, so
+  a value pasted from a driver's `RECORD` line works as-is). This is the shape post-swap reconciliation needs: the range
+  of interest is *the gap*, which is not a calendar week and sits inside the one a weekly bound excludes.
+  **Mutually exclusive with `--from-week` / `--to-week` / `--weeks-stride`** — those are offsets into a grid this mode
+  never builds, so combining them is refused rather than silently resolved. No new SQL is involved: `000005`'s blocks
+  were already parameterised by arbitrary `${WINDOW_LO}` / `${WINDOW_HI}`, and only the driver was generating week
+  boundaries; `--sample-mod`, `--drill-down`, `--receive-timeout` and the confirm-keys / version-ties resolution all
+  behave identically. The anchor scan is skipped (nothing needs a week grid), so unlike the weekly form the run does not
+  depend on `min`/`max(created_at)` holding still, and the `PASSED` line states the window it covered.
+  ```bash
+  ./scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces \
+      --window-from '<delta_start>' --window-to '<now, UTC>'
+  ```
 
 `verify.sh` exits non-zero if any window **mismatches or is INCONCLUSIVE**, and prints the window bounds either way;
 re-run with `--drill-down` to list the keys that differ or exist on one side only (it runs the `drill-down` block of
@@ -1702,6 +1929,16 @@ ones most often worth reading).
 - **schema-parity guards** — the cutover copies every base column of `traces`, and both tables expose the same base and
   materialized columns (a future migration that drifts either fails the build);
 - `EXCHANGE TABLES ... ON CLUSTER` and the single-shard `Distributed` wrapper both work;
+- **post-swap reconciliation, both directions** (OPIK-8238) — the forward sweep restores a trace written in the
+  `[last delta, EXCHANGE]` gap, with a **negative control** proving the write is simply lost when the step is skipped;
+  the sweep does not resurrect a gap-window trace deleted after the swap; a gap-window trace written again after the
+  swap keeps the newer version and is reported as `newer_keys` while the gate still passes; the post-swap replay masks a
+  delete bridged between the final pre-swap replay and the `EXCHANGE` (with the sweep alone shown to be insufficient, so
+  the two steps are not confused); the per-row staleness scope stops that same frozen guard destroying a post-swap
+  re-creation, **with its own negative control** showing the write disappear when the scope is inert; the reverse sweep
+  re-imports post-cutover writes with sentinel→`NULL` denormalization so their recomputed `duration` is `NULL` rather
+  than a large negative, and does not resurrect a trace deleted since `cutover_start`; and the four-count postcondition
+  classifies each key into exactly one bucket on the full `(workspace_id, project_id, id)` key;
 - **reversibility** — rollback at each stage (before EXCHANGE, after EXCHANGE, after wrap) restores the original and
   reverse-replays so a post-cutover delete does not resurrect;
 - **wrong-stage rollback guard** — the topology signals `rollback.sh` keys on (the `traces` engine and `end_time`
@@ -1730,10 +1967,26 @@ and a wrong verdict from a fidelity gate is the failure this whole procedure exi
 - refusing to report `PASSED` when the bounds selected **no** window (an empty range compares nothing, so a pass would be
   vacuous);
 - the `--to-week last-sealed` resolution — the current-calendar-week bound, capped at the last populated week;
-- its refusal when that resolution lands before `--from-week`, the all-data-in-the-current-week case.
+- its refusal when that resolution lands before `--from-week`, the all-data-in-the-current-week case;
+- `--window-from` / `--window-to`: that they are refused in combination with any of `--from-week` / `--to-week` /
+  `--weeks-stride`, that an empty or inverted range is refused rather than passed vacuously, and that the `PASSED` line
+  states the window it covered.
+
+`reconcile.sh` adds four of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
+an argument:
+
+- **direction detection** — forward on `traces_pre_cutover_backup`, reverse on a `traces_post_rollback_backup` that
+  carries the successor schema, refusal when both or neither is present, and the split-state diagnosis (EXCHANGE done,
+  post-swap `RENAME` not) with the completing `RENAME` printed;
+- **`--report-only`** issuing no mutation in either direction, and exiting non-zero when it finds a gap;
+- the **idempotent no-op**: a second run on a reconciled estate reads the postcondition, issues nothing and exits 0;
+- **failing loudly** rather than reporting progress when the gate is still non-zero after `--max-passes`.
+
+And `finalize.sh` adds one: refusing **both** branches without `--confirm-gap-reconciled`, with the right diagnosis for
+whichever backup is parked.
 
 Each rests on manual verification. Exercise them in the rehearsal alongside the driver guards, and treat a change to any
-of the three as needing the same.
+of them as needing the same.
 
 The **replication-settle gate** belongs in the same category — it decides a verdict rather than reading a single
 number — so it needs the rehearsal too, under **live ingestion**, in both directions:
@@ -1742,9 +1995,13 @@ number — so it needs the rehearsal too, under **live ingestion**, in both dire
   numbers printed);
 - it **does** abort on a genuinely lagging replica, naming the offending entries — stop or throttle a replica, or hold
   a mutation, and confirm the gate fails loudly rather than passing;
-- unfinished mutations on the shadow are judged unconditionally: one fails the gate however quiet the queue is, and
-  `--settle-timeout` bounds how long it waits to find out. Hold a mutation deliberately to see it — but note the gate
-  samples before the final deletion replay is issued, so that replay is not what this rehearses.
+- unfinished mutations in the gate's mutation scope are judged unconditionally: one fails the gate however quiet the
+  queue is, and `--settle-timeout` bounds how long it waits to find out. Hold a mutation deliberately to see it — but
+  note the pre-swap gate samples before the final deletion replay is issued, so that replay is not what this rehearses;
+- **and rehearse `reconcile.sh`'s scope separately**, because it is the one that changes: its mutation check covers the
+  **parked backup only**, so the rehearsal has to confirm both halves — that a delete still applying to the parked table
+  fails the gate, and that live-table deletes flowing throughout do **not**. The second half is the one that matters in
+  production: if it were gated, the gate would abort on every healthy post-swap cluster.
 
 The **argument guards** fail fast, before touching ClickHouse, so they are cheap to exercise by hand after any change
 here — `--with-wrap` and `--wrap-only` must both refuse without `--confirm-maintenance`, and `--settle-timeout` must
@@ -1768,11 +2025,12 @@ Watch these for the whole backfill→EXCHANGE window; wire alerts before startin
 - **Deletion-capture health** — capture is best-effort and **swallows** errors (so a bridge hiccup never blocks a user's
   delete), so watch the backend logs for `captureDeletions` failures. A silently-dropped capture would leak a delete.
   `verify.sh` catches that as a pre-EXCHANGE week mismatch (the row is live on the destination but gone on the source)
-  **for any capture failure up to the last pre-EXCHANGE verify** — but a capture that fails in the final
-  `exchange_and_wrap.sh` window (after the last verify, through the swap) is caught by neither `verify.sh` nor the final
-  deletion replay, only by this log-watch. So it is an early-warning signal, not a silent hole: treat repeated failures as
+  **for any capture failure up to the last pre-EXCHANGE verify**. A capture that fails *later* is narrower than it used
+  to be but is still not covered: the post-swap replay in `reconcile.sh` re-reads the bridge, so a delete whose capture
+  simply landed **late** is now caught, while one whose capture **errored** leaves no bridge row for anything to read and
+  remains visible only in this log-watch. So it is an early-warning signal, not a silent hole: treat repeated failures as
   an abort signal until capture is healthy, and treat **any** `captureDeletions` failure observed from the last verify
-  through the EXCHANGE as a swap-gating signal.
+  through the reconciliation as a swap-gating signal.
 
 **Roles.** Name an operator (runs the scripts), an independent observer (watches the dashboards), and the person with
 authority to call a rollback. **Abort thresholds** (decide the numbers up front): free disk below the per-volume alarm,
@@ -1787,26 +2045,17 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       **parallel traffic still flowing through the swap** — converging by stopping traffic tests an assumption this
       procedure does not make.
 - [ ] **Deletion test green** — `TracesLocalV2CutoverTest` passes; **0 deletion leaks** confirmed on staging.
-- [ ] **Tail write-gap accepted knowingly, or OPIK-8238 landed** — writes in the final-delta→`EXCHANGE` gap and the
-      cross-node swap skew stay in `traces_pre_cutover_backup` and nothing in this procedure carries them into the live
-      table yet (see "The final cutover window"). Size it straight after the swap with an **unbounded** post-`EXCHANGE`
-      compare plus `--drill-down`: the gap rows sit in the cutover week, which every weekly bound excludes, so a bounded
-      run cannot see them. The drill-down reports keys in three shapes and **two of them can be gap rows**, so do not
-      size this by key presence alone:
-      - **backup-only** (`dst_hash` NULL) — traces *created* in the tail. Gap.
-      - **both sides, hashes differ** — gap when the newer `last_updated_at` is **in the backup**: a trace *updated* in
-        the tail, whose successor row is an older version. A presence check finds nothing to do here and would report
-        the gap as clean. When the newer version is the **live** one, it is an ordinary post-swap update instead.
-      - **live-only** (`src_hash` NULL) — traces created after the swap. Harmless.
-
-      The drill-down prints hashes, not versions, so the middle shape needs a `last_updated_at` comparison per key
-      across the two tables to settle which way it points. Then either accept the total with whoever authorised the
-      cutover, or recover from the backup before `finalize.sh` retires it. OPIK-8238 replaces this item with its
-      reconciliation postcondition.
+- [ ] **Reconciliation postcondition returned 0** — `reconcile.sh` ran immediately after the `EXCHANGE` and reported
+      `missing_keys=0 stale_keys=0 payload_mismatch_keys=0`. A non-zero `newer_keys` alongside those three zeros is
+      expected, not a failure. Rehearse it on the prod-clone in **both** directions and record the sweep timings. This
+      is the item that closes the tail write-gap; nothing else in this checklist does, and a weekly `verify.sh` compare
+      cannot — the gap rows sit in the cutover week, which every weekly bound excludes.
 - [ ] **Final-delta→EXCHANGE gap kept short** — record the **whole** interval, not just the final replay's wall time:
       the replay's own `--time` output *plus* the elapsed-through-`EXCHANGE` figure `exchange_and_wrap.sh` prints in its
-      tail summary, which itemises the settle-gate wait. The tail's length is what decides how many writes land in the
-      gap above, and on a busy cluster the gate is the part of it that varies.
+      tail summary, which itemises the settle-gate wait. This does **not** substitute for the item above: the gap cannot
+      be driven to zero, because the procedure places a full deletion replay and a settle gate inside it. Its length
+      decides how much the sweep has to carry and how long gap-window traces are transiently absent from live reads, and
+      on a busy cluster the gate is the part of it that varies.
 - [ ] **Far-future partitions quantified — and `max_partitions_per_insert_block` sized from the result.** Run the
       bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
       `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised
@@ -1852,8 +2101,8 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       that one row out and still report `ok=1`. Reserve sampling/ranged runs for follow-up confidence *after* the full gate
       passes. Re-run `delta_replay.sh` then `verify.sh` until it PASSES. Read that PASS for what it is: writes never
       stop, so it certifies the copy **as of the last delta**, not that nothing arrived after it. The writes that
-      arrive after it land in the tail gap described in "The final cutover window" — do not quiesce traffic to force a
-      cleaner PASS.
+      arrive after it land in the tail gap described in "The final cutover window" and are covered by the
+      reconciliation item, not by this one — do not quiesce traffic to force a cleaner PASS.
 - [ ] **`Distributed` wrap gated on the DAO toggle** — apply the wrap (step 4, part 2) only once
       `databaseAnalyticsDataModel.tracesDistributedWrapEnabled=true` is live across the backend fleet (OPIK-7455), set in
       lockstep with the wrap so trace mutations target `traces_local`; otherwise stop after the `EXCHANGE`, since a

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -355,12 +355,29 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    > the delta shrinks it and then stops improving, which is what was observed on the cutover that motivated this step.
    > After the swap the parked table is **frozen**, so the sweep converges by construction and its postcondition is a
    > gate rather than a snapshot.
+   >
+   > **It reconciles ONE SHARD, and says which.** Every statement it issues is shard-local, and so is the forward
+   > postcondition — a per-shard run is therefore correct, but a single `RECONCILED` certifies only the shard it
+   > connected to, while `finalize.sh` drops the parked backup `ON CLUSTER`. So on a cluster reporting more than one
+   > shard the driver refuses without `--confirm-single-shard`, and with it labels the verdict `SCOPE: …`; an unreadable
+   > shard count fails closed, the same way `rollback.sh`'s guard does. On the single-shard estate this procedure
+   > targets today, neither path triggers.
+   >
+   > **It also reports `leaked_delete_keys`, which is NOT part of the gate.** Non-zero means captured deletes are still
+   > live on the successor — the residual the replay's staleness scope cannot prevent, because `last_updated_at` is
+   > client-supplied (see the residuals in ["The final cutover window"](#the-final-cutover-window)). Those keys are
+   > still in the bridge, so they can be re-applied by hand; the reconciliation itself is complete either way.
 6. **QA over the reconciled range — `verify.sh --window-from/--window-to`** for the payload-level picture over exactly
    what step 5 swept, alongside the usual bounded weekly compare (see "Verifying the migration"):
    ```bash
    ./scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces \
        --window-from '<delta_start>' --window-to '<now, UTC>'
    ```
+   This compares the traces **created** in that range — `000005` bounds on `created_at`, which the weekly mode's
+   partitioning and its superseded-version logic require — so a trace created earlier and merely *updated* in the gap is
+   not in it. That set is not left uncovered: it is exactly what step 5 reports as `stale_keys` and
+   `payload_mismatch_keys`, which compare by version rather than by window. The `PASSED` line states the distinction, so
+   the pass cannot be quoted as broader than it is.
    Then work the ["When the cutover is done"](#when-the-cutover-is-done) checklist before the soak.
 
 **Dedup note.** After the delta, a row can have two physical versions on `traces_local_v2` (the backfilled one and the
@@ -515,18 +532,30 @@ Keep step 3→4 short, and step 4→5 shorter:
 | **Writes** — all of them, since nothing holds any of them across the swap | **step 5's sweep** |
 | **Deletes** bridged after step 4's replay read but before the swap | **step 5's post-swap replay**, whose resurrection guard reads the frozen backup and is therefore race-free |
 
-**Three residuals remain, all narrow, all on the delete side, and all bounded by the same mitigation — so state it once:
-quiesce user DELETES across the swap, not merely reads.**
+**Four residuals remain, all narrow. The first three are on the delete side and share one mitigation — so state it
+once: quiesce user DELETES across the swap, not merely reads.**
 
 - A delete whose bridge row lands *after* step 5's read is invisible to it.
 - Capture writes the bridge row *before* the delete executes, so for the width of the `EXCHANGE` a delete can be bridged
   before `exchange_done` while its `DELETE` lands on the successor after the swap. That key is live in the frozen backup
   and bridged before the bound, so **step 5's sweep brings it back**. It needs the trace to be written *and* deleted
   inside the gap window, with the swap falling between its capture and its delete.
+- **A pre-swap trace carrying a client-supplied future `last_updated_at` keeps its captured delete.** `lastUpdatedAt`
+  is writable through the API and validated only as "before 2300", and `TraceDAO` binds it verbatim on the batch-ingest
+  path — so such a row falls outside the post-swap replay's `created_at AND last_updated_at < exchange_done` staleness
+  scope and is spared. The predicate stays that way deliberately: scoping on `created_at` alone would instead mask a
+  post-swap *patch* of a pre-existing trace (the merge path preserves `created_at`), destroying a write that exists only
+  on the successor. Over-sparing leaves a deleted trace visible with its key still in the bridge, so it can be
+  re-applied; over-masking cannot be undone. **Step 5 reports this one as `leaked_delete_keys`**, comparing the live
+  row's version against the versions the frozen backup held — which separates a leak from a legitimate post-swap
+  re-creation and needs no timestamp at all. That comparison is only possible as a *read*: it needs an unmasked read of
+  the backup, and a lightweight `DELETE` **accepts `apply_deleted_mask = 0` and then ignores it**, so folding the check
+  into the replay would produce a statement that reports success having masked nothing. Clamping future client
+  timestamps at ingestion is the durable fix and is not this procedure's to make.
 - Between the `EXCHANGE` and the sweep, gap-window traces are briefly absent from live reads — and `TraceDAO`'s merge
   path reads the old row to preserve `created_at`, so an update landing in that hole re-stamps it.
 
-The first and third are reasons to run step 5 *immediately*; the second is a reason to quiesce deletes rather than to
+The first and last are reasons to run step 5 *immediately*; the middle two are reasons to quiesce deletes rather than to
 skip the sweep, since skipping it loses every write in the gap instead.
 
 *Rejected alternatives, recorded so they are not re-proposed (OPIK-8239).* **Widening the async-insert buffer**
@@ -947,7 +976,7 @@ run by hand.** Each `.sql` file is the single source its driver reads those stat
 | 1 — backfill | `000001_backfill_traces_local_v2.sql` | `backfill.sh` |
 | 2 — delta + replay | `000002_delta_and_deletion_replay.sql` | `delta_replay.sh` |
 | 3 — settle gate, EXCHANGE + wrap (+ the final pre-swap replay, from `000002`'s `deletion-replay` block) | `000003_exchange_and_wrap.sql` | `exchange_and_wrap.sh` |
-| 4 — **post-swap reconciliation**, forward and reverse | `000006_post_swap_reconciliation.sql` (`forward-sweep` + `forward-deletion-replay`, or `reverse-sweep` followed by the unchanged `000004_rollback_reverse_replay.sql` + `000004_rollback_verify_replay.sql`) + its postcondition `000006_verify_reconciliation.sql`, and `000003`'s three `settle-*` blocks for its own gate | `reconcile.sh` |
+| 4 — **post-swap reconciliation**, forward and reverse | `000006_post_swap_reconciliation.sql` (`forward-sweep` + `forward-deletion-replay`, or `reverse-sweep` followed by the unchanged `000004_rollback_reverse_replay.sql` + `000004_rollback_verify_replay.sql`) + its postcondition `000006_verify_reconciliation.sql` (`verify-forward` / `verify-reverse`, plus the advisory `leak-check-forward`), and `000003`'s three `settle-*` blocks for its own gate | `reconcile.sh` |
 | QA — fidelity compare, weekly or over one window (+ `--drill-down`) | `000005_verify_migration.sql` | `verify.sh` |
 | rollback | `000004_rollback_stage_{a,b,c}_*.sql`, `000004_rollback_unwrap.sql`, `000004_rollback_reverse_replay.sql` + its postcondition `000004_rollback_verify_replay.sql`, `000004_rollback_sentinel_repair.sql` + its postcondition `000004_rollback_verify_sentinels.sql` | `rollback.sh` |
 | finalize — retire the parked backup (drop after cutover / recycle to empty shadow after rollback) | — | `finalize.sh` |
@@ -957,7 +986,8 @@ from a file, and the split is deliberate:
 
 - **In a versioned `.sql` file, extracted by marker:** every statement that changes data or schema, and every read
   whose result *is a verdict* the operator acts on. That second half is why `000005`'s `compare` / `confirm-keys` /
-  `version-ties` blocks, `000006`'s `verify-forward` / `verify-reverse` blocks and `000003`'s three `settle-*` blocks
+  `version-ties` blocks, `000006`'s `verify-forward` / `verify-reverse` / `leak-check-forward` blocks and
+  `000003`'s three `settle-*` blocks
   live in files despite being read-only — a fidelity gate, a reconciliation gate or a swap gate deciding wrongly is the
   failure this procedure exists to prevent, so its SQL is reviewed and versioned like a statement. The `settle-*` blocks
   are read by **two** drivers: `exchange_and_wrap.sh` before the swap and `reconcile.sh` after it, each rendering its own
@@ -1557,8 +1587,8 @@ Treat a stage B/C rollback as complete only when all of these hold:
 - [ ] **The post-cutover writes decided** — either recovered with
       `reconcile.sh --confirm-reimport-successor-writes` (see "Recovering the post-cutover writes"), or knowingly left
       discarded. `rollback.sh` prints the row count and both commands after the promote, so this is a decision with a
-      number attached rather than a shrug. **`finalize.sh` refuses without `--confirm-gap-reconciled`, which asserts the
-      decision was MADE** — not that a recovery ran.
+      number attached rather than a shrug. **`finalize.sh` refuses without `--confirm-post-cutover-decision`, which
+      asserts the decision was MADE** — not that a recovery ran.
 - [ ] **The parked successor still parked** — `traces_post_rollback_backup` retained, not finalized. It is the only copy
       of the post-cutover writes, and the only thing that makes a retry cheap.
 
@@ -1652,10 +1682,14 @@ reversible indefinitely via `--unwrap-only`, which needs only `traces` and `trac
   the soak, no cutover-related incidents open, and (if the wrap was applied) the retarget flag
   (`tracesDistributedWrapEnabled`) live and healthy across the backend fleet.
 
-Once those hold, run [`scripts/finalize.sh`](scripts/finalize.sh) **with `--confirm --confirm-gap-reconciled`** — the
-second flag is required on both branches and is refused by neither dry run, which name it so its first appearance is
-never a surprise. It asserts what no query can see: after a cutover, that `reconcile.sh` ran and returned `0`; after a
-rollback, that the accept-or-recover decision on the post-cutover writes has been made. The script auto-detects whichever
+Once those hold, run [`scripts/finalize.sh`](scripts/finalize.sh) **with `--confirm` plus the branch's own
+confirmation flag** — `--confirm-gap-reconciled` after a cutover, `--confirm-post-cutover-decision` after a rollback.
+They are separate flags because the two branches assert different facts, and a gate in front of an irreversible drop
+should not carry a name that is true on one branch and false on the other; each dry run names the one this estate needs,
+so its first appearance is never a surprise, and passing the other branch's flag is refused rather than accepted. They
+assert what no query can see: after a cutover, that `reconcile.sh` ran and returned `0` **on every shard** (its
+statements are shard-local, this DROP is `ON CLUSTER`); after a rollback, that the accept-or-recover decision on the
+post-cutover writes has been made. The script auto-detects whichever
 parked table is present
 (`traces_pre_cutover_backup` or `traces_post_rollback_backup`), never the live `traces`/`traces_local` or the working
 `traces_local_v2` shadow, and picks the action by case: after a **successful cutover** it **drops**
@@ -1972,7 +2006,7 @@ and a wrong verdict from a fidelity gate is the failure this whole procedure exi
   `--weeks-stride`, that an empty or inverted range is refused rather than passed vacuously, and that the `PASSED` line
   states the window it covered.
 
-`reconcile.sh` adds four of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
+`reconcile.sh` adds five of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
 an argument:
 
 - **direction detection** — forward on `traces_pre_cutover_backup`, reverse on a `traces_post_rollback_backup` that
@@ -1980,10 +2014,16 @@ an argument:
   post-swap `RENAME` not) with the completing `RENAME` printed;
 - **`--report-only`** issuing no mutation in either direction, and exiting non-zero when it finds a gap;
 - the **idempotent no-op**: a second run on a reconciled estate reads the postcondition, issues nothing and exits 0;
-- **failing loudly** rather than reporting progress when the gate is still non-zero after `--max-passes`.
+- **failing loudly** rather than reporting progress when the gate is still non-zero after `--max-passes`;
+- the **shard-scope guard**: a multi-shard estate refused without `--confirm-single-shard` (and refused outright in the
+  reverse direction, whose postcondition spans shards its replay cannot reach), an unreadable shard count failing
+  closed, and the `RECONCILED` line carrying its `SCOPE:` qualifier when the scope was asserted rather than proven.
+  Worth exercising by hand even on a single-shard estate — the consequence of getting it wrong is `finalize.sh`
+  dropping every shard's backup on a one-shard assertion.
 
-And `finalize.sh` adds one: refusing **both** branches without `--confirm-gap-reconciled`, with the right diagnosis for
-whichever backup is parked.
+And `finalize.sh` adds one: refusing each branch without ITS OWN confirmation flag — `--confirm-gap-reconciled` for
+the post-cutover drop, `--confirm-post-cutover-decision` for the post-rollback recycle — with the right diagnosis for
+whichever backup is parked, and refusing the other branch's flag rather than honoring it.
 
 Each rests on manual verification. Exercise them in the rehearsal alongside the driver guards, and treat a change to any
 of them as needing the same.
@@ -2045,11 +2085,17 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       **parallel traffic still flowing through the swap** — converging by stopping traffic tests an assumption this
       procedure does not make.
 - [ ] **Deletion test green** — `TracesLocalV2CutoverTest` passes; **0 deletion leaks** confirmed on staging.
-- [ ] **Reconciliation postcondition returned 0** — `reconcile.sh` ran immediately after the `EXCHANGE` and reported
-      `missing_keys=0 stale_keys=0 payload_mismatch_keys=0`. A non-zero `newer_keys` alongside those three zeros is
-      expected, not a failure. Rehearse it on the prod-clone in **both** directions and record the sweep timings. This
-      is the item that closes the tail write-gap; nothing else in this checklist does, and a weekly `verify.sh` compare
-      cannot — the gap rows sit in the cutover week, which every weekly bound excludes.
+- [ ] **Reconciliation postcondition returned 0, on every shard** — `reconcile.sh` ran immediately after the
+      `EXCHANGE` and reported `missing_keys=0 stale_keys=0 payload_mismatch_keys=0`. A non-zero `newer_keys` alongside
+      those three zeros is expected, not a failure. Rehearse it on the prod-clone in **both** directions and record the
+      sweep timings. This is the item that closes the tail write-gap; nothing else in this checklist does, and a weekly
+      `verify.sh` compare cannot — the gap rows sit in the cutover week, which every weekly bound excludes.
+      **Every statement it issues is shard-local while `finalize.sh` drops the backup `ON CLUSTER`**, so on more than one
+      shard this box needs a `RECONCILED` from each; the driver refuses a multi-shard run without `--confirm-single-shard`
+      and labels the verdict's scope when given it.
+      Also **record `leaked_delete_keys`**. It is not part of the gate — the reconciliation is complete either way — but
+      non-zero means captured deletes are still live on the successor (the client-timestamp residual in "The final
+      cutover window"), and those keys should be re-applied before the estate is called done.
 - [ ] **Final-delta→EXCHANGE gap kept short** — record the **whole** interval, not just the final replay's wall time:
       the replay's own `--time` output *plus* the elapsed-through-`EXCHANGE` figure `exchange_and_wrap.sh` prints in its
       tail summary, which itemises the settle-gate wait. This does **not** substitute for the item above: the gap cannot

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -478,7 +478,7 @@ would return a copy of each side per replica and multiply both). What the swap c
 |---|---|---|
 | unfinished **mutations** | the **parked backup** only | **Unconditional.** That table is frozen, so anything still applying to it is a user delete that fired before the swap and has not landed on this replica yet — and the mask-honored sweep would read the row as live and copy a deleted trace back. It drains rather than recurring, so demanding zero is reachable. |
 | unfinished **mutations** | the **live** table — **deliberately not gated** | After the swap the live table takes user deletes continuously, each an ordinary asynchronous mutation, so requiring zero would abort on healthy traffic. Nor is it a hazard: a delete still applying leaves the row visible, which the postcondition reads as *present*, never as missing; and deletes bridged across the swap are re-applied by the sweep's own replay, which carries `lightweight_deletes_sync = 2`. |
-| the **replication queue** | **both** tables | **Stuck-ness, not depth** — same thresholds, same reasoning as above. Either table short of a part on this replica skews the postcondition's join. |
+| the **replication queue** | both tables **and `deletion_events_local`** | **Stuck-ness, not depth** — same thresholds, same reasoning as above. Either trace table short of a part on this replica skews the postcondition's join. The **bridge** is in scope for a reason of its own: it is a `ReplicatedMergeTree`, and every read the reconciler makes of it resolves on the one replica it is connected to — the sweep's exclusion, the replay's bridge match and resurrection guard, the postcondition's exclusion and the leak-check advisory. A bridge part this replica has not fetched is invisible to all of them at once, so a genuinely deleted trace is swept back while the gate reports clean. Stuck-ness is still the verdict, so a busy-but-not-stuck bridge queue is accepted once the timeout expires: that narrows the window to the drain time rather than closing it. |
 
 The wait costs no cutover tail here, since the swap has already committed — but every second of it is a second the
 gap-window traces are still absent from live reads, so it is not free either. And it is spent **per gate**: once before
@@ -2025,7 +2025,7 @@ and a wrong verdict from a fidelity gate is the failure this whole procedure exi
   `--weeks-stride`, that an empty or inverted range is refused rather than passed vacuously, and that the `PASSED` line
   states the window it covered.
 
-`reconcile.sh` adds five of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
+`reconcile.sh` adds six of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
 an argument:
 
 - **direction detection** — forward on `traces_pre_cutover_backup`, reverse on a `traces_post_rollback_backup` that
@@ -2034,6 +2034,8 @@ an argument:
 - **`--report-only`** issuing no mutation in either direction, and exiting non-zero when it finds a gap;
 - the **idempotent no-op**: a second run on a reconciled estate reads the postcondition, issues nothing and exits 0;
 - **failing loudly** rather than reporting progress when the gate is still non-zero after `--max-passes`;
+- the **schema proof on the live table**, which requires `end_time` to be present before testing its shape — an
+  absent column is not the same as a non-Nullable one, and a bare test waves the first through;
 - the **shard-scope guard**: a multi-shard estate refused without `--confirm-single-shard` (and refused outright in the
   reverse direction, whose postcondition spans shards its replay cannot reach), an unreadable shard count failing
   closed, and the `RECONCILED` line carrying its `SCOPE:` qualifier when the scope was asserted rather than proven.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -2013,7 +2013,7 @@ ClickHouse rather than a stub, which is the stronger check, and it suffices beca
 refused argument, a lagging replica or a mis-marked SQL block aborts before any DDL or mutation is sent, so an untested
 guard costs a re-run, not data. Do not add per-driver suites here without revisiting that trade-off explicitly.
 
-So the cutover rehearsal is what covers the drivers: their argument validation, their topology guards, and three
+So the cutover rehearsal is what covers the drivers: their argument validation, their topology guards, and the
 `verify.sh` behaviours worth separating from the rest, because they decide a *verdict* rather than reject an argument —
 and a wrong verdict from a fidelity gate is the failure this whole procedure exists to avoid:
 
@@ -2022,11 +2022,11 @@ and a wrong verdict from a fidelity gate is the failure this whole procedure exi
 - the `--to-week last-sealed` resolution — the current-calendar-week bound, capped at the last populated week;
 - its refusal when that resolution lands before `--from-week`, the all-data-in-the-current-week case;
 - `--window-from` / `--window-to`: that they are refused in combination with any of `--from-week` / `--to-week` /
-  `--weeks-stride`, that an empty or inverted range is refused rather than passed vacuously, and that the `PASSED` line
-  states the window it covered.
+  `--weeks-stride`, that an empty or inverted range is refused rather than passed vacuously — including two bounds that
+  name the same instant at different precisions — and that the `PASSED` line states the window it covered.
 
-`reconcile.sh` adds six of the same kind, and they decide whether the estate is reconciled rather than merely rejecting
-an argument:
+`reconcile.sh` adds several of the same kind, and they decide whether the estate is reconciled rather than merely
+rejecting an argument:
 
 - **direction detection** — forward on `traces_pre_cutover_backup`, reverse on a `traces_post_rollback_backup` that
   carries the successor schema, refusal when both or neither is present, and the split-state diagnosis (EXCHANGE done,
@@ -2044,9 +2044,9 @@ an argument:
   Worth exercising by hand even on a single-shard estate — the consequence of getting it wrong is `finalize.sh`
   dropping every shard's backup on a one-shard assertion.
 
-And `finalize.sh` adds one: refusing each branch without ITS OWN confirmation flag — `--confirm-gap-reconciled` for
+And `finalize.sh` adds two: refusing each branch without ITS OWN confirmation flag — `--confirm-gap-reconciled` for
 the post-cutover drop, `--confirm-post-cutover-decision` for the post-rollback recycle — with the right diagnosis for
-whichever backup is parked, and refusing the other branch's flag rather than honoring it.
+whichever backup is parked; and refusing the OTHER branch's flag outright rather than honoring it.
 
 Each rests on manual verification. Exercise them in the rehearsal alongside the driver guards, and treat a change to any
 of them as needing the same.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -533,8 +533,8 @@ The tail is still worth running tightly, because its length is what decides how 
    sweeps the parked writes into the live successor, re-applies the deletes bridged across the swap, and does not exit 0
    until its four-count postcondition says the gap is closed. Pass the **recorded** `exchange_done`, never an estimate:
    the sweep and the gate apply the same `--swap-done` exclusion, so a value earlier than the real swap drops a key
-   deleted and re-created in between from *both*, leaving that trace missing under a clean gate. `--help` states both
-   directions of error; only `--gap-start` is free to widen.
+   deleted and re-created in between from *both*, leaving that trace missing under a clean gate. The driver's header
+   states both directions of error; only `--gap-start` is free to widen.
 
 Keep step 3→4 short, and step 4→5 shorter:
 
@@ -576,8 +576,8 @@ once: quiesce user DELETES across the swap, not merely reads.**
   timestamps at ingestion is the durable fix and is not this procedure's to make.
 - **A post-swap write that REGRESSES `last_updated_at` is overwritten by the sweep, and the gate reports it clean.**
   The same writable column as above, in the other direction. The sweep re-inserts the parked payload,
-  `ReplacingMergeTree` keeps the higher version, and a client-supplied value below the parked row's loses the live
-  write; the postcondition then compares the parked payload against itself and returns zeros, so `newer_keys` does not
+  `ReplacingMergeTree` keeps the higher version, and a client-supplied `last_updated_at` below the parked row's loses
+  the live write; the postcondition then compares the parked payload against itself and returns zeros, so `newer_keys` does not
   see it either. It needs a gap-window key *and* a post-swap write that moves `last_updated_at` backwards. Nothing in
   the reconciliation can fix it: skipping keys already live would abandon exactly the stale and partial rows the sweep
   exists to repair, and re-stamping the version would clobber legitimate newer writes. Clamping client timestamps at

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -58,8 +58,16 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
 > delete path (`TraceDAO.deleteForRetention*`) does not fire. The only deletes during the cutover window are
 > **user-initiated**, and those are captured by the bridge (`TraceService`, reason `USER_REQUEST`). The retention path is
 > intentionally **not** wired to the bridge. If Data Retention is ever enabled, either pause the retention job for the
-> whole backfill→EXCHANGE window, or first wire retention deletes into the bridge (a `RETENTION` reason recorded before
-> each `deleteForRetention*` delete). The test still exercises a synthetic large (retention-shape) delete batch, so the
+> whole backfill→**reconciliation** window, or first wire retention deletes into the bridge (a `RETENTION` reason
+> recorded before each `deleteForRetention*` delete).
+>
+> **The window outlasts the `EXCHANGE`, and step 5 is the reason.** A retention delete that fires after the parked
+> backup froze leaves its trace masked on the live table, still **live** in the frozen backup, and absent from the
+> bridge — so the sweep re-inserts it and the post-swap replay, which re-applies only *bridged* keys, leaves it live.
+> The delete is undone. Do not dismiss this as old-data-only: retention selects by `id` range (UUIDv7) while the gap
+> window matches `created_at` **or** `last_updated_at`, and the merge path stamps a fresh `last_updated_at` while
+> preserving `created_at` — so an old trace updated during the gap window is inside both at once. `reconcile.sh`
+> asserts `--confirm-retention-paused` for this, exactly as `exchange_and_wrap.sh` and `rollback.sh` do. The test still exercises a synthetic large (retention-shape) delete batch, so the
 > replay is proven to handle both batch sizes if retention is enabled later.
 
 ## Deletion scenarios and how each is handled
@@ -343,7 +351,8 @@ new table before the EXCHANGE. The replay matches the **full key**, not `id` alo
    absent from live `traces`.
    ```bash
    CLICKHOUSE_HOST=<host> CLICKHOUSE_PASSWORD=<pw> ./scripts/reconcile.sh --database opik \
-       --gap-start '<delta_start from step 2> UTC' --swap-done '<exchange_done from step 4> UTC'
+       --gap-start '<delta_start from step 2> UTC' --swap-done '<exchange_done from step 4> UTC' \
+       --confirm-retention-paused
    ```
    It derives the direction from the live topology (no `--direction` flag to get wrong), gates on the cluster-wide
    settle (the same gate as step 4, with a post-swap scope — see
@@ -1337,7 +1346,7 @@ The reverse direction of `reconcile.sh`. It re-imports into the restored origina
 ```bash
 ./scripts/reconcile.sh --database opik --report-only \
     --cutover-start '<ts> UTC' --swap-done '<promote_done from rollback.sh> UTC'   # size it first
-./scripts/reconcile.sh --database opik \
+./scripts/reconcile.sh --database opik --confirm-retention-paused \
     --cutover-start '<ts> UTC' --swap-done '<promote_done> UTC' --confirm-reimport-successor-writes
 ```
 
@@ -2118,10 +2127,12 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       restart for `tracesDistributedWrapEnabled` if the wrap is applied. Confirm you know
       how a backend restart is triggered on the target deployment and that it fits the schedule — see
       ["The one rolling restart"](#the-one-rolling-restart-tracecolumnsnonnullable).
-- [ ] **Data Retention confirmed disabled** for the cutover window (`RETENTION_ENABLED=false`). Retention deletes bypass
-      the deletion bridge, so a sweep in the window would leak/resurrect across the swap; `exchange_and_wrap.sh` and
-      `rollback.sh` (stages B/C) enforce `--confirm-retention-paused`, but that is an assertion — this item is the real
-      "it is actually paused on every backend" verification.
+- [ ] **Data Retention confirmed disabled** for the cutover window **through reconciliation** (`RETENTION_ENABLED=false`).
+      Retention deletes bypass the deletion bridge, so a sweep in the window would leak/resurrect across the swap — and
+      one firing *after* the backup freezes is undone by step 5's sweep, which is why the window does not end at the
+      `EXCHANGE` (see the retention note). `exchange_and_wrap.sh`, `rollback.sh` (stages B/C) and `reconcile.sh` all
+      enforce `--confirm-retention-paused`, but that is an assertion — this item is the real "it is actually paused on
+      every backend" verification.
 - [ ] **Reconciliation clean** — per-window source/dest counts within 0.01% across the whole backfill.
 - [ ] **Replication settled before the EXCHANGE** — no unfinished mutation on the shadow on **any** replica, and the
       replication queue either drained or demonstrably just busy rather than stuck (`exchange_and_wrap.sh` gates on

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -2036,6 +2036,8 @@ an argument:
 - **failing loudly** rather than reporting progress when the gate is still non-zero after `--max-passes`;
 - the **schema proof on the live table**, which requires `end_time` to be present before testing its shape — an
   absent column is not the same as a non-Nullable one, and a bare test waves the first through;
+- the **widen-only rule on the reverse `--gap-start`**: a later value is refused, since the reverse sweep and its
+  postcondition share that bound and narrowing it would hide exactly what it skipped;
 - the **shard-scope guard**: a multi-shard estate refused without `--confirm-single-shard` (and refused outright in the
   reverse direction, whose postcondition spans shards its replay cannot reach), an unreadable shard count failing
   closed, and the `RECONCILED` line carrying its `SCOPE:` qualifier when the scope was asserted rather than proven.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md
@@ -545,10 +545,20 @@ Keep step 3→4 short, and step 4→5 shorter:
 once: quiesce user DELETES across the swap, not merely reads.**
 
 - A delete whose bridge row lands *after* step 5's read is invisible to it.
-- Capture writes the bridge row *before* the delete executes, so for the width of the `EXCHANGE` a delete can be bridged
-  before `exchange_done` while its `DELETE` lands on the successor after the swap. That key is live in the frozen backup
-  and bridged before the bound, so **step 5's sweep brings it back**. It needs the trace to be written *and* deleted
-  inside the gap window, with the swap falling between its capture and its delete.
+- **A delete bridged below `exchange_done` but effective after the swap is undone by the sweep**, because the key is
+  live in the frozen backup and the bound does not exclude it — the sweep re-inserts it and the post-swap replay's
+  resurrection guard spares it. Two things put a delete there:
+  - *Capture ordering.* The bridge row is written **before** the `DELETE` executes, so a delete can be bridged below
+    the bound while its `DELETE` lands on the successor after the swap. One statement wide.
+  - *The bound trails the swap.* `exchange_done` is read after the `exchange` block returns, and that block holds the
+    `EXCHANGE` **and** the `RENAME` that parks the backup, both `ON CLUSTER`, so the RENAME and its distributed-DDL
+    wait sit inside the window. Stamping the clock between the two would shrink this and **not** close it: the
+    `EXCHANGE` is itself `ON CLUSTER`, so the hosts' commit skew stays inside the window wherever it is read. The
+    Go/No-Go records that interval; tighten the capture point only if it measures in seconds.
+
+  Either way the trace has to be written *and* deleted inside the gap window, with the swap falling between the
+  delete's capture and its effect — and quiescing deletes across the swap empties the window, which is why this shares
+  the mitigation above rather than getting its own.
 - **A pre-swap trace carrying a client-supplied future `last_updated_at` keeps its captured delete.** `lastUpdatedAt`
   is writable through the API and validated only as "before 2300", and `TraceDAO` binds it verbatim on the batch-ingest
   path — so such a row falls outside the post-swap replay's `created_at AND last_updated_at < exchange_done` staleness
@@ -2111,6 +2121,10 @@ cheap (stage A); the bridge stays enabled so nothing is lost on a retry.
       be driven to zero, because the procedure places a full deletion replay and a settle gate inside it. Its length
       decides how much the sweep has to carry and how long gap-window traces are transiently absent from live reads, and
       on a busy cluster the gate is the part of it that varies.
+      **Also record the `EXCHANGE`→`RENAME` interval inside the `exchange` block** (both `ON CLUSTER`; read it from
+      `query_log` by `log_comment`). It sits inside the delete-side resurrection window in "The final cutover window",
+      because `exchange_done` is read only after both statements return, and that section says what a large value
+      would justify.
 - [ ] **Far-future partitions quantified — and `max_partitions_per_insert_block` sized from the result.** Run the
       bad-`id` audit query above; remediated or explicitly accepted. The count is not just informational: if
       `far_future_weeks` exceeds the ClickHouse default of 100, the backfill **aborts** without a raised

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000003_exchange_and_wrap.sql
@@ -6,8 +6,8 @@
 -- runs the `wrap` block only with --with-wrap (or --wrap-only, which runs that block alone). Run it right after step 2's
 -- delta + replay, so the final-delta -> EXCHANGE gap stays small. Do NOT run this whole file wholesale — the driver runs one marked block at a time. Nothing here needs an
 -- ingestion-side config change: the EXCHANGE is atomic per node, so a concurrent insert always commits to a valid
--- table. Writes that land in the old one — in that gap or during the cross-node skew — stay in the parked backup: the
--- open tail write-gap tracked as OPIK-8238, stated in the runbook's "The final cutover window".
+-- table. Writes that land in the old one — in that gap or during the cross-node skew — stay in the parked backup until
+-- ../reconcile.sh sweeps them into the live table (OPIK-8238); see the runbook's "The final cutover window".
 --
 -- cutover_start is a now64(6) captured RIGHT BEFORE the EXCHANGE; a rollback after this point replays deletes that fired
 -- on the new live table since then. exchange_and_wrap.sh captures and prints it; record it for the rollback.
@@ -15,10 +15,20 @@
 -- Blocks, in the order the driver runs them: settle-sample, then settle-queue-detail / settle-mutation-detail only when
 -- the gate refuses, then `exchange`, then `wrap`. The first three are read-only. '{cluster}' is the macro, resolved
 -- server-side, as in the 000004 postcondition files.
+--
+-- THE THREE settle-* BLOCKS ARE READ BY TWO DRIVERS. exchange_and_wrap.sh gates the swap with them; reconcile.sh gates
+-- its post-swap sweep and postcondition with the same statements. The predicate is identical in both — a replica short
+-- of a part, or one still applying a mutation, is the same hazard either side of the swap — so the table sets are
+-- placeholders rather than literals and each driver renders its own scope and reaches its own verdict:
+--   ${SETTLE_QUEUE_TABLES}     quoted table list for the replication-queue side
+--   ${SETTLE_MUTATION_TABLES}  quoted table list for the unfinished-mutation side
+-- Duplicating the blocks per driver would mean two copies of a gate whose SQL is the same; parameterising the scope of
+-- a read is not the hazard that keeps the two deletion replays apart (see 000006's header).
 
 -- The gate's one sample, as seven numbers on a single row so the driver can read it as TSV: the replication queue's
 -- depth, its oldest entry's age in seconds, its highest num_tries and how many of its entries carry a last_exception;
--- then the count of unfinished mutations on the shadow, their oldest age and how many carry a latest_fail_reason. Every
+-- then the count of unfinished mutations in the mutation scope, their oldest age and how many carry a
+-- latest_fail_reason (the shadow pre-swap, the parked backup post-swap — see the placeholders above). Every
 -- column is numeric on purpose — the free-text exception columns would need quoting to survive TSV, and the two detail
 -- blocks below print them instead. max()/countIf() over an empty set yield 0, so a drained queue and an idle mutation
 -- list need no special casing. Each side is a single-row aggregate, so the CROSS JOIN is 1x1.
@@ -37,7 +47,7 @@ FROM (
            countIf(last_exception != '')               AS exc
     FROM clusterAllReplicas('{cluster}', system.replication_queue)
     WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
-      AND table IN ('traces', 'traces_local_v2')
+      AND table IN (${SETTLE_QUEUE_TABLES})
       AND type IN ('GET_PART', 'ATTACH_PART')
 ) AS q
 CROSS JOIN (
@@ -46,7 +56,7 @@ CROSS JOIN (
            countIf(latest_fail_reason != '')           AS fails
     FROM clusterAllReplicas('{cluster}', system.mutations)
     WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
-      AND table = 'traces_local_v2'
+      AND table IN (${SETTLE_MUTATION_TABLES})
       AND is_done = 0
 ) AS m;
 -- >>> END settle-sample
@@ -85,7 +95,7 @@ FROM (
            row_number() OVER (PARTITION BY hostName() ORDER BY (last_exception != '') DESC, create_time) AS failing_rank
     FROM clusterAllReplicas('{cluster}', system.replication_queue)
     WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
-      AND table IN ('traces', 'traces_local_v2')
+      AND table IN (${SETTLE_QUEUE_TABLES})
       AND type IN ('GET_PART', 'ATTACH_PART')
 )
 WHERE oldest_rank = 1
@@ -94,7 +104,7 @@ WHERE oldest_rank = 1
 ORDER BY replica, age_seconds DESC;
 -- >>> END settle-queue-detail
 
--- Printed when a mutation on the shadow has not finished on every replica by the gate's deadline. Bounded per replica
+-- Printed when a mutation in the mutation scope has not finished on every replica by the gate's deadline. Bounded per replica
 -- for the same reason as the queue detail above: the point is to name which replicas are behind, and a global cap
 -- would hide them behind whichever replica sorted first. Every row here is unfinished, so there is no equivalent of
 -- that block's decoy problem — only the ordering matters, and one carrying a latest_fail_reason explains more than an
@@ -109,7 +119,7 @@ SELECT hostName() AS replica,
        latest_fail_reason
 FROM clusterAllReplicas('{cluster}', system.mutations)
 WHERE database = '${ANALYTICS_DB_DATABASE_NAME}'
-  AND table = 'traces_local_v2'
+  AND table IN (${SETTLE_MUTATION_TABLES})
   AND is_done = 0
 ORDER BY (latest_fail_reason != '') DESC, create_time
 LIMIT 2 BY replica;

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000005_verify_migration.sql
@@ -25,6 +25,10 @@
 -- UTC bounds. Unpinned they would shift with the server timezone on both sides at once -- self-consistent, so no
 -- mismatch appears, while the first and last windows silently stop covering what the backfill actually copied.
 --
+-- The row fingerprint is repeated in every block below, and again in 000006_verify_reconciliation.sql, so that each
+-- block stays a statement that can be read and run on its own. KEEP THEM IN STEP BY HAND: two tools hashing the same
+-- rows differently would disagree about which rows match, and nothing would say so. Change one arm, change all of them.
+--
 -- ../verify.sh is the single driver: it reads this file and runs the blocks below, never this file by hand. Which block,
 -- and when:
 --   * `compare`       once per created_at week (optionally sampled), parsing the single verdict row;

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
@@ -79,9 +79,16 @@
 --
 -- Mask-honored: apply_deleted_mask stays at its default 1, so a row already lightweight-deleted on the old table when it
 -- was parked is never copied back. Idempotent: the target is a ReplacingMergeTree keyed on (workspace_id, project_id, id)
--- with last_updated_at as the version, so re-running the sweep re-inserts rows that lose to anything newer — including
--- every post-swap write, which is why the sweep cannot clobber live traffic. A key whose live row is NEWER keeps the
--- newer row; the postcondition reports that as `newer_keys` and tolerates it.
+-- with last_updated_at as the version, so re-running the sweep re-inserts rows that lose to anything newer. A key whose
+-- live row is NEWER keeps the newer row; the postcondition reports that as `newer_keys` and tolerates it.
+--
+-- That protects live traffic only as far as last_updated_at is MONOTONIC, and it is not: the column is client-writable
+-- and bound verbatim on the batch-ingest path, so a post-swap write can carry a value BELOW the parked row's. The
+-- parked payload then wins the version comparison and that write is lost, while the gate compares parked against parked
+-- and reports zeros. Nothing inside this statement fixes it: the version column is the successor's, and both
+-- alternatives defeat the sweep's purpose — skipping keys already live would abandon exactly the stale and partial rows
+-- it exists to repair, and re-stamping last_updated_at would clobber legitimate newer writes. Same root cause and the
+-- same durable fix as the runbook's client-timestamp residual: clamp client timestamps at ingestion.
 --
 -- The NOT IN arm is what stops the sweep resurrecting a gap-window trace the user deleted AFTER the swap: such a trace is
 -- still live in the frozen backup (it was live when the backup froze), so without this arm the sweep would insert a fresh

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
@@ -83,9 +83,9 @@
 -- live row is NEWER keeps the newer row; the postcondition reports that as `newer_keys` and tolerates it.
 --
 -- That protects live traffic only as far as last_updated_at is MONOTONIC, and it is not: the column is client-writable
--- and bound verbatim on the batch-ingest path, so a post-swap write can carry a value BELOW the parked row's. The
--- parked payload then wins the version comparison and that write is lost, while the gate compares parked against parked
--- and reports zeros. Nothing inside this statement fixes it: the version column is the successor's, and both
+-- and bound verbatim on the batch-ingest path, so a post-swap write can carry a last_updated_at BELOW the parked row's.
+-- The parked payload then wins the version comparison and that write is lost, while the gate compares parked against
+-- parked and reports zeros. Nothing inside this statement fixes it: the version column is the successor's, and both
 -- alternatives defeat the sweep's purpose — skipping keys already live would abandon exactly the stale and partial rows
 -- it exists to repair, and re-stamping last_updated_at would clobber legitimate newer writes. Same root cause and the
 -- same durable fix as the runbook's client-timestamp residual: clamp client timestamps at ingestion.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
@@ -201,6 +201,25 @@ SETTINGS max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
 -- while a newer version of the same key survives — which is what ReplacingMergeTree would have served anyway. The union
 -- of the two columns is complete for the same reason the gap window's is (see the header): a post-swap write stamps a
 -- fresh server created_at on the batch-ingest path, and a fresh server last_updated_at on the merge paths.
+--
+-- ARM 3's RESIDUAL, AND WHY THE PREDICATE STAYS AS IT IS. `last_updated_at` is CLIENT-SUPPLIED on the batch-ingest path:
+-- TraceDAO binds Trace.lastUpdatedAt verbatim, and the API accepts any value before 2300. So a genuinely PRE-swap row
+-- can carry a future timestamp, fall outside this scope, and keep its captured delete unmasked — a leaked delete. The
+-- two ways out are both worse:
+--   * Dropping the last_updated_at conjunct (scoping on created_at alone) inverts the failure. The merge path PRESERVES
+--     created_at, so a post-swap PATCH of a pre-existing trace would then be masked. Over-sparing leaves a deleted
+--     trace visible while its key is still in the bridge, so it can be re-masked; over-masking destroys a post-swap
+--     write that exists on the successor and nowhere else. This predicate is the recoverable side of that trade.
+--   * Comparing the row's VERSION against the versions the frozen backup held needs neither timestamp and would close
+--     both directions — but it is impossible in a MUTATION. Those backup rows were lightweight-deleted before the table
+--     was parked, so matching them needs an unmasked read, and a lightweight DELETE ACCEPTS apply_deleted_mask = 0 in
+--     SETTINGS and then IGNORES it (verified on 26.3): the subquery reads the backup mask-honored, matches nothing, and
+--     the statement reports success having masked NOTHING. Exactly the silent success this file is written to avoid.
+-- So the residual is DETECTED rather than prevented. That version comparison works in a READ, and ships as
+-- 000006_verify_reconciliation.sql's `leak-check-forward`, which ../reconcile.sh reports beside the four counts. The
+-- mitigation is the one the runbook already carries for the other delete-side residuals — quiesce user DELETEs across
+-- the swap, which empties the window this needs. Clamping a future client last_updated_at at ingestion is the durable
+-- fix and is not this procedure's to make.
 DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE}
 WHERE created_at      <  toDateTime64('${SWAP_DONE}', 6, 'UTC')
   AND last_updated_at <  toDateTime64('${SWAP_DONE}', 6, 'UTC')

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_post_swap_reconciliation.sql
@@ -1,0 +1,335 @@
+-- runbook traces-local-v2-cutover — POST-SWAP reconciliation sweep (reference statements)
+-- The gate test TracesLocalV2CutoverTest reimplements these statements inline; keep the two in step (see its Javadoc).
+--
+-- WHY THIS EXISTS (OPIK-8238). The last write-copying statement of the forward cutover is the delta INSERT in 000002.
+-- Between it and the EXCHANGE completing the procedure interposes a deletion replay, the operator's go/no-go gap, the
+-- topology guards, the cluster-wide settle gate and a SECOND full deletion replay. NOTHING holds writes across that
+-- window — the procedure takes no ingestion-path hold (OPIK-8239 removed the async-insert widening that was believed
+-- to, and largely did not) — so every trace written to the old `traces` in it is orphaned when that table is parked as
+-- `traces_pre_cutover_backup`. That loss has been observed on a real cutover.
+--
+-- WHY POST-SWAP AND NOT PRE-SWAP. Reconciling before the swap cannot converge: the source is live, so every pass opens a
+-- new gap — iterating the delta shrinks it and then stops improving. After the swap the parked table is FROZEN, so a
+-- sweep against it converges by construction — which is also what makes the postcondition in
+-- 000006_verify_reconciliation.sql a gate rather than a snapshot.
+--
+-- ../reconcile.sh is the single driver: it reads this file and runs the blocks its detected direction needs, after
+-- gating on the cluster-wide settle. Never run this file by hand. Which block, and when:
+--   * `forward-sweep`            after a cutover: copy the gap window out of the frozen pre-cutover backup;
+--   * `forward-deletion-replay`  right after it, so bridged deletes win over what the sweep just re-inserted;
+--   * `reverse-sweep`            after a rollback: re-import the post-cutover writes the promote made non-live. The
+--                                reverse direction needs no replay block here — it re-runs
+--                                000004_rollback_reverse_replay.sql unchanged, which already masks every key bridged
+--                                since cutover_start.
+--
+-- ALL FIVE placeholders the driver substitutes, so a new one is never missed here (an unsubstituted ${...} reaches the
+-- server as a literal and the statement fails):
+--   ${ANALYTICS_DB_DATABASE_NAME}          the analytics database
+--   ${LIVE_TABLE}                          the live table the sweep writes into: `traces`, or `traces_local` on a
+--                                          wrapped estate (a Distributed table accepts INSERT, but the deletion replay
+--                                          that follows the sweep is a mutation and a Distributed table rejects those,
+--                                          so the driver resolves ONE name the way tracesDistributedWrapEnabled does and
+--                                          uses it for every statement). Writing the shard directly is right, not a
+--                                          bypass of the sharding key: the parked backup is itself a per-shard table, so
+--                                          its rows already belong to the shard the sweep is connected to.
+--   ${GAP_START}                           what to COPY: the lower bound of the gap window, on created_at OR
+--                                          last_updated_at (see the anchor note below)
+--   ${SWAP_DONE}                           what NOT to RESURRECT: bridged deletes at or after this instant are excluded
+--                                          from the sweep (see the anchor note below)
+--   ${MAX_PARTITIONS_PER_INSERT_BLOCK}     partitions one block may span — a correctness gate, exactly as in 000001/000002
+--
+-- THE TWO ANCHORS HAVE DISTINCT JOBS, and confusing them loses data in opposite directions.
+--   * ${GAP_START} bounds what to copy. Forward it is the start of the last delta pass (`RECORD delta_start=`, printed by
+--     ../delta_replay.sh); reverse it is `cutover_start`. WIDENING IT IS FREE: the sweep is mask-honored and idempotent
+--     (ReplacingMergeTree, older versions lose), so re-copying rows that were already copied changes nothing. That makes
+--     `backfill_start` an always-valid fallback, and means a lost delta_start never forces an escalation — unlike
+--     `cutover_start` or the sentinel-repair window, where guessing destroys or resurrects data.
+--   * ${SWAP_DONE} bounds what not to resurrect, and is captured AFTER the swap statement returns
+--     (`RECORD exchange_done=` / `RECORD promote_done=`). Using `cutover_start` here instead would wrongly exclude a
+--     trace deleted and then re-created between `cutover_start` and the EXCHANGE: that trace is legitimately live in the
+--     frozen backup and must be swept back.
+--
+-- WHY `created_at OR last_updated_at` IS COMPLETE. Every write path stamps a fresh SERVER timestamp in at least one of
+-- them: TraceDAO's BATCH_INSERT omits created_at (so the column DEFAULT now64() applies) while binding a CLIENT-supplied
+-- last_updated_at, and the create/update merge paths preserve created_at while letting last_updated_at default to
+-- now64(). Neither column alone is therefore a reliable "written since" signal; their union is. This is the same argument
+-- 000002's delta anchor rests on. ../reconcile.sh's --slack-seconds widens ${GAP_START} downward to absorb cross-replica
+-- clock skew on those server defaults, which is free per the widening note above.
+--
+-- BOUNDED COST. Both bounds prune on the created_at / last_updated_at minmax skip indexes (migration 000088 on the
+-- original, and the equivalent indexes on the successor), so the sweep scales with the GAP, not with the table.
+--
+-- EVERY WINDOW BOUND PINS 'UTC', for the reason 000001's header gives at length: these columns are DateTime64(n, 'UTC')
+-- while an unpinned literal is parsed in the SERVER timezone, and the drivers capture their anchors with now64(6, 'UTC')
+-- so both halves of the pair agree.
+--
+-- THE COLUMN LISTS ARE SPELLED OUT, NOT SHARED, because each block has to stay a complete statement a driver can read
+-- and an operator can review. KEEP THEM IN STEP BY HAND with 000001's backfill and 000002's delta: an INSERT ... SELECT
+-- is positional, so every one of these statements must list AND project exactly the base columns of `traces`, in the
+-- same order. A base column added by a future migration and missed here is silently never copied — which is why
+-- TracesLocalV2CutoverTest#cutoverCopiesEveryBaseColumn fails the build until the cutover's column list is updated:
+-- treat that failure as the prompt to update these statements too.
+
+-- >>> BEGIN forward-sweep
+-- Forward: copy the gap window out of the FROZEN pre-cutover backup into the live successor.
+--
+-- Same projection as 000001/000002 — the source here is the old original, so end_time / ttft are still Nullable and are
+-- coalesced to the successor's epoch / NaN sentinels. The epoch literal stays unpinned, matching 000001 (it must agree
+-- with the successor's own DEFAULT and duration expression, which are unpinned too).
+--
+-- Mask-honored: apply_deleted_mask stays at its default 1, so a row already lightweight-deleted on the old table when it
+-- was parked is never copied back. Idempotent: the target is a ReplacingMergeTree keyed on (workspace_id, project_id, id)
+-- with last_updated_at as the version, so re-running the sweep re-inserts rows that lose to anything newer — including
+-- every post-swap write, which is why the sweep cannot clobber live traffic. A key whose live row is NEWER keeps the
+-- newer row; the postcondition reports that as `newer_keys` and tolerates it.
+--
+-- The NOT IN arm is what stops the sweep resurrecting a gap-window trace the user deleted AFTER the swap: such a trace is
+-- still live in the frozen backup (it was live when the backup froze), so without this arm the sweep would insert a fresh
+-- version and undo the delete. Deletes bridged BEFORE ${SWAP_DONE} are deliberately not excluded here — one of those may
+-- have been deleted and re-created before the freeze, in which case the backup's live row is the re-created one and must
+-- be swept back. Those are handled instead by the deletion replay ../reconcile.sh runs AFTER this sweep (000002's
+-- deletion-replay block, aimed at the live table with the frozen backup as its resurrection guard), so deletes win.
+--
+-- The length(...) = 36 guards match 000002 and 000004 for the same reason: toFixedString THROWS on a longer value, and a
+-- non-36-char bridge row cannot match a real trace id anyway, so skipping it turns a hard abort into a benign no-op.
+--
+-- ONE RESIDUAL THIS SWEEP INTRODUCES, stated because it is a delete that can come back. Capture writes the bridge row
+-- BEFORE the delete executes, so for the width of the EXCHANGE a delete can be bridged at t < ${SWAP_DONE} while its
+-- DELETE lands on the successor AFTER the swap. That key is then live in the frozen backup (the old table never saw the
+-- delete), bridged before ${SWAP_DONE} so the arm above does not exclude it, and spared by the following replay's guard
+-- for the same reason — so the sweep resurrects a trace the user deleted. It needs the trace to be written AND deleted
+-- inside the gap window with the swap falling between its capture and its delete, which is why the bound stays
+-- ${SWAP_DONE}: moving it to ${GAP_START} would trade this for a strictly likelier loss, dropping every trace that was
+-- deleted and re-created before the freeze. It is the same class as the residual the runbook already carries, and the
+-- same mitigation covers it: QUIESCE USER DELETES ACROSS THE SWAP, not merely reads.
+INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE} (
+    id,
+    workspace_id,
+    project_id,
+    name,
+    start_time,
+    end_time,
+    input,
+    output,
+    metadata,
+    tags,
+    created_at,
+    last_updated_at,
+    created_by,
+    last_updated_by,
+    error_info,
+    thread_id,
+    visibility_mode,
+    truncation_threshold,
+    input_slim,
+    output_slim,
+    ttft,
+    source,
+    environment
+)
+SELECT
+    id,
+    workspace_id,
+    project_id,
+    name,
+    start_time,
+    coalesce(end_time, toDateTime64('1970-01-01 00:00:00', 6)) AS end_time,
+    input,
+    output,
+    metadata,
+    tags,
+    created_at,
+    last_updated_at,
+    created_by,
+    last_updated_by,
+    error_info,
+    thread_id,
+    visibility_mode,
+    truncation_threshold,
+    input_slim,
+    output_slim,
+    coalesce(ttft, toFloat64('nan')) AS ttft,
+    source,
+    environment
+FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_pre_cutover_backup
+WHERE (created_at >= toDateTime64('${GAP_START}', 6, 'UTC')
+    OR last_updated_at >= toDateTime64('${GAP_START}', 6, 'UTC'))
+  AND (workspace_id, project_id, id) NOT IN (
+      SELECT
+          workspace_id,
+          toFixedString(project_id, 36),
+          toFixedString(deleted_id, 36)
+      FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+      WHERE source_table = 'traces'
+        AND event_time >= toDateTime64('${SWAP_DONE}', 6, 'UTC')
+        AND project_id != ''
+        AND length(project_id) = 36
+        AND length(deleted_id) = 36
+  )
+SETTINGS max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
+         log_comment = 'traces_local_v2_cutover:reconcile:forward_sweep';
+-- >>> END forward-sweep
+
+-- >>> BEGIN forward-deletion-replay
+-- Forward, immediately after the sweep: re-apply onto the live successor every delete the bridge recorded since
+-- ${GAP_START} that the frozen backup still shows as deleted. Run AFTER the sweep so deletes win over anything it
+-- re-inserted.
+--
+-- KEEP IN STEP WITH 000002's `deletion-replay` block, which this deliberately does NOT reuse. The two share a shape —
+-- the full-key match against the bridge, the toFixedString(36) casts, the length guards, the resurrection guard, both
+-- SETTINGS — but not their semantics, and the difference is the whole reason this file exists. 000002 runs PRE-swap
+-- against a LIVE source; this runs POST-swap against a FROZEN one. Parameterising one block to do both would mean a
+-- placeholder whose only job is to switch off the third arm below wherever the replay runs pre-swap, inside the
+-- statement whose silent failure leaks deletions. The same argument keeps 000004_rollback_reverse_replay.sql separate.
+--
+-- ARM 1 (the bridge match) is 000002's, with ${GAP_START} as the event_time floor rather than backfill_start. Widening
+-- that floor is safe — the two guards below decide what is masked, not this bound.
+--
+-- ARM 2 (the resurrection guard) reads the FROZEN backup, and that is what makes it race-free where 000002's cannot be:
+-- the source cannot change under the read. It is also what closes the delete-side residual the runbook otherwise accepts
+-- as inherent — a delete whose bridge row commits after the final pre-swap replay has read the bridge but before the
+-- EXCHANGE, which is covered by neither the forward replay nor the rollback reverse-replay.
+--
+-- ARM 3 (the staleness scope) is what keeps that frozen guard from destroying a post-cutover write, and it has no
+-- counterpart in 000002 because pre-swap there is nothing to protect: the shadow receives no writes except the copy. A
+-- frozen source cannot see a row written AFTER the swap, so a key deleted before the swap and then re-created or patched
+-- after it looks "still deleted" to arm 2 — and without this arm the replay would mask a live post-cutover write,
+-- turning the fix for write loss into a cause of it. Not exotic: trace ids are client-supplied and TraceDAO.UPDATE
+-- re-inserts a version, so an in-flight patch to a just-deleted trace does exactly this.
+--
+-- The scope is per ROW, not per key, which is stronger than sparing the key wholesale: a leaked stale copy is masked
+-- while a newer version of the same key survives — which is what ReplacingMergeTree would have served anyway. The union
+-- of the two columns is complete for the same reason the gap window's is (see the header): a post-swap write stamps a
+-- fresh server created_at on the batch-ingest path, and a fresh server last_updated_at on the merge paths.
+DELETE FROM ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE}
+WHERE created_at      <  toDateTime64('${SWAP_DONE}', 6, 'UTC')
+  AND last_updated_at <  toDateTime64('${SWAP_DONE}', 6, 'UTC')
+  AND (workspace_id, project_id, id) IN (
+      SELECT
+          workspace_id,
+          toFixedString(project_id, 36),
+          toFixedString(deleted_id, 36)
+      FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+      WHERE source_table = 'traces'
+        AND event_time >= toDateTime64('${GAP_START}', 6, 'UTC')
+        AND project_id != ''
+        AND length(project_id) = 36
+        AND length(deleted_id) = 36
+  )
+  AND (workspace_id, project_id, id) NOT IN (
+      SELECT
+          workspace_id,
+          project_id,
+          id
+      FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_pre_cutover_backup
+      WHERE id IN (
+          SELECT toFixedString(deleted_id, 36)
+          FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+          WHERE source_table = 'traces'
+            AND event_time >= toDateTime64('${GAP_START}', 6, 'UTC')
+            AND length(deleted_id) = 36
+      )
+  )
+-- allow_nondeterministic_mutations: a lightweight DELETE with cross-table subqueries is flagged nondeterministic, but
+-- deletion_events_local and the parked backup are replicated and identical on every node and the window predicate is
+-- fixed, so the subqueries resolve to the same set on every replica.
+-- lightweight_deletes_sync = 2: return only once the mask has applied on EVERY replica, so the postcondition in
+-- 000006_verify_reconciliation.sql — which reads one replica — cannot race an unapplied mutation.
+SETTINGS allow_nondeterministic_mutations = 1,
+         lightweight_deletes_sync = 2,
+         log_comment = 'traces_local_v2_cutover:reconcile:deletion_replay';
+-- >>> END forward-deletion-replay
+
+-- >>> BEGIN reverse-sweep
+-- Reverse: re-import the post-cutover writes a stage B/C promote made non-live, out of the parked successor
+-- (`traces_post_rollback_backup`) and back into the restored original.
+--
+-- THIS IS OPT-IN AND DELIBERATE. Those writes are exactly what --accept-post-cutover-write-loss acknowledged discarding,
+-- so ../reconcile.sh refuses this direction without --confirm-reimport-successor-writes. It is the right choice when the
+-- rollback was motivated by latency, merge load or the wrap rather than by data fidelity — there the discarded writes are
+-- good data — and the wrong one when the successor's CONTENT is what is suspect.
+--
+-- SENTINEL -> NULL DENORMALIZATION, the mirror of the forward projection. The successor stores an absent end_time as the
+-- epoch and an absent ttft as NaN; the original's convention is NULL, and its MATERIALIZED `duration` guards only
+-- `end_time IS NOT NULL` — it does not know the epoch sentinel — so importing the sentinel verbatim would give every
+-- unfinished trace a duration of roughly -1.79e12 ms instead of NULL. Restoring NULL is what makes the recomputed
+-- duration NULL, and the mutation-free INSERT path recomputes it on write.
+--
+-- THE EPOCH LITERAL PINS 'UTC' HERE, unlike the forward projection, and the asymmetry is intended. Forward, the sentinel
+-- being written must agree with the successor's own unpinned DEFAULT and duration expression. Reverse, the sentinel being
+-- READ was written by the BACKEND (traceColumnsNonNullable binds Instant.EPOCH, an absolute instant 0) for every row in
+-- this window, since the window starts at cutover_start and only post-cutover traffic wrote here. Same reasoning, and the
+-- same conclusion, as 000004_rollback_sentinel_repair.sql. On a UTC server the two spellings coincide.
+--
+-- ORDER MATTERS: ../reconcile.sh runs 000004_rollback_reverse_replay.sql AFTER this sweep, so a trace deleted since
+-- cutover_start is re-imported here and then masked there — deletes win, and 000004_rollback_verify_replay.sql still
+-- reports 0. The reverse replay carries no resurrection guard by design (see its header), so an id deleted and then
+-- re-created after cutover_start stays masked: the delete is honoured and the re-creation is lost with the other
+-- discarded writes, which is the rollback semantics the runbook already documents.
+INSERT INTO ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE} (
+    id,
+    workspace_id,
+    project_id,
+    name,
+    start_time,
+    end_time,
+    input,
+    output,
+    metadata,
+    tags,
+    created_at,
+    last_updated_at,
+    created_by,
+    last_updated_by,
+    error_info,
+    thread_id,
+    visibility_mode,
+    truncation_threshold,
+    input_slim,
+    output_slim,
+    ttft,
+    source,
+    environment
+)
+SELECT
+    id,
+    workspace_id,
+    project_id,
+    name,
+    start_time,
+    nullIf(end_time, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')) AS end_time,
+    input,
+    output,
+    metadata,
+    tags,
+    created_at,
+    last_updated_at,
+    created_by,
+    last_updated_by,
+    error_info,
+    thread_id,
+    visibility_mode,
+    truncation_threshold,
+    input_slim,
+    output_slim,
+    if(isNaN(ttft), NULL, ttft) AS ttft,
+    source,
+    environment
+FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_post_rollback_backup
+WHERE (created_at >= toDateTime64('${GAP_START}', 6, 'UTC')
+    OR last_updated_at >= toDateTime64('${GAP_START}', 6, 'UTC'))
+  AND (workspace_id, project_id, id) NOT IN (
+      SELECT
+          workspace_id,
+          toFixedString(project_id, 36),
+          toFixedString(deleted_id, 36)
+      FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+      WHERE source_table = 'traces'
+        AND event_time >= toDateTime64('${SWAP_DONE}', 6, 'UTC')
+        AND project_id != ''
+        AND length(project_id) = 36
+        AND length(deleted_id) = 36
+  )
+SETTINGS max_partitions_per_insert_block = ${MAX_PARTITIONS_PER_INSERT_BLOCK},
+         log_comment = 'traces_local_v2_cutover:reconcile:reverse_sweep';
+-- >>> END reverse-sweep

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
@@ -17,12 +17,15 @@
 --
 -- WHY IT IS RACE-FREE, which is the property that makes it a gate rather than a snapshot. The parked side is frozen, so
 -- its row set cannot move under the read. Post-swap traffic can only ever move a key from a gating bucket into the
--- tolerated one: a write bumps last_updated_at, so the key becomes `newer_keys`; it cannot turn a matching key into a
--- missing or stale one. So a 0 stays true, and a non-zero is a real finding rather than a race.
+-- tolerated one: a write that bumps last_updated_at makes the key `newer_keys`, and nothing turns a matching key into a
+-- missing or stale one. So a 0 stays true, and a non-zero is a real finding rather than a race. What a 0 does NOT
+-- certify is that every post-swap write SURVIVED: last_updated_at is client-writable and can regress, and a write that
+-- regresses it below the parked version is overwritten by the sweep and invisible here. See the sweep's note in
+-- 000006_post_swap_reconciliation.sql, and the runbook's residual.
 --
--- WHAT `newer_keys` MEANS, and why it is not a gate. It is EXPECTED to be non-zero on a busy estate: any gap-window trace
--- that was written again after the swap is newer on the live side, and the sweep deliberately leaves it that way (its
--- INSERT loses the ReplacingMergeTree version comparison). Gating on it would fail every healthy reconciliation. It is
+-- WHAT `newer_keys` MEANS, and why it is not a gate. It is EXPECTED to be non-zero on a busy estate: a gap-window trace
+-- whose post-swap write ADVANCED the version is newer on the live side, and the sweep deliberately leaves it that way
+-- (its INSERT loses the ReplacingMergeTree version comparison). Gating on it would fail every healthy reconciliation. It is
 -- reported because an operator sizing the window wants the number.
 --
 -- WHY NOT clusterAllReplicas, unlike 000004_rollback_verify_replay.sql. A Replicated table returns one full copy per
@@ -262,8 +265,9 @@ SETTINGS join_use_nulls = 1,
 --
 -- THE VERSION COMPARISON IS WHAT MAKES IT PRECISE, and it needs no timestamp. A leaked row is a COPY of a backup row
 -- (placed by the backfill/delta before the delete fired, or re-inserted by the sweep), so its (key, last_updated_at) is
--- one the backup holds. A legitimate post-swap re-creation carries a version the backup never held, whatever the client
--- claimed, because the client's value went into the successor and not into the frozen table.
+-- one the backup holds. A legitimate post-swap re-creation carries a version the backup never held, because the
+-- client's value went into the successor and not into the frozen table — unless it names the exact microsecond the
+-- backup recorded for that key, which makes this advisory OVER-report rather than miss.
 --
 -- WHY IT OVERRIDES THE DELETE MASK, given that ClickHouse filters lightweight-deleted rows automatically. That
 -- filtering is the obstacle, not a substitute: the versions to match against belong to rows DELETED in the backup, so

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
@@ -1,0 +1,249 @@
+-- runbook traces-local-v2-cutover — POST-SWAP reconciliation POSTCONDITION (driven by ../reconcile.sh)
+-- The gate test TracesLocalV2CutoverTest reimplements these statements inline; keep the two in step (see its Javadoc).
+--
+-- Read-only, and read repeatedly by the driver: once before any mutation (so a reconciled estate skips the sweep
+-- entirely and the mode is a true no-op), and once after each pass, as the gate. --report-only runs nothing else.
+--
+-- ONE ROW, FOUR COUNTS, read with `read -r` exactly as ../rollback.sh reads 000004_rollback_verify_sentinels.sql —
+-- including that file's idiom of carrying one deliberately-INFORMATIONAL count alongside the gates. For every key that is
+-- live in the PARKED table inside the gap window, the live table's version of that key is classified:
+--   * absent from the live table                              -> missing_keys          (GATE)
+--   * live version STRICTLY OLDER than the parked one         -> stale_keys            (GATE)
+--   * SAME version, differing normalized fingerprint          -> payload_mismatch_keys (GATE)
+--   * live version NEWER than the parked one                  -> newer_keys            (informational)
+-- THE GATE IS THE FIRST THREE AT 0. That is one number covering presence, version AND payload, which is why the
+-- reconciler needs no second fidelity query to decide whether it is done.
+--
+-- WHY IT IS RACE-FREE, which is the property that makes it a gate rather than a snapshot. The parked side is frozen, so
+-- its row set cannot move under the read. Post-swap traffic can only ever move a key from a gating bucket into the
+-- tolerated one: a write bumps last_updated_at, so the key becomes `newer_keys`; it cannot turn a matching key into a
+-- missing or stale one. So a 0 stays true, and a non-zero is a real finding rather than a race.
+--
+-- WHAT `newer_keys` MEANS, and why it is not a gate. It is EXPECTED to be non-zero on a busy estate: any gap-window trace
+-- that was written again after the swap is newer on the live side, and the sweep deliberately leaves it that way (its
+-- INSERT loses the ReplacingMergeTree version comparison). Gating on it would fail every healthy reconciliation. It is
+-- reported because an operator sizing the window wants the number.
+--
+-- WHY NOT clusterAllReplicas, unlike 000004_rollback_verify_replay.sql. A Replicated table returns one full copy per
+-- replica through that function, so the JOIN below would multiply both sides and the counts would be meaningless. The
+-- driver therefore runs the cluster-wide settle gate (empty replication_queue, mutations done) BEFORE reading this, which
+-- is what makes a single-replica read representative; that ordering is a requirement of this file, not an optimisation.
+--
+-- NORMALIZATION ARMS COME FROM 000005_verify_migration.sql VERBATIM — KEEP IN STEP WITH IT. Same microsecond-epoch
+-- timestamps, same absent-end_time -> 0 and absent-ttft -> 'nan' canonicalization, same toString on enums/project_id,
+-- same '\x1f' tag delimiter, same cityHash64. A fingerprint that diverged from the one verify.sh computes would make
+-- these two tools disagree about the same rows, and would classify keys here by a fingerprint the fidelity compare does
+-- not use. The VERSION is compared as a microsecond epoch for the same reason it is hashed as one: the copy truncates
+-- nanoseconds to microseconds, so comparing the raw columns would report every faithfully-copied row with a
+-- sub-microsecond last_updated_at as `stale_keys`.
+--
+-- FINAL on both sides, so the comparison is of the live, logical row; the default apply_deleted_mask = 1 keeps it to
+-- rows that are not lightweight-deleted. The `parked` CTE is referenced twice (once to pick the live side's candidate
+-- keys, once as the join's left side) and ClickHouse inlines rather than materializes a CTE, so it is evaluated twice —
+-- acceptable because it is bounded by the gap window and its skip indexes, not by the table.
+--
+-- ALL FOUR placeholders the driver substitutes, so a new one is never missed here:
+--   ${ANALYTICS_DB_DATABASE_NAME}   the analytics database
+--   ${LIVE_TABLE}                   `traces`, or `traces_local` on a wrapped estate (see 000006_post_swap_reconciliation.sql)
+--   ${GAP_START}                    the gap window's lower bound, the same value the sweep used
+--   ${SWAP_DONE}                    the instant the swap returned (forward block only)
+
+-- >>> BEGIN verify-forward
+-- Forward: parked = traces_pre_cutover_backup (OLD schema — Nullable, nanosecond); live = the successor (sentinels,
+-- microsecond). The exclusion arm mirrors the forward sweep's: a gap-window key deleted AFTER the swap is legitimately
+-- absent from the live table, so counting it as `missing_keys` would make the gate unreachable. Keys deleted BEFORE the
+-- swap are NOT excluded here, deliberately — one that is live in the frozen backup was re-created before the freeze and
+-- must be present live, and one that is not live in the backup never enters this set at all (FINAL + the delete mask).
+WITH
+    parked AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)) AS parked_version,
+            cityHash64(
+                id,
+                workspace_id,
+                toString(project_id),
+                name,
+                toUnixTimestamp64Micro(toDateTime64(start_time, 6)),
+                coalesce(toUnixTimestamp64Micro(toDateTime64(end_time, 6)), toInt64(0)),
+                input,
+                output,
+                metadata,
+                arrayStringConcat(tags, '\x1f'),
+                toUnixTimestamp64Micro(toDateTime64(created_at, 6)),
+                toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)),
+                created_by,
+                last_updated_by,
+                error_info,
+                thread_id,
+                toString(visibility_mode),
+                truncation_threshold,
+                input_slim,
+                output_slim,
+                if(ttft IS NULL, 'nan', toString(ttft)),
+                toString(source),
+                toString(environment)) AS parked_fingerprint
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_pre_cutover_backup FINAL
+        WHERE (created_at >= toDateTime64('${GAP_START}', 6, 'UTC')
+            OR last_updated_at >= toDateTime64('${GAP_START}', 6, 'UTC'))
+          AND (workspace_id, project_id, id) NOT IN (
+              SELECT
+                  workspace_id,
+                  toFixedString(project_id, 36),
+                  toFixedString(deleted_id, 36)
+              FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+              WHERE source_table = 'traces'
+                AND event_time >= toDateTime64('${SWAP_DONE}', 6, 'UTC')
+                AND project_id != ''
+                AND length(project_id) = 36
+                AND length(deleted_id) = 36
+          )
+    ),
+    live AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            toUnixTimestamp64Micro(last_updated_at) AS live_version,
+            cityHash64(
+                id,
+                workspace_id,
+                toString(project_id),
+                name,
+                toUnixTimestamp64Micro(start_time),
+                toUnixTimestamp64Micro(end_time),
+                input,
+                output,
+                metadata,
+                arrayStringConcat(tags, '\x1f'),
+                toUnixTimestamp64Micro(created_at),
+                toUnixTimestamp64Micro(last_updated_at),
+                created_by,
+                last_updated_by,
+                error_info,
+                thread_id,
+                toString(visibility_mode),
+                truncation_threshold,
+                input_slim,
+                output_slim,
+                if(isNaN(ttft), 'nan', toString(ttft)),
+                toString(source),
+                toString(environment)) AS live_fingerprint
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE} FINAL
+        -- Keys only, with no window predicate: the live row for a gap-window key may carry any created_at (the merge path
+        -- preserves the original, batch ingestion re-stamps it), so bounding this side by the window would report a
+        -- re-stamped row as missing.
+        WHERE (workspace_id, project_id, id) IN (SELECT key FROM parked)
+    )
+SELECT
+    countIf(live_version IS NULL) AS missing_keys,
+    countIf(live_version IS NOT NULL AND live_version < parked_version) AS stale_keys,
+    countIf(live_version IS NOT NULL AND live_version = parked_version
+            AND live_fingerprint != parked_fingerprint) AS payload_mismatch_keys,
+    countIf(live_version IS NOT NULL AND live_version > parked_version) AS newer_keys
+FROM parked
+LEFT JOIN live USING (key)
+-- join_use_nulls = 1 is required for correctness, for the same reason 000005's drill-down needs it: by default ClickHouse
+-- fills an unmatched side with the column's DEFAULT (0 for the hash, 0 for the version), which would make an absent key
+-- indistinguishable from a real 0 and leave the IS NULL predicate dead — so every missing key would be silently counted
+-- as `stale_keys` or, worse, as nothing at all.
+SETTINGS join_use_nulls = 1,
+         use_skip_indexes_if_final = 1,
+         log_comment = 'traces_local_v2_cutover:reconcile:verify_forward';
+-- >>> END verify-forward
+
+-- >>> BEGIN verify-reverse
+-- Reverse: parked = traces_post_rollback_backup (NEW schema — sentinels, microsecond); live = the restored original
+-- (Nullable, nanosecond). The shapes are the mirror image of the forward block, so the two normalization arms swap sides.
+--
+-- The exclusion arm is bounded by ${GAP_START} here, NOT by ${SWAP_DONE}, and that difference is load-bearing: the
+-- reverse replay ../reconcile.sh runs after the sweep is 000004_rollback_reverse_replay.sql, which masks every key
+-- bridged since cutover_start — so a key deleted anywhere in [cutover_start, now) is legitimately absent from the live
+-- table and must not be counted as missing. Forward, only post-swap deletes are legitimately absent, because the forward
+-- replay's resurrection guard spares anything that is live in the parked table.
+WITH
+    parked AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            toUnixTimestamp64Micro(last_updated_at) AS parked_version,
+            cityHash64(
+                id,
+                workspace_id,
+                toString(project_id),
+                name,
+                toUnixTimestamp64Micro(start_time),
+                toUnixTimestamp64Micro(end_time),
+                input,
+                output,
+                metadata,
+                arrayStringConcat(tags, '\x1f'),
+                toUnixTimestamp64Micro(created_at),
+                toUnixTimestamp64Micro(last_updated_at),
+                created_by,
+                last_updated_by,
+                error_info,
+                thread_id,
+                toString(visibility_mode),
+                truncation_threshold,
+                input_slim,
+                output_slim,
+                if(isNaN(ttft), 'nan', toString(ttft)),
+                toString(source),
+                toString(environment)) AS parked_fingerprint
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_post_rollback_backup FINAL
+        WHERE (created_at >= toDateTime64('${GAP_START}', 6, 'UTC')
+            OR last_updated_at >= toDateTime64('${GAP_START}', 6, 'UTC'))
+          AND (workspace_id, project_id, id) NOT IN (
+              SELECT
+                  workspace_id,
+                  toFixedString(project_id, 36),
+                  toFixedString(deleted_id, 36)
+              FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+              WHERE source_table = 'traces'
+                AND event_time >= toDateTime64('${GAP_START}', 6, 'UTC')
+                AND project_id != ''
+                AND length(project_id) = 36
+                AND length(deleted_id) = 36
+          )
+    ),
+    live AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)) AS live_version,
+            cityHash64(
+                id,
+                workspace_id,
+                toString(project_id),
+                name,
+                toUnixTimestamp64Micro(toDateTime64(start_time, 6)),
+                coalesce(toUnixTimestamp64Micro(toDateTime64(end_time, 6)), toInt64(0)),
+                input,
+                output,
+                metadata,
+                arrayStringConcat(tags, '\x1f'),
+                toUnixTimestamp64Micro(toDateTime64(created_at, 6)),
+                toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)),
+                created_by,
+                last_updated_by,
+                error_info,
+                thread_id,
+                toString(visibility_mode),
+                truncation_threshold,
+                input_slim,
+                output_slim,
+                if(ttft IS NULL, 'nan', toString(ttft)),
+                toString(source),
+                toString(environment)) AS live_fingerprint
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE} FINAL
+        WHERE (workspace_id, project_id, id) IN (SELECT key FROM parked)
+    )
+SELECT
+    countIf(live_version IS NULL) AS missing_keys,
+    countIf(live_version IS NOT NULL AND live_version < parked_version) AS stale_keys,
+    countIf(live_version IS NOT NULL AND live_version = parked_version
+            AND live_fingerprint != parked_fingerprint) AS payload_mismatch_keys,
+    countIf(live_version IS NOT NULL AND live_version > parked_version) AS newer_keys
+FROM parked
+LEFT JOIN live USING (key)
+SETTINGS join_use_nulls = 1,
+         use_skip_indexes_if_final = 1,
+         log_comment = 'traces_local_v2_cutover:reconcile:verify_reverse';
+-- >>> END verify-reverse

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/db-app-analytics/000006_verify_reconciliation.sql
@@ -1,8 +1,9 @@
 -- runbook traces-local-v2-cutover — POST-SWAP reconciliation POSTCONDITION (driven by ../reconcile.sh)
 -- The gate test TracesLocalV2CutoverTest reimplements these statements inline; keep the two in step (see its Javadoc).
 --
--- Read-only, and read repeatedly by the driver: once before any mutation (so a reconciled estate skips the sweep
--- entirely and the mode is a true no-op), and once after each pass, as the gate. --report-only runs nothing else.
+-- Read-only. `verify-forward` / `verify-reverse` are the GATE, read once before any mutation (so a reconciled estate
+-- skips the sweep entirely and the mode is a true no-op) and once after each pass. `leak-check-forward` is an ADVISORY
+-- read on the forward path only, taken at whichever of those the run exits on. --report-only runs nothing else.
 --
 -- ONE ROW, FOUR COUNTS, read with `read -r` exactly as ../rollback.sh reads 000004_rollback_verify_sentinels.sql —
 -- including that file's idiom of carrying one deliberately-INFORMATIONAL count alongside the gates. For every key that is
@@ -37,8 +38,9 @@
 -- nanoseconds to microseconds, so comparing the raw columns would report every faithfully-copied row with a
 -- sub-microsecond last_updated_at as `stale_keys`.
 --
--- FINAL on both sides, so the comparison is of the live, logical row; the default apply_deleted_mask = 1 keeps it to
--- rows that are not lightweight-deleted. The `parked` CTE is referenced twice (once to pick the live side's candidate
+-- FINAL on both sides of the GATE blocks, so the comparison is of the live, logical row; the default
+-- apply_deleted_mask = 1 keeps it to rows that are not lightweight-deleted. (`leak-check-forward` deliberately departs
+-- from both — see its own header.) The `parked` CTE is referenced twice (once to pick the live side's candidate
 -- keys, once as the join's left side) and ClickHouse inlines rather than materializes a CTE, so it is evaluated twice —
 -- acceptable because it is bounded by the gap window and its skip indexes, not by the table.
 --
@@ -46,7 +48,8 @@
 --   ${ANALYTICS_DB_DATABASE_NAME}   the analytics database
 --   ${LIVE_TABLE}                   `traces`, or `traces_local` on a wrapped estate (see 000006_post_swap_reconciliation.sql)
 --   ${GAP_START}                    the gap window's lower bound, the same value the sweep used
---   ${SWAP_DONE}                    the instant the swap returned (forward block only)
+--   ${SWAP_DONE}                    the instant the swap returned (`verify-forward` only; `leak-check-forward` needs
+--                                   no timestamp, which is the point of it)
 
 -- >>> BEGIN verify-forward
 -- Forward: parked = traces_pre_cutover_backup (OLD schema — Nullable, nanosecond); live = the successor (sentinels,
@@ -247,3 +250,71 @@ SETTINGS join_use_nulls = 1,
          use_skip_indexes_if_final = 1,
          log_comment = 'traces_local_v2_cutover:reconcile:verify_reverse';
 -- >>> END verify-reverse
+
+-- >>> BEGIN leak-check-forward
+-- FORWARD ONLY, ADVISORY, AND NOT PART OF THE FOUR COUNTS. One number: captured deletes still LIVE on the successor at
+-- a version the frozen backup itself held. Non-zero means deletes leaked; those keys are still in the bridge, so they
+-- can be re-applied by hand.
+--
+-- It reports the residual `forward-deletion-replay`'s ARM 3 cannot prevent — a pre-swap row carrying a client-supplied
+-- future last_updated_at falls outside that arm's staleness scope. See ARM 3's header in
+-- 000006_post_swap_reconciliation.sql for why the predicate stays as it is and why this check cannot live there.
+--
+-- THE VERSION COMPARISON IS WHAT MAKES IT PRECISE, and it needs no timestamp. A leaked row is a COPY of a backup row
+-- (placed by the backfill/delta before the delete fired, or re-inserted by the sweep), so its (key, last_updated_at) is
+-- one the backup holds. A legitimate post-swap re-creation carries a version the backup never held, whatever the client
+-- claimed, because the client's value went into the successor and not into the frozen table.
+--
+-- WHY IT OVERRIDES THE DELETE MASK, given that ClickHouse filters lightweight-deleted rows automatically. That
+-- filtering is the obstacle, not a substitute: the versions to match against belong to rows DELETED in the backup, so
+-- under the default the read returns nothing for exactly the keys that matter and a real leak reports 0 (verified on
+-- 26.3). Hence `apply_deleted_mask = 0` for the statement, with `_row_exists = 0` in the `deleted` CTE keeping only
+-- what the mask had hidden — precisely "live in the old table when the backfill copied it, deleted before the freeze".
+--
+-- The setting is STATEMENT-WIDE and cannot be narrowed to one subquery (attaching it to the CTE alone has no effect,
+-- also verified), so the live side restores mask-honoring by hand with `_row_exists = 1`. Without that the rows the
+-- replay correctly masked read as live, and since their versions are backup versions by construction, the check would
+-- report its own fix as a leak.
+--
+-- The `deleted` CTE deliberately omits FINAL: any version the backup ever held is one a copy could carry, so all of
+-- them are wanted. Only the live side needs FINAL, to compare against the row the successor actually serves.
+WITH
+    bridged AS (
+        SELECT
+            workspace_id,
+            toFixedString(project_id, 36) AS project_id,
+            toFixedString(deleted_id, 36) AS id
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.deletion_events_local
+        WHERE source_table = 'traces'
+          AND event_time >= toDateTime64('${GAP_START}', 6, 'UTC')
+          AND project_id != ''
+          AND length(project_id) = 36
+          AND length(deleted_id) = 36
+    ),
+    deleted AS (
+        SELECT
+            (workspace_id, project_id, id) AS key,
+            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)) AS version
+        FROM ${ANALYTICS_DB_DATABASE_NAME}.traces_pre_cutover_backup
+        WHERE _row_exists = 0
+          AND (workspace_id, project_id, id) IN (SELECT workspace_id, project_id, id FROM bridged)
+    )
+SELECT count() AS leaked_delete_keys
+FROM (
+    SELECT
+        (workspace_id, project_id, id) AS key,
+        toUnixTimestamp64Micro(last_updated_at) AS version
+    FROM ${ANALYTICS_DB_DATABASE_NAME}.${LIVE_TABLE} FINAL
+    -- `_row_exists = 1` restores mask-honoring for THIS side by hand, because apply_deleted_mask = 0 is statement-wide
+    -- and the live table must still be read as the product reads it. Without it every key the replay correctly masked
+    -- would come back as live and be reported as a leak — the check would indict its own fix. FINAL picks the newest
+    -- version first and a lightweight delete rewrites that row's mask without bumping the version, so a properly masked
+    -- key is dropped here and a leaked one (still unmasked on the successor) is kept.
+    WHERE _row_exists = 1
+      AND (workspace_id, project_id, id) IN (SELECT workspace_id, project_id, id FROM bridged)
+) AS live
+WHERE (live.key, live.version) IN (SELECT key, version FROM deleted)
+SETTINGS apply_deleted_mask = 0,
+         use_skip_indexes_if_final = 1,
+         log_comment = 'traces_local_v2_cutover:reconcile:leak_check_forward';
+-- >>> END leak-check-forward

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/delta_replay.sh
@@ -5,6 +5,10 @@
 # Reads db-app-analytics/000002_delta_and_deletion_replay.sql (the single source), substitutes the placeholders and runs
 # it. Run it after backfill.sh, then verify.sh, then exchange_and_wrap.sh.
 #
+# It also prints the two numbers the POST-SWAP reconciliation needs: `RECORD delta_start=`, which is the gap anchor
+# reconcile.sh sweeps from, and the pending-delta size, which is how much this pass left behind for that sweep. Neither
+# is a gate — the gap cannot be closed before the swap, because the source is live — but both make it observable.
+#
 # Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
 # NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
 # --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
@@ -87,8 +91,9 @@ done
 CH_ARGS=()
 [[ -z "$CH_HOST" ]] || CH_ARGS+=(--host "$CH_HOST")
 [[ -z "$CH_PORT" ]] || CH_ARGS+=(--port "$CH_PORT")
-# No --log_comment here: this driver issues one call, and both statements in 000002 set their own log_comment in
-# SETTINGS. A per-query value overrides the session one, so a tag added here would never reach query_log.
+# No --log_comment here: the main call runs 000002, whose two statements set their own log_comment in SETTINGS, and a
+# per-query value overrides the session one — so a tag added here would never reach query_log for the statements that
+# matter. The driver's own anchor and pending-delta queries carry no SETTINGS clause, so those pass the flag per call.
 CH_ARGS+=(--database "$DATABASE" --receive_timeout="$RECEIVE_TIMEOUT")
 [[ -n "$BACKFILL_START" ]] || { echo "ERROR: --backfill-start is required (printed by backfill.sh)" >&2; exit 2; }
 # Strip the ' UTC' marker the flag is required to carry (see its option doc). For these bounds a wrong zone is worse
@@ -213,12 +218,41 @@ if grep -qF '${MAX_INSERT_THREADS}' <<<"$mit_masked"; then
     exit 2
 fi
 # <<< END max_insert_threads rendering
+# delta_start: the instant this pass began READING the source. It is the forward reconciliation's GAP_START — the lower
+# bound of what reconcile.sh sweeps out of the parked backup after the swap — so it is captured BEFORE the delta INSERT
+# and printed with the ' UTC' marker reconcile.sh requires. Captured in UTC because 000006 parses it as UTC; both halves
+# of the pair have to agree, exactly as for backfill_start (see 000001's timezone header).
+#
+# Losing it is not an escalation: widening the gap window is free, because the sweep is mask-honored and idempotent, so
+# backfill_start is always a valid fallback. That is deliberately unlike cutover_start, where estimating destroys or
+# resurrects data.
+DELTA_START="$(clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:delta_replay' \
+    --query "SELECT toString(now64(6, 'UTC'))")"
+echo "RECORD delta_start=$DELTA_START UTC  (the gap anchor for the POST-SWAP sweep; pass it with the marker:"
+echo "       reconcile.sh --gap-start '$DELTA_START UTC')"
+
 # --time makes clickhouse-client print each statement's elapsed seconds to stderr (it prints nothing under a bare
-# --query). The SECOND number is the deletion replay's wall time, which is how the operator sizes the tail: it sits
-# inside the final-delta -> EXCHANGE gap, which is where tail writes are left behind (see the runbook's "The final
-# cutover window"; OPIK-8238). Without this flag there is no way to record it short of digging in query_log.
+# --query). The SECOND number is the deletion replay's wall time, which is one component of the final-delta ->
+# EXCHANGE gap: the window whose writes land only on the old table and are swept back after the swap by reconcile.sh
+# (OPIK-8238). Without this flag there is no way to record it short of digging in query_log.
 echo "Statement wall times (seconds, in order: delta-insert, deletion-replay):"
 clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
 
-echo "Delta + deletion replay complete. RECORD the deletion-replay wall time above (the second value) — it sizes the"
-echo "final-delta -> EXCHANGE gap where tail writes are left behind. Run verify.sh before the EXCHANGE."
+# The PENDING DELTA: rows the source took while this pass was running, i.e. exactly what a swap issued now would strand
+# in the parked backup for reconcile.sh to sweep. Printing it makes convergence something the operator WATCHES rather
+# than guesses; before this, nothing showed the gap at all. It is the same predicate the delta itself uses, so it prunes
+# on the created_at / last_updated_at minmax skip indexes (migration 000088) and costs a gap-sized read, not a table scan.
+#
+# It cannot reach 0 while the source is live — that is the whole reason reconciliation happens AFTER the swap, where the
+# parked table is frozen and convergence is by construction. Watch it to size the gap and to decide when the tail is as
+# tight as it will get, not as a gate.
+PENDING="$(clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:delta_replay:pending' --query \
+    "SELECT count() FROM $DATABASE.traces
+     WHERE created_at >= toDateTime64('$DELTA_START', 6, 'UTC')
+        OR last_updated_at >= toDateTime64('$DELTA_START', 6, 'UTC')")"
+echo "Pending delta since delta_start: $PENDING row(s) written to 'traces' while this pass ran."
+echo "  That is the gap an EXCHANGE issued now would strand in traces_pre_cutover_backup — reconcile.sh sweeps it back"
+echo "  after the swap. Re-run this driver to watch it shrink; it will not reach 0 while the source is live."
+
+echo "Delta + deletion replay complete. RECORD delta_start above (reconcile.sh needs it) and the deletion-replay wall"
+echo "time (the second value), which sizes the gap it will sweep. Run verify.sh before the EXCHANGE."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -229,8 +229,12 @@ if [[ "$WRAP_ONLY" != "1" && "$CONFIRM_RETENTION_PAUSED" != "1" ]]; then
     exit 2
 fi
 
+# --format TabSeparated is explicit, not redundant: clickhouse-client takes a default format from the user's own client
+# config, and a pretty/bordered default would put headers and box-drawing into every scalar read below. Those are parsed
+# as engines, counts and timestamps, so the failure would not be an error — it would be a wrong verdict.
 ch() {
-    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "$1"
+    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' \
+        --format TabSeparated --query "$1"
 }
 
 # Same connection, but rendered for a human — used only for the settle gate's detail blocks, whose interesting columns
@@ -431,6 +435,19 @@ assert_replication_settled() {
         row="$(ch "$sample_sql")" || row=""
         [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
         read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
+        # A short or non-numeric row must not be read as a settled cluster. `read` leaves the unfilled variables EMPTY,
+        # and bash arithmetic evaluates an empty string as 0 — so a header line, a truncated row or a changed block
+        # would sail through every comparison below as "queue drained, no unfinished mutations" and pass the gate
+        # silently, immediately before the EXCHANGE. Seven numeric fields or nothing.
+        for _field in "$queue" "$age" "$tries" "$failures" "$mutations" "$mut_age" "$mut_failed"; do
+            [[ "$_field" =~ ^[0-9]+$ ]] || {
+                echo "ERROR: the settle gate read '$row' from cluster '$cluster', which is not the seven numeric fields the" >&2
+                echo "       settle-sample block returns. Refusing to reach a verdict on it — an unparsed field would be" >&2
+                echo "       treated as 0 and pass the gate. Check the block's markers in $SQL_FILE, and that no client" >&2
+                echo "       config overrides the output format." >&2
+                exit 1
+            }
+        done
 
         if (( queue == 0 && mutations == 0 )); then
             echo "Replication settled across cluster '$cluster': queue drained, no unfinished mutations on the shadow."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -259,16 +259,16 @@ extract() {
 #
 # RETURN, not exit: `render` calls this inside a command substitution, where an exit would end only that subshell and
 # hand the caller partial SQL. Every caller assigns first and adds `|| exit 2`, so a refusal still stops the run.
- # KEEP IN STEP WITH reconcile.sh's require_rendered. The two copies are the SAME validation contract, and a
+# KEEP IN STEP WITH reconcile.sh's require_rendered. The two copies are the SAME validation contract, and a
 # gap between them is SILENT: drop the out-of-order check and a reordered END captures to end of file past every
-# remaining guard, which is then read as a verdict. All four checks, and their ORDER, must
-# stay identical — exactly one BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped,
-# the caller's identity token present, and no surviving ${...} placeholder. The marker grammar they parse is shared
-# too, so a change to one is a change to both.
+# remaining guard, which is then read as a verdict. The checks, and their ORDER, must stay identical — exactly one
+# BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped, the caller's identity token
+# present, and no surviving ${...} placeholder. The marker grammar they parse is shared too, so a change to one is a
+# change to both.
 #
-# The ONLY difference that is allowed is how failure propagates: this copy RETURNS 2, which render() propagates to callers that then exit. The
-# duplication is deliberate: this directory has no sourced helpers, and ch(), extract() and the settle gate are
-# duplicated the same way.
+# The one allowed difference is how a refusal propagates: the return above, versus an exit in reconcile.sh, where the
+# primary call site is at top level. The duplication is deliberate: this directory has no sourced helpers, and ch(),
+# extract() and the settle gate are duplicated the same way.
 require_rendered() {
     local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
     # Both structural checks read the FILE, not the extraction, because the content checks below cannot see a run-on

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -406,6 +406,14 @@ assert_pre_wrap_topology() {
 #     SETTLE_STUCK_NUM_TRIES, or any last_exception means a replica is genuinely lagging, and the gate fails naming the
 #     offending entries per replica. The sample counts only the entry types that mean a replica lacks data, so ordinary
 #     merge activity neither holds the gate open nor trips it (see the settle-sample block for why).
+ # KEEP IN STEP WITH reconcile.sh's assert_replication_settled. The two drivers run the SAME GATE on opposite
+# sides of the swap, and the half that decides a verdict — the three settle-* blocks — is already shared, from
+# 000003_exchange_and_wrap.sql, each driver rendering its own table scope. What is duplicated is the control flow around
+# it, and these parts MUST NOT DRIFT: the stuck thresholds and the poll interval, the requirement that the sample be
+# SEVEN NUMERIC FIELDS ON ONE ROW before any arithmetic reads it, the polling bound (iteration cap AND deadline), and
+# the two verdicts (mutations unconditional, queue on stuck-ness). Only the table scope and the operator messages may
+# legitimately differ, being specific to what each side is about to do. The driver rehearsal exercises BOTH copies, so a
+# behavioural drift fails there rather than waiting for a reviewer.
 assert_replication_settled() {
     local cluster deadline polls poll row
     local sample_sql queue_detail_sql mutation_detail_sql
@@ -434,6 +442,15 @@ assert_replication_settled() {
     for (( poll = 1; poll <= polls; poll++ )); do
         row="$(ch "$sample_sql")" || row=""
         [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
+        # ONE row: `read` consumes only the first line, so a second row would be discarded in silence and the gate
+        # would reach a verdict on a fragment. The settle-sample is a 1x1 CROSS JOIN of two single-row aggregates, so
+        # more than one row means the markers moved onto a different statement, not that the cluster said more.
+        [[ "$row" != *$'\n'* ]] || {
+            echo "ERROR: the settle gate read MORE THAN ONE ROW from cluster '$cluster'. settle-sample returns exactly" >&2
+            echo "       one row; extra rows mean the markers are around a different statement. Refusing to reach a" >&2
+            echo "       verdict on the first line of it." >&2
+            exit 1
+        }
         read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
         # A short or non-numeric row must not be read as a settled cluster. `read` leaves the unfilled variables EMPTY,
         # and bash arithmetic evaluates an empty string as 0 — so a header line, a truncated row or a changed block

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -259,6 +259,16 @@ extract() {
 #
 # RETURN, not exit: `render` calls this inside a command substitution, where an exit would end only that subshell and
 # hand the caller partial SQL. Every caller assigns first and adds `|| exit 2`, so a refusal still stops the run.
+ # KEEP IN STEP WITH reconcile.sh's require_rendered. The two copies are the SAME validation contract, and a
+# gap between them is SILENT: drop the out-of-order check and a reordered END captures to end of file past every
+# remaining guard, which is then read as a verdict. All four checks, and their ORDER, must
+# stay identical — exactly one BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped,
+# the caller's identity token present, and no surviving ${...} placeholder. The marker grammar they parse is shared
+# too, so a change to one is a change to both.
+#
+# The ONLY difference that is allowed is how failure propagates: this copy RETURNS 2, which render() propagates to callers that then exit. The
+# duplication is deliberate: this directory has no sourced helpers, and ch(), extract() and the settle gate are
+# duplicated the same way.
 require_rendered() {
     local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
     # Both structural checks read the FILE, not the extraction, because the content checks below cannot see a run-on
@@ -413,7 +423,7 @@ assert_pre_wrap_topology() {
 # SEVEN NUMERIC FIELDS ON ONE ROW before any arithmetic reads it, the polling bound (iteration cap AND deadline), and
 # the two verdicts (mutations unconditional, queue on stuck-ness). Only the table scope and the operator messages may
 # legitimately differ, being specific to what each side is about to do. The driver rehearsal exercises BOTH copies, so a
-# behavioural drift fails there rather than waiting for a reviewer.
+# behavioural drift fails there rather than going unnoticed.
 assert_replication_settled() {
     local cluster deadline polls poll row
     local sample_sql queue_detail_sql mutation_detail_sql

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/exchange_and_wrap.sh
@@ -112,6 +112,12 @@ SETTLE_POLL_SECONDS=5
 SETTLE_STUCK_AGE_SECONDS=60
 SETTLE_STUCK_NUM_TRIES=3
 
+# The scope 000003's shared settle-* blocks are rendered with. Pre-swap that is both tables for the queue (either could
+# leave a replica short of a part the swap then exposes) and the shadow alone for mutations (the only table this step
+# has mutated). reconcile.sh renders the same blocks with its own post-swap scope.
+SETTLE_QUEUE_TABLES="'traces', 'traces_local_v2'"
+SETTLE_MUTATION_TABLES="'traces_local_v2'"
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -300,6 +306,8 @@ render() {
     local sql
     sql="$(extract "$1" "$2")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${SETTLE_QUEUE_TABLES}'/$SETTLE_QUEUE_TABLES}"
+    sql="${sql//'${SETTLE_MUTATION_TABLES}'/$SETTLE_MUTATION_TABLES}"
     [[ -z "$BACKFILL_START" ]] || sql="${sql//'${BACKFILL_START}'/$BACKFILL_START}"
     require_rendered "$sql" "$1" "$3" "$2" || return 2
     printf '%s' "$sql"
@@ -510,8 +518,9 @@ run_block() {
 # is captured HERE, so a delete bridged in that final gap would be covered by neither the forward replay nor the rollback
 # reverse-replay (which starts at cutover_start) and would leak live across the swap. Re-running the deletion-replay block
 # (from the single-source 000002) right after capturing cutover_start extends forward coverage to it — the arm is
-# idempotent and user-scale (retention off), so it is cheap. Deletions only: the writes in that gap, and those that land
-# in the old table during the cross-node EXCHANGE skew, are the open tail write-gap (OPIK-8238), not this step's job.
+# idempotent and user-scale (retention off), so it is cheap. Deletions only: the writes in that gap, and those that
+# land in the old table during the cross-node EXCHANGE skew, are swept back AFTER the swap by reconcile.sh
+# (OPIK-8238) — not this step's job, and not something an ingestion-side setting can hold.
 run_final_deletion_replay() {
     local sql
     # A silent no-op here is the worst failure in this script: the deletes it masks are covered by neither the forward
@@ -572,6 +581,14 @@ run_block exchange
 EXCHANGE_SECONDS=$SECONDS
 echo "EXCHANGE done: 'traces' is now the partitioned data; the old data is parked as 'traces_pre_cutover_backup'."
 
+# exchange_done: captured AFTER the swap statement returned, which is what makes it usable as the sweep's "do not
+# resurrect" bound. It must NOT be cutover_start: that instant precedes the final deletion replay and the swap itself, so
+# using it would wrongly exclude a trace deleted and then re-created in between — a trace that is legitimately live in
+# the parked backup and has to be swept back. Captured in UTC, because 000006 parses it as UTC.
+EXCHANGE_DONE="$(clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:exchange_and_wrap' --query "SELECT toString(now64(6, 'UTC'))")"
+echo "RECORD exchange_done=$EXCHANGE_DONE UTC  (the sweep's exclusion bound; pass it with the marker:"
+echo "       reconcile.sh --swap-done '$EXCHANGE_DONE UTC')"
+
 if [[ "$WITH_WRAP" == "1" ]]; then
     run_block wrap
     echo "Distributed wrap done: 'traces' fronts 'traces_local' via sipHash64(project_id)."
@@ -581,15 +598,25 @@ else
 fi
 
 echo
-echo "TAIL WRITE-GAP: traces written between the last delta and this swap — and any routed at a not-yet-swapped node"
-echo "during it — are in traces_pre_cutover_backup, NOT in live traces. Nothing in this procedure carries them across"
-echo "yet (OPIK-8238)."
-echo "  Length: ${EXCHANGE_SECONDS}s from this driver's start through the EXCHANGE, of which ${SETTLE_SECONDS}s was the"
-echo "  settle gate. Add the final delta_replay's replay time (its --time output) for the whole gap."
-echo "  Size it now with the post-EXCHANGE compare and --drill-down. TWO of its three key shapes are gap rows: keys"
-echo "  shown backup-only (created in the tail), and keys on BOTH sides whose hashes differ with the newer"
-echo "  last_updated_at in the backup (updated in the tail — sizing by key presence alone misses these). Differing"
-echo "  hashes whose newer version is live are ordinary post-swap writes. The drill-down prints hashes, not versions,"
-echo "  so compare last_updated_at per key. Then accept the gap, or recover from the backup BEFORE finalize.sh retires it."
-echo "Then verify, and keep traces_pre_cutover_backup for the soak. No ingestion-side config was changed, so there is"
-echo "nothing to restore."
+# The banner, not a footnote. Everything written to the old table between the last delta pass and the swap is sitting in
+# traces_pre_cutover_backup and is NOT live. The cutover is not done until reconcile.sh has swept it back and its
+# postcondition has returned 0; finalize.sh refuses to retire the backup without --confirm-gap-reconciled for exactly
+# that reason.
+echo "================================================================================"
+echo "  CUTOVER INCOMPLETE — the gap between the last delta and this swap is NOT live."
+echo "================================================================================"
+echo "Traces written to the old table since the last delta_replay.sh pass — and any routed at a not-yet-swapped node"
+echo "during the EXCHANGE — are in 'traces_pre_cutover_backup' and absent from live 'traces'. Reconcile it NOW, before"
+echo "the soak and before any verify verdict is trusted:"
+echo
+echo "  ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
+echo "      --gap-start '<delta_start printed by the last delta_replay.sh run> UTC' \\"
+echo "      --swap-done '$EXCHANGE_DONE UTC'"
+echo
+echo "  Gap length: ${EXCHANGE_SECONDS}s from this driver's start through the EXCHANGE, of which ${SETTLE_SECONDS}s was"
+echo "  the settle gate. Add the final delta_replay's replay time (its --time output) for the whole gap. Add"
+echo "  --report-only to size the gap in keys before sweeping it."
+echo "If delta_start was not recorded, pass backfill_start instead: widening the gap window is free (the sweep is"
+echo "mask-honored and idempotent), so a lost delta_start is never an escalation."
+echo "Then keep traces_pre_cutover_backup for the soak — finalize.sh refuses to retire it without"
+echo "--confirm-gap-reconciled. No ingestion-side config was changed, so there is nothing to restore."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
@@ -44,6 +44,18 @@
 #                             ClickHouse's own 300. In this driver it also sets distributed_ddl_task_timeout, which is
 #                             the binding limit -- see the CH_ARGS comment below, and ../README.md for the trade-off.
 #   --confirm         actually run the drop/recycle; without it, prints what would happen and exits (dry run).
+#   --confirm-gap-reconciled  REQUIRED on BOTH branches. The parked backup is the ONLY copy of the writes that sit either
+#                     side of the swap, and this script is what destroys it:
+#                       * after a cutover  — traces_pre_cutover_backup holds every trace written to the old table between
+#                         the last delta pass and the EXCHANGE. Nothing holds those writes across the swap, so they are
+#                         NOT live until reconcile.sh has swept them back. Asserts `reconcile.sh` ran and its
+#                         postcondition returned 0 (missing_keys / stale_keys / payload_mismatch_keys all zero).
+#                       * after a rollback — traces_post_rollback_backup holds the post-cutover writes the promote made
+#                         non-live. Asserts the accept-or-recover decision rollback.sh printed has been MADE: either
+#                         `reconcile.sh --confirm-reimport-successor-writes` merged them back, or they are knowingly
+#                         being discarded. Not that a recovery ran — that neither outcome is an accident.
+#                     Neither is checkable from SQL (nothing records that a driver ran), so it is operator-asserted, the
+#                     same shape as --confirm-retention-paused.
 
 set -euo pipefail
 
@@ -52,11 +64,13 @@ CH_HOST=""                # host; empty = clickhouse-client default/env. See --h
 CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 RECEIVE_TIMEOUT=1800      # seconds tolerated between server packets, not total query time. See --receive-timeout.
 CONFIRM=0
+CONFIRM_GAP_RECONCILED=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --confirm) CONFIRM=1; shift ;;
+        --confirm-gap-reconciled) CONFIRM_GAP_RECONCILED=1; shift ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         --receive-timeout) RECEIVE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -143,6 +157,31 @@ else
     exit 0
 fi
 
+# The gap gate, on BOTH branches. Checked once the parked name is known so the diagnostic can name the right hazard, and
+# only on the acting path: a dry run exists to read the estate, and refusing it would tell the operator nothing. Both dry
+# runs name the flag, so its first appearance is never a surprise at the --confirm step.
+if [[ "$CONFIRM" == "1" && "$CONFIRM_GAP_RECONCILED" != "1" ]]; then
+    echo "ERROR: retiring '$BACKUP' requires --confirm-gap-reconciled." >&2
+    if [[ "$BACKUP" == "traces_pre_cutover_backup" ]]; then
+        echo "       This table holds every trace written to the old table between the last delta pass and the EXCHANGE." >&2
+        echo "       Nothing holds those writes across the swap, so they are not live on the successor until reconcile.sh" >&2
+        echo "       has swept them back. Dropping the backup now would destroy the only copy. Run, and confirm it" >&2
+        echo "       reports missing_keys=0 stale_keys=0 payload_mismatch_keys=0:" >&2
+        echo "         ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --report-only \\" >&2
+        echo "             --gap-start '<delta_start> UTC' --swap-done '<exchange_done> UTC'" >&2
+    else
+        echo "       This table holds the post-cutover writes the promote made non-live. Recycling it discards them for" >&2
+        echo "       good. The flag asserts the accept-or-recover decision rollback.sh printed has been MADE — either" >&2
+        echo "       'reconcile.sh --confirm-reimport-successor-writes' merged them back into the restored original, or" >&2
+        echo "       they are knowingly being discarded. To size what would be lost first:" >&2
+        echo "         ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --report-only \\" >&2
+        echo "             --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'" >&2
+    fi
+    echo "       Nothing in the data records that a driver ran, so this cannot be checked from SQL — it is asserted, the" >&2
+    echo "       same shape as --confirm-retention-paused. Re-run with the flag once it is true." >&2
+    exit 2
+fi
+
 LIVE_ROWS="$(max_rows traces)"
 BACKUP_ROWS="$(max_rows "$BACKUP")"
 
@@ -183,7 +222,8 @@ if [[ "$BACKUP" == "traces_post_rollback_backup" ]]; then
     fi
     if [[ "$CONFIRM" != "1" ]]; then
         echo "DRY RUN: would recycle $DATABASE.$BACKUP into an empty $DATABASE.traces_local_v2 (TRUNCATE + RENAME)."
-        echo "         Re-run with --confirm."
+        echo "         Re-run with --confirm --confirm-gap-reconciled — the second flag asserts the accept-or-recover"
+        echo "         decision on the post-cutover writes this table holds has been made (see rollback.sh's output)."
         exit 0
     fi
     ch "TRUNCATE TABLE $BACKUP ON CLUSTER '{cluster}' SETTINGS max_table_size_to_drop = 0"
@@ -191,7 +231,9 @@ if [[ "$BACKUP" == "traces_post_rollback_backup" ]]; then
     echo "Recycled $DATABASE.$BACKUP into an empty $DATABASE.traces_local_v2. The rollback is finalized."
 else
     if [[ "$CONFIRM" != "1" ]]; then
-        echo "DRY RUN: would DROP TABLE $DATABASE.$BACKUP. Re-run with --confirm to drop it."
+        echo "DRY RUN: would DROP TABLE $DATABASE.$BACKUP."
+        echo "         Re-run with --confirm --confirm-gap-reconciled — the second flag asserts reconcile.sh has swept"
+        echo "         the last delta -> EXCHANGE gap out of this table and its postcondition returned 0."
         exit 0
     fi
     ch "DROP TABLE IF EXISTS $BACKUP ON CLUSTER '{cluster}' SYNC SETTINGS max_table_size_to_drop = 0"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
@@ -175,9 +175,24 @@ fi
 if [[ "$BACKUP" == "traces_pre_cutover_backup" ]]; then
     REQUIRED_FLAG="--confirm-gap-reconciled"
     FLAG_GIVEN="$CONFIRM_GAP_RECONCILED"
+    WRONG_FLAG="--confirm-post-cutover-decision"
+    WRONG_GIVEN="$CONFIRM_POST_CUTOVER_DECISION"
 else
     REQUIRED_FLAG="--confirm-post-cutover-decision"
     FLAG_GIVEN="$CONFIRM_POST_CUTOVER_DECISION"
+    WRONG_FLAG="--confirm-gap-reconciled"
+    WRONG_GIVEN="$CONFIRM_GAP_RECONCILED"
+fi
+
+# The other branch's flag is an ERROR, not surplus. Demanding the right one already stops the gate being discharged by
+# the wrong assertion alone, so this catches the other shape: both passed, which means the operator asserted a fact
+# that is not established on this estate — copy-paste rather than a decision. reconcile.sh refuses its own
+# cross-direction flags for the same reason, and the two drivers should not disagree on that.
+if [[ "$WRONG_GIVEN" == "1" ]]; then
+    echo "ERROR: $WRONG_FLAG does not apply to this estate — '$BACKUP' is parked, so the assertion this step needs is" >&2
+    echo "       $REQUIRED_FLAG. The two are not interchangeable and asserting both asserts something that is not" >&2
+    echo "       established here. Drop $WRONG_FLAG and re-run." >&2
+    exit 2
 fi
 
 if [[ "$CONFIRM" == "1" && "$FLAG_GIVEN" != "1" ]]; then

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/finalize.sh
@@ -44,18 +44,24 @@
 #                             ClickHouse's own 300. In this driver it also sets distributed_ddl_task_timeout, which is
 #                             the binding limit -- see the CH_ARGS comment below, and ../README.md for the trade-off.
 #   --confirm         actually run the drop/recycle; without it, prints what would happen and exits (dry run).
-#   --confirm-gap-reconciled  REQUIRED on BOTH branches. The parked backup is the ONLY copy of the writes that sit either
-#                     side of the swap, and this script is what destroys it:
-#                       * after a cutover  — traces_pre_cutover_backup holds every trace written to the old table between
-#                         the last delta pass and the EXCHANGE. Nothing holds those writes across the swap, so they are
-#                         NOT live until reconcile.sh has swept them back. Asserts `reconcile.sh` ran and its
-#                         postcondition returned 0 (missing_keys / stale_keys / payload_mismatch_keys all zero).
-#                       * after a rollback — traces_post_rollback_backup holds the post-cutover writes the promote made
-#                         non-live. Asserts the accept-or-recover decision rollback.sh printed has been MADE: either
-#                         `reconcile.sh --confirm-reimport-successor-writes` merged them back, or they are knowingly
-#                         being discarded. Not that a recovery ran — that neither outcome is an accident.
-#                     Neither is checkable from SQL (nothing records that a driver ran), so it is operator-asserted, the
-#                     same shape as --confirm-retention-paused.
+#                   ONE OF THE TWO FLAGS BELOW IS REQUIRED with --confirm, and WHICH ONE depends on the branch. The
+#                   parked backup is the ONLY copy of the writes that sit either side of the swap and this script is what
+#                   destroys it, so the flag has to state the fact the operator is actually asserting. They are separate
+#                   flags rather than one because the two branches assert DIFFERENT things, and a gate in front of an
+#                   irreversible drop should not have a name that is true on one branch and false on the other. Neither
+#                   is checkable from SQL — nothing in the data records that a driver ran — so both are operator-asserted,
+#                   the same shape as --confirm-retention-paused. Both dry runs name the one this estate needs.
+#   --confirm-gap-reconciled
+#                     AFTER A CUTOVER, for the DROP of traces_pre_cutover_backup, which holds every trace written to the
+#                     old table between the last delta pass and the EXCHANGE. Nothing holds those writes across the swap,
+#                     so they are NOT live until reconcile.sh has swept them back. Asserts `reconcile.sh` ran and its
+#                     postcondition returned 0 (missing_keys / stale_keys / payload_mismatch_keys all zero) — on EVERY
+#                     shard, since every statement it issues is shard-local while this DROP is ON CLUSTER.
+#   --confirm-post-cutover-decision
+#                     AFTER A ROLLBACK, for the RECYCLE of traces_post_rollback_backup, which holds the post-cutover
+#                     writes the promote made non-live. Asserts the accept-or-recover decision rollback.sh printed has
+#                     been MADE: either `reconcile.sh --confirm-reimport-successor-writes` merged them back, or they are
+#                     knowingly being discarded. NOT that a recovery ran — that neither outcome is an accident.
 
 set -euo pipefail
 
@@ -64,13 +70,15 @@ CH_HOST=""                # host; empty = clickhouse-client default/env. See --h
 CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
 RECEIVE_TIMEOUT=1800      # seconds tolerated between server packets, not total query time. See --receive-timeout.
 CONFIRM=0
-CONFIRM_GAP_RECONCILED=0
+CONFIRM_GAP_RECONCILED=0        # post-cutover branch. See --confirm-gap-reconciled.
+CONFIRM_POST_CUTOVER_DECISION=0 # post-rollback branch. See --confirm-post-cutover-decision.
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
         --confirm) CONFIRM=1; shift ;;
         --confirm-gap-reconciled) CONFIRM_GAP_RECONCILED=1; shift ;;
+        --confirm-post-cutover-decision) CONFIRM_POST_CUTOVER_DECISION=1; shift ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
         --receive-timeout) RECEIVE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -157,16 +165,29 @@ else
     exit 0
 fi
 
-# The gap gate, on BOTH branches. Checked once the parked name is known so the diagnostic can name the right hazard, and
-# only on the acting path: a dry run exists to read the estate, and refusing it would tell the operator nothing. Both dry
-# runs name the flag, so its first appearance is never a surprise at the --confirm step.
-if [[ "$CONFIRM" == "1" && "$CONFIRM_GAP_RECONCILED" != "1" ]]; then
-    echo "ERROR: retiring '$BACKUP' requires --confirm-gap-reconciled." >&2
+# The parked-writes gate. Which flag is required depends on the branch, because the two branches assert different facts
+# — see their option docs. Checked once the parked name is known, so the diagnostic can name the right flag and the right
+# hazard, and only on the acting path: a dry run exists to read the estate, and refusing it would tell the operator
+# nothing. Both dry runs name the flag this estate needs, so its first appearance is never a surprise at --confirm.
+#
+# Passing the OTHER branch's flag is refused rather than accepted: each one asserts a fact that is not established on
+# this branch, so honoring it would let the operator discharge the gate with the wrong assertion.
+if [[ "$BACKUP" == "traces_pre_cutover_backup" ]]; then
+    REQUIRED_FLAG="--confirm-gap-reconciled"
+    FLAG_GIVEN="$CONFIRM_GAP_RECONCILED"
+else
+    REQUIRED_FLAG="--confirm-post-cutover-decision"
+    FLAG_GIVEN="$CONFIRM_POST_CUTOVER_DECISION"
+fi
+
+if [[ "$CONFIRM" == "1" && "$FLAG_GIVEN" != "1" ]]; then
+    echo "ERROR: retiring '$BACKUP' requires $REQUIRED_FLAG." >&2
     if [[ "$BACKUP" == "traces_pre_cutover_backup" ]]; then
         echo "       This table holds every trace written to the old table between the last delta pass and the EXCHANGE." >&2
         echo "       Nothing holds those writes across the swap, so they are not live on the successor until reconcile.sh" >&2
-        echo "       has swept them back. Dropping the backup now would destroy the only copy. Run, and confirm it" >&2
-        echo "       reports missing_keys=0 stale_keys=0 payload_mismatch_keys=0:" >&2
+        echo "       has swept them back. Dropping the backup now would destroy the only copy — and this DROP is" >&2
+        echo "       ON CLUSTER, so it destroys every shard's. Run, and confirm it reports" >&2
+        echo "       missing_keys=0 stale_keys=0 payload_mismatch_keys=0 on EVERY shard:" >&2
         echo "         ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --report-only \\" >&2
         echo "             --gap-start '<delta_start> UTC' --swap-done '<exchange_done> UTC'" >&2
     else
@@ -178,7 +199,7 @@ if [[ "$CONFIRM" == "1" && "$CONFIRM_GAP_RECONCILED" != "1" ]]; then
         echo "             --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'" >&2
     fi
     echo "       Nothing in the data records that a driver ran, so this cannot be checked from SQL — it is asserted, the" >&2
-    echo "       same shape as --confirm-retention-paused. Re-run with the flag once it is true." >&2
+    echo "       same shape as --confirm-retention-paused. Re-run with $REQUIRED_FLAG once it is true." >&2
     exit 2
 fi
 
@@ -222,8 +243,9 @@ if [[ "$BACKUP" == "traces_post_rollback_backup" ]]; then
     fi
     if [[ "$CONFIRM" != "1" ]]; then
         echo "DRY RUN: would recycle $DATABASE.$BACKUP into an empty $DATABASE.traces_local_v2 (TRUNCATE + RENAME)."
-        echo "         Re-run with --confirm --confirm-gap-reconciled — the second flag asserts the accept-or-recover"
-        echo "         decision on the post-cutover writes this table holds has been made (see rollback.sh's output)."
+        echo "         Re-run with --confirm --confirm-post-cutover-decision — the second flag asserts the"
+        echo "         accept-or-recover decision on the post-cutover writes this table holds has been MADE"
+        echo "         (see rollback.sh's output); it does not assert that a recovery ran."
         exit 0
     fi
     ch "TRUNCATE TABLE $BACKUP ON CLUSTER '{cluster}' SETTINGS max_table_size_to_drop = 0"
@@ -233,7 +255,7 @@ else
     if [[ "$CONFIRM" != "1" ]]; then
         echo "DRY RUN: would DROP TABLE $DATABASE.$BACKUP."
         echo "         Re-run with --confirm --confirm-gap-reconciled — the second flag asserts reconcile.sh has swept"
-        echo "         the last delta -> EXCHANGE gap out of this table and its postcondition returned 0."
+        echo "         the last delta -> EXCHANGE gap out of this table and its postcondition returned 0 on every shard."
         exit 0
     fi
     ch "DROP TABLE IF EXISTS $BACKUP ON CLUSTER '{cluster}' SYNC SETTINGS max_table_size_to_drop = 0"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -584,13 +584,25 @@ extract() {
 # is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and the
 # step prints its success line having done nothing. Same guard, same reasoning, as exchange_and_wrap.sh's.
 require_rendered() {
-    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends
+    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
     # Exactly one pair, checked on the FILE rather than the extraction: the awk stops at the first END and otherwise runs
     # to EOF, so a missing or renamed END sweeps every later block into this one. The content checks cannot see that.
     begins="$(grep -cxF -e "-- >>> BEGIN $what" "$file" || true)"
     ends="$(grep -cxF -e "-- >>> END $what" "$file" || true)"
     if (( begins != 1 || ends != 1 )); then
         echo "ERROR: $file holds $begins '-- >>> BEGIN $what' and $ends '-- >>> END $what'; expected one of each." >&2
+        exit 2
+    fi
+    # Second: the END must sit AFTER its BEGIN, the same check exchange_and_wrap.sh's copy makes. Counting alone misses
+    # a reordered END, which still counts 1 and 1: extract's awk clears its flag only on a line equal to END, so with
+    # the END behind the BEGIN it captures to end of file and sweeps every later block in. That run-on is non-empty,
+    # mentions the identity token and holds no placeholder, so all the checks below pass on several statements — and
+    # the multi-result-set output it produces is what read_postcondition would otherwise read a verdict from.
+    read -r begin_line end_line <<<"$(awk -v b="-- >>> BEGIN $what" -v e="-- >>> END $what" \
+        '$0 == b {bl = NR} $0 == e {el = NR} END {print bl, el}' "$file")"
+    if (( end_line <= begin_line )); then
+        echo "ERROR: $file has the '$what' markers out of order (BEGIN at line $begin_line, END at line $end_line)," >&2
+        echo "       so the block would capture to end of file and sweep every later block into it. Refusing to run it." >&2
         exit 2
     fi
     masked="$(sed 's/--.*$//' <<<"$sql")"
@@ -677,7 +689,7 @@ verify_reverse_replay() {
     sql="$(cat "$REVERSE_VERIFY_SQL")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
     sql="${sql//'${CUTOVER_START}'/$CUTOVER_START}"
-    resurrected="$(clickhouse-client "${CH_ARGS[@]}" --query "$sql")"
+    resurrected="$(clickhouse-client "${CH_ARGS[@]}" --format TabSeparated --query "$sql")"
     if [[ "$resurrected" == "0" ]]; then
         echo "  Reverse-replay postcondition OK: no id bridged since cutover_start is live on the restored '$LIVE_TABLE'."
         return 0
@@ -714,7 +726,7 @@ validate_block() {
 # The four counts, as one tab-separated line, so the driver gates on them instead of leaving numbers on a screen.
 # Called inside a command substitution, so it deliberately does NO validation of its own — see validate_blocks.
 reconciliation_counts() {
-    clickhouse-client "${CH_ARGS[@]}" --multiquery \
+    clickhouse-client "${CH_ARGS[@]}" --format TabSeparated --multiquery \
         --query "$(render "$(extract "$VERIFY_SQL" "verify-$DIRECTION")")"
 }
 
@@ -724,6 +736,17 @@ MISSING=""; STALE=""; PAYLOAD=""; NEWER=""
 read_postcondition() {
     local out
     if ! out="$(reconciliation_counts)"; then out=""; fi
+    # ONE row, for the same reason the settle gate insists on it: `read` takes only the first line, so a second result
+    # set is discarded in silence and the verdict is reached on a fragment — and every field on line 1 can be a
+    # legitimate number, so the regex below cannot catch it. This is the read finalize.sh's --confirm-gap-reconciled
+    # rests on, and a false clean here ends with the parked backup dropped ON CLUSTER. verify-forward / verify-reverse
+    # are single global aggregates with no GROUP BY, so more than one row means the markers are around a different
+    # statement — the state require_rendered's out-of-order check catches at the file level.
+    if [[ "$out" == *$'\n'* ]]; then
+        echo "ERROR: the reconciliation postcondition read MORE THAN ONE ROW. verify-$DIRECTION returns exactly one;" >&2
+        echo "       extra rows mean the markers are around a different statement in $VERIFY_SQL." >&2
+        return 1
+    fi
     read -r MISSING STALE PAYLOAD NEWER <<< "$out"
     [[ "$MISSING" =~ ^[0-9]+$ && "$STALE" =~ ^[0-9]+$ && "$PAYLOAD" =~ ^[0-9]+$ && "$NEWER" =~ ^[0-9]+$ ]]
 }
@@ -856,6 +879,14 @@ print_leak_check
 if gate_is_clean; then
     echo "Nothing to reconcile: every key live in '$PARKED_TABLE' inside the gap window is present on '$LIVE_TABLE' at the"
     echo "same version or newer. No statement issued."
+    # Same qualifier as the RECONCILED verdict below, and for the same reason: this is a success outcome an operator
+    # acts on with finalize.sh, whose DROP is ON CLUSTER. A shard-local "nothing to do" must not read as an estate-wide
+    # one either. (The --report-only exit below needs no qualifier: it exits non-zero saying the estate is NOT
+    # reconciled, and assert_shard_scope has already named the scope on stderr.)
+    [[ -z "$SHARD_SCOPE_NOTE" ]] || {
+        echo "SCOPE: $SHARD_SCOPE_NOTE. This covers that shard ONLY — every other shard needs its own clean gate"
+        echo "       before finalize.sh, which drops the parked backup on all of them."
+    }
     exit 0
 fi
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -101,6 +101,18 @@
 #                                 the connected shard alone, and will repeat it on every shard before finalize.sh.
 #                             It does NOT unlock the REVERSE direction on more than one shard: the replay there is
 #                             shard-local while its postcondition reads every shard, so no single run can satisfy it.
+#   --confirm-retention-paused
+#                             REQUIRED unless --report-only, in BOTH directions, the same assertion
+#                             exchange_and_wrap.sh and rollback.sh already take. Retention deletes bypass the deletion
+#                             bridge, so the sweep cannot know about them: a retention delete that fires AFTER the
+#                             parked table froze leaves its row masked on the live table, still LIVE in the frozen
+#                             backup and absent from the bridge — so the sweep re-inserts it and the deletion replay,
+#                             which only re-applies BRIDGED keys, does not mask it again. The trace comes back.
+#                             It is not confined to old data, which is the tempting reason to dismiss it: retention
+#                             selects by `id` range (UUIDv7), while the gap window matches created_at OR
+#                             last_updated_at — and the merge path stamps a fresh last_updated_at while preserving
+#                             created_at, so an OLD trace updated during the gap window sits inside the sweep's window
+#                             and inside retention's id range at once.
 #   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120, capped at
 #                             3600; 0 takes a single sample. Unlike the pre-swap gate this one sits AFTER the swap, so
 #                             its wait costs no cutover tail — but every second is a second the gap-window traces are
@@ -139,6 +151,7 @@ MAX_PARTITIONS_PER_INSERT_BLOCK=2000
 REPORT_ONLY=0
 CONFIRM_REIMPORT=0
 CONFIRM_SINGLE_SHARD=0
+CONFIRM_RETENTION_PAUSED=0
 FORCE=0
 SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
 SETTLE_TIMEOUT_MAX=3600   # its accepted ceiling; the validation below explains why the check is lexical.
@@ -173,6 +186,7 @@ while [[ $# -gt 0 ]]; do
         --report-only) REPORT_ONLY=1; shift ;;
         --confirm-reimport-successor-writes) CONFIRM_REIMPORT=1; shift ;;
         --confirm-single-shard) CONFIRM_SINGLE_SHARD=1; shift ;;
+        --confirm-retention-paused) CONFIRM_RETENTION_PAUSED=1; shift ;;
         --force) FORCE=1; shift ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -384,6 +398,14 @@ detect_direction() {
 #     healthy-cluster property. It passes the moment the queue drains; failing that, an entry aged past
 #     SETTLE_STUCK_AGE_SECONDS, more retries than SETTLE_STUCK_NUM_TRIES, or any last_exception is a genuinely lagging
 #     replica and fails the gate naming the offending entries.
+ # KEEP IN STEP WITH exchange_and_wrap.sh's assert_replication_settled. The two drivers run the SAME GATE on opposite
+# sides of the swap, and the half that decides a verdict — the three settle-* blocks — is already shared, from
+# 000003_exchange_and_wrap.sql, each driver rendering its own table scope. What is duplicated is the control flow around
+# it, and these parts MUST NOT DRIFT: the stuck thresholds and the poll interval, the requirement that the sample be
+# SEVEN NUMERIC FIELDS ON ONE ROW before any arithmetic reads it, the polling bound (iteration cap AND deadline), and
+# the two verdicts (mutations unconditional, queue on stuck-ness). Only the table scope and the operator messages may
+# legitimately differ, being specific to what each side is about to do. The driver rehearsal exercises BOTH copies, so a
+# behavioural drift fails there rather than waiting for a reviewer.
 assert_replication_settled() {
     local cluster deadline polls poll row
     local sample_sql queue_detail_sql mutation_detail_sql
@@ -410,6 +432,15 @@ assert_replication_settled() {
     for (( poll = 1; poll <= polls; poll++ )); do
         row="$(ch "$sample_sql")" || row=""
         [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
+        # ONE row: `read` consumes only the first line, so a second row would be discarded in silence and the gate
+        # would reach a verdict on a fragment. The settle-sample is a 1x1 CROSS JOIN of two single-row aggregates, so
+        # more than one row means the markers moved onto a different statement, not that the cluster said more.
+        [[ "$row" != *$'\n'* ]] || {
+            echo "ERROR: the settle gate read MORE THAN ONE ROW from cluster '$cluster'. settle-sample returns exactly" >&2
+            echo "       one row; extra rows mean the markers are around a different statement. Refusing to reach a" >&2
+            echo "       verdict on the first line of it." >&2
+            exit 1
+        }
         read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
         # A short or non-numeric row must not be read as a settled cluster. `read` leaves the unfilled variables EMPTY,
         # and bash arithmetic evaluates an empty string as 0 — so a header line, a truncated row or a changed block
@@ -775,6 +806,20 @@ else
         echo "       so this state is not one a promote produces. Resolve by hand." >&2
         exit 1
     }
+fi
+
+# Retention is disabled in every deployment and the runbook requires it stay paused for the window — but the window it
+# names ends at the EXCHANGE, and this driver runs after it, which is exactly where a retention delete would be undone.
+# Asserted here for the same reason exchange_and_wrap.sh and rollback.sh assert it, and skipped for --report-only, which
+# issues no statement.
+if [[ "$REPORT_ONLY" != "1" && "$CONFIRM_RETENTION_PAUSED" != "1" ]]; then
+    echo "ERROR: reconciliation requires --confirm-retention-paused. Retention deletes bypass the deletion bridge, so" >&2
+    echo "       this driver cannot see them: one that fired after '$PARKED_TABLE' froze leaves its trace masked on" >&2
+    echo "       '$LIVE_TABLE', still live in the frozen backup and absent from the bridge — the sweep re-inserts it and" >&2
+    echo "       the replay, which only re-applies bridged keys, leaves it live. The delete is undone." >&2
+    echo "       Confirm RETENTION_ENABLED=false on every backend for the whole window INCLUDING this step, then re-run." >&2
+    echo "       Use --report-only to read the counts without issuing any statement; it does not need this flag." >&2
+    exit 2
 fi
 
 assert_shard_scope

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -70,15 +70,18 @@
 #   --swap-done TS            what NOT to RESURRECT: the instant the swap statement RETURNED — `RECORD exchange_done=`
 #                             (forward) or `RECORD promote_done=` (reverse). Required. Bridged deletes at or after it are
 #                             excluded from the sweep, so a gap-window trace deleted after the swap is not brought back.
-#                             UNLIKE --gap-start THIS IS NOT FREE TO GUESS, and the two directions of error are not
-#                             symmetric — WHEN IN DOUBT, GUESS EARLY:
-#                               * too EARLY excludes too much, so a legitimately live key stays missing and the
-#                                 postcondition FAILS LOUDLY. Widen and re-run.
+#                             UNLIKE --gap-start THIS IS NOT FREE TO GUESS. PASS THE RECORDED VALUE. The two directions
+#                             of error are not symmetric, but NEITHER is fully self-reporting:
+#                               * too EARLY excludes too much. Usually that leaves a live key missing and the
+#                                 postcondition fails, so you widen and re-run. It is SILENT for one shape: a key
+#                                 deleted and then RE-CREATED between the value passed and the real swap. The gate
+#                                 applies the same exclusion as the sweep, so both drop that key and the re-created
+#                                 trace stays missing under a clean gate.
 #                               * too LATE excludes too little: a delete that fired AFTER the swap is bridged below the
 #                                 bound, the key is live in the frozen backup, the sweep re-inserts it and the replay's
 #                                 resurrection guard spares it. The delete is undone, and nothing reports it.
 #                             If the printed value was lost, use `cutover_start` — earlier than the swap by
-#                             construction, i.e. on the side that fails loudly. Do NOT round it up "to be safe": the
+#                             construction, i.e. on the side that usually reports. Do NOT round it up "to be safe": the
 #                             recorded value already trails the swap (../README.md, "The final cutover window"), so
 #                             every second added is a second of silent resurrection window.
 #   --slack-seconds N         widen --gap-start DOWNWARD by N seconds (default 300) to absorb cross-replica clock skew on
@@ -999,8 +1002,8 @@ echo "RECONCILIATION FAILED: the gate is still non-zero after $MAX_PASSES pass(e
 echo "  missing_keys=$MISSING stale_keys=$STALE payload_mismatch_keys=$PAYLOAD" >&2
 echo "This is NOT convergence stalling on write volume: the parked table is frozen, so repeated passes cannot keep" >&2
 echo "finding new work unless something else is wrong. Investigate before re-running:" >&2
-echo "  * missing_keys — the sweep did not land those rows. Check the run's errors, and check that --swap-done is not" >&2
-echo "    LATER than the actual swap (a late value under-excludes; an early one over-excludes and shows up exactly here)." >&2
+echo "  * missing_keys — the sweep did not land those rows. Check the run's errors, and check --swap-done against the" >&2
+echo "    RECORDED value (a late value under-excludes; an early one over-excludes and usually surfaces here)." >&2
 echo "  * stale_keys / payload_mismatch_keys — the live row disagrees with the frozen one at the same or an older" >&2
 echo "    version, which a sweep cannot fix by re-inserting. Triage with:" >&2
 # verify.sh's --old-table is always the OLD-SCHEMA side (Nullable, nanosecond), which is the parked backup forward and

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -58,8 +58,10 @@
 #                             than total query time. Trade-off and shared rationale: ../README.md.
 #   --gap-start TS            what to COPY: the lower bound of the gap window, matched on created_at OR last_updated_at.
 #                             FORWARD it is REQUIRED and is the start of the last delta pass — the `RECORD delta_start=`
-#                             line delta_replay.sh prints. REVERSE it defaults to --cutover-start and rarely needs
-#                             passing. Must carry an explicit ' UTC' marker, as the drivers print it.
+#                             line delta_replay.sh prints. REVERSE it defaults to --cutover-start, rarely needs passing,
+#                             and may only WIDEN — a later value is REFUSED, because narrowing this bound hides
+#                             exactly what it skips.
+#                             Must carry an explicit ' UTC' marker, as the drivers print it.
 #                             WIDENING IT IS FREE: the sweep is mask-honored and idempotent, so `backfill_start` is
 #                             always a valid fallback and a lost delta_start never forces an escalation.
 #   --cutover-start TS        REVERSE only, and required there: the `RECORD cutover_start=` value exchange_and_wrap.sh
@@ -849,8 +851,22 @@ else
         echo "       Estimating it loses data in either direction — if it was lost, stop and escalate (see the runbook)." >&2
         exit 2
     }
-    # cutover_start is the reverse gap anchor by definition; --gap-start only ever widens it.
+    # cutover_start is the reverse gap anchor by definition, and --gap-start may only WIDEN it. Narrowing is the
+    # silent-later-anchor hazard the runbook already names for the backfill anchor, in its sharpest form: here the
+    # sweep and its postcondition share the bound, so a later value shrinks the work and the check together and the
+    # gate cannot see what it skipped. Only the replay keeps its own bound, so it still masks deletes for keys the
+    # sweep never re-imported — a clean gate over a restored original that is short of writes, which finalize.sh then
+    # recycles the only copy of. Lexical comparison is chronological because both anchors passed the fixed-width shape
+    # check above, as verify.sh's --window-from/--window-to ordering check relies on.
     [[ -n "$GAP_START" ]] || GAP_START="$CUTOVER_START"
+    [[ ! "$GAP_START" > "$CUTOVER_START" ]] || {
+        echo "ERROR: --gap-start '$GAP_START' is LATER than --cutover-start '$CUTOVER_START'. In the reverse direction" >&2
+        echo "       cutover_start IS the anchor — everything the promote made non-live was written at or after it —" >&2
+        echo "       so a later value narrows the sweep and its postcondition together, and the gate would report clean" >&2
+        echo "       over writes it never re-imported. Widening is free: pass an EARLIER value, or omit the flag to use" >&2
+        echo "       cutover_start." >&2
+        exit 2
+    }
     if [[ "$REPORT_ONLY" != "1" && "$CONFIRM_REIMPORT" != "1" ]]; then
         echo "ERROR: the reverse direction requires --confirm-reimport-successor-writes. The sweep re-imports exactly the" >&2
         echo "       post-cutover writes --accept-post-cutover-write-loss acknowledged discarding, so this asserts you now" >&2

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -3,10 +3,10 @@
 # POST-SWAP reconciliation driver for the traces cutover (runbook: ../README.md).
 #
 # The cutover loses writes across the swap (OPIK-8238). The last write-copying statement is the delta INSERT in step 2;
-# between it and the EXCHANGE completing sit a deletion replay, the operator's go/no-go gap, the topology guards, the
-# cluster-wide settle gate and a second full deletion replay. Nothing holds writes across that window — the procedure
-# takes no ingestion-path hold (OPIK-8239) — so every trace written to the old `traces` in it is orphaned when that
-# table is parked.
+# between it and the EXCHANGE completing, the procedure interposes a deletion replay, the operator's go/no-go gap, the
+# topology guards, the cluster-wide settle gate and a second full deletion replay. Nothing holds writes across that
+# window — the procedure takes no ingestion-path hold (OPIK-8239) — so every trace written to the old `traces` in it is
+# orphaned when that table is parked.
 #
 # Reconciling BEFORE the swap cannot converge — the source is live, so every pass opens a new gap. After the swap the
 # parked table is frozen, so this driver's sweep converges by construction, and its postcondition is a gate rather than a
@@ -604,17 +604,19 @@ extract() {
 
 # Refuse rendered SQL that is not what the caller asked for. A marker renamed, moved, indented or split yields text that
 # is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and the
-# step prints its success line having done nothing. Same guard, same reasoning, as exchange_and_wrap.sh's.
- # KEEP IN STEP WITH exchange_and_wrap.sh's require_rendered. The two copies are the SAME validation contract, and a
-# gap between them is SILENT: drop the out-of-order check and a reordered END captures to end of file past every
-# remaining guard, which is then read as a verdict. All four checks, and their ORDER, must
-# stay identical — exactly one BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped,
-# the caller's identity token present, and no surviving ${...} placeholder. The marker grammar they parse is shared
-# too, so a change to one is a change to both.
+# step prints its success line having done nothing.
 #
-# The ONLY difference that is allowed is how failure propagates: this copy EXITS, because its callers run it inside command substitutions where a return would be swallowed. The
-# duplication is deliberate: this directory has no sourced helpers, and ch(), extract() and the settle gate are
-# duplicated the same way.
+# KEEP IN STEP WITH exchange_and_wrap.sh's require_rendered. The two copies are the SAME validation contract, and a
+# gap between them is SILENT: drop the out-of-order check and a reordered END captures to end of file past every
+# remaining guard, which is then read as a verdict. The checks, and their ORDER, must stay identical — exactly one
+# BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped, the caller's identity token
+# present, and no surviving ${...} placeholder. The marker grammar they parse is shared too, so a change to one is a
+# change to both.
+#
+# The one allowed difference is how a refusal propagates: this copy EXITS, which is decisive at validate_blocks'
+# top-level call — the reason that pre-validation exists, since an exit from a command substitution ends only the
+# subshell. The substitution call sites pair it with `|| exit 2`. The duplication is deliberate: this directory has no
+# sourced helpers, and ch(), extract() and the settle gate are duplicated the same way.
 require_rendered() {
     local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
     # Exactly one pair, checked on the FILE rather than the extraction: the awk stops at the first END and otherwise runs
@@ -856,8 +858,9 @@ else
     # sweep and its postcondition share the bound, so a later value shrinks the work and the check together and the
     # gate cannot see what it skipped. Only the replay keeps its own bound, so it still masks deletes for keys the
     # sweep never re-imported — a clean gate over a restored original that is short of writes, which finalize.sh then
-    # recycles the only copy of. Lexical comparison is chronological because both anchors passed the fixed-width shape
-    # check above, as verify.sh's --window-from/--window-to ordering check relies on.
+    # recycles the only copy of. Lexical comparison is chronological because cutover_start is always a now64(6, 'UTC')
+    # capture, so it carries exactly six fractional digits: the shape check above permits a variable-length fraction,
+    # and two differing precisions naming the same instant would not compare correctly (verify.sh normalizes for that).
     [[ -n "$GAP_START" ]] || GAP_START="$CUTOVER_START"
     [[ ! "$GAP_START" > "$CUTOVER_START" ]] || {
         echo "ERROR: --gap-start '$GAP_START' is LATER than --cutover-start '$CUTOVER_START'. In the reverse direction" >&2

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -318,23 +318,32 @@ resolve_live_table() {
 # Direction from the live topology, the same signals finalize.sh classifies on: which backup is parked, plus the
 # end_time nullability that says which schema each table carries. Presence of a name is convention; the schema is proof.
 detect_direction() {
-    local pre_cutover post_rollback_end_time live_end_time
-    pre_cutover="$(traces_engine traces_pre_cutover_backup)"
-    post_rollback_end_time="$(traces_endtime_type traces_post_rollback_backup)"
-    live_end_time="$(traces_endtime_type "$LIVE_TABLE")"
+    local pre_cutover_engine post_rollback_end_time_type live_end_time_type
+    pre_cutover_engine="$(traces_engine traces_pre_cutover_backup)"
+    post_rollback_end_time_type="$(traces_endtime_type traces_post_rollback_backup)"
+    live_end_time_type="$(traces_endtime_type "$LIVE_TABLE")"
 
-    if [[ -n "$pre_cutover" && -n "$post_rollback_end_time" ]]; then
+    if [[ -n "$pre_cutover_engine" && -n "$post_rollback_end_time_type" ]]; then
         echo "ERROR: both 'traces_pre_cutover_backup' and 'traces_post_rollback_backup' exist, so the direction is" >&2
         echo "       ambiguous — a clean estate never holds both. Refusing rather than guessing which way to sweep;" >&2
         echo "       resolve the estate by hand (finalize.sh refuses the same state, for the same reason)." >&2
         exit 1
     fi
 
-    if [[ -n "$pre_cutover" ]]; then
+    if [[ -n "$pre_cutover_engine" ]]; then
         DIRECTION="forward"
         PARKED_TABLE="traces_pre_cutover_backup"
         MUTATING_BLOCKS=(forward-sweep forward-deletion-replay)
-        [[ "$live_end_time" != Nullable* ]] || {
+        # Require the column to EXIST before testing its shape, the same way rollback.sh's --unwrap-only check does
+        # and for the same reason: traces_endtime_type returns an empty string for a missing column, and "" is not
+        # Nullable*, so a bare non-Nullable test waves through a table that has no end_time at all. Only this branch
+        # needs it — the reverse branch below tests `== Nullable*`, which an empty string already fails.
+        [[ -n "$live_end_time_type" ]] || {
+            echo "ERROR: the live '$LIVE_TABLE' has no 'end_time' column, so it is not the traces table this driver can" >&2
+            echo "       reconcile — the sweep and the replay would target the wrong object. Resolve the estate by hand." >&2
+            exit 1
+        }
+        [[ "$live_end_time_type" != Nullable* ]] || {
             echo "ERROR: 'traces_pre_cutover_backup' is parked, but the live '$LIVE_TABLE' still has a Nullable end_time —" >&2
             echo "       i.e. it is the ORIGINAL schema, so the EXCHANGE has not run (or has been rolled back) while a" >&2
             echo "       pre-cutover backup name survives. There is no forward gap to sweep from that state. Resolve the" >&2
@@ -344,8 +353,8 @@ detect_direction() {
         return 0
     fi
 
-    if [[ -n "$post_rollback_end_time" ]]; then
-        [[ "$post_rollback_end_time" != Nullable* ]] || {
+    if [[ -n "$post_rollback_end_time_type" ]]; then
+        [[ "$post_rollback_end_time_type" != Nullable* ]] || {
             echo "ERROR: 'traces_post_rollback_backup' exists but carries the ORIGINAL schema (Nullable end_time), so it is" >&2
             echo "       not the successor a rollback parks there. The name is convention; the schema is the proof, and it" >&2
             echo "       disagrees. Refusing — resolve by hand." >&2
@@ -354,9 +363,9 @@ detect_direction() {
         DIRECTION="reverse"
         PARKED_TABLE="traces_post_rollback_backup"
         MUTATING_BLOCKS=(reverse-sweep)
-        [[ "$live_end_time" == Nullable* ]] || {
+        [[ "$live_end_time_type" == Nullable* ]] || {
             echo "ERROR: the successor is parked as 'traces_post_rollback_backup', but the live '$LIVE_TABLE' is not the" >&2
-            echo "       restored ORIGINAL (its end_time is '${live_end_time:-<absent>}', not Nullable). A promote leaves" >&2
+            echo "       restored ORIGINAL (its end_time is '${live_end_time_type:-<absent>}', not Nullable). A promote leaves" >&2
             echo "       the original live; this estate does not match, so the reverse sweep has no valid target." >&2
             exit 1
         }
@@ -366,7 +375,7 @@ detect_direction() {
     # Neither parked name exists. Before refusing, name the one state that is recoverable in one command: the forward
     # EXCHANGE committed but its post-swap RENAME did not, so the parked original is still sitting under traces_local_v2.
     # exchange_and_wrap.sh and rollback.sh print the same remediation.
-    if [[ "$live_end_time" != Nullable* && -n "$(traces_engine traces_local_v2)" ]]; then
+    if [[ -n "$live_end_time_type" && "$live_end_time_type" != Nullable* && -n "$(traces_engine traces_local_v2)" ]]; then
         echo "ERROR: the EXCHANGE ran (the live '$LIVE_TABLE' holds the successor schema) but 'traces_local_v2' still" >&2
         echo "       exists — the post-swap RENAME did not complete, so the parked original is under the wrong name and" >&2
         echo "       there is nothing this driver can sweep from. Finish that RENAME, then re-run this command:" >&2
@@ -398,12 +407,23 @@ detect_direction() {
 #     traffic and push the operator to --force. Nor is it a hazard: a live-table delete still applying leaves the row
 #     visible, which the postcondition reads as present — never as missing — and bridged deletes are re-applied by the
 #     replay, which carries lightweight_deletes_sync = 2 of its own.
-#   * the replication QUEUE: scoped to BOTH tables, because either one short of a part on this replica skews the
-#     postcondition's join, and judged on STUCK-NESS rather than depth for the same reason the pre-swap gate does —
+#   * the replication QUEUE: scoped to both tables AND to deletion_events_local, judged on STUCK-NESS rather than
+#     depth for the same reason the pre-swap gate does —
 #     under live ingestion a GET_PART entry exists for every part not yet fetched, so an instantaneous zero is not a
 #     healthy-cluster property. It passes the moment the queue drains; failing that, an entry aged past
 #     SETTLE_STUCK_AGE_SECONDS, more retries than SETTLE_STUCK_NUM_TRIES, or any last_exception is a genuinely lagging
 #     replica and fails the gate naming the offending entries.
+#
+#     THE BRIDGE IS IN THAT SCOPE FOR A REASON OF ITS OWN. deletion_events_local is a ReplicatedMergeTree (migration
+#     000096), and EVERY read this driver makes of it resolves on the one replica it is connected to: the sweep's "do
+#     not resurrect" exclusion, the replay's bridge match and resurrection guard, the postcondition's exclusion arm and
+#     the leak-check advisory. So a bridge part this replica has not fetched is invisible to all of them at once — the
+#     sweep re-inserts the key, the replay does not mask it, the postcondition does not expect it missing, and the
+#     advisory does not report it. A genuinely deleted trace comes back while the gate reports clean, and no other
+#     signal in this driver sees it.
+#     The limit: the queue verdict is stuck-ness, not depth, so a bridge queue that is BUSY but not stuck is still
+#     accepted once the timeout expires. That narrows the window to the drain time rather than closing it; quiescing
+#     user DELETEs across the swap is what empties it.
  # KEEP IN STEP WITH exchange_and_wrap.sh's assert_replication_settled. The two drivers run the SAME GATE on opposite
 # sides of the swap, and the half that decides a verdict — the three settle-* blocks — is already shared, from
 # 000003_exchange_and_wrap.sql, each driver rendering its own table scope. What is duplicated is the control flow around
@@ -411,7 +431,7 @@ detect_direction() {
 # SEVEN NUMERIC FIELDS ON ONE ROW before any arithmetic reads it, the polling bound (iteration cap AND deadline), and
 # the two verdicts (mutations unconditional, queue on stuck-ness). Only the table scope and the operator messages may
 # legitimately differ, being specific to what each side is about to do. The driver rehearsal exercises BOTH copies, so a
-# behavioural drift fails there rather than waiting for a reviewer.
+# behavioural drift fails there rather than going unnoticed.
 assert_replication_settled() {
     local cluster deadline polls poll row
     local sample_sql queue_detail_sql mutation_detail_sql
@@ -583,6 +603,16 @@ extract() {
 # Refuse rendered SQL that is not what the caller asked for. A marker renamed, moved, indented or split yields text that
 # is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and the
 # step prints its success line having done nothing. Same guard, same reasoning, as exchange_and_wrap.sh's.
+ # KEEP IN STEP WITH exchange_and_wrap.sh's require_rendered. The two copies are the SAME validation contract, and a
+# gap between them is SILENT: drop the out-of-order check and a reordered END captures to end of file past every
+# remaining guard, which is then read as a verdict. All four checks, and their ORDER, must
+# stay identical — exactly one BEGIN and one END, the END after its BEGIN, executable SQL after comments are stripped,
+# the caller's identity token present, and no surviving ${...} placeholder. The marker grammar they parse is shared
+# too, so a change to one is a change to both.
+#
+# The ONLY difference that is allowed is how failure propagates: this copy EXITS, because its callers run it inside command substitutions where a return would be swallowed. The
+# duplication is deliberate: this directory has no sourced helpers, and ch(), extract() and the settle gate are
+# duplicated the same way.
 require_rendered() {
     local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends begin_line end_line
     # Exactly one pair, checked on the FILE rather than the extraction: the awk stops at the first END and otherwise runs
@@ -633,7 +663,7 @@ render_settle() {
     local sql queue_tables mutation_tables
     # Built as variables, not inlined: the replacement half of ${x//pat/repl} does not honor nested quoting, so a
     # literal "'$A', '$B'" there would substitute the double quotes into the SQL as well.
-    queue_tables="'$LIVE_TABLE', '$PARKED_TABLE'"
+    queue_tables="'$LIVE_TABLE', '$PARKED_TABLE', 'deletion_events_local'"
     mutation_tables="'$PARKED_TABLE'"
     sql="$(extract "$SETTLE_SQL" "$1")"
     sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -16,17 +16,21 @@
 #   reverse (after a rollback) sweep traces_post_rollback_backup -> the restored original, then re-run the reverse replay.
 #
 # The direction is derived from the live topology, the way finalize.sh detects which backup is parked; there is no
-# --direction flag to get wrong. It refuses on an ambiguous or absent estate.
+# --direction flag to get wrong. It refuses on an ambiguous or absent estate, and — because every statement it issues is
+# shard-local while finalize.sh drops the parked backup ON CLUSTER — on a multi-shard or unreadable topology unless the
+# scope is asserted with --confirm-single-shard. See assert_shard_scope.
 #
 # Idempotent and re-runnable: it reads the postcondition BEFORE mutating anything, so a second run on a reconciled estate
 # issues no statement and exits 0.
 #
 # The SQL is NOT duplicated here. The sweeps and the forward deletion replay come from
 # db-app-analytics/000006_post_swap_reconciliation.sql, the postcondition from
-# db-app-analytics/000006_verify_reconciliation.sql, and the reverse replay from 000004_rollback_reverse_replay.sql plus
-# its postcondition 000004_rollback_verify_replay.sql, both unchanged. The forward replay is a POST-swap statement of its
-# own rather than a re-run of 000002's pre-swap one: it reads its resurrection guard from the frozen backup, and carries
-# a third arm that pre-swap has no counterpart for. See that block's header.
+# db-app-analytics/000006_verify_reconciliation.sql (its gate blocks plus the advisory leak-check-forward), the settle
+# gate from 000003_exchange_and_wrap.sql's three settle-* blocks — shared with exchange_and_wrap.sh, each driver
+# rendering its own table scope — and the reverse replay from 000004_rollback_reverse_replay.sql plus its postcondition
+# 000004_rollback_verify_replay.sql, both unchanged. The forward replay is a POST-swap statement of its own rather than a
+# re-run of 000002's pre-swap one: it reads its resurrection guard from the frozen backup, and carries a third arm that
+# pre-swap has no counterpart for. See that block's header.
 #
 # Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
 # NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
@@ -89,6 +93,14 @@
 #                             this asserts the operator now WANTS them back. That is right when the rollback was
 #                             motivated by latency, merge load or the wrap; it is wrong when the successor's CONTENT is
 #                             what is suspect, since it re-imports the very data the rollback existed to discard.
+#   --confirm-single-shard    assert the run's SHARD SCOPE yourself, the same shape and the same name as in rollback.sh.
+#                             Needed in two states, because every statement here and the forward postcondition are
+#                             shard-local while finalize.sh drops the parked backup ON CLUSTER:
+#                               * the shard count is unreadable or 0 (unknown topology) — you assert it is one shard;
+#                               * FORWARD on a cluster reporting more than one shard — you accept that this run covers
+#                                 the connected shard alone, and will repeat it on every shard before finalize.sh.
+#                             It does NOT unlock the REVERSE direction on more than one shard: the replay there is
+#                             shard-local while its postcondition reads every shard, so no single run can satisfy it.
 #   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120, capped at
 #                             3600; 0 takes a single sample. Unlike the pre-swap gate this one sits AFTER the swap, so
 #                             its wait costs no cutover tail — but every second is a second the gap-window traces are
@@ -126,6 +138,7 @@ MAX_PASSES=3
 MAX_PARTITIONS_PER_INSERT_BLOCK=2000
 REPORT_ONLY=0
 CONFIRM_REIMPORT=0
+CONFIRM_SINGLE_SHARD=0
 FORCE=0
 SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
 SETTLE_TIMEOUT_MAX=3600   # its accepted ceiling; the validation below explains why the check is lexical.
@@ -140,6 +153,7 @@ DIRECTION=""              # forward | reverse, derived from the live topology
 LIVE_TABLE=""             # traces, or traces_local on a wrapped estate
 PARKED_TABLE=""           # traces_pre_cutover_backup | traces_post_rollback_backup
 EFFECTIVE_GAP_START=""    # --gap-start widened downward by --slack-seconds, computed server-side
+SHARD_SCOPE_NOTE=""       # set by assert_shard_scope when the run is knowingly shard-local; qualifies the verdict
 # The 000006 blocks this direction mutates with, IN THE ORDER THEY MUST RUN. Forward: sweep first, then the replay, so
 # bridged deletes win over anything the sweep just re-inserted. Reverse has no replay block here — it re-runs 000004's
 # unchanged. Set by detect_direction, and an array rather than a string so no IFS or globbing surprise can reorder or
@@ -158,6 +172,7 @@ while [[ $# -gt 0 ]]; do
         --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
         --report-only) REPORT_ONLY=1; shift ;;
         --confirm-reimport-successor-writes) CONFIRM_REIMPORT=1; shift ;;
+        --confirm-single-shard) CONFIRM_SINGLE_SHARD=1; shift ;;
         --force) FORCE=1; shift ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
         --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -235,8 +250,12 @@ CH_ARGS=()
 [[ -z "$CH_PORT" ]] || CH_ARGS+=(--port "$CH_PORT")
 CH_ARGS+=(--database "$DATABASE" --receive_timeout="$RECEIVE_TIMEOUT")
 
+# --format TabSeparated is explicit, not redundant: clickhouse-client takes a default format from the user's own client
+# config, and a pretty/bordered default would put headers and box-drawing into every scalar read below. Those are parsed
+# as numbers and timestamps, so the failure would not be an error — it would be a wrong verdict.
 ch() {
-    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:reconcile' --query "$1"
+    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:reconcile' \
+        --format TabSeparated --query "$1"
 }
 
 # Same connection, but rendered for a human — used only for the settle gate's detail blocks, whose interesting columns
@@ -392,6 +411,19 @@ assert_replication_settled() {
         row="$(ch "$sample_sql")" || row=""
         [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
         read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
+        # A short or non-numeric row must not be read as a settled cluster. `read` leaves the unfilled variables EMPTY,
+        # and bash arithmetic evaluates an empty string as 0 — so a header line, a truncated row or a changed block
+        # would sail through every comparison below as "queue drained, nothing mutating" and pass the gate silently.
+        # Seven numeric fields or nothing.
+        for _field in "$queue" "$age" "$tries" "$failures" "$mutations" "$mut_age" "$mut_failed"; do
+            [[ "$_field" =~ ^[0-9]+$ ]] || {
+                echo "ERROR: the settle gate read '$row' from cluster '$cluster', which is not the seven numeric fields the" >&2
+                echo "       settle-sample block returns. Refusing to reach a verdict on it — an unparsed field would be" >&2
+                echo "       treated as 0 and pass the gate. Check the block's markers in $SETTLE_SQL, and that no client" >&2
+                echo "       config overrides the output format." >&2
+                exit 1
+            }
+        done
 
         if (( queue == 0 && mutations == 0 )); then
             echo "Replication settled across cluster '$cluster': queue drained, nothing still mutating '$PARKED_TABLE'."
@@ -443,29 +475,66 @@ settle() {
     fi
 }
 
-# The reverse direction re-runs 000004_rollback_reverse_replay.sql, which is deliberately NOT ON CLUSTER (it travels by
-# replication, which spans a shard's replicas and not other shards) while its postcondition reads clusterAllReplicas,
-# which spans every shard. On more than one shard those scopes disagree: the replay fixes one shard and the check keeps
-# failing. rollback.sh refuses the same combination for the same reason. The forward direction has no such mismatch —
-# both its sweep and its own postcondition are shard-local — so this is asserted only where it bites.
-assert_single_shard_for_reverse() {
+# EVERY STATEMENT THIS DRIVER ISSUES IS SHARD-LOCAL, and so is the forward postcondition. The sweep reads a per-shard
+# parked backup and writes the per-shard live table; the replay is a mutation, which travels by replication (a shard's
+# replicas, not other shards); the forward postcondition joins two tables and so cannot use clusterAllReplicas. That
+# makes a per-shard forward run correct — but it also means a single run's RECONCILED certifies ONE SHARD, and
+# finalize.sh drops the parked backup ON CLUSTER, on every shard, on the strength of that assertion. So the scope has to
+# be established before anything mutates, in BOTH directions, and an unreadable count fails closed exactly as
+# rollback.sh's does:
+#
+#   * more than one shard, REVERSE — refused outright. The reverse replay this driver re-runs is shard-local while its
+#     postcondition (000004_rollback_verify_replay.sql) reads clusterAllReplicas, so no single run can satisfy it. Worse
+#     here than in rollback.sh, because that postcondition is advisory in this driver: the run would repair one shard,
+#     warn, and still print RECONCILED off the shard-local four counts. rollback.sh refuses the same combination.
+#   * more than one shard, FORWARD — allowed only with --confirm-single-shard, which is then an acknowledgment that this
+#     run covers the connected shard alone and must be repeated on every shard before finalize.sh. Refusing outright
+#     would leave a multi-shard estate with no driver path for a gap the drivers can actually close.
+#   * count unreadable or 0 — the topology is UNKNOWN, so fail closed in both directions unless the operator asserts it
+#     with --confirm-single-shard. Assuming the safe case is the run this check exists to stop. Zero is not one shard: an
+#     empty system.macros match yields a default, so a missing 'cluster' macro returns 0 — and that also guarantees the
+#     reverse postcondition's clusterAllReplicas('{cluster}', ...) cannot resolve.
+assert_shard_scope() {
     local shards
     shards="$(ch "SELECT uniqExact(shard_num) FROM system.clusters
                   WHERE cluster = (SELECT substitution FROM system.macros WHERE macro = 'cluster')" 2>/dev/null || true)"
+
     if [[ "$shards" =~ ^[0-9]+$ ]] && (( shards > 1 )); then
-        echo "ERROR: this cluster reports $shards shards. The reverse replay this driver re-runs after the sweep reaches" >&2
-        echo "       only the shard you are connected to, while its postcondition reads every shard, so no single run can" >&2
-        echo "       satisfy it. Apply the statements from $SQL_DIR by hand, one shard at a time, then check the" >&2
-        echo "       postcondition once — the same path rollback.sh documents for its own reverse replay." >&2
-        exit 1
+        if [[ "$DIRECTION" == "reverse" ]]; then
+            echo "ERROR: this cluster reports $shards shards. The reverse replay this driver re-runs after the sweep reaches" >&2
+            echo "       only the shard you are connected to, while its postcondition reads every shard, so no single run can" >&2
+            echo "       satisfy it. Apply the statements from $SQL_DIR by hand, one shard at a time, then check the" >&2
+            echo "       postcondition once — the same path rollback.sh documents for its own reverse replay." >&2
+            exit 1
+        fi
+        if [[ "$CONFIRM_SINGLE_SHARD" != "1" ]]; then
+            echo "ERROR: this cluster reports $shards shards, and every statement this driver issues — plus its" >&2
+            echo "       postcondition — covers only the shard you are connected to. A RECONCILED here would certify one" >&2
+            echo "       shard while finalize.sh drops the parked backup ON CLUSTER, destroying the only copy of whatever" >&2
+            echo "       is still unswept on the others." >&2
+            echo "       Run this driver once PER SHARD with --confirm-single-shard, and do not run finalize.sh until every" >&2
+            echo "       shard has reported RECONCILED." >&2
+            exit 1
+        fi
+        SHARD_SCOPE_NOTE="this run covered ONE of $shards shards"
+        echo "NOTE: $shards shards; proceeding on --confirm-single-shard. This run reconciles and certifies only the shard" >&2
+        echo "      reached through ${CH_HOST:-the default host}. Repeat it on every shard before finalize.sh." >&2
+        return 0
     fi
-    # Unreadable is a NOTE rather than a refusal here, unlike rollback.sh's --sentinel-repair-only: this driver issues no
-    # whole-table rewrite, and the reverse replay it runs is the same statement the rollback already ran once on this
-    # estate. {cluster} inside a table function is substituted from the server's config rather than read from
-    # system.macros, so the postcondition still evaluates on the usual cause (a missing SELECT on system.clusters).
+
     if ! [[ "$shards" =~ ^[0-9]+$ ]] || (( shards == 0 )); then
-        echo "NOTE: could not read the shard count ('${shards:-<empty>}'); it needs SELECT on system.clusters and" >&2
-        echo "      system.macros. Proceeding — on a multi-shard cluster this would reconcile only the connected shard." >&2
+        if [[ "$CONFIRM_SINGLE_SHARD" == "1" ]]; then
+            echo "NOTE: could not read the shard count; proceeding on --confirm-single-shard. If the cluster in fact has" >&2
+            echo "      more than one shard, this reconciles and certifies only the shard you are connected to." >&2
+            SHARD_SCOPE_NOTE="shard count unread; scope asserted by --confirm-single-shard"
+            return 0
+        fi
+        echo "ERROR: the shard count came back unusable ('${shards:-<empty>}'), so this cluster's topology is unknown. It" >&2
+        echo "       needs SELECT on system.clusters and system.macros, and a 0 means the 'cluster' macro did not resolve." >&2
+        echo "       Every statement here is shard-local, so on more than one shard this would reconcile one shard and" >&2
+        echo "       report RECONCILED for the estate — which finalize.sh then acts on by dropping the backup ON CLUSTER." >&2
+        echo "       Grant the reads, or pass --confirm-single-shard to assert the topology yourself." >&2
+        exit 1
     fi
 }
 
@@ -593,6 +662,7 @@ verify_reverse_replay() {
 validate_blocks() {
     local block
     validate_block "$VERIFY_SQL" "verify-$DIRECTION"
+    [[ "$DIRECTION" != "forward" ]] || validate_block "$VERIFY_SQL" leak-check-forward
     [[ "$REPORT_ONLY" == "1" ]] && return 0
     for block in "${MUTATING_BLOCKS[@]}"; do
         validate_block "$SWEEP_SQL" "$block"
@@ -625,6 +695,33 @@ print_counts() {
     echo "  missing_keys=$MISSING stale_keys=$STALE payload_mismatch_keys=$PAYLOAD (gate: all three at 0)"
     echo "  newer_keys=$NEWER  — informational, and EXPECTED to be non-zero: a gap-window trace written again after the"
     echo "                        swap is newer on the live side, which the sweep deliberately leaves alone."
+}
+
+# 000006_verify_reconciliation.sql's leak-check-forward: bridged deletes still LIVE on the successor at a version the
+# frozen backup itself held. Forward only, and NOT part of the gate — it reports the residual arm 3 of the deletion
+# replay cannot prevent (a pre-swap row carrying a client-supplied FUTURE last_updated_at falls outside its staleness
+# scope; see that block's header). Advisory, and non-fatal on a read failure: the four counts are what this driver exits
+# on, and a failed advisory read must not turn a clean reconciliation into a failure. Printed AFTER the gate so a
+# non-zero here is read as "reconciled, and these deletes need re-applying by hand", which is what it means.
+print_leak_check() {
+    local leaked
+    [[ "$DIRECTION" == "forward" ]] || return 0
+    leaked="$(clickhouse-client "${CH_ARGS[@]}" --format TabSeparated \
+        --query "$(render "$(extract "$VERIFY_SQL" leak-check-forward)")" 2>/dev/null || true)"
+    if [[ "$leaked" == "0" ]]; then
+        echo "  leaked_delete_keys=0 — no captured delete is live on '$LIVE_TABLE' at a version the backup held."
+        return 0
+    fi
+    if ! [[ "$leaked" =~ ^[0-9]+$ ]]; then
+        echo "  WARNING: the deletion-leak advisory could not be read; the four counts above still stand." >&2
+        return 0
+    fi
+    echo "  WARNING: leaked_delete_keys=$leaked — that many CAPTURED DELETES are still live on '$LIVE_TABLE'." >&2
+    echo "           The reconciliation itself is complete; this is the residual the replay's staleness scope cannot" >&2
+    echo "           prevent, because last_updated_at is client-supplied (see 000006's ARM 3 header). Those keys are" >&2
+    echo "           still in deletion_events_local, so they can be re-applied by hand — list them with the" >&2
+    echo "           leak-check-forward block in $VERIFY_SQL, dropping its outer count()." >&2
+    return 0
 }
 
 gate_is_clean() {
@@ -678,8 +775,9 @@ else
         echo "       so this state is not one a promote produces. Resolve by hand." >&2
         exit 1
     }
-    assert_single_shard_for_reverse
 fi
+
+assert_shard_scope
 
 # Widen the gap anchor downward by --slack-seconds, server-side: no host date math and no timezone ambiguity, the same
 # reason every other window bound in this runbook is computed in ClickHouse.
@@ -702,6 +800,7 @@ read_postcondition || {
 }
 echo "Postcondition BEFORE any mutation:"
 print_counts
+print_leak_check
 
 if gate_is_clean; then
     echo "Nothing to reconcile: every key live in '$PARKED_TABLE' inside the gap window is present on '$LIVE_TABLE' at the"
@@ -735,6 +834,13 @@ while (( PASS < MAX_PASSES )); do
     if gate_is_clean; then
         echo
         echo "RECONCILED after $PASS pass(es): missing_keys=0 stale_keys=0 payload_mismatch_keys=0."
+        print_leak_check
+        # A shard-local verdict must never read as an estate-wide one: finalize.sh destroys the parked backup ON CLUSTER
+        # on the strength of this line, so when the scope was asserted rather than proven, the line says so.
+        [[ -z "$SHARD_SCOPE_NOTE" ]] || {
+            echo "SCOPE: $SHARD_SCOPE_NOTE. This verdict covers that shard ONLY — every other shard needs its own"
+            echo "       RECONCILED before finalize.sh, which drops the parked backup on all of them."
+        }
         if [[ "$DIRECTION" == "forward" ]]; then
             echo "Every trace written to the old table in the [$EFFECTIVE_GAP_START, swap) gap is live on '$LIVE_TABLE'."
             echo

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -1,0 +1,780 @@
+#!/usr/bin/env bash
+#
+# POST-SWAP reconciliation driver for the traces cutover (runbook: ../README.md).
+#
+# The cutover loses writes across the swap (OPIK-8238). The last write-copying statement is the delta INSERT in step 2;
+# between it and the EXCHANGE completing sit a deletion replay, the operator's go/no-go gap, the topology guards, the
+# cluster-wide settle gate and a second full deletion replay. Nothing holds writes across that window — the procedure
+# takes no ingestion-path hold (OPIK-8239) — so every trace written to the old `traces` in it is orphaned when that
+# table is parked.
+#
+# Reconciling BEFORE the swap cannot converge — the source is live, so every pass opens a new gap. After the swap the
+# parked table is frozen, so this driver's sweep converges by construction, and its postcondition is a gate rather than a
+# snapshot. It runs in both directions:
+#
+#   forward (after a cutover)  sweep traces_pre_cutover_backup   -> the live successor, then re-apply bridged deletes.
+#   reverse (after a rollback) sweep traces_post_rollback_backup -> the restored original, then re-run the reverse replay.
+#
+# The direction is derived from the live topology, the way finalize.sh detects which backup is parked; there is no
+# --direction flag to get wrong. It refuses on an ambiguous or absent estate.
+#
+# Idempotent and re-runnable: it reads the postcondition BEFORE mutating anything, so a second run on a reconciled estate
+# issues no statement and exits 0.
+#
+# The SQL is NOT duplicated here. The sweeps and the forward deletion replay come from
+# db-app-analytics/000006_post_swap_reconciliation.sql, the postcondition from
+# db-app-analytics/000006_verify_reconciliation.sql, and the reverse replay from 000004_rollback_reverse_replay.sql plus
+# its postcondition 000004_rollback_verify_replay.sql, both unchanged. The forward replay is a POST-swap statement of its
+# own rather than a re-run of 000002's pre-swap one: it reads its resurrection guard from the frozen backup, and carries
+# a third arm that pre-swap has no counterpart for. See that block's header.
+#
+# Connection: CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment, plus --host and --port. CLICKHOUSE_PORT is
+# NOT honored by clickhouse-client, and CLICKHOUSE_HOST is honored only when no connection flag is given, so pass
+# --host and --port together. The user must be able to set `log_comment` (used for cutover attribution in
+# query_log): a `readonly = 1` profile rejects it outright ("Cannot modify 'log_comment' setting in readonly mode"),
+# so a read-only assessor needs `readonly = 2` and the migration user needs a non-readonly profile.
+#
+# PRIVILEGES: the forward path MUTATES THE LIVE NAME, which the rest of the forward cutover does not. On top of the
+# forward grant set it needs INSERT and ALTER UPDATE(_row_exists) on `traces` (or `traces_local` on a wrapped estate) and
+# SELECT on `traces_pre_cutover_backup`. See the runbook's privileges table — that widening is deliberate and is called
+# out there rather than buried here.
+#
+# Options:
+#   --database NAME           analytics database (e.g. opik). Required.
+#   --port N                  ClickHouse NATIVE port, when it is not the default 9000 — e.g. reaching a cluster through
+#                             a port-forward or bastion on a local port. Required because clickhouse-client honors
+#                             CLICKHOUSE_HOST / CLICKHOUSE_USER / CLICKHOUSE_PASSWORD from the environment but does
+#                             NOT honor CLICKHOUSE_PORT, so the port cannot be passed via env.
+#   --host HOST               ClickHouse host. Pass it together with --port: clickhouse-client honors CLICKHOUSE_HOST
+#                             ONLY when no connection flag is given, so supplying --port alone silently reverts the host
+#                             to localhost. User/password still come from CLICKHOUSE_USER / CLICKHOUSE_PASSWORD (keeping
+#                             the password out of argv).
+#   --receive-timeout N       seconds clickhouse-client waits for the NEXT PACKET before giving up (receive_timeout).
+#                             Default 1800, against ClickHouse's own 300, which bounds the GAP between packets rather
+#                             than total query time. Trade-off and shared rationale: ../README.md.
+#   --gap-start TS            what to COPY: the lower bound of the gap window, matched on created_at OR last_updated_at.
+#                             FORWARD it is REQUIRED and is the start of the last delta pass — the `RECORD delta_start=`
+#                             line delta_replay.sh prints. REVERSE it defaults to --cutover-start and rarely needs
+#                             passing. Must carry an explicit ' UTC' marker, as the drivers print it.
+#                             WIDENING IT IS FREE: the sweep is mask-honored and idempotent, so `backfill_start` is
+#                             always a valid fallback and a lost delta_start never forces an escalation.
+#   --cutover-start TS        REVERSE only, and required there: the `RECORD cutover_start=` value exchange_and_wrap.sh
+#                             printed. It bounds the reverse deletion replay this driver re-runs after the sweep, exactly
+#                             as it does in rollback.sh. Rejected in the forward direction, which replays nothing from it.
+#   --swap-done TS            what NOT to RESURRECT: the instant the swap statement RETURNED — `RECORD exchange_done=`
+#                             (forward) or `RECORD promote_done=` (reverse). Required. Bridged deletes at or after it are
+#                             excluded from the sweep, so a gap-window trace deleted after the swap is not brought back.
+#                             UNLIKE --gap-start THIS IS NOT FREE TO GUESS, and the two directions of error are not
+#                             symmetric: too EARLY excludes too much, so a legitimately live key stays missing and the
+#                             postcondition FAILS LOUDLY; too LATE excludes too little and can RESURRECT a deleted trace
+#                             silently. If the printed value was lost, use `cutover_start` — it is earlier than the swap
+#                             by construction, i.e. on the side that fails loudly.
+#   --slack-seconds N         widen --gap-start DOWNWARD by N seconds (default 300) to absorb cross-replica clock skew on
+#                             the server-side timestamp defaults the gap window matches on. Free, per the widening note
+#                             above. Pass 0 to use the anchor exactly as given.
+#   --max-passes N            give up after N sweep -> replay -> postcondition passes (default 3). A pass whose
+#                             postcondition is still non-zero is retried, because concurrent traffic can add to the gap
+#                             while the sweep runs; a run that exhausts the passes FAILS rather than reporting progress.
+#   --max-partitions-per-insert-block N
+#                             partitions one insert block of the sweep may span (SETTINGS
+#                             max_partitions_per_insert_block). Default 2000; 0 = unlimited. Same correctness gate as in
+#                             backfill.sh / delta_replay.sh — the forward sweep writes into the same weekly-partitioned
+#                             successor, and far-future UUIDv7 ids reach ClickHouse's default of 100, which ABORTS the
+#                             INSERT (throw_on_max_partitions_per_insert_block = 1). Pass the value used for the backfill.
+#   --report-only             read the postcondition and stop. Issues NO mutation, in either direction. Exits 0 only when
+#                             the gate is already clean — a report that finds a gap is not a pass.
+#   --confirm-reimport-successor-writes
+#                             REVERSE only, and required there unless --report-only. The reverse sweep re-imports exactly
+#                             the post-cutover writes that --accept-post-cutover-write-loss acknowledged discarding, so
+#                             this asserts the operator now WANTS them back. That is right when the rollback was
+#                             motivated by latency, merge load or the wrap; it is wrong when the successor's CONTENT is
+#                             what is suspect, since it re-imports the very data the rollback existed to discard.
+#   --settle-timeout N        seconds the replication-settle gate polls before giving a verdict. Default 120, capped at
+#                             3600; 0 takes a single sample. Unlike the pre-swap gate this one sits AFTER the swap, so
+#                             its wait costs no cutover tail — but every second is a second the gap-window traces are
+#                             still absent from live reads, so it is not free either. Note it is spent PER GATE: once
+#                             before the first postcondition read and once per pass, so the worst case is
+#                             (1 + --max-passes) x this value, and only on a queue that stays busy-but-not-stuck (a
+#                             drained queue returns immediately). See assert_replication_settled for the verdicts.
+#   --force                   skip the replication-settle gate. By default the run aborts while a replica is still
+#                             applying a mutation to the PARKED table or its replication queue is genuinely stuck,
+#                             because the sweep reads that table mask-honored and the postcondition reads ONE replica
+#                             (it cannot use clusterAllReplicas — a Replicated table returns a copy per replica, which
+#                             would multiply both sides of its join). Use only if settlement is confirmed out of band.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SQL_DIR="$SCRIPT_DIR/db-app-analytics"
+SWEEP_SQL="$SQL_DIR/000006_post_swap_reconciliation.sql"
+VERIFY_SQL="$SQL_DIR/000006_verify_reconciliation.sql"
+REVERSE_REPLAY_SQL="$SQL_DIR/000004_rollback_reverse_replay.sql"
+REVERSE_VERIFY_SQL="$SQL_DIR/000004_rollback_verify_replay.sql"
+# The settle gate's three blocks are shared with exchange_and_wrap.sh, which reads the same statements with its own
+# pre-swap table scope — see that file's header. Same hazard, same SQL, different scope.
+SETTLE_SQL="$SQL_DIR/000003_exchange_and_wrap.sql"
+
+DATABASE=""
+CH_HOST=""                # host; empty = clickhouse-client default/env. See --host.
+CH_PORT=""                # native port; empty = clickhouse-client default (9000). See --port.
+RECEIVE_TIMEOUT=1800      # seconds tolerated between server packets, not total query time. See --receive-timeout.
+GAP_START=""
+CUTOVER_START=""
+SWAP_DONE=""
+SLACK_SECONDS=300
+MAX_PASSES=3
+MAX_PARTITIONS_PER_INSERT_BLOCK=2000
+REPORT_ONLY=0
+CONFIRM_REIMPORT=0
+FORCE=0
+SETTLE_TIMEOUT=120        # seconds the settle gate polls before deciding. See --settle-timeout.
+SETTLE_TIMEOUT_MAX=3600   # its accepted ceiling; the validation below explains why the check is lexical.
+
+# Stuck-ness thresholds for the replication queue, and the poll interval. Deliberately not flags, and the same values
+# exchange_and_wrap.sh uses: they describe what "a replica is genuinely lagging" means, not a per-run choice.
+SETTLE_POLL_SECONDS=5
+SETTLE_STUCK_AGE_SECONDS=60
+SETTLE_STUCK_NUM_TRIES=3
+
+DIRECTION=""              # forward | reverse, derived from the live topology
+LIVE_TABLE=""             # traces, or traces_local on a wrapped estate
+PARKED_TABLE=""           # traces_pre_cutover_backup | traces_post_rollback_backup
+EFFECTIVE_GAP_START=""    # --gap-start widened downward by --slack-seconds, computed server-side
+# The 000006 blocks this direction mutates with, IN THE ORDER THEY MUST RUN. Forward: sweep first, then the replay, so
+# bridged deletes win over anything the sweep just re-inserted. Reverse has no replay block here — it re-runs 000004's
+# unchanged. Set by detect_direction, and an array rather than a string so no IFS or globbing surprise can reorder or
+# drop a block whose order is load-bearing.
+MUTATING_BLOCKS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --database) DATABASE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --gap-start) GAP_START="${2:?"$1 requires a value"}"; shift 2 ;;
+        --cutover-start) CUTOVER_START="${2:?"$1 requires a value"}"; shift 2 ;;
+        --swap-done) SWAP_DONE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --slack-seconds) SLACK_SECONDS="${2:?"$1 requires a value"}"; shift 2 ;;
+        --settle-timeout) SETTLE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-passes) MAX_PASSES="${2:?"$1 requires a value"}"; shift 2 ;;
+        --max-partitions-per-insert-block) MAX_PARTITIONS_PER_INSERT_BLOCK="${2:?"$1 requires a value"}"; shift 2 ;;
+        --report-only) REPORT_ONLY=1; shift ;;
+        --confirm-reimport-successor-writes) CONFIRM_REIMPORT=1; shift ;;
+        --force) FORCE=1; shift ;;
+        --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
+        --port) CH_PORT="${2:?"$1 requires a value"}"; shift 2 ;;
+        --receive-timeout) RECEIVE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$DATABASE" ]] || { echo "ERROR: --database is required" >&2; exit 2; }
+# --database and the three anchors are interpolated into the reference SQL; validate their shapes so none can alter it.
+[[ "$DATABASE" =~ ^[A-Za-z0-9_]+$ ]] || { echo "ERROR: --database must be a ClickHouse identifier (letters, digits, underscore)." >&2; exit 2; }
+[[ -z "$CH_HOST" || "$CH_HOST" =~ ^[A-Za-z0-9._-]+$ ]] || { echo "ERROR: --host must be a hostname or IP." >&2; exit 2; }
+[[ -z "$CH_PORT" || "$CH_PORT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --port must be a positive integer." >&2; exit 2; }
+[[ "$RECEIVE_TIMEOUT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --receive-timeout must be a positive integer (seconds)." >&2; exit 2; }
+[[ "$SLACK_SECONDS" =~ ^[0-9]+$ ]] || { echo "ERROR: --slack-seconds must be a non-negative integer." >&2; exit 2; }
+# Digit-capped BEFORE any arithmetic sees it, for the reason exchange_and_wrap.sh's identical check spells out: a leading
+# zero reads as octal, and past 2^63 bash arithmetic wraps silently, which would make the gate's `polls` negative, run
+# its loop zero times, and pass a verdict on unset (0) counters without having read replication at all.
+[[ "$SETTLE_TIMEOUT" =~ ^(0|[1-9][0-9]{0,3})$ ]] && (( SETTLE_TIMEOUT <= SETTLE_TIMEOUT_MAX )) || { echo "ERROR: --settle-timeout must be an integer between 0 and $SETTLE_TIMEOUT_MAX seconds, with no leading zero; 0 takes a single sample." >&2; exit 2; }
+[[ "$MAX_PASSES" =~ ^[1-9][0-9]?$ ]] || { echo "ERROR: --max-passes must be 1..99." >&2; exit 2; }
+# 0 is meaningful (ClickHouse reads it as "unlimited"). Upper-bounded at 6 digits for the same reason as in backfill.sh:
+# an out-of-range value would otherwise be rendered into the SQL and rejected by the server mid-run instead of here.
+[[ "$MAX_PARTITIONS_PER_INSERT_BLOCK" =~ ^(0|[1-9][0-9]{0,5})$ ]] || { echo "ERROR: --max-partitions-per-insert-block must be 0 (unlimited) or 1..999999." >&2; exit 2; }
+
+for _f in "$SWEEP_SQL" "$VERIFY_SQL" "$REVERSE_REPLAY_SQL" "$REVERSE_VERIFY_SQL" "$SETTLE_SQL"; do
+    [[ -f "$_f" ]] || { echo "ERROR: cannot find $_f" >&2; exit 2; }
+done
+
+# Strip the ' UTC' marker every anchor flag is required to carry, exactly as the other drivers do. For these bounds a
+# wrong zone is worse than a wrong shape: the statements parse the value as UTC, so one captured elsewhere shifts
+# silently rather than failing.
+strip_utc_marker() {
+    local flag="$1" value="$2"
+    case "$value" in
+        "") printf '%s' ""; return 0 ;;
+        *" UTC")
+            value="${value% UTC}"
+            # A bare marker strips to empty, which elsewhere means "not supplied" — two meanings for one value, and the
+            # later "required" diagnostic would point away from the actual mistake.
+            [[ -n "$value" ]] || { echo "ERROR: $flag has no timestamp before the ' UTC' marker." >&2; exit 2; }
+            ;;
+        *)
+            echo "ERROR: $flag must carry an explicit ' UTC' marker, as the drivers print it:" >&2
+            echo "       $flag '<YYYY-MM-DD HH:MM:SS[.ffffff]> UTC'" >&2
+            echo "       The value is parsed as UTC; without the marker the zone it was captured in is unknown." >&2
+            exit 2
+            ;;
+    esac
+    [[ "$value" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] \
+        || { echo "ERROR: $flag must be 'YYYY-MM-DD HH:MM:SS[.ffffff] UTC'." >&2; exit 2; }
+    printf '%s' "$value"
+}
+
+# `|| exit 2` is not redundant belt-and-braces: strip_utc_marker's own `exit` runs in the command substitution's
+# SUBSHELL, so it ends that subshell rather than the script. The assignment then carries the failed status and `set -e`
+# does abort — but only for as long as these stay plain assignments. Making the refusal explicit here means a later
+# `local`, an `||` or a `readonly` in front of one of them cannot silently turn a rejected anchor into an empty one.
+GAP_START="$(strip_utc_marker --gap-start "$GAP_START")" || exit 2
+CUTOVER_START="$(strip_utc_marker --cutover-start "$CUTOVER_START")" || exit 2
+SWAP_DONE="$(strip_utc_marker --swap-done "$SWAP_DONE")" || exit 2
+
+[[ -n "$SWAP_DONE" ]] || {
+    echo "ERROR: --swap-done is required. It is the instant the swap statement RETURNED — 'RECORD exchange_done=' after a" >&2
+    echo "       cutover, 'RECORD promote_done=' after a rollback — and it is what stops the sweep resurrecting a trace" >&2
+    echo "       deleted after the swap. If the printed value was lost, pass cutover_start instead: it is earlier than" >&2
+    echo "       the swap by construction, and erring early makes the postcondition fail loudly rather than resurrect." >&2
+    exit 2
+}
+
+# One place for the connection and client-side options, so every call site below carries the same host, port, database
+# and receive_timeout, and cannot drift. No --log_comment here: every statement this driver runs sets its own in a
+# trailing SETTINGS clause, and a per-query value beats a client-level one, so a flag here would never reach query_log.
+CH_ARGS=()
+[[ -z "$CH_HOST" ]] || CH_ARGS+=(--host "$CH_HOST")
+[[ -z "$CH_PORT" ]] || CH_ARGS+=(--port "$CH_PORT")
+CH_ARGS+=(--database "$DATABASE" --receive_timeout="$RECEIVE_TIMEOUT")
+
+ch() {
+    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:reconcile' --query "$1"
+}
+
+# Same connection, but rendered for a human — used only for the settle gate's detail blocks, whose interesting columns
+# are free text (last_exception, postpone_reason, latest_fail_reason) that must not be parsed.
+ch_vertical() {
+    clickhouse-client "${CH_ARGS[@]}" --log_comment 'traces_local_v2_cutover:reconcile' \
+        --format Vertical --query "$1"
+}
+
+# Single scalar (empty string if the object does not exist).
+traces_engine() {
+    ch "SELECT engine FROM system.tables WHERE database = '$DATABASE' AND name = '$1'"
+}
+traces_endtime_type() {
+    ch "SELECT type FROM system.columns WHERE database = '$DATABASE' AND table = '$1' AND name = 'end_time'"
+}
+
+# The live table this run reads, writes and mutates. On a wrapped estate `traces` is a Distributed wrapper: it accepts
+# INSERT but REJECTS mutations (code 36/48), so the deletion replay after the sweep would fail. Resolve ONE name the way
+# databaseAnalyticsDataModel.tracesDistributedWrapEnabled does in TraceDAO — traces_local when `traces` is Distributed —
+# and use it for every statement, so a wrapped estate stays reconcilable. Writing the shard directly is correct rather
+# than a bypass of the Distributed sharding key: the parked backup is itself a per-shard table, so its rows already
+# belong to the shard this run is connected to.
+resolve_live_table() {
+    local engine
+    engine="$(traces_engine traces)"
+    [[ -n "$engine" ]] || { echo "ERROR: no 'traces' table found in database '$DATABASE'." >&2; exit 1; }
+    if [[ "$engine" == "Distributed" ]]; then
+        LIVE_TABLE="traces_local"
+        [[ -n "$(traces_engine traces_local)" ]] || {
+            echo "ERROR: 'traces' is a Distributed wrapper but 'traces_local' (the shard it fronts) does not exist, so" >&2
+            echo "       there is no table to reconcile. The topology is not a clean post-wrap state — resolve by hand." >&2
+            exit 1
+        }
+    else
+        LIVE_TABLE="traces"
+    fi
+}
+
+# Direction from the live topology, the same signals finalize.sh classifies on: which backup is parked, plus the
+# end_time nullability that says which schema each table carries. Presence of a name is convention; the schema is proof.
+detect_direction() {
+    local pre_cutover post_rollback_end_time live_end_time
+    pre_cutover="$(traces_engine traces_pre_cutover_backup)"
+    post_rollback_end_time="$(traces_endtime_type traces_post_rollback_backup)"
+    live_end_time="$(traces_endtime_type "$LIVE_TABLE")"
+
+    if [[ -n "$pre_cutover" && -n "$post_rollback_end_time" ]]; then
+        echo "ERROR: both 'traces_pre_cutover_backup' and 'traces_post_rollback_backup' exist, so the direction is" >&2
+        echo "       ambiguous — a clean estate never holds both. Refusing rather than guessing which way to sweep;" >&2
+        echo "       resolve the estate by hand (finalize.sh refuses the same state, for the same reason)." >&2
+        exit 1
+    fi
+
+    if [[ -n "$pre_cutover" ]]; then
+        DIRECTION="forward"
+        PARKED_TABLE="traces_pre_cutover_backup"
+        MUTATING_BLOCKS=(forward-sweep forward-deletion-replay)
+        [[ "$live_end_time" != Nullable* ]] || {
+            echo "ERROR: 'traces_pre_cutover_backup' is parked, but the live '$LIVE_TABLE' still has a Nullable end_time —" >&2
+            echo "       i.e. it is the ORIGINAL schema, so the EXCHANGE has not run (or has been rolled back) while a" >&2
+            echo "       pre-cutover backup name survives. There is no forward gap to sweep from that state. Resolve the" >&2
+            echo "       estate by hand." >&2
+            exit 1
+        }
+        return 0
+    fi
+
+    if [[ -n "$post_rollback_end_time" ]]; then
+        [[ "$post_rollback_end_time" != Nullable* ]] || {
+            echo "ERROR: 'traces_post_rollback_backup' exists but carries the ORIGINAL schema (Nullable end_time), so it is" >&2
+            echo "       not the successor a rollback parks there. The name is convention; the schema is the proof, and it" >&2
+            echo "       disagrees. Refusing — resolve by hand." >&2
+            exit 1
+        }
+        DIRECTION="reverse"
+        PARKED_TABLE="traces_post_rollback_backup"
+        MUTATING_BLOCKS=(reverse-sweep)
+        [[ "$live_end_time" == Nullable* ]] || {
+            echo "ERROR: the successor is parked as 'traces_post_rollback_backup', but the live '$LIVE_TABLE' is not the" >&2
+            echo "       restored ORIGINAL (its end_time is '${live_end_time:-<absent>}', not Nullable). A promote leaves" >&2
+            echo "       the original live; this estate does not match, so the reverse sweep has no valid target." >&2
+            exit 1
+        }
+        return 0
+    fi
+
+    # Neither parked name exists. Before refusing, name the one state that is recoverable in one command: the forward
+    # EXCHANGE committed but its post-swap RENAME did not, so the parked original is still sitting under traces_local_v2.
+    # exchange_and_wrap.sh and rollback.sh print the same remediation.
+    if [[ "$live_end_time" != Nullable* && -n "$(traces_engine traces_local_v2)" ]]; then
+        echo "ERROR: the EXCHANGE ran (the live '$LIVE_TABLE' holds the successor schema) but 'traces_local_v2' still" >&2
+        echo "       exists — the post-swap RENAME did not complete, so the parked original is under the wrong name and" >&2
+        echo "       there is nothing this driver can sweep from. Finish that RENAME, then re-run this command:" >&2
+        echo "         clickhouse-client ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} --database $DATABASE --query \"RENAME TABLE $DATABASE.traces_local_v2 TO $DATABASE.traces_pre_cutover_backup ON CLUSTER '{cluster}'\"" >&2
+        exit 1
+    fi
+    echo "ERROR: no parked backup found — neither 'traces_pre_cutover_backup' nor 'traces_post_rollback_backup' exists." >&2
+    echo "       Reconciliation sweeps FROM the frozen parked table, so there is nothing to reconcile against. Either no" >&2
+    echo "       cutover has run here, or finalize.sh has already retired the backup — and finalize refuses without" >&2
+    echo "       --confirm-gap-reconciled precisely so that cannot happen before this driver has run." >&2
+    exit 1
+}
+
+# Pre-verify gate, and a pre-SWEEP one. Two distinct reasons, both needing this replica to hold what the others do:
+#
+#   * the postcondition reads ONE replica by necessity (it joins two sides, and clusterAllReplicas would return a full
+#     copy of each per replica and multiply both), so a part this replica has not fetched reads as a missing key;
+#   * the sweep READS THE PARKED TABLE mask-honored. A user delete issued against the old table just before the swap is
+#     an ordinary asynchronous mutation — no lightweight_deletes_sync there, unlike the cutover's own replays — so if it
+#     has not applied on the replica the sweep reads, the sweep sees the row as live and copies a deleted trace back.
+#
+# It reuses 000003's three settle-* blocks with a POST-SWAP scope, and the verdict differs from the pre-swap one by
+# exactly what the swap changed about which table is quiet:
+#
+#   * unfinished MUTATIONS: scoped to the PARKED table and judged UNCONDITIONALLY, within --settle-timeout. That table
+#     is frozen, so anything still applying to it is a pre-swap delete mid-flight — the second hazard above — and it
+#     drains rather than recurring. The LIVE table is deliberately NOT in this scope: after the swap it takes user
+#     deletes continuously, each an ordinary asynchronous mutation, so requiring zero there would abort on healthy
+#     traffic and push the operator to --force. Nor is it a hazard: a live-table delete still applying leaves the row
+#     visible, which the postcondition reads as present — never as missing — and bridged deletes are re-applied by the
+#     replay, which carries lightweight_deletes_sync = 2 of its own.
+#   * the replication QUEUE: scoped to BOTH tables, because either one short of a part on this replica skews the
+#     postcondition's join, and judged on STUCK-NESS rather than depth for the same reason the pre-swap gate does —
+#     under live ingestion a GET_PART entry exists for every part not yet fetched, so an instantaneous zero is not a
+#     healthy-cluster property. It passes the moment the queue drains; failing that, an entry aged past
+#     SETTLE_STUCK_AGE_SECONDS, more retries than SETTLE_STUCK_NUM_TRIES, or any last_exception is a genuinely lagging
+#     replica and fails the gate naming the offending entries.
+assert_replication_settled() {
+    local cluster deadline polls poll row
+    local sample_sql queue_detail_sql mutation_detail_sql
+    local queue age tries failures mutations mut_age mut_failed
+
+    # Resolved here only to fail fast with a clear message and to name the cluster in what follows; the blocks reach it
+    # through '{cluster}' themselves.
+    cluster="$(ch "SELECT getMacro('cluster')")"
+    [[ -n "$cluster" ]] || { echo "ERROR: could not resolve the '{cluster}' macro (getMacro('cluster') was empty). Pass --force only if you have confirmed replication settlement out of band." >&2; exit 1; }
+
+    # All three rendered up front: a malformed marker then aborts before the first poll rather than midway through a
+    # failure report, and the loop reuses one rendered string. Each token identifies exactly one block in 000003, so a
+    # marker wrapped around the wrong statement is caught — clusterAllReplicas would match all three and prove nothing.
+    sample_sql="$(render_settle settle-sample "CROSS JOIN")" || exit 2
+    queue_detail_sql="$(render_settle settle-queue-detail postpone_reason)" || exit 2
+    mutation_detail_sql="$(render_settle settle-mutation-detail latest_failed_part)" || exit 2
+
+    # Bounded two ways on purpose: the loop header caps the iteration count, so the gate cannot spin whatever the clock
+    # does, and the deadline check keeps a slow-reading cluster from overrunning the seconds --settle-timeout promises.
+    # --settle-timeout 0 collapses this to a single sample. The last iteration always breaks (poll == polls fails the
+    # guard), so the verdict below always runs against a sample that was actually read.
+    polls=$(( SETTLE_TIMEOUT / SETTLE_POLL_SECONDS + 1 ))
+    deadline=$(( SECONDS + SETTLE_TIMEOUT ))
+    for (( poll = 1; poll <= polls; poll++ )); do
+        row="$(ch "$sample_sql")" || row=""
+        [[ -n "$row" ]] || { echo "ERROR: the settle gate could not read system.replication_queue / system.mutations across cluster '$cluster'. Grant SELECT ON system.* plus REMOTE and CLUSTER, or confirm settlement out of band and pass --force." >&2; exit 1; }
+        read -r queue age tries failures mutations mut_age mut_failed <<<"$row"
+
+        if (( queue == 0 && mutations == 0 )); then
+            echo "Replication settled across cluster '$cluster': queue drained, nothing still mutating '$PARKED_TABLE'."
+            return 0
+        fi
+        (( poll < polls && SECONDS < deadline )) || break
+        echo "  settling: replication_queue=$queue (oldest ${age}s, max num_tries=$tries, with last_exception=$failures)," \
+             "unfinished mutations on '$PARKED_TABLE'=$mutations — polling up to ${SETTLE_TIMEOUT}s..."
+        sleep "$SETTLE_POLL_SECONDS"
+    done
+
+    if (( mutations != 0 )); then
+        echo "ERROR: a mutation on the parked '$PARKED_TABLE' has not finished on every replica after ${SETTLE_TIMEOUT}s" >&2
+        echo "       ($mutations unfinished, oldest ${mut_age}s, $mut_failed carrying a latest_fail_reason). That table is frozen," >&2
+        echo "       so this is a user delete that fired against it before the swap and is still applying. The sweep reads" >&2
+        echo "       it mask-honored, so sweeping now would copy a deleted trace back into the live table." >&2
+        echo "       Unfinished mutations:" >&2
+        ch_vertical "$mutation_detail_sql" >&2 || true
+        echo "       Let it finish (or fix the cause), then re-run. Raise --settle-timeout for a slow-but-progressing" >&2
+        echo "       cluster; --force skips the gate entirely and the runbook's Go/No-Go forbids it in production." >&2
+        exit 1
+    fi
+
+    if (( age > SETTLE_STUCK_AGE_SECONDS || tries > SETTLE_STUCK_NUM_TRIES || failures > 0 )); then
+        echo "ERROR: a replica is lagging, not merely busy — after ${SETTLE_TIMEOUT}s the replication queue for" >&2
+        echo "       $LIVE_TABLE / $PARKED_TABLE still holds $queue entries: oldest ${age}s (stuck above ${SETTLE_STUCK_AGE_SECONDS}s)," >&2
+        echo "       max num_tries=$tries (stuck above ${SETTLE_STUCK_NUM_TRIES}), $failures carrying a last_exception." >&2
+        echo "       The postcondition reads one replica, so a behind replica reads as missing keys and the sweep would" >&2
+        echo "       re-copy rows that are already there. Oldest / most-retried entries:" >&2
+        ch_vertical "$queue_detail_sql" >&2 || true
+        echo "       Resolve the lag, then re-run. Raise --settle-timeout for a slow-but-progressing cluster; --force" >&2
+        echo "       skips the gate entirely and the runbook's Go/No-Go forbids it in production." >&2
+        exit 1
+    fi
+
+    # "Not stuck" rather than "moving": a snapshot predicate over the last sample read, with no path here comparing
+    # consecutive samples. Polling only gives the queue time to drain (the early return above) or a stuck entry time to
+    # age past the thresholds, so a shorter --settle-timeout is a weaker gate by exactly that much.
+    echo "Replication settled enough across cluster '$cluster': nothing still mutating '$PARKED_TABLE', and no queue"
+    echo "entry is stuck — $queue entries, oldest ${age}s, max num_tries=$tries, none with a last_exception."
+    echo "That is ordinary ingest churn on a live table."
+}
+
+settle() {
+    if [[ "$FORCE" == "1" ]]; then
+        echo "WARNING: --force set; skipping the replication-settle gate. The postcondition below reads one replica." >&2
+    else
+        assert_replication_settled
+    fi
+}
+
+# The reverse direction re-runs 000004_rollback_reverse_replay.sql, which is deliberately NOT ON CLUSTER (it travels by
+# replication, which spans a shard's replicas and not other shards) while its postcondition reads clusterAllReplicas,
+# which spans every shard. On more than one shard those scopes disagree: the replay fixes one shard and the check keeps
+# failing. rollback.sh refuses the same combination for the same reason. The forward direction has no such mismatch —
+# both its sweep and its own postcondition are shard-local — so this is asserted only where it bites.
+assert_single_shard_for_reverse() {
+    local shards
+    shards="$(ch "SELECT uniqExact(shard_num) FROM system.clusters
+                  WHERE cluster = (SELECT substitution FROM system.macros WHERE macro = 'cluster')" 2>/dev/null || true)"
+    if [[ "$shards" =~ ^[0-9]+$ ]] && (( shards > 1 )); then
+        echo "ERROR: this cluster reports $shards shards. The reverse replay this driver re-runs after the sweep reaches" >&2
+        echo "       only the shard you are connected to, while its postcondition reads every shard, so no single run can" >&2
+        echo "       satisfy it. Apply the statements from $SQL_DIR by hand, one shard at a time, then check the" >&2
+        echo "       postcondition once — the same path rollback.sh documents for its own reverse replay." >&2
+        exit 1
+    fi
+    # Unreadable is a NOTE rather than a refusal here, unlike rollback.sh's --sentinel-repair-only: this driver issues no
+    # whole-table rewrite, and the reverse replay it runs is the same statement the rollback already ran once on this
+    # estate. {cluster} inside a table function is substituted from the server's config rather than read from
+    # system.macros, so the postcondition still evaluates on the usual cause (a missing SELECT on system.clusters).
+    if ! [[ "$shards" =~ ^[0-9]+$ ]] || (( shards == 0 )); then
+        echo "NOTE: could not read the shard count ('${shards:-<empty>}'); it needs SELECT on system.clusters and" >&2
+        echo "      system.macros. Proceeding — on a multi-shard cluster this would reconcile only the connected shard." >&2
+    fi
+}
+
+# Extract one `-- >>> BEGIN <name>` .. `-- >>> END <name>` block (exact-line markers) from a reference file.
+extract() {
+    awk -v begin="-- >>> BEGIN $2" -v end="-- >>> END $2" '$0 == begin {f = 1; next} $0 == end {f = 0} f' "$1"
+}
+
+# Refuse rendered SQL that is not what the caller asked for. A marker renamed, moved, indented or split yields text that
+# is empty or only the block's own comments, and clickhouse-client exits 0 on either, so `set -e` never fires and the
+# step prints its success line having done nothing. Same guard, same reasoning, as exchange_and_wrap.sh's.
+require_rendered() {
+    local sql="$1" what="$2" must_contain="$3" file="$4" masked begins ends
+    # Exactly one pair, checked on the FILE rather than the extraction: the awk stops at the first END and otherwise runs
+    # to EOF, so a missing or renamed END sweeps every later block into this one. The content checks cannot see that.
+    begins="$(grep -cxF -e "-- >>> BEGIN $what" "$file" || true)"
+    ends="$(grep -cxF -e "-- >>> END $what" "$file" || true)"
+    if (( begins != 1 || ends != 1 )); then
+        echo "ERROR: $file holds $begins '-- >>> BEGIN $what' and $ends '-- >>> END $what'; expected one of each." >&2
+        exit 2
+    fi
+    masked="$(sed 's/--.*$//' <<<"$sql")"
+    if [[ -z "${masked//[[:space:]]/}" ]]; then
+        echo "ERROR: the '$what' block from $file rendered no executable SQL (empty, or comments only)." >&2
+        echo "       Expected the exact marker lines '-- >>> BEGIN $what' and '-- >>> END $what'." >&2
+        exit 2
+    fi
+    if ! grep -qF "$must_contain" <<<"$masked"; then
+        echo "ERROR: the '$what' block from $file has no '$must_contain' outside its comments, so the markers are" >&2
+        echo "       around the wrong statement. Refusing to run it." >&2
+        exit 2
+    fi
+    if grep -qF '${' <<<"$masked"; then
+        echo "ERROR: the '$what' block from $file still holds an unsubstituted \${...} placeholder after rendering." >&2
+        echo "       Refusing to send SQL containing a literal placeholder." >&2
+        exit 2
+    fi
+}
+
+# One of 000003's shared settle-* blocks, rendered with this driver's POST-SWAP scope: the queue side covers both tables
+# the postcondition joins, the mutation side only the frozen parked one. Kept separate from render() because it
+# substitutes a different placeholder set — the sweep's anchors mean nothing here, and the settle scope means nothing
+# there — so neither function can silently leave the other's placeholder in place.
+#
+# require_rendered's `exit` runs in this function's own command substitution at the call sites, hence their `|| exit 2`.
+render_settle() {
+    local sql queue_tables mutation_tables
+    # Built as variables, not inlined: the replacement half of ${x//pat/repl} does not honor nested quoting, so a
+    # literal "'$A', '$B'" there would substitute the double quotes into the SQL as well.
+    queue_tables="'$LIVE_TABLE', '$PARKED_TABLE'"
+    mutation_tables="'$PARKED_TABLE'"
+    sql="$(extract "$SETTLE_SQL" "$1")"
+    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${SETTLE_QUEUE_TABLES}'/$queue_tables}"
+    sql="${sql//'${SETTLE_MUTATION_TABLES}'/$mutation_tables}"
+    require_rendered "$sql" "$1" "$2" "$SETTLE_SQL"
+    printf '%s' "$sql"
+}
+
+# Substitutions shared by every block this driver renders.
+render() {
+    local sql="$1"
+    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${LIVE_TABLE}'/$LIVE_TABLE}"
+    sql="${sql//'${GAP_START}'/$EFFECTIVE_GAP_START}"
+    sql="${sql//'${SWAP_DONE}'/$SWAP_DONE}"
+    sql="${sql//'${MAX_PARTITIONS_PER_INSERT_BLOCK}'/$MAX_PARTITIONS_PER_INSERT_BLOCK}"
+    printf '%s' "$sql"
+}
+
+# One marked block of 000006. Called BARE, never in a `||` list, so `set -e` aborts the run if the statement fails —
+# which is right: a sweep that did not land its rows, or a replay that did not apply, must not be followed by a verdict.
+run_block() {
+    local block="$1" sql
+    sql="$(render "$(extract "$SWEEP_SQL" "$block")")"
+    require_rendered "$sql" "$block" "$PARKED_TABLE" "$SWEEP_SQL"   # re-checked per pass: cheap, and catches a mid-run edit
+    # --time prints the statement's elapsed seconds to stderr (a bare --query prints nothing). These wall times are what
+    # size the reconciliation step in the runbook's timings, so they are recorded rather than guessed.
+    clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
+}
+
+# The reverse replay, unchanged from the rollback path: 000004_rollback_reverse_replay.sql re-applies every delete
+# bridged since cutover_start onto the restored original (deliberately guard-less — see its header). Run AFTER the sweep,
+# which is what makes deletes win over the re-imported writes.
+#
+# Called BARE, never in a `||` list: a failing statement here means post-cutover deletes were not re-applied, so `set -e`
+# aborting the run is the correct outcome. (Inside a condition context bash suppresses `set -e` for a function's whole
+# body, which would let a failed DELETE fall through to the check below and be reported as a clean replay.)
+run_reverse_deletion_replay() {
+    local sql
+    sql="$(cat "$REVERSE_REPLAY_SQL")"
+    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${CUTOVER_START}'/$CUTOVER_START}"
+    clickhouse-client "${CH_ARGS[@]}" --time --multiquery --query "$sql"
+}
+
+# 000004_rollback_verify_replay.sql, unchanged: asserts no id bridged since cutover_start is live again. Advisory here,
+# unlike in rollback.sh — the reconciliation postcondition is the gate this driver exits on, and it would report the same
+# key as a divergence — so this is the one call that belongs in a condition context. It names which check spoke, so a
+# resurrected key is not confused with a sweep that failed to land rows.
+verify_reverse_replay() {
+    local sql resurrected
+    sql="$(cat "$REVERSE_VERIFY_SQL")"
+    sql="${sql//'${ANALYTICS_DB_DATABASE_NAME}'/$DATABASE}"
+    sql="${sql//'${CUTOVER_START}'/$CUTOVER_START}"
+    resurrected="$(clickhouse-client "${CH_ARGS[@]}" --query "$sql")"
+    if [[ "$resurrected" == "0" ]]; then
+        echo "  Reverse-replay postcondition OK: no id bridged since cutover_start is live on the restored '$LIVE_TABLE'."
+        return 0
+    fi
+    if ! [[ "$resurrected" =~ ^[0-9]+$ ]]; then
+        echo "  WARNING: reverse-replay postcondition COULD NOT BE EVALUATED — the query returned no usable count." >&2
+    else
+        echo "  WARNING: reverse-replay postcondition FAILED — $resurrected id(s) deleted after cutover_start are live" >&2
+        echo "           again on '$LIVE_TABLE'. The sweep re-imported them and the replay did not mask them." >&2
+    fi
+    return 1
+}
+
+# Render and validate every block this run will use, ONCE, at top level. It is not merely an early check: the counts are
+# read inside a command substitution, where an exit from require_rendered ends only the subshell — so a renamed marker or
+# a surviving placeholder would reach the caller as "the counts could not be read", pointing at connectivity instead of
+# at the file. rollback.sh validates its sentinel SQL up front for exactly this reason. Only the blocks the chosen
+# direction and mode actually run are checked, so an unrelated block's breakage does not block a --report-only.
+validate_blocks() {
+    local block
+    validate_block "$VERIFY_SQL" "verify-$DIRECTION"
+    [[ "$REPORT_ONLY" == "1" ]] && return 0
+    for block in "${MUTATING_BLOCKS[@]}"; do
+        validate_block "$SWEEP_SQL" "$block"
+    done
+    return 0
+}
+
+validate_block() {
+    require_rendered "$(render "$(extract "$1" "$2")")" "$2" "$PARKED_TABLE" "$1"
+}
+
+# The four counts, as one tab-separated line, so the driver gates on them instead of leaving numbers on a screen.
+# Called inside a command substitution, so it deliberately does NO validation of its own — see validate_blocks.
+reconciliation_counts() {
+    clickhouse-client "${CH_ARGS[@]}" --multiquery \
+        --query "$(render "$(extract "$VERIFY_SQL" "verify-$DIRECTION")")"
+}
+
+MISSING=""; STALE=""; PAYLOAD=""; NEWER=""
+# Reads the postcondition into the four globals. Returns non-zero when the output is not four counts (a dead client, a
+# refused read) — which is "not verified" rather than "clean", and must never be allowed to read as a pass.
+read_postcondition() {
+    local out
+    if ! out="$(reconciliation_counts)"; then out=""; fi
+    read -r MISSING STALE PAYLOAD NEWER <<< "$out"
+    [[ "$MISSING" =~ ^[0-9]+$ && "$STALE" =~ ^[0-9]+$ && "$PAYLOAD" =~ ^[0-9]+$ && "$NEWER" =~ ^[0-9]+$ ]]
+}
+
+print_counts() {
+    echo "  missing_keys=$MISSING stale_keys=$STALE payload_mismatch_keys=$PAYLOAD (gate: all three at 0)"
+    echo "  newer_keys=$NEWER  — informational, and EXPECTED to be non-zero: a gap-window trace written again after the"
+    echo "                        swap is newer on the live side, which the sweep deliberately leaves alone."
+}
+
+gate_is_clean() {
+    (( MISSING == 0 && STALE == 0 && PAYLOAD == 0 ))
+}
+
+resolve_live_table
+detect_direction
+
+# Direction-dependent argument rules, asserted now that the topology has named the direction. Each rejected flag asserts
+# a precondition for something the other direction does, so accepting one would confirm a wrong mental model.
+if [[ "$DIRECTION" == "forward" ]]; then
+    [[ -n "$GAP_START" ]] || {
+        echo "ERROR: the forward direction requires --gap-start: the start of the last delta pass, which delta_replay.sh" >&2
+        echo "       prints as 'RECORD delta_start='. It bounds what the sweep copies. Widening it is free — the sweep is" >&2
+        echo "       mask-honored and idempotent — so pass backfill_start if delta_start was not recorded." >&2
+        exit 2
+    }
+    [[ -z "$CUTOVER_START" ]] || {
+        echo "ERROR: --cutover-start belongs to the reverse direction, which replays deletes from it. The forward" >&2
+        echo "       reconciliation bounds its copy with --gap-start and its exclusion with --swap-done; neither is" >&2
+        echo "       cutover_start, and using it as either would be wrong (see the option docs)." >&2
+        exit 2
+    }
+    [[ "$CONFIRM_REIMPORT" != "1" ]] || {
+        echo "ERROR: --confirm-reimport-successor-writes belongs to the reverse direction. Forward, the sweep restores" >&2
+        echo "       writes the cutover LOST rather than writes a rollback chose to discard, so there is nothing to" >&2
+        echo "       acknowledge: it is repair, not a reversal of a decision." >&2
+        exit 2
+    }
+else
+    [[ -n "$CUTOVER_START" ]] || {
+        echo "ERROR: the reverse direction requires --cutover-start (the value exchange_and_wrap.sh printed). It bounds" >&2
+        echo "       the reverse deletion replay this driver re-runs after the sweep, exactly as it does in rollback.sh." >&2
+        echo "       Estimating it loses data in either direction — if it was lost, stop and escalate (see the runbook)." >&2
+        exit 2
+    }
+    # cutover_start is the reverse gap anchor by definition; --gap-start only ever widens it.
+    [[ -n "$GAP_START" ]] || GAP_START="$CUTOVER_START"
+    if [[ "$REPORT_ONLY" != "1" && "$CONFIRM_REIMPORT" != "1" ]]; then
+        echo "ERROR: the reverse direction requires --confirm-reimport-successor-writes. The sweep re-imports exactly the" >&2
+        echo "       post-cutover writes --accept-post-cutover-write-loss acknowledged discarding, so this asserts you now" >&2
+        echo "       want them back. That is right when the rollback was motivated by latency, merge load or the wrap; it" >&2
+        echo "       is WRONG when the successor's content is what is suspect, since it re-imports the very data the" >&2
+        echo "       rollback existed to discard. Use --report-only to size the gap without re-importing anything." >&2
+        exit 2
+    fi
+    [[ "$LIVE_TABLE" == "traces" ]] || {
+        echo "ERROR: the reverse direction expects the restored original live under 'traces', but this estate resolves its" >&2
+        echo "       live table to '$LIVE_TABLE' (i.e. 'traces' is a Distributed wrapper). A rollback removes the wrapper," >&2
+        echo "       so this state is not one a promote produces. Resolve by hand." >&2
+        exit 1
+    }
+    assert_single_shard_for_reverse
+fi
+
+# Widen the gap anchor downward by --slack-seconds, server-side: no host date math and no timezone ambiguity, the same
+# reason every other window bound in this runbook is computed in ClickHouse.
+EFFECTIVE_GAP_START="$(ch "SELECT toString(subtractSeconds(toDateTime64('$GAP_START', 6, 'UTC'), $SLACK_SECONDS))")"
+[[ "$EFFECTIVE_GAP_START" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] || {
+    echo "ERROR: could not compute the slack-widened gap anchor from '$GAP_START' - ${SLACK_SECONDS}s (got '$EFFECTIVE_GAP_START')." >&2
+    exit 1
+}
+
+validate_blocks
+
+echo "Direction: $DIRECTION  (parked '$PARKED_TABLE' -> live '$LIVE_TABLE')"
+echo "Gap window from $EFFECTIVE_GAP_START UTC (= $GAP_START minus ${SLACK_SECONDS}s slack); swap_done $SWAP_DONE UTC"
+
+settle
+read_postcondition || {
+    echo "ERROR: the reconciliation postcondition could not be read, so it is unknown whether there is a gap." >&2
+    echo "       Treat this as unverified, not as clean. Fix connectivity and re-run — no mutation was issued." >&2
+    exit 1
+}
+echo "Postcondition BEFORE any mutation:"
+print_counts
+
+if gate_is_clean; then
+    echo "Nothing to reconcile: every key live in '$PARKED_TABLE' inside the gap window is present on '$LIVE_TABLE' at the"
+    echo "same version or newer. No statement issued."
+    exit 0
+fi
+
+if [[ "$REPORT_ONLY" == "1" ]]; then
+    echo "--report-only: no mutation issued. The estate is NOT reconciled — re-run without --report-only to sweep it." >&2
+    exit 1
+fi
+
+PASS=0
+while (( PASS < MAX_PASSES )); do
+    PASS=$(( PASS + 1 ))
+    echo "Pass $PASS/$MAX_PASSES:"
+    for block in "${MUTATING_BLOCKS[@]}"; do
+        run_block "$block"
+    done
+    if [[ "$DIRECTION" == "reverse" ]]; then
+        run_reverse_deletion_replay
+        verify_reverse_replay || true
+    fi
+    settle
+    read_postcondition || {
+        echo "ERROR: the reconciliation postcondition could not be read after pass $PASS. The sweep ran, so treat the" >&2
+        echo "       estate as UNVERIFIED rather than reconciled: fix connectivity and re-run (this driver is idempotent)." >&2
+        exit 1
+    }
+    print_counts
+    if gate_is_clean; then
+        echo
+        echo "RECONCILED after $PASS pass(es): missing_keys=0 stale_keys=0 payload_mismatch_keys=0."
+        if [[ "$DIRECTION" == "forward" ]]; then
+            echo "Every trace written to the old table in the [$EFFECTIVE_GAP_START, swap) gap is live on '$LIVE_TABLE'."
+            echo
+            echo "NEXT:"
+            echo "  1. Payload-level picture over exactly the range that was reconciled, alongside the usual weekly compare:"
+            echo "       ./verify.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
+            echo "           --old-table traces_pre_cutover_backup --new-table $LIVE_TABLE \\"
+            echo "           --window-from '$EFFECTIVE_GAP_START' --window-to '<now, UTC>'"
+            echo "  2. Keep '$PARKED_TABLE' for the soak. finalize.sh refuses to retire it without --confirm-gap-reconciled,"
+            echo "     which is this run."
+        else
+            echo "The post-cutover writes the rollback discarded are live again on '$LIVE_TABLE', with sentinels"
+            echo "denormalized back to NULL, and every delete bridged since cutover_start is still masked."
+            echo
+            echo "NEXT: the post-rollback fidelity compare no longer needs the --to-week exclusion for WRITES — this run"
+            echo "      removed that divergence. Residual differences are post-cutover deletes and post-promote writes."
+        fi
+        exit 0
+    fi
+    echo "  Gate still non-zero after pass $PASS; retrying (concurrent traffic can add to the gap while the sweep runs)."
+done
+
+echo >&2
+echo "RECONCILIATION FAILED: the gate is still non-zero after $MAX_PASSES pass(es) —" >&2
+echo "  missing_keys=$MISSING stale_keys=$STALE payload_mismatch_keys=$PAYLOAD" >&2
+echo "This is NOT convergence stalling on write volume: the parked table is frozen, so repeated passes cannot keep" >&2
+echo "finding new work unless something else is wrong. Investigate before re-running:" >&2
+echo "  * missing_keys — the sweep did not land those rows. Check the run's errors, and check that --swap-done is not" >&2
+echo "    LATER than the actual swap (a late value under-excludes; an early one over-excludes and shows up exactly here)." >&2
+echo "  * stale_keys / payload_mismatch_keys — the live row disagrees with the frozen one at the same or an older" >&2
+echo "    version, which a sweep cannot fix by re-inserting. Triage with:" >&2
+# verify.sh's --old-table is always the OLD-SCHEMA side (Nullable, nanosecond), which is the parked backup forward and
+# the live original in reverse — the two directions put opposite tables there, so the pair is resolved rather than fixed.
+if [[ "$DIRECTION" == "forward" ]]; then
+    verify_pair="--old-table $PARKED_TABLE --new-table $LIVE_TABLE"
+else
+    verify_pair="--old-table $LIVE_TABLE --new-table $PARKED_TABLE"
+fi
+echo "      ./verify.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\" >&2
+echo "          $verify_pair \\" >&2
+echo "          --window-from '$EFFECTIVE_GAP_START' --window-to '<now, UTC>' --drill-down" >&2
+echo "Do NOT run finalize.sh: the parked backup is the only copy of whatever is still missing." >&2
+exit 1

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/reconcile.sh
@@ -69,10 +69,16 @@
 #                             (forward) or `RECORD promote_done=` (reverse). Required. Bridged deletes at or after it are
 #                             excluded from the sweep, so a gap-window trace deleted after the swap is not brought back.
 #                             UNLIKE --gap-start THIS IS NOT FREE TO GUESS, and the two directions of error are not
-#                             symmetric: too EARLY excludes too much, so a legitimately live key stays missing and the
-#                             postcondition FAILS LOUDLY; too LATE excludes too little and can RESURRECT a deleted trace
-#                             silently. If the printed value was lost, use `cutover_start` — it is earlier than the swap
-#                             by construction, i.e. on the side that fails loudly.
+#                             symmetric — WHEN IN DOUBT, GUESS EARLY:
+#                               * too EARLY excludes too much, so a legitimately live key stays missing and the
+#                                 postcondition FAILS LOUDLY. Widen and re-run.
+#                               * too LATE excludes too little: a delete that fired AFTER the swap is bridged below the
+#                                 bound, the key is live in the frozen backup, the sweep re-inserts it and the replay's
+#                                 resurrection guard spares it. The delete is undone, and nothing reports it.
+#                             If the printed value was lost, use `cutover_start` — earlier than the swap by
+#                             construction, i.e. on the side that fails loudly. Do NOT round it up "to be safe": the
+#                             recorded value already trails the swap (../README.md, "The final cutover window"), so
+#                             every second added is a second of silent resurrection window.
 #   --slack-seconds N         widen --gap-start DOWNWARD by N seconds (default 300) to absorb cross-replica clock skew on
 #                             the server-side timestamp defaults the gap window matches on. Free, per the widening note
 #                             above. Pass 0 to use the anchor exactly as given.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -32,10 +32,15 @@
 #
 # POST-CUTOVER WRITES: stages B/C promote the frozen pre-cutover backup back to live `traces`, so traces WRITTEN to the
 # successor after cutover_start stop being live. They are NOT destroyed — the successor is parked as
-# traces_post_rollback_backup and retained until finalize.sh, so they can be recovered from there during the soak — but
-# the live table no longer serves them. This is inherent to promoting a point-in-time backup and cannot be "fixed"
-# (auto-merging the successor's writes would re-import the very data the rollback is discarding);
-# --accept-post-cutover-write-loss makes the operator acknowledge it before the promote.
+# traces_post_rollback_backup and retained until finalize.sh. --accept-post-cutover-write-loss makes the operator
+# acknowledge that before the promote.
+#
+# Acknowledging it is a CHOICE, not a verdict, and this driver prints both options with the gap already sized. Merging
+# those writes back is right when the rollback was motivated by latency, merge load or the wrap — there they are good
+# data — and wrong when the successor's CONTENT is what is suspect, since it re-imports exactly what the rollback existed
+# to discard. `reconcile.sh --confirm-reimport-successor-writes` is the supported way to take the first option; it sweeps
+# them out of the parked successor with sentinel -> NULL denormalization and then re-runs the reverse replay, so
+# post-cutover deletes still win. Whichever is chosen, decide it BEFORE finalize.sh, which destroys the only copy.
 #
 # SAFETY: the stages are mutually exclusive and each lives in its OWN file, so no single file mixes a TRUNCATE with an
 # EXCHANGE/DROP — running any file does exactly one stage. Before running, this asserts the live `traces` topology matches
@@ -300,8 +305,12 @@ fi
 if [[ ( "$STAGE" == "B" || "$STAGE" == "C" ) && "$ACCEPT_WRITE_LOSS" != "1" ]]; then
     echo "ERROR: rollback --stage $STAGE requires --accept-post-cutover-write-loss. Promoting the frozen backup makes" >&2
     echo "       traces written to the successor after cutover_start non-live. They are NOT destroyed — the successor is" >&2
-    echo "       parked as traces_post_rollback_backup until finalize.sh, so recover them during the soak — but the live" >&2
-    echo "       table will no longer serve them. Re-run with the flag once you accept this." >&2
+    echo "       parked as traces_post_rollback_backup until finalize.sh." >&2
+    echo "       The flag acknowledges the loss; it does not commit you to it. After the promote this driver prints how" >&2
+    echo "       many such traces there are and the 'reconcile.sh --confirm-reimport-successor-writes' command that merges" >&2
+    echo "       them back (post-cutover deletes still win). Take that route when the rollback is about latency, merge" >&2
+    echo "       load or the wrap; leave the writes discarded when the successor's CONTENT is what is suspect." >&2
+    echo "       Re-run with the flag once you accept that the promote makes them non-live." >&2
     exit 2
 fi
 
@@ -571,6 +580,18 @@ sentinel_counts() {
     sql="${sql//'${SENTINEL_WINDOW_FROM}'/$from}"
     sql="${sql//'${SENTINEL_WINDOW_TO}'/$to}"
     clickhouse-client "${CH_ARGS[@]}" --query "$sql"
+}
+
+PROMOTE_DONE=""   # set by record_promote_done after a stage B/C promote; the reverse sweep's "do not resurrect" bound.
+
+# Captured immediately AFTER the promote RENAME returns and BEFORE the reverse replay, which is what makes it usable as
+# reconcile.sh's --swap-done. It is deliberately not cutover_start: that instant precedes the promote, so using it as the
+# exclusion bound would wrongly drop a trace deleted and then re-created on the successor before the promote — a trace
+# the parked successor legitimately holds live and that the reverse sweep has to bring back.
+record_promote_done() {
+    PROMOTE_DONE="$(ch "SELECT toString(now64(6, 'UTC'))")"
+    echo "RECORD promote_done=$PROMOTE_DONE UTC  (the reverse sweep's exclusion bound; pass it with the marker:"
+    echo "       reconcile.sh --swap-done '$PROMOTE_DONE UTC')"
 }
 
 run_file() {
@@ -865,6 +886,7 @@ case "$STAGE" in
     B)
         [[ -n "$CUTOVER_START" ]] || { echo "ERROR: --cutover-start is required for stage B" >&2; exit 2; }
         run_file 000004_rollback_stage_b_exchange_back.sql
+        record_promote_done
         run_file 000004_rollback_reverse_replay.sql
         verify_replay_postcondition || REPLAY_CHECK_FAILED=1
         echo "Stage B done: tables swapped back and deletes since cutover_start re-applied."
@@ -872,6 +894,7 @@ case "$STAGE" in
     C)
         [[ -n "$CUTOVER_START" ]] || { echo "ERROR: --cutover-start is required for stage C" >&2; exit 2; }
         run_file 000004_rollback_stage_c_promote_original.sql
+        record_promote_done
         run_file 000004_rollback_reverse_replay.sql
         verify_replay_postcondition || REPLAY_CHECK_FAILED=1
         echo "Stage C done: wrapper dropped, original promoted, deletes since cutover_start re-applied."
@@ -880,6 +903,38 @@ esac
 
 if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     echo "Now in the canonical state: traces = original data (live), traces_post_rollback_backup = successor data (parked)."
+    echo
+    # Size the loss instead of describing it. --accept-post-cutover-write-loss was an acknowledgment, not a verdict, and
+    # the operator cannot weigh the choice against a number nobody has printed. Same predicate the reverse sweep uses
+    # (created_at OR last_updated_at, prunes on the successor's minmax skip indexes), so this IS the set reconcile.sh
+    # would re-import. Advisory and non-fatal: the rollback has already succeeded, and the guidance below still has to
+    # print — a failed read must not swallow it.
+    discarded="$(ch "SELECT count() FROM $DATABASE.traces_post_rollback_backup
+                     WHERE created_at >= toDateTime64('$CUTOVER_START', 6, 'UTC')
+                        OR last_updated_at >= toDateTime64('$CUTOVER_START', 6, 'UTC')" 2>/dev/null || true)"
+    if [[ "$discarded" =~ ^[0-9]+$ ]]; then
+        echo "POST-CUTOVER WRITES NOW NON-LIVE: $discarded row(s) in traces_post_rollback_backup were written after"
+        echo "cutover_start and are no longer served by the live table."
+    else
+        echo "POST-CUTOVER WRITES NOW NON-LIVE: the count could not be read just now, but the set is every row in"
+        echo "traces_post_rollback_backup with created_at or last_updated_at at/after cutover_start."
+    fi
+    echo "You have two options, and both are only available while that table is parked (finalize.sh ends both):"
+    echo "  * ACCEPT the loss — do nothing. Right when the successor's CONTENT is what is suspect, since merging those"
+    echo "    writes back would re-import the very data this rollback existed to discard."
+    echo "  * RECOVER them — right when the rollback was about latency, merge load or the wrap, where they are good data:"
+    if [[ -n "$PROMOTE_DONE" ]]; then
+        echo "      ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
+        echo "          --cutover-start '$CUTOVER_START UTC' --swap-done '$PROMOTE_DONE UTC' \\"
+        echo "          --confirm-reimport-successor-writes"
+    else
+        echo "      ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
+        echo "          --cutover-start '$CUTOVER_START UTC' --swap-done '<promote_done, UTC>' \\"
+        echo "          --confirm-reimport-successor-writes"
+    fi
+    echo "    It re-imports them with the successor's epoch/NaN sentinels denormalized back to NULL (so their recomputed"
+    echo "    duration is NULL, not a large negative), then re-runs the reverse replay so post-cutover deletes still win."
+    echo "    Add --report-only first to see the four reconciliation counts without importing anything."
     # The divergence is bounded by the CUTOVER WINDOW, not by the calendar, so print the offset of the last week wholly
     # before cutover_start: unlike a calendar-relative bound it stays correct if the verify runs days later. Same anchor
     # math verify.sh uses on this table, capped at its last populated week (LAST_WEEK, from max(created_at)) because
@@ -903,6 +958,13 @@ if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
         echo "  where N could not be computed just now: it is the whole weeks between toMonday(min(created_at)) on"
         echo "  'traces' and cutover_start's Monday, minus 1."
     fi
+    echo "THAT BOUND IS FOR THE 'ACCEPT' OPTION ONLY. If you take the RECOVER option above, the cutover week no longer"
+    echo "legitimately mismatches BY WRITES — reconcile.sh has just put them back — so DROP the --to-week bound and run"
+    echo "the compare unbounded. What remains expected there is not writes: post-cutover DELETES (masked on the restored"
+    echo "original by the reverse replay, still live in the parked successor) and anything written after the promote."
+    echo "Running the bounded form after a recovery is not wrong, only weaker: it stops short of the week the recovery"
+    echo "was about."
+    echo
     echo "A mismatch inside that bound is NOT automatically corruption. Any write touching a PRE-EXISTING trace after"
     echo "cutover_start diverges it in a sealed week, which no weekly bound excludes: the update endpoint keeps the row's"
     echo "created_at (so the key differs on both sides), while batch ingestion re-stamps it (so the key goes missing from"
@@ -936,7 +998,9 @@ if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     echo "LAST, and only once every step above has landed: finalize.sh recycles traces_post_rollback_backup into an"
     echo "empty traces_local_v2. That is the irreversible step — it destroys the only copy of the post-cutover writes"
     echo "this rollback discarded, and with it the cheap retry. Do not run it until the flag reverts, the sentinel"
-    echo "repair and the checks above are done (runbook: 'When the rollback is done')."
+    echo "repair and the checks above are done (runbook: 'When the rollback is done'). It refuses without"
+    echo "--confirm-gap-reconciled, which is you asserting that the accept-or-recover decision above has been MADE —"
+    echo "not that a recovery ran."
 fi
 
 # Last, so the guidance above always prints: a caller reading only $? must not be told this rollback succeeded.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -926,11 +926,11 @@ if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     if [[ -n "$PROMOTE_DONE" ]]; then
         echo "      ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
         echo "          --cutover-start '$CUTOVER_START UTC' --swap-done '$PROMOTE_DONE UTC' \\"
-        echo "          --confirm-reimport-successor-writes"
+        echo "          --confirm-reimport-successor-writes --confirm-retention-paused"
     else
         echo "      ./reconcile.sh --database $DATABASE ${CH_HOST:+--host $CH_HOST} ${CH_PORT:+--port $CH_PORT} \\"
         echo "          --cutover-start '$CUTOVER_START UTC' --swap-done '<promote_done, UTC>' \\"
-        echo "          --confirm-reimport-successor-writes"
+        echo "          --confirm-reimport-successor-writes --confirm-retention-paused"
     fi
     echo "    It re-imports them with the successor's epoch/NaN sentinels denormalized back to NULL (so their recomputed"
     echo "    duration is NULL, not a large negative), then re-runs the reverse replay so post-cutover deletes still win."

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/rollback.sh
@@ -999,8 +999,8 @@ if [[ "$STAGE" == "B" || "$STAGE" == "C" ]]; then
     echo "empty traces_local_v2. That is the irreversible step — it destroys the only copy of the post-cutover writes"
     echo "this rollback discarded, and with it the cheap retry. Do not run it until the flag reverts, the sentinel"
     echo "repair and the checks above are done (runbook: 'When the rollback is done'). It refuses without"
-    echo "--confirm-gap-reconciled, which is you asserting that the accept-or-recover decision above has been MADE —"
-    echo "not that a recovery ran."
+    echo "--confirm-post-cutover-decision, which is you asserting that the accept-or-recover decision above has been"
+    echo "MADE — not that a recovery ran."
 fi
 
 # Last, so the guidance above always prints: a caller reading only $? must not be told this rollback succeeded.

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -159,10 +159,20 @@ if [[ -n "$WINDOW_FROM" || -n "$WINDOW_TO" ]]; then
         [[ "$_bound" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] \
             || { echo "ERROR: --window-from/--window-to must be 'YYYY-MM-DD HH:MM:SS[.ffffff]' (an optional ' UTC' marker is accepted): '$_bound'" >&2; exit 2; }
     done
-    # String comparison is exact here because both bounds have passed the fixed-width shape check above, so lexical order
-    # is chronological order. An empty half-open range would compare nothing and report a vacuous pass, which is the one
-    # answer a fidelity gate must never give — the same reason the checked==0 guard exists below.
-    [[ "$WINDOW_FROM" < "$WINDOW_TO" ]] \
+    # Compare on a fraction padded to DateTime64(6)'s six digits, not on the bounds as given. Lexical order is
+    # chronological for these strings in every case but one: when one fraction is a prefix of the other, the same
+    # instant at two precisions ('10:00:00' and '10:00:00.000000') compares as strictly ordered, so the EMPTY range it
+    # names passes the check below and the run reports PASSED over nothing — the one answer a fidelity gate must never
+    # give, and one the checked==0 guard does not catch, since window mode always compares exactly one window. That
+    # shape is reachable: the check above permits a variable-length fraction, and the bounds come from different
+    # places, one pasted from a driver's RECORD line and one typed.
+    _cmp=()
+    for _bound in "$WINDOW_FROM" "$WINDOW_TO"; do
+        _frac="000000"
+        [[ "$_bound" != *.* ]] || _frac="${_bound#*.}000000"
+        _cmp+=("${_bound%%.*}.${_frac:0:6}")
+    done
+    [[ "${_cmp[0]}" < "${_cmp[1]}" ]] \
         || { echo "ERROR: --window-from must be strictly before --window-to (the window is half-open, so an empty range compares nothing)." >&2; exit 2; }
 fi
 

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -65,6 +65,15 @@
 #                       boundaries. --sample-mod, --drill-down, --receive-timeout and the confirm-keys / version-ties
 #                       resolution all work unchanged. In this mode the anchor scan is skipped (nothing needs a week
 #                       grid), so the run also does not depend on min/max(created_at) holding still.
+#                       IT COMPARES TRACES *CREATED* IN THE WINDOW, not every trace touched in it, and the PASSED line
+#                       says so. 000005's blocks bound on created_at and have to: the weekly mode's partitions and its
+#                       superseded-version artifact logic are created_at-based, and widening the predicate to
+#                       `created_at OR last_updated_at` would put one row in two week windows and break both. So a trace
+#                       created earlier and merely UPDATED inside the window is not in this compare. That is not a hole
+#                       in the reconciliation — those keys are precisely what reconcile.sh's postcondition reports as
+#                       stale_keys / payload_mismatch_keys, which is version-driven and sees them where a created_at
+#                       window cannot. Read a PASS here as "the traces created in this range are faithful", and the four
+#                       counts as what covers the ones merely updated in it.
 #   --drill-down        on any week the compare reported as differing, print up to 100 keys that differ or exist on one
 #                       side only. Not limited to a MISMATCH: the artifact and INCONCLUSIVE verdicts are reached from the
 #                       same differing-key set, and those are the ones an operator most often needs to see.
@@ -443,7 +452,11 @@ fi
 # weekly form prints its bounds and stride. In window mode that is the explicit window, which is the whole point of the
 # mode: a reconciliation compare has to be quotable as "this exact range was checked".
 if (( WINDOW_MODE == 1 )); then
-    COVERED="window [$WINDOW_FROM .. $WINDOW_TO) UTC, sample 1/$SAMPLE_MOD"
+    # "created in" rather than just the range: 000005 bounds on created_at, so a trace created earlier and merely
+    # updated inside the window is not in this compare (see --window-from's doc). Saying so on the PASSED line is what
+    # stops the pass being quoted as broader than it is — reconcile.sh's stale_keys / payload_mismatch_keys are what
+    # cover the updated ones.
+    COVERED="traces CREATED in window [$WINDOW_FROM .. $WINDOW_TO) UTC, sample 1/$SAMPLE_MOD"
 else
     COVERED="weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD"
 fi

--- a/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
+++ b/apps/opik-backend/data-migrations/traces-local-v2-cutover/scripts/verify.sh
@@ -53,6 +53,18 @@
 #                       'last-sealed' stops before the current calendar week: a convenience when the compare runs in the
 #                       same week as whatever it means to exclude, otherwise pass the offset explicitly.
 #   --weeks-stride S    compare every S-th week (S>1 samples partitions for a quick pass). Default 1.
+#   --window-from TS / --window-to TS
+#                       compare ONE arbitrary created_at window instead of walking weeks — the shape the post-swap
+#                       reconciliation needs, where the range of interest is "the gap", not a calendar week. Half-open
+#                       [from, to). 'YYYY-MM-DD HH:MM:SS[.ffffff]', with an optional ' UTC' marker so a value pasted
+#                       straight from a driver's RECORD line works; either way BOTH bounds are interpreted as UTC,
+#                       matching every other window bound in this runbook.
+#                       MUTUALLY EXCLUSIVE with --from-week / --to-week / --weeks-stride, which are 0-based offsets into
+#                       a week grid this mode does not build. No new compare SQL is involved: 000005's blocks are already
+#                       parameterised by arbitrary ${WINDOW_LO} / ${WINDOW_HI}, and only the driver was generating week
+#                       boundaries. --sample-mod, --drill-down, --receive-timeout and the confirm-keys / version-ties
+#                       resolution all work unchanged. In this mode the anchor scan is skipped (nothing needs a week
+#                       grid), so the run also does not depend on min/max(created_at) holding still.
 #   --drill-down        on any week the compare reported as differing, print up to 100 keys that differ or exist on one
 #                       side only. Not limited to a MISMATCH: the artifact and INCONCLUSIVE verdicts are reached from the
 #                       same differing-key set, and those are the ones an operator most often needs to see.
@@ -73,6 +85,12 @@ TO_WEEK=""
 WEEKS_STRIDE=1              # 1 = every week; S skips to every S-th weekly partition for a quick, pruned pass
 DRILL_DOWN=0
 RECEIVE_TIMEOUT=1800        # seconds tolerated between server packets, not total query time. See --receive-timeout.
+WINDOW_FROM=""              # single arbitrary created_at window, half-open [from, to). See --window-from.
+WINDOW_TO=""
+# The week bounds carry defaults, so "was it passed?" cannot be read off their values — an explicit --from-week 0 or
+# --weeks-stride 1 has to conflict with --window-from just as any other value would, or the mutual exclusion would be
+# silently partial exactly where an operator is most likely to combine them by habit.
+WEEK_BOUND_FLAGS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -80,9 +98,11 @@ while [[ $# -gt 0 ]]; do
         --old-table) OLD_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
         --new-table) NEW_TABLE="${2:?"$1 requires a value"}"; shift 2 ;;
         --sample-mod) SAMPLE_MOD="${2:?"$1 requires a value"}"; shift 2 ;;
-        --from-week) FROM_WEEK="${2:?"$1 requires a value"}"; shift 2 ;;
-        --to-week) TO_WEEK="${2:?"$1 requires a value"}"; shift 2 ;;
-        --weeks-stride) WEEKS_STRIDE="${2:?"$1 requires a value"}"; shift 2 ;;
+        --from-week) FROM_WEEK="${2:?"$1 requires a value"}"; WEEK_BOUND_FLAGS+=("$1"); shift 2 ;;
+        --to-week) TO_WEEK="${2:?"$1 requires a value"}"; WEEK_BOUND_FLAGS+=("$1"); shift 2 ;;
+        --weeks-stride) WEEKS_STRIDE="${2:?"$1 requires a value"}"; WEEK_BOUND_FLAGS+=("$1"); shift 2 ;;
+        --window-from) WINDOW_FROM="${2:?"$1 requires a value"}"; shift 2 ;;
+        --window-to) WINDOW_TO="${2:?"$1 requires a value"}"; shift 2 ;;
         --drill-down) DRILL_DOWN=1; shift ;;
         --receive-timeout) RECEIVE_TIMEOUT="${2:?"$1 requires a value"}"; shift 2 ;;
         --host) CH_HOST="${2:?"$1 requires a value"}"; shift 2 ;;
@@ -106,6 +126,36 @@ done
 [[ -z "$TO_WEEK" || "$TO_WEEK" == last-sealed || "$TO_WEEK" =~ ^[0-9]+$ ]] \
     || { echo "ERROR: --to-week must be a non-negative integer or 'last-sealed'." >&2; exit 2; }
 [[ -f "$VERIFY_SQL" ]] || { echo "ERROR: cannot find verify SQL at $VERIFY_SQL" >&2; exit 2; }
+
+# Window mode: one arbitrary created_at range instead of a week grid. The two modes cannot be combined — the week bounds
+# are offsets into a grid this mode never builds — so refuse rather than silently letting one win.
+WINDOW_MODE=0
+if [[ -n "$WINDOW_FROM" || -n "$WINDOW_TO" ]]; then
+    WINDOW_MODE=1
+    [[ -n "$WINDOW_FROM" && -n "$WINDOW_TO" ]] \
+        || { echo "ERROR: --window-from and --window-to must be passed together (the window is half-open [from, to))." >&2; exit 2; }
+    if (( ${#WEEK_BOUND_FLAGS[@]} > 0 )); then
+        echo "ERROR: --window-from/--window-to are mutually exclusive with ${WEEK_BOUND_FLAGS[*]}. Those are 0-based" >&2
+        echo "       OFFSETS into a weekly grid anchored on toMonday(min(created_at)); window mode compares one explicit" >&2
+        echo "       range and builds no grid at all, so there is nothing for an offset to mean." >&2
+        exit 2
+    fi
+    # Accept the ' UTC' marker the drivers print, so a value pasted from a RECORD line works, but do not require it: the
+    # bounds are interpreted as UTC either way (the SQL pins 'UTC'), which is what --sentinel-window-from also does. The
+    # consequence of a wrong zone here is a shifted comparison window, not a mutation — unlike the anchors reconcile.sh
+    # and rollback.sh take, where the marker is mandatory because a shifted value silently destroys or resurrects rows.
+    WINDOW_FROM="${WINDOW_FROM% UTC}"
+    WINDOW_TO="${WINDOW_TO% UTC}"
+    for _bound in "$WINDOW_FROM" "$WINDOW_TO"; do
+        [[ "$_bound" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}\ [0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?$ ]] \
+            || { echo "ERROR: --window-from/--window-to must be 'YYYY-MM-DD HH:MM:SS[.ffffff]' (an optional ' UTC' marker is accepted): '$_bound'" >&2; exit 2; }
+    done
+    # String comparison is exact here because both bounds have passed the fixed-width shape check above, so lexical order
+    # is chronological order. An empty half-open range would compare nothing and report a vacuous pass, which is the one
+    # answer a fidelity gate must never give — the same reason the checked==0 guard exists below.
+    [[ "$WINDOW_FROM" < "$WINDOW_TO" ]] \
+        || { echo "ERROR: --window-from must be strictly before --window-to (the window is half-open, so an empty range compares nothing)." >&2; exit 2; }
+fi
 
 # One place for the connection and client-side options, so the four call sites below cannot drift — in particular so
 # --receive-timeout applies to the confirm-keys re-check and the drill-down, not only to the window compare.
@@ -235,111 +285,136 @@ if [[ "$ROWS" == "0" ]]; then
 fi
 
 # Week range from the old table's created_at (bounded and real; covers rows whose id_at is far-future from the bad-id bug
-# but whose created_at is real). Same anchor math as backfill.sh.
-ANCHOR="$(ch "SELECT toString(toMonday(min(created_at))) FROM $OLD_TABLE")"
-HORIZON="$(ch "SELECT toString(addWeeks(toMonday(max(created_at)), 1)) FROM $OLD_TABLE")"
-LAST_WEEK="$(ch "SELECT dateDiff('week', toDate('$ANCHOR'), toDate('$HORIZON')) - 1")"
-[[ -n "$TO_WEEK" ]] || TO_WEEK="$LAST_WEEK"
-# Every week past the last one with data is empty by construction, so a larger --to-week only walks empty windows. This
-# also catches the realistic mix-up: a weekly PARTITION name passes the integer test and would otherwise walk millions of
-# empty windows with no error and no result. The anchor comes from created_at above, so far-future id_at values never
-# inflate a legitimate offset however far ahead they sit — only what the caller typed can be out of range.
-if [[ "$TO_WEEK" =~ ^[0-9]+$ ]] && (( TO_WEEK > LAST_WEEK )); then
-    echo "ERROR: --to-week $TO_WEEK is past the last week with data (offset $LAST_WEEK). These bounds are 0-based week" >&2
-    echo "       OFFSETS from the anchor Monday ($ANCHOR), not dates — if that was a YYYYMMDD partition name, pass an" >&2
-    echo "       offset instead, or 'last-sealed' for the last complete week, or omit the bound to cover every week." >&2
-    exit 2
-fi
-# 'last-sealed' excludes the current CALENDAR week — the only one that can still change — and not merely the newest week
-# holding data: on a quiet table max(created_at) may already sit in a sealed week, and excluding that one would leave the
-# newest populated week uncompared. Capped at LAST_WEEK so a quiet table still verifies everything it holds. now('UTC')
-# matches created_at's own timezone, so the boundary agrees with the anchor even where the server timezone is not UTC.
-if [[ "$TO_WEEK" == last-sealed ]]; then
-    CURRENT_WEEK="$(ch "SELECT dateDiff('week', toDate('$ANCHOR'), toDate(toMonday(now('UTC'))))")"
-    TO_WEEK=$(( LAST_WEEK < CURRENT_WEEK - 1 ? LAST_WEEK : CURRENT_WEEK - 1 ))
-    (( TO_WEEK >= FROM_WEEK )) || {
-        echo "ERROR: --to-week last-sealed resolved to week $TO_WEEK, which is before --from-week $FROM_WEEK: all of" >&2
-        echo "       '$OLD_TABLE' sits in the current (unsealed) week, so there is no sealed week to compare. Verify" >&2
-        echo "       once a week has closed, or pass an explicit --to-week to include the current one." >&2
+# but whose created_at is real). Same anchor math as backfill.sh. Skipped entirely in window mode: the bounds are given,
+# so there is no grid to anchor — and with it goes this scan's one liability, that both bounds are read live and can move
+# under a table still taking writes.
+resolve_week_grid() {
+    ANCHOR="$(ch "SELECT toString(toMonday(min(created_at))) FROM $OLD_TABLE")"
+    HORIZON="$(ch "SELECT toString(addWeeks(toMonday(max(created_at)), 1)) FROM $OLD_TABLE")"
+    LAST_WEEK="$(ch "SELECT dateDiff('week', toDate('$ANCHOR'), toDate('$HORIZON')) - 1")"
+    [[ -n "$TO_WEEK" ]] || TO_WEEK="$LAST_WEEK"
+    # Every week past the last one with data is empty by construction, so a larger --to-week only walks empty windows. This
+    # also catches the realistic mix-up: a weekly PARTITION name passes the integer test and would otherwise walk millions of
+    # empty windows with no error and no result. The anchor comes from created_at above, so far-future id_at values never
+    # inflate a legitimate offset however far ahead they sit — only what the caller typed can be out of range.
+    if [[ "$TO_WEEK" =~ ^[0-9]+$ ]] && (( TO_WEEK > LAST_WEEK )); then
+        echo "ERROR: --to-week $TO_WEEK is past the last week with data (offset $LAST_WEEK). These bounds are 0-based week" >&2
+        echo "       OFFSETS from the anchor Monday ($ANCHOR), not dates — if that was a YYYYMMDD partition name, pass an" >&2
+        echo "       offset instead, or 'last-sealed' for the last complete week, or omit the bound to cover every week." >&2
+        echo "       To compare one explicit time range instead of a week grid, use --window-from/--window-to." >&2
         exit 2
-    }
-fi
+    fi
+    # 'last-sealed' excludes the current CALENDAR week — the only one that can still change — and not merely the newest week
+    # holding data: on a quiet table max(created_at) may already sit in a sealed week, and excluding that one would leave the
+    # newest populated week uncompared. Capped at LAST_WEEK so a quiet table still verifies everything it holds. now('UTC')
+    # matches created_at's own timezone, so the boundary agrees with the anchor even where the server timezone is not UTC.
+    if [[ "$TO_WEEK" == last-sealed ]]; then
+        CURRENT_WEEK="$(ch "SELECT dateDiff('week', toDate('$ANCHOR'), toDate(toMonday(now('UTC'))))")"
+        TO_WEEK=$(( LAST_WEEK < CURRENT_WEEK - 1 ? LAST_WEEK : CURRENT_WEEK - 1 ))
+        (( TO_WEEK >= FROM_WEEK )) || {
+            echo "ERROR: --to-week last-sealed resolved to week $TO_WEEK, which is before --from-week $FROM_WEEK: all of" >&2
+            echo "       '$OLD_TABLE' sits in the current (unsealed) week, so there is no sealed week to compare. Verify" >&2
+            echo "       once a week has closed, or pass an explicit --to-week to include the current one." >&2
+            exit 2
+        }
+    fi
+}
 
-log "Verify: $OLD_TABLE vs $NEW_TABLE | weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE | sample 1/$SAMPLE_MOD"
+(( WINDOW_MODE == 1 )) || resolve_week_grid
+
+if (( WINDOW_MODE == 1 )); then
+    log "Verify: $OLD_TABLE vs $NEW_TABLE | window [$WINDOW_FROM .. $WINDOW_TO) UTC | sample 1/$SAMPLE_MOD"
+else
+    log "Verify: $OLD_TABLE vs $NEW_TABLE | weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE | sample 1/$SAMPLE_MOD"
+fi
 
 mismatches=0
 artifacts=0
 inconclusive=0
 uncertifiable=0
 checked=0
-for (( week=FROM_WEEK; week<=TO_WEEK; week+=WEEKS_STRIDE )); do
-    LO="$(ch "SELECT toString(addWeeks(toDate('$ANCHOR'), $week))") 00:00:00"
-    HI="$(ch "SELECT toString(addWeeks(toDate('$ANCHOR'), $((week + 1))))") 00:00:00"
+# One window, verdict and all. Factored out so the week grid and the single arbitrary window share EXACTLY this logic —
+# the compare, the confirm-keys re-check, the version-ties decision, the drill-down and every verdict counter. A second
+# copy for window mode would be a second place for a fidelity verdict to be decided, which is the last thing this file
+# should hold two of. $1 labels the window in the log ("week 3", or "window"); $2/$3 are its half-open bounds.
+compare_one_window() {
+    local label="$1" LO="$2" HI="$3"
+    local compare_out src_rows dst_rows src_checksum dst_checksum ok window_certified unresolved ties_out src_ties dst_ties
 
     # Capture first (not read <<< "$(...)"): a here-string command substitution is exempt from set -e, so a
-    # clickhouse-client failure here would be swallowed, leaving `ok` empty and the week mislabeled as a MISMATCH. A
+    # clickhouse-client failure here would be swallowed, leaving `ok` empty and the window mislabeled as a MISMATCH. A
     # plain assignment IS caught by set -e, so an infra blip aborts with the real error instead of a false fidelity fail.
     compare_out="$(compare_window "$LO" "$HI")"
     read -r src_rows dst_rows src_checksum dst_checksum ok <<< "$compare_out"
     checked=$((checked + 1))
     if [[ "$ok" == "1" ]]; then
-        log "week $week ($LO .. $HI): OK (rows=$src_rows)"
-    else
-        week_certified=0   # set only by the artifact verdict, which differs but passes; gates the drill-down nudge
-        # A window difference is not yet a fidelity failure: windowing on created_at under FINAL can surface a
-        # SUPERSEDED version on one side only. Re-check the differing keys on the sorting key, where FINAL
-        # always sees every version, and let that decide. Plain assignment so set -e catches an infra blip
-        # instead of an empty result being read as "artifact" and silently passing a real mismatch.
-        unresolved="$(confirm_keys_window "$LO" "$HI")"
-        [[ "$unresolved" =~ ^[0-9]+$ ]] || {
-            log "FAILED week $week: confirm-keys returned '$unresolved' (expected a count) — treating as a real mismatch." >&2
-            unresolved=-1
-        }
-        if [[ "$unresolved" == "0" ]]; then
-            # The artifact reading holds only where FINAL had a forced winner for every key. Ask now, where it decides
-            # the verdict, rather than on every differing window.
-            # Read failure feeds the UNCERTIFIABLE branch below rather than aborting: that verdict exists for exactly
-            # this case, and a mid-loop abort would lose the remaining windows and the summary. Unlike confirm-keys
-            # above, where an infra blip is meant to stop the run before any verdict is drawn.
-            ties_out="$(version_ties_window "$LO" "$HI")" || ties_out=""
-            read -r src_ties dst_ties <<< "$ties_out"
-            # Output that is not two counts cannot certify the window, but it is not a tie either: encoding it as one
-            # would print a tie diagnosis, and a triage procedure, for what is a client or infrastructure failure.
-            if ! [[ "$src_ties" =~ ^[0-9]+$ && "$dst_ties" =~ ^[0-9]+$ ]]; then
-                uncertifiable=$((uncertifiable + 1))
-                log "UNCERTIFIABLE week $week ($LO .. $HI): version-ties returned '$ties_out', expected two counts." >&2
-                log "  The window differs and its re-check found nothing genuinely differing, but whether that verdict is" >&2
-                log "  decidable could not be established. This is a read failure, not a version tie." >&2
-            elif (( src_ties == 0 && dst_ties == 0 )); then
-                artifacts=$((artifacts + 1))
-                week_certified=1
-                log "week $week ($LO .. $HI): OK — superseded-version artifact (src_rows=$src_rows dst_rows=$dst_rows); every differing key's live row is identical on both sides, and no key's newest version is tied"
-            else
-                inconclusive=$((inconclusive + 1))
-                log "INCONCLUSIVE week $week ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows version_ties=src:$src_ties/dst:$dst_ties" >&2
-                log "  Every differing key's live row matched, but this window holds keys whose newest last_updated_at is" >&2
-                log "  carried by MORE THAN ONE DISTINCT ROW, so FINAL chose between rows that actually differ and may have" >&2
-                log "  landed on the same one on both sides by luck — including where one side is missing a version." >&2
-                log "  NOT certified either way." >&2
-            fi
-        else
-            mismatches=$((mismatches + 1))
-            log "MISMATCH week $week ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows src_checksum=$src_checksum dst_checksum=$dst_checksum genuinely_differing_keys=$unresolved" >&2
-            log "  A version tie can also produce this: where a key's newest last_updated_at is carried by more than one" >&2
-            log "  DISTINCT row, FINAL may pick a different one per side, the part layouts differing. See the runbook's triage." >&2
-        fi
-        if [[ "$DRILL_DOWN" == "1" ]]; then
-            log "  differing keys (key, src_hash, dst_hash; NULL = missing on that side):" >&2
-            # Non-fatal on purpose: the verdict for this window is already decided above, and since --drill-down now
-            # runs on artifact windows too, an unguarded failure here under set -e would abort a run that was passing.
-            drill_down_window "$LO" "$HI" >&2 || log "  drill-down failed for week $week; the verdict above stands" >&2
-        elif (( week_certified == 0 )); then
-            # Only suggested where there is something to investigate. An artifact window differs but passes, so nudging
-            # an operator to drill into it would read as an unresolved problem on a clean run.
-            log "  re-run with --drill-down to list the differing keys for this window" >&2
-        fi
+        log "$label ($LO .. $HI): OK (rows=$src_rows)"
+        return 0
     fi
-done
+    window_certified=0   # set only by the artifact verdict, which differs but passes; gates the drill-down nudge
+    # A window difference is not yet a fidelity failure: windowing on created_at under FINAL can surface a
+    # SUPERSEDED version on one side only. Re-check the differing keys on the sorting key, where FINAL
+    # always sees every version, and let that decide. Plain assignment so set -e catches an infra blip
+    # instead of an empty result being read as "artifact" and silently passing a real mismatch.
+    unresolved="$(confirm_keys_window "$LO" "$HI")"
+    [[ "$unresolved" =~ ^[0-9]+$ ]] || {
+        log "FAILED $label: confirm-keys returned '$unresolved' (expected a count) — treating as a real mismatch." >&2
+        unresolved=-1
+    }
+    if [[ "$unresolved" == "0" ]]; then
+        # The artifact reading holds only where FINAL had a forced winner for every key. Ask now, where it decides
+        # the verdict, rather than on every differing window.
+        # Read failure feeds the UNCERTIFIABLE branch below rather than aborting: that verdict exists for exactly
+        # this case, and a mid-loop abort would lose the remaining windows and the summary. Unlike confirm-keys
+        # above, where an infra blip is meant to stop the run before any verdict is drawn.
+        ties_out="$(version_ties_window "$LO" "$HI")" || ties_out=""
+        read -r src_ties dst_ties <<< "$ties_out"
+        # Output that is not two counts cannot certify the window, but it is not a tie either: encoding it as one
+        # would print a tie diagnosis, and a triage procedure, for what is a client or infrastructure failure.
+        if ! [[ "$src_ties" =~ ^[0-9]+$ && "$dst_ties" =~ ^[0-9]+$ ]]; then
+            uncertifiable=$((uncertifiable + 1))
+            log "UNCERTIFIABLE $label ($LO .. $HI): version-ties returned '$ties_out', expected two counts." >&2
+            log "  The window differs and its re-check found nothing genuinely differing, but whether that verdict is" >&2
+            log "  decidable could not be established. This is a read failure, not a version tie." >&2
+        elif (( src_ties == 0 && dst_ties == 0 )); then
+            artifacts=$((artifacts + 1))
+            window_certified=1
+            log "$label ($LO .. $HI): OK — superseded-version artifact (src_rows=$src_rows dst_rows=$dst_rows); every differing key's live row is identical on both sides, and no key's newest version is tied"
+        else
+            inconclusive=$((inconclusive + 1))
+            log "INCONCLUSIVE $label ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows version_ties=src:$src_ties/dst:$dst_ties" >&2
+            log "  Every differing key's live row matched, but this window holds keys whose newest last_updated_at is" >&2
+            log "  carried by MORE THAN ONE DISTINCT ROW, so FINAL chose between rows that actually differ and may have" >&2
+            log "  landed on the same one on both sides by luck — including where one side is missing a version." >&2
+            log "  NOT certified either way." >&2
+        fi
+    else
+        mismatches=$((mismatches + 1))
+        log "MISMATCH $label ($LO .. $HI): src_rows=$src_rows dst_rows=$dst_rows src_checksum=$src_checksum dst_checksum=$dst_checksum genuinely_differing_keys=$unresolved" >&2
+        log "  A version tie can also produce this: where a key's newest last_updated_at is carried by more than one" >&2
+        log "  DISTINCT row, FINAL may pick a different one per side, the part layouts differing. See the runbook's triage." >&2
+    fi
+    if [[ "$DRILL_DOWN" == "1" ]]; then
+        log "  differing keys (key, src_hash, dst_hash; NULL = missing on that side):" >&2
+        # Non-fatal on purpose: the verdict for this window is already decided above, and since --drill-down now
+        # runs on artifact windows too, an unguarded failure here under set -e would abort a run that was passing.
+        drill_down_window "$LO" "$HI" >&2 || log "  drill-down failed for $label; the verdict above stands" >&2
+    elif (( window_certified == 0 )); then
+        # Only suggested where there is something to investigate. An artifact window differs but passes, so nudging
+        # an operator to drill into it would read as an unresolved problem on a clean run.
+        log "  re-run with --drill-down to list the differing keys for this window" >&2
+    fi
+}
+
+if (( WINDOW_MODE == 1 )); then
+    compare_one_window window "$WINDOW_FROM" "$WINDOW_TO"
+else
+    for (( week=FROM_WEEK; week<=TO_WEEK; week+=WEEKS_STRIDE )); do
+        LO="$(ch "SELECT toString(addWeeks(toDate('$ANCHOR'), $week))") 00:00:00"
+        HI="$(ch "SELECT toString(addWeeks(toDate('$ANCHOR'), $((week + 1))))") 00:00:00"
+        compare_one_window "week $week" "$LO" "$HI"
+    done
+fi
 
 # Fidelity mismatch is the hard failure, and so is a window the re-check could not decide (both exit 1).
 if (( mismatches != 0 || inconclusive != 0 || uncertifiable != 0 )); then
@@ -358,15 +433,25 @@ fi
 if [[ "$checked" == "0" ]]; then
     # An empty range compared nothing, so "all windows match" would be vacuously true — the one answer a fidelity gate
     # must never give. Fail instead: reaching here means the bounds excluded every week, not that the data agrees.
+    # Unreachable in window mode, where the from < to check up front guarantees exactly one window; kept unconditional
+    # so the guard does not depend on that argument staying true.
     log "FAILED: no window was compared — weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE selects nothing." >&2
     log "        Nothing was verified, so this is NOT a pass. Widen the range (--from-week/--to-week)." >&2
     exit 1
 fi
+# The PASSED line states the range it covered, so a pass can never be read as broader than it was — the same reason the
+# weekly form prints its bounds and stride. In window mode that is the explicit window, which is the whole point of the
+# mode: a reconciliation compare has to be quotable as "this exact range was checked".
+if (( WINDOW_MODE == 1 )); then
+    COVERED="window [$WINDOW_FROM .. $WINDOW_TO) UTC, sample 1/$SAMPLE_MOD"
+else
+    COVERED="weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD"
+fi
 if [[ "$artifacts" != "0" ]]; then
-    log "PASSED: all $checked windows match (weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD); $artifacts window(s) held a superseded-version"
+    log "PASSED: all $checked windows match ($COVERED); $artifacts window(s) held a superseded-version"
     log "        artifact only — a key written more than once lands its stale version in an earlier created_at week on"
     log "        one side. Live data is identical on both sides and no key in those windows had a tied newest version,"
     log "        so the re-check was decisive; nothing to fix (see the confirm-keys block)."
 else
-    log "PASSED: all $checked windows match (weeks [$FROM_WEEK..$TO_WEEK] stride $WEEKS_STRIDE, sample 1/$SAMPLE_MOD)."
+    log "PASSED: all $checked windows match ($COVERED)."
 fi

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -1671,7 +1671,8 @@ class TracesLocalV2CutoverTest {
         reconcileForward(deltaStart, swapDone);
 
         assertThat(newestNames("traces", idStrings(target), workspaceId))
-                .as("the sweep's re-insert loses to the post-swap version — it cannot clobber live traffic")
+                .as("the sweep's re-insert loses to the post-swap version, so live traffic that ADVANCED the"
+                        + " version survives it")
                 .containsOnly("post-swap");
         assertThat(forwardCounts(deltaStart, swapDone))
                 .as("reported as newer_keys, which is informational: the three gating buckets are still 0")
@@ -2094,9 +2095,13 @@ class TracesLocalV2CutoverTest {
      * <p>The second key is the control, and it is what makes the first assertion mean anything: identical in every
      * respect except that its post-swap version moves FORWARD, it keeps its live payload and lands in
      * {@code newer_keys}. So the sweep is behaving normally on this estate and the loss is the regression's doing.
+     * Carrying it here rather than leaning on {@link #sweepKeepsANewerPostSwapVersionAndTheGateStillPasses()} is
+     * deliberate: on one estate, under one sweep, the version direction is the only variable between the two keys.
+     *
+     * @see #sweepKeepsANewerPostSwapVersionAndTheGateStillPasses() the same sweep where the version advances
      */
     @Test
-    void aPostSwapWriteThatRegressesTheVersionIsOverwrittenAndTheGateStillReportsReconciled() {
+    void postSwapWriteRegressingTheVersionIsOverwrittenAndTheGateStillReportsReconciled() {
         var workspaceId = UUID.randomUUID().toString();
         var projectId = ID_GENERATOR.generateId();
         var at = Instant.parse("2025-03-04T10:00:00Z");
@@ -2117,16 +2122,16 @@ class TracesLocalV2CutoverTest {
         insertShapedTrace(honest, workspaceId, projectId, "honest-live", at, Instant.EPOCH, Double.NaN, at,
                 at.plusSeconds(60));
 
-        forwardSweep("traces", gapStart, swapDone);
+        reconcileForward(gapStart, swapDone);
 
-        assertThat(countMatchingLive(workspaceId, "name = 'regressed-live'"))
-                .as("the residual: the post-swap write carried a version below the parked row's, so the sweep's"
-                        + " re-insert wins the version comparison and that write is no longer live")
-                .isZero();
-        assertThat(countMatchingLive(workspaceId, "name = 'honest-live'"))
-                .as("control: the same sweep on the same estate leaves a post-swap write alone when its version moves"
+        assertThat(newestNames("traces", Set.of(regressed), workspaceId))
+                .as("the residual: the post-swap write carried a last_updated_at below the parked row's, so the"
+                        + " sweep's re-insert wins the version comparison and the parked payload is what is live")
+                .containsOnly("regressed-parked");
+        assertThat(newestNames("traces", Set.of(honest), workspaceId))
+                .as("control: the same pass on the same estate leaves a post-swap write alone when its version moves"
                         + " forward, so the loss above is the regression and not the sweep")
-                .isEqualTo(1L);
+                .containsOnly("honest-live");
         assertThat(forwardCounts(gapStart, swapDone))
                 .as("and the gate cannot see the loss: the live row IS the parked payload, so the key matches on both"
                         + " version and fingerprint and enters no bucket — only the control shows, as newer_keys")
@@ -2147,11 +2152,15 @@ class TracesLocalV2CutoverTest {
      * runbook tells the operator to pass the RECORDED {@code exchange_done}: neither {@code EXCHANGE} nor
      * {@code RENAME} leaves a server-side commit instant to validate an estimate against.
      *
-     * <p>The same estate is then swept again with the recorded anchor. That is the control: the key comes back and
-     * the gate still reads clean, so the first result is attributable to the anchor and not to a broken fixture.
+     * <p>The same estate is then reconciled again with the recorded anchor. That is the control: the key comes back
+     * and the gate still reads clean, so the first result is attributable to the anchor and not to a broken fixture.
+     * {@link #sweepRestoresAGapWindowTraceDeletedAndReCreatedBeforeTheSwap()} covers that recovery from a full
+     * cutover; holding it here too is what isolates the anchor as the single variable.
+     *
+     * @see #sweepRestoresAGapWindowTraceDeletedAndReCreatedBeforeTheSwap() the same shape with a correct anchor
      */
     @Test
-    void anEarlySwapDoneDropsARecreatedKeyFromTheSweepAndTheGateAlike() {
+    void earlySwapDoneDropsARecreatedKeyFromTheSweepAndTheGateAlike() {
         var workspaceId = UUID.randomUUID().toString();
         var projectId = ID_GENERATOR.generateId();
         var at = Instant.parse("2025-03-04T10:00:00Z");
@@ -2171,7 +2180,7 @@ class TracesLocalV2CutoverTest {
         exchangeTables();
         var swapDone = nowMicros();
 
-        forwardSweep("traces", gapStart, earlyAnchor);
+        reconcileForward(gapStart, earlyAnchor);
 
         assertThat(liveCount("traces", Set.of(id), workspaceId))
                 .as("the residual: the bridged delete sits at or after the early anchor, so the exclusion arm fires"
@@ -2182,12 +2191,12 @@ class TracesLocalV2CutoverTest {
                         + " reconciled over a trace that is missing")
                 .isEqualTo(reconciled());
 
-        forwardSweep("traces", gapStart, swapDone);
+        reconcileForward(gapStart, swapDone);
 
-        assertThat(countMatchingLive(workspaceId, "name = 'recreated-again'"))
-                .as("control: with the RECORDED anchor the delete falls below the bound, the key is swept, and the"
-                        + " version that lands is the re-created one")
-                .isEqualTo(1L);
+        assertThat(newestNames("traces", Set.of(id), workspaceId))
+                .as("control: with the RECORDED anchor the delete falls below the bound, the sweep copies the key and"
+                        + " the replay's guard spares it, so the re-created version is what lands")
+                .containsOnly("recreated-again");
         assertThat(forwardCounts(gapStart, swapDone))
                 .as("and the gate agrees on the same estate, so the fixture reconciles when the anchor is right")
                 .isEqualTo(reconciled());

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -2076,6 +2076,124 @@ class TracesLocalV2CutoverTest {
     }
 
     /**
+     * <b>Residual:</b> a post-swap write that REGRESSES {@code last_updated_at} is overwritten by the sweep, and the
+     * gate reports the estate clean.
+     *
+     * <p>The sweep is safe to re-run because its INSERT is meant to LOSE the {@code ReplacingMergeTree} version
+     * comparison against anything written after the swap. That rests on {@code last_updated_at} being monotonic, and
+     * it is not: the column is client-writable and bound verbatim on the batch-ingest path (see class Javadoc), so a
+     * post-swap write can carry a value below the parked row's. The parked payload then wins and the live write is
+     * gone, while the gate compares the parked payload against itself and returns zeros.
+     *
+     * <p><b>This asserts the residual, not a bug to be fixed here.</b> Neither alternative survives contact with the
+     * sweep's purpose: skipping keys already live would abandon exactly the stale and partial rows it exists to
+     * repair, and re-stamping the version would clobber legitimate newer writes. Clamping client timestamps at
+     * ingestion is the durable fix, as it is for the future-dated residual in
+     * {@link #postSwapReplaySparesAFutureDatedRowAndTheLeakCheckReportsIt()}.
+     *
+     * <p>The second key is the control, and it is what makes the first assertion mean anything: identical in every
+     * respect except that its post-swap version moves FORWARD, it keeps its live payload and lands in
+     * {@code newer_keys}. So the sweep is behaving normally on this estate and the loss is the regression's doing.
+     */
+    @Test
+    void aPostSwapWriteThatRegressesTheVersionIsOverwrittenAndTheGateStillReportsReconciled() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var at = Instant.parse("2025-03-04T10:00:00Z");
+        var gapStart = "2025-03-04 09:00:00";
+
+        // Both written pre-swap inside the gap window, at the same version, carrying the payload the backup freezes.
+        var regressed = ID_GENERATOR.generateId().toString();
+        var honest = ID_GENERATOR.generateId().toString();
+        insertShapedTrace(regressed, workspaceId, projectId, "regressed-parked", at, null, null, at, at);
+        insertShapedTrace(honest, workspaceId, projectId, "honest-parked", at, null, null, at, at);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        // Post-swap traffic on both keys, differing ONLY in the client-supplied version each write carries.
+        insertShapedTrace(regressed, workspaceId, projectId, "regressed-live", at, Instant.EPOCH, Double.NaN, at,
+                at.minusSeconds(60));
+        insertShapedTrace(honest, workspaceId, projectId, "honest-live", at, Instant.EPOCH, Double.NaN, at,
+                at.plusSeconds(60));
+
+        forwardSweep("traces", gapStart, swapDone);
+
+        assertThat(countMatchingLive(workspaceId, "name = 'regressed-live'"))
+                .as("the residual: the post-swap write carried a version below the parked row's, so the sweep's"
+                        + " re-insert wins the version comparison and that write is no longer live")
+                .isZero();
+        assertThat(countMatchingLive(workspaceId, "name = 'honest-live'"))
+                .as("control: the same sweep on the same estate leaves a post-swap write alone when its version moves"
+                        + " forward, so the loss above is the regression and not the sweep")
+                .isEqualTo(1L);
+        assertThat(forwardCounts(gapStart, swapDone))
+                .as("and the gate cannot see the loss: the live row IS the parked payload, so the key matches on both"
+                        + " version and fingerprint and enters no bucket — only the control shows, as newer_keys")
+                .isEqualTo(ReconciliationCounts.builder().missing(0).stale(0).payloadMismatch(0).newer(1).build());
+    }
+
+    /**
+     * <b>Residual:</b> a {@code --swap-done} EARLIER than the real swap silently drops a key that was deleted and
+     * RE-CREATED in between — from the sweep and from the gate alike.
+     *
+     * <p>The exclusion arm is what stops the sweep resurrecting a trace the user deleted after the swap, and
+     * {@code verify-forward} applies the identical arm so the gate cannot demand a key the sweep is right to skip.
+     * That sharing is also the hazard. With an anchor earlier than the swap, a delete that fired BEFORE the swap sits
+     * at or after the bound, so both arms drop the key — and the backup's live row for it is the RE-CREATED trace, a
+     * genuine gap-window write. It stays missing under a clean gate.
+     *
+     * <p>So the early direction is not the safe one it looks like, which is why the flag's help says so and why the
+     * runbook tells the operator to pass the RECORDED {@code exchange_done}: neither {@code EXCHANGE} nor
+     * {@code RENAME} leaves a server-side commit instant to validate an estimate against.
+     *
+     * <p>The same estate is then swept again with the recorded anchor. That is the control: the key comes back and
+     * the gate still reads clean, so the first result is attributable to the anchor and not to a broken fixture.
+     */
+    @Test
+    void anEarlySwapDoneDropsARecreatedKeyFromTheSweepAndTheGateAlike() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var at = Instant.parse("2025-03-04T10:00:00Z");
+        var gapStart = "2025-03-04 09:00:00";
+        // The bridge rows below carry the column's now64() default, so this sits before them and stands in for an
+        // operator estimate that predates the swap.
+        var earlyAnchor = "2025-03-04 09:30:00";
+
+        // Written, deleted and RE-CREATED inside the gap window, all before the swap: the backup freezes with the
+        // re-created row live, and the bridge holds the delete.
+        var id = ID_GENERATOR.generateId().toString();
+        insertShapedTrace(id, workspaceId, projectId, "recreated-first", at, null, null, at, at);
+        recordDeletionEvents(Set.of(id), workspaceId, projectId.toString(), "user_request");
+        lightweightDeleteScoped(Set.of(id), workspaceId, projectId);
+        insertShapedTrace(id, workspaceId, projectId, "recreated-again", at, null, null, at, at.plusSeconds(60));
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        forwardSweep("traces", gapStart, earlyAnchor);
+
+        assertThat(liveCount("traces", Set.of(id), workspaceId))
+                .as("the residual: the bridged delete sits at or after the early anchor, so the exclusion arm fires"
+                        + " and the re-created trace is never copied")
+                .isZero();
+        assertThat(forwardCounts(gapStart, earlyAnchor))
+                .as("and the gate applies that same arm, so the key never enters the parked set and the estate reads"
+                        + " reconciled over a trace that is missing")
+                .isEqualTo(reconciled());
+
+        forwardSweep("traces", gapStart, swapDone);
+
+        assertThat(countMatchingLive(workspaceId, "name = 'recreated-again'"))
+                .as("control: with the RECORDED anchor the delete falls below the bound, the key is swept, and the"
+                        + " version that lands is the re-created one")
+                .isEqualTo(1L);
+        assertThat(forwardCounts(gapStart, swapDone))
+                .as("and the gate agrees on the same estate, so the fixture reconciles when the anchor is right")
+                .isEqualTo(reconciled());
+    }
+
+    /**
      * The postcondition's classification, one key per bucket, on the FULL {@code (workspace_id, project_id, id)} key.
      *
      * <p>The baseline matters as much as the perturbations: a clean sweep must classify NOTHING, which is what makes a

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -97,7 +97,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * the exclusion that stops a post-swap delete being resurrected, the newer-version-wins property that makes the sweep
  * safe against live traffic, the delete-side residual the frozen resurrection guard now closes, the per-row staleness
  * scope that stops that same frozen guard destroying a post-swap re-creation (with its own negative control), the
- * reverse re-import with sentinel&rarr;{@code NULL} denormalization, and the four-count postcondition's classification.
+ * residual that same scope leaves open when a client supplies a future {@code last_updated_at} — pinned with the
+ * advisory that reports it, so the trade-off behind the predicate cannot be flipped silently — the reverse re-import
+ * with sentinel&rarr;{@code NULL} denormalization and the sweep/replay ordering that keeps a re-created key deleted,
+ * and the four-count postcondition's classification.
  *
  * <p>It also confirms {@code EXCHANGE TABLES ... ON CLUSTER} on the single-shard cluster, the sharding-ready
  * {@code Distributed} wrapper reading transparently on one shard, newest-version-wins for concurrent upserts, and it
@@ -1910,11 +1913,28 @@ class TracesLocalV2CutoverTest {
     /**
      * Deletes still win over the re-imported writes. The reverse sweep runs BEFORE
      * {@code 000004_rollback_reverse_replay.sql}, so a trace deleted on the successor after {@code cutover_start} is
-     * masked in the parked copy (and so never swept back) and masked again on the restored original by the replay —
-     * and that file's own postcondition still reports 0, which is the box the runbook's rollback checklist ticks.
+     * re-imported by the sweep and then masked again on the restored original by the replay — and that file's own
+     * postcondition still reports 0, which is the box the runbook's rollback checklist ticks.
+     *
+     * <p><b>The fixture has to be DELETED AND RE-CREATED, and finding that out is the point.</b> Two shapes of
+     * post-cutover delete reach the sweep completely differently:
+     * <ul>
+     *   <li>a plain delete — the mask is applied to the successor before the promote parks it, so the sweep's
+     *   mask-honored read never sees the key. It cannot resurrect what it cannot read, whatever the row's timestamps
+     *   are. A seeded survivor is doubly invisible: a lightweight delete bumps no version, and its back-dated
+     *   {@code created_at}/{@code last_updated_at} also sit outside the sweep's window. Asserting on either shape
+     *   passes without the sweep/replay ordering being exercised at all.</li>
+     *   <li>a delete FOLLOWED BY a re-creation under the same id — the key is live again in the parked successor, its
+     *   delete is still in the bridge, and the sweep genuinely re-imports it. Only the replay running afterwards keeps
+     *   it deleted, which is the ordering this test exists for and the behaviour
+     *   {@code 000006_post_swap_reconciliation.sql}'s {@code reverse-sweep} header specifies: the delete is honoured
+     *   and the re-creation is discarded with the rest of the post-cutover writes.</li>
+     * </ul>
+     * Both are asserted — the first as the reason the second is the only meaningful fixture, the second with a negative
+     * control showing the sweep alone brings the key back.
      */
     @Test
-    void reverseSweepDoesNotResurrectATraceDeletedAfterCutoverStart() {
+    void reverseSweepReimportsThenTheReplayReDeletesARecreatedPostCutoverKey() {
         var workspaceId = UUID.randomUUID().toString();
         var projectId = ID_GENERATOR.generateId();
         var survivors = mintIds(SURVIVORS_PER_WEEK);
@@ -1930,28 +1950,114 @@ class TracesLocalV2CutoverTest {
         exchangeTables();
 
         var postCutoverAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
-        var postCutover = mintIdsAt(2, postCutoverAt);
+        var postCutover = mintIdsAt(3, postCutoverAt);
         insertRows(postCutover, workspaceId, projectId, "post-cutover", _ -> postCutoverAt);
 
-        // Deleted on the successor after the cutover, so the rollback must honour it however the writes are handled.
-        var deletedAfterCutover = Set.of(survivors.getFirst().id().toString());
-        recordDeletionEvents(deletedAfterCutover, workspaceId, projectId.toString(), "user_request");
-        lightweightDelete(deletedAfterCutover, workspaceId);
+        var recreated = postCutover.getFirst();
+        var plainlyDeleted = postCutover.get(1);
+        var untouched = Set.of(postCutover.get(2).id().toString());
+
+        // Shape 1: deleted and left deleted. The mask lands on the successor before the promote, so the parked copy
+        // carries it and the sweep's mask-honored read skips the key entirely.
+        recordDeletionEvents(Set.of(plainlyDeleted.id().toString()), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(Set.of(plainlyDeleted.id().toString()), workspaceId);
+
+        // Shape 2: deleted, then re-created under the same id at a newer version — so it is LIVE in the parked copy
+        // while its delete is still in the bridge. This is the one the sweep will bring back.
+        recordDeletionEvents(Set.of(recreated.id().toString()), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(Set.of(recreated.id().toString()), workspaceId);
+        var recreatedAt = postCutoverAt.plusSeconds(1);
+        insertRows(List.of(recreated), workspaceId, projectId, "re-created", _ -> recreatedAt);
 
         rollbackExchangeBack(cutoverStart);
         var promoteDone = nowMicros();
 
+        // Negative control: the sweep ALONE resurrects the re-created key, which is what makes the ordering
+        // load-bearing rather than incidental — and leaves the plainly-deleted one alone, which is why it is not a
+        // usable fixture. Asserted before the replay runs, on the same estate the full run then repairs.
+        reverseSweep(cutoverStart, promoteDone);
+        assertThat(liveCount("traces", Set.of(recreated.id().toString()), workspaceId))
+                .as("negative control: the sweep on its own re-imports the re-created key")
+                .isEqualTo(1L);
+        assertThat(liveCount("traces", Set.of(plainlyDeleted.id().toString()), workspaceId))
+                .as("while a plainly-deleted key is masked in the parked copy, so the sweep cannot see it at all")
+                .isZero();
+
         reconcileReverse(cutoverStart, promoteDone);
 
-        assertThat(liveCount("traces", deletedAfterCutover, workspaceId))
-                .as("the re-import does not resurrect a post-cutover delete")
+        assertThat(liveCount("traces", Set.of(recreated.id().toString()), workspaceId))
+                .as("after the replay the post-cutover delete wins over the re-creation the sweep brought back")
                 .isZero();
         assertThat(verifyReplayPostcondition(cutoverStart))
                 .as("and 000004_rollback_verify_replay.sql still reports 0 after the re-import")
                 .isZero();
-        assertThat(liveCount("traces", idStrings(postCutover), workspaceId))
-                .as("while the post-cutover writes that were NOT deleted are live again")
-                .isEqualTo(postCutover.size());
+        assertThat(liveCount("traces", untouched, workspaceId))
+                .as("while a post-cutover write that was never deleted is live again")
+                .isEqualTo(untouched.size());
+    }
+
+    /**
+     * The delete-side residual the post-swap replay's staleness scope cannot prevent, pinned so the trade-off behind it
+     * cannot be flipped by accident — and the advisory that makes it visible.
+     *
+     * <p>{@code last_updated_at} is CLIENT-SUPPLIED on the batch-ingest path: {@code TraceDAO} binds
+     * {@code Trace.lastUpdatedAt} verbatim and the API accepts any value before 2300. A genuinely pre-swap trace can
+     * therefore carry a future timestamp, fall outside the replay's
+     * {@code created_at < swap_done AND last_updated_at < swap_done} scope, and keep its captured delete unmasked.
+     *
+     * <p><b>This asserts the residual, not a bug to be fixed here.</b> Scoping on {@code created_at} alone would close
+     * it and open a worse one: the merge path preserves {@code created_at}, so a post-swap PATCH of a pre-existing
+     * trace would then be masked, destroying a write that lives only on the successor. Over-sparing leaves a deleted
+     * trace visible with its key still in the bridge, so it can be re-applied; over-masking is unrecoverable. The
+     * companion assertion is the one that matters operationally: {@code leak-check-forward} reports the key, so the
+     * residual is surfaced rather than silent. A control row deleted with an ordinary timestamp proves the replay is
+     * working normally on the same estate, so a green here is not just "the replay did nothing".
+     */
+    @Test
+    void postSwapReplaySparesAFutureDatedRowAndTheLeakCheckReportsIt() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var at = Instant.parse("2025-03-04T10:00:00Z");
+        var gapStart = "2025-03-04 09:00:00";
+
+        // Both written pre-swap, inside the gap window, and both deleted before the swap. They differ only in the
+        // client-supplied last_updated_at: one honest, one dated past any plausible swap_done.
+        var honest = ID_GENERATOR.generateId().toString();
+        var futureDated = ID_GENERATOR.generateId().toString();
+        insertShapedTrace(honest, workspaceId, projectId, "gap", at, null, null, at, at);
+        insertShapedTrace(futureDated, workspaceId, projectId, "gap", at, null, null, at,
+                Instant.parse("2027-01-01T00:00:00Z"));
+
+        // The end state is CONSTRUCTED rather than played out, because the delta anchor cannot be placed before a
+        // back-dated created_at. It is the same state either way, and the state is all the replay reads: the successor
+        // holds each key as a copy carrying the source's version, the parked backup has each key MASKED, and the bridge
+        // holds both events. In production the copy comes from the backfill/delta and the mask from a delete that fired
+        // too late for the final pre-swap replay — the only window in which the post-swap replay is what has to mask it.
+        exchangeTables();
+        var swapDone = nowMicros();
+        forwardSweep("traces", gapStart, swapDone);
+
+        var deleted = Set.of(honest, futureDated);
+        recordDeletionEvents(deleted, workspaceId, projectId.toString(), "user_request");
+        lightweightDeleteFrom("traces_pre_cutover_backup", deleted, workspaceId, projectId);
+
+        postSwapDeletionReplay("traces", gapStart, swapDone);
+
+        assertThat(liveCount("traces", Set.of(honest), workspaceId))
+                .as("control: an ordinarily-dated pre-swap row IS masked, so the replay is working on this estate")
+                .isZero();
+        assertThat(liveCount("traces", Set.of(futureDated), workspaceId))
+                .as("the residual: a client-supplied future last_updated_at puts the row outside the staleness scope,"
+                        + " so its captured delete is not re-applied")
+                .isEqualTo(1L);
+        assertThat(forwardCounts(gapStart, swapDone))
+                .as("and the four counts cannot see it — the key is not live in the frozen backup, so it never enters"
+                        + " the parked set the gate classifies")
+                .isEqualTo(reconciled());
+        assertThat(leakCheckForward(gapStart))
+                .as("which is why the advisory exists: it reports exactly the leaked key, by version rather than by"
+                        + " timestamp")
+                .isEqualTo(1L);
     }
 
     /**
@@ -3033,12 +3139,20 @@ class TracesLocalV2CutoverTest {
     }
 
     private void lightweightDeleteScoped(Set<String> ids, String workspaceId, UUID projectId) {
+        lightweightDeleteFrom("traces", ids, workspaceId, projectId);
+    }
+
+    /**
+     * The same lightweight delete against a named table, so a test can put the PARKED backup into the state a delete
+     * that fired before the freeze would have left it in.
+     */
+    private void lightweightDeleteFrom(String table, Set<String> ids, String workspaceId, UUID projectId) {
         execute("""
-                DELETE FROM traces
+                DELETE FROM %s
                 WHERE workspace_id = :workspace_id
                   AND project_id = :project_id
                   AND id IN :ids
-                """,
+                """.formatted(table),
                 statement -> statement
                         .bind("workspace_id", workspaceId)
                         .bind("project_id", projectId)
@@ -3209,6 +3323,55 @@ class TracesLocalV2CutoverTest {
     /** Forward direction: the parked pre-cutover backup (OLD shape) against the live successor. */
     private ReconciliationCounts forwardCounts(String gapStart, String swapDone) {
         return reconciliationCounts("traces_pre_cutover_backup", Shape.OLD, "traces", gapStart, swapDone);
+    }
+
+    /**
+     * 000006's {@code leak-check-forward}: captured deletes still live on the successor at a version the frozen backup
+     * itself held. {@code apply_deleted_mask = 0} is what lets the backup side see rows the mask hides, and
+     * {@code _row_exists = 1} restores mask-honoring on the live side by hand, since the setting is statement-wide.
+     */
+    private long leakCheckForward(String gapStart) {
+        var sql = """
+                WITH
+                    bridged AS (
+                        SELECT
+                            workspace_id,
+                            toFixedString(project_id, 36) AS project_id,
+                            toFixedString(deleted_id, 36) AS id
+                        FROM deletion_events_local
+                        WHERE source_table = 'traces'
+                          AND event_time >= toDateTime64(:gap_start, 6, 'UTC')
+                          AND project_id != ''
+                          AND length(project_id) = 36
+                          AND length(deleted_id) = 36
+                    ),
+                    deleted AS (
+                        SELECT
+                            (workspace_id, project_id, id) AS key,
+                            toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6)) AS version
+                        FROM traces_pre_cutover_backup
+                        WHERE _row_exists = 0
+                          AND (workspace_id, project_id, id) IN (SELECT workspace_id, project_id, id FROM bridged)
+                    )
+                SELECT count() AS c
+                FROM (
+                    SELECT
+                        (workspace_id, project_id, id) AS key,
+                        toUnixTimestamp64Micro(last_updated_at) AS version
+                    FROM traces FINAL
+                    WHERE _row_exists = 1
+                      AND (workspace_id, project_id, id) IN (SELECT workspace_id, project_id, id FROM bridged)
+                ) AS live
+                WHERE (live.key, live.version) IN (SELECT key, version FROM deleted)
+                SETTINGS apply_deleted_mask = 0, use_skip_indexes_if_final = 1
+                """;
+        return template
+                .nonTransaction(connection -> Mono
+                        .from(connection.createStatement(sql)
+                                .bind("gap_start", gapStart)
+                                .execute())
+                        .flatMap(result -> Mono.from(result.map((row, ignored) -> row.get("c", Long.class)))))
+                .block();
     }
 
     /** Reverse direction: the parked successor (NEW shape) against the restored original. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -1451,6 +1451,15 @@ class TracesLocalV2CutoverTest {
         var gapWritten = mintIdsAt(5, gapAt);
         insertRows(gapWritten, workspaceId, projectId, "gap", _ -> gapAt);
 
+        // Also in the gap window, but DELETED on the old table before the freeze — and deliberately NOT bridged, since
+        // capture is best-effort and an unrecorded delete is reachable. That absence is what isolates the property:
+        // the replay cannot mask a key the bridge never recorded, so if this stays gone the only thing keeping it gone
+        // is the sweep honoring the delete mask on its read of the frozen backup. Masked rows never enter the parked
+        // set either (it reads FINAL), so the four counts below are unaffected.
+        var gapDeleted = mintIdsAt(2, gapAt);
+        insertRows(gapDeleted, workspaceId, projectId, "gap-deleted", _ -> gapAt);
+        lightweightDeleteScoped(idStrings(gapDeleted), workspaceId, projectId);
+
         exchangeTables();
         var swapDone = nowMicros();
 
@@ -1472,6 +1481,10 @@ class TracesLocalV2CutoverTest {
         assertThat(liveCount("traces", idStrings(gapWritten), workspaceId))
                 .as("after the sweep every gap-window trace is live on the successor")
                 .isEqualTo(gapWritten.size());
+        assertThat(liveCount("traces", idStrings(gapDeleted), workspaceId))
+                .as("while a gap-window trace deleted before the freeze is NOT brought back — the sweep reads the"
+                        + " parked backup mask-honored, and with no bridge row nothing else could have masked it")
+                .isZero();
         assertThat(forwardCounts(deltaStart, swapDone))
                 .as("and the gate clears: nothing missing, nothing stale, no payload differing")
                 .isEqualTo(reconciled());
@@ -1766,7 +1779,8 @@ class TracesLocalV2CutoverTest {
 
         forwardSweep("traces", deltaStart, swapDone);
         assertThat(liveCount("traces", idStrings(leaked), workspaceId))
-                .as("the sweep alone cannot fix a delete — it is mask-honored, so it neither copies nor removes it")
+                .as("the sweep alone cannot fix a delete: these rows pre-date the gap window, so it never reads them"
+                        + " — only the replay can mask them")
                 .isEqualTo(leaked.size());
 
         postSwapDeletionReplay("traces", deltaStart, swapDone);
@@ -1835,7 +1849,8 @@ class TracesLocalV2CutoverTest {
                 .as("the post-swap re-creation SURVIVES: the staleness scope spares any row written since the swap")
                 .isEqualTo(1L);
         assertThat(forwardCounts(deltaStart, swapDone))
-                .as("and the gate clears — the key is masked in the frozen backup, so it never enters the parked set")
+                .as("and the gate clears — the key pre-dates the gap window, so it never enters the parked set the"
+                        + " four counts classify")
                 .isEqualTo(reconciled());
 
         // NEGATIVE CONTROL: the same replay with the PRE-swap scope, which is inert, destroys the write.

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/TracesLocalV2CutoverTest.java
@@ -54,6 +54,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * full-volume prod clone in the QA gate (OPIK-7405). The inline statements here are kept aligned with the reference SQL
  * — identical functions, precision, and {@code 'UTC'} — so this gate and the shipped SQL stay in step.
  *
+ * <p>Nothing here reads a reference file, deliberately. The statements below are copied, and drift between a copy and
+ * the file it mirrors is accepted: it is caught by the cutover rehearsal, which runs the drivers themselves. What this
+ * suite owns is the cutover's <i>logic</i>. The one thing it does pin to the live database is the column list
+ * ({@link #cutoverCopiesEveryBaseColumn()}), because a base column silently left uncopied is data loss rather than
+ * drift — and the reference files carry that same list, so a failure here is the prompt to update them too.
+ *
  * <p><b>Deletions must survive the swap (the core property).</b> A lightweight DELETE flips a hidden row mask; it does
  * not bump {@code last_updated_at} (the {@code ReplacingMergeTree} version column), so the version-based delta-insert is
  * blind to deletes that land while the table is being copied — the already-copied row stays alive on the destination
@@ -81,6 +87,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * covered: a normal upsert (new {@code last_updated_at}) and a row created during the window with a client-backdated
  * {@code last_updated_at} that only the {@code created_at} arm catches.
  *
+ * <p><b>Writes must survive the swap too (OPIK-8238).</b> Deletions were only half the problem. The last write-copying
+ * statement is the delta INSERT, and between it and the {@code EXCHANGE} the procedure interposes a deletion replay, the
+ * operator's go/no-go gap, the settle gate and a second replay — so every trace written to the old table in that window
+ * is orphaned when it is parked. Nothing holds writes across that window — the procedure takes no ingestion-path hold
+ * (OPIK-8239). Reconciliation is deliberately POST-swap, because a pre-swap sweep cannot converge against a live source
+ * while a post-swap one converges against a frozen table by construction.
+ * The suite covers both directions of it: the forward sweep with a negative control proving the step is load-bearing,
+ * the exclusion that stops a post-swap delete being resurrected, the newer-version-wins property that makes the sweep
+ * safe against live traffic, the delete-side residual the frozen resurrection guard now closes, the per-row staleness
+ * scope that stops that same frozen guard destroying a post-swap re-creation (with its own negative control), the
+ * reverse re-import with sentinel&rarr;{@code NULL} denormalization, and the four-count postcondition's classification.
+ *
  * <p>It also confirms {@code EXCHANGE TABLES ... ON CLUSTER} on the single-shard cluster, the sharding-ready
  * {@code Distributed} wrapper reading transparently on one shard, newest-version-wins for concurrent upserts, and it
  * measures the replay wall time, which the runbook counts toward the cutover tail. Finally it proves the
@@ -104,10 +122,12 @@ import static org.assertj.core.api.Assertions.assertThat;
  * (e.g. {@code DeletionEventTest}).
  *
  * <p><b>Scope: this gate validates the cutover SQL logic, not the driver scripts.</b> The safety guards in the runbook's
- * bash drivers — {@code backfill.sh}'s reconciliation abort, {@code rollback.sh}'s wrong-stage topology assertions,
- * {@code exchange_and_wrap.sh}'s replication-settle gate, {@code finalize.sh}'s empty-live refusal — are exercised by the
- * OPIK-6901 staging dry-run, not by this test (which runs the SQL those scripts wrap, directly). This test asserts the
- * logic is correct when invoked; the staging rehearsal asserts the scripts invoke it safely.
+ * bash drivers — {@code backfill.sh}'s reconciliation abort, {@code rollback.sh}'s wrong-stage topology assertions, the
+ * replication-settle gate both {@code exchange_and_wrap.sh} and {@code reconcile.sh} run (each with its own table
+ * scope), {@code reconcile.sh}'s direction detection and pass loop, {@code finalize.sh}'s empty-live refusal — are
+ * exercised by the OPIK-6901 staging dry-run, not by this test (which runs the SQL those scripts wrap, directly). This
+ * test asserts the logic is correct when invoked; the staging rehearsal asserts the scripts invoke it safely. What this
+ * suite does cover of the reconciliation is every statement those drivers issue, and its postcondition's four counts.
  *
  * <p><b>On the {@code SETTINGS} these statements carry.</b> They hardcode {@code max_insert_block_size = 100000}
  * and {@code max_partitions_per_insert_block = 2000}, and omit {@code max_insert_threads} — while
@@ -1393,6 +1413,610 @@ class TracesLocalV2CutoverTest {
     }
 
     /**
+     * The forward post-swap reconciliation (000006 {@code forward-sweep} + 000002's deletion replay aimed at the live
+     * table), and the negative control that proves it is load-bearing.
+     *
+     * <p>This is the defect OPIK-8238 exists for. The last write-copying statement is the delta INSERT; everything
+     * written to the old table after it is orphaned when that table is parked, and nothing holds those writes across
+     * the swap. The negative control here is the shape a real cutover hit: without the sweep, a trace written in the
+     * gap is simply gone from the live table while sitting intact in the backup.
+     *
+     * <p>The assertions run in the order an operator would trust them: the trace is back, the gate reports zero across
+     * all three of its gating buckets, and the whole workspace's normalized fingerprint matches the frozen backup —
+     * presence, version and payload, not just a row count.
+     */
+    @Test
+    void postSwapSweepRestoresTheGapAndWithoutItThoseWritesAreLost() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        seedTraces(survivors, workspaceId, projectId);
+        seedFidelityCohort(workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        // delta_start: the instant the LAST delta pass began reading. Everything written after it lands only on the old
+        // table, which is exactly what the post-swap sweep has to carry.
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+        replayDeletions(backfillStart);
+
+        // The gap: written to the OLD traces after that read, so neither the delta nor the final replay saw it.
+        var gapAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        var gapWritten = mintIdsAt(5, gapAt);
+        insertRows(gapWritten, workspaceId, projectId, "gap", _ -> gapAt);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        assertThat(liveCount("traces", idStrings(gapWritten), workspaceId))
+                .as("negative control: with reconciliation skipped, every trace written in the gap is LOST from the live"
+                        + " table — the failure this whole step exists to repair")
+                .isZero();
+        assertThat(liveCount("traces_pre_cutover_backup", idStrings(gapWritten), workspaceId))
+                .as("...and is sitting intact in the frozen backup, which is why it is recoverable at all")
+                .isEqualTo(gapWritten.size());
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("the gate SEES the loss before anything is repaired: five keys live in the parked backup inside the"
+                        + " gap window are absent from the live table")
+                .isEqualTo(ReconciliationCounts.builder().missing(gapWritten.size()).stale(0).payloadMismatch(0)
+                        .newer(0).build());
+
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(gapWritten), workspaceId))
+                .as("after the sweep every gap-window trace is live on the successor")
+                .isEqualTo(gapWritten.size());
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("and the gate clears: nothing missing, nothing stale, no payload differing")
+                .isEqualTo(reconciled());
+        assertThat(fingerprint("traces", Shape.NEW, workspaceId))
+                .as("the reconciled successor matches the frozen backup field-for-field, not merely key-for-key")
+                .isEqualTo(fingerprint("traces_pre_cutover_backup", Shape.OLD, workspaceId));
+
+        // A SECOND pass, because reconcile.sh runs one whenever the gate is still non-zero (up to --max-passes) and
+        // because the runbook promises a re-run on a reconciled estate is a no-op. Both make pass 2 a real code path,
+        // not a hypothetical: it re-inserts every swept row and re-runs the replay against an estate that is already
+        // correct. Same idempotence check, and same reason, as deleteThenResurrectSurvivesTheReplay's repeated replay.
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("a second pass changes nothing: the gate is still clean")
+                .isEqualTo(reconciled());
+        assertThat(fingerprint("traces", Shape.NEW, workspaceId))
+                .as("and no row moved — the re-inserted copies lose to the versions already there")
+                .isEqualTo(fingerprint("traces_pre_cutover_backup", Shape.OLD, workspaceId));
+    }
+
+    /**
+     * The sweep must not undo a delete that landed AFTER the swap. A trace that was live when the backup froze is still
+     * live in it, so a sweep with no exclusion would insert a fresh version and resurrect it — the mirror image of the
+     * bug it is fixing.
+     *
+     * <p>The realistic shape, and the one built here: a trace that existed before the backfill (so it IS on the
+     * successor) and was UPDATED inside the gap window, which is what puts it in the sweep's range. The user then
+     * deletes it on the live table after the swap. It has to stay deleted, and the postcondition must not count it as
+     * missing — a gate that did would be unreachable on any estate where users delete things.
+     */
+    @Test
+    void sweepDoesNotResurrectAGapWindowTraceDeletedAfterTheSwap() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        var target = mintIdsAt(1, weekInstant(0, 1));
+        seedTraces(survivors, workspaceId, projectId);
+        seedTraces(target, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+
+        // Updated on the OLD table inside the gap window: its created_at stays historical, so only the
+        // last_updated_at arm of the window predicate selects it — the arm a created_at-only sweep would miss.
+        var updatedAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        insertRows(target, workspaceId, projectId, "gap-updated", _ -> updatedAt);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        recordDeletionEvents(idStrings(target), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(idStrings(target), workspaceId);
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("baseline: the post-swap delete masked the stale copy the cutover had left live")
+                .isZero();
+
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("the sweep does not resurrect it: the exclusion arm drops every key bridged since swap_done")
+                .isZero();
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("and the gate still clears — a key deleted after the swap is legitimately absent, not missing")
+                .isEqualTo(reconciled());
+        assertThat(liveCount("traces", idStrings(survivors), workspaceId))
+                .as("every other survivor is untouched")
+                .isEqualTo(survivors.size());
+
+        // The pass reconcile.sh would run next if the gate had not cleared. A delete is the thing a repeated sweep
+        // could plausibly undo, so this is where idempotence matters most.
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("a second pass does not resurrect it either")
+                .isZero();
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("and the gate is still clean after it")
+                .isEqualTo(reconciled());
+    }
+
+    /**
+     * The counterweight to {@link #sweepDoesNotResurrectAGapWindowTraceDeletedAfterTheSwap()}, and the reason the
+     * sweep's exclusion is bounded at {@code swap_done} rather than at {@code gap_start}.
+     *
+     * <p>A trace deleted and then re-created BEFORE the swap is legitimately live in the frozen backup — the re-creation
+     * is what the backup froze — so it must be swept back, even though the bridge holds a delete event for it. Bounding
+     * the exclusion at {@code gap_start} would drop every such key instead: a silent write loss of exactly the kind this
+     * step exists to prevent, which no other test here would notice, because the postcondition excludes the same keys
+     * the sweep does and the estate would therefore look clean.
+     *
+     * <p>That makes this the test standing between the runbook and a plausible "hardening" — narrowing the bound to
+     * close the capture-before-delete residual documented in 000006 would trade a rare resurrection for a likelier loss.
+     */
+    @Test
+    void sweepRestoresAGapWindowTraceDeletedAndReCreatedBeforeTheSwap() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        var target = mintIdsAt(1, weekInstant(0, 1));
+        seedTraces(survivors, workspaceId, projectId);
+        seedTraces(target, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+
+        // Deleted and re-created inside the gap window, both BEFORE the swap: the bridge carries the delete, and the
+        // old table — and so the frozen backup — carries the re-created row as live.
+        recordDeletionEvents(idStrings(target), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(idStrings(target), workspaceId);
+        var reCreatedAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        insertRows(target, workspaceId, projectId, "re-created-before-swap", _ -> reCreatedAt);
+        // The final pre-swap replay, as exchange_and_wrap.sh runs it: its guard reads the LIVE source, where the key is
+        // live again, so it correctly leaves the successor's copy alone rather than masking it.
+        replayDeletions(backfillStart);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        assertThat(newestNames("traces_pre_cutover_backup", idStrings(target), workspaceId))
+                .as("precondition: the frozen backup holds the RE-CREATION as live, not the delete")
+                .containsOnly("re-created-before-swap");
+        assertThat(newestNames("traces", idStrings(target), workspaceId))
+                .as("and the swap left the successor on the pre-delete version the backfill copied — the re-creation"
+                        + " landed after the last delta, so it is in the gap like any other write")
+                .containsOnly("seed");
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("the gate sees that as a STALE key, the bucket for a live row older than the parked one — the shape"
+                        + " an incomplete cutover leaves behind when the key exists on both sides")
+                .isEqualTo(ReconciliationCounts.builder().missing(0).stale(1).payloadMismatch(0).newer(0).build());
+
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(newestNames("traces", idStrings(target), workspaceId))
+                .as("the re-creation is swept back: its delete was bridged BEFORE swap_done, so the exclusion arm does"
+                        + " not drop it, and the replay's guard spares it because the frozen backup shows it live")
+                .containsOnly("re-created-before-swap");
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("and the gate clears")
+                .isEqualTo(reconciled());
+    }
+
+    /**
+     * A gap-window trace that was written again AFTER the swap keeps the newer version. The sweep inserts the frozen
+     * one, which loses the {@code ReplacingMergeTree} version comparison — that is what makes the sweep safe to run
+     * against live traffic rather than a race with it.
+     *
+     * <p>It also pins the postcondition's one informational bucket: such a key is reported as {@code newer_keys}, which
+     * is expected to be non-zero on a busy estate, and the gate still passes. Gating on that count would fail every
+     * healthy reconciliation.
+     */
+    @Test
+    void sweepKeepsANewerPostSwapVersionAndTheGateStillPasses() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var target = mintIdsAt(1, weekInstant(0, 1));
+        seedTraces(target, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+
+        var updatedAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        insertRows(target, workspaceId, projectId, "gap-updated", _ -> updatedAt);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        // A post-swap write on the live successor, newer than anything the frozen backup holds.
+        var postSwapAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        insertRows(target, workspaceId, projectId, "post-swap", _ -> postSwapAt);
+
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(newestNames("traces", idStrings(target), workspaceId))
+                .as("the sweep's re-insert loses to the post-swap version — it cannot clobber live traffic")
+                .containsOnly("post-swap");
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("reported as newer_keys, which is informational: the three gating buckets are still 0")
+                .isEqualTo(ReconciliationCounts.builder().missing(0).stale(0).payloadMismatch(0).newer(1).build());
+    }
+
+    /**
+     * Reconciling a WRAPPED estate, which is the ordinary path and not an edge case: {@code exchange_and_wrap.sh
+     * --with-wrap} applies the wrap in the same run, so the CUTOVER INCOMPLETE banner is printed with {@code traces}
+     * already a {@code Distributed} wrapper and the reconciliation runs against that topology.
+     *
+     * <p>A {@code Distributed} table accepts {@code INSERT} but rejects mutations, so the replay after the sweep would
+     * fail against {@code traces} — which is why {@code reconcile.sh} resolves one name the way
+     * {@code tracesDistributedWrapEnabled} does and aims every statement at {@code traces_local}. Writing the shard
+     * directly is correct rather than a bypass of the sharding key: the parked backup is itself a per-shard table, so
+     * its rows already belong to this shard.
+     *
+     * <p>What this pins that the driver's own guard cannot: that the swept rows are then readable THROUGH the wrapper,
+     * and that the gate — which also reads the resolved name — agrees.
+     */
+    @Test
+    void reconciliationWorksOnAWrappedEstateThroughTracesLocal() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        seedTraces(survivors, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+
+        var gapAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        var gapWritten = mintIdsAt(3, gapAt);
+        insertRows(gapWritten, workspaceId, projectId, "gap", _ -> gapAt);
+        // A gap-window delete too, so the replay half runs against traces_local rather than being a no-op.
+        var gapDeleted = mintIds(2);
+        seedTraces(gapDeleted, workspaceId, projectId);
+        backfillWeek(0);
+        recordDeletionEvents(idStrings(gapDeleted), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(idStrings(gapDeleted), workspaceId);
+
+        exchangeTables();
+        wrapInDistributed();
+        var swapDone = nowMicros();
+
+        assertThat(isDistributed("traces"))
+                .as("precondition: --with-wrap leaves the estate wrapped before reconciliation runs")
+                .isTrue();
+
+        // Every statement aimed at the shard, exactly as the driver resolves it.
+        reconcileForward("traces_local", deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(gapWritten), workspaceId))
+                .as("the swept rows are readable through the Distributed wrapper")
+                .isEqualTo(gapWritten.size());
+        assertThat(liveCount("traces", idStrings(gapDeleted), workspaceId))
+                .as("and the replay's mask applied to the shard is visible through it too")
+                .isZero();
+        assertThat(reconciliationCounts("traces_pre_cutover_backup", Shape.OLD, "traces_local", deltaStart, swapDone))
+                .as("the gate, read against the same resolved name, clears")
+                .isEqualTo(reconciled());
+    }
+
+    /**
+     * The delete-side residual the runbook previously accepted as inherent: a delete whose bridge row commits after the
+     * final pre-swap replay has read the bridge, but before the EXCHANGE. It is covered by neither the forward replay
+     * (already run) nor the rollback reverse-replay ({@code event_time >= cutover_start}), so it leaks live across the
+     * swap.
+     *
+     * <p>Post-swap it is closable, because the resurrection guard can read the FROZEN backup instead of a live source:
+     * there is no race left to lose. The test walks all three states so the sweep and the replay are not confused for
+     * one another — the leak is present after the swap, still present after the sweep alone (which is mask-honored and
+     * therefore cannot fix a delete), and gone after the replay.
+     */
+    @Test
+    void postSwapReplayMasksADeleteBridgedBetweenTheFinalReplayAndTheExchange() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        var leaked = mintIds(3);
+        seedTraces(survivors, workspaceId, projectId);
+        seedTraces(leaked, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+        replayDeletions(backfillStart); // the final pre-swap replay reads the bridge HERE
+
+        // ...and the bridge row lands after that read. Nothing pre-swap can mask it any more.
+        recordDeletionEvents(idStrings(leaked), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(idStrings(leaked), workspaceId);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+
+        assertThat(liveCount("traces", idStrings(leaked), workspaceId))
+                .as("negative control: the delete leaked live across the swap")
+                .isEqualTo(leaked.size());
+
+        forwardSweep("traces", deltaStart, swapDone);
+        assertThat(liveCount("traces", idStrings(leaked), workspaceId))
+                .as("the sweep alone cannot fix a delete — it is mask-honored, so it neither copies nor removes it")
+                .isEqualTo(leaked.size());
+
+        postSwapDeletionReplay("traces", deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(leaked), workspaceId))
+                .as("the post-swap replay masks it: the frozen backup says it is still deleted, race-free")
+                .isZero();
+        assertThat(liveCount("traces", idStrings(survivors), workspaceId))
+                .as("and no survivor is dropped with it")
+                .isEqualTo(survivors.size());
+    }
+
+    /**
+     * The hazard the frozen resurrection guard introduces, and the scope that closes it. A frozen source cannot see a
+     * row written AFTER the swap, so a key deleted before the swap and then re-created or patched after it looks "still
+     * deleted" to the guard — and the replay would mask a live post-cutover write, turning the fix for write loss into a
+     * cause of it. It is not exotic: trace ids are client-supplied and {@code TraceDAO.UPDATE} re-inserts a version, so
+     * any in-flight patch to a just-deleted trace does exactly this.
+     *
+     * <p>The staleness scope is what prevents it, per ROW rather than per key: only rows whose own {@code created_at}
+     * AND {@code last_updated_at} both predate the swap may be masked. The re-creation here carries a historical
+     * {@code created_at} and a post-swap {@code last_updated_at}, so it is spared by the {@code last_updated_at} arm
+     * alone — the harder of the two, and the one a batch-ingest write would not exercise.
+     *
+     * <p>The negative control then runs the same replay with that scope omitted — 000002's pre-swap two-arm shape,
+     * aimed post-swap — and watches the write disappear, so the scope is proven load-bearing rather than merely present.
+     */
+    @Test
+    void postSwapReplayDoesNotMaskATraceReCreatedAfterTheSwap() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        var target = mintIdsAt(1, weekInstant(0, 1));
+        seedTraces(survivors, workspaceId, projectId);
+        seedTraces(target, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        var deltaStart = nowMicros();
+        deltaInsert(backfillStart);
+
+        // Deleted in the gap, bridged, and correctly masked on the successor by the final pre-swap replay.
+        recordDeletionEvents(idStrings(target), workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(idStrings(target), workspaceId);
+        replayDeletions(backfillStart);
+
+        exchangeTables();
+        var swapDone = nowMicros();
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("baseline: the delete was honoured across the swap")
+                .isZero();
+
+        // After the swap a client re-sends the same id — the row is live again on the successor, and the frozen backup
+        // cannot know it.
+        var reCreatedAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        insertRows(target, workspaceId, projectId, "re-created", _ -> reCreatedAt);
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("baseline: the re-creation is live")
+                .isEqualTo(1L);
+
+        reconcileForward(deltaStart, swapDone);
+
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("the post-swap re-creation SURVIVES: the staleness scope spares any row written since the swap")
+                .isEqualTo(1L);
+        assertThat(forwardCounts(deltaStart, swapDone))
+                .as("and the gate clears — the key is masked in the frozen backup, so it never enters the parked set")
+                .isEqualTo(reconciled());
+
+        // NEGATIVE CONTROL: the same replay with the PRE-swap scope, which is inert, destroys the write.
+        postSwapDeletionReplayWithoutStalenessScope(deltaStart);
+        assertThat(liveCount("traces", idStrings(target), workspaceId))
+                .as("without the staleness scope the frozen guard masks a live post-cutover write — the regression the"
+                        + " scope exists to prevent")
+                .isZero();
+    }
+
+    /**
+     * The reverse direction (000006 {@code reverse-sweep}): re-import into the restored original the post-cutover writes
+     * a stage B/C promote made non-live. This is what turns {@code --accept-post-cutover-write-loss} from a verdict into
+     * a choice — right when the rollback was about latency, merge load or the wrap, and wrong when the successor's
+     * content is what is suspect.
+     *
+     * <p>The sentinel denormalization is the part that cannot be skipped, and it is asserted through {@code duration}
+     * rather than through {@code end_time} alone. The successor stores an unfinished trace's {@code end_time} as the
+     * epoch; the original's convention is {@code NULL} and its MATERIALIZED {@code duration} guards only
+     * {@code end_time IS NOT NULL}, so importing the sentinel verbatim would give every unfinished trace a duration of
+     * roughly -1.79e12 ms. Restoring {@code NULL} is what makes the recomputed duration {@code NULL}.
+     */
+    @Test
+    void reverseSweepReimportsPostCutoverWritesWithSentinelsDenormalizedToNull() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        seedTraces(survivors, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        deltaInsert(backfillStart);
+
+        var cutoverStart = nowMicros();
+        exchangeTables();
+
+        // Accepted by the successor after cutover_start: in-progress traces, so end_time and ttft take the successor's
+        // epoch / NaN DEFAULTs — the shape whose denormalization matters.
+        var postCutoverAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        var postCutover = mintIdsAt(3, postCutoverAt);
+        insertRows(postCutover, workspaceId, projectId, "post-cutover", _ -> postCutoverAt);
+
+        rollbackExchangeBack(cutoverStart);
+        var promoteDone = nowMicros();
+
+        assertThat(liveCount("traces", idStrings(postCutover), workspaceId))
+                .as("baseline: the promote made the post-cutover writes non-live on the restored original")
+                .isZero();
+        assertThat(reverseCounts(cutoverStart, cutoverStart))
+                .as("the gate sizes the loss: three keys the parked successor holds are absent from the live original")
+                .isEqualTo(ReconciliationCounts.builder().missing(postCutover.size()).stale(0).payloadMismatch(0)
+                        .newer(0).build());
+
+        reconcileReverse(cutoverStart, promoteDone);
+
+        assertThat(liveCount("traces", idStrings(postCutover), workspaceId))
+                .as("re-imported into the restored original")
+                .isEqualTo(postCutover.size());
+        assertThat(countMatching(workspaceId,
+                "name = 'post-cutover' AND end_time IS NULL AND ttft IS NULL AND duration IS NULL"))
+                .as("with the sentinels denormalized, so the recomputed duration is NULL — not the large NEGATIVE the"
+                        + " original's expression produces from an epoch end_time it does not recognise")
+                .isEqualTo(postCutover.size());
+        assertThat(countMatching(workspaceId,
+                "name = 'post-cutover' AND end_time = toDateTime64('1970-01-01 00:00:00', 9, 'UTC')"))
+                .as("negative control: no re-imported row kept the successor's epoch sentinel")
+                .isZero();
+        assertThat(reverseCounts(cutoverStart, cutoverStart))
+                .as("and the reverse gate clears")
+                .isEqualTo(reconciled());
+    }
+
+    /**
+     * Deletes still win over the re-imported writes. The reverse sweep runs BEFORE
+     * {@code 000004_rollback_reverse_replay.sql}, so a trace deleted on the successor after {@code cutover_start} is
+     * masked in the parked copy (and so never swept back) and masked again on the restored original by the replay —
+     * and that file's own postcondition still reports 0, which is the box the runbook's rollback checklist ticks.
+     */
+    @Test
+    void reverseSweepDoesNotResurrectATraceDeletedAfterCutoverStart() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var survivors = mintIds(SURVIVORS_PER_WEEK);
+        seedTraces(survivors, workspaceId, projectId);
+
+        var backfillStart = nowMicros();
+        for (int week = 0; week < SEED_WEEKS; week++) {
+            backfillWeek(week);
+        }
+        deltaInsert(backfillStart);
+
+        var cutoverStart = nowMicros();
+        exchangeTables();
+
+        var postCutoverAt = Instant.from(ClickHouseDateTimeFormat.MICROS.parse(nowMicros()));
+        var postCutover = mintIdsAt(2, postCutoverAt);
+        insertRows(postCutover, workspaceId, projectId, "post-cutover", _ -> postCutoverAt);
+
+        // Deleted on the successor after the cutover, so the rollback must honour it however the writes are handled.
+        var deletedAfterCutover = Set.of(survivors.getFirst().id().toString());
+        recordDeletionEvents(deletedAfterCutover, workspaceId, projectId.toString(), "user_request");
+        lightweightDelete(deletedAfterCutover, workspaceId);
+
+        rollbackExchangeBack(cutoverStart);
+        var promoteDone = nowMicros();
+
+        reconcileReverse(cutoverStart, promoteDone);
+
+        assertThat(liveCount("traces", deletedAfterCutover, workspaceId))
+                .as("the re-import does not resurrect a post-cutover delete")
+                .isZero();
+        assertThat(verifyReplayPostcondition(cutoverStart))
+                .as("and 000004_rollback_verify_replay.sql still reports 0 after the re-import")
+                .isZero();
+        assertThat(liveCount("traces", idStrings(postCutover), workspaceId))
+                .as("while the post-cutover writes that were NOT deleted are live again")
+                .isEqualTo(postCutover.size());
+    }
+
+    /**
+     * The postcondition's classification, one key per bucket, on the FULL {@code (workspace_id, project_id, id)} key.
+     *
+     * <p>The baseline matters as much as the perturbations: a clean sweep must classify NOTHING, which is what makes a
+     * zero meaningful. Each cohort is then moved into exactly one bucket by editing the live side only — masking the
+     * swept row and re-inserting where a different version is needed, so every side holds one physical row and
+     * {@code FINAL} has no arbitrary choice to make. Building the "matching" row with the sweep itself, rather than by
+     * hand, is deliberate: it makes the baseline a statement about the real copy path rather than about whether two
+     * tables happen to share column DEFAULTs.
+     *
+     * <p>The reused id is the full-key case: the same id under two projects, matching in one and absent in the other,
+     * counts once as missing. A gate keyed on {@code id} alone would report zero there.
+     */
+    @Test
+    void reconciliationCountsClassifyEachKeyByItsVersionRelationOnTheFullKey() {
+        var workspaceId = UUID.randomUUID().toString();
+        var projectId = ID_GENERATOR.generateId();
+        var otherProjectId = ID_GENERATOR.generateId();
+        var at = Instant.parse("2025-03-04T10:00:00Z");
+        var gapStart = "2025-03-04 09:00:00";
+
+        var matching = ID_GENERATOR.generateId().toString();
+        var stale = ID_GENERATOR.generateId().toString();
+        var payload = ID_GENERATOR.generateId().toString();
+        var newer = ID_GENERATOR.generateId().toString();
+        var missing = ID_GENERATOR.generateId().toString();
+        var reused = ID_GENERATOR.generateId().toString();
+        for (var id : List.of(matching, stale, payload, newer, missing, reused)) {
+            insertShapedTrace(id, workspaceId, projectId, "cohort", at, null, null, at, at);
+        }
+        insertShapedTrace(reused, workspaceId, otherProjectId, "cohort", at, null, null, at, at);
+
+        // Park the seeded rows and start from an empty successor, so every live row below is one this test placed.
+        exchangeTables();
+        var swapDone = nowMicros();
+        forwardSweep("traces", gapStart, swapDone);
+
+        assertThat(forwardCounts(gapStart, swapDone))
+                .as("baseline: a clean sweep classifies nothing — which is what makes a zero in any bucket meaningful")
+                .isEqualTo(reconciled());
+
+        // MISSING: absent from the live table, with no bridge event, so the exclusion arm does not forgive it.
+        lightweightDeleteScoped(Set.of(missing), workspaceId, projectId);
+        // MISSING, full-key: present under one project and absent under the other; it must count once, not zero.
+        lightweightDeleteScoped(Set.of(reused), workspaceId, otherProjectId);
+        // STALE: the live row is at an OLDER version than the parked one.
+        lightweightDeleteScoped(Set.of(stale), workspaceId, projectId);
+        insertShapedTrace(stale, workspaceId, projectId, "cohort", at, Instant.EPOCH, Double.NaN, at,
+                at.minusSeconds(60));
+        // PAYLOAD MISMATCH: same version, differing content — the case a version comparison alone cannot see.
+        lightweightDeleteScoped(Set.of(payload), workspaceId, projectId);
+        insertShapedTrace(payload, workspaceId, projectId, "differs", at, Instant.EPOCH, Double.NaN, at, at);
+        // NEWER: post-swap traffic touched it; informational, and must not gate.
+        insertShapedTrace(newer, workspaceId, projectId, "cohort", at, Instant.EPOCH, Double.NaN, at,
+                at.plusSeconds(60));
+
+        assertThat(forwardCounts(gapStart, swapDone))
+                .as("each key lands in exactly one bucket, counted per full key: two missing (one of them the reused"
+                        + " id's other project), one stale, one payload mismatch, one newer")
+                .isEqualTo(ReconciliationCounts.builder().missing(2).stale(1).payloadMismatch(1).newer(1).build());
+    }
+
+    /**
      * The backfill's window bounds. A {@code DateTime64} literal carrying no timezone is parsed in the session's
      * timezone, while every column it meets is {@code DateTime64(n, 'UTC')}, so the session is set explicitly here: an
      * unpinned literal only diverges where it is not UTC. The row is seeded an hour into the week, so a bound read in
@@ -1803,6 +2427,290 @@ class TracesLocalV2CutoverTest {
     }
 
     /**
+     * The POST-SWAP forward deletion replay (000006 {@code forward-deletion-replay}), run right after the sweep so
+     * bridged deletes win over what it re-inserted. A separate statement from {@link #replayDeletions(String)}, exactly
+     * as it is a separate block from 000002 in the shipped SQL: it masks rows on the LIVE table and reads its
+     * resurrection guard from the FROZEN backup, which is race-free where a live source cannot be — and is what closes
+     * the delete-side residual (a delete bridged after the final pre-swap replay read the bridge, but before the swap).
+     *
+     * <p>The third arm — the staleness scope on {@code swapDone} — has no counterpart pre-swap, because the shadow
+     * receives no writes except the copy. It is what stops the frozen guard destroying a post-cutover write: the guard
+     * cannot see a row written after the swap, so a key deleted before it and re-created after looks "still deleted".
+     * The scope is per ROW, so a leaked stale copy is masked while a newer version of the same key survives.
+     * {@link #postSwapDeletionReplayWithoutStalenessScope} is the negative control that proves it load-bearing.
+     */
+    private void postSwapDeletionReplay(String liveTable, String gapStart, String swapDone) {
+        execute("""
+                DELETE FROM %s
+                WHERE created_at      <  toDateTime64(:swap_done, 6, 'UTC')
+                  AND last_updated_at <  toDateTime64(:swap_done, 6, 'UTC')
+                  AND (workspace_id, project_id, id) IN (
+                      SELECT
+                          workspace_id,
+                          toFixedString(project_id, 36),
+                          toFixedString(deleted_id, 36)
+                      FROM deletion_events_local
+                      WHERE source_table = 'traces'
+                        AND event_time >= toDateTime64(:gap_start, 6, 'UTC')
+                        AND project_id != ''
+                        AND length(project_id) = 36
+                        AND length(deleted_id) = 36
+                  )
+                  AND (workspace_id, project_id, id) NOT IN (
+                      SELECT
+                          workspace_id,
+                          project_id,
+                          id
+                      FROM traces_pre_cutover_backup
+                      WHERE id IN (
+                          SELECT toFixedString(deleted_id, 36)
+                          FROM deletion_events_local
+                          WHERE source_table = 'traces'
+                            AND event_time >= toDateTime64(:gap_start, 6, 'UTC')
+                            AND length(deleted_id) = 36
+                      )
+                  )
+                SETTINGS allow_nondeterministic_mutations = 1,
+                         lightweight_deletes_sync = 2
+                """.formatted(liveTable),
+                statement -> statement.bind("gap_start", gapStart).bind("swap_done", swapDone));
+    }
+
+    /**
+     * NEGATIVE CONTROL for {@link #postSwapDeletionReplay}: the same statement with the staleness scope deliberately
+     * omitted, i.e. 000002's two-arm predicate aimed at the post-swap estate. It exists to be run once, on a trace
+     * re-created after the swap, and watched to destroy it — without which "the scope is load-bearing" is an assertion
+     * about code nobody has seen fail. Never a shape the runbook ships.
+     */
+    private void postSwapDeletionReplayWithoutStalenessScope(String gapStart) {
+        execute("""
+                DELETE FROM traces
+                WHERE (workspace_id, project_id, id) IN (
+                      SELECT
+                          workspace_id,
+                          toFixedString(project_id, 36),
+                          toFixedString(deleted_id, 36)
+                      FROM deletion_events_local
+                      WHERE source_table = 'traces'
+                        AND event_time >= toDateTime64(:gap_start, 6, 'UTC')
+                        AND project_id != ''
+                        AND length(project_id) = 36
+                        AND length(deleted_id) = 36
+                  )
+                  AND (workspace_id, project_id, id) NOT IN (
+                      SELECT
+                          workspace_id,
+                          project_id,
+                          id
+                      FROM traces_pre_cutover_backup
+                      WHERE id IN (
+                          SELECT toFixedString(deleted_id, 36)
+                          FROM deletion_events_local
+                          WHERE source_table = 'traces'
+                            AND event_time >= toDateTime64(:gap_start, 6, 'UTC')
+                            AND length(deleted_id) = 36
+                      )
+                  )
+                SETTINGS allow_nondeterministic_mutations = 1,
+                         lightweight_deletes_sync = 2
+                """, statement -> statement.bind("gap_start", gapStart));
+    }
+
+    /**
+     * One forward reconciliation pass, in the order {@code reconcile.sh} runs the two blocks: sweep, then replay, so
+     * bridged deletes win over anything the sweep re-inserted. Encoded once because that order is load-bearing — a test
+     * that reversed it would still pass on every case where nothing was deleted.
+     *
+     * <p>Callers that need to observe the two halves separately — proving the sweep alone cannot fix a delete, or that
+     * the replay without its staleness scope destroys a re-creation — call them individually instead.
+     */
+    private void reconcileForward(String gapStart, String swapDone) {
+        reconcileForward("traces", gapStart, swapDone);
+    }
+
+    /** As above against the live table {@code reconcile.sh} resolves: {@code traces_local} on a wrapped estate. */
+    private void reconcileForward(String liveTable, String gapStart, String swapDone) {
+        forwardSweep(liveTable, gapStart, swapDone);
+        postSwapDeletionReplay(liveTable, gapStart, swapDone);
+    }
+
+    /**
+     * One reverse reconciliation pass: the sweep, then {@code 000004_rollback_reverse_replay.sql} unchanged. Same
+     * ordering rule, same reason — the replay is what makes post-cutover deletes win over the re-imported writes.
+     */
+    private void reconcileReverse(String cutoverStart, String promoteDone) {
+        reverseSweep(cutoverStart, promoteDone);
+        reverseReplay(cutoverStart);
+    }
+
+    /**
+     * The POST-SWAP forward sweep (000006 {@code forward-sweep}): copy the gap window out of the FROZEN
+     * {@code traces_pre_cutover_backup} into the live successor. The source is the old original, so the projection is
+     * the backfill's: {@code end_time} and {@code ttft} are still Nullable and coalesce to the successor's sentinels.
+     * The live table is the statement's one parameter, mirroring the {@code ${LIVE_TABLE}} the shipped block carries.
+     *
+     * <p>Mask-honored ({@code apply_deleted_mask} stays at its default) and idempotent (the target is a
+     * {@code ReplacingMergeTree}, so a re-inserted row loses to anything newer). The {@code NOT IN} arm is what stops it
+     * resurrecting a gap-window trace deleted AFTER the swap; deletes bridged BEFORE the swap are handled instead by the
+     * deletion replay that runs after it, so a trace deleted and re-created before the freeze is still swept back.
+     */
+    private void forwardSweep(String liveTable, String gapStart, String swapDone) {
+        execute("""
+                INSERT INTO %s (
+                    id,
+                    workspace_id,
+                    project_id,
+                    name,
+                    start_time,
+                    end_time,
+                    input,
+                    output,
+                    metadata,
+                    tags,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
+                    error_info,
+                    thread_id,
+                    visibility_mode,
+                    truncation_threshold,
+                    input_slim,
+                    output_slim,
+                    ttft,
+                    source,
+                    environment
+                )
+                SELECT
+                    id,
+                    workspace_id,
+                    project_id,
+                    name,
+                    start_time,
+                    coalesce(end_time, toDateTime64('1970-01-01 00:00:00', 6)) AS end_time,
+                    input,
+                    output,
+                    metadata,
+                    tags,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
+                    error_info,
+                    thread_id,
+                    visibility_mode,
+                    truncation_threshold,
+                    input_slim,
+                    output_slim,
+                    coalesce(ttft, toFloat64('nan')) AS ttft,
+                    source,
+                    environment
+                FROM traces_pre_cutover_backup
+                WHERE (created_at >= toDateTime64(:gap_start, 6, 'UTC')
+                    OR last_updated_at >= toDateTime64(:gap_start, 6, 'UTC'))
+                  AND (workspace_id, project_id, id) NOT IN (
+                      SELECT
+                          workspace_id,
+                          toFixedString(project_id, 36),
+                          toFixedString(deleted_id, 36)
+                      FROM deletion_events_local
+                      WHERE source_table = 'traces'
+                        AND event_time >= toDateTime64(:swap_done, 6, 'UTC')
+                        AND project_id != ''
+                        AND length(project_id) = 36
+                        AND length(deleted_id) = 36
+                  )
+                SETTINGS max_partitions_per_insert_block = 2000
+                """.formatted(liveTable),
+                statement -> statement.bind("gap_start", gapStart).bind("swap_done", swapDone));
+    }
+
+    /**
+     * The REVERSE sweep (000006 {@code reverse-sweep}): re-import the post-cutover writes a promote made non-live, out
+     * of {@code traces_post_rollback_backup} and back into the restored original.
+     *
+     * <p>The projection is the inverse of the forward one, and it is what this statement is about: the successor's
+     * non-nullable epoch / NaN sentinels are denormalized back to the original's {@code NULL} convention. Without that,
+     * the original's MATERIALIZED {@code duration} — which guards {@code end_time IS NOT NULL} and knows nothing of the
+     * epoch — recomputes a large NEGATIVE value for every re-imported trace that had not ended.
+     *
+     * <p>The epoch literal pins {@code 'UTC'} here and deliberately does not in the forward direction: forward, the
+     * sentinel being WRITTEN has to agree with the successor's own unpinned DEFAULT and duration expression; reverse,
+     * the sentinel being READ was written by the backend as an absolute {@code Instant.EPOCH}. Same asymmetry, and the
+     * same reasoning, as 000004_rollback_sentinel_repair.sql.
+     */
+    private void reverseSweep(String gapStart, String swapDone) {
+        execute("""
+                INSERT INTO traces (
+                    id,
+                    workspace_id,
+                    project_id,
+                    name,
+                    start_time,
+                    end_time,
+                    input,
+                    output,
+                    metadata,
+                    tags,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
+                    error_info,
+                    thread_id,
+                    visibility_mode,
+                    truncation_threshold,
+                    input_slim,
+                    output_slim,
+                    ttft,
+                    source,
+                    environment
+                )
+                SELECT
+                    id,
+                    workspace_id,
+                    project_id,
+                    name,
+                    start_time,
+                    nullIf(end_time, toDateTime64('1970-01-01 00:00:00', 6, 'UTC')) AS end_time,
+                    input,
+                    output,
+                    metadata,
+                    tags,
+                    created_at,
+                    last_updated_at,
+                    created_by,
+                    last_updated_by,
+                    error_info,
+                    thread_id,
+                    visibility_mode,
+                    truncation_threshold,
+                    input_slim,
+                    output_slim,
+                    if(isNaN(ttft), NULL, ttft) AS ttft,
+                    source,
+                    environment
+                FROM traces_post_rollback_backup
+                WHERE (created_at >= toDateTime64(:gap_start, 6, 'UTC')
+                    OR last_updated_at >= toDateTime64(:gap_start, 6, 'UTC'))
+                  AND (workspace_id, project_id, id) NOT IN (
+                      SELECT
+                          workspace_id,
+                          toFixedString(project_id, 36),
+                          toFixedString(deleted_id, 36)
+                      FROM deletion_events_local
+                      WHERE source_table = 'traces'
+                        AND event_time >= toDateTime64(:swap_done, 6, 'UTC')
+                        AND project_id != ''
+                        AND length(project_id) = 36
+                        AND length(deleted_id) = 36
+                  )
+                SETTINGS max_partitions_per_insert_block = 2000
+                """,
+                statement -> statement.bind("gap_start", gapStart).bind("swap_done", swapDone));
+    }
+
+    /**
      * The atomic swap (000003 exchange block): EXCHANGE puts the successor under {@code traces} and the old data under
      * {@code traces_local_v2}, then a RENAME moves the old data to {@code traces_pre_cutover_backup} so its name says it
      * is the retained pre-cutover backup, not the "v2" successor.
@@ -2206,6 +3114,121 @@ class TracesLocalV2CutoverTest {
                                 .execute())
                         .flatMap(result -> Mono.from(result.map((row, ignored) -> row.get("resurrected", Long.class)))))
                 .block();
+    }
+
+    /**
+     * The reconciliation postcondition (000006_verify_reconciliation), reimplemented inline like the rest of this class.
+     * For every key live in the PARKED table inside the gap window, the live table's version of that key is classified:
+     * absent -> {@code missing}; strictly older -> {@code stale}; same version with a differing normalized fingerprint
+     * -> {@code payloadMismatch}; newer -> {@code newer}. The gate is the first three at 0; {@code newer} is
+     * informational and expected to be non-zero on a busy estate, the same idiom
+     * {@code 000004_rollback_verify_sentinels.sql} uses for {@code negative_from_sentinel}.
+     *
+     * <p>The fingerprints come from {@link #rowHash}, so they are the exact normalization {@code verify.sh} and the
+     * fidelity assertions use, and they follow {@link #COPIED_COLUMNS} — which means a base column added by a future
+     * migration is covered here by construction, not by a second hand-maintained list. The VERSION is compared as a
+     * microsecond epoch for the same reason it is hashed as one: the copy truncates nanoseconds to microseconds, so
+     * comparing the raw columns would report every faithfully-copied row with a sub-microsecond {@code last_updated_at}
+     * as stale.
+     *
+     * <p>No {@code clusterAllReplicas}, unlike the replay and sentinel gates: a Replicated table returns one copy per
+     * replica through it, which would multiply both sides of the join. The driver runs the cluster-wide settle gate
+     * before reading this instead, which is what makes a single-replica read representative.
+     *
+     * @param exclusionFrom the bridge {@code event_time} floor for keys that are LEGITIMATELY absent from the live
+     *                      table: {@code swap_done} forward (only post-swap deletes are absent, the forward replay's
+     *                      resurrection guard sparing anything live in the parked table), {@code cutover_start} reverse
+     *                      (the guard-less reverse replay masks every key bridged since then).
+     */
+    private ReconciliationCounts reconciliationCounts(String parkedTable, Shape parkedShape, String liveTable,
+            String gapStart, String exclusionFrom) {
+        var parkedHash = rowHash(parkedShape == Shape.OLD ? OLD_HASH_OVERRIDES : NEW_HASH_OVERRIDES);
+        var liveHash = rowHash(parkedShape == Shape.OLD ? NEW_HASH_OVERRIDES : OLD_HASH_OVERRIDES);
+        var parkedVersion = parkedShape == Shape.OLD
+                ? "toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6))"
+                : "toUnixTimestamp64Micro(last_updated_at)";
+        var liveVersion = parkedShape == Shape.OLD
+                ? "toUnixTimestamp64Micro(last_updated_at)"
+                : "toUnixTimestamp64Micro(toDateTime64(last_updated_at, 6))";
+        var sql = """
+                WITH
+                    parked AS (
+                        SELECT
+                            (workspace_id, project_id, id) AS key,
+                            %s AS parked_version,
+                            %s AS parked_fingerprint
+                        FROM %s FINAL
+                        WHERE (created_at >= toDateTime64(:gap_start, 6, 'UTC')
+                            OR last_updated_at >= toDateTime64(:gap_start, 6, 'UTC'))
+                          AND (workspace_id, project_id, id) NOT IN (
+                              SELECT
+                                  workspace_id,
+                                  toFixedString(project_id, 36),
+                                  toFixedString(deleted_id, 36)
+                              FROM deletion_events_local
+                              WHERE source_table = 'traces'
+                                AND event_time >= toDateTime64(:exclusion_from, 6, 'UTC')
+                                AND project_id != ''
+                                AND length(project_id) = 36
+                                AND length(deleted_id) = 36
+                          )
+                    ),
+                    live AS (
+                        SELECT
+                            (workspace_id, project_id, id) AS key,
+                            %s AS live_version,
+                            %s AS live_fingerprint
+                        FROM %s FINAL
+                        WHERE (workspace_id, project_id, id) IN (SELECT key FROM parked)
+                    )
+                SELECT
+                    countIf(live_version IS NULL) AS missing_keys,
+                    countIf(live_version IS NOT NULL AND live_version < parked_version) AS stale_keys,
+                    countIf(live_version IS NOT NULL AND live_version = parked_version
+                            AND live_fingerprint != parked_fingerprint) AS payload_mismatch_keys,
+                    countIf(live_version IS NOT NULL AND live_version > parked_version) AS newer_keys
+                FROM parked
+                LEFT JOIN live USING (key)
+                SETTINGS join_use_nulls = 1, use_skip_indexes_if_final = 1
+                """.formatted(parkedVersion, parkedHash, parkedTable, liveVersion, liveHash, liveTable);
+        return template
+                .nonTransaction(connection -> Mono
+                        .from(connection.createStatement(sql)
+                                .bind("gap_start", gapStart)
+                                .bind("exclusion_from", exclusionFrom)
+                                .execute())
+                        .flatMap(result -> Mono.from(result.map((row, ignored) -> ReconciliationCounts.builder()
+                                .missing(row.get("missing_keys", Long.class))
+                                .stale(row.get("stale_keys", Long.class))
+                                .payloadMismatch(row.get("payload_mismatch_keys", Long.class))
+                                .newer(row.get("newer_keys", Long.class))
+                                .build()))))
+                .block();
+    }
+
+    /** Forward direction: the parked pre-cutover backup (OLD shape) against the live successor. */
+    private ReconciliationCounts forwardCounts(String gapStart, String swapDone) {
+        return reconciliationCounts("traces_pre_cutover_backup", Shape.OLD, "traces", gapStart, swapDone);
+    }
+
+    /** Reverse direction: the parked successor (NEW shape) against the restored original. */
+    private ReconciliationCounts reverseCounts(String gapStart, String cutoverStart) {
+        return reconciliationCounts("traces_post_rollback_backup", Shape.NEW, "traces", gapStart, cutoverStart);
+    }
+
+    /**
+     * The counts 000006_verify_reconciliation.sql returns. {@code missing}, {@code stale} and {@code payloadMismatch}
+     * are the gate; {@code newer} is informational and expected to be non-zero wherever post-swap traffic touched a
+     * gap-window key. Built through the builder at every call site so each expected number is read with the bucket it
+     * belongs to — four positional longs would be indistinguishable from each other at a glance.
+     */
+    @Builder(toBuilder = true)
+    private record ReconciliationCounts(long missing, long stale, long payloadMismatch, long newer) {
+    }
+
+    /** The passing gate: nothing missing, nothing stale, no payload differing, and no post-swap write to tolerate. */
+    private static ReconciliationCounts reconciled() {
+        return ReconciliationCounts.builder().missing(0).stale(0).payloadMismatch(0).newer(0).build();
     }
 
     /**

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -101,7 +101,7 @@ $RUNBOOK/scripts/estimate.sh --database opik --max-rows-per-insert 400 --pause-s
 #    --in-progress-ratio is likewise REQUIRED to exercise the pre-swap window's sentinel / negative-duration caveat:
 #    without it every trace is ended, so no trace is ever written with an absent end_time and the caveat (plus its
 #    rollback repair) produces ZERO affected rows. live_traffic.py warns if it left none in progress.
-#    --duration 900 is a starting point, not a recommendation: it has to outlast steps 4-8. Extend it (or re-launch
+#    --duration 900 is a starting point, not a recommendation: it has to outlast steps 4-9. Extend it (or re-launch
 #    both generators) rather than letting them expire before the EXCHANGE.
 python tests_load/tests/traces-local-v2-cutover/live_traffic.py   --tps 10 --duration 900 --update-ratio 0.2 --in-progress-ratio 0.15
 python tests_load/tests/traces-local-v2-cutover/delete_traffic.py --tps 3  --duration 900 --resurrect-ratio 0.05
@@ -131,7 +131,7 @@ $RUNBOOK/scripts/verify.sh --database opik            # --drill-down lists the d
 
 # 7. MANDATORY CONFIG STEP, and the one most easily skipped in a rehearsal: roll out traceColumnsNonNullable=true
 #    BEFORE the EXCHANGE (runbook "The final cutover window"). This is the only restart the cutover itself needs, and
-#    it carries no steady-state latency cost, though the roll itself consumes ingestion capacity; step 10's optional
+#    it carries no steady-state latency cost, though the roll itself consumes ingestion capacity; step 12's optional
 #    wrap has its own. Use recreate_backend() from "Changing backend config mid-rehearsal" above.
 #    Skipping this leaves the whole read-side half of the flag unexercised — and its failure mode is SILENT (writes still
 #    succeed either way; absent end_time just reads back as 1970-01-01 instead of null).
@@ -143,7 +143,7 @@ recreate_backend
 
 # 8. Final delta + replay (the last write-facing step), then the EXCHANGE immediately after. The EXCHANGE is the data
 #    cutover and leaves traces a MergeTree so the backend's deletes keep working; it also renames the displaced old data
-#    to traces_pre_cutover_backup. --skip-wrap defers the sharding-ready Distributed wrap (step 10).
+#    to traces_pre_cutover_backup. --skip-wrap defers the sharding-ready Distributed wrap (step 12).
 #    --confirm-retention-paused holds trivially here (retention is disabled by default).
 $RUNBOOK/scripts/delta_replay.sh --database opik --backfill-start '<backfill_start> UTC'
 $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfill_start> UTC' \
@@ -151,29 +151,47 @@ $RUNBOOK/scripts/exchange_and_wrap.sh --database opik --backfill-start '<backfil
 #    The settle gate polls (default 120s) instead of demanding an instantaneous replication_queue of 0, so with the
 #    traffic from step 3 still flowing it should pass on ordinary churn rather than abort. Watch what it prints: it
 #    reports the queue depth, the oldest entry's age and max num_tries, and says which of the two verdicts it reached.
-#    Record the cutover_start it prints. With traffic running there WILL be traces left in the tail write-gap — in
-#    traces_pre_cutover_backup but not in live traces (runbook "The final cutover window"; OPIK-8238 adds the sweep
-#    that carries them). Seeing that gap is part of the point of rehearsing with traffic, and it takes TWO different
-#    compares, because the gap and a fidelity defect live in different weeks:
+#    Record BOTH anchors: the delta_start delta_replay.sh printed and the exchange_done this driver prints (plus
+#    cutover_start, for a rollback). Note the CUTOVER INCOMPLETE banner it ends with — with traffic running there WILL
+#    be traces left in the tail write-gap, in traces_pre_cutover_backup but not in live traces (runbook "The final
+#    cutover window"). Seeing that gap is part of the point of rehearsing with traffic, and step 9 is what closes it.
 #
-#    (a) SIZE THE GAP — unbounded, straight after the swap, with --drill-down. The gap rows are in the cutover week,
-#        which every weekly bound excludes, so a bounded run cannot see them. Classify the output by the runbook's
-#        Go/No-Go item, which owns the taxonomy: backup-only keys AND both-sides keys whose newer last_updated_at is
-#        in the backup are both gap rows, so counting backup-only alone under-reports it. live_traffic.py's
-#        --update-ratio is what makes that second shape reachable here — it updates traces created earlier in the run,
-#        so some of those updates land in the tail against a trace the backfill already copied. Keep it non-zero.
-$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --drill-down
+#    SIZE IT FIRST, before reconciling, so the rehearsal records what the sweep had to carry. --report-only issues no
+#    mutation, and its four counts are the gap's own taxonomy: missing_keys for traces CREATED in the tail, stale_keys
+#    for traces UPDATED in the tail (already on the successor at an older last_updated_at, which a presence check would
+#    report as clean). live_traffic.py's --update-ratio is what makes stale_keys reachable here, since it updates traces
+#    created earlier in the run; keep it non-zero or that arm goes unexercised.
+$RUNBOOK/scripts/reconcile.sh --database opik --report-only \
+    --gap-start '<delta_start from step 8> UTC' --swap-done '<exchange_done> UTC'
+
+# 9. RECONCILE — the second half of the data cutover, not a check. Sweeps the parked writes into live traces, re-applies
+#    the deletes bridged across the swap, and does not exit 0 until its postcondition reports
+#    missing_keys=0 stale_keys=0 payload_mismatch_keys=0. A non-zero newer_keys alongside those three is expected: those
+#    are gap-window traces written AGAIN after the swap, which the sweep deliberately leaves alone.
+#    Its settle gate is step 8's gate with a post-swap scope, and the half worth watching is the one that only shows
+#    under traffic: delete_traffic.py is still mutating live traces throughout, and the gate must NOT abort on that —
+#    it gates unfinished mutations on the PARKED table only (runbook "The replication-settle gate").
+$RUNBOOK/scripts/reconcile.sh --database opik \
+    --gap-start '<delta_start from step 8> UTC' --swap-done '<exchange_done> UTC'
+
+# 10. QA after the sweep. Two different compares, because the swept gap and a fidelity defect live in different weeks:
 #
-#    (b) CHECK FIDELITY — bounded below the cutover week, where any mismatch IS a defect rather than the known gap.
-#        The parked backup is frozen at cutover_start while live `traces` keeps taking writes, so the current week
-#        diverges for good. ('last-sealed' excludes the current calendar week, which in a same-week local rehearsal is
-#        the cutover week; elsewhere bound below cutover_start's week explicitly.)
+#     (a) THE RECONCILED WINDOW — payload-level fidelity over exactly what step 9 swept. The four counts already cover
+#         presence, version and payload, so this is the picture rather than a second gate. Expect the traces written
+#         after the swap to show as live-only; --drill-down lists the keys behind anything else.
+$RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces \
+    --window-from '<delta_start from step 8>' --window-to '<now>'
+#
+#     (b) SEALED HISTORY — bounded below the cutover week, where any mismatch IS a defect rather than the known
+#         divergence. The parked backup is frozen at cutover_start while live `traces` keeps taking writes, so the
+#         current week diverges for good. ('last-sealed' excludes the current calendar week, which in a same-week local
+#         rehearsal is the cutover week; elsewhere bound below cutover_start's week explicitly.)
 $RUNBOOK/scripts/verify.sh --database opik --old-table traces_pre_cutover_backup --new-table traces --to-week last-sealed
 
-# 9. Leave the config as it is: keep traceColumnsNonNullable=true and deletion capture ON — capture must stay live
-#    through the soak, since the rollback reverse-replay reads the bridge.
+# 11. Leave the config as it is: keep traceColumnsNonNullable=true and deletion capture ON — capture must stay live
+#     through the soak, since the rollback reverse-replay reads the bridge.
 
-# 10. OPTIONAL — the deferred Distributed wrap. Flip tracesDistributedWrapEnabled=true FIRST (it retargets trace
+# 12. OPTIONAL — the deferred Distributed wrap. Flip tracesDistributedWrapEnabled=true FIRST (it retargets trace
 #     mutations at traces_local). --confirm-maintenance is a SEPARATE, unrelated concern: it asserts traffic is
 #     quiesced or a maintenance window is in effect for the wrap's cross-node ON CLUSTER skew, which hits reads and
 #     which no ingestion-side setting covers. Both wrap paths (--with-wrap and --wrap-only) require it.
@@ -250,6 +268,19 @@ $RUNBOOK/scripts/rollback.sh --database opik --stage C --cutover-start '<cutover
 # If a stage B/C run's reverse-replay was interrupted, re-apply just it (idempotent):
 $RUNBOOK/scripts/rollback.sh --database opik --reverse-replay-only --cutover-start '<cutover_start> UTC' \
     --confirm-retention-paused
+
+# The REVERSE reconciliation — the other half of what --accept-post-cutover-write-loss above acknowledged discarding.
+# rollback.sh prints the discarded-write count and the accept-or-recover choice; this is the recover side, and it is
+# where the sentinel->NULL denormalization is exercised (the parked successor stores epoch/NaN for absent end_time/ttft,
+# the restored original wants NULL). Size it first, then run it. It picks the direction up from the topology on its own
+# — traces_post_rollback_backup parked, the Nullable original live — so there is no direction flag to pass:
+$RUNBOOK/scripts/reconcile.sh --database opik --report-only \
+    --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'
+$RUNBOOK/scripts/reconcile.sh --database opik --confirm-reimport-successor-writes \
+    --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'
+# Worth checking afterwards, since it is the property the sweep must not break: a trace deleted AFTER cutover_start must
+# still be gone. The sweep re-imports the post-cutover writes and the reverse replay it re-runs masks those deletes, so
+# the run's own postcondition covers it — but with --resurrect-ratio traffic above, spot-check one id by hand too.
 
 # Un-wrap — reverses the WRAP while keeping the cutover, landing in the post-EXCHANGE/pre-wrap state. Needs no
 # cutover_start and no write-loss flag: the successor stays live, so nothing is discarded and nothing is replayed.

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -171,7 +171,7 @@ $RUNBOOK/scripts/reconcile.sh --database opik --report-only \
 #    Its settle gate is step 8's gate with a post-swap scope, and the half worth watching is the one that only shows
 #    under traffic: delete_traffic.py is still mutating live traces throughout, and the gate must NOT abort on that —
 #    it gates unfinished mutations on the PARKED table only (runbook "The replication-settle gate").
-$RUNBOOK/scripts/reconcile.sh --database opik \
+$RUNBOOK/scripts/reconcile.sh --database opik --confirm-retention-paused \
     --gap-start '<delta_start from step 8> UTC' --swap-done '<exchange_done> UTC'
 
 # 10. QA after the sweep. Two different compares, because the swept gap and a fidelity defect live in different weeks:
@@ -277,7 +277,7 @@ $RUNBOOK/scripts/rollback.sh --database opik --reverse-replay-only --cutover-sta
 $RUNBOOK/scripts/reconcile.sh --database opik --report-only \
     --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'
 $RUNBOOK/scripts/reconcile.sh --database opik --confirm-reimport-successor-writes \
-    --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'
+    --confirm-retention-paused --cutover-start '<cutover_start> UTC' --swap-done '<promote_done> UTC'
 # Worth checking afterwards, since it is the property the sweep must not break: a trace deleted AFTER cutover_start must
 # still be gone. The sweep re-imports the post-cutover writes and the reverse replay it re-runs masks those deletes, so
 # the run's own postcondition covers it — but with --resurrect-ratio traffic above, spot-check one id by hand too.

--- a/tests_load/tests/traces-local-v2-cutover/README.md
+++ b/tests_load/tests/traces-local-v2-cutover/README.md
@@ -293,9 +293,11 @@ $RUNBOOK/scripts/rollback.sh --database opik --unwrap-only --confirm-maintenance
   again with `traces_local`/`traces_dist_old` gone and post-wrap writes still live, then re-apply with
   `exchange_and_wrap.sh --wrap-only …`. Note the writes surviving: this is the contrast with stage C, which would
   discard them.
-* *After `finalize.sh --confirm`* — the case with no alternative. Stages B/C now refuse (their parked original is gone),
-  so this is the only wrap recovery left. The closing message correctly reports the re-wrap as unavailable here, since
-  `--wrap-only` refuses without the parked original; do not hand-roll around that.
+* *After `finalize.sh --confirm --confirm-gap-reconciled`* — the case with no alternative. Stages B/C now refuse (their
+  parked original is gone), so this is the only wrap recovery left. The closing message correctly reports the re-wrap as
+  unavailable here, since `--wrap-only` refuses without the parked original; do not hand-roll around that. The second
+  flag is required on this branch and asserts the gap was reconciled — so run step 9 before reaching for this, or you
+  are rehearsing the drop with writes still parked.
 
 Then flip `tracesDistributedWrapEnabled` back to `false` and restart. Triggering that window on purpose is instructive:
 between the DDL and the restart, deletes fail with `Code: 60 … Table opik.traces_local does not exist` while reads and
@@ -322,9 +324,11 @@ untouched — a re-run of `backfill.sh` reuses the original anchor from the stat
 physical object, so this restores the shadow with its data intact), then resumes at `delta_replay.sh`. So all three
 stages chain on one seeded volume, with no irreversible step in between.
 
-`finalize.sh --confirm` is the *other* option and a different trade: its recycle branch TRUNCATEs the backup into an
-empty shadow, which discards the copy and forces a full re-backfill. Use it to rehearse that branch on purpose, not to
-get from one stage to the next.
+`finalize.sh --confirm --confirm-post-cutover-decision` is the *other* option and a different trade: its recycle branch
+TRUNCATEs the backup into an empty shadow, which discards the copy and forces a full re-backfill. The second flag is
+required on this branch — it asserts the accept-or-recover decision on the post-cutover writes has been made — and
+rehearsing it is also how you see that gate work. Use this to rehearse that branch on purpose, not to get from one stage
+to the next.
 
 **Then finish the config half of the rollback** — `rollback.sh` prints both steps, and stage B/C is not complete without
 them (runbook: "Rolling back the `traceColumnsNonNullable` flip"). Set `traceColumnsNonNullable=false` and


### PR DESCRIPTION
## Details

The traces cutover loses writes across the `EXCHANGE`, and this adds the step that carries them back and proves it did. The cutover's last write-copying statement is the delta INSERT; between that and the swap the procedure interposes a deletion replay, the operator's go/no-go gap, the topology guards, a cluster-wide settle gate and a second full deletion replay. Nothing holds writes across that window, so every trace written to the old table in it is orphaned when the table is parked. The loss has been observed on a real cutover, with traces left in `traces_pre_cutover_backup` and absent from the live table.

**Reconciliation is post-swap by necessity.** Before the swap it cannot converge, because the source is live and every pass opens a new gap behind itself — iterating the delta shrinks it and then stops improving. After the swap the parked table is frozen, so the sweep converges by construction and its postcondition is a gate rather than a snapshot.

- **New `scripts/reconcile.sh`** derives its direction from the live topology (no `--direction` flag to get wrong), gates on the cluster-wide settle, then **sweeps → replays deletes → asserts a four-count postcondition**, looping to `--max-passes` and failing loudly rather than reporting progress. It reads the postcondition before mutating anything, so a second run on a reconciled estate is a no-op. `--report-only` sizes the gap without touching anything.
- **Forward**: sweeps `traces_pre_cutover_backup` into the live successor. **Reverse**: re-imports the post-cutover writes a rollback made non-live, denormalizing the successor's epoch/NaN sentinels back to `NULL` so the original's recomputed `duration` is `NULL` rather than a large negative. On a wrapped estate it resolves the live name the way `tracesDistributedWrapEnabled` does, because a `Distributed` table accepts `INSERT` but rejects the mutation that follows.
- **The postcondition is version-driven, not presence-driven.** It classifies every key live in the parked table inside the gap window by its version relation on the live side: `missing_keys`, `stale_keys` and `payload_mismatch_keys` gate; `newer_keys` is informational and expected to be non-zero under traffic. A presence check is not enough — a trace merely *updated* in the tail is already on the successor at an older `last_updated_at`, and would be reported as clean.
- **Two anchors with distinct jobs.** `gap_start` bounds what to copy (widening it is free, so a lost anchor never forces an escalation); `swap_done` bounds what not to resurrect, and is captured *after* the swap statement returns — using `cutover_start` there would wrongly drop a trace deleted and re-created before the freeze.
- **The post-swap deletion replay is its own block**, not a parameterisation of `000002`'s. It reads its resurrection guard from the *frozen* backup, which is race-free and closes a delete-side residual the runbook previously accepted as inherent, and it carries a third arm with no pre-swap counterpart: a **per-row staleness scope**, without which that frozen guard would mask a live post-cutover write — turning the fix for write loss into a cause of it. `000002` is untouched.
- **The replication-settle gate is now shared.** `000003`'s three `settle-*` blocks take their table sets as placeholders, so `exchange_and_wrap.sh` renders the pre-swap scope and `reconcile.sh` the post-swap one — same hazard, same SQL, unlike the two deletion replays which stay duplicated because their *semantics* differ. The post-swap scope differs where the swap changed which table is quiet: unfinished mutations are gated **unconditionally on the parked table** (frozen, so anything still applying is a pre-swap delete mid-flight, which the mask-honored sweep would copy back), the live table's mutations are **deliberately not gated** (after the swap it takes user deletes continuously, and one still applying leaves the row visible, which the postcondition reads as present rather than missing), and the queue is judged on stuck-ness across both tables.
- **Driver support around it**: `delta_replay.sh` records `delta_start` and prints the pending-delta size, so convergence is watched rather than guessed; `exchange_and_wrap.sh` records `exchange_done` and ends with a **CUTOVER INCOMPLETE** banner naming the reconcile command; `rollback.sh` records `promote_done`, sizes the writes the promote discarded and prints both the accept and the recover option; `finalize.sh` refuses **both** branches without `--confirm-gap-reconciled`, so the only copy cannot be retired before the decision is made; `verify.sh` gains `--window-from`/`--window-to` to compare one arbitrary window, needing no new SQL because `000005`'s blocks were already parameterised by arbitrary bounds.
- **No feature toggles added or removed.** No application code changes — this is runbook SQL, operator drivers and the gate test.

**Reviewer's guide.** The diff is large but its risk is concentrated. Worth real attention: `000006_post_swap_reconciliation.sql` (the two anchors and the replay's three arms), `000006_verify_reconciliation.sql` (the four counts and `join_use_nulls`), and `reconcile.sh`'s direction detection and pass loop. Automated review tends to be strongest on bash and SQL shape and weakest on the cross-statement temporal reasoning here — capture writing the bridge row before the delete executes, frozen-vs-live guard semantics, and why the exclusion bound is `swap_done` and not `gap_start`. The runbook prose is the operator artifact and the bulk of the line count; it needs the least scrutiny.

**Two known residuals, both stated in the runbook.** A delete whose bridge row lands after the reconciler's read is invisible to it; and because capture writes the bridge row *before* the delete executes, for the width of the `EXCHANGE` a delete bridged before `swap_done` can have its `DELETE` land after, in which case the sweep brings that trace back. Moving the bound to `gap_start` would trade a rare resurrection for a likelier loss, so both fold into the existing mitigation: quiesce user DELETEs across the swap, not merely reads.

## Change checklist
- [ ] User facing
- [x] Documentation update

## Issues

- OPIK-8238

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation — reconciliation SQL, drivers, gate tests and runbook
- Human verification: iterative code review across multiple passes (implementation, test-focused, post-rebase), plus review of every generated statement against the reference SQL it must stay in step with. Automated verification listed under Testing. **Not yet rehearsed on a production-shape cluster** — see the caveats there.

## Testing

**Automated, run locally:**

- `mvn -o test -Dtest=TracesLocalV2CutoverTest` from `apps/opik-backend` — **30 tests, 0 failures/errors/skips.** The suite is the executable specification of the cutover SQL; this change adds coverage for both reconciliation directions:
  - the forward sweep, with a **negative control** proving the step is load-bearing (without it, a gap-window trace is simply gone from the live table while sitting intact in the backup — the shape the real cutover hit);
  - the exclusion that stops a post-swap delete being resurrected, and the converse case that justifies the `swap_done` bound (a trace deleted **and re-created** before the freeze must be swept back);
  - newer-version-wins, so the sweep cannot clobber live traffic, with the gate still passing;
  - the post-swap replay masking a delete bridged between the final pre-swap replay and the `EXCHANGE`, and **not** masking a trace re-created after the swap — the staleness scope, with its own negative control;
  - the reverse re-import with sentinel→`NULL` denormalization asserted through `duration`, plus a negative control that no row kept the epoch sentinel; and that a post-cutover delete is not resurrected while `000004`'s own postcondition still reports 0;
  - the four-count postcondition's classification, one key per bucket, on the full `(workspace_id, project_id, id)` key — including a reused id present under one project and absent under the other, which a gate keyed on `id` alone would report as zero;
  - reconciliation through `traces_local` on a wrapped estate.
- **Driver-logic rehearsal against a canned `clickhouse-client`** — 105 assertions, 0 failures: argument validation and the direction-dependent flag rules, direction detection including the ambiguous, absent and split-state estates, `--report-only` issuing no mutation, the idempotent no-op, block order (sweep before replay) and count per pass, the loop terminating at exactly `--max-passes`, and all nine settle-gate verdict paths in both scopes.
- **Placeholder and parse audit**: all 24 driver-substituted SQL blocks rendered across every scope combination — 0 surviving `${...}` placeholders, and all 24 parse under `clickhouse-format` on the server version in use (26.3).
- **Column-list audit**: all four copy statements (`000001` backfill, `000002` delta, both `000006` sweeps) list *and* project exactly the same 23 base columns in the same order; the 22 `cityHash64` occurrences across `000005`/`000006` reduce to 3 distinct argument lists (old shape, new shape, single-arg predicates).
- **Inline-SQL drift check**: the test's inline reimplementation of the three `000006` mutating blocks matches the reference files.
- `spotless:check` passes on the touched Java. Broader CI intentionally left to the pipeline.

**Not run, with reasons:**

- **Prod-clone rehearsal in both directions with sweep timings** — a ticket acceptance criterion that cannot be met from a local environment. It remains open, and the runbook's Go/No-Go requires it before any production cutover.
- **The settle gate against a non-empty `replication_queue`.** Its logic is covered at nine branch points, but a single-replica Testcontainer's queue is always empty and the rehearsal feeds it fabricated samples, so the predicate has not run against real `system.*` tables on a multi-replica cluster. The runbook's rehearsal checklist calls this out specifically, including the half that only appears under traffic: live-table deletes must **not** abort the gate.
- **`reconcile.sh`'s privilege set** (`INSERT` + column-scoped `ALTER UPDATE(_row_exists)` on the live name, `SELECT` on the parked backup). These cannot be exercised by the pre-swap privilege smoke test, because the objects do not hold those roles yet; a gap surfaces post-swap with the cutover already committed. Documented in the privileges table and as a rehearsal item.

## Documentation

- `apps/opik-backend/data-migrations/traces-local-v2-cutover/README.md` — the operator runbook. Adds the reconciliation step to the sequence and a "When the cutover is done" checklist; replaces the unsatisfiable tail-gap Go/No-Go item with the reconciliation postcondition; documents the shared settle gate's two scopes and its per-pass cost; corrects both verification sections (a bounded weekly compare is the wrong instrument for this gap, since the rows sit in the cutover week every bound excludes); and rewrites the least-privilege boundary statement, which the forward path's new mutation of the live name genuinely widens.
- `tests_load/tests/traces-local-v2-cutover/README.md` — the local rehearsal harness gains the reconcile step in both directions, including which generator flags make each postcondition bucket reachable.
- Reference SQL headers in `000006_post_swap_reconciliation.sql` and `000006_verify_reconciliation.sql` carry the design rationale and the `KEEP IN STEP WITH` notes for the statements they must not drift from.
