### PR TITLE
[issue-7849] [SDK] fix: pass the exception as a logging format arg in the Cerebras stream error paths

### DIFF
--- a/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
@@ -41,7 +41,7 @@ def patch_sync_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from cerebras.Stream.",
+                    "Exception raised from cerebras.Stream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -94,7 +94,7 @@ def patch_async_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from cerebras.AsyncStream.",
+                    "Exception raised from cerebras.AsyncStream: %s",
                     str(exception),
                     exc_info=True,
                 )


### PR DESCRIPTION
## Details

The two `LOGGER.debug` calls in the Cerebras stream wrappers pass `str(exception)` positionally to a message with no `%s`:

```python
LOGGER.debug(
    "Exception raised from cerebras.Stream.",
    str(exception),
    exc_info=True,
)
```

`logging` defers `msg % args` to the handler, so with debug logging on the interpolation raises inside `Handler.emit`, `handleError()` prints a `--- Logging error ---` block to stderr, and the record — including the `exc_info` traceback — is never emitted. Nothing propagates to the caller; the cost is that the only diagnostic for a mid-stream failure is silently lost.

This is the same defect as #7849, fixed by #7850. That PR covered the twelve call sites that existed when it merged on 2026-08-26; the Cerebras integration landed afterwards in #7342, so these two were never in its scope. The fix is the `: %s` suffix the sibling call sites already use — nothing outside the rendered log text changes.

An AST pass over `sdks/python/src/opik` for `LOGGER.<level>(msg, ...)` calls whose message carries fewer `%`-placeholders than positional arguments reports **2 matches on `main`, both here, and 0 after this change**. Worth noting for anyone tracking #7849: `mistral/stream_patchers.py` and the `anthropic` Beta stream wrappers look similar on a grep because their messages also lack `%s`, but they pass only `exc_info=True` — a keyword argument, not a positional format arg — so they are correct as written.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #7849

## Testing

No new tests, matching #7850, which changed six files without adding any. The behaviour is a property of `logging`'s deferred interpolation rather than of this code path, and the AST check above is a more direct guard against regression than a unit test asserting on log output would be.

`pytest tests/library_integration/cerebras/` → 8 passed. `ruff check` and `ruff format --check` clean.

## Documentation

None needed — the change is two string literals in a debug message.
