### PR TITLE
[NA] [BE][FE] chore: sync provider model definitions

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenaiModelName.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/llm/openai/OpenaiModelName.java
@@ -81,7 +81,9 @@ public enum OpenaiModelName implements StructuredOutputSupported {
     GPT_O3_MINI("o3-mini", false),
     GPT_O3_PRO("o3-pro", true),
     GPT_O4_MINI("o4-mini", true),
-    GPT_O4_MINI_DEEP_RESEARCH("o4-mini-deep-research", true);
+    GPT_O4_MINI_DEEP_RESEARCH("o4-mini-deep-research", true),
+    GPT_IMAGE_2_5_FLARE("gpt-image-2.5-flare", false),
+    GPT_IMAGE_2_5_SUNBURST("gpt-image-2.5-sunburst", false);
 
     private static final String WARNING_UNKNOWN_MODEL = "could not find OpenaiModelName with value '{}'";
 

--- a/apps/opik-backend/src/main/resources/llm-models-default.yaml
+++ b/apps/opik-backend/src/main/resources/llm-models-default.yaml
@@ -115,6 +115,8 @@ openai:
   - id: "gpt-image-1-mini"
   - id: "gpt-image-1.5"
   - id: "gpt-image-2"
+  - id: "gpt-image-2.5-flare"
+  - id: "gpt-image-2.5-sunburst"
   - id: "o1-2024-12-17"
     reasoning: true
   - id: "o1-mini"

--- a/apps/opik-frontend/src/types/providers.ts
+++ b/apps/opik-frontend/src/types/providers.ts
@@ -97,6 +97,8 @@ export enum PROVIDER_MODEL_TYPE {
   GPT_O3_PRO = "o3-pro",
   GPT_O4_MINI = "o4-mini",
   GPT_O4_MINI_DEEP_RESEARCH = "o4-mini-deep-research",
+  GPT_IMAGE_2_5_FLARE = "gpt-image-2.5-flare",
+  GPT_IMAGE_2_5_SUNBURST = "gpt-image-2.5-sunburst",
 
   //  <----- anthropic
   CLAUDE_SONNET_3_7 = "claude-3-7-sonnet-20250219",


### PR DESCRIPTION
## Details

Automated sync of LLM provider model definitions from source APIs and prices JSON.

**Sync summary:**
```
## Provider Model Sync

### Openrouter
- Stale 269 model(s) (not in source, manual review needed):
  ? ai21/jamba-large-1.7
  ? ai21/jamba-mini-1.7
  ? aion-labs/aion-1.0
  ? aion-labs/aion-1.0-mini
  ? alfredpros/codellama-7b-instruct-solidity
  ? alibaba/tongyi-deepresearch-30b-a3b
  ? alibaba/tongyi-deepresearch-30b-a3b:free
  ? allenai/molmo-2-8b
  ? allenai/olmo-2-0325-32b-instruct
  ? allenai/olmo-3-32b-think
  ? allenai/olmo-3-7b-instruct
  ? allenai/olmo-3-7b-think
  ? allenai/olmo-3.1-32b-instruct
  ? allenai/olmo-3.1-32b-think
  ? alpindale/goliath-120b
  ? anthropic/claude-3.5-haiku
  ? anthropic/claude-3.5-sonnet
  ? anthropic/claude-3.7-sonnet
  ? anthropic/claude-3.7-sonnet:thinking
  ? anthropic/claude-opus-4.6-fast
  ? anthropic/claude-opus-4.7-fast
  ? anthropic/claude-opus-4.8-fast
  ? anthropic/claude-opus-5-fast
  ? arcee-ai/afm-4.5b
  ? arcee-ai/coder-large
  ? arcee-ai/maestro-reasoning
  ? arcee-ai/spotlight
  ? arcee-ai/trinity-large-preview
  ? arcee-ai/trinity-large-preview:free
  ? arcee-ai/trinity-large-thinking:free
  ? arcee-ai/trinity-mini
  ? arcee-ai/trinity-mini:free
  ? arcee-ai/virtuoso-large
  ? arliai/qwq-32b-arliai-rpr-v1
  ? arliai/qwq-32b-arliai-rpr-v1:free
  ? baidu/cobuddy:free
  ? baidu/ernie-4.5-21b-a3b
  ? baidu/ernie-4.5-21b-a3b-thinking
  ? baidu/ernie-4.5-300b-a47b
  ? baidu/ernie-4.5-vl-28b-a3b
  ? baidu/qianfan-ocr-fast
  ? baidu/qianfan-ocr-fast:free
  ? cognitivecomputations/dolphin-mistral-24b-venice-edition:free
  ? deepcogito/cogito-v2-preview-deepseek-671b
  ? deepcogito/cogito-v2-preview-llama-109b-moe
  ? deepcogito/cogito-v2-preview-llama-405b
  ? deepcogito/cogito-v2-preview-llama-70b
  ? deepcogito/cogito-v2.1-671b
  ? deepseek/deepseek-chat-v3-0324:free
  ? deepseek/deepseek-prover-v2
  ? deepseek/deepseek-r1-0528-qwen3-8b
  ? deepseek/deepseek-r1-0528-qwen3-8b:free
  ? deepseek/deepseek-r1-0528:free
  ? deepseek/deepseek-r1-distill-llama-70b:free
  ? deepseek/deepseek-r1-distill-qwen-14b
  ? deepseek/deepseek-r1-distill-qwen-32b
  ? deepseek/deepseek-r1:free
  ? deepseek/deepseek-v3.1-terminus:exacto
  ? deepseek/deepseek-v3.2-speciale
  ? deepseek/deepseek-v4-flash:free
  ? eleutherai/llemma_7b
  ? essentialai/rnj-1-instruct
  ? google/gemini-2.0-flash-001
  ? google/gemini-2.0-flash-exp:free
  ? google/gemini-2.0-flash-lite-001
  ? google/gemini-2.5-flash-image-preview
  ? google/gemini-2.5-flash-lite-preview-09-2025
  ? google/gemini-2.5-flash-preview-09-2025
  ? google/gemini-3-pro-preview
  ? google/gemma-2-9b-it
  ? google/gemma-3-12b-it:free
  ? google/gemma-3-27b-it:free
  ? google/gemma-3-4b-it:free
  ? google/gemma-3n-e2b-it:free
  ? google/gemma-3n-e4b-it
  ? google/gemma-3n-e4b-it:free
  ? ibm-granite/granite-4.1-8b
  ? inception/mercury
  ? inception/mercury-2.5-preview
  ? inception/mercury-coder
  ? inclusionai/ling-2.6-1t
  ? inclusionai/ling-2.6-1t:free
  ? inclusionai/ling-2.6-flash
  ? inclusionai/ling-2.6-flash:free
  ? inclusionai/ling-3.0-flash:free
  ? inclusionai/ling-3.0-tiny:free
  ? inclusionai/ring-2.6-1t
  ? inclusionai/ring-2.6-1t:free
  ? inflection/inflection-3-pi
  ? inflection/inflection-3-productivity
  ? kwaipilot/kat-coder-air-v2.5
  ? kwaipilot/kat-coder-pro
  ? kwaipilot/kat-coder-pro:free
  ? liquid/lfm-2-24b-a2b
  ? liquid/lfm-2.2-6b
  ? liquid/lfm-2.5-1.2b-instruct:free
  ? liquid/lfm-2.5-1.2b-thinking:free
  ? liquid/lfm2-8b-a1b
  ? meituan/longcat-flash-chat
  ? meituan/longcat-flash-chat:free
  ? meta-llama/llama-3-70b-instruct
  ? meta-llama/llama-3-8b-instruct
  ? meta-llama/llama-3.1-405b
  ? meta-llama/llama-3.1-405b-instruct
  ? meta-llama/llama-3.2-11b-vision-instruct
  ? meta-llama/llama-3.2-3b-instruct:free
  ? meta-llama/llama-3.2-90b-vision-instruct
  ? meta-llama/llama-3.3-70b-instruct:free
  ? meta-llama/llama-guard-2-8b
  ? meta-llama/llama-guard-3-8b
  ? meta-llama/llama-guard-4-12b:free
  ? microsoft/mai-ds-r1
  ? microsoft/mai-ds-r1:free
  ? microsoft/phi-3-medium-128k-instruct
  ? microsoft/phi-3-mini-128k-instruct
  ? microsoft/phi-3.5-mini-128k-instruct
  ? microsoft/phi-4-mini-instruct
  ? microsoft/phi-4-multimodal-instruct
  ? microsoft/phi-4-reasoning-plus
  ? minimax/minimax-m2.5:free
  ? minimax/minimax-m2.7:free
  ? minimax/minimax-m3:free
  ? mistralai/codestral-2501
  ? mistralai/codestral-2508:batch
  ? mistralai/devstral-medium
  ? mistralai/devstral-small
  ? mistralai/devstral-small-2505
  ? mistralai/magistral-medium-2506
  ? mistralai/magistral-medium-2506:thinking
  ? mistralai/magistral-small-2506
  ? mistralai/ministral-3b
  ? mistralai/ministral-8b
  ? mistralai/ministral-8b-2512:batch
  ? mistralai/mistral-7b-instruct
  ? mistralai/mistral-7b-instruct-v0.1
  ? mistralai/mistral-7b-instruct-v0.2
  ? mistralai/mistral-7b-instruct-v0.3
  ? mistralai/mistral-7b-instruct:free
  ? mistralai/mistral-large-2411
  ? mistralai/mistral-large-2512:batch
  ? mistralai/mistral-medium-3.1:batch
  ? mistralai/mistral-nemo:free
  ? mistralai/mistral-small
  ? mistralai/mistral-small-24b-instruct-2501:free
  ? mistralai/mistral-small-2603:batch
  ? mistralai/mistral-small-3.1-24b-instruct:free
  ? mistralai/mistral-small-3.2-24b-instruct:free
  ? mistralai/mistral-small-creative
  ? mistralai/mistral-tiny
  ? mistralai/mixtral-8x7b-instruct
  ? mistralai/pixtral-12b
  ? mistralai/pixtral-large-2411
  ? moonshotai/kimi-dev-72b
  ? moonshotai/kimi-k2-0905:exacto
  ? moonshotai/kimi-k2.6:free
  ? moonshotai/kimi-k2.7-code:batch
  ? moonshotai/kimi-k2:free
  ? moonshotai/kimi-linear-48b-a3b-instruct
  ? neversleep/llama-3.1-lumimaid-8b
  ? neversleep/noromaid-20b
  ? nex-agi/deepseek-v3.1-nex-n1
  ? nex-agi/nex-n2-mini
  ? nex-agi/nex-n2-pro
  ? nex-agi/nex-n2-pro:free
  ? nousresearch/deephermes-3-mistral-24b-preview
  ? nousresearch/hermes-2-pro-llama-3-8b
  ? nousresearch/hermes-3-llama-3.1-405b:free
  ? nousresearch/hermes-4-70b
  ? nvidia/llama-3.1-nemotron-70b-instruct
  ? nvidia/llama-3.1-nemotron-ultra-253b-v1
  ? nvidia/llama-3.3-nemotron-super-49b-v1.5
  ? nvidia/nemotron-3-nano-30b-a3b:free
  ? nvidia/nemotron-3-ultra-550b-a55b:batch
  ? nvidia/nemotron-nano-12b-v2-vl
  ? nvidia/nemotron-nano-12b-v2-vl:free
  ? nvidia/nemotron-nano-9b-v2
  ? nvidia/nemotron-nano-9b-v2:free
  ? openai/chatgpt-4o-latest
  ? openai/codex-mini
  ? openai/gpt-4-0314
  ? openai/gpt-4-1106-preview
  ? openai/gpt-4o-audio-preview
  ? openai/gpt-4o-mini-search-preview
  ? openai/gpt-4o-search-preview
  ? openai/gpt-4o:extended
  ? openai/gpt-5-chat
  ? openai/gpt-5-codex
  ? openai/gpt-5-codex:batch
  ? openai/gpt-5.1-chat
  ? openai/gpt-5.2-chat-latest
  ? openai/gpt-5.3-chat
  ? openai/gpt-oss-120b:exacto
  ? openai/gpt-oss-120b:free
  ? openai/gpt-oss-20b:free
  ? openai/o1-pro:batch
  ? openai/o1:batch
  ? openai/o3-deep-research
  ? openai/o3-mini-high:batch
  ? openai/o3-pro:batch
  ? openai/o4-mini-deep-research
  ? openai/o4-mini-high:batch
  ? opengvlab/internvl3-78b
  ? openrouter/elephant-alpha
  ? openrouter/healer-alpha
  ? openrouter/hunter-alpha
  ? openrouter/owl-alpha
  ? perplexity/sonar-reasoning
  ? poolside/laguna-m.1
  ? poolside/laguna-m.1:free
  ? poolside/laguna-xs.2
  ? poolside/laguna-xs.2:free
  ? prime-intellect/intellect-3
  ? qwen/qwen-2.5-72b-instruct:free
  ? qwen/qwen-2.5-coder-32b-instruct:free
  ? qwen/qwen-2.5-vl-7b-instruct
  ? qwen/qwen-max
  ? qwen/qwen-plus-2025-07-28:thinking
  ? qwen/qwen-turbo
  ? qwen/qwen-vl-max
  ? qwen/qwen-vl-plus
  ? qwen/qwen2.5-coder-7b-instruct
  ? qwen/qwen2.5-vl-32b-instruct
  ? qwen/qwen2.5-vl-32b-instruct:free
  ? qwen/qwen3-14b:free
  ? qwen/qwen3-235b-a22b:free
  ? qwen/qwen3-30b-a3b:free
  ? qwen/qwen3-4b:free
  ? qwen/qwen3-coder:exacto
  ? qwen/qwen3-coder:free
  ? qwen/qwen3-next-80b-a3b-instruct:free
  ? qwen/qwen3.6-plus-preview:free
  ? qwen/qwen3.6-plus:free
  ? qwen/qwen3.8-max
  ? qwen/qwq-32b
  ? raifle/sorcererlm-8x22b
  ? reka/reka-edge
  ? sao10k/l3-euryale-70b
  ? sao10k/l3.1-70b-hanami-x1
  ? stealth/ox-alpha
  ? stepfun-ai/step3
  ? stepfun/step-3.5-flash:free
  ? switchpoint/router
  ? tencent/hy3-preview:free
  ? tencent/hy3:free
  ? thedrummer/anubis-70b-v1.1
  ? thedrummer/rocinante-12b
  ? thudm/glm-4.1v-9b-thinking
  ? tngtech/deepseek-r1t-chimera
  ? tngtech/deepseek-r1t-chimera:free
  ? tngtech/deepseek-r1t2-chimera
  ? tngtech/deepseek-r1t2-chimera:free
  ? x-ai/grok-3
  ? x-ai/grok-3-beta
  ? x-ai/grok-3-mini
  ? x-ai/grok-3-mini-beta
  ? x-ai/grok-4
  ? x-ai/grok-4-fast
  ? x-ai/grok-4.1-fast
  ? x-ai/grok-4.1-fast:free
  ? x-ai/grok-4.20-beta
  ? x-ai/grok-4.20-multi-agent-beta
  ? x-ai/grok-code-fast-1
  ? xiaomi/mimo-v2-flash
  ? xiaomi/mimo-v2-omni
  ? xiaomi/mimo-v2-pro
  ? z-ai/glm-4-32b
  ? z-ai/glm-4.5-air:free
  ? z-ai/glm-4.6:exacto
  ? z-ai/glm-5.2:free
- Deprecated 1 model(s) (past deprecation_date, excluded from dropdown):
  ✗ google/gemini-2.0-flash-001
- Total models: 699 (dropdown: 698)

### Openai
- Added 2 model(s):
  + gpt-image-2.5-flare
  + gpt-image-2.5-sunburst
- Stale 15 model(s) (not in source, manual review needed):
  ? chatgpt-4o-latest
  ? gpt-4-0125-preview
  ? gpt-4-0314
  ? gpt-4-1106-preview
  ? gpt-4-turbo-2024-04-09
  ? gpt-4-turbo-preview
  ? gpt-4o-2024-05-13
  ? gpt-4o-2024-08-06
  ? gpt-4o-2024-11-20
  ? gpt-4o-mini-2024-07-18
  ? o1-2024-12-17
  ? o1-mini
  ? o1-mini-2024-09-12
  ? o1-preview
  ? o1-preview-2024-09-12
- Deprecated 15 model(s) (past deprecation_date, excluded from dropdown):
  ✗ chatgpt-4o-latest
  ✗ gpt-4-0125-preview
  ✗ gpt-4-0314
  ✗ gpt-4-turbo-preview
  ✗ gpt-5-chat-latest
  ✗ gpt-5-codex
  ✗ gpt-5.1-chat-latest
  ✗ gpt-5.1-codex
  ✗ gpt-5.1-codex-max
  ✗ gpt-5.1-codex-mini
  ✗ gpt-5.2-chat-latest
  ✗ gpt-5.2-codex
  ✗ gpt-5.3-chat-latest
  ✗ o3-deep-research
  ✗ o4-mini-deep-research
- Total models: 71 (dropdown: 24)

### Anthropic
- Stale 5 model(s) (not in source, manual review needed):
  ? claude-3-7-sonnet-20250219
  ? claude-opus-4-1-20250805
  ? claude-opus-4-20250514
  ? claude-sonnet-4-20250514
  ? claude-sonnet-4-5
- Deprecated 4 model(s) (past deprecation_date, excluded from dropdown):
  ✗ claude-3-7-sonnet-20250219
  ✗ claude-opus-4-1-20250805
  ✗ claude-opus-4-20250514
  ✗ claude-sonnet-4-20250514
- Total models: 16 (dropdown: 11)

### Gemini
- Stale 10 model(s) (not in source, manual review needed):
  ? aqa
  ? gemini-1.0-pro
  ? gemini-1.5-flash-latest
  ? gemini-1.5-pro-latest
  ? gemini-2.0-flash
  ? gemini-2.0-flash-lite
  ? gemini-3-pro-preview
  ? gemini-flash-latest-high-res-exp
  ? gemini-pro-vision
  ? text-embedding-004
- Deprecated 6 model(s) (past deprecation_date, excluded from dropdown):
  ✗ gemini-2.0-flash
  ✗ gemini-2.0-flash-lite
  ✗ gemini-3-pro-image-preview
  ✗ gemini-3-pro-preview
  ✗ gemini-3.1-flash-image-preview
  ✗ gemini-3.1-flash-lite-preview
- Total models: 38 (dropdown: 20)

### Vertexai
- Stale 9 model(s) (not in source, manual review needed):
  ? vertex_ai/gemini-2.0-flash-001
  ? vertex_ai/gemini-2.0-flash-lite-001
  ? vertex_ai/gemini-2.5-flash
  ? vertex_ai/gemini-2.5-flash-lite-preview-06-17
  ? vertex_ai/gemini-2.5-flash-preview-04-17
  ? vertex_ai/gemini-2.5-pro
  ? vertex_ai/gemini-2.5-pro-exp-03-25
  ? vertex_ai/gemini-2.5-pro-preview-03-25
  ? vertex_ai/gemini-2.5-pro-preview-05-06
- Total models: 19 (dropdown: 14)

```

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- NA

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: GitHub Actions (`sync_provider_models.yml`)
  - Model(s): N/A (scripted automation)
  - Scope: Automated model list sync
  - Human verification: Requires manual review before merge

## Testing

- Script dry-run passed in CI
- Changes are add-only; stale/deprecated models flagged for manual review

## Documentation

N/A