### PR TITLE
[NA] [SDK] fix: address the Cerebras review findings raised on #7342

### DIFF
--- a/.github/workflows/lib-cerebras-tests.yml
+++ b/.github/workflows/lib-cerebras-tests.yml
@@ -7,7 +7,8 @@ run-name: "SDK Lib Cerebras Tests ${{ github.ref_name }} by @${{ github.actor }}
 permissions:
   contents: read
 env:
-  CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
+  # No CEREBRAS_API_KEY: these tests mock the transport and never reach the API,
+  # so the secret would be exposed to PR-controlled code for nothing.
   OPIK_ENABLE_LITELLM_MODELS_MONITORING: False
   OPIK_SENTRY_ENABLE: False
 on:

--- a/sdks/python/src/opik/integrations/cerebras/chat_completion_chunks_aggregator.py
+++ b/sdks/python/src/opik/integrations/cerebras/chat_completion_chunks_aggregator.py
@@ -34,6 +34,7 @@ def aggregate(
         }
 
         text_chunks: List[str] = []
+        reasoning_chunks: List[str] = []
 
         for chunk in items:
             if chunk.choices and chunk.choices[0].delta:
@@ -48,6 +49,11 @@ def aggregate(
                 if delta.content:
                     text_chunks.append(delta.content)
 
+                # Cerebras streams reasoning separately from content; without this the
+                # aggregated span would show an empty answer for reasoning models.
+                if delta.reasoning:
+                    reasoning_chunks.append(delta.reasoning)
+
             if chunk.choices and chunk.choices[0].finish_reason:
                 aggregated_response["choices"][0]["finish_reason"] = chunk.choices[
                     0
@@ -57,6 +63,10 @@ def aggregate(
                 aggregated_response["usage"] = chunk.usage.model_dump()
 
         aggregated_response["choices"][0]["message"]["content"] = "".join(text_chunks)
+        if reasoning_chunks:
+            aggregated_response["choices"][0]["message"]["reasoning"] = "".join(
+                reasoning_chunks
+            )
         result = ChatCompletionChunksAggregated(**aggregated_response)
 
         return result

--- a/sdks/python/src/opik/integrations/cerebras/opik_tracker.py
+++ b/sdks/python/src/opik/integrations/cerebras/opik_tracker.py
@@ -67,4 +67,9 @@ def track_cerebras(
 
 
 def _extract_metadata_from_client(client: CerebrasClient) -> Dict[str, Any]:
-    return {"base_url": str(client.base_url)}
+    # Scheme, host and path only. A caller-supplied base_url may carry credentials
+    # in the userinfo, query or fragment, and span metadata reaches the Opik
+    # backend; the path is kept because self-hosted deployments route on it.
+    url = client.base_url
+    host = url.host if url.port is None else f"{url.host}:{url.port}"
+    return {"base_url": f"{url.scheme}://{host}{url.path}"}

--- a/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
@@ -41,7 +41,7 @@ def patch_sync_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from cerebras.Stream.",
+                    "Exception raised from cerebras.Stream: %s",
                     str(exception),
                     exc_info=True,
                 )
@@ -94,7 +94,7 @@ def patch_async_stream(
                     yield item
             except Exception as exception:
                 LOGGER.debug(
-                    "Exception raised from cerebras.AsyncStream.",
+                    "Exception raised from cerebras.AsyncStream: %s",
                     str(exception),
                     exc_info=True,
                 )

--- a/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
+++ b/sdks/python/src/opik/integrations/cerebras/stream_patchers.py
@@ -51,11 +51,11 @@ def patch_sync_stream(
                 if hasattr(self, "opik_tracked_instance"):
                     delattr(self, "opik_tracked_instance")
                     output = (
-                        generations_aggregator(accumulated_items)
+                        self.opik_generations_aggregator(accumulated_items)
                         if error_info is None
                         else None
                     )
-                    finally_callback(
+                    self.opik_finally_callback(
                         output=output,
                         error_info=error_info,
                         capture_output=True,
@@ -70,6 +70,8 @@ def patch_sync_stream(
     stream.opik_tracked_instance = True
     stream.span_to_end = span_to_end
     stream.trace_to_end = trace_to_end
+    stream.opik_generations_aggregator = generations_aggregator
+    stream.opik_finally_callback = finally_callback
 
     return stream
 
@@ -104,11 +106,11 @@ def patch_async_stream(
                 if hasattr(self, "opik_tracked_instance"):
                     delattr(self, "opik_tracked_instance")
                     output = (
-                        generations_aggregator(accumulated_items)
+                        self.opik_generations_aggregator(accumulated_items)
                         if error_info is None
                         else None
                     )
-                    finally_callback(
+                    self.opik_finally_callback(
                         output=output,
                         error_info=error_info,
                         capture_output=True,
@@ -125,5 +127,7 @@ def patch_async_stream(
     stream.opik_tracked_instance = True
     stream.span_to_end = span_to_end
     stream.trace_to_end = trace_to_end
+    stream.opik_generations_aggregator = generations_aggregator
+    stream.opik_finally_callback = finally_callback
 
     return stream

--- a/sdks/python/tests/library_integration/cerebras/test_cerebras.py
+++ b/sdks/python/tests/library_integration/cerebras/test_cerebras.py
@@ -3,6 +3,10 @@ import asyncio
 import cerebras.cloud.sdk as cerebras
 import pytest
 from cerebras.cloud.sdk.types.chat.chat_completion import (
+    ChatChunkResponse,
+    ChatChunkResponseChoice,
+    ChatChunkResponseChoiceDelta,
+    ChatChunkResponseTimeInfo,
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
     ChatCompletionResponseChoiceMessage,
@@ -12,7 +16,12 @@ from cerebras.cloud.sdk.types.chat.chat_completion import (
 
 import opik
 from opik.config import OPIK_PROJECT_DEFAULT_NAME
-from opik.integrations.cerebras import track_cerebras
+from opik.integrations.cerebras import (
+    chat_completion_chunks_aggregator,
+    opik_tracker,
+    stream_patchers,
+    track_cerebras,
+)
 
 from ...testlib import (
     ANY_BUT_NONE,
@@ -160,3 +169,109 @@ def test_cerebras_chat_completions_create__error__span_and_trace_finished_gracef
     trace_tree = fake_backend.trace_trees[0]
     assert trace_tree.spans[0].error_info is not None
     assert trace_tree.spans[0].provider == "cerebras"
+
+
+def _chunk(content=None, reasoning=None, role=None, finish_reason=None):
+    return ChatChunkResponse(
+        id="c1",
+        object="chat.completion.chunk",
+        created=0,
+        model=MODEL,
+        system_fingerprint="fp_test",
+        time_info=ChatChunkResponseTimeInfo(),
+        choices=[
+            ChatChunkResponseChoice(
+                index=0,
+                finish_reason=finish_reason,
+                delta=ChatChunkResponseChoiceDelta(
+                    role=role, content=content, reasoning=reasoning
+                ),
+            )
+        ],
+    )
+
+
+def test_aggregate__reasoning_deltas__kept_alongside_content():
+    """Cerebras streams reasoning in its own delta field, unlike OpenAI."""
+    aggregated = chat_completion_chunks_aggregator.aggregate(
+        [
+            _chunk(role="assistant"),
+            _chunk(reasoning="The sky scatters "),
+            _chunk(reasoning="short wavelengths."),
+            _chunk(content="Blue."),
+            _chunk(finish_reason="stop"),
+        ]
+    )
+
+    message = aggregated.choices[0]["message"]
+    assert message["content"] == "Blue."
+    assert message["reasoning"] == "The sky scatters short wavelengths."
+
+
+def test_aggregate__no_reasoning_deltas__reasoning_key_absent():
+    aggregated = chat_completion_chunks_aggregator.aggregate(
+        [
+            _chunk(role="assistant"),
+            _chunk(content="Blue."),
+            _chunk(finish_reason="stop"),
+        ]
+    )
+
+    assert "reasoning" not in aggregated.choices[0]["message"]
+
+
+def test_extract_metadata_from_client__credentials_in_base_url__stripped():
+    """base_url reaches span metadata, so userinfo and query must not ride along."""
+    client = cerebras.Cerebras(
+        api_key="fake-api-key",
+        base_url="https://user:secret@proxy.internal:8443/openai/v1?token=abc#frag",
+    )
+
+    metadata = opik_tracker._extract_metadata_from_client(client)
+
+    assert metadata == {"base_url": "https://proxy.internal:8443/openai/v1"}
+    assert "secret" not in metadata["base_url"]
+    assert "abc" not in metadata["base_url"]
+
+
+def test_patch_sync_stream__two_streams_patched_before_iteration__each_uses_its_own_callback():
+    """The patch is installed on the class, so per-call state must live on the instance."""
+    finalized = []
+
+    def make_callback(tag):
+        def callback(
+            output,
+            error_info,
+            capture_output,
+            generators_span_to_end,
+            generators_trace_to_end,
+        ):
+            finalized.append((tag, generators_span_to_end, output))
+
+        return callback
+
+    class FakeStream(cerebras.Stream):
+        def __init__(self, items):
+            self._items = items
+
+    original = stream_patchers.original_stream_iter_method
+    stream_patchers.original_stream_iter_method = lambda self: iter(self._items)
+    try:
+        first = FakeStream(["a1", "a2"])
+        second = FakeStream(["b1", "b2"])
+        stream_patchers.patch_sync_stream(
+            first, "SPAN_A", None, list, make_callback("A")
+        )
+        stream_patchers.patch_sync_stream(
+            second, "SPAN_B", None, list, make_callback("B")
+        )
+
+        assert list(first) == ["a1", "a2"]
+        assert list(second) == ["b1", "b2"]
+    finally:
+        stream_patchers.original_stream_iter_method = original
+
+    assert finalized == [
+        ("A", "SPAN_A", ["a1", "a2"]),
+        ("B", "SPAN_B", ["b1", "b2"]),
+    ]


### PR DESCRIPTION
## Details

The automated review comments on #7342 arrived shortly before it merged, so none of them were addressed in it. Nine findings; four are fixed here, five are answered below rather than changed. Two of the findings were also overstated, and I'd rather say which than quietly fix around them.

**Stacked on #8238** (the `%s` logging fix, which is a separate defect with its own issue). Review that one first — this branch contains it. Happy to rebase if you'd prefer them independent.

### Fixed

**1. A second `track_cerebras()` call could finalise the first client's stream.** This is the only correctness bug of the four. `patch_sync_stream` rebinds `Stream.__iter__` on the *class*, closing over that call's `finally_callback` and `generations_aggregator`. A second `track_cerebras()` on a different client overwrites the class attribute, so a stream created by the first client is finalised by the second client's callback — under the wrong project name. Two interleaved streams reproduce it: span `A` came back paired with callback `B`. The aggregator and callback now live on the stream instance next to `span_to_end`, which makes the class-level patch stateless.

The review comment says the wrong *span/trace* can be finalised. That part isn't right — `span_to_end` and `trace_to_end` were already per-instance and were always correct. Only the callback and aggregator leaked.

**2. Streamed `reasoning` was dropped.** `ChatChunkResponseChoiceDelta` carries `reasoning` alongside `content` (cerebras-cloud-sdk 1.91.0). The OpenAI chunk type this aggregator was adapted from has no such field, so it never looked for it, and a reasoning model logged an empty answer. Now aggregated into `message["reasoning"]`, key omitted when there is none.

**3. `base_url` reached span metadata verbatim.** `_extract_metadata_from_client` stored `str(client.base_url)`, so a caller-supplied URL carrying credentials in the userinfo or a token in the query rode into span metadata sent to the backend. Now scheme, host and path only:

| before | after |
|---|---|
| `https://user:secret@proxy.internal:8443/openai/v1?token=abc#frag` | `https://proxy.internal:8443/openai/v1` |

I kept the path rather than reducing to the origin, since self-hosted deployments route on it and dropping it would cost real debugging information. Say if you'd rather it were stricter.

**4. `CEREBRAS_API_KEY` at workflow scope.** All 21 `lib-*-tests.yml` set their key this way, so it isn't unusual — but this is the one case where it buys nothing, because these tests monkeypatch `_post` and never reach the API. Removed.

### Not changed, and why

**Duplicated aggregation and stream-patching logic** (vs the OpenAI integration). Deliberate. Every integration under `src/opik/integrations/` is a copy of this shape; factoring out a shared helper means touching all of them, which seems like a repo-wide call rather than something a new integration should do unilaterally. Glad to open it separately if you want it.

**Optional import at package load.** Matches every other integration — `openai/opik_tracker.py` does `import openai` at module scope, and `groq/` is identical. `opik/__init__.py` imports only `integrations.sagemaker`, so plain `import opik` is unaffected.

**Interrupted streams recorded as successful.** This one is real: `except Exception` misses `GeneratorExit` and `asyncio.CancelledError`, so a cancelled stream reports partial output with `error_info=None`. Not fixed here because it behaves identically in all twenty integrations, and changing Cerebras alone would make its spans the inconsistent ones. I'd rather send it as one cross-integration PR — tell me if you'd prefer it here instead.

**"`LOGGER.debug` raises a TypeError."** It doesn't — `logging` absorbs the formatting error via `handleError` and the `raise` on the next line is unaffected. The real cost is the dropped record. Fixed in #8238 for that reason.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #

## Testing

`pytest tests/library_integration/cerebras/` → **8 passed**. Three of those are new, one per behavioural fix; with `src/opik/integrations/cerebras/` reverted to `main` they fail and the rest pass (**3 failed, 5 passed**), so they test the fixes rather than the scaffolding.

`pytest tests/unit` → **6 failed, 5273 passed, 2 skipped**. All six also fail on a clean `main` checkout (`tests/unit/evaluation` → 6 failed, 1039 passed): four in `test_heuristics.py` and two order-dependent ones in `test_litellm_chat_model.py` that pass in isolation on both. None are related to this change.

`ruff check` and `ruff format --check` clean.

**Not verified:** no live Cerebras call anywhere — the transport is mocked throughout, so the `reasoning` change is verified against the SDK's declared chunk schema rather than a real reasoning-model stream. The concurrency reproduction uses a `FakeStream` with the module's `original_stream_iter_method` swapped, not two real HTTP streams.

## Documentation

None. Happy to add a docs page for the integration as a follow-up if that's wanted.
