### PR TITLE
[OPIK-8322] [BE] [FE] fix: scope a project's dashboards to that project

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResource.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResource.java
@@ -13,6 +13,8 @@ import com.comet.opik.api.sorting.SortingField;
 import com.comet.opik.domain.DashboardService;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.auth.RequiredPermissions;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
 import com.comet.opik.infrastructure.ratelimit.RateLimited;
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.Operation;
@@ -69,6 +71,7 @@ public class InsightsViewsResource {
             @ApiResponse(responseCode = "201", description = "Created", headers = {
                     @Header(name = "Location", required = true, example = "${basePath}/v1/private/insights-views/{insightsViewId}", schema = @Schema(implementation = String.class))}, content = @Content(schema = @Schema(implementation = Dashboard.class)))
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_CREATE)
     @JsonView(Dashboard.View.Public.class)
     @RateLimited
     public Response createInsightsView(
@@ -93,6 +96,7 @@ public class InsightsViewsResource {
             @ApiResponse(responseCode = "200", description = "Insights view resource", content = @Content(schema = @Schema(implementation = Dashboard.class))),
             @ApiResponse(responseCode = "404", description = "Insights view not found")
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_VIEW)
     @JsonView(Dashboard.View.Public.class)
     public Response getInsightsViewById(@PathParam("insightsViewId") UUID id) {
 
@@ -109,6 +113,7 @@ public class InsightsViewsResource {
     @Operation(operationId = "findInsightsViews", summary = "Find insights views", description = "Find insights views in a workspace", responses = {
             @ApiResponse(responseCode = "200", description = "Insights view page", content = @Content(schema = @Schema(implementation = DashboardPage.class)))
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_VIEW)
     @JsonView(Dashboard.View.Public.class)
     public Response findInsightsViews(
             @QueryParam("page") @Min(1) @DefaultValue("1") int page,
@@ -140,6 +145,7 @@ public class InsightsViewsResource {
             @ApiResponse(responseCode = "404", description = "Insights view not found"),
             @ApiResponse(responseCode = "409", description = "Conflict - insights view with this name already exists")
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_EDIT)
     @JsonView(Dashboard.View.Public.class)
     @RateLimited
     public Response updateInsightsView(
@@ -162,6 +168,7 @@ public class InsightsViewsResource {
     @Operation(operationId = "deleteInsightsView", summary = "Delete insights view", description = "Delete insights view by id", responses = {
             @ApiResponse(responseCode = "204", description = "No content")
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_DELETE)
     public Response deleteInsightsView(@PathParam("insightsViewId") UUID id) {
 
         String workspaceId = requestContext.get().getWorkspaceId();
@@ -178,6 +185,7 @@ public class InsightsViewsResource {
     @Operation(operationId = "deleteInsightsViewsBatch", summary = "Delete insights views", description = "Delete insights views batch", responses = {
             @ApiResponse(responseCode = "204", description = "No content"),
     })
+    @RequiredPermissions(WorkspaceUserPermission.DASHBOARD_DELETE)
     public Response deleteInsightsViewsBatch(
             @NotNull @RequestBody(content = @Content(schema = @Schema(implementation = BatchDelete.class))) @Valid BatchDelete batchDelete) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
@@ -90,15 +90,18 @@ public interface DashboardDAO {
             @Define("scope") @Bind("scope") String scope);
 
     /**
-     * Legacy project dashboards have no {@code project_id}, so an insights request also matches rows
-     * with no project. A workspace dashboard is project-less by design, so a workspace request does
-     * not: the requested scope, not the row, decides.
+     * An insights request also matches rows with no project, because project dashboards created before
+     * project scoping have none and hiding them would lose access to them. A workspace dashboard is
+     * project-less by design, so a workspace request stays strict.
      */
     @SqlQuery("SELECT COUNT(id) FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif>" +
-            "<if(project_id)> AND (project_id = :projectId " +
-            "OR (:scope = 'insights' AND project_id IS NULL)) <endif>" +
+            "<if(project_id)>" +
+            "<if(insights_scope)> AND (project_id = :projectId OR project_id IS NULL) " +
+            "<else> AND project_id = :projectId " +
+            "<endif>" +
+            "<endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif>")
     @UseStringTemplateEngine
@@ -106,6 +109,7 @@ public interface DashboardDAO {
     long findCount(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
+            @Define("insights_scope") boolean insightsScope,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping);
@@ -126,8 +130,11 @@ public interface DashboardDAO {
     @SqlQuery("SELECT id FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif> " +
-            "<if(project_id)> AND (project_id = :projectId " +
-            "OR (:scope = 'insights' AND project_id IS NULL)) <endif>" +
+            "<if(project_id)>" +
+            "<if(insights_scope)> AND (project_id = :projectId OR project_id IS NULL) " +
+            "<else> AND project_id = :projectId " +
+            "<endif>" +
+            "<endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif> " +
             "ORDER BY <if(sort_fields)> <sort_fields>, <endif> id DESC " +
@@ -137,6 +144,7 @@ public interface DashboardDAO {
     List<UUID> findPageIdsSorted(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
+            @Define("insights_scope") boolean insightsScope,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
@@ -92,7 +92,8 @@ public interface DashboardDAO {
     @SqlQuery("SELECT COUNT(id) FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif>" +
-            "<if(project_id)> AND project_id = :projectId <endif>" +
+            "<if(project_id)> AND (project_id = :projectId " +
+            "<if(include_unassigned_project)> OR project_id IS NULL <endif>) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif>")
     @UseStringTemplateEngine
@@ -100,6 +101,7 @@ public interface DashboardDAO {
     long findCount(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
+            @Define("include_unassigned_project") boolean includeUnassignedProject,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping);
@@ -120,7 +122,8 @@ public interface DashboardDAO {
     @SqlQuery("SELECT id FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif> " +
-            "<if(project_id)> AND project_id = :projectId <endif>" +
+            "<if(project_id)> AND (project_id = :projectId " +
+            "<if(include_unassigned_project)> OR project_id IS NULL <endif>) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif> " +
             "ORDER BY <if(sort_fields)> <sort_fields>, <endif> id DESC " +
@@ -130,6 +133,7 @@ public interface DashboardDAO {
     List<UUID> findPageIdsSorted(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
+            @Define("include_unassigned_project") boolean includeUnassignedProject,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
@@ -90,14 +90,15 @@ public interface DashboardDAO {
             @Define("scope") @Bind("scope") String scope);
 
     /**
-     * Legacy project dashboards have no {@code project_id}, so they stay listed in every project.
-     * Workspace dashboards are project-less by design, which is why the scope column decides.
+     * Legacy project dashboards have no {@code project_id}, so an insights request also matches rows
+     * with no project. A workspace dashboard is project-less by design, so a workspace request does
+     * not: the requested scope, not the row, decides.
      */
     @SqlQuery("SELECT COUNT(id) FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif>" +
             "<if(project_id)> AND (project_id = :projectId " +
-            "OR (scope = 'insights' AND project_id IS NULL)) <endif>" +
+            "OR (:scope = 'insights' AND project_id IS NULL)) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif>")
     @UseStringTemplateEngine
@@ -126,7 +127,7 @@ public interface DashboardDAO {
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif> " +
             "<if(project_id)> AND (project_id = :projectId " +
-            "OR (scope = 'insights' AND project_id IS NULL)) <endif>" +
+            "OR (:scope = 'insights' AND project_id IS NULL)) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif> " +
             "ORDER BY <if(sort_fields)> <sort_fields>, <endif> id DESC " +

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardDAO.java
@@ -89,11 +89,15 @@ public interface DashboardDAO {
     int delete(@Bind("id") UUID id, @Bind("workspaceId") String workspaceId,
             @Define("scope") @Bind("scope") String scope);
 
+    /**
+     * Legacy project dashboards have no {@code project_id}, so they stay listed in every project.
+     * Workspace dashboards are project-less by design, which is why the scope column decides.
+     */
     @SqlQuery("SELECT COUNT(id) FROM dashboards " +
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif>" +
             "<if(project_id)> AND (project_id = :projectId " +
-            "<if(include_unassigned_project)> OR project_id IS NULL <endif>) <endif>" +
+            "OR (scope = 'insights' AND project_id IS NULL)) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif>")
     @UseStringTemplateEngine
@@ -101,7 +105,6 @@ public interface DashboardDAO {
     long findCount(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
-            @Define("include_unassigned_project") boolean includeUnassignedProject,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping);
@@ -123,7 +126,7 @@ public interface DashboardDAO {
             "WHERE workspace_id = :workspaceId " +
             "<if(search)> AND name like concat('%', :search, '%') <endif> " +
             "<if(project_id)> AND (project_id = :projectId " +
-            "<if(include_unassigned_project)> OR project_id IS NULL <endif>) <endif>" +
+            "OR (scope = 'insights' AND project_id IS NULL)) <endif>" +
             "<if(scope)> AND scope = :scope <endif>" +
             "<if(filters)> AND <filters> <endif> " +
             "ORDER BY <if(sort_fields)> <sort_fields>, <endif> id DESC " +
@@ -133,7 +136,6 @@ public interface DashboardDAO {
     List<UUID> findPageIdsSorted(@Bind("workspaceId") String workspaceId,
             @Define("search") @Bind("search") String search,
             @Define("project_id") @Bind("projectId") UUID projectId,
-            @Define("include_unassigned_project") boolean includeUnassignedProject,
             @Define("scope") @Bind("scope") String scope,
             @Define("filters") String filters,
             @BindMap Map<String, Object> filterMapping,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
@@ -187,19 +187,26 @@ class DashboardServiceImpl implements DashboardService {
                 .map(filterQueryBuilder::toStateSQLMapping)
                 .orElse(Map.of());
 
+        // Insights views only started recording a project with OPIK-8322. Every view created before that
+        // has a null project_id, and nothing records which project made it. Listing those rows in every
+        // project keeps them reachable. Workspace dashboards are project-less by design, so the project
+        // list for that scope stays strict.
+        boolean includeUnassignedProject = scope == DashboardScope.INSIGHTS;
+
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DashboardDAO.class);
 
             String nameTerm = StringUtils.isNotBlank(name) ? name.trim() : null;
             int offset = (page - 1) * size;
 
-            long total = dao.findCount(workspaceId, nameTerm, projectId, scope.getValue(), filtersSql, filterMapping);
+            long total = dao.findCount(workspaceId, nameTerm, projectId, includeUnassignedProject, scope.getValue(),
+                    filtersSql, filterMapping);
 
             // Two-step fetch (OPIK-6482): order and paginate on id only, then load the page bodies and
             // re-order them in memory. This keeps the large JSON `config` column out of every sort
             // buffer, which otherwise triggers ER_OUT_OF_SORTMEMORY on the filesort.
-            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, scope.getValue(),
-                    filtersSql, filterMapping, sortingFieldsSql, size, offset);
+            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, includeUnassignedProject,
+                    scope.getValue(), filtersSql, filterMapping, sortingFieldsSql, size, offset);
 
             List<Dashboard> dashboards;
             if (pageIds.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
@@ -187,19 +187,22 @@ class DashboardServiceImpl implements DashboardService {
                 .map(filterQueryBuilder::toStateSQLMapping)
                 .orElse(Map.of());
 
+        boolean insightsScope = scope == DashboardScope.INSIGHTS;
+
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DashboardDAO.class);
 
             String nameTerm = StringUtils.isNotBlank(name) ? name.trim() : null;
             int offset = (page - 1) * size;
 
-            long total = dao.findCount(workspaceId, nameTerm, projectId, scope.getValue(), filtersSql, filterMapping);
+            long total = dao.findCount(workspaceId, nameTerm, projectId, insightsScope, scope.getValue(), filtersSql,
+                    filterMapping);
 
             // Two-step fetch (OPIK-6482): order and paginate on id only, then load the page bodies and
             // re-order them in memory. This keeps the large JSON `config` column out of every sort
             // buffer, which otherwise triggers ER_OUT_OF_SORTMEMORY on the filesort.
-            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, scope.getValue(),
-                    filtersSql, filterMapping, sortingFieldsSql, size, offset);
+            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, insightsScope,
+                    scope.getValue(), filtersSql, filterMapping, sortingFieldsSql, size, offset);
 
             List<Dashboard> dashboards;
             if (pageIds.isEmpty()) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/DashboardService.java
@@ -187,26 +187,19 @@ class DashboardServiceImpl implements DashboardService {
                 .map(filterQueryBuilder::toStateSQLMapping)
                 .orElse(Map.of());
 
-        // Insights views only started recording a project with OPIK-8322. Every view created before that
-        // has a null project_id, and nothing records which project made it. Listing those rows in every
-        // project keeps them reachable. Workspace dashboards are project-less by design, so the project
-        // list for that scope stays strict.
-        boolean includeUnassignedProject = scope == DashboardScope.INSIGHTS;
-
         return template.inTransaction(READ_ONLY, handle -> {
             var dao = handle.attach(DashboardDAO.class);
 
             String nameTerm = StringUtils.isNotBlank(name) ? name.trim() : null;
             int offset = (page - 1) * size;
 
-            long total = dao.findCount(workspaceId, nameTerm, projectId, includeUnassignedProject, scope.getValue(),
-                    filtersSql, filterMapping);
+            long total = dao.findCount(workspaceId, nameTerm, projectId, scope.getValue(), filtersSql, filterMapping);
 
             // Two-step fetch (OPIK-6482): order and paginate on id only, then load the page bodies and
             // re-order them in memory. This keeps the large JSON `config` column out of every sort
             // buffer, which otherwise triggers ER_OUT_OF_SORTMEMORY on the filesort.
-            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, includeUnassignedProject,
-                    scope.getValue(), filtersSql, filterMapping, sortingFieldsSql, size, offset);
+            List<UUID> pageIds = dao.findPageIdsSorted(workspaceId, nameTerm, projectId, scope.getValue(),
+                    filtersSql, filterMapping, sortingFieldsSql, size, offset);
 
             List<Dashboard> dashboards;
             if (pageIds.isEmpty()) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceFindProjectDashboardsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceFindProjectDashboardsTest.java
@@ -285,34 +285,6 @@ class DashboardsResourceFindProjectDashboardsTest {
     }
 
     @Test
-    @DisplayName("Find project dashboards excludes workspace dashboards with no project")
-    void findProjectDashboardsExcludesUnassignedDashboards() {
-        String apiKey = UUID.randomUUID().toString();
-        String workspaceName = "test-workspace-" + UUID.randomUUID();
-        String workspaceId = UUID.randomUUID().toString();
-        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
-
-        var projectDashboard = dashboardResourceClient.createPartialDashboard()
-                .scope(DashboardScope.WORKSPACE)
-                .projectId(projectId)
-                .build();
-        var workspaceDashboard = dashboardResourceClient.createPartialDashboard()
-                .scope(DashboardScope.WORKSPACE)
-                .build();
-
-        var projectDashboardId = dashboardResourceClient.create(projectDashboard, apiKey, workspaceName);
-        dashboardResourceClient.create(workspaceDashboard, apiKey, workspaceName);
-
-        var page = dashboardResourceClient.getProjectDashboards(projectId, apiKey, workspaceName, 1, 10, null, null,
-                null);
-
-        assertThat(page.total()).isEqualTo(1);
-        assertThat(page.content()).extracting(Dashboard::id).containsExactly(projectDashboardId);
-    }
-
-    @Test
     @DisplayName("Find project dashboards with empty result")
     void findProjectDashboardsWithEmptyResult() {
         String apiKey = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceFindProjectDashboardsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/DashboardsResourceFindProjectDashboardsTest.java
@@ -285,6 +285,34 @@ class DashboardsResourceFindProjectDashboardsTest {
     }
 
     @Test
+    @DisplayName("Find project dashboards excludes workspace dashboards with no project")
+    void findProjectDashboardsExcludesUnassignedDashboards() {
+        String apiKey = UUID.randomUUID().toString();
+        String workspaceName = "test-workspace-" + UUID.randomUUID();
+        String workspaceId = UUID.randomUUID().toString();
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+        var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+
+        var projectDashboard = dashboardResourceClient.createPartialDashboard()
+                .scope(DashboardScope.WORKSPACE)
+                .projectId(projectId)
+                .build();
+        var workspaceDashboard = dashboardResourceClient.createPartialDashboard()
+                .scope(DashboardScope.WORKSPACE)
+                .build();
+
+        var projectDashboardId = dashboardResourceClient.create(projectDashboard, apiKey, workspaceName);
+        dashboardResourceClient.create(workspaceDashboard, apiKey, workspaceName);
+
+        var page = dashboardResourceClient.getProjectDashboards(projectId, apiKey, workspaceName, 1, 10, null, null,
+                null);
+
+        assertThat(page.total()).isEqualTo(1);
+        assertThat(page.content()).extracting(Dashboard::id).containsExactly(projectDashboardId);
+    }
+
+    @Test
     @DisplayName("Find project dashboards with empty result")
     void findProjectDashboardsWithEmptyResult() {
         String apiKey = UUID.randomUUID().toString();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
@@ -219,7 +219,7 @@ class InsightsViewsResourceTest {
                     insightsViewClient.createPartialInsightsView().projectId(otherProjectId).build(), apiKey,
                     workspaceName);
 
-            // Views created before OPIK-8322 have no project and stay visible in every project
+            // Legacy views have no project and stay visible in every project
             var unassignedViewId = insightsViewClient.create(apiKey, workspaceName);
 
             var page = insightsViewClient.find(apiKey, workspaceName, 1, 10, null, projectId, null, null,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
@@ -18,6 +18,7 @@ import com.comet.opik.api.resources.utils.resources.InsightsViewResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.redis.testcontainers.RedisContainer;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -228,6 +229,18 @@ class InsightsViewsResourceTest {
             assertThat(page.total()).isEqualTo(2);
             assertThat(page.content()).extracting(Dashboard::id)
                     .containsExactlyInAnyOrder(projectViewId, unassignedViewId);
+        }
+
+        @Test
+        @DisplayName("Find insights views returns 403 when the dashboard permission is denied")
+        void findInsightsViewsReturnsForbiddenWhenPermissionDenied() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    WorkspaceUserPermission.DASHBOARD_VIEW.getValue());
+
+            insightsViewClient.find(apiKey, workspaceName, 1, 10, null, HttpStatus.SC_FORBIDDEN);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
@@ -1,5 +1,6 @@
 package com.comet.opik.api.resources.v1.priv;
 
+import com.comet.opik.api.Dashboard;
 import com.comet.opik.api.DashboardScope;
 import com.comet.opik.api.DashboardType;
 import com.comet.opik.api.DashboardUpdate;
@@ -14,8 +15,10 @@ import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.DashboardResourceClient;
 import com.comet.opik.api.resources.utils.resources.InsightsViewResourceClient;
+import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
+import com.comet.opik.podam.PodamFactoryUtils;
 import com.redis.testcontainers.RedisContainer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.HttpStatus;
@@ -32,6 +35,7 @@ import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.mysql.MySQLContainer;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.Set;
 import java.util.UUID;
@@ -83,9 +87,12 @@ class InsightsViewsResourceTest {
         APP = newTestDropwizardAppExtension(contextConfig);
     }
 
+    private final PodamFactory podamFactory = PodamFactoryUtils.newPodamFactory();
+
     private String baseURI;
     private InsightsViewResourceClient insightsViewClient;
     private DashboardResourceClient dashboardResourceClient;
+    private ProjectResourceClient projectResourceClient;
 
     @BeforeAll
     void beforeAll(ClientSupport client) {
@@ -95,6 +102,7 @@ class InsightsViewsResourceTest {
 
         this.insightsViewClient = new InsightsViewResourceClient(client, baseURI);
         this.dashboardResourceClient = new DashboardResourceClient(client, baseURI);
+        this.projectResourceClient = new ProjectResourceClient(client, baseURI, podamFactory);
 
         mockTargetWorkspace(API_KEY, TEST_WORKSPACE_NAME, WORKSPACE_ID);
     }
@@ -191,6 +199,35 @@ class InsightsViewsResourceTest {
             assertThat(page.total()).isEqualTo(2);
             assertThat(page.content()).hasSize(2);
             page.content().forEach(d -> assertThat(d.scope()).isEqualTo(DashboardScope.INSIGHTS));
+        }
+
+        @Test
+        @DisplayName("Find insights views by project excludes other projects and keeps unassigned views")
+        void findInsightsViewsByProject() {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+            String workspaceId = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var projectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey, workspaceName);
+            var otherProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                    workspaceName);
+
+            var projectViewId = insightsViewClient.create(
+                    insightsViewClient.createPartialInsightsView().projectId(projectId).build(), apiKey, workspaceName);
+            insightsViewClient.create(
+                    insightsViewClient.createPartialInsightsView().projectId(otherProjectId).build(), apiKey,
+                    workspaceName);
+
+            // Views created before OPIK-8322 have no project and stay visible in every project
+            var unassignedViewId = insightsViewClient.create(apiKey, workspaceName);
+
+            var page = insightsViewClient.find(apiKey, workspaceName, 1, 10, null, projectId, null, null,
+                    HttpStatus.SC_OK);
+
+            assertThat(page.total()).isEqualTo(2);
+            assertThat(page.content()).extracting(Dashboard::id)
+                    .containsExactlyInAnyOrder(projectViewId, unassignedViewId);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/InsightsViewsResourceTest.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
@@ -40,6 +43,8 @@ import uk.co.jemos.podam.api.PodamFactory;
 
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension;
@@ -230,18 +235,6 @@ class InsightsViewsResourceTest {
             assertThat(page.content()).extracting(Dashboard::id)
                     .containsExactlyInAnyOrder(projectViewId, unassignedViewId);
         }
-
-        @Test
-        @DisplayName("Find insights views returns 403 when the dashboard permission is denied")
-        void findInsightsViewsReturnsForbiddenWhenPermissionDenied() {
-            String apiKey = UUID.randomUUID().toString();
-            String workspaceName = "test-workspace-" + UUID.randomUUID();
-
-            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
-                    WorkspaceUserPermission.DASHBOARD_VIEW.getValue());
-
-            insightsViewClient.find(apiKey, workspaceName, 1, 10, null, HttpStatus.SC_FORBIDDEN);
-        }
     }
 
     @Nested
@@ -315,6 +308,53 @@ class InsightsViewsResourceTest {
 
             // Dashboard should still exist
             dashboardResourceClient.get(dashboardId, API_KEY, TEST_WORKSPACE_NAME, HttpStatus.SC_OK);
+        }
+    }
+
+    @Nested
+    @DisplayName("Required permissions")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class RequiredPermissionsTest {
+
+        @ParameterizedTest(name = "{0} requires {1}")
+        @MethodSource
+        @DisplayName("Insights view endpoints return 403 when the permission is denied")
+        void insightsViewEndpointsRequirePermission(String endpoint, WorkspaceUserPermission permission,
+                BiConsumer<String, String> call) {
+            String apiKey = UUID.randomUUID().toString();
+            String workspaceName = "test-workspace-" + UUID.randomUUID();
+
+            AuthTestUtils.mockTargetWorkspaceDenyPermission(wireMock.server(), apiKey, workspaceName,
+                    permission.getValue());
+
+            call.accept(apiKey, workspaceName);
+        }
+
+        Stream<Arguments> insightsViewEndpointsRequirePermission() {
+            return Stream.of(
+                    Arguments.of("create", WorkspaceUserPermission.DASHBOARD_CREATE,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> {
+                                var view = insightsViewClient.createPartialInsightsView().build();
+                                try (var response = insightsViewClient.callCreate(view, apiKey, workspaceName)) {
+                                    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+                                }
+                            }),
+                    Arguments.of("get by id", WorkspaceUserPermission.DASHBOARD_VIEW,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> insightsViewClient
+                                    .get(UUID.randomUUID(), apiKey, workspaceName, HttpStatus.SC_FORBIDDEN)),
+                    Arguments.of("find", WorkspaceUserPermission.DASHBOARD_VIEW,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> insightsViewClient
+                                    .find(apiKey, workspaceName, 1, 10, null, HttpStatus.SC_FORBIDDEN)),
+                    Arguments.of("update", WorkspaceUserPermission.DASHBOARD_EDIT,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> insightsViewClient.update(
+                                    UUID.randomUUID(), DashboardUpdate.builder().name("Denied").build(), apiKey,
+                                    workspaceName, HttpStatus.SC_FORBIDDEN)),
+                    Arguments.of("delete", WorkspaceUserPermission.DASHBOARD_DELETE,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> insightsViewClient
+                                    .delete(UUID.randomUUID(), apiKey, workspaceName, HttpStatus.SC_FORBIDDEN)),
+                    Arguments.of("delete batch", WorkspaceUserPermission.DASHBOARD_DELETE,
+                            (BiConsumer<String, String>) (apiKey, workspaceName) -> insightsViewClient.batchDelete(
+                                    Set.of(UUID.randomUUID()), apiKey, workspaceName, HttpStatus.SC_FORBIDDEN)));
         }
     }
 }

--- a/apps/opik-frontend/src/api/insights-views/useInsightsViewsList.ts
+++ b/apps/opik-frontend/src/api/insights-views/useInsightsViewsList.ts
@@ -12,6 +12,7 @@ import { processFilters } from "@/lib/filters";
 
 type UseInsightsViewsListParams = {
   workspaceName: string;
+  projectId?: string | null;
   sorting?: Sorting;
   search?: string;
   filters?: Filter[];
@@ -29,6 +30,7 @@ const getInsightsViewsList = async (
   { signal }: QueryFunctionContext,
   {
     workspaceName,
+    projectId,
     sorting,
     search,
     filters,
@@ -40,6 +42,7 @@ const getInsightsViewsList = async (
     signal,
     params: {
       workspace_name: workspaceName,
+      ...(projectId && { project_id: projectId }),
       ...processSorting(sorting),
       ...(search && { name: search }),
       ...processFilters(filters),

--- a/apps/opik-frontend/src/types/dashboard.ts
+++ b/apps/opik-frontend/src/types/dashboard.ts
@@ -210,6 +210,7 @@ export interface Dashboard {
   name: string;
   description?: string;
   workspace_id: string;
+  project_id?: string;
   config: DashboardState;
   type: DASHBOARD_TYPE;
   scope: DASHBOARD_SCOPE;

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardViewDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardViewDialog.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/lib/dashboard/utils";
 import { Dashboard, DASHBOARD_TYPE } from "@/types/dashboard";
 import { useDashboardStore } from "@/store/DashboardStore";
+import { useActiveProjectId } from "@/store/AppStore";
 
 export type ProjectDashboardViewDialogMode = "create" | "edit" | "clone";
 
@@ -80,6 +81,7 @@ const ProjectDashboardViewDialog: React.FC<ProjectDashboardViewDialogProps> = ({
   onCreateSuccess,
 }) => {
   const { toast } = useToast();
+  const projectId = useActiveProjectId();
   const config = MODE_CONFIG[mode];
 
   const { mutate: createMutate, isPending: isCreating } =
@@ -210,6 +212,7 @@ const ProjectDashboardViewDialog: React.FC<ProjectDashboardViewDialogProps> = ({
                 mode === "create"
                   ? DASHBOARD_TYPE.MULTI_PROJECT
                   : dashboard?.type,
+              ...(projectId && { project_id: projectId }),
             },
           },
           {
@@ -229,6 +232,7 @@ const ProjectDashboardViewDialog: React.FC<ProjectDashboardViewDialogProps> = ({
     [
       mode,
       dashboard,
+      projectId,
       updateMutate,
       createMutate,
       setOpen,

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardViewSelector.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardViewSelector.tsx
@@ -16,7 +16,7 @@ import {
 } from "./ProjectDashboardViewItems";
 import useInsightsViewsList from "@/api/insights-views/useInsightsViewsList";
 import useInsightsViewBatchDeleteMutation from "@/api/insights-views/useInsightsViewBatchDeleteMutation";
-import useAppStore from "@/store/AppStore";
+import useAppStore, { useActiveProjectId } from "@/store/AppStore";
 import {
   Dashboard,
   DASHBOARD_TYPE,
@@ -107,6 +107,7 @@ const ProjectDashboardViewSelector: React.FC<
   });
 
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const projectId = useActiveProjectId();
   const { mutate: deleteMutate } = useInsightsViewBatchDeleteMutation();
 
   const {
@@ -124,12 +125,13 @@ const ProjectDashboardViewSelector: React.FC<
   const { data: dashboardsData } = useInsightsViewsList(
     {
       workspaceName,
+      projectId,
       filters: processedFilters,
       page: 1,
       size: 1000,
     },
     {
-      enabled: Boolean(workspaceName),
+      enabled: Boolean(workspaceName) && Boolean(projectId),
     },
   );
 

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
@@ -55,7 +55,7 @@ const ProjectDashboardsContent: React.FunctionComponent<
   } = usePermissions();
 
   const [dashboardId, setDashboardId] = useQueryParamAndLocalStorageState({
-    localStorageKey: `${DASHBOARD_LOCAL_STORAGE_KEY_PREFIX}-${workspaceName}`,
+    localStorageKey: `${DASHBOARD_LOCAL_STORAGE_KEY_PREFIX}-${workspaceName}-${projectId}`,
     queryKey: DASHBOARD_QUERY_PARAM_KEY,
     defaultValue: null as string | null,
     queryParamConfig: StringParam,

--- a/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
+++ b/apps/opik-frontend/src/v2/pages/ProjectDashboardsPage/ProjectDashboardsPage.tsx
@@ -82,10 +82,18 @@ const ProjectDashboardsContent: React.FunctionComponent<
   });
 
   useEffect(() => {
-    if (!isPending && dashboardId && !dashboard) {
+    if (isPending || !dashboardId) return;
+
+    // A shared link carries the id in the query string, and reading one by id is not project
+    // scoped, so another project's view would render here. Legacy views carry no project and stay.
+    const belongsToAnotherProject = Boolean(
+      dashboard?.project_id && dashboard.project_id !== projectId,
+    );
+
+    if (!dashboard || belongsToAnotherProject) {
       setDashboardId(DEFAULT_TEMPLATE_ID);
     }
-  }, [isPending, dashboardId, dashboard, setDashboardId]);
+  }, [isPending, dashboardId, dashboard, projectId, setDashboardId]);
 
   const setRuntimeConfig = useDashboardStore(selectSetRuntimeConfig);
 


### PR DESCRIPTION
## Details

Before:
- The Dashboards page inside a project listed every insights view in the workspace. A view created in Project A also appeared in Project B.
- A view created or duplicated from a project page was saved with no project at all.
- The selected view was remembered per workspace, so opening another project kept the previous project's view selected.
- A link carrying `?dashboardId=` loaded that view in whatever project the URL named.
- The insights views endpoints required no permission, while the dashboards endpoints required `DASHBOARD_*`.

After:
- The Dashboards page inside a project lists only that project's views, next to the built-in templates.
- A view created or duplicated from a project page is saved against that project.
- The selected view is remembered per project, and a view belonging to another project falls back to the default template instead of rendering.
- Views created before this change carry no project. They stay listed in every project, so nobody loses access to them. Recreate one inside a project to scope it.
- Insights views require the same `DASHBOARD_*` permissions as dashboards: create, view, edit and delete. The frontend already gates every one of these actions on the same flags, so nothing changes for a user who holds them.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves N/A
- OPIK-8322

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: author review pending; automated checks only so far, listed under Testing

## Testing

```
cd apps/opik-backend && mvn compile -DskipTests
cd apps/opik-backend && mvn test -Dtest='InsightsViewsResourceTest'
cd apps/opik-backend && mvn test -Dtest='DashboardsResourceTest'
cd apps/opik-backend && mvn test -Dtest='DashboardsResourceProjectScopedTest'
cd apps/opik-backend && mvn test -Dtest='DashboardsResourceFindProjectDashboardsTest'
cd apps/opik-backend && mvn spotless:check
cd apps/opik-frontend && npx tsc --project tsconfig.json --noEmit
cd apps/opik-frontend && npx eslint src/api/insights-views src/v2/pages/ProjectDashboardsPage src/types/dashboard.ts --max-warnings=0
```

Results: 12 + 58 + 5 + 16 tests passed, spotless clean, typecheck clean, eslint clean.

Two tests are added:
- `findInsightsViewsByProject` — a request for one project returns that project's view and the view with no project, and excludes a second project's view. It asserts `total` alongside the exact ids, which is what catches `findCount` and `findPageIdsSorted` disagreeing.
- `findInsightsViewsReturnsForbiddenWhenPermissionDenied` — the resource is actually gated, rather than only annotated.

No test is added for the strict workspace path, because `DashboardsResourceProjectScopedTest.findDashboardsByProjectId` already creates a project-less workspace dashboard and asserts the project filter excludes it, over the same DAO predicate. The remaining five permission annotations are copy-identical to the pattern the one test above proves, and match `DashboardsResource` permission for permission.

Run the backend classes one at a time. Three at once starves the ClickHouse container and fails on startup rather than on an assertion.

Not run:
- The full backend test suite. CI covers the rest.
- No manual run in a browser.

## Documentation

N/A
