### PR TITLE
[OPIK-8241] [BE] [CI] fix: stop wrapped week bounds and narrow id expressions hiding far-future rows

### DIFF
--- a/.semgrep/java-sql-narrow-datetime.java
+++ b/.semgrep/java-sql-narrow-datetime.java
@@ -1,0 +1,137 @@
+// Fixtures for java-sql-narrow-datetime.yaml. Run with:
+//   semgrep test --config .semgrep/java-sql-narrow-datetime.yaml .semgrep/java-sql-narrow-datetime.java
+//
+// Semgrep's own annotations drive the assertions: a rule-id comment above a line marks one the
+// rule MUST flag, and the negative form marks one it must NOT.
+//
+// The accepted cases matter as much as the rejected ones. Two of them are the reason the rule
+// anchors on `\(`: `toDate32(` and `toDateTime64(` are the correct forms and share a prefix with
+// the narrow ones, so a rule written without that anchor rejects the fix it is meant to enforce.
+class JavaSqlNarrowDatetimeFixtures {
+
+    // ---------------------------------------------------------------------------
+    // REJECTED — a narrow conversion of an id-derived value.
+    // ---------------------------------------------------------------------------
+
+    // ruleid: sql-narrow-datetime-on-id
+    static final String WEEK_BOUND_BOTH_OPERANDS = """
+            SELECT id
+            FROM spans
+            WHERE workspace_id = :workspace_id
+            AND id >= :uuid_from_time
+            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+            """;
+
+    // The half-converted form: the column side is already Date32 and only the bound wraps. This is
+    // the one a "convert the column" fix leaves behind, and on an equality it is worse than
+    // leaving both — the two sides can then never agree for a far-future id.
+    // ruleid: sql-narrow-datetime-on-id
+    static final String WEEK_BOUND_ONLY_THE_BOUND_WRAPS = """
+            SELECT id
+            FROM traces
+            WHERE id = :id
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                = toMonday(UUIDv7ToDateTime(toUUID(:id), 'UTC'))
+            """;
+
+    // ruleid: sql-narrow-datetime-on-id
+    static final String DATE_PROJECTION = """
+            SELECT toDate(UUIDv7ToDateTime(toUUID(id))) AS day
+            FROM traces
+            WHERE workspace_id = :workspace_id
+            GROUP BY day
+            """;
+
+    // ruleid: sql-narrow-datetime-on-id
+    static final String DATETIME_BUCKETING = """
+            SELECT countIf(error_info != '' AND toDateTime(UUIDv7ToDateTime(toUUID(t.id))) > now()) AS recent
+            FROM traces t
+            """;
+
+    // A bare expression string passed as a StringTemplate attribute, not a whole statement. The
+    // rule carries no SELECT/WITH guard precisely so this shape is still caught.
+    // ruleid: sql-narrow-datetime-on-id
+    static final String TEMPLATE_ATTRIBUTE = "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))";
+
+    // ruleid: sql-narrow-datetime-on-id
+    static final String NARROWED_PARTITION_COLUMN = """
+            SELECT toDateTime(id_at) AS at
+            FROM spans
+            """;
+
+    // A table-qualified column. These DAOs alias their tables (`t.id`, `s.span_time`), so the qualifier
+    // has to be tolerated or the rule misses the most ordinary way of writing the same mistake.
+    // ruleid: sql-narrow-datetime-on-id
+    static final String QUALIFIED_COLUMN = """
+            SELECT toMonday(t.id_at) AS week
+            FROM traces t
+            """;
+
+    // Wrapped across lines, as the long nested bounds in these DAOs are.
+    // ruleid: sql-narrow-datetime-on-id
+    static final String SPLIT_ACROSS_LINES = """
+            SELECT toDate(
+                       UUIDv7ToDateTime(toUUID(id))) AS day
+            FROM traces
+            """;
+
+    // ---------------------------------------------------------------------------
+    // ACCEPTED — the wide forms, and narrow conversions of columns that are not id-derived.
+    // ---------------------------------------------------------------------------
+
+    // ok: sql-narrow-datetime-on-id
+    static final String DATE32_WEEK_EXPRESSION = """
+            SELECT id
+            FROM spans
+            WHERE workspace_id = :workspace_id
+            AND id >= :uuid_from_time
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
+                    - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))
+            """;
+
+    // ok: sql-narrow-datetime-on-id
+    static final String ADD_WEEKS_OVER_DATE32 = """
+            DELETE FROM traces
+            WHERE id \\< :cutoff_id
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                \\< addWeeks(toDate32(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC'))
+                    - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC'), 1)), 1)
+            """;
+
+    // ok: sql-narrow-datetime-on-id
+    static final String DATE32_PROJECTION = """
+            SELECT toDate32(UUIDv7ToDateTime(toUUID(id))) AS day
+            FROM traces
+            GROUP BY day
+            """;
+
+    // ok: sql-narrow-datetime-on-id
+    static final String PINNED_DATETIME64_BUCKET = "toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_from_time)), 0, 'UTC')";
+
+    // ok: sql-narrow-datetime-on-id
+    static final String PINNED_WITH_FILL_BOUND = """
+            SELECT bucket, value
+            FROM series
+            ORDER BY bucket
+            WITH FILL FROM :from
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
+                STEP toIntervalDay(1)
+            """;
+
+    // Server-stamped columns are honest to 2299 and every value in them is ordinary, so narrowing
+    // them is not this rule's concern.
+    // ok: sql-narrow-datetime-on-id
+    static final String NARROW_ON_SERVER_STAMPED_COLUMNS = """
+            SELECT toDate(created_at), toDateTime(start_time), toMonday(last_updated_at)
+            FROM traces
+            """;
+
+    // ok: sql-narrow-datetime-on-id
+    static final String ID_RANGE_WITHOUT_ANY_CONVERSION = """
+            SELECT id
+            FROM spans
+            WHERE id >= :uuid_from_time
+            AND id \\<= :uuid_to_time
+            """;
+}

--- a/.semgrep/java-sql-narrow-datetime.yaml
+++ b/.semgrep/java-sql-narrow-datetime.yaml
@@ -1,0 +1,66 @@
+# Narrow-returning datetime conversions applied to a UUIDv7-derived value, for
+# apps/opik-backend/src/main/java.
+#
+# ClickHouse's toMonday and toDate return a 16-bit Date (1970..2149) and toDateTime a 32-bit
+# DateTime (1970..2106). All three WRAP past their ceiling rather than saturating, so applied
+# to a value derived from a row's UUIDv7 id they fold a far-future timestamp — a client with a
+# broken clock (BerriAI/litellm#31294 mints ~2201) — into a plausible recent date.
+#
+# Two shapes have shipped as bugs, and the cost differs:
+#
+#   * As a week bound paired with an id-range (`toMonday(id_at) >= toMonday(...)`), the bound is
+#     documented as a strict consequence of the id-range: a pruning hint that must never exclude
+#     a row the id-range admits. Wrapped, it becomes a filter, and far-future rows disappear from
+#     every time-bounded query (traces: PR #8096; spans and retention: OPIK-8241).
+#   * As a bucketing expression (`toDateTime(UUIDv7ToDateTime(toUUID(t.id)))`), it IS the answer
+#     rather than a hint, so no wider id-range recovers it — a far-future trace was counted as a
+#     recent error (OPIK-8241).
+#
+# The wide replacements are toDate32(...), toDateTime64(..., 0, 'UTC'), and for a week start the
+# partition key's own expression `toDate32(E) - toIntervalDay(toDayOfWeek(E, 1))` on BOTH operands.
+#
+# Why a lint and not only tests: the spans read paths carried the wrapping form for months with a
+# full partitioning suite passing, because the suite was written against the shape the DAO already
+# had. Tests cover the predicates that exist; the failure mode is a new time-bounded query copied
+# from a neighbouring one, and only a check on the text catches that.
+#
+# Scope is production code only — the hook's `files:` regex excludes test sources, where these
+# functions legitimately appear as the oracle a far-future test compares against.
+#
+# The rule matches where the query is DECLARED, not where it executes: Opik holds SQL in
+# `static final` text blocks rendered through StringTemplate, so call-site patterns match nothing.
+# `pattern: $X` binds every expression node and `metavariable-regex` then inspects the string
+# literal's own contents, text blocks included. Comments are never bound, so the javadoc in these
+# DAOs can keep naming `toMonday(id_at)` to explain why it is not used.
+#
+# Deliberately NOT guarded by a leading SELECT/WITH: two of the sites OPIK-8241 fixed were bare
+# expression strings passed as StringTemplate attributes, not whole statements, so requiring a
+# SQL keyword would have missed exactly the shape that is easiest to add by hand.
+#
+# Fixtures live in java-sql-narrow-datetime.java next to this file. Run them after any edit here:
+#   semgrep test --config .semgrep/java-sql-narrow-datetime.yaml .semgrep/java-sql-narrow-datetime.java
+rules:
+  - id: sql-narrow-datetime-on-id
+    languages: [java]
+    severity: ERROR
+    message: >-
+      This SQL applies a narrow-returning datetime function to a UUIDv7-derived value.
+      toMonday/toDate return a 16-bit Date (1970..2149) and toDateTime a 32-bit DateTime
+      (1970..2106), and all three wrap rather than saturate, so a far-future id folds into a
+      plausible recent date — silently dropping rows from time-bounded queries, or bucketing
+      them into the wrong period. Use toDate32(...) or toDateTime64(..., 0, 'UTC'); for a week
+      start use the partition key's own `toDate32(E) - toIntervalDay(toDayOfWeek(E, 1))` on BOTH
+      operands. See OPIK-8241.
+    patterns:
+      - pattern: $X
+      # `\(` immediately after the name is what separates the narrow functions from their wide
+      # counterparts: `toDate32(` cannot match `toDate\(`, nor `toDateTime64(` match `toDateTime\(`.
+      # The lookbehind stops a longer identifier ending in one of these names from matching.
+      #
+      # The optional qualifier admits `toMonday(t.id_at)`: these DAOs alias their tables, so the
+      # unqualified form alone would miss the most ordinary way of writing the same mistake. Two levels
+      # cover `db.table.column`. The trailing boundary keeps a longer identifier that merely ends in
+      # `id_at` from matching.
+      - metavariable-regex:
+          metavariable: $X
+          regex: (?s)^".*(?<![A-Za-z0-9_])to(?:Monday|DateTime|Date)\(\s*(?:[A-Za-z_][A-Za-z0-9_]*\.){0,2}(?:id_at|UUIDv7ToDateTime)(?![A-Za-z0-9_]).*"$

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/KpiCardDAO.java
@@ -202,8 +202,10 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id AND project_id = :project_id
                       AND id >= :uuid_from_time AND id \\<= :uuid_to_time
-                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
-                      AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
+                      AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                          >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))
+                      AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                          \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))
                       AND trace_id IN (SELECT id FROM traces_filtered)
                     GROUP BY trace_id
                 )
@@ -317,8 +319,10 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     AND workspace_id = :workspace_id
                     AND id >= :uuid_from_time
                     AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))
                     <if(span_filters)> AND <span_filters> <endif>
                     <if(span_feedback_scores_filters)>
                     AND id in (
@@ -512,8 +516,10 @@ class KpiCardDAOImpl implements KpiCardDAO {
                     FROM spans FINAL
                     WHERE workspace_id = :workspace_id AND project_id = :project_id
                       AND id >= :uuid_from_time AND id \\<= :uuid_to_time
-                      AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))
-                      AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))
+                      AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                          >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))
+                      AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                          \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))
                 ) s
                 JOIN traces_final tr ON s.trace_id = tr.id
                 GROUP BY tr.thread_id

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectMetricsDAO.java
@@ -482,7 +482,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -521,7 +521,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -551,9 +551,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                 ) s ON s.trace_id = t.id
             )
             SELECT <bucket> AS bucket,
@@ -563,10 +565,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
-            """.formatted(TRACE_FILTERED_PREFIX);
+            """
+            .formatted(TRACE_FILTERED_PREFIX);
 
     private static final String GET_COST_WITH_BREAKDOWN = """
             %s, spans_dedup AS (
@@ -583,9 +586,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                 ) s ON s.trace_id = t.id
             )
             SELECT <bucket> AS bucket,
@@ -595,7 +600,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             GROUP BY bucket, group_name
             ORDER BY bucket, group_name
             SETTINGS log_comment = '<log_comment>';
-            """.formatted(TRACE_FILTERED_PREFIX);
+            """
+            .formatted(TRACE_FILTERED_PREFIX);
 
     private static final String GET_TOKEN_USAGE = """
             %s, spans_dedup AS (
@@ -612,9 +618,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                 ) s ON s.trace_id = t.id
                 ARRAY JOIN mapKeys(usage) AS name, mapValues(usage) AS value
                 WHERE value > 0
@@ -627,10 +635,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY name, bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
-            """.formatted(TRACE_FILTERED_PREFIX);
+            """
+            .formatted(TRACE_FILTERED_PREFIX);
 
     private static final String GET_TOKEN_USAGE_WITH_BREAKDOWN = """
             %s, spans_dedup AS (
@@ -648,9 +657,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     AND workspace_id = :workspace_id
                     AND trace_id IN (SELECT id FROM traces_filtered)
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                 ) s ON s.trace_id = t.id
                 ARRAY JOIN mapKeys(usage) AS name, mapValues(usage) AS value
                 WHERE value > 0
@@ -663,7 +674,8 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             GROUP BY group_name, bucket
             ORDER BY group_name, bucket
             SETTINGS log_comment = '<log_comment>';
-            """.formatted(TRACE_FILTERED_PREFIX);
+            """
+            .formatted(TRACE_FILTERED_PREFIX);
 
     private static final String GET_FEEDBACK_SCORES = """
             %s, feedback_scores_deduplication AS (
@@ -681,7 +693,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY name, bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -716,7 +728,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -750,7 +762,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY name, bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -792,7 +804,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -831,7 +843,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -864,7 +876,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY name, bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -910,7 +922,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY name, bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
@@ -1005,7 +1017,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
@@ -1039,7 +1051,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
@@ -1078,7 +1090,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -1092,7 +1104,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(TRACE_FILTERED_PREFIX);
@@ -1106,7 +1118,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -1120,7 +1132,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -1134,7 +1146,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(SPAN_FILTERED_PREFIX);
@@ -1148,7 +1160,7 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
             """.formatted(THREAD_FILTERED_PREFIX);
@@ -1168,9 +1180,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     WHERE project_id = :project_id
                     AND workspace_id = :workspace_id
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                 ) s ON s.trace_id = tr.id
             )
             SELECT <bucket> AS bucket,
@@ -1180,10 +1194,11 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
             ORDER BY bucket
             <if(with_fill)>WITH FILL
                 FROM <fill_from>
-                TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                 STEP <step><endif>
             SETTINGS log_comment = '<log_comment>';
-            """.formatted(THREAD_FILTERED_PREFIX);
+            """
+            .formatted(THREAD_FILTERED_PREFIX);
 
     @Override
     public Mono<List<Entry>> getDuration(@NonNull UUID projectId, @NonNull ProjectMetricRequest request) {
@@ -1577,13 +1592,13 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                     userName, projectId.toString());
 
             if (isTotal) {
-                template.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");
+                template.add("bucket", "toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_from_time)), 0, 'UTC')");
             } else {
                 template.add("step", intervalToSql(request.interval()))
-                        .add("bucket", wrapWeekly(request.interval(),
+                        .add("bucket", pinBucket(
                                 "toStartOfInterval(%s, %s)".formatted(getTimeField(request.metricType()),
                                         intervalToSql(request.interval()))))
-                        .add("fill_from", wrapWeekly(request.interval(),
+                        .add("fill_from", pinBucket(
                                 "toStartOfInterval(UUIDv7ToDateTime(toUUID(:uuid_from_time)), %s)"
                                         .formatted(intervalToSql(request.interval()))));
             }
@@ -1795,12 +1810,25 @@ class ProjectMetricsDAOImpl implements ProjectMetricsDAO {
                 .build()));
     }
 
-    private String wrapWeekly(TimeInterval interval, String stmt) {
-        if (interval == TimeInterval.WEEKLY) {
-            return "toDateTime(%s)".formatted(stmt);
-        }
-
-        return stmt;
+    /**
+     * Pins a {@code WITH FILL} time expression to {@code DateTime64(0, 'UTC')}, so {@code bucket},
+     * {@code fill_from} and the {@code TO} clause share one width — ClickHouse rejects a {@code WITH FILL} whose
+     * three disagree (code 475), so they are pinned together or not at all.
+     * <p>
+     * Every interval needs it, unlike the {@code wrapWeekly} this replaces: that cast only the weekly bucket,
+     * because {@code toStartOfInterval} returns a {@code Date} for a week and a {@code DateTime} for a day or hour,
+     * and {@code DateTime} was what the old {@code TO} produced. {@code TO} is now
+     * {@code toDateTime64(UUIDv7ToDateTime(...), 0, 'UTC')} so a far-future bound cannot wrap, and <b>both</b>
+     * unpinned forms are rejected against it — a conditional pin fails every daily and hourly query.
+     * <p>
+     * This makes the fill frame width-consistent, not the bucket <em>value</em> honest: {@code toStartOfInterval}
+     * narrows internally, so a far-future id still buckets into a wrapped week and no outer cast recovers it.
+     * Closing that needs {@code enable_extended_results_for_datetime_functions} (OPIK-7770), which widens those
+     * returns. It is unreachable while the window has an upper bound, since the id-range then excludes far-future
+     * rows before bucketing — and {@code WITH FILL} is only emitted when it does.
+     */
+    private String pinBucket(String stmt) {
+        return "toDateTime64(%s, 0, 'UTC')".formatted(stmt);
     }
 
     private String intervalToSql(TimeInterval interval) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -853,10 +853,21 @@ public class SpanDAO {
      * immaterial since it is id-bounded and {@code LIMIT 1 BY id}. Field exclusion ({@code exclude_fields}) and
      * truncation are layered on top without dropping the sort key.
      * <p>
-     * Each {@code spans} id-range bound carries a parallel {@code toMonday(id_at)} bound: a strict consequence of the
+     * Each {@code spans} id-range bound carries a parallel week-start bound: a strict consequence of the
      * id-range — and, unlike a {@code created_at} predicate, safe against late-arriving rows since it derives from
      * {@code id} — that lets the planner prune partitions once {@code spans} is partitioned. The {@code page_wide}
      * re-read carries the same week bounds via the window it re-reads.
+     * <p>
+     * <b>Both</b> operands are the partition expression of 000115, {@code toDate32(E) -
+     * toIntervalDay(toDayOfWeek(E, 1))}, and never {@code toMonday(E)} (OPIK-8241): {@code toMonday} returns a 16-bit
+     * {@code Date} that wraps past 2149, folding a far-future week into a past one, so the bound would filter rather
+     * than prune. {@code Date32} saturates, and still prunes, being the key's own expression.
+     * <p>
+     * The <em>bound</em> side is what makes this reachable before the spans cutover, while {@code spans.id_at} is
+     * still a 32-bit {@code DateTime} (migration 000105): it reads the id directly, so it is honest on either schema.
+     * {@code :last_received_span_id} is a cursor lifted from a row this query returned, and far-future spans sort
+     * first under {@code ORDER BY id DESC}, so page two's cursor can be one. The <em>upper</em> bound is the damaging
+     * direction: every ordinary row has a later week, fails {@code <=}, and the page comes back empty.
      * <p>
      * When aggregates are enrichment-only ({@code page_keyed_aggregates}, see
      * {@code shouldPageKeyAggregates}), the feedback-score and comment CTEs are keyed on
@@ -872,11 +883,14 @@ public class SpanDAO {
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(last_received_span_id)> AND id \\< :last_received_span_id
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC'), 1))) <endif>
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1050,11 +1064,14 @@ public class SpanDAO {
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(last_received_span_id)> AND id \\< :last_received_span_id
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC'), 1))) <endif>
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1100,9 +1117,12 @@ public class SpanDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 AND id IN (SELECT id FROM page_ids)
-                <if(uuid_from_time)> AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
-                <if(uuid_to_time)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
-                <if(last_received_span_id)> AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) <endif>
+                <if(uuid_from_time)> AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                    >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
+                <if(uuid_to_time)> AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                    \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
+                <if(last_received_span_id)> AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                    \\<= (toDate32(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC'), 1))) <endif>
                 <if(stream)>
                 ORDER BY (workspace_id, project_id, id) DESC, last_updated_at DESC
                 <else>
@@ -1158,9 +1178,11 @@ public class SpanDAO {
                 WHERE workspace_id = :workspace_id
                 AND project_id = :project_id
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1243,9 +1265,11 @@ public class SpanDAO {
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1284,8 +1308,9 @@ public class SpanDAO {
      * <p>
      * Filters on {@code trace_id} only. Unlike {@code TraceDAO}, the spans retention range is keyed on
      * {@code trace_id} while the future partition column {@code id_at} is MATERIALIZED from the span's own UUIDv7 id
-     * (migration 000105). A span's id can land in a later week than its {@code trace_id}, so a {@code toMonday(id_at)}
-     * bound derived from the trace-id range would wrongly exclude valid candidates. No partition-pruning predicate is
+     * (migration 000105). A span's id can land in a later week than its {@code trace_id}, so a week bound on
+     * {@code id_at} derived from the trace-id range would wrongly exclude valid candidates — whatever the
+     * expression's width, since the objection is which column the range keys on. No partition-pruning predicate is
      * applied here until {@code spans} can be pruned by a column aligned with {@code trace_id}.
      */
     private static final String DELETE_FOR_RETENTION = """
@@ -1464,9 +1489,11 @@ public class SpanDAO {
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>
@@ -1608,9 +1635,11 @@ public class SpanDAO {
                 WHERE project_id = :project_id
                 AND workspace_id = :workspace_id
                 <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1))) <endif>
                 <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) <endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1))) <endif>
                 <if(trace_id)> AND trace_id = :trace_id <endif>
                 <if(type)> AND type = :type <endif>
                 <if(filters)> AND <filters> <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanDAO.java
@@ -869,6 +869,19 @@ public class SpanDAO {
      * first under {@code ORDER BY id DESC}, so page two's cursor can be one. The <em>upper</em> bound is the damaging
      * direction: every ordinary row has a later week, fails {@code <=}, and the page comes back empty.
      * <p>
+     * <b>The column side is only honest on the partitioned successor, which leaves one accepted residual</b> — the
+     * same one traces carries (see {@code TraceDAO.SELECT_BY_PROJECT_ID}). On the pre-cutover table {@code id_at} has
+     * already truncated a far-future timestamp into a plausible year, and no read predicate can recover the honest
+     * week from it, so a far-future <em>lower</em> bound admits nothing there. {@code toMonday} passed that case only
+     * incidentally, both sides having wrapped into agreement.
+     * <p>
+     * It is accepted rather than fixed. Reaching it needs a caller supplying a {@code startTime} beyond 2106, which
+     * the UI cannot produce, and it is not the cursor shape — a cursor is an upper bound, where this form is the
+     * better one. It changes only whether far-future rows are visible, never ordinary ones, and it resolves at the
+     * cutover, when {@code id_at} becomes honest. Deriving each bound as a union over both {@code id_at} widths
+     * instead — what {@code WeeklyPartitions} does for mutations — was rejected as disproportionate: it would touch
+     * every predicate here to buy a case no real client reaches.
+     * <p>
      * When aggregates are enrichment-only ({@code page_keyed_aggregates}, see
      * {@code shouldPageKeyAggregates}), the feedback-score and comment CTEs are keyed on
      * {@code IN (SELECT arrayJoin((SELECT groupArray(id) FROM page_ids)))} instead of

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/SpanMetricsQueries.java
@@ -6,9 +6,11 @@ package com.comet.opik.domain;
  * aggregation; the only difference is the project predicate, which each DAO selects by setting the matching
  * StringTemplate flag, so both DAOs stay in sync when the CTE changes.
  * <p>
- * Each {@code id}-range bound on the {@code spans} scan carries a parallel {@code toMonday(id_at)} bound: a strict
+ * Each {@code id}-range bound on the {@code spans} scan carries a parallel week-start bound on {@code id_at}: a strict
  * consequence of the id-range that scans the same rows but engages weekly-partition pruning once {@code spans} is
- * partitioned, which the planner can't infer through {@code UUIDv7ToDateTime}.
+ * partitioned, which the planner can't infer through {@code UUIDv7ToDateTime}. Both operands are the partition key's
+ * own {@code toDate32(E) - toIntervalDay(toDayOfWeek(E, 1))} and never {@code toMonday(E)}, which wraps past 2149 and
+ * would turn the hint into a filter — see {@code SpanDAO.SELECT_BY_PROJECT_ID} (OPIK-8241).
  */
 final class SpanMetricsQueries {
 
@@ -124,9 +126,11 @@ final class SpanMetricsQueries {
                     WHERE workspace_id = :workspace_id
                     AND project_id IN :project_ids
                     <if(uuid_from_time)> AND id >= :uuid_from_time
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        >= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_from_time), 'UTC'), 1)))<endif>
                     <if(uuid_to_time)> AND id \\<= :uuid_to_time
-                    AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'))<endif>
+                    AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                        \\<= (toDate32(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:uuid_to_time), 'UTC'), 1)))<endif>
                     <if(span_filters)> AND <span_filters> <endif>
                     <if(span_feedback_scores_filters)>
                     AND id in (

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1990,19 +1990,29 @@ class TraceDAOImpl implements TraceDAO {
     /**
      * Retention sweep for the applyToPast=true window {@code [lower_bound, cutoff_id)}.
      * <p>
-     * {@code toMonday(id_at)} is the future weekly partition expression ({@code id_at} is MATERIALIZED from
-     * the UUIDv7 id as UTC). Bounding it to the cutoff's week range never excludes a row the id-range would
-     * delete, so it does not change which rows are deleted; once {@code traces} is partitioned (OPIK-6900) it
-     * lets the sweep prune to the partitions in range. The bounds use UTC to match {@code id_at}, and the
-     * upper bound advances one week so rows sharing the cutoff's week stay in scope.
+     * {@code toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1))} is the weekly partition expression of 000114
+     * ({@code id_at} is MATERIALIZED from the UUIDv7 id as UTC). Bounding it to the cutoff's week range never
+     * excludes a row the id-range would delete, so it does not change which rows are deleted; once {@code traces} is
+     * partitioned (OPIK-6900) it lets the sweep prune to the partitions in range. The bounds use UTC to match
+     * {@code id_at}, and the upper bound advances one week so rows sharing the cutoff's week stay in scope.
+     * <p>
+     * Both operands use that expression rather than {@code toMonday}, which wraps past 2149 (OPIK-8241). The two
+     * agree here — the sweep is ANDed with {@code id \\< :cutoff_id}, whose cutoff comes from retention config, so
+     * every admitted row is well inside {@code toMonday}'s range — and it is converted so the wrapping form is left
+     * nowhere in this DAO to be copied from.
+     * <p>
+     * A consequence of keying retention on the id range, unchanged either way: a far-future row is never inside a
+     * retention window, so retention does not reclaim those rows.
      */
     private static final String DELETE_FOR_RETENTION = """
             DELETE FROM <traces_mutation_table>
             WHERE workspace_id IN :workspace_ids
             AND id >= :lower_bound
             AND id \\< :cutoff_id
-            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC'))
-            AND toMonday(id_at) \\< addWeeks(toMonday(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')), 1)
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                >= (toDate32(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC'), 1)))
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                \\< addWeeks(toDate32(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC'), 1)), 1)
             AND id NOT IN (
                 SELECT trace_id FROM experiment_items
                 WHERE workspace_id IN :workspace_ids
@@ -2017,9 +2027,9 @@ class TraceDAOImpl implements TraceDAO {
      * The per-workspace bounded counterpart of {@link #DELETE_FOR_RETENTION}: each workspace carries its own
      * {@code id} floor, so the windows are OR-ed rather than sharing one {@code :lower_bound}.
      * <p>
-     * The {@code toMonday(id_at)} week bounds use the global {@code :min_lower_bound}, which is {@code <=} every
-     * per-workspace {@code :lb_i}, so the single floor never excludes a row that any per-workspace id-range would
-     * delete. UTC matches {@code id_at}.
+     * The week bounds use the global {@code :min_lower_bound}, which is {@code <=} every per-workspace
+     * {@code :lb_i}, so the single floor never excludes a row that any per-workspace id-range would delete. UTC
+     * matches {@code id_at}, and both operands are the Date32 week expression as in {@link #DELETE_FOR_RETENTION}.
      * <p>
      * The OR-ed predicates are a template loop over {@code getQueryItemPlaceHolder}, matching {@code BATCH_INSERT} and
      * the other variable-arity queries in this DAO, so the query text is declared once and every value is bound. It was
@@ -2034,8 +2044,10 @@ class TraceDAOImpl implements TraceDAO {
                     <if(item.hasNext)>OR<endif>
                 }>
             )
-            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:min_lower_bound), 'UTC'))
-            AND toMonday(id_at) \\< addWeeks(toMonday(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')), 1)
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                >= (toDate32(UUIDv7ToDateTime(toUUID(:min_lower_bound), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:min_lower_bound), 'UTC'), 1)))
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                \\< addWeeks(toDate32(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC'), 1)), 1)
             AND id NOT IN (
                 SELECT trace_id FROM experiment_items
                 WHERE workspace_id IN :workspace_ids_flat
@@ -2049,32 +2061,44 @@ class TraceDAOImpl implements TraceDAO {
     /**
      * Lightweight pre-delete count for observability. Omits the {@code experiment_items} exclusion subquery
      * to avoid the join cost, making it an upper-bound ceiling with &gt;99% precision in practice (very few
-     * traces are linked to experiments). Carries the same {@code toMonday(id_at)} week bounds as
-     * {@code DELETE_FOR_RETENTION} so the count prunes to the same partitions post-cutover rather than
-     * scanning (and loading cold-tier marks for) every partition each cycle.
+     * traces are linked to experiments). Carries the same Date32 week bounds as {@code DELETE_FOR_RETENTION} so the
+     * count prunes to the same partitions post-cutover rather than scanning (and loading cold-tier marks for) every
+     * partition each cycle.
      */
     private static final String COUNT_FOR_RETENTION = """
             SELECT count() FROM traces
             WHERE workspace_id IN :workspace_ids
             AND id >= :lower_bound
             AND id \\< :cutoff_id
-            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC'))
-            AND toMonday(id_at) \\< addWeeks(toMonday(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')), 1)
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                >= (toDate32(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:lower_bound), 'UTC'), 1)))
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                \\< addWeeks(toDate32(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:cutoff_id), 'UTC'), 1)), 1)
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
     /**
-     * The {@code toMonday(id_at)} bounds mirror the {@code [range_start, range_end)} id-range: a strict consequence
-     * that doesn't change which rows are scanned but engages partition pruning once {@code traces} is partitioned.
+     * The week bounds mirror the {@code [range_start, range_end)} id-range: a strict consequence that doesn't change
+     * which rows are scanned but engages partition pruning once {@code traces} is partitioned. Both operands are the
+     * Date32 week expression, as in {@link #DELETE_FOR_RETENTION}.
+     * <p>
+     * The projected {@code day} is {@code toDate32}, not {@code toDate}: a 16-bit {@code Date} wraps past 2149, so a
+     * far-future id would report an ordinary-looking day and, being the {@code ORDER BY day LIMIT 1} winner, could
+     * name a first-day-with-data that no row is actually in. Latent today rather than reachable — the id-range above
+     * derives from retention config and so admits nothing far-future before the projection sees it — and converted
+     * because {@code toDate} is not among the functions OPIK-7770's global setting widens, so this site would
+     * otherwise survive that change too.
      */
     private static final String SCOUT_FIRST_DAY_WITH_DATA = """
-            SELECT toDate(UUIDv7ToDateTime(toUUID(id))) AS day
+            SELECT toDate32(UUIDv7ToDateTime(toUUID(id))) AS day
             FROM traces
             WHERE workspace_id = :workspace_id
             AND id >= :range_start AND id \\< :range_end
-            AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:range_start), 'UTC'))
-            AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:range_end), 'UTC'))
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                >= (toDate32(UUIDv7ToDateTime(toUUID(:range_start), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:range_start), 'UTC'), 1)))
+            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                \\<= (toDate32(UUIDv7ToDateTime(toUUID(:range_end), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:range_end), 'UTC'), 1)))
             GROUP BY day
             ORDER BY day
             LIMIT 1
@@ -2341,12 +2365,20 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
-    // Split-A: traces + spans aggregation. All feedback-score CTEs stay so the existing
-    // feedback_scores_filters / span_feedback_scores_filters / *_empty_filters slots inside
-    // trace_final still resolve. The feedback_scores_agg and span_feedback_scores_agg CTEs
-    // are no longer referenced by the final SELECT and CH prunes them; the per-trace feedback
-    // aggregates are produced in parallel by SELECT_FEEDBACK_SCORES_STATS and merged by
-    // StatsMerger.
+    /**
+     * Split-A: traces + spans aggregation. All feedback-score CTEs stay so the existing
+     * {@code feedback_scores_filters} / {@code span_feedback_scores_filters} / {@code *_empty_filters} slots inside
+     * {@code trace_final} still resolve. The {@code feedback_scores_agg} and {@code span_feedback_scores_agg} CTEs
+     * are no longer referenced by the final SELECT and CH prunes them; the per-trace feedback aggregates are produced
+     * in parallel by {@code SELECT_FEEDBACK_SCORES_STATS} and merged by {@code StatsMerger}.
+     * <p>
+     * The {@code project_stats} arm derives each trace's event time as
+     * {@code toDateTime64(UUIDv7ToDateTime(toUUID(t.id)), 0, 'UTC')} and never {@code toDateTime(...)} (OPIK-8241),
+     * which narrows to a 32-bit {@code DateTime} and wraps modulo 2<sup>32</sup> seconds: a trace dated circa 2162
+     * folded into the current week and counted as a recent error. Unlike the week bounds elsewhere in this DAO this
+     * is not a pruning hint a wider id-range could recover — the expression <em>is</em> the bucketing decision, and
+     * it reads {@code t.id} directly, so it was wrong on both schemas.
+     */
     private static final String SELECT_TRACES_SPANS_STATS = """
              WITH spans_data AS (
                 SELECT
@@ -2762,8 +2794,8 @@ class TraceDAOImpl implements TraceDAO {
                 toDecimal128(total_estimated_cost_sum_, 12) AS total_estimated_cost_sum,
                 sum(g.failed_count) AS guardrails_failed_count,
                 <if(project_stats)>
-                countIf(t.error_info != '' AND toDateTime(UUIDv7ToDateTime(toUUID(t.id))) BETWEEN toStartOfDay(subtractDays(now(), 7)) AND now64(9)) AS recent_error_count,
-                countIf(t.error_info != '' AND toDateTime(UUIDv7ToDateTime(toUUID(t.id))) \\< toStartOfDay(subtractDays(now(), 7))) AS past_period_error_count
+                countIf(t.error_info != '' AND toDateTime64(UUIDv7ToDateTime(toUUID(t.id)), 0, 'UTC') BETWEEN toStartOfDay(subtractDays(now(), 7)) AND now64(9)) AS recent_error_count,
+                countIf(t.error_info != '' AND toDateTime64(UUIDv7ToDateTime(toUUID(t.id)), 0, 'UTC') \\< toStartOfDay(subtractDays(now(), 7))) AS past_period_error_count
                 <else>
                 countIf(t.error_info, t.error_info != '') AS error_count
                 <endif>

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/WorkspaceMetricsDAO.java
@@ -113,8 +113,10 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
             WHERE workspace_id = :workspace_id
                 <if(project_ids)> AND project_id IN :project_ids <endif>
                 AND id BETWEEN :id_prior_start AND :id_end
-                AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'))
-                AND toMonday(id_at) \\<= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
+                AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                    >= (toDate32(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_prior_start), 'UTC'), 1)))
+                AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                    \\<= (toDate32(UUIDv7ToDateTime(toUUID(:id_end), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'), 1)))
                 AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_prior_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9);
             """;
 
@@ -203,8 +205,10 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 WHERE workspace_id = :workspace_id
                   AND project_id IN :project_ids
                   AND id BETWEEN :id_start AND :id_end
-                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
-                  AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
+                  AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                      >= (toDate32(UUIDv7ToDateTime(toUUID(:id_start), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'), 1)))
+                  AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                      <= (toDate32(UUIDv7ToDateTime(toUUID(:id_end), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'), 1)))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 GROUP BY project_id, bucket
                 ORDER BY project_id, bucket
@@ -229,8 +233,10 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 FROM spans final
                 WHERE workspace_id = :workspace_id
                   AND id BETWEEN :id_start AND :id_end
-                  AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'))
-                  AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'))
+                  AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                      >= (toDate32(UUIDv7ToDateTime(toUUID(:id_start), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_start), 'UTC'), 1)))
+                  AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                      <= (toDate32(UUIDv7ToDateTime(toUUID(:id_end), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_end), 'UTC'), 1)))
                   AND start_time BETWEEN parseDateTime64BestEffort(:timestamp_start, 9) AND parseDateTime64BestEffort(:timestamp_end, 9)
                 GROUP BY bucket
                 ORDER BY bucket
@@ -273,7 +279,7 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                 ORDER BY name, bucket
                 <if(with_fill)>WITH FILL
                     FROM <fill_from>
-                    TO toDateTime(UUIDv7ToDateTime(toUUID(:uuid_to_time)))
+                    TO toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_to_time)), 0, 'UTC')
                     STEP <step><endif>
             )
             SELECT NULL AS project_id,
@@ -414,12 +420,12 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
                     userName, request.projectIds().size());
 
             if (isTotal) {
-                stTemplate.add("bucket", "toDateTime(UUIDv7ToDateTime(toUUID(:uuid_from_time)))");
+                stTemplate.add("bucket", "toDateTime64(UUIDv7ToDateTime(toUUID(:uuid_from_time)), 0, 'UTC')");
             } else {
                 stTemplate.add("step", intervalToSql(interval))
-                        .add("bucket", wrapWeekly(interval,
+                        .add("bucket", pinBucket(
                                 "toStartOfInterval(span_time, %s)".formatted(intervalToSql(interval))))
-                        .add("fill_from", wrapWeekly(interval,
+                        .add("fill_from", pinBucket(
                                 "toStartOfInterval(UUIDv7ToDateTime(toUUID(:uuid_from_time)), %s)"
                                         .formatted(intervalToSql(interval))));
             }
@@ -469,11 +475,14 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
         });
     }
 
-    private String wrapWeekly(TimeInterval interval, String stmt) {
-        if (interval == TimeInterval.WEEKLY) {
-            return "toDateTime(%s)".formatted(stmt);
-        }
-        return stmt;
+    /**
+     * Pins a {@code WITH FILL} time expression to {@code DateTime64(0, 'UTC')}, so {@code bucket},
+     * {@code fill_from} and the {@code TO} clause share one width; ClickHouse rejects a {@code WITH FILL} whose
+     * three disagree (code 475). See {@code ProjectMetricsDAO.pinBucket} for why every interval needs it, and for
+     * what it does <em>not</em> fix.
+     */
+    private String pinBucket(String stmt) {
+        return "toDateTime64(%s, 0, 'UTC')".formatted(stmt);
     }
 
     private String intervalToSql(TimeInterval interval) {
@@ -579,8 +588,12 @@ class WorkspaceMetricsDAOImpl implements WorkspaceMetricsDAO {
         return dataItems.isEmpty() ? null : dataItems;
     }
 
-    // Bucket timestamps come back as OffsetDateTime for DateTime64 columns (e.g. the cost query's start_time) but as
-    // LocalDateTime for plain DateTime expressions (e.g. UUIDv7ToDateTime-derived span_time). Both represent UTC.
+    /**
+     * Both bucket shapes this DAO produces, read as one {@code Instant}: the span-metric buckets are
+     * {@code DateTime64} — {@link #pinBucket} casts them — and arrive as {@code OffsetDateTime}, while the daily
+     * cost and feedback buckets are a bare {@code toStartOfInterval} and arrive as {@code LocalDateTime}. Both
+     * represent UTC.
+     */
     private Instant toInstant(Object bucket) {
         return switch (bucket) {
             case OffsetDateTime offsetDateTime -> offsetDateTime.toInstant();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceDBUtils.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/traces/TraceDBUtils.java
@@ -2,6 +2,7 @@ package com.comet.opik.api.resources.utils.traces;
 
 import com.comet.opik.api.Trace;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
+import com.comet.opik.utils.JsonUtils;
 import io.r2dbc.spi.Result;
 import io.r2dbc.spi.Statement;
 import org.apache.commons.lang3.StringUtils;
@@ -28,7 +29,8 @@ public class TraceDBUtils {
                     created_by,
                     last_updated_by,
                     thread_id,
-                    environment
+                    environment,
+                    error_info
                 )
                 SELECT
                     :id,
@@ -46,7 +48,8 @@ public class TraceDBUtils {
                     if(:created_by IS NULL, toString(generateUUIDv4()), :created_by),
                     if(:last_updated_by IS NULL, toString(generateUUIDv4()), :last_updated_by),
                     :thread_id,
-                    :environment
+                    :environment,
+                    :error_info
                 ;
                 """;
         templateAsync.nonTransaction(connection -> {
@@ -62,7 +65,12 @@ public class TraceDBUtils {
                     .bind("metadata", trace.metadata().toString())
                     .bind("tags", trace.tags().toArray())
                     .bind("thread_id", trace.threadId())
-                    .bind("environment", StringUtils.defaultString(trace.environment()));
+                    .bind("environment", StringUtils.defaultString(trace.environment()))
+                    // The DDL default is '', which is also how the read path spells "no error", so a null ErrorInfo
+                    // must bind '' rather than SQL NULL — error_info is not Nullable.
+                    .bind("error_info", trace.errorInfo() == null
+                            ? ""
+                            : JsonUtils.readTree(trace.errorInfo()).toString());
 
             if (trace.createdAt() != null) {
                 statement.bind("created_at", trace.createdAt().toString());

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/FindSpansResourceTest.java
@@ -1124,6 +1124,54 @@ class FindSpansResourceTest {
             assertSpan(actualSpans, expectedSpans, USER);
         }
 
+        /**
+         * The cursor is whatever id the previous page ended on, so it can carry a far-future timestamp: a UUIDv7
+         * minted by a broken clock (litellm BerriAI/litellm#31294) sorts above every real id, so it comes back first
+         * under {@code ORDER BY id DESC} and becomes the cursor for page two.
+         *
+         * <p>Each id-range bound in the read path carries a parallel week-start bound on {@code id_at}, a pruning hint
+         * that must never exclude a row the id-range admits. When that bound was {@code toMonday} it broke exactly
+         * here (OPIK-8241): a far-future cursor folded into a past week and every ordinary span — whose week is later
+         * — failed {@code <=}, so the page came back empty and pagination stopped dead.
+         *
+         * <p>This reaches the <b>legacy</b> {@code spans} table, the default topology of this suite and of any install
+         * that has not cut over, because the wrap is on the <b>bound</b> side, which reads the id directly and is
+         * honest whatever width {@code spans.id_at} has. No far-future span is needed — {@code lastRetrievedId} is an
+         * unvalidated cursor on the request, so ingestion, which would reject such an id, is not involved.
+         */
+        @Test
+        void searchSpansStream__whenCursorCarriesAFarFutureTimestamp__thenSpansAreStillReturned() {
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "workspace-" + RandomStringUtils.secure().nextAlphanumeric(32);
+            var workspaceId = UUID.randomUUID().toString();
+            var projectName = RandomStringUtils.secure().nextAlphanumeric(32);
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var spans = PodamFactoryUtils.manufacturePojoList(podamFactory, Span.class)
+                    .stream()
+                    .map(span -> span.toBuilder()
+                            .projectName(projectName)
+                            .feedbackScores(null)
+                            .duration(DurationUtils.getDurationInMillisWithSubMilliPrecision(
+                                    span.startTime(), span.endTime()))
+                            .build())
+                    .sorted(Comparator.comparing(Span::id).reversed())
+                    .toList();
+            spanResourceClient.batchCreateSpans(spans, apiKey, workspaceName);
+
+            // Sorts above every seeded id, so `id < :cursor` admits all of them and only the week bound can drop them.
+            var farFutureCursor = idGenerator.generateId(Instant.parse("2201-06-01T00:00:00Z"));
+
+            var streamRequest = SpanSearchStreamRequest.builder()
+                    .projectName(projectName)
+                    .lastRetrievedId(farFutureCursor)
+                    .limit(spans.size())
+                    .build();
+            var actualSpans = spanResourceClient.getStreamAndAssertContent(apiKey, workspaceName, streamRequest);
+
+            assertSpan(actualSpans, spans, USER);
+        }
+
         @ParameterizedTest
         @MethodSource("getFilterTestArguments")
         void whenFilterIdAndNameEqual__thenReturnSpansFiltered(String endpoint, SpanPageTestAssertion testAssertion) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -41,6 +41,7 @@ import com.comet.opik.api.resources.utils.resources.GuardrailsResourceClient;
 import com.comet.opik.api.resources.utils.resources.ProjectResourceClient;
 import com.comet.opik.api.resources.utils.resources.SpanResourceClient;
 import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
+import com.comet.opik.api.resources.utils.traces.TraceDBUtils;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
@@ -57,6 +58,7 @@ import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.DatabaseAnalyticsFactory;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.auth.WorkspaceUserPermission;
+import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
 import com.comet.opik.podam.PodamFactoryUtils;
 import com.comet.opik.utils.JsonUtils;
 import com.comet.opik.utils.ValidationUtils;
@@ -2387,6 +2389,65 @@ class ProjectsResourceTest {
                     .projectName(projectName)
                     .id(idGenerator.generateId(idInstant))
                     .build();
+        }
+
+        /**
+         * The project-stats arm buckets errors by each trace's own event time, derived from its UUIDv7 id. That
+         * derivation was {@code toDateTime(UUIDv7ToDateTime(toUUID(t.id)))}, which narrows to a 32-bit
+         * {@code DateTime} and wraps modulo 2<sup>32</sup> seconds, so a trace dated circa 2162 read as circa 2026 and
+         * was counted in {@code recent_error_count} — inflating a project's recent-error stat, and its deviation, with
+         * an error that has not happened.
+         * <p>
+         * Pinned through the stats API rather than at the DAO, since {@code recent_error_count} is folded into
+         * {@link ErrorCountWithDeviation} by {@code StatsMapper} before anything else can observe it. The far-future
+         * trace is inserted straight into ClickHouse because ingestion validates a UUIDv7's embedded timestamp against
+         * a 24h window (OPIK-6888) and would reject it.
+         * <p>
+         * The expectation covers the whole summary, over every seeded trace: a far-future trace is still a trace, so
+         * it belongs in {@code traceCount} and in the duration quantiles, and only its error bucketing is special. The
+         * shared oracle already derives that correctly — it classifies by the id's own instant, which falls in neither
+         * window — so passing it the full list states the property rather than restating the arithmetic. The two
+         * follow-up assertions name it independently of the oracle, so the two cannot drift into agreement.
+         */
+        @Test
+        @DisplayName("when a trace's id carries a far-future timestamp, then it is counted in neither error period")
+        void getProjectStats__whenTraceIdIsFarFuture__thenItCountsAsNeitherRecentNorPastError(
+                TransactionTemplateAsync templateAsync) {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var project = factory.manufacturePojo(Project.class);
+            var projectId = createProject(project, apiKey, workspaceName);
+
+            var ordinaryTraces = createTracesWithSpecificErrors(project.name(), workspaceName, apiKey,
+                    PodamUtils.getIntegerInRange(1, 5), PodamUtils.getIntegerInRange(1, 5));
+
+            // 2162-10-08 sits in the band toDateTime folds into the current week — the whole point of the case.
+            var farFutureTrace = createTraceWithError(project.name(), Instant.now())
+                    .toBuilder()
+                    .id(idGenerator.generateId(Instant.parse("2162-10-08T23:40:56Z")))
+                    .projectId(projectId)
+                    .createdBy(USER)
+                    .lastUpdatedBy(USER)
+                    .build();
+            TraceDBUtils.createTraceViaDB(farFutureTrace, workspaceId, templateAsync);
+
+            var allTraces = Stream.concat(ordinaryTraces.stream(), Stream.of(farFutureTrace)).toList();
+            var expectedProjectsSummary = List.of(
+                    mapFromProjectToSummary(
+                            createProjectSummary(project.toBuilder().id(projectId).build(), allTraces), allTraces));
+
+            var actualProjectsSummary = projectResourceClient.getProjectStatsSummary(project.name(), apiKey,
+                    workspaceName);
+
+            assertSummaryResponse(actualProjectsSummary, expectedProjectsSummary);
+
+            var actualItem = actualProjectsSummary.content().getFirst();
+            assertThat(actualItem.traceCount()).isEqualTo(allTraces.size());
+            assertThat(actualItem.errorCount().count()).isEqualTo(ordinaryTraces.size());
         }
 
         private void assertSummaryResponse(ProjectStatsSummary actualProjectsSummary,

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspacesResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/WorkspacesResourceTest.java
@@ -108,6 +108,9 @@ class WorkspacesResourceTest {
     private static final String WORKSPACE_ID = UUID.randomUUID().toString();
     private static final String WORKSPACE_NAME = RandomStringUtils.randomAlphabetic(10);
 
+    /** Usage every span from {@link #createSpansWithUsage} carries, so a total can be asserted exactly. */
+    private static final int TOKENS_PER_SPAN = 10;
+
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER_CONTAINER = ClickHouseContainerUtils.newZookeeperContainer();
     private final ClickHouseContainer CLICKHOUSE_CONTAINER = ClickHouseContainerUtils
@@ -644,6 +647,38 @@ class WorkspacesResourceTest {
             assertSeriesMatch(seriesFromWorkspace(all.results()), seriesFromWorkspace(selected.results()));
         }
 
+        /**
+         * Every interval the endpoint accepts, because each renders a different bucket expression and ClickHouse
+         * rejects a {@code WITH FILL} whose bucket, {@code FROM} and {@code TO} disagree in width (code 475).
+         * {@code HOURLY} — the only interval the rest of this class uses — cannot detect that on its own:
+         * {@code toStartOfInterval} returns a {@code Date} for {@code WEEKLY} where it returns a {@code DateTime} for
+         * the other two, and {@code TOTAL} emits no {@code WITH FILL} at all, so only running all four reaches every
+         * branch of the bucket pinning (OPIK-8241).
+         *
+         * <p>The token total does not depend on how the window is bucketed, so one expectation covers every interval.
+         */
+        @ParameterizedTest
+        @EnumSource(TimeInterval.class)
+        void spanTokenUsage_totalIsIndependentOfTheInterval(TimeInterval interval) {
+            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, UUID.randomUUID().toString());
+
+            var projectName = RandomStringUtils.randomAlphabetic(10);
+            projectResourceClient.createProject(projectName, apiKey, workspaceName);
+            var spans = createSpansWithUsage(projectName, apiKey, workspaceName, Instant.now(), "completion_tokens",
+                    List.of("openai", "anthropic", "openai"));
+
+            var endTime = Instant.now();
+            var startTime = endTime.minus(Duration.ofDays(1));
+
+            var actual = workspaceResourceClient.getWorkspaceSpanMetric(
+                    spanRequest(MetricType.SPAN_TOKEN_USAGE, null, startTime, endTime, null, interval),
+                    apiKey, workspaceName);
+
+            assertThat(sumValues(actual.results())).isEqualTo(spans.size() * TOKENS_PER_SPAN);
+        }
+
         @Test
         void allProjects_returnsEmpty_whenWorkspaceHasNoData() {
             var workspaceName = UUID.randomUUID().toString();
@@ -953,9 +988,14 @@ class WorkspacesResourceTest {
 
     private WorkspaceSpanMetricRequest spanRequest(MetricType metricType, Set<UUID> projectIds, Instant startTime,
             Instant endTime, BreakdownConfig breakdown) {
+        return spanRequest(metricType, projectIds, startTime, endTime, breakdown, TimeInterval.HOURLY);
+    }
+
+    private WorkspaceSpanMetricRequest spanRequest(MetricType metricType, Set<UUID> projectIds, Instant startTime,
+            Instant endTime, BreakdownConfig breakdown, TimeInterval interval) {
         return WorkspaceSpanMetricRequest.builder()
                 .metricType(metricType)
-                .interval(TimeInterval.HOURLY)
+                .interval(interval)
                 .intervalStart(startTime)
                 .intervalEnd(endTime)
                 .projectIds(projectIds)
@@ -1012,7 +1052,7 @@ class WorkspacesResourceTest {
                         .projectId(null)
                         .projectName(projectName)
                         .provider(provider)
-                        .usage(Map.of(usageKey, 10))
+                        .usage(Map.of(usageKey, TOKENS_PER_SPAN))
                         .feedbackScores(null)
                         .build())
                 .toList();

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/retention/RetentionPolicyServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/retention/RetentionPolicyServiceTest.java
@@ -17,6 +17,7 @@ import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.retention.RetentionPeriod;
 import com.comet.opik.domain.IdGenerator;
 import com.comet.opik.domain.SpanType;
+import com.comet.opik.domain.TraceDAO;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -331,9 +332,9 @@ class RetentionPolicyServiceTest {
             var rule = retentionClient.buildWorkspaceRule(RetentionPeriod.BASE_60D).build();
             retentionClient.createAndGet(rule, API_KEY, wsName);
 
-            // Pin the cutoff to cutoffDay so a row one day older shares its ISO week (same Monday). This
-            // exercises the upper bound toMonday(id_at) < addWeeks(toMonday(cutoff), 1): the row must still be
-            // deleted regardless of where in the week the cutoff lands.
+            // Pin the cutoff to cutoffDay so a row one day older shares its ISO week (same Monday). This exercises
+            // the sweep's upper week bound — the Date32 week of id_at below addWeeks(the cutoff's Date32 week, 1) —
+            // so the row must still be deleted regardless of where in the week the cutoff lands.
             var cutoffDate = LocalDate.now(ZoneOffset.UTC).minusDays(90)
                     .with(TemporalAdjusters.previousOrSame(cutoffDay));
             var now = cutoffDate.plusDays(RetentionPeriod.BASE_60D.getDays())
@@ -364,9 +365,10 @@ class RetentionPolicyServiceTest {
         /**
          * Drives a full retention cycle and asserts a span whose own {@code id} is a much later ISO week than its
          * {@code trace_id} is still deleted — purely on {@code trace_id}. The span's {@code id} (and thus the future
-         * partition column {@code id_at}) is client-assigned and can lag its {@code trace_id}'s week, which is why the
-         * retention paths carry no {@code toMonday(id_at)} bound. This test would fail if such a bound were
-         * reintroduced, since it would exclude the late-id span from the sweep.
+         * partition column {@code id_at}) is client-assigned and can lag its {@code trace_id}'s week, which is why
+         * {@code SpanDAO}'s retention paths carry no week bound on {@code id_at} at all — whatever the expression's
+         * width, since the objection is which column the sweep's range keys on. This test fails if one is introduced,
+         * since it would exclude the late-id span from the sweep.
          */
         @Test
         @DisplayName("Retention cycle deletes a span whose id is a later week than its trace_id")
@@ -381,7 +383,7 @@ class RetentionPolicyServiceTest {
             Instant now = Instant.now();
 
             // Deletable: trace_id 61d old (past the 60d cutoff, inside the sliding window), but the span's own id is
-            // only 5d old — a much later ISO week, the case a toMonday(id_at) upper bound would have excluded.
+            // only 5d old — a much later ISO week, the case an upper week bound on id_at would have excluded.
             var oldTraceId = idGenerator.generateId(now.minus(61, ChronoUnit.DAYS));
             var lateSpanId = idGenerator.generateId(now.minus(5, ChronoUnit.DAYS));
             createTestTrace(oldTraceId, API_KEY, wsName);
@@ -654,6 +656,76 @@ class RetentionPolicyServiceTest {
             assertThat(updated.catchUpCursor()).isNull();
         }
 
+    }
+
+    /**
+     * {@code SCOUT_FIRST_DAY_WITH_DATA} against a real ClickHouse. Its only production caller is
+     * {@code RetentionEstimationService.scoutFirstDataCursor}, reached solely when the full estimation query throws
+     * TOO_MANY_ROWS — which the suite exercises with a mocked {@code TraceDAO}, because the row-limit profile that
+     * provokes it also blocks the INSERTs the fixture needs. So the statement had no coverage, and neither thing
+     * OPIK-8241 changed about it is one a mock can catch:
+     *
+     * <ul>
+     *   <li>the projected {@code day} became {@code toDate32(...)}, which has to keep binding into the
+     *   {@code LocalDate} the DAO reads it as;</li>
+     *   <li>the week bounds became the {@code Date32} expression on both operands, and one that over-restricts here
+     *   fails silently — it reports a later first day, moving the catch-up cursor past real data.</li>
+     * </ul>
+     */
+    @Nested
+    @DisplayName("Scout first day with data")
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ScoutFirstDayWithData {
+
+        private static final String WS_SCOUT = UUID.randomUUID().toString();
+        private static final String WS_SCOUT_API_KEY = UUID.randomUUID().toString();
+        private static final String WS_SCOUT_NAME = "workspace" + RandomStringUtils.secure().nextAlphanumeric(36);
+        private static final String WS_SCOUT_USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(36);
+
+        @BeforeAll
+        void setUp() {
+            AuthTestUtils.mockTargetWorkspace(wireMock.server(), WS_SCOUT_API_KEY, WS_SCOUT_NAME, WS_SCOUT,
+                    WS_SCOUT_USER);
+        }
+
+        /**
+         * Three traces spanning three distinct ISO weeks, so the scan is not satisfiable from a single week and both
+         * bounds have something to admit. The oldest day must come back: it is the {@code ORDER BY day LIMIT 1}
+         * winner, and it is the answer the caller turns into a catch-up cursor.
+         */
+        @Test
+        @DisplayName("returns the earliest day in range, across several weeks")
+        void returnsTheEarliestDayInRange(TraceDAO traceDAO) {
+            var oldest = Instant.now().minus(30, ChronoUnit.DAYS);
+            var ids = List.of(
+                    idGenerator.generateId(oldest),
+                    idGenerator.generateId(oldest.plus(10, ChronoUnit.DAYS)),
+                    idGenerator.generateId(oldest.plus(20, ChronoUnit.DAYS)));
+            ids.forEach(id -> createTestTrace(id, WS_SCOUT_API_KEY, WS_SCOUT_NAME));
+            waitForRows("traces", WS_SCOUT, ids.size());
+
+            var actualFirstDay = traceDAO.scoutFirstDayWithData(WS_SCOUT,
+                    idGenerator.generateId(oldest.minus(1, ChronoUnit.DAYS)),
+                    idGenerator.generateId(Instant.now())).block();
+
+            assertThat(actualFirstDay).isEqualTo(oldest.truncatedTo(ChronoUnit.DAYS));
+        }
+
+        /**
+         * The empty answer, which the caller distinguishes from a real day by the {@code Instant.MAX} sentinel: a
+         * range below every seeded id must scout nothing rather than fall back to the earliest row in the table.
+         */
+        @Test
+        @DisplayName("returns the no-data sentinel for a range holding nothing")
+        void returnsTheSentinelForAnEmptyRange(TraceDAO traceDAO) {
+            var rangeEnd = Instant.now().minus(365, ChronoUnit.DAYS);
+
+            var actualFirstDay = traceDAO.scoutFirstDayWithData(WS_SCOUT,
+                    idGenerator.generateId(rangeEnd.minus(30, ChronoUnit.DAYS)),
+                    idGenerator.generateId(rangeEnd)).block();
+
+            assertThat(actualFirstDay).isEqualTo(Instant.MAX);
+        }
     }
 
     // -- Resource client insert helpers --

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/SpansLocalV2PartitioningTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/SpansLocalV2PartitioningTest.java
@@ -42,31 +42,39 @@ import static org.assertj.core.api.Assertions.assertThat;
  * MATERIALIZED UUIDv7ToDateTime(toUUID(id))} → {@code PARTITION BY toYYYYMMDD(toDate32(id_at) -
  * toIntervalDay(toDayOfWeek(id_at, 1)))} chain. The key computes the honest Monday of {@code id_at}'s week in
  * {@code Date32}, so it never wraps a far-future id the way a 16-bit {@code toMonday} {@code Date} would. The
- * counterpart of {@link TracesLocalV2PartitioningTest}, pinning the same two behaviors as permanent regression guards:
+ * counterpart of {@link TracesLocalV2PartitioningTest}, pinning the same behaviors as permanent regression guards:
  *
  * <ul>
  *   <li><b>Partition stability across upserts.</b> {@code id_at} is computed by ClickHouse from the immutable
  *   {@code id}, so two versions of the same logical row (differing only in {@code last_updated_at}) must land in one
  *   weekly partition — the property {@code ReplacingMergeTree}'s in-partition dedup depends on. Regresses if the
  *   {@code id_at} expression or the partition key stops deriving from the immutable {@code id}.</li>
- *   <li><b>Pruning with the unchanged read predicates.</b> The {@code SpanDAO} read path emits {@code toMonday(id_at)}
- *   bounds paired with its id-range. The key expression is not {@code toMonday}, yet those bounds still prune:
- *   {@code id_at} is a column of the partition key, so ClickHouse keeps a {@code MinMax} over {@code id_at} per part,
- *   and {@code toMonday(id_at)} is monotonic over a part's narrow {@code id_at} range — so the predicate prunes parts
- *   via that {@code MinMax}. An id-range predicate alone does not prune (the planner doesn't infer
- *   {@code id → id_at} monotonicity through {@code UUIDv7ToDateTime}). Read via {@code EXPLAIN indexes = 1}: the
- *   {@code MinMax} block's selected count drops below the total exactly when pruning engages.</li>
+ *   <li><b>Pruning with the read predicates.</b> The {@code SpanDAO} read path emits the same {@code Date32}
+ *   week-start bounds as the partition key, paired with its id-range, and they prune where the id-range alone does
+ *   not (the planner doesn't infer {@code id → id_at} monotonicity through {@code UUIDv7ToDateTime}). Read via
+ *   {@code EXPLAIN indexes = 1} across the {@code MinMax} and {@code Partition} entries — see {@link #prunedParts}.</li>
+ *   <li><b>Both operands, in every direction.</b> The wrap is reachable through the bound as well as the column, and
+ *   how it fails depends on direction: a wrapped lower bound only widens, a wrapped <b>upper</b> bound drops every
+ *   ordinary row, and a wrapped equality never matches. All three are pinned below, since a lower-bound case alone
+ *   cannot detect a wrapped bound at all (OPIK-8241).</li>
+ *   <li><b>Honest far-future isolation.</b> A legitimate row whose UUIDv7 carries a far-future timestamp lands in its
+ *   own distinct, honest weekly partition, never mixed with a real recent week.</li>
+ *   <li><b>Week-expression correctness.</b> The {@code Date32} Monday equals {@code toMonday} across the in-range
+ *   calendar and stays honest where {@code toMonday} wraps — both far-future ids and the epoch week a non-v7 id lands
+ *   in — independent of the datetime setting.</li>
  * </ul>
  *
- * <p>Spans add a third guard with no traces analogue: a {@code trace_id}-keyed scan must keep every partition. Spans
- * are partitioned on their own id's week, which can be later than their trace's, so pruning such a scan by a week
- * derived from {@code trace_id} would silently drop valid spans (see {@code SpanDAO.DELETE_FOR_RETENTION}).</p>
+ * <p>Spans add a guard with no traces analogue: a {@code trace_id}-keyed scan must keep every partition. Spans are
+ * partitioned on their own id's week, which can be later than their trace's, so pruning such a scan by a week derived
+ * from {@code trace_id} would silently drop valid spans (see {@code SpanDAO.DELETE_FOR_RETENTION}).</p>
  *
  * <p>Otherwise this keeps full parity with {@link TracesLocalV2PartitioningTest}, including the point-lookup equality
- * shape that no {@code SpanDAO} path emits today — its by-id reads carry no {@code id_at} predicate at all. The two
- * DAOs are close relatives that evolve separately, so the shapes are pinned on both sides rather than only where each
- * is currently reachable: that is what turns this suite into a regression net for a spans read path that later grows
- * the bound {@code TraceDAO} already has.</p>
+ * shape that no {@code SpanDAO} path emits today. The two DAOs are close relatives that evolve separately, so the
+ * shapes are pinned on both sides rather than only where each is currently reachable.</p>
+ *
+ * <p>The far-future cases here run against the partitioned successor, where {@code id_at} is honest and the wrap is
+ * worst. The counterpart on the legacy table — the default topology of this suite, and of any install that has not
+ * cut over — is {@code FindSpansResourceTest.searchSpansStream__whenCursorCarriesAFarFutureTimestamp__*}.</p>
  *
  * <p>Runs directly against ClickHouse via {@link TransactionTemplateAsync} over the test container's connection factory
  * — no Dropwizard app — mirroring the raw column-level access of {@link SpansLocalV2TableTest}.</p>
@@ -132,7 +140,7 @@ class SpansLocalV2PartitioningTest {
     void idRangePredicateAloneDoesNotPrunePartitions() {
         var seed = seedConsecutiveWeeklyPartitions();
 
-        var actualParts = minMaxParts("""
+        var actualParts = prunedParts("""
                 SELECT
                     id
                 FROM spans_local_v2
@@ -144,20 +152,20 @@ class SpansLocalV2PartitioningTest {
                 .bind("id_lo", seed.ids().get(1))
                 .bind("id_hi", seed.ids().get(2)));
 
-        // Queries the same inner id range (weeks 1..2 of the four seeded) as idRangeWithToMondayBoundPrunesPartitions,
-        // so the two are a controlled pair whose only difference is the added toMonday(id_at) bound. With no id_at
-        // predicate the id_at MinMax has nothing to constrain (the planner doesn't infer id -> id_at monotonicity
-        // through UUIDv7ToDateTime), so every part is read. Should the target LTS start inferring that, this fails —
-        // the signal to revisit whether the read path still needs its explicit id_at predicate.
+        // Queries the same inner id range (weeks 1..2 of the four seeded) as
+        // idRangeWithWeekStartBoundPrunesPartitions, so the two are a controlled pair whose only difference is the
+        // added week-start bound. With no id_at predicate neither the id_at MinMax nor the partition key has anything
+        // to constrain (the planner doesn't infer id -> id_at monotonicity through UUIDv7ToDateTime), so every part is
+        // read. Should the target LTS start inferring that, this fails — the signal to revisit whether the read path
+        // still needs its explicit id_at predicate.
         assertThat(actualParts.selected()).isEqualTo(actualParts.total());
     }
 
     /**
-     * The predicate the SpanDAO read path emits: each id-range bound carries a parallel {@code toMonday(id_at)} bound
-     * derived from the same UUIDv7. The key expression is not {@code toMonday}, but {@code id_at} is one of its
-     * columns, so ClickHouse keeps a {@code MinMax} over {@code id_at} per part and {@code toMonday} is monotonic over
-     * a part's narrow {@code id_at} range — the bounds prune through that {@code MinMax} (the Partition entry then
-     * reports the already-pruned set).
+     * The predicate the SpanDAO read path emits: each id-range bound carries a parallel {@code Date32} week-start
+     * bound derived from the same UUIDv7, the same expression on both sides. That makes it the partition key's own
+     * expression, which the planner matches directly rather than inferring monotonicity over each part's {@code id_at}
+     * {@code MinMax} — see {@link #prunedParts}.
      * <p>
      * Both bounds are pinned independently rather than through a single {@code selected < total}, which one bound
      * working alone would already satisfy. ids 1..2 are the inner two of the four seeded weeks, so week 0 sits below
@@ -166,43 +174,53 @@ class SpansLocalV2PartitioningTest {
      * the container-wide table, which the other tests in this class also write to.
      */
     @Test
-    void idRangeWithToMondayBoundPrunesPartitions() {
+    void idRangeWithWeekStartBoundPrunesPartitions() {
         var seed = seedConsecutiveWeeklyPartitions();
         Consumer<Statement> binder = statement -> statement
                 .bind("workspace_id", seed.workspaceId())
                 .bind("id_lo", seed.ids().get(1))
                 .bind("id_hi", seed.ids().get(2));
 
-        var lowerBoundOnly = minMaxParts("""
-                SELECT
-                    id
-                FROM spans_local_v2
-                WHERE workspace_id = :workspace_id
-                    AND id >= :id_lo
-                    AND id <= :id_hi
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC'))
-                """, binder);
-        var upperBoundOnly = minMaxParts("""
-                SELECT
-                    id
-                FROM spans_local_v2
-                WHERE workspace_id = :workspace_id
-                    AND id >= :id_lo
-                    AND id <= :id_hi
-                    AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC'))
-                """, binder);
+        var lowerBoundOnly = prunedParts(
+                """
+                        SELECT
+                            id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                            AND id >= :id_lo
+                            AND id <= :id_hi
+                            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                                >= (toDate32(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC'), 1)))
+                        """,
+                binder);
+        var upperBoundOnly = prunedParts(
+                """
+                        SELECT
+                            id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                            AND id >= :id_lo
+                            AND id <= :id_hi
+                            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                                <= (toDate32(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC'), 1)))
+                        """,
+                binder);
         // Run last on purpose: a background merge can only ever collapse parts, so measuring the two-bound query
         // against the most-merged state keeps the inequalities below one-directional.
-        var bothBounds = minMaxParts("""
-                SELECT
-                    id
-                FROM spans_local_v2
-                WHERE workspace_id = :workspace_id
-                    AND id >= :id_lo
-                    AND id <= :id_hi
-                    AND toMonday(id_at) >= toMonday(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC'))
-                    AND toMonday(id_at) <= toMonday(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC'))
-                """, binder);
+        var bothBounds = prunedParts(
+                """
+                        SELECT
+                            id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                            AND id >= :id_lo
+                            AND id <= :id_hi
+                            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                                >= (toDate32(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC'), 1)))
+                            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                                <= (toDate32(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_hi), 'UTC'), 1)))
+                        """,
+                binder);
 
         // Each bound prunes what the other cannot: the week-3 parts only the upper bound excludes, and the week-0
         // parts only the lower one does. Together they also imply pruning happens at all, since a planner that ignored
@@ -213,30 +231,123 @@ class SpansLocalV2PartitioningTest {
     }
 
     /**
-     * The equality counterpart of the range bounds above. No {@code SpanDAO} read path emits {@code toMonday(id_at) =}
+     * The equality counterpart of the range bounds above. No {@code SpanDAO} read path emits a week-start equality
      * today — its by-id lookups carry no {@code id_at} predicate at all — but the shape is pinned anyway for parity with
      * {@link TracesLocalV2PartitioningTest}: the two DAOs are close relatives that evolve separately, so if a spans
      * by-id path later grows the equality bound that {@code TraceDAO.SELECT_DETAILS_BY_ID} already has, this is the
      * guard that says whether it prunes.
      */
     @Test
-    void idPointLookupWithToMondayEqualityPrunesPartitions() {
+    void idPointLookupWithWeekStartEqualityPrunesPartitions() {
         var seed = seedConsecutiveWeeklyPartitions();
 
-        var actualParts = minMaxParts("""
-                SELECT
-                    id
-                FROM spans_local_v2
-                WHERE workspace_id = :workspace_id
-                    AND id = :id
-                    AND toMonday(id_at) = toMonday(UUIDv7ToDateTime(toUUID(:id), 'UTC'))
-                """, statement -> statement
-                .bind("workspace_id", seed.workspaceId())
-                .bind("id", seed.ids().get(1)));
+        var actualParts = prunedParts(
+                """
+                        SELECT
+                            id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                            AND id = :id
+                            AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                                = (toDate32(UUIDv7ToDateTime(toUUID(:id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id), 'UTC'), 1)))
+                        """,
+                statement -> statement
+                        .bind("workspace_id", seed.workspaceId())
+                        .bind("id", seed.ids().get(1)));
 
-        // Equality on toMonday(id_at) prunes via the id_at MinMax to the single week id 1 lands in; the other three
-        // seeded weeks (and every out-of-window part) fall away, so selected drops below total.
+        // Equality on the week-start expression prunes to the single week id 1 lands in; the other three seeded weeks
+        // (and every out-of-window part) fall away, so selected drops below total.
         assertThat(actualParts.selected()).isLessThan(actualParts.total());
+    }
+
+    /**
+     * The read-path counterpart of {@link #farFutureRowIsolatesIntoItsOwnHonestWeeklyPartition()}, and the regression
+     * that shipped for traces (OPIK-7456) and was left on spans until OPIK-8241: honest partitioning is worthless if
+     * the read predicate then filters those rows back out. Every {@code id}-range bound in the DAOs carries a parallel
+     * week-start bound documented as "a strict consequence of the id-range" — so it must never exclude a row the
+     * id-range admits. Under {@code toMonday} it did: a ~2201 id clears {@code id >= :id_lo} but its 16-bit
+     * {@code Date} wraps to a ~2021 Monday and fails the week bound, so the row vanishes from a result it belongs in.
+     * Seeds a present-day span and a far-future span, applies the exact predicate the read path emits with the
+     * present-day id as the lower bound, and asserts BOTH come back.
+     */
+    @Test
+    void weekStartLowerBoundKeepsFarFutureRowsThatTheIdRangeAdmits() {
+        var seed = seedPresentAndFarFuture();
+
+        var returnedIds = idsMatching(
+                """
+                        SELECT id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                        AND id >= :id_lo
+                        AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                            >= (toDate32(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id_lo), 'UTC'), 1)))
+                        """,
+                seed.workspaceId(), statement -> statement.bind("id_lo", seed.present()));
+
+        assertThat(returnedIds).containsExactlyInAnyOrder(seed.present().toString(), seed.farFuture().toString());
+    }
+
+    /**
+     * The mirror of {@link #weekStartLowerBoundKeepsFarFutureRowsThatTheIdRangeAdmits()}, and the direction where a
+     * wrapped bound is catastrophic rather than merely imprecise: on an <b>upper</b> bound it does not lose the
+     * far-future row, it loses every <em>ordinary</em> row.
+     *
+     * <p>{@code :last_received_span_id} is a pagination cursor lifted from a row the previous page returned, so it is
+     * a real span id and can itself be far-future — the far-future spans sort first under {@code ORDER BY id DESC},
+     * which is exactly when it happens. With {@code toMonday} on the bound side that cursor wraps to a past week, and
+     * every ordinary row — whose honest week is later — fails {@code <=}. The page comes back empty and pagination
+     * stops dead. Seeds both rows, pages with the far-future id as the cursor, and asserts the present-day row still
+     * returns.
+     */
+    @Test
+    void weekStartUpperBoundKeepsOrdinaryRowsWhenTheCursorIsFarFuture() {
+        var seed = seedPresentAndFarFuture();
+
+        var returnedIds = idsMatching(
+                """
+                        SELECT id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                        AND id < :last_received_span_id
+                        AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                            <= (toDate32(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:last_received_span_id), 'UTC'), 1)))
+                        """,
+                seed.workspaceId(), statement -> statement.bind("last_received_span_id", seed.farFuture()));
+
+        assertThat(returnedIds).containsExactly(seed.present().toString());
+    }
+
+    /**
+     * The bound side of a week bound has to be Date32 too, and an equality is where mixing the forms fails hardest:
+     * it holds only if both sides agree for every id, so a {@code toMonday} bound against the honest column never
+     * matches a far-future row at all.
+     *
+     * <p>Only converting the <em>column</em> is what this catches, and it is the trap a single-operand check falls
+     * into: with {@code toMonday} on both sides the equality still holds for a far-future id, because both operands
+     * wrap into the same wrong week and agree there. It fails only once the column is honest and the bound is not —
+     * which is why the column-side fix alone leaves the wrap reachable.
+     *
+     * <p>No {@code SpanDAO} path emits this shape today, for the reason given on
+     * {@link #idPointLookupWithWeekStartEqualityPrunesPartitions()}. Asserts that the far-future id <em>resolves</em>,
+     * not merely that it is not lost: an equality matching nothing is indistinguishable from an absent row.
+     */
+    @Test
+    void weekStartEqualityResolvesAFarFutureId() {
+        var seed = seedPresentAndFarFuture();
+
+        var returnedIds = idsMatching(
+                """
+                        SELECT id
+                        FROM spans_local_v2
+                        WHERE workspace_id = :workspace_id
+                        AND id = :id
+                        AND (toDate32(id_at) - toIntervalDay(toDayOfWeek(id_at, 1)))
+                            = (toDate32(UUIDv7ToDateTime(toUUID(:id), 'UTC')) - toIntervalDay(toDayOfWeek(UUIDv7ToDateTime(toUUID(:id), 'UTC'), 1)))
+                        """,
+                seed.workspaceId(), statement -> statement.bind("id", seed.farFuture()));
+
+        assertThat(returnedIds).containsExactly(seed.farFuture().toString());
     }
 
     /**
@@ -329,7 +440,7 @@ class SpansLocalV2PartitioningTest {
     void traceIdPredicateAloneRetainsAllPartitions() {
         var seed = seedConsecutiveWeeklyPartitions();
 
-        var actualParts = minMaxParts("""
+        var actualParts = prunedParts("""
                 SELECT
                     id
                 FROM spans_local_v2
@@ -354,6 +465,35 @@ class SpansLocalV2PartitioningTest {
         var actualIds = idsForTrace(seed.workspaceId(), seed.traceId());
 
         assertThat(actualIds).containsExactlyInAnyOrderElementsOf(seed.ids());
+    }
+
+    /**
+     * Runs the given {@code SELECT id} and returns the ids it yields, binding {@code workspace_id} for the caller.
+     * Takes the whole statement rather than a fragment, like {@link #prunedParts}, so each read-path case shows the
+     * query it pins in full.
+     */
+    private List<String> idsMatching(String selectSql, String workspaceId, Consumer<Statement> binder) {
+        return transactionTemplateAsync.stream(connection -> {
+            var statement = connection.createStatement(selectSql);
+            statement.bind("workspace_id", workspaceId);
+            binder.accept(statement);
+            return Flux.from(statement.execute())
+                    .flatMap(result -> result.map((row, ignored) -> row.get("id", String.class)));
+        }).collectList().block();
+    }
+
+    /**
+     * Seeds one present-day span and one far-future span under a fresh workspace — the fixture every read-path case
+     * shares. Each case then differs only in the predicate it applies and what it expects back, which is the whole of
+     * what distinguishes them.
+     */
+    private FarFutureSeed seedPresentAndFarFuture() {
+        var workspaceId = UUID.randomUUID().toString();
+        var present = ID_GENERATOR.generateId(weekInstant(0));
+        var farFuture = ID_GENERATOR.generateId(FAR_FUTURE_INSTANT);
+        insert(List.of(present, farFuture), workspaceId, ID_GENERATOR.generateId(), ID_GENERATOR.generateId(),
+                weekInstant(0));
+        return FarFutureSeed.builder().workspaceId(workspaceId).present(present).farFuture(farFuture).build();
     }
 
     /**
@@ -494,17 +634,27 @@ class SpansLocalV2PartitioningTest {
     }
 
     /**
-     * Runs {@code EXPLAIN indexes = 1, json = 1} for the query and returns its {@code MinMax} index entry. That entry
-     * reflects part-level pruning on the partition-expression column ({@code id_at}): {@code Initial Parts} is every
-     * active part in the (reused) table, {@code Selected Parts} is what survives partition pruning.
+     * Runs {@code EXPLAIN indexes = 1, json = 1} for the query and reports part-level pruning: {@code total} is every
+     * active part in the (reused) table, {@code selected} is what survives partition analysis.
+     * <p>
+     * Reads the {@code MinMax} and {@code Partition} entries together, because which of the two carries the condition
+     * is a planner decision, not a property of the query. ClickHouse applies them in that order, each narrowing the
+     * previous one's selection, so {@code total} is {@code MinMax}'s initial count and {@code selected} is whichever
+     * of the two ran last.
+     * <p>
+     * Reading both matters because the entry moved with OPIK-8241's fix: a {@code toMonday} bound cannot match the
+     * partition key as a whole, so ClickHouse inferred monotonicity of the left expression over each part's
+     * {@code id_at} {@code MinMax}; deriving both sides the same way makes the predicate the key's own expression,
+     * which it matches directly. Net pruning is unchanged — the same parts and granules survive either way — but a
+     * reader of {@code MinMax} alone would report the converted predicate as pruning nothing.
      * <p>
      * The table also carries four minmax skip indexes (on {@code id}, {@code id_at}, {@code created_at} and
-     * {@code last_updated_at}), but EXPLAIN reports those under type {@code Skip}; {@code MinMax} is the partition-level
-     * entry, and these queries read one table through one scan, so exactly one must appear. Asserting that — rather than
-     * taking the first match — keeps the guards from silently reading some other entry's part counts if a future
-     * ClickHouse version changes how the block is reported.
+     * {@code last_updated_at}), but EXPLAIN reports those under type {@code Skip}. These queries read one table
+     * through one scan, so exactly one {@code MinMax} entry must appear; asserting that — rather than taking the first
+     * match — keeps the guards from silently reading some other entry's part counts if a future ClickHouse version
+     * changes how the block is reported.
      */
-    private MinMaxParts minMaxParts(String selectSql, Consumer<Statement> binder) {
+    private PrunedParts prunedParts(String selectSql, Consumer<Statement> binder) {
         var explainRows = transactionTemplateAsync.stream(connection -> {
             var statement = connection.createStatement("EXPLAIN indexes = 1, json = 1 %s".formatted(selectSql));
             binder.accept(statement);
@@ -513,12 +663,26 @@ class SpansLocalV2PartitioningTest {
         }).collectList().block();
 
         var explain = String.join("\n", explainRows);
-        var minMaxIndexes = JsonUtils.getJsonNodeFromString(explain).findValues("Indexes").stream()
+        var entries = JsonUtils.getJsonNodeFromString(explain).findValues("Indexes").stream()
                 .flatMap(JsonNode::valueStream)
-                .filter(index -> "MinMax".equals(index.path("Type").asText()))
                 .toList();
-        assertThat(minMaxIndexes).as("MinMax index entries in EXPLAIN output:%n%s", explain).hasSize(1);
-        return JsonUtils.treeToValue(minMaxIndexes.getFirst(), MinMaxParts.class);
+
+        var minMax = entriesOfType(entries, "MinMax");
+        var partition = entriesOfType(entries, "Partition");
+        assertThat(minMax).as("MinMax index entries in EXPLAIN output:%n%s", explain).hasSize(1);
+        assertThat(partition).as("Partition index entries in EXPLAIN output:%n%s", explain).hasSizeLessThan(2);
+
+        var minMaxParts = JsonUtils.treeToValue(minMax.getFirst(), PrunedParts.class);
+        return partition.isEmpty()
+                ? minMaxParts
+                : PrunedParts.builder()
+                        .selected(JsonUtils.treeToValue(partition.getFirst(), PrunedParts.class).selected())
+                        .total(minMaxParts.total())
+                        .build();
+    }
+
+    private List<JsonNode> entriesOfType(List<JsonNode> entries, String type) {
+        return entries.stream().filter(entry -> type.equals(entry.path("Type").asText())).toList();
     }
 
     private Instant weekInstant(int weekOffset) {
@@ -529,9 +693,15 @@ class SpansLocalV2PartitioningTest {
     private record Seed(String workspaceId, UUID projectId, UUID traceId, List<UUID> ids) {
     }
 
+    /** Built through the builder, not positionally: the two ids are both {@code UUID} and swapping them would invert
+     * every case below without a compile error. */
+    @Builder(toBuilder = true)
+    private record FarFutureSeed(String workspaceId, UUID present, UUID farFuture) {
+    }
+
     @Builder(toBuilder = true)
     @JsonIgnoreProperties(ignoreUnknown = true)
-    private record MinMaxParts(
+    private record PrunedParts(
             @JsonProperty("Selected Parts") int selected,
             @JsonProperty("Initial Parts") int total) {
     }

--- a/scripts/precommit-hook-descriptions.tsv
+++ b/scripts/precommit-hook-descriptions.tsv
@@ -29,7 +29,7 @@ helm-docs	Regenerate Helm chart README
 actionlint	Lint GitHub Actions workflows
 zizmor	Security-scan GitHub Actions workflows
 hadolint	Lint Dockerfiles
-semgrep	Block SQL injection-prone string formatting
+semgrep	Enforce the repo's own backend Java rules
 spotless	Format Java code
 eslint	Lint + autofix JS/TS
 typecheck	Whole-project tsc type check


### PR DESCRIPTION
## Details

Completes the far-future week-bound fix that #8096 started. That PR was scoped to the traces read path so the hot patch stayed minimal, leaving three groups behind: the **spans** read paths, the **retention** sweeps, and a class of narrow-datetime expressions its `toMonday` grep never saw. This closes all three, so the wrap class is gone from the service rather than deferred to the next cutover.

ClickHouse's `toMonday` and `toDate` return a 16-bit `Date` (1970..2149) and `toDateTime` a 32-bit `DateTime` (1970..2106); all three wrap past their ceiling rather than saturating. Every id-range bound in the read paths carries a parallel week bound on `id_at`, documented as a strict consequence of the id-range — a pruning hint that must never exclude a row the id-range admits. A UUIDv7 carrying a far-future timestamp ([BerriAI/litellm#31294](https://github.com/BerriAI/litellm/issues/31294) mints ~2201) clears the id bound but folds into a past week and fails the week bound.

- **Spans read paths — 41 week bounds** converted to the partition key's own `Date32` expression, `toDate32(E) - toIntervalDay(toDayOfWeek(E, 1))`, on **both** operands: `SpanDAO` 17, `SpanMetricsQueries` 2, plus the span legs of the shared metrics DAOs that #8096 reverted (`ProjectMetricsDAO` 10, `KpiCardDAO` 6, `WorkspaceMetricsDAO` 6). Reachable **before** the spans cutover, not only after it: the wrap is on the *bound* side, which reads the id directly and is honest whatever width `spans.id_at` has. `SELECT_BY_PROJECT_ID` paginates on `id < :last_received_span_id` and span ids sort newest-first, so a far-future span becomes page one's cursor and page two comes back empty, stopping pagination dead.
- **Retention — 8 traces week bounds** converted, and `SCOUT_FIRST_DAY_WITH_DATA` now projects `toDate32`. Behaviour-neutral (every sweep is ANDed with `id < :cutoff_id`, so every admitted row sits well inside `toMonday`'s range); converted so the wrapping form is left nowhere in the DAO for the next time-bounded query to be copied from — which is how the spans paths came to carry it. `SpanDAO`'s retention statements are keyed on `trace_id` and still carry no week bound by design, since a span's own id week can run ahead of its trace's.
- **25 `toDateTime(UUIDv7ToDateTime(...))` narrowings** pinned to `toDateTime64(..., 0, 'UTC')`. One was a live correctness gap — `recent_error_count` counted a circa-2162-dated trace as a *recent* error, inflating a project's recent-error stat and its deviation with an error that has not happened. The other 23 are the `WITH FILL` `bucket` / `fill_from` / `TO` expressions in the two metrics DAOs. `wrapWeekly` becomes `pinBucket` and pins every interval, which is required rather than cosmetic: with a `DateTime64` `TO`, an unpinned daily or hourly bucket is a `DateTime` and ClickHouse rejects the whole query with code 475.
- **CI guard** — `.semgrep/java-sql-narrow-datetime.yaml` fails the build on `toMonday`/`toDate`/`toDateTime` applied to `id_at` or `UUIDv7ToDateTime` in any production DAO, with fixtures asserted by `semgrep test`. It sits beside the repo's existing Java-SQL rules, so pre-commit and the CI matrix already run it; because semgrep binds expressions, the javadoc explaining why `toMonday` is *not* used cannot false-positive.

Partition pruning is unchanged, measured with `EXPLAIN indexes = 1` and `EXPLAIN ESTIMATE` on both span topologies. Only the route differs: the predicate is now the partition key's own expression and matches the `Partition` entry directly, rather than relying on a monotonicity inference over a function that is not in fact monotonic at the wrap. On the legacy unpartitioned table a week bound prunes nothing whichever form it takes, so the conversion costs it nothing.

One residual is unchanged from #8096 and accepted: a far-future *lower* bound against the unpartitioned table, where `id_at` has already truncated ~2200 into 2064 and no read predicate can recover the honest week. It needs a caller supplying a `startTime` beyond 2106 — which the UI cannot produce, and which is not the cursor shape — and it resolves at the cutover.

Sequencing: this lands before OPIK_7770's global `enable_extended_results_for_datetime_functions` flip and removes that ticket's only breaking surface, since pinning the metrics buckets was its one item that changes behaviour. The setting also does not cover `toDate` or `toDateTime`, so it would not close this class on its own.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- OPIK-8241

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: full implementation, tests, and the semgrep rule
- Human verification: author code review, plus every behavioural claim re-derived independently on a local ClickHouse 26.3.16.16 container before implementation, and each new test verified as a negative control

## Testing

Backend suites, run locally against testcontainers (ClickHouse 26.3.16.16 + ZooKeeper + MySQL + Redis):

```
cd apps/opik-backend
mvn test -Dtest=SpansLocalV2PartitioningTest          # 27
mvn test -Dtest=TracesLocalV2PartitioningTest         # 25
mvn test -Dtest=FindSpansResourceTest                 # 1536
mvn test -Dtest=GetTracesByProjectResourceTest        # 1765
mvn test -Dtest=SpansResourceTest                     # 294
mvn test -Dtest=TracesResourceTest                    # 392
mvn test -Dtest=ProjectMetricsResourceTest            # 255
mvn test -Dtest=KpiCardsResourceTest                  # 89
mvn test -Dtest=WorkspacesResourceTest                # 74
mvn test -Dtest=ProjectMetricsWithBreakdownResourceTest
mvn test -Dtest=RetentionPolicyServiceTest            # 20
mvn test -Dtest='DashboardsResourceTest,DashboardsResourceProjectScopedTest,DashboardsResourceFindProjectDashboardsTest'  # 79
mvn test -Dtest=SpansLocalV2TableTest
```

Plus `semgrep test --config .semgrep/java-sql-narrow-datetime.yaml .semgrep/java-sql-narrow-datetime.java` and `pre-commit run spotless --files <changed>`. All green.

**Scenarios validated**

- Far-future rows on the partitioned successor, in all three comparison directions: a lower bound must keep the far-future row the id-range admits, an upper bound (the pagination-cursor shape) must keep every *ordinary* row, and an equality must *resolve* the far-future id rather than match nothing. Ingestion rejects such ids by design, so the row is seeded directly.
- Far-future pagination cursor through the real spans API against the **legacy** table — the default suite topology, and the case reachable today. Needs no far-future span, because the cursor is an unvalidated request field.
- `recent_error_count` end to end, with a circa-2162-dated trace seeded past the ingestion-window validation that would reject it. Asserts the whole project-stats summary via the existing oracle, so the far-future trace still counts as a trace and only its error bucketing is special.
- `SCOUT_FIRST_DAY_WITH_DATA`, which had no coverage at all: its only caller is reached on a path the suite exercises with a mocked DAO, so neither the new `toDate32` projection nor an over-restricting week bound would have failed anything. Both the earliest-day and the no-data-sentinel cases are covered.
- Every `TimeInterval` on the workspace metrics endpoint, replacing HOURLY-only coverage, so the `WEEKLY` and `TOTAL` bucket branches are reached.
- Retention: pre-existing sweeps still delete what they should, asserted on outcomes rather than on absence of errors (the delete path logs and continues on failure, so an outcome assertion is what catches breakage).

**Negative controls** — each new case was confirmed to fail when the fix is reverted:

- lower bound → only the present-day span returns; upper bound → nothing returns at all.
- the equality case fails only against the *mixed* form (honest column, wrapped bound): with `toMonday` on **both** sides it still passes, because both operands wrap into the same wrong week and agree there. That is exactly why converting only the column is not the fix.
- `recent_error_count` → the whole-summary assertion fails, with the far-future trace inflating both the count and the deviation percentage.
- the spans API cursor → the page returns 0 of 5.
- the workspace interval test → 3 of 4 intervals fail as HTTP 500 (code 475); `TOTAL` passes, emitting no `WITH FILL`.
- the semgrep rule → blocks on a reverted `SpanDAO` bound, naming both operands, while reporting 0 findings over the production sources as shipped.

**Not run locally**: the full backend suite and the E2E suite — left to the pipeline.

## Documentation

N/A — no user-facing documentation changes. The DAO javadocs, `SpansLocalV2PartitioningTest`'s class doc and the `RetentionPolicyServiceTest` comments that asserted the old `toMonday` invariant were corrected in place. Shipped migrations `000114`/`000115` still describe it; they are deliberately untouched, since `apps/opik-backend/docs/traces-schema-ddl.md` is explicit that shipped migrations are never edited and those comments sit inside the changeset body, where an edit would change the Liquibase checksum.
