### PR TITLE
feat(opik-frontend): bulk annotate traces and spans from table actions panel (#1010)

### DIFF
--- a/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
+++ b/apps/opik-frontend/src/api/traces/useTraceFeedbackScoreSetMutation.ts
@@ -28,6 +28,7 @@ type UseTraceFeedbackScoreSetMutationParams = {
   value: number;
   reason?: string;
   sourceQueueId?: string;
+  silent?: boolean;
 };
 
 const useTraceFeedbackScoreSetMutation = () => {
@@ -60,7 +61,14 @@ const useTraceFeedbackScoreSetMutation = () => {
 
       return data;
     },
-    onError: (error: AxiosError) => {
+    onError: (
+      error: AxiosError,
+      variables: UseTraceFeedbackScoreSetMutationParams,
+    ) => {
+      if (variables?.silent) {
+        return;
+      }
+
       const message = get(
         error,
         ["response", "data", "message"],

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AnnotateTracesDialog from "./AnnotateTracesDialog";
+import { Span, Trace } from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { FEEDBACK_DEFINITION_TYPE } from "@/types/feedback-definitions";
+
+const mockSetFeedbackScore = vi.fn();
+const mockToast = vi.fn();
+const mockSetOpen = vi.fn();
+
+vi.mock("@/api/feedback-definitions/useFeedbackDefinitionsList", () => ({
+  default: vi.fn(() => ({
+    data: {
+      content: [
+        {
+          name: "helpfulness",
+          type: FEEDBACK_DEFINITION_TYPE.numerical,
+          details: { min: 0, max: 10 },
+        },
+        {
+          name: "satisfaction",
+          type: FEEDBACK_DEFINITION_TYPE.categorical,
+          details: { categories: { good: 1, bad: 0 } },
+        },
+        {
+          name: "thumbs",
+          type: FEEDBACK_DEFINITION_TYPE.boolean,
+          details: { true_label: "up", false_label: "down" },
+        },
+      ],
+      total: 3,
+    },
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/api/traces/useTraceFeedbackScoreSetMutation", () => ({
+  default: vi.fn(() => ({
+    mutateAsync: mockSetFeedbackScore,
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/store/AppStore", () => ({
+  default: vi.fn((selector) =>
+    selector({
+      activeWorkspaceName: "test-workspace",
+      activeProjectId: "test-project-id",
+      loggedInUserName: "tester",
+    }),
+  ),
+}));
+
+vi.mock("@/shared/SelectBox/SelectBox", () => ({
+  default: ({
+    options,
+    onChange,
+    testId,
+  }: {
+    options: Array<{ label: string; value: string }>;
+    onChange: (value?: string) => void;
+    testId?: string;
+  }) => (
+    <div data-testid={testId}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`${testId}-option-${option.value}`}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: vi.fn(() => ({ toast: mockToast })),
+}));
+
+const mockTraces: Trace[] = [
+  { id: "trace-1" } as Trace,
+  { id: "trace-2" } as Trace,
+];
+
+const renderDialog = (
+  rows: Array<Trace | Span> = mockTraces,
+  type: TRACE_DATA_TYPE = TRACE_DATA_TYPE.traces,
+) => {
+  render(
+    <AnnotateTracesDialog
+      rows={rows}
+      open={true}
+      setOpen={mockSetOpen}
+      type={type}
+    />,
+  );
+};
+
+const selectNumericalScore = async () => {
+  fireEvent.click(
+    screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+  );
+  fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
+    target: { value: "7" },
+  });
+  await waitFor(() => {
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+  });
+};
+
+describe("AnnotateTracesDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the dialog with selection count and disabled apply button", () => {
+    renderDialog();
+
+    expect(screen.getByText("Annotate traces")).toBeInTheDocument();
+    expect(screen.getByText(/2 selected/)).toBeInTheDocument();
+    const applyButton = screen.getByTestId("annotate-bulk-apply-button");
+    expect(applyButton).toBeDisabled();
+  });
+
+  it("enables apply after selecting a score and entering a valid value", async () => {
+    renderDialog();
+    await selectNumericalScore();
+  });
+
+  it("submits an annotation for every selected row", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "helpfulness",
+        value: 7,
+        traceId: "trace-1",
+      }),
+    );
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "helpfulness",
+        value: 7,
+        traceId: "trace-2",
+      }),
+    );
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Annotations applied" }),
+    );
+  });
+
+  it("preserves the entered reason when switching scores", async () => {
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.change(screen.getByTestId("annotate-bulk-reason-input"), {
+      target: { value: "looks good" },
+    });
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-satisfaction"),
+    );
+
+    expect(screen.getByTestId("annotate-bulk-reason-input")).toHaveValue(
+      "looks good",
+    );
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeDisabled();
+  });
+
+  it("disables apply and skips submission for out-of-range values", async () => {
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-helpfulness"),
+    );
+    fireEvent.change(screen.getByTestId("annotate-bulk-score-input"), {
+      target: { value: "99" },
+    });
+
+    expect(screen.getByTestId("annotate-bulk-apply-button")).toBeDisabled();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+    expect(mockSetFeedbackScore).not.toHaveBeenCalled();
+  });
+
+  it("supports categorical scores via category selection", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-satisfaction"),
+    );
+    fireEvent.click(screen.getByTestId("annotate-bulk-category-toggle-good"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "satisfaction",
+          categoryName: "good",
+          value: 1,
+        }),
+      );
+    });
+  });
+
+  it("maps boolean scores to their labels and numeric values", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    renderDialog();
+
+    fireEvent.click(
+      screen.getByTestId("annotate-bulk-score-select-option-thumbs"),
+    );
+    fireEvent.click(screen.getByText("up"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("annotate-bulk-apply-button")).toBeEnabled();
+    });
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "thumbs",
+          value: 1,
+          categoryName: "up",
+        }),
+      );
+    });
+  });
+
+  it("fans out span annotations with spanId and parent traceId", async () => {
+    mockSetFeedbackScore.mockResolvedValue({});
+    const spans: Span[] = [
+      { id: "span-1", trace_id: "trace-1" } as Span,
+      { id: "span-2", trace_id: "trace-1" } as Span,
+    ];
+    renderDialog(spans, TRACE_DATA_TYPE.spans);
+
+    expect(screen.getByText("Annotate spans")).toBeInTheDocument();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-1",
+        spanId: "span-1",
+      }),
+    );
+    expect(mockSetFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        traceId: "trace-1",
+        spanId: "span-2",
+      }),
+    );
+  });
+
+  it("toasts a full failure when every mutation is rejected", async () => {
+    mockSetFeedbackScore.mockRejectedValue(new Error("boom"));
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Error" }),
+      );
+    });
+    expect(mockSetOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("toasts a partial failure with the success count", async () => {
+    mockSetFeedbackScore
+      .mockResolvedValueOnce({})
+      .mockRejectedValueOnce(new Error("boom"));
+    renderDialog();
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Partially applied" }),
+      );
+    });
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: "1 of 2 traces annotated successfully.",
+      }),
+    );
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.test.tsx
@@ -8,31 +8,11 @@ import { FEEDBACK_DEFINITION_TYPE } from "@/types/feedback-definitions";
 const mockSetFeedbackScore = vi.fn();
 const mockToast = vi.fn();
 const mockSetOpen = vi.fn();
+const mockRefetchDefinitions = vi.fn();
+const mockUseFeedbackDefinitionsList = vi.fn();
 
 vi.mock("@/api/feedback-definitions/useFeedbackDefinitionsList", () => ({
-  default: vi.fn(() => ({
-    data: {
-      content: [
-        {
-          name: "helpfulness",
-          type: FEEDBACK_DEFINITION_TYPE.numerical,
-          details: { min: 0, max: 10 },
-        },
-        {
-          name: "satisfaction",
-          type: FEEDBACK_DEFINITION_TYPE.categorical,
-          details: { categories: { good: 1, bad: 0 } },
-        },
-        {
-          name: "thumbs",
-          type: FEEDBACK_DEFINITION_TYPE.boolean,
-          details: { true_label: "up", false_label: "down" },
-        },
-      ],
-      total: 3,
-    },
-    isPending: false,
-  })),
+  default: (...args: unknown[]) => mockUseFeedbackDefinitionsList(...args),
 }));
 
 vi.mock("@/api/traces/useTraceFeedbackScoreSetMutation", () => ({
@@ -115,6 +95,31 @@ const selectNumericalScore = async () => {
 describe("AnnotateTracesDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseFeedbackDefinitionsList.mockReturnValue({
+      data: {
+        content: [
+          {
+            name: "helpfulness",
+            type: FEEDBACK_DEFINITION_TYPE.numerical,
+            details: { min: 0, max: 10 },
+          },
+          {
+            name: "satisfaction",
+            type: FEEDBACK_DEFINITION_TYPE.categorical,
+            details: { categories: { good: 1, bad: 0 } },
+          },
+          {
+            name: "thumbs",
+            type: FEEDBACK_DEFINITION_TYPE.boolean,
+            details: { true_label: "up", false_label: "down" },
+          },
+        ],
+        total: 3,
+      },
+      isLoading: false,
+      isError: false,
+      refetch: mockRefetchDefinitions,
+    });
   });
 
   it("renders the dialog with selection count and disabled apply button", () => {
@@ -311,5 +316,81 @@ describe("AnnotateTracesDialog", () => {
         description: "1 of 2 traces annotated successfully.",
       }),
     );
+  });
+
+  it("renders loading state when feedback definitions are loading", () => {
+    mockUseFeedbackDefinitionsList.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      refetch: mockRefetchDefinitions,
+    });
+    renderDialog();
+
+    expect(
+      screen.getByText("Loading feedback definitions…"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders error state and retries on button click when definitions query fails", () => {
+    mockUseFeedbackDefinitionsList.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetchDefinitions,
+    });
+    renderDialog();
+
+    expect(
+      screen.getByText(/Failed to load feedback definitions/),
+    ).toBeInTheDocument();
+    const retryButton = screen.getByRole("button", { name: "Retry" });
+    fireEvent.click(retryButton);
+    expect(mockRefetchDefinitions).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows destructive toast and closes dialog when rows exceed 500", () => {
+    const manyRows: Trace[] = Array.from({ length: 501 }, (_, i) => ({
+      id: `trace-${i}`,
+    })) as Trace[];
+    renderDialog(manyRows);
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Error",
+        description:
+          "You can only annotate up to 500 traces at a time. Please select fewer items.",
+        variant: "destructive",
+      }),
+    );
+    expect(mockSetOpen).toHaveBeenCalledWith(false);
+  });
+
+  it("enforces bounded concurrency with up to 5 concurrent mutations", async () => {
+    let running = 0;
+    let maxRunning = 0;
+    mockSetFeedbackScore.mockImplementation(async () => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      running--;
+      return {};
+    });
+
+    const eightRows: Trace[] = Array.from({ length: 8 }, (_, i) => ({
+      id: `trace-${i}`,
+    })) as Trace[];
+
+    renderDialog(eightRows);
+    await selectNumericalScore();
+
+    fireEvent.click(screen.getByTestId("annotate-bulk-apply-button"));
+
+    await waitFor(() => {
+      expect(mockSetFeedbackScore).toHaveBeenCalledTimes(8);
+    });
+
+    expect(maxRunning).toBeLessThanOrEqual(5);
+    expect(maxRunning).toBeGreaterThan(1);
   });
 });

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -14,6 +14,7 @@ import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
 import useTraceFeedbackScoreSetMutation from "@/api/traces/useTraceFeedbackScoreSetMutation";
 import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
 import useAppStore from "@/store/AppStore";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   FEEDBACK_DEFINITION_TYPE,
   FeedbackDefinition,
@@ -46,6 +47,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
   AnnotateTracesDialogProps
 > = ({ rows, open, setOpen, type }) => {
   const { toast } = useToast();
+  const queryClient = useQueryClient();
   const workspaceName = useAppStore((state) => state.activeWorkspaceName);
   const {
     data: feedbackDefinitionsData,
@@ -80,7 +82,11 @@ const AnnotateTracesDialog: React.FunctionComponent<
   );
 
   const isValueValid = useMemo(() => {
-    if (!selectedDefinition || draft.value === undefined) {
+    if (
+      !selectedDefinition ||
+      draft.value === undefined ||
+      draft.value === null
+    ) {
       return false;
     }
     if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
@@ -89,8 +95,27 @@ const AnnotateTracesDialog: React.FunctionComponent<
         draft.value,
       );
     }
-    return true;
-  }, [selectedDefinition, draft.value]);
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
+      const categories = selectedDefinition.details?.categories || {};
+      return (
+        draft.categoryName !== undefined &&
+        draft.categoryName !== null &&
+        Object.prototype.hasOwnProperty.call(categories, draft.categoryName) &&
+        categories[draft.categoryName] !== null &&
+        categories[draft.categoryName] !== undefined &&
+        categories[draft.categoryName] === draft.value
+      );
+    }
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
+      return (
+        (draft.categoryName === selectedDefinition.details.true_label &&
+          draft.value === 1) ||
+        (draft.categoryName === selectedDefinition.details.false_label &&
+          draft.value === 0)
+      );
+    }
+    return false;
+  }, [selectedDefinition, draft.value, draft.categoryName]);
 
   useEffect(() => {
     if (open && rows.length > MAX_ANNOTATE_ROWS) {
@@ -120,7 +145,6 @@ const AnnotateTracesDialog: React.FunctionComponent<
     setIsSubmitting(true);
 
     const results: Array<PromiseSettledResult<void>> = [];
-    const queue = [...rows];
     const submitOne = async (row: Trace | Span) => {
       try {
         await setFeedbackScore({
@@ -130,6 +154,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
           reason: draft.reason || undefined,
           traceId: isSpanType ? (row as Span).trace_id : (row as Trace).id,
           spanId: isSpanType ? (row as Span).id : undefined,
+          silent: true,
         });
         results.push({ status: "fulfilled", value: undefined });
       } catch (error) {
@@ -137,24 +162,30 @@ const AnnotateTracesDialog: React.FunctionComponent<
       }
     };
 
+    let cursor = 0;
+    const workerCount = Math.min(MAX_CONCURRENT_ANNOTATIONS, rows.length);
     await Promise.all(
-      Array.from(
-        { length: Math.min(MAX_CONCURRENT_ANNOTATIONS, queue.length) },
-        async () => {
-          while (queue.length > 0) {
-            const row = queue.shift();
-            if (!row) {
-              break;
-            }
-            await submitOne(row);
+      Array.from({ length: workerCount }, async () => {
+        while (cursor < rows.length) {
+          const index = cursor++;
+          if (index >= rows.length) {
+            break;
           }
-        },
-      ),
+          const row = rows[index];
+          await submitOne(row);
+        }
+      }),
     );
 
     const failed = results.filter(
       (result) => result.status === "rejected",
     ).length;
+
+    if (results.some((result) => result.status === "fulfilled")) {
+      await queryClient.invalidateQueries({
+        queryKey: [isSpanType ? "spans" : "traces"],
+      });
+    }
 
     setIsSubmitting(false);
 
@@ -189,6 +220,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
     isSpanType,
     entityCopy,
     setFeedbackScore,
+    queryClient,
     setOpen,
     toast,
   ]);
@@ -234,6 +266,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
                   onChange={handleScoreNameChange}
                   className="h-8 min-w-[200px] py-1"
                   testId="annotate-bulk-score-select"
+                  disabled={isSubmitting}
                   renderTrigger={(value) => {
                     if (!value) {
                       return <div className="truncate">Select a score</div>;
@@ -254,6 +287,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
                     feedbackDefinition={selectedDefinition}
                     value={draft.value ?? ""}
                     categoryName={draft.categoryName}
+                    disabled={isSubmitting}
                     onChange={({
                       value: newValue,
                       categoryName: newCategory,
@@ -281,6 +315,7 @@ const AnnotateTracesDialog: React.FunctionComponent<
                     }
                     className="min-h-8 resize-none py-1"
                     data-testid="annotate-bulk-reason-input"
+                    disabled={isSubmitting}
                   />
                 </div>
               )}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog.tsx
@@ -1,0 +1,312 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog";
+import { Button } from "@/ui/button";
+import { useToast } from "@/ui/use-toast";
+import { Loader2 } from "lucide-react";
+import { Span, Trace } from "@/types/traces";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import useTraceFeedbackScoreSetMutation from "@/api/traces/useTraceFeedbackScoreSetMutation";
+import useFeedbackDefinitionsList from "@/api/feedback-definitions/useFeedbackDefinitionsList";
+import useAppStore from "@/store/AppStore";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import SelectBox from "@/shared/SelectBox/SelectBox";
+import { SelectItem } from "@/ui/select";
+import { DropdownOption } from "@/types/shared";
+import { Textarea } from "@/ui/textarea";
+import FeedbackScoreValueInput from "@/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
+
+const MAX_ANNOTATE_ROWS = 500;
+const MAX_CONCURRENT_ANNOTATIONS = 5;
+
+type AnnotateTracesDialogProps = {
+  rows: Array<Trace | Span>;
+  open: boolean | number;
+  setOpen: (open: boolean | number) => void;
+  type: TRACE_DATA_TYPE;
+};
+
+type DraftScore = {
+  name?: string;
+  value?: number;
+  categoryName?: string;
+  reason?: string;
+};
+
+const AnnotateTracesDialog: React.FunctionComponent<
+  AnnotateTracesDialogProps
+> = ({ rows, open, setOpen, type }) => {
+  const { toast } = useToast();
+  const workspaceName = useAppStore((state) => state.activeWorkspaceName);
+  const {
+    data: feedbackDefinitionsData,
+    isLoading: isDefinitionsLoading,
+    isError: isDefinitionsError,
+    refetch: refetchDefinitions,
+  } = useFeedbackDefinitionsList(
+    {
+      workspaceName,
+      page: 1,
+      size: 1000,
+    },
+    { enabled: Boolean(open) },
+  );
+  const { mutateAsync: setFeedbackScore } = useTraceFeedbackScoreSetMutation();
+
+  const [draft, setDraft] = useState<DraftScore>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isSpanType = type === TRACE_DATA_TYPE.spans;
+  const entityCopy = isSpanType ? "spans" : "traces";
+
+  const feedbackDefinitions: FeedbackDefinition[] = useMemo(
+    () => feedbackDefinitionsData?.content || [],
+    [feedbackDefinitionsData?.content],
+  );
+
+  const selectedDefinition = useMemo(
+    () =>
+      feedbackDefinitions.find((definition) => definition.name === draft.name),
+    [feedbackDefinitions, draft.name],
+  );
+
+  const isValueValid = useMemo(() => {
+    if (!selectedDefinition || draft.value === undefined) {
+      return false;
+    }
+    if (selectedDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+      return isNumericFeedbackScoreValid(
+        selectedDefinition.details as { min: number; max: number },
+        draft.value,
+      );
+    }
+    return true;
+  }, [selectedDefinition, draft.value]);
+
+  useEffect(() => {
+    if (open && rows.length > MAX_ANNOTATE_ROWS) {
+      toast({
+        title: "Error",
+        description: `You can only annotate up to ${MAX_ANNOTATE_ROWS} ${entityCopy} at a time. Please select fewer items.`,
+        variant: "destructive",
+      });
+      setOpen(false);
+    }
+  }, [open, rows.length, entityCopy, setOpen, toast]);
+
+  const handleScoreNameChange = useCallback((name: string) => {
+    setDraft((d) => ({
+      name,
+      value: undefined,
+      categoryName: undefined,
+      reason: d.reason,
+    }));
+  }, []);
+
+  const handleApply = useCallback(async () => {
+    if (!isValueValid || !draft.name || draft.value === undefined) {
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    const results: Array<PromiseSettledResult<void>> = [];
+    const queue = [...rows];
+    const submitOne = async (row: Trace | Span) => {
+      try {
+        await setFeedbackScore({
+          name: draft.name!,
+          value: draft.value!,
+          categoryName: draft.categoryName,
+          reason: draft.reason || undefined,
+          traceId: isSpanType ? (row as Span).trace_id : (row as Trace).id,
+          spanId: isSpanType ? (row as Span).id : undefined,
+        });
+        results.push({ status: "fulfilled", value: undefined });
+      } catch (error) {
+        results.push({ status: "rejected", reason: error });
+      }
+    };
+
+    await Promise.all(
+      Array.from(
+        { length: Math.min(MAX_CONCURRENT_ANNOTATIONS, queue.length) },
+        async () => {
+          while (queue.length > 0) {
+            const row = queue.shift();
+            if (!row) {
+              break;
+            }
+            await submitOne(row);
+          }
+        },
+      ),
+    );
+
+    const failed = results.filter(
+      (result) => result.status === "rejected",
+    ).length;
+
+    setIsSubmitting(false);
+
+    if (failed === 0) {
+      toast({
+        title: "Annotations applied",
+        description: `Successfully annotated ${rows.length} ${entityCopy}.`,
+      });
+      setDraft({});
+      setOpen(false);
+    } else if (failed === rows.length) {
+      toast({
+        title: "Error",
+        description: `Failed to annotate all selected ${entityCopy}.`,
+        variant: "destructive",
+      });
+    } else {
+      toast({
+        title: "Partially applied",
+        description: `${rows.length - failed} of ${
+          rows.length
+        } ${entityCopy} annotated successfully.`,
+        variant: "destructive",
+      });
+      setDraft({});
+      setOpen(false);
+    }
+  }, [
+    isValueValid,
+    draft,
+    rows,
+    isSpanType,
+    entityCopy,
+    setFeedbackScore,
+    setOpen,
+    toast,
+  ]);
+
+  return (
+    <Dialog open={Boolean(open)} onOpenChange={setOpen}>
+      <DialogContent className="max-w-lg" data-testid="annotate-bulk-dialog">
+        <DialogHeader>
+          <DialogTitle>Annotate {entityCopy}</DialogTitle>
+        </DialogHeader>
+        <p className="comet-body-s text-light-slate">
+          Apply the same feedback score to {rows.length} selected {entityCopy}.
+        </p>
+        <div className="flex flex-col gap-3 py-2">
+          {isDefinitionsError ? (
+            <div
+              className="comet-body-s text-red-600"
+              data-testid="annotate-bulk-error"
+            >
+              Failed to load feedback definitions.
+              <Button
+                variant="link"
+                size="sm"
+                onClick={() => refetchDefinitions()}
+              >
+                Retry
+              </Button>
+            </div>
+          ) : isDefinitionsLoading ? (
+            <div className="comet-body-s text-light-slate">
+              Loading feedback definitions…
+            </div>
+          ) : (
+            <>
+              <div>
+                <div className="comet-body-s-accented pb-1">Score</div>
+                <SelectBox
+                  value={draft.name ?? ""}
+                  options={feedbackDefinitions.map((definition) => ({
+                    label: definition.name,
+                    value: definition.name,
+                  }))}
+                  onChange={handleScoreNameChange}
+                  className="h-8 min-w-[200px] py-1"
+                  testId="annotate-bulk-score-select"
+                  renderTrigger={(value) => {
+                    if (!value) {
+                      return <div className="truncate">Select a score</div>;
+                    }
+                    return <span className="text-nowrap">{value}</span>;
+                  }}
+                  renderOption={(option: DropdownOption<string>) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  )}
+                />
+              </div>
+              {selectedDefinition && (
+                <div>
+                  <div className="comet-body-s-accented pb-1">Value</div>
+                  <FeedbackScoreValueInput
+                    feedbackDefinition={selectedDefinition}
+                    value={draft.value ?? ""}
+                    categoryName={draft.categoryName}
+                    onChange={({
+                      value: newValue,
+                      categoryName: newCategory,
+                    }) =>
+                      setDraft((d) => ({
+                        ...d,
+                        value: newValue,
+                        categoryName: newCategory,
+                      }))
+                    }
+                    testIdPrefix="annotate-bulk"
+                  />
+                </div>
+              )}
+              {selectedDefinition && (
+                <div>
+                  <div className="comet-body-s-accented pb-1">
+                    Reason (optional)
+                  </div>
+                  <Textarea
+                    placeholder="Add a reason..."
+                    value={draft.reason ?? ""}
+                    onChange={(event) =>
+                      setDraft((d) => ({ ...d, reason: event.target.value }))
+                    }
+                    className="min-h-8 resize-none py-1"
+                    data-testid="annotate-bulk-reason-input"
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => setOpen(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleApply}
+            disabled={!isValueValid || isSubmitting}
+            data-testid="annotate-bulk-apply-button"
+          >
+            {isSubmitting && <Loader2 className="mr-1 size-3 animate-spin" />}
+            Apply to {rows.length} {entityCopy}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AnnotateTracesDialog;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
@@ -211,4 +211,25 @@ describe("FeedbackScoreValueInput", () => {
       status: "valid",
     });
   });
+
+  it("selects empty category via dropdown option with sentinel encoding", () => {
+    const onChange = vi.fn();
+    const emptyKeyDef = {
+      name: "satisfaction",
+      type: FEEDBACK_DEFINITION_TYPE.categorical,
+      details: { categories: { "": 0, good: 1, great: 2 } },
+    };
+    renderInput(emptyKeyDef as unknown as FeedbackDefinition, onChange);
+
+    const optionBtn = screen.getByTestId(
+      "fsvi-category-select-option-__EMPTY_CATEGORY_SENTINEL__",
+    );
+    fireEvent.click(optionBtn);
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 0,
+      categoryName: "",
+      status: "valid",
+    });
+  });
 });

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import FeedbackScoreValueInput, {
+  FeedbackScoreValue,
+} from "./FeedbackScoreValueInput";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+
+vi.mock("@/shared/SelectBox/SelectBox", () => ({
+  default: ({
+    options,
+    onChange,
+    testId,
+  }: {
+    options: Array<{ label: string; value: string }>;
+    onChange: (value?: string) => void;
+    testId?: string;
+  }) => (
+    <div data-testid={testId}>
+      {options.map((option) => (
+        <button
+          key={option.value}
+          type="button"
+          data-testid={`${testId}-option-${option.value}`}
+          onClick={() => onChange(option.value)}
+        >
+          {option.label}
+        </button>
+      ))}
+      <button
+        type="button"
+        data-testid={`${testId}-clear`}
+        onClick={() => onChange("")}
+      >
+        Clear selection
+      </button>
+    </div>
+  ),
+}));
+
+const numericalDef = {
+  name: "helpfulness",
+  type: FEEDBACK_DEFINITION_TYPE.numerical,
+  details: { min: 0, max: 10 },
+};
+const booleanDef = {
+  name: "thumbs",
+  type: FEEDBACK_DEFINITION_TYPE.boolean,
+  details: { true_label: "up", false_label: "down" },
+};
+const categoricalDef = {
+  name: "satisfaction",
+  type: FEEDBACK_DEFINITION_TYPE.categorical,
+  details: { categories: { good: 1, bad: 0 } },
+};
+const categoricalLongDef = {
+  name: "satisfaction",
+  type: FEEDBACK_DEFINITION_TYPE.categorical,
+  details: { categories: { excellent: 3, average: 2, poor: 1 } },
+};
+
+const renderInput = (
+  feedbackDefinition: FeedbackDefinition,
+  onChange: (update: FeedbackScoreValue) => void,
+  props?: { value?: number | ""; categoryName?: string },
+) => {
+  render(
+    <FeedbackScoreValueInput
+      feedbackDefinition={feedbackDefinition}
+      value={props?.value ?? ""}
+      categoryName={props?.categoryName}
+      onChange={onChange}
+      testIdPrefix="fsvi"
+    />,
+  );
+};
+
+describe("FeedbackScoreValueInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits valid numeric values", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "7" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: 7,
+        status: "valid",
+      });
+    });
+  });
+
+  it("marks out-of-range numeric input as invalid without clearing it", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange, {
+      value: 7,
+    });
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "99" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: undefined,
+        status: "invalid",
+      });
+    });
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ status: "empty" }),
+    );
+  });
+
+  it("marks empty numeric input as an explicit clear", async () => {
+    const onChange = vi.fn();
+    renderInput(numericalDef as unknown as FeedbackDefinition, onChange, {
+      value: 7,
+    });
+
+    fireEvent.change(screen.getByTestId("fsvi-score-input"), {
+      target: { value: "" },
+    });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        value: undefined,
+        status: "empty",
+      });
+    });
+  });
+
+  it("exposes an accessible name on the numeric input", () => {
+    renderInput(numericalDef as unknown as FeedbackDefinition, vi.fn());
+    expect(screen.getByLabelText("helpfulness")).toBeInTheDocument();
+  });
+
+  it("maps boolean labels to values", () => {
+    const onChange = vi.fn();
+    renderInput(booleanDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-boolean-toggle-up"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 1,
+      categoryName: "up",
+      status: "valid",
+    });
+  });
+
+  it("maps short categorical lists to toggle items", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-toggle-good"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 1,
+      categoryName: "good",
+      status: "valid",
+    });
+  });
+
+  it("uses a select for long categorical lists", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalLongDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-select-option-average"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 2,
+      categoryName: "average",
+      status: "valid",
+    });
+  });
+
+  it("emits a clear event when no empty-string key exists", () => {
+    const onChange = vi.fn();
+    renderInput(categoricalLongDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-select-clear"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: undefined,
+      categoryName: undefined,
+      status: "empty",
+    });
+  });
+
+  it("treats an empty-string key as a selectable category when defined", () => {
+    const onChange = vi.fn();
+    const emptyKeyDef = {
+      name: "satisfaction",
+      type: FEEDBACK_DEFINITION_TYPE.categorical,
+      details: { categories: { "": 0, good: 1, great: 2 } },
+    };
+    renderInput(emptyKeyDef as unknown as FeedbackDefinition, onChange);
+
+    fireEvent.click(screen.getByTestId("fsvi-category-select-clear"));
+
+    expect(onChange).toHaveBeenCalledWith({
+      value: 0,
+      categoryName: "",
+      status: "valid",
+    });
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
@@ -1,0 +1,241 @@
+import React, { useCallback } from "react";
+import sortBy from "lodash/sortBy";
+import DebounceInput from "@/shared/DebounceInput/DebounceInput";
+import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import { isNumericFeedbackScoreValid } from "@/lib/traces";
+import SelectBox from "@/shared/SelectBox/SelectBox";
+import { SelectItem } from "@/ui/select";
+import { DropdownOption } from "@/types/shared";
+import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
+
+export const SET_VALUE_DEBOUNCE_DELAY = 500;
+
+export type FeedbackScoreValue = {
+  value?: number;
+  categoryName?: string;
+  /**
+   * Why the value changed: "empty" = user explicitly cleared input,
+   * "invalid" = out-of-range/non-numeric input was rejected,
+   * "valid" = a valid usable value was entered.
+   */
+  status?: "empty" | "invalid" | "valid";
+};
+
+type FeedbackScoreValueInputProps = {
+  feedbackDefinition: FeedbackDefinition;
+  value: number | "";
+  categoryName?: string;
+  onChange: (update: FeedbackScoreValue) => void;
+  testIdPrefix?: string;
+};
+
+/**
+ * Controlled input for a feedback definition value.
+ * Encodes the shared domain rules for numerical (range validation), boolean
+ * (label/value mapping), and categorical (category/value mapping) feedback scores.
+ */
+const FeedbackScoreValueInput: React.FunctionComponent<
+  FeedbackScoreValueInputProps
+> = ({ feedbackDefinition, value, categoryName, onChange, testIdPrefix }) => {
+  const prefix = testIdPrefix ?? "feedback-score-value";
+
+  const handleNumericChange = useCallback(
+    (inputValue: string | number | readonly string[] | undefined) => {
+      if (inputValue === undefined || inputValue === "") {
+        onChange({ value: undefined, status: "empty" });
+        return;
+      }
+      const num = Number(inputValue);
+      if (
+        typeof num !== "number" ||
+        Number.isNaN(num) ||
+        !isNumericFeedbackScoreValid(
+          feedbackDefinition.details as { min: number; max: number },
+          num,
+        )
+      ) {
+        onChange({ value: undefined, status: "invalid" });
+        return;
+      }
+      onChange({ value: num, status: "valid" });
+    },
+    [feedbackDefinition, onChange],
+  );
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
+    return (
+      <DebounceInput
+        className="my-0.5 h-7 min-w-[100px] py-1"
+        max={feedbackDefinition.details.max}
+        min={feedbackDefinition.details.min}
+        step="any"
+        dimension="sm"
+        delay={SET_VALUE_DEBOUNCE_DELAY}
+        onValueChange={handleNumericChange}
+        placeholder="Score"
+        type="number"
+        value={value}
+        aria-label={feedbackDefinition.name}
+        data-testid={`${prefix}-score-input`}
+      />
+    );
+  }
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
+    const onBooleanValueChange = (label?: string) => {
+      if (!label) {
+        return;
+      }
+      onChange({
+        value: label === feedbackDefinition.details.true_label ? 1 : 0,
+        categoryName: label,
+        status: "valid",
+      });
+    };
+
+    return (
+      <ToggleGroup
+        className="min-w-fit p-0.5"
+        onValueChange={onBooleanValueChange}
+        variant="outline"
+        type="single"
+        size="md"
+        value={categoryName}
+      >
+        <ToggleGroupItem
+          className="w-full"
+          key="true"
+          value={feedbackDefinition.details.true_label}
+          data-testid={`${prefix}-boolean-toggle-${feedbackDefinition.details.true_label}`}
+        >
+          <div className="text-nowrap">
+            {feedbackDefinition.details.true_label}
+          </div>
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          className="w-full"
+          key="false"
+          value={feedbackDefinition.details.false_label}
+          data-testid={`${prefix}-boolean-toggle-${feedbackDefinition.details.false_label}`}
+        >
+          <div className="text-nowrap">
+            {feedbackDefinition.details.false_label}
+          </div>
+        </ToggleGroupItem>
+      </ToggleGroup>
+    );
+  }
+
+  if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
+    const onCategoricalValueChange = (label?: string) => {
+      // An empty-string category can be a legitimate key; only treat "" as
+      // "clear" when no such key exists in the definition.
+      const hasEmptyKey = Object.prototype.hasOwnProperty.call(
+        feedbackDefinition.details.categories,
+        "",
+      );
+      if ((label === undefined || label === "") && !hasEmptyKey) {
+        onChange({ value: undefined, categoryName: undefined, status: "empty" });
+        return;
+      }
+      const categoryEntry = Object.entries(
+        feedbackDefinition.details.categories,
+      ).find(([name]) => name === label);
+
+      if (categoryEntry) {
+        onChange({
+          value: categoryEntry[1],
+          categoryName: label,
+          status: "valid",
+        });
+      }
+    };
+
+    const categoricalOptionList = sortBy(
+      Object.entries(feedbackDefinition.details.categories).map(
+        ([name, val]) => ({
+          name,
+          value: val,
+        }),
+      ),
+      "value",
+    );
+
+    const hasLongNames = categoricalOptionList.some((item) => {
+      const label = categoryOptionLabelRenderer(item.name, item.value);
+      return label.length > 10;
+    });
+    const hasMultipleOptions = categoricalOptionList.length > 2;
+
+    if (hasLongNames || hasMultipleOptions) {
+      const categoricalSelectOptionList = categoricalOptionList.map((item) => ({
+        label: item.name,
+        value: item.name,
+        description: String(item.value),
+      }));
+      return (
+        <SelectBox
+          value={categoryName || ""}
+          options={categoricalSelectOptionList}
+          onChange={onCategoricalValueChange}
+          className="my-0.5 h-7 min-w-[100px] py-1"
+          testId={`${prefix}-category-select`}
+          renderTrigger={(val) => {
+            const selectedOption = categoricalOptionList.find(
+              (item) => item.name.trim() === (val || "").trim(),
+            );
+
+            if (!selectedOption) {
+              return <div className="truncate">Select a category</div>;
+            }
+
+            return (
+              <span className="text-nowrap">
+                {categoryOptionLabelRenderer(val, selectedOption.value)}
+              </span>
+            );
+          }}
+          renderOption={(option: DropdownOption<string>) => (
+            <SelectItem key={option.value} value={option.value}>
+              {categoryOptionLabelRenderer(option.value, option.description)}
+            </SelectItem>
+          )}
+        />
+      );
+    }
+
+    return (
+      <ToggleGroup
+        className="min-w-fit p-0.5"
+        onValueChange={onCategoricalValueChange}
+        variant="outline"
+        type="single"
+        size="md"
+        value={String(categoryName)}
+      >
+        {categoricalOptionList.map(({ name, value: categoryValue }) => {
+          return (
+            <ToggleGroupItem
+              className="w-full"
+              key={name}
+              value={name}
+              data-testid={`${prefix}-category-toggle-${name}`}
+            >
+              <div className="text-nowrap">
+                {categoryOptionLabelRenderer(name, categoryValue)}
+              </div>
+            </ToggleGroupItem>
+          );
+        })}
+      </ToggleGroup>
+    );
+  }
+
+  return null;
+};
+
+export default FeedbackScoreValueInput;

--- a/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/FeedbackScoreValueInput/FeedbackScoreValueInput.tsx
@@ -12,7 +12,39 @@ import { SelectItem } from "@/ui/select";
 import { DropdownOption } from "@/types/shared";
 import { categoryOptionLabelRenderer } from "@/lib/feedback-scores";
 
-export const SET_VALUE_DEBOUNCE_DELAY = 500;
+export const getCollisionFreeEmptyCategorySentinel = (
+  categories: Record<string, number>,
+): string => {
+  let sentinel = "__EMPTY_CATEGORY_SENTINEL__";
+  while (Object.prototype.hasOwnProperty.call(categories, sentinel)) {
+    sentinel = `_${sentinel}_`;
+  }
+  return sentinel;
+};
+
+export const encodeCategoryOptionValue = (
+  name: string,
+  categories: Record<string, number>,
+): string => {
+  if (name === "") {
+    return getCollisionFreeEmptyCategorySentinel(categories);
+  }
+  return name;
+};
+
+export const decodeCategoryOptionValue = (
+  value: string | undefined,
+  categories: Record<string, number>,
+): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const sentinel = getCollisionFreeEmptyCategorySentinel(categories);
+  if (value === sentinel) {
+    return "";
+  }
+  return value;
+};
 
 export type FeedbackScoreValue = {
   value?: number;
@@ -31,6 +63,7 @@ type FeedbackScoreValueInputProps = {
   categoryName?: string;
   onChange: (update: FeedbackScoreValue) => void;
   testIdPrefix?: string;
+  disabled?: boolean;
 };
 
 /**
@@ -40,7 +73,14 @@ type FeedbackScoreValueInputProps = {
  */
 const FeedbackScoreValueInput: React.FunctionComponent<
   FeedbackScoreValueInputProps
-> = ({ feedbackDefinition, value, categoryName, onChange, testIdPrefix }) => {
+> = ({
+  feedbackDefinition,
+  value,
+  categoryName,
+  onChange,
+  testIdPrefix,
+  disabled = false,
+}) => {
   const prefix = testIdPrefix ?? "feedback-score-value";
 
   const handleNumericChange = useCallback(
@@ -81,6 +121,7 @@ const FeedbackScoreValueInput: React.FunctionComponent<
         value={value}
         aria-label={feedbackDefinition.name}
         data-testid={`${prefix}-score-input`}
+        disabled={disabled}
       />
     );
   }
@@ -105,6 +146,7 @@ const FeedbackScoreValueInput: React.FunctionComponent<
         type="single"
         size="md"
         value={categoryName}
+        disabled={disabled}
       >
         <ToggleGroupItem
           className="w-full"
@@ -171,22 +213,37 @@ const FeedbackScoreValueInput: React.FunctionComponent<
     });
     const hasMultipleOptions = categoricalOptionList.length > 2;
 
+    const categoriesMap = feedbackDefinition.details.categories || {};
+    const encodedSelectedValue =
+      categoryName !== undefined
+        ? encodeCategoryOptionValue(categoryName, categoriesMap)
+        : "";
+
     if (hasLongNames || hasMultipleOptions) {
       const categoricalSelectOptionList = categoricalOptionList.map((item) => ({
-        label: item.name,
-        value: item.name,
+        label: item.name === "" ? '""' : item.name,
+        value: encodeCategoryOptionValue(item.name, categoriesMap),
         description: String(item.value),
       }));
+
+      const handleSelectChange = (encodedVal?: string) => {
+        const decoded = decodeCategoryOptionValue(encodedVal, categoriesMap);
+        onCategoricalValueChange(decoded);
+      };
+
       return (
         <SelectBox
-          value={categoryName || ""}
+          value={encodedSelectedValue}
           options={categoricalSelectOptionList}
-          onChange={onCategoricalValueChange}
+          onChange={handleSelectChange}
           className="my-0.5 h-7 min-w-[100px] py-1"
           testId={`${prefix}-category-select`}
+          disabled={disabled}
           renderTrigger={(val) => {
+            const actualName =
+              decodeCategoryOptionValue(val, categoriesMap) ?? "";
             const selectedOption = categoricalOptionList.find(
-              (item) => item.name.trim() === (val || "").trim(),
+              (item) => item.name === actualName,
             );
 
             if (!selectedOption) {
@@ -195,35 +252,53 @@ const FeedbackScoreValueInput: React.FunctionComponent<
 
             return (
               <span className="text-nowrap">
-                {categoryOptionLabelRenderer(val, selectedOption.value)}
+                {categoryOptionLabelRenderer(
+                  selectedOption.name,
+                  selectedOption.value,
+                )}
               </span>
             );
           }}
-          renderOption={(option: DropdownOption<string>) => (
-            <SelectItem key={option.value} value={option.value}>
-              {categoryOptionLabelRenderer(option.value, option.description)}
-            </SelectItem>
-          )}
+          renderOption={(option: DropdownOption<string>) => {
+            const actualName =
+              decodeCategoryOptionValue(option.value, categoriesMap) ?? "";
+            return (
+              <SelectItem key={option.value} value={option.value}>
+                {categoryOptionLabelRenderer(actualName, option.description)}
+              </SelectItem>
+            );
+          }}
         />
       );
     }
 
+    const toggleValue =
+      categoryName !== undefined
+        ? encodeCategoryOptionValue(categoryName, categoriesMap)
+        : undefined;
+
     return (
       <ToggleGroup
         className="min-w-fit p-0.5"
-        onValueChange={onCategoricalValueChange}
+        onValueChange={(val) => {
+          onCategoricalValueChange(
+            decodeCategoryOptionValue(val, categoriesMap),
+          );
+        }}
         variant="outline"
         type="single"
         size="md"
-        value={String(categoryName)}
+        value={toggleValue}
+        disabled={disabled}
       >
         {categoricalOptionList.map(({ name, value: categoryValue }) => {
+          const itemVal = encodeCategoryOptionValue(name, categoriesMap);
           return (
             <ToggleGroupItem
               className="w-full"
-              key={name}
-              value={name}
-              data-testid={`${prefix}-category-toggle-${name}`}
+              key={itemVal}
+              value={itemVal}
+              data-testid={`${prefix}-category-toggle-${name || "empty"}`}
             >
               <div className="text-nowrap">
                 {categoryOptionLabelRenderer(name, categoryValue)}

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.test.tsx
@@ -1,0 +1,163 @@
+import { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/ui/tooltip";
+import AnnotateRow from "./AnnotateRow";
+import {
+  FEEDBACK_DEFINITION_TYPE,
+  FeedbackDefinition,
+} from "@/types/feedback-definitions";
+import { FEEDBACK_SCORE_TYPE } from "@/types/traces";
+
+vi.mock("@/store/AppStore", () => ({
+  useLoggedInUserNameOrOpenSourceDefaultUser: vi.fn(() => "tester"),
+}));
+
+vi.mock("@/ui/use-toast", () => ({
+  useToast: vi.fn(() => ({ toast: vi.fn() })),
+}));
+
+const numericalDef: FeedbackDefinition = {
+  id: "def-1",
+  name: "helpfulness",
+  type: FEEDBACK_DEFINITION_TYPE.numerical,
+  details: { min: 0, max: 10 },
+  created_at: "",
+  last_updated_at: "",
+};
+
+const booleanDef: FeedbackDefinition = {
+  id: "def-2",
+  name: "thumbs",
+  type: FEEDBACK_DEFINITION_TYPE.boolean,
+  details: { true_label: "up", false_label: "down" },
+  created_at: "",
+  last_updated_at: "",
+};
+
+describe("AnnotateRow", () => {
+  let queryClient: QueryClient;
+  const onUpdateFeedbackScore = vi.fn();
+  const onDeleteFeedbackScore = vi.fn();
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  const renderWithWrapper = (ui: React.ReactElement) => {
+    return render(ui, {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>{children}</TooltipProvider>
+        </QueryClientProvider>
+      ),
+    });
+  };
+
+  it("calls onUpdateFeedbackScore when a valid numeric score is entered", async () => {
+    renderWithWrapper(
+      <AnnotateRow
+        name="helpfulness"
+        feedbackDefinition={numericalDef}
+        feedbackScore={{
+          name: "helpfulness",
+          value: 5,
+          source: FEEDBACK_SCORE_TYPE.ui,
+        }}
+        onUpdateFeedbackScore={onUpdateFeedbackScore}
+        onDeleteFeedbackScore={onDeleteFeedbackScore}
+      />,
+    );
+
+    const input = screen.getByTestId("annotate-score-input");
+    fireEvent.change(input, { target: { value: "8" } });
+
+    await waitFor(() => {
+      expect(onUpdateFeedbackScore).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "helpfulness",
+          value: 8,
+        }),
+      );
+    });
+    expect(onDeleteFeedbackScore).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onDeleteFeedbackScore when an invalid out-of-range numeric score is entered", async () => {
+    renderWithWrapper(
+      <AnnotateRow
+        name="helpfulness"
+        feedbackDefinition={numericalDef}
+        feedbackScore={{
+          name: "helpfulness",
+          value: 5,
+          source: FEEDBACK_SCORE_TYPE.ui,
+        }}
+        onUpdateFeedbackScore={onUpdateFeedbackScore}
+        onDeleteFeedbackScore={onDeleteFeedbackScore}
+      />,
+    );
+
+    const input = screen.getByTestId("annotate-score-input");
+    fireEvent.change(input, { target: { value: "99" } });
+
+    // Wait past debounce time
+    await new Promise((r) => setTimeout(r, 600));
+
+    expect(onDeleteFeedbackScore).not.toHaveBeenCalled();
+    expect(onUpdateFeedbackScore).not.toHaveBeenCalledWith(
+      expect.objectContaining({ value: 99 }),
+    );
+  });
+
+  it("calls onDeleteFeedbackScore when the numeric score is cleared", async () => {
+    renderWithWrapper(
+      <AnnotateRow
+        name="helpfulness"
+        feedbackDefinition={numericalDef}
+        feedbackScore={{
+          name: "helpfulness",
+          value: 5,
+          source: FEEDBACK_SCORE_TYPE.ui,
+        }}
+        onUpdateFeedbackScore={onUpdateFeedbackScore}
+        onDeleteFeedbackScore={onDeleteFeedbackScore}
+      />,
+    );
+
+    const input = screen.getByTestId("annotate-score-input");
+    fireEvent.change(input, { target: { value: "" } });
+
+    await waitFor(() => {
+      expect(onDeleteFeedbackScore).toHaveBeenCalledWith("helpfulness");
+    });
+  });
+
+  it("calls onUpdateFeedbackScore when boolean option is clicked", () => {
+    renderWithWrapper(
+      <AnnotateRow
+        name="thumbs"
+        feedbackDefinition={booleanDef}
+        onUpdateFeedbackScore={onUpdateFeedbackScore}
+        onDeleteFeedbackScore={onDeleteFeedbackScore}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("annotate-boolean-toggle-up"));
+
+    expect(onUpdateFeedbackScore).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "thumbs",
+        value: 1,
+        categoryName: "up",
+      }),
+    );
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TraceDetailsPanel/TraceAnnotateViewer/AnnotateRow.tsx
@@ -6,34 +6,23 @@ import React, {
   useState,
 } from "react";
 import isNumber from "lodash/isNumber";
-import sortBy from "lodash/sortBy";
 import { Copy, Trash, X } from "lucide-react";
-import DebounceInput from "@/shared/DebounceInput/DebounceInput";
-import { ToggleGroup, ToggleGroupItem } from "@/ui/toggle-group";
-import {
-  FEEDBACK_DEFINITION_TYPE,
-  FeedbackDefinition,
-} from "@/types/feedback-definitions";
+import { FeedbackDefinition } from "@/types/feedback-definitions";
 import { TraceFeedbackScore } from "@/types/traces";
 import { Button } from "@/ui/button";
-import { isNumericFeedbackScoreValid } from "@/lib/traces";
 import ColoredTagNew from "@/shared/ColoredTag/ColoredTagNew";
-import SelectBox from "@/shared/SelectBox/SelectBox";
-import { SelectItem } from "@/ui/select";
-import { DropdownOption } from "@/types/shared";
 import { updateTextAreaHeight } from "@/lib/utils";
 import { Textarea } from "@/ui/textarea";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import {
-  categoryOptionLabelRenderer,
-  findValueByAuthor,
-  hasValuesByAuthor,
-} from "@/lib/feedback-scores";
+import { findValueByAuthor, hasValuesByAuthor } from "@/lib/feedback-scores";
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import copy from "clipboard-copy";
 import { useToast } from "@/ui/use-toast";
 import { UpdateFeedbackScoreData } from "./types";
 import { useLoggedInUserNameOrOpenSourceDefaultUser } from "@/store/AppStore";
+import FeedbackScoreValueInput, {
+  FeedbackScoreValue,
+} from "../../FeedbackScoreValueInput/FeedbackScoreValueInput";
 
 const SET_VALUE_DEBOUNCE_DELAY = 500;
 
@@ -136,11 +125,11 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
   });
 
   const handleChangeValue = useCallback(
-    (value: number, categoryName?: string) => {
+    (newValue: number, newCategoryName?: string) => {
       onUpdateFeedbackScore({
-        categoryName,
+        categoryName: newCategoryName,
         name,
-        value,
+        value: newValue,
         reason: reasonValue,
       });
     },
@@ -153,185 +142,31 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [name, setReasonValue]);
 
+  const handleValueChange = useCallback(
+    (update: FeedbackScoreValue) => {
+      if (update.status === "invalid") {
+        return;
+      }
+
+      if (update.status === "empty" || update.value === undefined) {
+        setValue("");
+        deleteFeedbackScore();
+        return;
+      }
+
+      setCategoryName(update.categoryName);
+      setValue(update.value);
+      handleChangeValue(update.value, update.categoryName);
+    },
+    [deleteFeedbackScore, handleChangeValue],
+  );
+
   const handleCopyReasonClick = async (v: string) => {
     await copy(v);
 
     toast({
       description: "Reason successfully copied to clipboard",
     });
-  };
-
-  const renderOptions = (feedbackDefinition: FeedbackDefinition) => {
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.numerical) {
-      return (
-        <DebounceInput
-          className="my-0.5 h-7 min-w-[100px] py-1"
-          max={feedbackDefinition.details.max}
-          min={feedbackDefinition.details.min}
-          step="any"
-          dimension="sm"
-          delay={SET_VALUE_DEBOUNCE_DELAY}
-          onValueChange={(value) => {
-            const newValue = value === "" ? "" : Number(value);
-
-            setValue(newValue);
-
-            if (newValue === "") {
-              deleteFeedbackScore();
-              return;
-            }
-
-            if (
-              isNumericFeedbackScoreValid(feedbackDefinition.details, newValue)
-            ) {
-              handleChangeValue(newValue as number);
-            }
-          }}
-          placeholder="Score"
-          type="number"
-          value={value}
-          data-testid="annotate-score-input"
-        />
-      );
-    }
-
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.boolean) {
-      const onBooleanValueChange = (value?: string) => {
-        const boolValue =
-          value === feedbackDefinition.details.true_label ? 1 : 0;
-        const categoryName = value;
-
-        setCategoryName(categoryName);
-        setValue(boolValue);
-        handleChangeValue(boolValue, categoryName);
-      };
-
-      return (
-        <ToggleGroup
-          className="min-w-fit p-0.5"
-          onValueChange={onBooleanValueChange}
-          variant="outline"
-          type="single"
-          size="md"
-          value={categoryName}
-        >
-          <ToggleGroupItem
-            className="w-full"
-            key="true"
-            value={feedbackDefinition.details.true_label}
-          >
-            <div className="text-nowrap">
-              {feedbackDefinition.details.true_label}
-            </div>
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            className="w-full"
-            key="false"
-            value={feedbackDefinition.details.false_label}
-          >
-            <div className="text-nowrap">
-              {feedbackDefinition.details.false_label}
-            </div>
-          </ToggleGroupItem>
-        </ToggleGroup>
-      );
-    }
-
-    if (feedbackDefinition.type === FEEDBACK_DEFINITION_TYPE.categorical) {
-      const onCategoricalValueChange = (value?: string) => {
-        if (value === "") {
-          deleteFeedbackScore();
-          return;
-        }
-
-        const categoryEntry = Object.entries(
-          feedbackDefinition.details.categories,
-        ).find(([categoryName]) => categoryName === value);
-
-        if (categoryEntry) {
-          const categoryValue = categoryEntry[1];
-
-          setCategoryName(value);
-          setValue(categoryValue);
-          handleChangeValue(categoryValue, value);
-        }
-      };
-      const categoricalOptionList = sortBy(
-        Object.entries(feedbackDefinition.details.categories).map(
-          ([name, value]) => ({
-            name,
-            value,
-          }),
-        ),
-        "value",
-      );
-
-      const hasLongNames = categoricalOptionList.some((item) => {
-        const label = categoryOptionLabelRenderer(item.name, item.value);
-        return label.length > 10;
-      });
-      const hasMultipleOptions = categoricalOptionList.length > 2;
-
-      if (hasLongNames || hasMultipleOptions) {
-        const categoricalSelectOptionList = categoricalOptionList.map(
-          (item) => ({
-            label: item.name,
-            value: item.name,
-            description: String(item.value),
-          }),
-        );
-        return (
-          <SelectBox
-            value={categoryName || ""}
-            options={categoricalSelectOptionList}
-            onChange={onCategoricalValueChange}
-            className="my-0.5 h-7 min-w-[100px] py-1"
-            renderTrigger={(value) => {
-              const selectedOption = categoricalOptionList.find(
-                (item) => item.name.trim() === value.trim(),
-              );
-
-              if (!selectedOption) {
-                return <div className="truncate">Select a category</div>;
-              }
-
-              return (
-                <span className="text-nowrap">
-                  {categoryOptionLabelRenderer(value, selectedOption.value)}
-                </span>
-              );
-            }}
-            renderOption={(option: DropdownOption<string>) => (
-              <SelectItem key={option.value} value={option.value}>
-                {categoryOptionLabelRenderer(option.value, option.description)}
-              </SelectItem>
-            )}
-          ></SelectBox>
-        );
-      }
-      return (
-        <ToggleGroup
-          className="min-w-fit p-0.5"
-          onValueChange={onCategoricalValueChange}
-          variant="outline"
-          type="single"
-          size="md"
-          value={String(categoryName)}
-        >
-          {categoricalOptionList.map(({ name, value }) => {
-            return (
-              <ToggleGroupItem className="w-full" key={name} value={name}>
-                <div className="text-nowrap">
-                  {name} ({value})
-                </div>
-              </ToggleGroupItem>
-            );
-          })}
-        </ToggleGroup>
-      );
-    }
-
-    return null;
   };
 
   return (
@@ -346,7 +181,13 @@ const AnnotateRow: React.FunctionComponent<AnnotateRowProps> = ({
       >
         {feedbackDefinition ? (
           <div className="min-w-0 flex-1 overflow-auto">
-            {renderOptions(feedbackDefinition)}
+            <FeedbackScoreValueInput
+              feedbackDefinition={feedbackDefinition}
+              value={value}
+              categoryName={categoryName}
+              onChange={handleValueChange}
+              testIdPrefix="annotate"
+            />
           </div>
         ) : (
           <div>{feedbackScoreData?.value}</div>

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.test.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.test.tsx
@@ -1,0 +1,93 @@
+import { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/ui/tooltip";
+import TracesActionsPanel from "./TracesActionsPanel";
+import { TRACE_DATA_TYPE } from "@/hooks/useTracesOrSpansList";
+import { Trace } from "@/types/traces";
+
+vi.mock("@/api/traces/useTraceBatchDeleteMutation", () => ({
+  default: vi.fn(() => ({ mutate: vi.fn() })),
+}));
+
+vi.mock("@/api/automations/useFilteredRulesList", () => ({
+  default: vi.fn(() => ({ rules: [], isLoading: false })),
+}));
+
+vi.mock("@/contexts/feature-toggles-provider", () => ({
+  useIsFeatureEnabled: vi.fn(() => true),
+}));
+
+vi.mock("@/contexts/PermissionsContext", () => ({
+  usePermissions: vi.fn(() => ({
+    permissions: {
+      canDeleteTraces: true,
+      canLogTraceSpanThread: true,
+      canAnnotateTraceSpanThread: true,
+    },
+  })),
+}));
+
+vi.mock(
+  "@/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog",
+  () => ({
+    default: ({ open }: { open: boolean }) =>
+      open ? <div data-testid="mock-annotate-dialog">Annotate Dialog</div> : null,
+  }),
+);
+
+describe("TracesActionsPanel", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+  });
+
+  const renderPanel = (selectedRows: Trace[] = []) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <TracesActionsPanel
+            type={TRACE_DATA_TYPE.traces}
+            getDataForExport={async () => []}
+            selectedRows={selectedRows}
+            columnsToExport={[]}
+            projectName="test-project"
+            projectId="test-project-id"
+          />
+        </TooltipProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  it("renders the Annotate button", () => {
+    renderPanel();
+    expect(screen.getByTestId("traces-bulk-annotate-button")).toBeInTheDocument();
+  });
+
+  it("disables the Annotate button when no rows are selected", () => {
+    renderPanel([]);
+    expect(screen.getByTestId("traces-bulk-annotate-button")).toBeDisabled();
+  });
+
+  it("enables the Annotate button when rows are selected and opens dialog on click", () => {
+    const rows = [{ id: "t-1" } as Trace];
+    renderPanel(rows);
+
+    const button = screen.getByTestId("traces-bulk-annotate-button");
+    expect(button).toBeEnabled();
+
+    expect(screen.queryByTestId("mock-annotate-dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(screen.getByTestId("mock-annotate-dialog")).toBeInTheDocument();
+  });
+});

--- a/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
+++ b/apps/opik-frontend/src/v2/pages-shared/traces/TracesActionsPanel/TracesActionsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useCallback } from "react";
-import { Tag, Trash } from "lucide-react";
+import { PenLine, Tag, Trash } from "lucide-react";
 import slugify from "slugify";
 import { cn } from "@/lib/utils";
 import { Button, ButtonProps } from "@/ui/button";
@@ -12,6 +12,7 @@ import useTracesBatchDeleteMutation from "@/api/traces/useTraceBatchDeleteMutati
 import TooltipWrapper from "@/shared/TooltipWrapper/TooltipWrapper";
 import ExportToButton from "@/shared/ExportToButton/ExportToButton";
 import AddTagDialog from "@/v2/pages-shared/traces/AddTagDialog/AddTagDialog";
+import AnnotateTracesDialog from "@/v2/pages-shared/traces/AnnotateTracesDialog/AnnotateTracesDialog";
 import EvaluateButton from "@/v2/pages-shared/automations/EvaluateButton/EvaluateButton";
 import RunEvaluationDialog from "@/v2/pages-shared/automations/RunEvaluationDialog/RunEvaluationDialog";
 import useFilteredRulesList from "@/api/automations/useFilteredRulesList";
@@ -70,7 +71,11 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
   const isExportEnabled = useIsFeatureEnabled(FeatureToggleKeys.EXPORT_ENABLED);
 
   const {
-    permissions: { canDeleteTraces, canLogTraceSpanThread },
+    permissions: {
+      canDeleteTraces,
+      canLogTraceSpanThread,
+      canAnnotateTraceSpanThread,
+    },
   } = usePermissions();
 
   const showEvaluate =
@@ -121,6 +126,15 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
           confirmButtonVariant="destructive"
         />
       )}
+      {canAnnotateTraceSpanThread && (
+        <AnnotateTracesDialog
+          key={`annotate-${resetKeyRef.current}`}
+          rows={selectedRows}
+          open={open === 5}
+          setOpen={setOpen}
+          type={type}
+        />
+      )}
       {canLogTraceSpanThread && (
         <AddTagDialog
           key={`tag-${resetKeyRef.current}`}
@@ -151,6 +165,23 @@ const TracesActionsPanel: React.FunctionComponent<TracesActionsPanelProps> = ({
         buttonVariant={buttonVariant}
         buttonSize={buttonSize}
       />
+      {canAnnotateTraceSpanThread && (
+        <TooltipWrapper content="Annotate">
+          <Button
+            variant={buttonVariant}
+            size={buttonSize}
+            onClick={() => {
+              setOpen(5);
+              resetKeyRef.current = resetKeyRef.current + 1;
+            }}
+            disabled={disabled}
+            data-testid="traces-bulk-annotate-button"
+          >
+            <PenLine className={leadIconClassName} />
+            <span>Annotate</span>
+          </Button>
+        </TooltipWrapper>
+      )}
       {canLogTraceSpanThread && (
         <TooltipWrapper content="Manage tags">
           <Button


### PR DESCRIPTION
## Summary
Adds bulk annotation support for selected traces and spans directly from the table actions panel, fulfilling the feature request in #1010.

/claim #1010
Resolves #1010

### Key Changes
- **`FeedbackScoreValueInput`**: Reusable controlled input component encapsulating numerical range validation, boolean toggles, and categorical options (including proper handling of empty-string keys and accessible aria labels).
- **`AnnotateTracesDialog`**: Modal dialog launched from the bulk actions panel that applies feedback scores, categories, and optional reasons to all selected traces or spans with controlled concurrency and informative progress toast feedback.
- **`TracesActionsPanel`**: Added the "Annotate" action button gated on `canAnnotateTraceSpanThread` permissions.
- **`AnnotateRow`**: Refactored to leverage `FeedbackScoreValueInput` while ensuring invalid numeric inputs do not delete existing feedback scores.
- **Comprehensive Unit Tests**: Added full test coverage for `AnnotateTracesDialog`, `FeedbackScoreValueInput`, `AnnotateRow`, and `TracesActionsPanel` integration.

## Testing
- [x] Full test suite passed (159 test files, 2359 tests passed)
- [x] Typecheck passed cleanly with `tsc --noEmit`
- [x] Verified numerical bounds, empty string clearing, and permission toggling

---
**Bounty Payout Address (USDC on Base L2):**
`0x46D5318E4397cFcBED06a235c1604E473682Ea1F`
