### PR TITLE
[NA] [DOCS] docs: document Opik-specific OTel span attributes

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx
@@ -124,3 +124,38 @@ OpenAIInstrumentor().instrument()
   Make sure to import the `http` trace exporter (`opentelemetry.exporter.otlp.proto.http.trace_exporter`), if you use
   the GRPC exporter you will face errors.
 </Warning>
+
+## Opik-specific span attributes
+
+Opik reads a small set of span attributes and maps them to Opik fields. Set them with
+the standard OpenTelemetry API on any span.
+
+| Attribute | Effect |
+| --- | --- |
+| `opik.tags` | Adds tags to the span. On the root span, Opik also adds the tags to the trace, so you can filter your traces by tag. |
+| `opik.metadata.<key>` | Adds `<key>` to the metadata of the span. The metadata of the root span also becomes the metadata of the trace. |
+| `thread_id` | Groups traces into one conversational thread. See [Multi-turn conversations](/evaluation/evaluate_threads). |
+| `opik.trace_id`, `opik.parent_span_id`, `opik.span_id` | Attaches the span to an Opik trace and parent span that already exist. See [Distributed traces](/tracing/advanced/log_distributed_traces). |
+
+### Tagging traces and spans
+
+Opik accepts three formats for the `opik.tags` attribute:
+
+- A list of strings: `["production", "chatbot"]`
+- A JSON array in a string: `'["production", "chatbot"]'`
+- A comma-separated string: `"production,chatbot"`
+
+```python wordWrap
+with tracer.start_as_current_span("chatbot_conversation") as conversation_span:
+    # The root span carries the tags, so the trace carries them too
+    conversation_span.set_attribute("opik.tags", ["production", "chatbot"])
+    conversation_span.set_attribute("opik.metadata.environment", "staging")
+
+    with tracer.start_as_current_span("llm_completion") as llm_span:
+        # A child span carries the tags on the span only
+        llm_span.set_attribute("opik.tags", ["llm-call"])
+```
+
+<Note>
+  Set `opik.tags` on the root span if you want to filter traces by tag. Tags on a child span apply to that span only.
+</Note>


### PR DESCRIPTION
## Details

- The OpenTelemetry integration page lists the `opik.*` span attributes that Opik reads: `opik.tags`, `opik.metadata.<key>`, `thread_id`, and the `opik.trace_id` / `opik.parent_span_id` / `opik.span_id` linking attributes.
- A new "Tagging traces and spans" section documents the three accepted formats for `opik.tags` (list of strings, JSON array string, comma-separated string).
- The page states that `opik.tags` on the root span also tags the trace, which is what makes trace-level tag filtering work. Tags on a child span stay on that span.

Follow-up documentation for #7537, which added the trace-level propagation. That PR shipped without docs, and the attribute reference did not exist anywhere on the site.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- Resolves #
- OPIK-

Documentation follow-up to PR #7537.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Wrote the new documentation section in `opentelemetry.mdx` after reading the backend mapping code.
- Human verification: Author reviewed the content against `OpenTelemetryService`, `OpenTelemetryMapper`, `GeneralMappingRules`, and `OpenTelemetryMappingUtils.extractTags`.

## Testing

Documentation only. No code changes and no tests run. The behavior described is covered by `testRootSpanTagsPropagateToTrace` in `OpenTelemetryResourceTest`.

Cross-links use root-relative slugs verified against `navigation:` in `fern/docs.yml`:
- `/evaluation/evaluate_threads`
- `/tracing/advanced/log_distributed_traces`

## Documentation

This PR is the documentation change: `apps/opik-documentation/documentation/fern/docs-v2/integrations/opentelemetry.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
