### PR TITLE
[OPIK-7791] [QA] Proposed e2e specs from the 2.2.56 → 2.2.57 release exploration

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -266,7 +266,7 @@ areas:
       trace-ordering:         { covered: true,  tier: t1-smoke }
       open-trace-panel:       { covered: true,  tier: t1-smoke }
       span-tree-expand:       { covered: true,  tier: t2-cuj }
-      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls; also reasoning-token billing on perplexity/sonar-deep-research (the only shipped-price-table model that can observe it) — the reasoning rate applied and subtracted from the standard-output bucket, the bare OTel usage key as a fallback for the original_usage. one, and both clamps" }
+      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls; also reasoning-token billing on perplexity/sonar-deep-research (the only shipped-price-table model that can observe it) — the reasoning rate applied and subtracted from the standard-output bucket, the bare OTel usage key as a fallback for the original_usage. one, and both clamps; also a non-token price key (mistral/voxtral-mini-tts-latest, priced per input character) billed from usage.input_characters, against an identical span carrying the same token counts and no character count as the negative control" }
       trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
@@ -339,7 +339,7 @@ areas:
       turn-order-io:           { covered: true,  tier: t1-smoke }
       thread-feedback-score:   { covered: true,  tier: t2-cuj }
       thread-actions-panel:    { covered: false }
-      thread-level-metrics:    { covered: true,  tier: t2-cuj, note: "conversational metrics" }
+      thread-level-metrics:    { covered: true,  tier: t2-cuj, note: "conversational metrics; also the thread panel header's duration, asserted at both ends of formatDuration(_, false) — a 3_615_300 ms thread (float remainder 15.300000000000182) rendering as '1h 15.3s', and a 5 ms thread keeping '0.005s'" }
 
     visual:
       logs-threads-view:   { covered: true,  state: default, spec: "visual-comparison.spec.ts 03" }

--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -266,7 +266,7 @@ areas:
       trace-ordering:         { covered: true,  tier: t1-smoke }
       open-trace-panel:       { covered: true,  tier: t1-smoke }
       span-tree-expand:       { covered: true,  tier: t2-cuj }
-      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls; also reasoning-token billing on perplexity/sonar-deep-research (the only shipped-price-table model that can observe it) — the reasoning rate applied and subtracted from the standard-output bucket, the bare OTel usage key as a fallback for the original_usage. one, and both clamps; also a non-token price key (mistral/voxtral-mini-tts-latest, priced per input character) billed from usage.input_characters, against an identical span carrying the same token counts and no character count as the negative control" }
+      span-model-cost-tokens: { covered: true,  tier: t2-cuj, note: "model/tokens/cost in the span panel, plus server-side price resolution: spans logged with usage and no total_cost, asserted at the API and in the panel, with two undated look-alike model ids as negative controls; also reasoning-token billing on perplexity/sonar-deep-research (the only shipped-price-table model that can observe it) — the reasoning rate applied and subtracted from the standard-output bucket, the bare OTel usage key as a fallback for the original_usage one, and both clamps; also a non-token price key (mistral/voxtral-mini-tts-latest, priced per input character) billed from usage.input_characters, against an identical span carrying the same token counts and no character count as the negative control" }
       trace-tag-add-remove:   { covered: true,  tier: t2-cuj }
       manual-feedback-score:  { covered: true,  tier: t2-cuj }
       toggle-spans-view:      { covered: false, note: "Logs has a 3rd toggle (Spans); only Traces+Threads covered" }
@@ -329,6 +329,7 @@ areas:
     routes: ["/projects/$projectId/logs?type=threads"]
     spec_dir: trace-explore
     specs:
+      - trace-explore/thread-duration-format.spec.ts
       - trace-explore/thread-evaluation.spec.ts
       - trace-explore/thread-id-prefilter.spec.ts
       - trace-explore/thread-logging-smoke.spec.ts

--- a/tests_end_to_end/e2e/fixtures/index.ts
+++ b/tests_end_to_end/e2e/fixtures/index.ts
@@ -1,4 +1,4 @@
-export { test, expect } from './summarised-datasets.fixture';
+export { test, expect } from './timed-threads.fixture';
 export type {
   OauthProviderSeed,
   UnreachableProviderSeed,
@@ -126,4 +126,9 @@ export type {
   SummarisedDatasetsFixtures,
 } from './summarised-datasets.fixture';
 export { SUMMARISED_DATASET_SHAPES } from './summarised-datasets.fixture';
+export type {
+  TimedThreadRef,
+  DurationThreadsRef,
+  TimedThreadsFixtures,
+} from './timed-threads.fixture';
 export type { ProjectRef } from '../core/backend';

--- a/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
@@ -223,10 +223,11 @@ const CHARACTER_PRICE_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
 ];
 
 /**
- * Twelve LLM spans: five whose model ids each exercise one step of server-side
- * price resolution (with the two ways it could go wrong), five that cover
- * reasoning-token billing over a single model, and two over a model priced per
- * input character rather than per token.
+ * Twelve LLM spans: five that exercise server-side price resolution from the
+ * model id — three ids that must resolve, covering four normalisation steps
+ * between them, and two controls for the two ways it could go wrong — five
+ * that cover reasoning-token billing over a single model, and two over a model
+ * priced per input character rather than per token.
  *
  * Costs are the shipped price table's own numbers at 1M prompt + 1M completion
  * tokens (`model_prices_and_context_window.json` / `model_prices_overrides.json`):

--- a/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
@@ -309,7 +309,11 @@ const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
  *
  * Teardown deletes the trace (and with it its spans) here rather than in the
  * test: an assertion failure must not leave priced spans behind, since the
- * project's own rolled-up cost is one of the things asserted.
+ * project's own rolled-up cost is one of the things asserted. It runs from a
+ * `finally` that opens the moment the trace exists, because the REST seeds and
+ * the span-count check all run BEFORE `use()` — a failure in any of them would
+ * otherwise skip the only cleanup and leave a half-seeded, already-priced trace
+ * behind.
  */
 export const test = baseTest.extend<ModelCostSpansFixtures>({
   modelCostSpans: async ({ sdkClient, backendClient, project, testNamespace }, use, testInfo) => {
@@ -343,46 +347,50 @@ export const test = baseTest.extend<ModelCostSpansFixtures>({
       })),
     });
 
-    if (created.span_count !== sdkSpans.length) {
-      throw new Error(
-        `[modelCostSpans fixture] expected ${sdkSpans.length} spans, bridge reported ${created.span_count}`,
-      );
-    }
+    try {
+      if (created.span_count !== sdkSpans.length) {
+        throw new Error(
+          `[modelCostSpans fixture] expected ${sdkSpans.length} spans, bridge reported ${created.span_count}`,
+        );
+      }
 
-    for (const span of restSpans) {
-      await backendClient.createSpan({
-        id: uuid7(),
+      for (const span of restSpans) {
+        await backendClient.createSpan({
+          id: uuid7(),
+          traceId: created.id,
+          projectName: project.name,
+          name: span.name,
+          source: 'sdk',
+          type: 'llm',
+          model: span.model,
+          provider: span.provider,
+          usage: usageFor(span),
+        });
+      }
+
+      const ref: ModelCostSpansRef = {
         traceId: created.id,
-        projectName: project.name,
-        name: span.name,
-        source: 'sdk',
-        type: 'llm',
-        model: span.model,
-        provider: span.provider,
-        usage: usageFor(span),
+        spans,
+        promptTokens: PROMPT_TOKENS,
+        completionTokens: COMPLETION_TOKENS,
+        expectedTraceCost: spans.reduce((acc, s) => acc + s.expectedCost, 0),
+      };
+
+      await testInfo.attach('opik.modelCostSpans', {
+        body: JSON.stringify(ref, null, 2),
+        contentType: 'application/json',
       });
-    }
 
-    const ref: ModelCostSpansRef = {
-      traceId: created.id,
-      spans,
-      promptTokens: PROMPT_TOKENS,
-      completionTokens: COMPLETION_TOKENS,
-      expectedTraceCost: spans.reduce((acc, s) => acc + s.expectedCost, 0),
-    };
-
-    await testInfo.attach('opik.modelCostSpans', {
-      body: JSON.stringify(ref, null, 2),
-      contentType: 'application/json',
-    });
-
-    await use(ref);
-
-    if (!shouldLeaveArtifacts(testInfo)) {
-      try {
-        await backendClient.deleteTraces([created.id]);
-      } catch (err) {
-        console.warn(`[modelCostSpans fixture] delete warning for trace ${created.id}:`, err);
+      await use(ref);
+    } finally {
+      // Swallow-and-warn, never rethrow: a delete that fails here would replace
+      // whichever seeding or assertion error actually broke the test.
+      if (!shouldLeaveArtifacts(testInfo)) {
+        try {
+          await backendClient.deleteTraces([created.id]);
+        } catch (err) {
+          console.warn(`[modelCostSpans fixture] delete warning for trace ${created.id}:`, err);
+        }
       }
     }
   },

--- a/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/model-cost-spans.fixture.ts
@@ -16,8 +16,15 @@ import type { SpanSeedUsage } from '../core/sdk';
  * the assertion would pass for the wrong reason. Spans that genuinely carry
  * bare OTel keys arrive via OTel ingestion rather than the SDK, so those seeds
  * are written straight to `POST /v1/private/spans` instead.
+ *
+ * `raw-usage-rest` is the same bypass for a different reason: a usage key that
+ * is not a token count at all. `input_characters` is what a per-character model
+ * prices from, and the SDK's usage builders model provider token shapes — so a
+ * seed sent through the bridge can arrive with the key dropped, and a span that
+ * prices at nothing is indistinguishable from the negative control it is
+ * supposed to be discriminated against.
  */
-export type ModelCostSpanWriter = 'python-sdk' | 'otel-rest';
+export type ModelCostSpanWriter = 'python-sdk' | 'otel-rest' | 'raw-usage-rest';
 
 export interface ModelCostSpanSeed {
   /** Stable, namespace-free handle a spec can look a vector up by. */
@@ -34,6 +41,14 @@ export interface ModelCostSpanSeed {
    * answer and this is only what the test compares it against.
    */
   expectedCost: number;
+  /**
+   * Why a vector with `expectedCost: 0` must not be billed, for the assertion
+   * message. The controls do not all fail the same way — one is a model id the
+   * table must not match, another is a model it does match but whose priced
+   * quantity is absent — and a shared message would mis-describe whichever one
+   * actually broke.
+   */
+  zeroCostReason?: string;
   /**
    * Usage keys this span carries on top of the shared prompt/completion counts,
    * spelled exactly as they must reach the backend.
@@ -63,6 +78,13 @@ export interface ModelCostSpansFixtures {
  */
 const PROMPT_TOKENS = 1_000_000;
 const COMPLETION_TOKENS = 1_000_000;
+
+/**
+ * The `usage` key an audio-speech model's price is multiplied by. The backend
+ * reads it under the `original_usage.` prefix first and bare second, so a seed
+ * carrying the bare key exercises the same arithmetic either way.
+ */
+const INPUT_CHARACTERS_KEY = 'input_characters';
 
 /** The `usage` key SDK 1.6.0+ logs reasoning/thinking tokens under. */
 const SDK_REASONING_KEY = 'original_usage.completion_tokens_details.reasoning_tokens';
@@ -154,9 +176,57 @@ const REASONING_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
 ];
 
 /**
- * Ten LLM spans: five whose model ids each exercise one step of server-side
- * price resolution (with the two ways it could go wrong), and five that cover
- * reasoning-token billing over a single model.
+ * Two vectors over one model whose price has no token term at all
+ * (`SpanCostCalculator.audioSpeechCost`).
+ *
+ * `mistral/voxtral-mini-tts-latest` is priced at $1.6e-05 per INPUT CHARACTER
+ * and publishes no input or output token rate, so its cost comes from a usage
+ * key the other eleven spans do not carry. This is the class of price entry
+ * `ModelCostData` has to model field by field: a key it does not declare reads
+ * as no price at all, and the span renders with a token count and no cost chip
+ * while the trace above it still rolls up a plausible-looking total. Release
+ * 2.2.57 moved this model onto `input_cost_per_character`, which is a field the
+ * backend does read; three `twelvelabs.marengo-embed-2-7` entries moved onto
+ * `input_cost_per_query`, which is not — see the PR description.
+ *
+ * The two vectors differ ONLY in the character count:
+ *
+ *   1M input_characters x $1.6e-05  -> $16.00
+ *   no input_characters             -> nothing billed
+ *
+ * Both carry the same 1M prompt + 1M completion tokens as every other seed
+ * here, which is what makes the pair discriminating: a cost that came from the
+ * token counts rather than the character count would price them identically.
+ */
+const CHARACTER_PRICE_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
+  {
+    key: 'characters-priced',
+    model: 'mistral/voxtral-mini-tts-latest',
+    provider: 'mistral',
+    usageExtras: { [INPUT_CHARACTERS_KEY]: 1_000_000 },
+    expectedCost: 16,
+    // Not `python-sdk`: input_characters is not a token count, and a builder
+    // that drops it would leave this vector indistinguishable from the control
+    // below. See ModelCostSpanWriter.
+    writer: 'raw-usage-rest',
+  },
+  {
+    key: 'characters-absent',
+    model: 'mistral/voxtral-mini-tts-latest',
+    provider: 'mistral',
+    expectedCost: 0,
+    zeroCostReason:
+      'this model is priced per input character and this span reports none; a cost here means the ' +
+      'token counts were billed at some rate the model does not publish',
+    writer: 'raw-usage-rest',
+  },
+];
+
+/**
+ * Twelve LLM spans: five whose model ids each exercise one step of server-side
+ * price resolution (with the two ways it could go wrong), five that cover
+ * reasoning-token billing over a single model, and two over a model priced per
+ * input character rather than per token.
  *
  * Costs are the shipped price table's own numbers at 1M prompt + 1M completion
  * tokens (`model_prices_and_context_window.json` / `model_prices_overrides.json`):
@@ -170,7 +240,7 @@ const REASONING_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
  * them would silently bill another model's rate, and the failure would look
  * exactly like an ordinary cost.
  *
- * See REASONING_SEEDS above for the reasoning half.
+ * See REASONING_SEEDS and CHARACTER_PRICE_SEEDS above for the other two halves.
  */
 const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
   {
@@ -203,6 +273,9 @@ const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
     model: 'gpt-5.2-99999999',
     provider: 'openai',
     expectedCost: 0,
+    zeroCostReason:
+      'this model id has no price in the table; a cost here means the date strip ran on a build ' +
+      "number and billed another model's rate",
     writer: 'python-sdk',
   },
   {
@@ -211,13 +284,17 @@ const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
     model: 'gpt-5.2-20251345',
     provider: 'openai',
     expectedCost: 0,
+    zeroCostReason:
+      'this model id has no price in the table; a cost here means the date strip ran on a build ' +
+      "number and billed another model's rate",
     writer: 'python-sdk',
   },
   ...REASONING_SEEDS,
+  ...CHARACTER_PRICE_SEEDS,
 ];
 
 /**
- * One trace carrying ten LLM spans that report token `usage` and **no**
+ * One trace carrying twelve LLM spans that report `usage` and **no**
  * `total_cost`, so the backend has to price them itself.
  *
  * Every other cost fixture in the estate (`tracedAgent`, the thread seeds)
@@ -225,10 +302,10 @@ const SPAN_SEEDS: Array<Omit<ModelCostSpanSeed, 'name'>> = [
  * resolution path has never been exercised end to end — a wrong price there is
  * invisible, because the number still renders as a perfectly ordinary cost.
  *
- * Most spans go through the bridge; the ones carrying bare OTel usage keys are
- * written straight to `POST /v1/private/spans` afterwards, because the SDK
- * would normalise exactly the key they exist to test. Both land on the same
- * trace, so the rolled-up total covers all ten either way.
+ * Most spans go through the bridge; the ones whose usage key the SDK would
+ * normalise or drop are written straight to `POST /v1/private/spans`
+ * afterwards, because that key is exactly what they exist to test. Both land on
+ * the same trace, so the rolled-up total covers all twelve either way.
  *
  * Teardown deletes the trace (and with it its spans) here rather than in the
  * test: an assertion failure must not leave priced spans behind, since the
@@ -250,7 +327,7 @@ export const test = baseTest.extend<ModelCostSpansFixtures>({
     });
 
     const sdkSpans = spans.filter((s) => s.writer === 'python-sdk');
-    const otelSpans = spans.filter((s) => s.writer === 'otel-rest');
+    const restSpans = spans.filter((s) => s.writer !== 'python-sdk');
 
     const created = await sdkClient.python.createNestedTrace({
       project_name: project.name,
@@ -272,7 +349,7 @@ export const test = baseTest.extend<ModelCostSpansFixtures>({
       );
     }
 
-    for (const span of otelSpans) {
+    for (const span of restSpans) {
       await backendClient.createSpan({
         id: uuid7(),
         traceId: created.id,

--- a/tests_end_to_end/e2e/fixtures/timed-threads.fixture.ts
+++ b/tests_end_to_end/e2e/fixtures/timed-threads.fixture.ts
@@ -1,0 +1,188 @@
+import { test as baseTest } from './summarised-datasets.fixture';
+import { shouldLeaveArtifacts } from '../core/artifacts';
+import { uuid7, type BackendClient } from '../core/backend';
+
+/**
+ * One thread whose wall-clock span is an exact, chosen number of milliseconds.
+ *
+ * `durationMs` is the axis under test. The backend derives a thread's duration
+ * as `dateDiff('microsecond', min(start_time), max(end_time)) / 1000` over the
+ * thread's traces, so a thread that has to span an exact interval has to
+ * control both ends of it — which the SDK bridge cannot do (it stamps its own
+ * times), hence the REST seeds below.
+ */
+export interface TimedThreadRef {
+  threadId: string;
+  /** Trace ids in the order they were seeded, oldest first. */
+  traceIds: string[];
+  /** Exactly what `GET /v1/private/traces/threads` must report for `duration`. */
+  durationMs: number;
+  /** What `formatDuration(durationMs, false)` must render in the thread panel. */
+  expectedDisplay: string;
+}
+
+export interface DurationThreadsRef {
+  projectId: string;
+  projectName: string;
+  /**
+   * An hour plus a remainder, spanned by two traces.
+   *
+   * 3_615_300 ms is not an arbitrary interval: `3615.3 % 3600` is
+   * 15.300000000000182 in IEEE-754 doubles, so this is the value that renders
+   * the raw float when the hour remainder is not re-rounded (OPIK-8248).
+   */
+  hourPlusRemainder: TimedThreadRef;
+  /**
+   * 5 ms, spanned by a single trace — the other end of the same formatter
+   * branch, and the one a "round the remainder harder" fix would break by
+   * flattening a real 5 ms interval to "0s".
+   */
+  subSecond: TimedThreadRef;
+}
+
+export interface TimedThreadsFixtures {
+  durationThreads: DurationThreadsRef;
+}
+
+/** ms between the thread's first trace start and its last trace end. */
+const HOUR_PLUS_REMAINDER_MS = 3_615_300;
+const SUB_SECOND_MS = 5;
+
+/** Length of the first trace of the two-turn thread; immaterial to the total. */
+const FIRST_TURN_MS = 1_000;
+
+interface TraceSeed {
+  label: string;
+  /** ms after the thread's first start_time. */
+  startOffsetMs: number;
+  endOffsetMs: number;
+}
+
+const HOUR_PLUS_REMAINDER_TRACES: TraceSeed[] = [
+  { label: 'turn-1', startOffsetMs: 0, endOffsetMs: FIRST_TURN_MS },
+  {
+    label: 'turn-2',
+    startOffsetMs: 3_600_000,
+    // The thread's last end_time, and so the one that fixes its duration.
+    endOffsetMs: HOUR_PLUS_REMAINDER_MS,
+  },
+];
+
+const SUB_SECOND_TRACES: TraceSeed[] = [
+  { label: 'turn-1', startOffsetMs: 0, endOffsetMs: SUB_SECOND_MS },
+];
+
+async function seedThread(
+  backendClient: BackendClient,
+  projectName: string,
+  namespace: string,
+  label: string,
+  firstStart: Date,
+  traces: TraceSeed[],
+  durationMs: number,
+  expectedDisplay: string,
+): Promise<TimedThreadRef> {
+  const threadId = `${namespace}-${label}-thread`;
+  const traceIds: string[] = [];
+
+  for (const seed of traces) {
+    const id = uuid7();
+    await backendClient.createTraceWithSource({
+      id,
+      projectName,
+      name: `${namespace}-${label}-${seed.label}`,
+      source: 'sdk',
+      threadId,
+      input: `${namespace} ${label} ${seed.label} input`,
+      output: `${namespace} ${label} ${seed.label} output`,
+      startTime: new Date(firstStart.getTime() + seed.startOffsetMs),
+      // Never omitted: a trace with no end_time contributes no end to the
+      // thread's `max(end_time)`, and the aggregate answers a null duration —
+      // which no rendering assertion could tell apart from a formatter bug.
+      endTime: new Date(firstStart.getTime() + seed.endOffsetMs),
+    });
+    traceIds.push(id);
+  }
+
+  return { threadId, traceIds, durationMs, expectedDisplay };
+}
+
+/**
+ * Two threads in one project, each spanning an exact interval, for the two ends
+ * of `formatDuration(_, false)` — the thread panel's own header formatter.
+ *
+ * Seeded through `POST /v1/private/traces` rather than the SDK bridge because
+ * the interval IS the subject: the bridge stamps `start_time`/`end_time` from
+ * its own clock, so a thread seeded through it spans however long the seed
+ * happened to take, and neither of the two intervals below could be reproduced.
+ *
+ * Both threads land in the same project so one page load can reach either, and
+ * so the thread list the spec reads has a known total.
+ *
+ * Teardown deletes the traces explicitly: deleting a project does not take its
+ * traces with it, and `global-teardown`'s run-prefix sweep does not know about
+ * traces at all.
+ */
+export const test = baseTest.extend<TimedThreadsFixtures>({
+  durationThreads: async ({ backendClient, project, testNamespace }, use, testInfo) => {
+    // Anchored so both threads END at roughly "now" — a thread whose start is
+    // an hour back still sits inside every default Logs window, while one
+    // seeded an hour into the future would not.
+    const now = Date.now();
+
+    const seeded: TimedThreadRef[] = [];
+    try {
+      const hourPlusRemainder = await seedThread(
+        backendClient,
+        project.name,
+        testNamespace,
+        'hour-remainder',
+        new Date(now - HOUR_PLUS_REMAINDER_MS),
+        HOUR_PLUS_REMAINDER_TRACES,
+        HOUR_PLUS_REMAINDER_MS,
+        '1h 15.3s',
+      );
+      seeded.push(hourPlusRemainder);
+
+      const subSecond = await seedThread(
+        backendClient,
+        project.name,
+        testNamespace,
+        'sub-second',
+        new Date(now - SUB_SECOND_MS),
+        SUB_SECOND_TRACES,
+        SUB_SECOND_MS,
+        '0.005s',
+      );
+      seeded.push(subSecond);
+
+      const ref: DurationThreadsRef = {
+        projectId: project.id,
+        projectName: project.name,
+        hourPlusRemainder,
+        subSecond,
+      };
+
+      await testInfo.attach('opik.durationThreads', {
+        body: JSON.stringify(ref, null, 2),
+        contentType: 'application/json',
+      });
+
+      await use(ref);
+    } finally {
+      // In a `finally`, and driven by what was actually written: a failure
+      // seeding the second thread must still take the first one's traces with
+      // it, or the next run's thread list starts with a stranger in it.
+      if (!shouldLeaveArtifacts(testInfo) && seeded.length > 0) {
+        const ids = seeded.flatMap((t) => t.traceIds);
+        try {
+          await backendClient.deleteTraces(ids);
+        } catch (err) {
+          console.warn('[durationThreads fixture] trace delete warning:', err);
+        }
+      }
+    }
+  },
+});
+
+export { expect } from './summarised-datasets.fixture';

--- a/tests_end_to_end/e2e/pom/thread-panel.page.ts
+++ b/tests_end_to_end/e2e/pom/thread-panel.page.ts
@@ -66,6 +66,25 @@ export class ThreadPanelPage {
     return this.turn(traceId).getByText(output, { exact: true });
   }
 
+  /**
+   * The header's duration chip, matched on the formatted string it must show.
+   *
+   * The chip is an unlabelled `<div>` holding a clock icon and the output of
+   * `formatDuration(thread.duration, false)`; its only accessible name is a
+   * hover tooltip ("Thread duration") rendered in a portal, so there is no
+   * role, label or testid to select it by. Matching the expected text exactly
+   * and scoped to the panel is the most stable handle available on a deployed
+   * build — the FE should grow a `data-testid="thread-duration"` here, and this
+   * should move to it.
+   *
+   * Exact, not substring: "0.005s" is a substring of nothing else here, but
+   * "1h 15.3s" would also match a hypothetical "1h 15.3s ago", and a duration
+   * assertion that passes on a longer string is not asserting the format.
+   */
+  durationChip(formatted: string): Locator {
+    return this.root.getByText(formatted, { exact: true });
+  }
+
   // --- Feedback scores tab ---
   //
   // The panel's second tab. It renders the same ConfigurableFeedbackScoreTable

--- a/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
@@ -14,7 +14,7 @@ import type { BackendClient, SpanCostRef } from '@e2e/core/backend';
  * too eagerly reads as some other model's price. Both render as a perfectly
  * ordinary number on a page people read to decide what their LLM spend is.
  *
- * The fixture logs ten LLM spans with `usage` and **no** `total_cost`:
+ * The fixture logs twelve LLM spans with `usage` and **no** `total_cost`:
  *
  *  - Five for id normalisation. Three exercise a step each (provider-prefix
  *    strip, dot-normalising, compact-date strip, and an alias); two are controls
@@ -22,6 +22,11 @@ import type { BackendClient, SpanCostRef } from '@e2e/core/backend';
  *    another model's row.
  *  - Five for reasoning tokens, all on one model, differing only in the
  *    reasoning count and the usage key it arrives under.
+ *  - Two for a model priced per input character rather than per token
+ *    (OPIK-7791), differing only in whether the character count is there. A
+ *    price key the backend does not read is the same silent failure as a model
+ *    id it cannot resolve: no cost chip on the span, and a trace total that
+ *    still looks like a number.
  *
  * The expected amounts are the shipped price table's own numbers — see the
  * fixture. They are asserted at both surfaces because that is where the two can
@@ -134,11 +139,11 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
       }
     });
 
-    await test.step('The two undated look-alikes are billed nothing', async () => {
+    await test.step('Every control is billed nothing', async () => {
       for (const seed of controls(modelCostSpans.spans)) {
         expect(
           attributedCost(byName.get(seed.name)!),
-          `${seed.model} has no price in the table; a cost here means the date strip ran on a build number and billed another model's rate`,
+          `${seed.key} (${seed.model}): ${seed.zeroCostReason ?? 'this vector must not be billed'}`,
         ).toBe(0);
       }
     });
@@ -230,6 +235,44 @@ test.describe('Span cost — server-side price resolution', { tag: ['@t2-cuj', '
         cost('reasoning-negative'),
         'a negative reasoning count must floor at 0, pricing identically to the absent-key control',
       ).toBeCloseTo(cost('reasoning-absent'), 6);
+    });
+  });
+
+  test('A model priced per input character bills from its character count, not from its tokens', { tag: ['@cap:traces.span-model-cost-tokens'] }, async ({
+    modelCostSpans,
+    project,
+    backendClient,
+  }) => {
+    // No page, for the same reason as the reasoning-token test above: the
+    // subject is which usage key the backend multiplies a price by. The
+    // panel's rendering of the priced one is covered by the UI test below.
+
+    const byName = await test.step('Read the seeded spans back once all of them are queryable', async () =>
+      readSeededSpans(backendClient, project.id, modelCostSpans));
+
+    await test.step('The character-priced span is billed at the table rate', async () => {
+      // mistral/voxtral-mini-tts-latest publishes input_cost_per_character and
+      // no token rate at all: 1M characters x $1.6e-05 -> $16.00. A model whose
+      // price key ModelCostData does not declare resolves to nothing instead,
+      // and nothing is what this assertion exists to tell apart from $16.
+      expect(
+        costOf(byName, modelCostSpans, 'characters-priced'),
+        'characters-priced: 1.0M input_characters x $1.6e-05/character',
+      ).toBeCloseTo(16, 6);
+    });
+
+    await test.step('The same model without a character count is billed nothing', async () => {
+      // The discriminating half. Both vectors carry the identical 1M prompt +
+      // 1M completion tokens and differ only in `input_characters`, so a cost
+      // that had come from the token counts would price them the same.
+      const control = modelCostSpans.spans.find((s) => s.key === 'characters-absent');
+      expect(control, "the fixture must seed a 'characters-absent' vector").toBeDefined();
+      const span = byName.get(control!.name);
+      expect(span, `span ${control!.name} was seeded`).toBeDefined();
+      expect(
+        attributedCost(span!),
+        `characters-absent: ${control!.zeroCostReason}`,
+      ).toBe(0);
     });
   });
 

--- a/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts
@@ -16,10 +16,11 @@ import type { BackendClient, SpanCostRef } from '@e2e/core/backend';
  *
  * The fixture logs twelve LLM spans with `usage` and **no** `total_cost`:
  *
- *  - Five for id normalisation. Three exercise a step each (provider-prefix
- *    strip, dot-normalising, compact-date strip, and an alias); two are controls
- *    whose eight trailing digits are not dates and must not be stripped onto
- *    another model's row.
+ *  - Five for id normalisation. Three carry ids that must resolve, covering
+ *    four steps between them (provider-prefix strip, dot-normalising,
+ *    compact-date strip, and an alias — the first id needs three of them at
+ *    once); two are controls whose eight trailing digits are not dates and
+ *    must not be stripped onto another model's row.
  *  - Five for reasoning tokens, all on one model, differing only in the
  *    reasoning count and the usage key it arrives under.
  *  - Two for a model priced per input character rather than per token

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
@@ -1,0 +1,151 @@
+import { test, expect } from '@e2e/fixtures';
+import type { DurationThreadsRef, TimedThreadRef } from '@e2e/fixtures';
+import { LogsPage } from '@e2e/pom/logs.page';
+import type { BackendClient } from '@e2e/core/backend';
+
+/**
+ * How the thread panel renders a thread's duration (OPIK-8248).
+ *
+ * `formatDuration(value, false)` splits a duration into units and renders the
+ * leftover seconds. The remainder is a float — `3615.3 % 3600` is
+ * 15.300000000000182 — so an unrounded remainder reaches the page verbatim and
+ * an hour-long thread reads "1h 15.300000000000182s". Nothing in the estate
+ * asserts a formatted duration anywhere, and `src/lib/date.ts` carries no
+ * `@area:` of its own, so the thread panel header is the one caller of this
+ * branch a Playwright test can reach.
+ *
+ * Two intervals, because the obvious wrong fix for the leak is to round the
+ * remainder harder, and that is invisible from the hour case alone: rounding to
+ * whole seconds also turns a real 5 ms thread into "0s", losing information on
+ * the sub-second branch the fix deliberately did not touch. Each is asserted at
+ * the API first — the rendered string is only meaningful against a duration
+ * known to be the seeded one, and a thread whose aggregate never landed would
+ * otherwise fail as an indistinguishable "text not found".
+ */
+
+/**
+ * The seeded threads as `GET /v1/private/traces/threads` answers, once both are
+ * aggregated.
+ *
+ * The total is asserted, not just the two lookups: the project is fresh and
+ * holds exactly these two threads, so a read that also returned a third — or
+ * that merged the two into one — must fail here rather than further down.
+ */
+async function readSeededThreads(
+  backendClient: BackendClient,
+  seed: DurationThreadsRef,
+): Promise<Map<string, number | null>> {
+  const expectedIds = [seed.hourPlusRemainder.threadId, seed.subSecond.threadId];
+
+  await expect
+    .poll(
+      async () => {
+        const { threads } = await backendClient.listThreads({ projectId: seed.projectId });
+        return threads.filter((t) => expectedIds.includes(t.id)).length;
+      },
+      { timeout: 60_000, intervals: [500, 1_000, 2_000] },
+    )
+    .toBe(expectedIds.length);
+
+  const { total, threads } = await backendClient.listThreads({ projectId: seed.projectId });
+  expect(total, 'the project holds exactly the two seeded threads').toBe(expectedIds.length);
+  expect(threads, 'one row per seeded thread').toHaveLength(expectedIds.length);
+  return new Map(threads.map((t) => [t.id, t.duration]));
+}
+
+/**
+ * The duration the backend attributed to one seeded thread.
+ *
+ * Asserts it is there before returning it: a null duration is what this
+ * endpoint answers for a thread with no usable end_time, and letting that
+ * through as a zero would hand the rendering assertions a value the fixture
+ * never seeded.
+ */
+function durationOf(
+  byId: Map<string, number | null>,
+  thread: TimedThreadRef,
+): number {
+  const duration = byId.get(thread.threadId);
+  expect(duration, `thread ${thread.threadId} was aggregated`).toBeDefined();
+  expect(
+    duration,
+    `thread ${thread.threadId} must report a duration — an absent one is a failure, not a zero`,
+  ).not.toBeNull();
+  return duration!;
+}
+
+test.describe('Thread duration — panel formatting', { tag: ['@t2-cuj', '@area:threads'] }, () => {
+  test('A thread spanning more than an hour renders a rounded remainder, not the raw float', { tag: ['@cap:threads.thread-level-metrics'] }, async ({
+    durationThreads,
+    backendClient,
+    page,
+  }) => {
+    const thread = durationThreads.hourPlusRemainder;
+
+    await test.step('The thread really spans the seeded interval', async () => {
+      const byId = await readSeededThreads(backendClient, durationThreads);
+      expect(
+        durationOf(byId, thread),
+        'the panel assertion below is only about formatting if the duration behind it is the one seeded',
+      ).toBe(thread.durationMs);
+    });
+
+    const panel = await test.step('Open the thread detail panel', async () => {
+      const logs = new LogsPage(page);
+      await logs.gotoThreads(durationThreads.projectId);
+      await logs.waitForThreadsReady(thread.threadId);
+      const panel = await logs.openThreadById(thread.threadId);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+
+    await test.step('The header reads the formatted duration', async () => {
+      // toHaveCount(1) before toBeVisible: two chips rendering the same string
+      // would mean the header is not the element being asserted on.
+      await expect(panel.durationChip(thread.expectedDisplay)).toHaveCount(1);
+      await expect(panel.durationChip(thread.expectedDisplay)).toBeVisible();
+    });
+
+    await test.step('The unrounded remainder appears nowhere in the panel', async () => {
+      // The whole panel, not just the chip: the same value also reaches the
+      // header tooltip, and a leak into either is the regression.
+      await expect(panel.root).not.toContainText('15.30000');
+    });
+  });
+
+  test('A sub-second thread keeps its precision instead of flattening to zero', { tag: ['@cap:threads.thread-level-metrics'] }, async ({
+    durationThreads,
+    backendClient,
+    page,
+  }) => {
+    const thread = durationThreads.subSecond;
+
+    await test.step('The thread really spans the seeded interval', async () => {
+      const byId = await readSeededThreads(backendClient, durationThreads);
+      expect(
+        durationOf(byId, thread),
+        'a 5 ms thread is only a precision test if the backend agrees it is 5 ms',
+      ).toBe(thread.durationMs);
+    });
+
+    const panel = await test.step('Open the thread detail panel', async () => {
+      const logs = new LogsPage(page);
+      await logs.gotoThreads(durationThreads.projectId);
+      await logs.waitForThreadsReady(thread.threadId);
+      const panel = await logs.openThreadById(thread.threadId);
+      await panel.waitForFullyLoaded();
+      return panel;
+    });
+
+    await test.step('The header keeps the millisecond precision', async () => {
+      await expect(panel.durationChip(thread.expectedDisplay)).toHaveCount(1);
+      await expect(panel.durationChip(thread.expectedDisplay)).toBeVisible();
+    });
+
+    await test.step('Nothing in the panel reads as a zero-length thread', async () => {
+      // The failure mode a coarser rounding of the hour remainder would
+      // introduce here: a real interval rendered as no interval at all.
+      await expect(panel.durationChip('0s')).toHaveCount(0);
+    });
+  });
+});

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
@@ -117,10 +117,13 @@ test.describe('Thread duration — panel formatting', { tag: ['@t2-cuj', '@area:
     });
 
     await test.step('The unrounded remainder appears nowhere in the panel', async () => {
-      // The whole panel, not just the chip. The header tooltip is the static
-      // string "Thread duration" and never carries the value, but the panel
-      // renders per-turn durations through the same formatter, so a leak is
-      // worth ruling out everywhere it could surface rather than in one chip.
+      // Scoped to the whole panel rather than the chip, but only as a
+      // belt-and-braces guard: today the header chip is the panel's ONLY
+      // caller of formatDuration — `TraceMessages`/`TraceMessage` render no
+      // per-turn duration, and the header's tooltip is the static string
+      // "Thread duration" — so this currently overlaps the assertion above.
+      // It earns its keep against a second copy of the value arriving later
+      // (a per-turn duration, a hover card) with the rounding left off.
       await expect(
         panel.root,
         'the raw float remainder (15.300000000000182) must not reach any duration the panel renders',

--- a/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
+++ b/tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts
@@ -102,14 +102,29 @@ test.describe('Thread duration — panel formatting', { tag: ['@t2-cuj', '@area:
     await test.step('The header reads the formatted duration', async () => {
       // toHaveCount(1) before toBeVisible: two chips rendering the same string
       // would mean the header is not the element being asserted on.
-      await expect(panel.durationChip(thread.expectedDisplay)).toHaveCount(1);
-      await expect(panel.durationChip(thread.expectedDisplay)).toBeVisible();
+      //
+      // The locator is built FROM the expected string, so a miss reports "0
+      // elements" and says nothing about what the header actually read — hence
+      // the messages, which name the regression this count is standing in for.
+      await expect(
+        panel.durationChip(thread.expectedDisplay),
+        `the header must read exactly '${thread.expectedDisplay}' for a ${thread.durationMs} ms thread; zero matches means the remainder reached the page unrounded`,
+      ).toHaveCount(1);
+      await expect(
+        panel.durationChip(thread.expectedDisplay),
+        'the duration chip must be on screen, not merely in the DOM',
+      ).toBeVisible();
     });
 
     await test.step('The unrounded remainder appears nowhere in the panel', async () => {
-      // The whole panel, not just the chip: the same value also reaches the
-      // header tooltip, and a leak into either is the regression.
-      await expect(panel.root).not.toContainText('15.30000');
+      // The whole panel, not just the chip. The header tooltip is the static
+      // string "Thread duration" and never carries the value, but the panel
+      // renders per-turn durations through the same formatter, so a leak is
+      // worth ruling out everywhere it could surface rather than in one chip.
+      await expect(
+        panel.root,
+        'the raw float remainder (15.300000000000182) must not reach any duration the panel renders',
+      ).not.toContainText('15.30000');
     });
   });
 
@@ -138,14 +153,23 @@ test.describe('Thread duration — panel formatting', { tag: ['@t2-cuj', '@area:
     });
 
     await test.step('The header keeps the millisecond precision', async () => {
-      await expect(panel.durationChip(thread.expectedDisplay)).toHaveCount(1);
-      await expect(panel.durationChip(thread.expectedDisplay)).toBeVisible();
+      await expect(
+        panel.durationChip(thread.expectedDisplay),
+        `the header must read exactly '${thread.expectedDisplay}' for a ${thread.durationMs} ms thread; zero matches means the sub-second branch lost precision`,
+      ).toHaveCount(1);
+      await expect(
+        panel.durationChip(thread.expectedDisplay),
+        'the duration chip must be on screen, not merely in the DOM',
+      ).toBeVisible();
     });
 
     await test.step('Nothing in the panel reads as a zero-length thread', async () => {
       // The failure mode a coarser rounding of the hour remainder would
       // introduce here: a real interval rendered as no interval at all.
-      await expect(panel.durationChip('0s')).toHaveCount(0);
+      await expect(
+        panel.durationChip('0s'),
+        'a 5 ms thread must never render as "0s" — that is formatDuration\'s empty-result fallback, not a duration',
+      ).toHaveCount(0);
     });
   });
 });


### PR DESCRIPTION
## Details

**Generated by the release QA side flow (test-proposal step). It is a draft and needs review before merge — please read the assertions, not just the green run.**

These specs come from the exploratory pass over the 2.2.56 → 2.2.57 release, where a human drove each flow by hand on staging first. Two of the three verified candidates are proposed here; the third was dropped, see below.

They were **written and run against the `2.2.57` release ref** (commit `033a62f`), which is what the assertions were verified on. `main` is the base only because a GitHub PR base must be a branch and `2.2.57` is a tag — `main` is 2 commits ahead of it (docs, helm chart, TS SDK package bumps), none of them under `tests_end_to_end/`.

### 1. Span cost — a model priced per input character

`tests_end_to_end/e2e/tests/trace-explore/span-cost-resolution.spec.ts` (extended) and its `modelCostSpans` fixture.

- **Capability:** `@cap:traces.span-model-cost-tokens` (already `covered: true`; note extended, not the coverage flag).
- **What it asserts:** the price table carries entries whose cost has no token term at all. `mistral/voxtral-mini-tts-latest` is priced at `input_cost_per_character` and publishes no token rate, so its cost comes from a usage key none of the other seeds carry. The fixture grows two vectors over that model — 1M `input_characters` → **$16.00**, and an identical span carrying the same 1M prompt + 1M completion tokens and **no** character count → **nothing billed**. The pair is what makes it discriminating: a cost that had come from the token counts would price them the same. The trace roll-up and the panel assertions in the existing tests pick both up for free (trace total moves $102.75 → $118.75).
- **Why it matters:** a price key `ModelCostData` does not declare resolves to no cost at all. On the span that is visible (a token count and no cost chip); one level up it is silent — the trace still rolls up a perfectly plausible total, just a smaller one.
- **Surface:** API for the arithmetic, UI for the rendering — the candidate named `both`, and the existing UI test already walks every priced span.

### 2. Thread duration — panel formatting at both ends

`tests_end_to_end/e2e/tests/trace-explore/thread-duration-format.spec.ts` (new), `fixtures/timed-threads.fixture.ts` (new), one accessor added to `pom/thread-panel.page.ts`.

- **Capability:** `@cap:threads.thread-level-metrics` (already `covered: true`; note extended). Flagged for the reviewer: that key's note reads "conversational metrics", and a thread's duration is a thread-level metric shown in the same panel — but if you read the key as meaning evaluation scores only, say so and I will retag rather than stretch it.
- **What it asserts:** no spec in the estate asserted a formatted duration anywhere, and `src/lib/date.ts` carries no `@area:` of its own, so the thread panel header is the one caller of `formatDuration(_, false)` a Playwright test can reach. Two threads with exact wall-clock spans: 3,615,300 ms (whose float remainder is `15.300000000000182`) must read **`1h 15.3s`** with the raw float appearing nowhere in the panel, and 5 ms must still read **`0.005s`**.
- **Why the second one:** the obvious wrong fix for an unrounded remainder is to round harder, and that is invisible from the hour case alone — it also flattens a real 5 ms thread to `0s` on the sub-second branch the fix deliberately did not touch.
- **Surface:** each test asserts the thread's `duration` at `GET /v1/private/traces/threads` **before** opening the browser, so the rendered string is anchored to a known input rather than to whatever the backend happened to compute. The candidate suggested the sub-second half be a 5 ms *span*; it is a 5 ms *thread* here so both halves exercise the same `onlySeconds=false` branch the change was about. The span Duration cell uses `onlySeconds=true` and is a different code path.

### Notes for the reviewer

- **One selector is a scoped exact-text match**, not a testid: the header duration chip is an unlabelled `<div>` whose only accessible name is a portal-rendered hover tooltip. Per `conventions.md` this would normally mean adding a `data-testid` in the same change — but these specs are verified against a *deployed* staging build, where a new FE attribute does not exist yet, and an unverifiable spec is worse than a documented selector. The POM comment says so and names the testid the FE should grow (`thread-duration`). Happy to add it here if you would rather take the spec unverified against a rebuilt FE.
- **`taxonomy.yaml`: `specs:` lists deliberately untouched.** The nightly reconcile job derives them from the `@area:` tags; hand-editing them is what made this file the most-conflicted in the queue. Both capabilities were already `covered: true` at `t2-cuj`, so only the two `note:` strings changed, to record the new vectors.
- `tests_end_to_end/e2e/fixtures/index.ts` moves the chain head to the new fixture, which is the estate's existing pattern for adding one.

### What I deliberately did not write

- **The `twelvelabs.marengo-embed-2-7` half of candidate 1.** The exploration found all three variants stopped pricing in 2.2.57 (they were $70.00 at 1M prompt tokens in 2.2.56) because the table moved them from `input_cost_per_token` to `input_cost_per_query`, which `ModelCostData` has no field for. That is a real behaviour change worth a look — but **what the right cost is, is an open engineering call**: if `input_cost_per_query` is upstream truth then a per-query model should bill $0.00007 per call, not $70.00, and a spec asserting the old number would pin 2.2.56 behaviour that may itself be wrong. Asserting the *current* zero would be worse: it would mark the behaviour as tested forever. So it is reported, not encoded. The character-priced vectors above cover the same class — a non-token price key — with an expectation nobody has to adjudicate.
- **Candidate 3, the mixed-batch valueless `ScoreResult` in a Python rule.** Marked `weak` by the exploration and skipped per the skill: `online-evaluation.python-rule-scores` is already covered five ways, the automation-log half landed in #8172/#8151, and it passes today. It adds a vector, not a capability.
- Candidates the exploration itself did not propose (chat-completions casing, the two new OpenAI models, ClickHouse settings, the cutover runbook, the Cursor extension, the project-metrics duration axis) — either verified working with no defect to pin, blocked on workspace configuration this run must not change, or not reachable from a Playwright/API estate at all.

## Change checklist

- [ ] User facing
- [ ] Documentation update
- [x] Tests only — no product code changed
- [x] New specs run green against a live environment before opening (see Testing)
- [x] `@area:` / `@cap:` tags resolve in `taxonomy.yaml`; `tag_lint.py` clean

## Issues

- OPIK-7791

Related but **not** resolved here, and referenced without linking per CONTRIBUTING.md: the release items behind the two flows are OPIK_8248 (duration rendering) and the 2.2.57 price-table update, plus the marengo per-query finding described above, which needs a ticket of its own once someone decides what the correct cost is.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code, running the `release-test-proposal` QA skill
- Model(s): Claude Opus 5
- Scope: the whole diff — both specs, the two fixtures, the POM accessor and the two taxonomy `note:` strings
- Human verification: **not yet.** The underlying flows were verified by hand on staging by a human during the release exploration, and the specs were run green against that same environment (below), but the spec code itself has not been human-reviewed. That is what this draft is for.

## Testing

All commands run from `tests_end_to_end/e2e/`, against `OPIK_BASE_URL=https://staging.dev.comet.com/opik` (workspace `opik-testing`, `OPIK_DEPLOYMENT=cloud`) — the same environment the exploration used. Only the specs in this PR were run.

```
$ npx playwright test tests/trace-explore/thread-duration-format.spec.ts --reporter=list
  ✓ A thread spanning more than an hour renders a rounded remainder, not the raw float (10.5s)
  ✓ A sub-second thread keeps its precision instead of flattening to zero (10.2s)
  2 passed (21.9s)

$ npx playwright test tests/trace-explore/span-cost-resolution.spec.ts --reporter=list
  ✓ LLM spans logged without a cost are priced from their model id, and undated look-alikes are not (5.9s)
  ✓ Reasoning tokens bill at the reasoning rate and come out of the standard-output bucket (5.3s)
  ✓ A model priced per input character bills from its character count, not from its tokens (5.1s)
  ✓ The trace panel renders the server-resolved cost for the trace and for each priced span (11.4s)
  4 passed (24.4s)

$ python3 tests_end_to_end/coverage/tag_lint.py --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
  tag-lint: 76 specs checked, 1 exempt, 0 problem(s)
```

Nothing was skipped and nothing is `.skip`-ed. Both spec files were run twice (once mid-iteration, once as committed) and were stable.

**Not run, with reasons:**

- **The rest of `tests/trace-explore/`.** The estate's own gate asks for the feature-directory run when a shared POM changes. The two shared things this PR touches are additive: a new method on `ThreadPanelPage` (no existing behaviour altered) and two extra seeds in `modelCostSpans`, whose only consumer in the estate is `span-cost-resolution.spec.ts` — which ran in full above. So the affected set is exactly what was run.
- **`npx tsc --noEmit`.** It fails on this checkout before reaching any of my files: `tsconfig.json` sets `baseUrl`, which the pinned `typescript@7.0.2` has removed (`error TS5102`). Pre-existing and repo-wide, so not fixed here. Typechecking instead ran through a scratch config identical but for `baseUrl` (dropped) and explicit `types: ["node"]`: **clean over the whole estate apart from one pre-existing `TS2300: Duplicate identifier 'deleteDashboard'` in `core/backend/client.ts`**, which this PR does not touch. Worth a separate ticket for both.

## Documentation

No documentation change needed. This PR adds e2e specs and their fixtures; there is no user-facing behaviour, API, SDK surface or configuration change to document.
