### PR TITLE
[OPIK-7403] [DOCS] docs: document UUIDv7 ingestion validation

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
@@ -43,14 +43,21 @@ Two separate checks run on a client-supplied `id`.
 - **Both bounds** — when a trace or span is created with a caller-chosen `id`. An embedded timestamp
   further than the window into either the past (`too_old`) or the future (`too_far_future`) is
   rejected.
-- **The future bound only** — wherever an existing id is referenced: updating a trace or span, a
-  span's `traceId` and `parentSpanId`, and ids referenced by dataset items, feedback scores,
-  comments, attachments and guardrails. Old ids are legitimate on those paths — a late span on a
-  month-old trace is normal — so only future-dating is rejected.
+- **The future bound only** — when a single trace or span is updated by id, and wherever an existing
+  id is referenced: a span's `traceId` and `parentSpanId`, and ids referenced by dataset items,
+  feedback scores, comments, attachments and guardrails. Old ids are legitimate on those paths — a
+  late span on a month-old trace is normal — so only future-dating is rejected.
 
-The checks live in the backend's service layer, so they cover every ingestion path alike: the REST
-API, the batch endpoints, and the OpenTelemetry endpoint. Ids that Opik generates itself are always
-in window; only client-supplied ids can fail.
+### Where the ids come from
+
+The checks live in the backend's service layer, so the creation paths are covered alike: the REST
+API, the batch ingestion endpoints, and the OpenTelemetry endpoint.
+
+Worth knowing if you only send OTel: the OpenTelemetry endpoint does not carry Opik ids, so the
+backend derives them — but it derives them from **your spans' start timestamps**, not from the
+current time, so that a trace and its spans share one reference point. An exporter replaying spans
+whose start times are outside the window is therefore rejected too, even though it never set an `id`
+itself. Backfilling historical traces over OTel needs a window wide enough to cover them.
 
 ## Before you turn it on
 
@@ -135,8 +142,9 @@ Each detection is logged at `INFO` with a fixed, searchable prefix:
 UUIDv7 audit: would-reject id, embedded timestamp '...' outside window '...', reason '...', resource '...', workspace '...'
 ```
 
-Once the count has settled at zero for the clients you care about, set `uuidV7ValidationAuditOnly`
-back to `false` to start enforcing.
+Once no new detections are arriving for the clients you care about, set
+`uuidV7ValidationAuditOnly` back to `false` to start enforcing. Query the counter's **rate**, not
+its value, when deciding that — see below.
 
 ## Monitoring
 
@@ -151,8 +159,13 @@ rollout:
 | `workspace_id` | Audit path only. `unknown` on the paths that do not carry the request workspace. |
 | `http_route` | Reject path only. The matched route, for example `/v1/private/traces/batch`. |
 
-Watch this counter for a full traffic cycle before switching from audit to reject, not just the
-first hours: a client that only runs nightly will not show up in a one-hour sample.
+`opik.ingestion.uuid_v7.rejected` is a **cumulative, monotonic counter**: it only ever increases, so
+its value never returns to zero once a single id has failed. Gate the rollout on an interval delta
+or rate — `increase(...[1h])` or `rate(...[5m])` in PromQL, with the labels you care about — rather
+than on the raw total.
+
+Watch it for a full traffic cycle before switching from audit to reject, not just the first hours: a
+client that only runs nightly will not show up in a one-hour sample.
 
 ## Turning it back off
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
@@ -1,0 +1,168 @@
+---
+headline: UUIDv7 ingestion validation
+og:description: Turn on UUIDv7 ingestion validation in Opik — the window, audit
+  (shadow) mode, and the kill-switch — and check your clients before enabling it.
+og:site_name: Opik Documentation
+og:title: UUIDv7 Ingestion Validation in Opik
+subtitle: Bound the timestamp a client may embed in a trace or span id
+title: UUIDv7 ingestion validation
+---
+
+# UUIDv7 Ingestion Validation
+
+Opik lets a client choose the `id` of a trace or span it creates. That `id` must be a UUIDv7, and
+the timestamp embedded in its top 48 bits is what ClickHouse uses to place the row in a partition.
+
+A client that embeds a wrong timestamp therefore does more than mislabel one row: an `id` claiming a
+date years in the future lands in a partition that retention never reaches, and one claiming a date
+years in the past lands in a partition that has already been retained away. Either way the partition
+layout degrades, silently, and the row is hard to find again.
+
+UUIDv7 ingestion validation bounds that timestamp at write time. Writes whose `id` embeds a timestamp
+further than the configured window from now are rejected with **HTTP 400**, so a broken client shows
+up as a failed request instead of as partition corruption discovered months later.
+
+<Callout intent="info">
+  Validation is **off by default** on self-hosted deployments — it is opt-in, and turning it on is a
+  deliberate step. Opik Cloud is managed by Comet and has it on. Work through
+  [Before you turn it on](#before-you-turn-it-on) first: the check only ever rejects ids your own
+  clients chose, so what matters is which of them embed their own timestamps.
+</Callout>
+
+## What is validated
+
+Two separate checks apply to a client-supplied `id`:
+
+| Check | Applies | Configurable |
+| ----- | ------- | ------------ |
+| The `id` is a valid UUIDv7 (`reason: not_v7`) | Always | No — this check is always on, whatever you set below |
+| The embedded timestamp is within the window (`reason: too_old` / `too_far_future`) | Creating a trace or span | Yes — see [Configuration](#configuration) |
+| The embedded timestamp is not in the future (`reason: too_far_future`) | Updating a trace or span | Yes — same setting |
+
+On the update path only the future bound is enforced, so updating a long-lived entity created months
+ago is never rejected for being old.
+
+Validation is applied in the backend's service layer, so it covers **every** trace and span ingestion
+path — the REST API, the batch endpoints, and the OpenTelemetry endpoint alike. Ids that Opik
+generates itself are always in window; only client-supplied ids can fail.
+
+## Before you turn it on
+
+<Steps>
+  <Step title="Upgrade the LiteLLM Opik integration if you use it">
+    LiteLLM's native Opik integration emitted out-of-window ids until
+    [BerriAI/litellm#31294](https://github.com/BerriAI/litellm/pull/31294). If you send traces to
+    Opik through that integration, upgrade LiteLLM to **`v1.94.0-rc.1` or newer** before enabling
+    validation. On an older LiteLLM, ingestion through it starts returning 400 as soon as the check
+    is on.
+  </Step>
+  <Step title="Check your own instrumentation">
+    If your code passes an explicit `id` to Opik, confirm the value is a UUIDv7 built from the
+    current time. The Opik SDKs do this for you; hand-rolled ids, ids replayed from an archive, and
+    ids derived from another system's identifiers are the cases that fail.
+  </Step>
+  <Step title="Find offenders without breaking them">
+    Turn validation on in [audit mode](#audit-shadow-mode) first. Out-of-window ids are then counted
+    and logged, but still ingested, so you can identify every offending client before anything
+    starts failing.
+  </Step>
+</Steps>
+
+## Configuration
+
+| Environment variable | Helm value (`databaseAnalytics.*`) | Default | Description |
+| -------------------- | ---------------------------------- | ------- | ----------- |
+| `UUID_VALIDATION_ENABLED` | `uuidV7ValidationEnabled` | `false` | Master switch. While `false`, embedded timestamps are not checked at all, and the two settings below have no effect. |
+| `UUID_VALIDATION_AUDIT_ONLY` | `uuidV7ValidationAuditOnly` | `false` | Count and log out-of-window ids instead of rejecting them. Only has an effect while `UUID_VALIDATION_ENABLED` is `true`. |
+| `UUID_VALIDATION_WINDOW` | `uuidV7ValidationWindow` | `24h` | How far from now an embedded timestamp may be, in either direction. Must be between `12h` and `45d`; the backend refuses to start outside that range. |
+
+Together the first two settings give three modes:
+
+| `UUID_VALIDATION_ENABLED` | `UUID_VALIDATION_AUDIT_ONLY` | Effective mode |
+| ------------------------- | ---------------------------- | -------------- |
+| `false` | *(ignored)* | **Disabled** — no timestamp check. The default. |
+| `true` | `true` | **Audit** — count and log, still ingest |
+| `true` | `false` | **Reject** — HTTP 400 |
+
+### Docker Compose
+
+The Compose file reads all three from the environment, so exporting them before starting Opik is
+enough:
+
+```bash
+export UUID_VALIDATION_ENABLED=true
+export UUID_VALIDATION_AUDIT_ONLY=false
+export UUID_VALIDATION_WINDOW=24h
+
+./opik.sh
+```
+
+### Helm
+
+```yaml
+databaseAnalytics:
+  uuidV7ValidationEnabled: true
+  uuidV7ValidationAuditOnly: false
+  uuidV7ValidationWindow: 24h
+```
+
+## Audit (shadow) mode
+
+Audit mode is the safe way to introduce validation on a deployment whose clients you do not fully
+control. Out-of-window ids are counted and logged, but the write still goes through:
+
+```yaml
+databaseAnalytics:
+  uuidV7ValidationEnabled: true
+  uuidV7ValidationAuditOnly: true
+```
+
+Each detection is logged at `INFO` with a fixed, searchable prefix:
+
+```
+UUIDv7 audit: would-reject id, embedded timestamp '...' outside window '...', reason '...', resource '...', workspace '...'
+```
+
+Once the count has settled at zero for the clients you care about, set `uuidV7ValidationAuditOnly`
+back to `false` to start enforcing.
+
+## Monitoring
+
+Both modes increment the `opik.ingestion.uuid_v7.rejected` counter, so one query covers the whole
+rollout:
+
+| Label | Values |
+| ----- | ------ |
+| `mode` | `audit` (counted, still ingested) or `reject` (HTTP 400) |
+| `reason` | `not_v7`, `too_old`, `too_far_future` |
+| `resource` | `trace`, `span` — audit mode only |
+| `workspace_id` | The workspace that sent the id — audit mode only |
+| `http_route` | The matched route, e.g. `/v1/private/traces/batch` — reject mode only |
+
+Watch this counter for a full traffic cycle before switching from audit to reject, not just the first
+hours: a client that only runs nightly will not show up in a one-hour sample.
+
+## Turning it back off
+
+If legitimate traffic starts being rejected, you have three options, in order of preference:
+
+1. **Drop to audit mode** — keeps the signal, stops the 400s:
+   ```yaml
+   databaseAnalytics:
+     uuidV7ValidationAuditOnly: true
+   ```
+2. **Widen the window** — if the rejected ids are legitimate but just outside `24h`. The accepted
+   range is `12h`–`45d`:
+   ```yaml
+   databaseAnalytics:
+     uuidV7ValidationWindow: 48h
+   ```
+3. **Turn the check off entirely**:
+   ```yaml
+   databaseAnalytics:
+     uuidV7ValidationEnabled: false
+   ```
+
+All three take effect once the backend has restarted. Nothing is migrated and no data is rewritten,
+so any of them is safe to do at any time — writes that were rejected while the check was on are not
+recovered, though, so the client has to send them again.

--- a/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/self-host/configure/uuid_validation.mdx
@@ -1,50 +1,56 @@
 ---
-headline: UUIDv7 ingestion validation
+title: UUIDv7 ingestion validation
+headline: UUIDv7 ingestion validation | Opik Documentation
+og:title: UUIDv7 ingestion validation — Opik
 og:description: Turn on UUIDv7 ingestion validation in Opik — the window, audit
   (shadow) mode, and the kill-switch — and check your clients before enabling it.
 og:site_name: Opik Documentation
-og:title: UUIDv7 Ingestion Validation in Opik
 subtitle: Bound the timestamp a client may embed in a trace or span id
-title: UUIDv7 ingestion validation
 ---
-
-# UUIDv7 Ingestion Validation
 
 Opik lets a client choose the `id` of a trace or span it creates. That `id` must be a UUIDv7, and
 the timestamp embedded in its top 48 bits is what ClickHouse uses to place the row in a partition.
+UUIDv7 ingestion validation bounds that timestamp at write time, so a client embedding wrong
+timestamps fails loudly instead of quietly degrading the partition layout.
 
-A client that embeds a wrong timestamp therefore does more than mislabel one row: an `id` claiming a
-date years in the future lands in a partition that retention never reaches, and one claiming a date
-years in the past lands in a partition that has already been retained away. Either way the partition
-layout degrades, silently, and the row is hard to find again.
-
-UUIDv7 ingestion validation bounds that timestamp at write time. Writes whose `id` embeds a timestamp
-further than the configured window from now are rejected with **HTTP 400**, so a broken client shows
-up as a failed request instead of as partition corruption discovered months later.
-
-<Callout intent="info">
+<Note>
   Validation is **off by default** on self-hosted deployments — it is opt-in, and turning it on is a
   deliberate step. Opik Cloud is managed by Comet and has it on. Work through
   [Before you turn it on](#before-you-turn-it-on) first: the check only ever rejects ids your own
   clients chose, so what matters is which of them embed their own timestamps.
-</Callout>
+</Note>
+
+## Why it exists
+
+A client that embeds a wrong timestamp does more than mislabel one row. An `id` claiming a date
+years in the future lands in a partition that retention never reaches, and one claiming a date years
+in the past lands in a partition that has already been retained away. Either way the partition
+layout degrades, silently, and the row is hard to find again.
+
+Bounding the timestamp at ingestion turns that into an **HTTP 400** on the offending write, so a
+broken client surfaces as a failed request rather than as partition corruption discovered months
+later.
 
 ## What is validated
 
-Two separate checks apply to a client-supplied `id`:
+Two separate checks run on a client-supplied `id`.
 
-| Check | Applies | Configurable |
-| ----- | ------- | ------------ |
-| The `id` is a valid UUIDv7 (`reason: not_v7`) | Always | No — this check is always on, whatever you set below |
-| The embedded timestamp is within the window (`reason: too_old` / `too_far_future`) | Creating a trace or span | Yes — see [Configuration](#configuration) |
-| The embedded timestamp is not in the future (`reason: too_far_future`) | Updating a trace or span | Yes — same setting |
+**The version check.** The `id` must be a version 7 UUID, or the write is rejected with
+`reason: not_v7`. This check is always on and none of the settings below affect it.
 
-On the update path only the future bound is enforced, so updating a long-lived entity created months
-ago is never rejected for being old.
+**The window check.** This is the configurable part, and it applies in two forms:
 
-Validation is applied in the backend's service layer, so it covers **every** trace and span ingestion
-path — the REST API, the batch endpoints, and the OpenTelemetry endpoint alike. Ids that Opik
-generates itself are always in window; only client-supplied ids can fail.
+- **Both bounds** — when a trace or span is created with a caller-chosen `id`. An embedded timestamp
+  further than the window into either the past (`too_old`) or the future (`too_far_future`) is
+  rejected.
+- **The future bound only** — wherever an existing id is referenced: updating a trace or span, a
+  span's `traceId` and `parentSpanId`, and ids referenced by dataset items, feedback scores,
+  comments, attachments and guardrails. Old ids are legitimate on those paths — a late span on a
+  month-old trace is normal — so only future-dating is rejected.
+
+The checks live in the backend's service layer, so they cover every ingestion path alike: the REST
+API, the batch endpoints, and the OpenTelemetry endpoint. Ids that Opik generates itself are always
+in window; only client-supplied ids can fail.
 
 ## Before you turn it on
 
@@ -72,15 +78,21 @@ generates itself are always in window; only client-supplied ids can fail.
 
 | Environment variable | Helm value (`databaseAnalytics.*`) | Default | Description |
 | -------------------- | ---------------------------------- | ------- | ----------- |
-| `UUID_VALIDATION_ENABLED` | `uuidV7ValidationEnabled` | `false` | Master switch. While `false`, embedded timestamps are not checked at all, and the two settings below have no effect. |
+| `UUID_VALIDATION_ENABLED` | `uuidV7ValidationEnabled` | `false` | Master switch for the window check. While `false`, no timestamp check runs at ingestion. |
 | `UUID_VALIDATION_AUDIT_ONLY` | `uuidV7ValidationAuditOnly` | `false` | Count and log out-of-window ids instead of rejecting them. Only has an effect while `UUID_VALIDATION_ENABLED` is `true`. |
-| `UUID_VALIDATION_WINDOW` | `uuidV7ValidationWindow` | `24h` | How far from now an embedded timestamp may be, in either direction. Must be between `12h` and `45d`; the backend refuses to start outside that range. |
+| `UUID_VALIDATION_WINDOW` | `uuidV7ValidationWindow` | `24h` | How far from now an embedded timestamp may be, in either direction. Must be between `12h` and `45d`. |
+
+<Warning>
+  The window is validated at **startup, whatever `UUID_VALIDATION_ENABLED` is set to**. A value
+  outside `12h`–`45d` stops the backend from starting even when validation is switched off — so
+  turning the check off does not make an out-of-range window safe to leave behind.
+</Warning>
 
 Together the first two settings give three modes:
 
 | `UUID_VALIDATION_ENABLED` | `UUID_VALIDATION_AUDIT_ONLY` | Effective mode |
 | ------------------------- | ---------------------------- | -------------- |
-| `false` | *(ignored)* | **Disabled** — no timestamp check. The default. |
+| `false` | *(ignored)* | **Disabled** — no timestamp check at ingestion. The default. |
 | `true` | `true` | **Audit** — count and log, still ingest |
 | `true` | `false` | **Reject** — HTTP 400 |
 
@@ -134,13 +146,13 @@ rollout:
 | Label | Values |
 | ----- | ------ |
 | `mode` | `audit` (counted, still ingested) or `reject` (HTTP 400) |
-| `reason` | `not_v7`, `too_old`, `too_far_future` |
-| `resource` | `trace`, `span` — audit mode only |
-| `workspace_id` | The workspace that sent the id — audit mode only |
-| `http_route` | The matched route, e.g. `/v1/private/traces/batch` — reject mode only |
+| `reason` | `too_old` and `too_far_future` on either path. `not_v7` only ever appears with `mode=reject` — the version check is unconditional and runs before the window check, so it never reaches the audit path. |
+| `resource` | Audit path only. The entity whose id failed: `Trace`, `Span`, `Span trace`, `Span parent`, and the referenced-id names used by the other endpoints (`dataset_item trace`, `project`, `annotation queue`, and so on). |
+| `workspace_id` | Audit path only. `unknown` on the paths that do not carry the request workspace. |
+| `http_route` | Reject path only. The matched route, for example `/v1/private/traces/batch`. |
 
-Watch this counter for a full traffic cycle before switching from audit to reject, not just the first
-hours: a client that only runs nightly will not show up in a one-hour sample.
+Watch this counter for a full traffic cycle before switching from audit to reject, not just the
+first hours: a client that only runs nightly will not show up in a one-hour sample.
 
 ## Turning it back off
 
@@ -166,3 +178,10 @@ If legitimate traffic starts being rejected, you have three options, in order of
 All three take effect once the backend has restarted. Nothing is migrated and no data is rewritten,
 so any of them is safe to do at any time — writes that were rejected while the check was on are not
 recovered, though, so the client has to send them again.
+
+Note that none of these switch off the version check: a non-UUIDv7 `id` is rejected regardless.
+
+## Next steps
+
+- [Self-host troubleshooting](/self-host/troubleshooting) — other ingestion and startup failures
+- [Self-hosting overview](/self-host/overview) — how the backend picks up configuration

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -1043,6 +1043,9 @@ navigation:
           - page: LLM model registry
             path: ./docs-v2/self-host/configure/llm-model-registry.mdx
             slug: llm-model-registry
+          - page: UUIDv7 ingestion validation
+            path: ./docs-v2/self-host/configure/uuid_validation.mdx
+            slug: uuid_validation
   - tab: reference
     layout:
       - page: Overview


### PR DESCRIPTION
## Details

Adds a self-host configuration page documenting UUIDv7 ingestion validation, and registers it in the fern nav. **Documentation only** — no behavior change, no default change, nothing touched outside `apps/opik-documentation`.

The feature shipped in #7179 with no user-facing docs, so its knobs, the LiteLLM prerequisite and the escape hatches only existed in `config.yml` comments and in the Java. This closes the docs half of OPIK-7403; the SaaS-production enablement is comet-ml/comet-helm#1382.

## What the page says

New page at **self-host → Configuration → UUIDv7 ingestion validation** (`/self-host/configure/uuid_validation`):

- What is validated — and the distinction that the UUIDv7 *version* check is always on, while the *window* check is the configurable part
- That validation is service-layer, so it covers every trace/span ingestion path: REST, batch, and OTel
- The pre-enable checklist, led by the prerequisite: users of LiteLLM's native Opik integration need `v1.94.0-rc.1` or newer ([BerriAI/litellm#31294](https://github.com/BerriAI/litellm/pull/31294)) before turning validation on, or ingestion through it starts returning 400
- All three settings with their real shipped defaults, the Compose and Helm forms, and the three effective modes (disabled / audit / reject)
- Audit (shadow) mode as the recommended first step, with the searchable log prefix
- The `opik.ingestion.uuid_v7.rejected` label vocabulary, including that `workspace_id` is only tagged on the audit path and `http_route` only on the reject path
- Turning it back off: drop to audit mode, widen the window (`12h`–`45d`), or flip the switch

## On defaults

The page documents validation as **off by default and opt-in**, because that is what ships:

| Surface | Value |
| ------- | ----- |
| `apps/opik-backend/config.yml` | `${UUID_VALIDATION_ENABLED:-false}` |
| `deployment/helm_chart/opik/values.yaml` | `uuidV7ValidationEnabled: false` |
| `deployment/docker-compose/docker-compose.yaml` | `${UUID_VALIDATION_ENABLED:-false}` |

All three agree, so there is no default-flip here and nothing breaking for existing self-hosted or OSS deployments — hence no self-host changelog entry. The page notes that Opik Cloud is managed by Comet and has validation on.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- OPIK-7403

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5 (1M context)
- Scope: the whole diff — the new `uuid_validation.mdx` page and the `docs.yml` nav entry.
- Human verification: pending review by @thiagohora. Behavioral claims were read out of `UuidV7TimestampValidator`, `UuidValidationConfig`, `UuidValidationMetrics`, `InvalidUUIDExceptionMapper` and `IdGenerator` in this repo, not from the ticket text; the documented defaults were cross-checked against all three config surfaces in the table above. Reviewer should sanity-check the LiteLLM minimum version against what the upgrade campaign actually told users.

## Testing

- `docs.yml` parses; the new page resolves to exactly one nav entry, at slug `uuid_validation` under the `self-host` tab's `/configure` section
- Frontmatter parses; JSX tags balance; every in-page anchor link resolves to a heading on the page
- MDX components used (`Callout intent="info"`, `Steps`/`Step`) are already in use elsewhere under `docs-v2/self-host/`
- Every default in the configuration table was diffed against `config.yml`, `deployment/helm_chart/opik/values.yaml` and `deployment/docker-compose/docker-compose.yaml` — all three read `false` / `false` / `24h`
- The `12h`–`45d` window bound matches the `@MinDuration`/`@MaxDuration` constraints on `UuidValidationConfig`; the metric labels match `UuidValidationMetrics`; the audit log line matches the format string in `UuidV7TimestampValidator`
- Not run locally: `fern generate --docs --preview` and the `linkinator` link check (need Fern credentials). Both run in CI on this PR.

## Documentation

This PR *is* the documentation change.

Jira: [OPIK-7403](https://comet-ml.atlassian.net/browse/OPIK-7403) (docs scope) · pairs with comet-ml/comet-helm#1382 · documents the feature from #7179

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[OPIK-7403]: https://comet-ml.atlassian.net/browse/OPIK-7403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ