### PR TITLE
[issue-8138] [SDK] fix: prevent errors for abandoned Responses streams

### DIFF
--- a/sdks/python/src/opik/integrations/openai/response_events_aggregator.py
+++ b/sdks/python/src/opik/integrations/openai/response_events_aggregator.py
@@ -25,6 +25,9 @@ def aggregate(
             )
         ]
 
+        if not completed_event:
+            return None
+
         response = completed_event[0].response
         return response
     except Exception as exception:

--- a/sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py
+++ b/sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py
@@ -1,0 +1,128 @@
+import asyncio
+
+import logging
+from unittest import mock
+
+import openai
+import pytest
+
+from opik.integrations.openai import response_events_aggregator, stream_patchers
+
+
+def test_aggregate__no_terminal_event__returns_none_without_error_log(caplog):
+    with caplog.at_level(logging.ERROR, logger=response_events_aggregator.__name__):
+        assert response_events_aggregator.aggregate([]) is None
+
+    assert caplog.records == []
+
+
+@pytest.fixture(autouse=True)
+def restore_stream_patches():
+    sync_iter_method = openai.Stream.__iter__
+    async_iter_method = openai.AsyncStream.__aiter__
+    sync_original_method = stream_patchers.original_stream_iter_method
+    async_original_method = stream_patchers.original_async_stream_aiter_method
+
+    yield
+
+    openai.Stream.__iter__ = sync_iter_method
+    openai.AsyncStream.__aiter__ = async_iter_method
+    stream_patchers.original_stream_iter_method = sync_original_method
+    stream_patchers.original_async_stream_aiter_method = async_original_method
+
+
+def _partial_stream(_stream):
+    yield object()
+
+
+async def _partial_async_stream(_stream):
+    yield object()
+
+
+def _assert_abandoned_stream_callback(callback):
+    callback.assert_called_once_with(
+        output=None,
+        error_info=None,
+        capture_output=True,
+        generators_span_to_end=None,
+        generators_trace_to_end=None,
+    )
+
+
+def test_patch_sync_stream__abandoned_before_terminal_event__finishes_without_error_log(
+    caplog,
+):
+    stream_patchers.original_stream_iter_method = _partial_stream
+    callback = mock.Mock()
+    stream = stream_patchers.patch_sync_stream(
+        stream=object.__new__(openai.Stream),
+        span_to_end=None,
+        trace_to_end=None,
+        generations_aggregator=response_events_aggregator.aggregate,
+        finally_callback=callback,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=response_events_aggregator.__name__):
+        iterator = iter(stream)
+        next(iterator)
+        iterator.close()
+
+    _assert_abandoned_stream_callback(callback)
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_patch_async_stream__abandoned_before_terminal_event__finishes_without_error_log(
+    caplog,
+):
+    stream_patchers.original_async_stream_aiter_method = _partial_async_stream
+    callback = mock.Mock()
+    stream = stream_patchers.patch_async_stream(
+        stream=object.__new__(openai.AsyncStream),
+        span_to_end=None,
+        trace_to_end=None,
+        generations_aggregator=response_events_aggregator.aggregate,
+        finally_callback=callback,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=response_events_aggregator.__name__):
+        iterator = stream.__aiter__()
+        await anext(iterator)
+        await iterator.aclose()
+
+    _assert_abandoned_stream_callback(callback)
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_patch_async_stream__cancelled_before_terminal_event__finishes_without_error_log(
+    caplog,
+):
+    stream_started = asyncio.Event()
+
+    async def partial_stream_then_wait(_stream):
+        yield object()
+        stream_started.set()
+        await asyncio.Event().wait()
+
+    stream_patchers.original_async_stream_aiter_method = partial_stream_then_wait
+    callback = mock.Mock()
+    stream = stream_patchers.patch_async_stream(
+        stream=object.__new__(openai.AsyncStream),
+        span_to_end=None,
+        trace_to_end=None,
+        generations_aggregator=response_events_aggregator.aggregate,
+        finally_callback=callback,
+    )
+
+    with caplog.at_level(logging.ERROR, logger=response_events_aggregator.__name__):
+        iterator = stream.__aiter__()
+        await anext(iterator)
+        next_item = asyncio.create_task(anext(iterator))
+        await stream_started.wait()
+        next_item.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await next_item
+
+    _assert_abandoned_stream_callback(callback)
+    assert caplog.records == []


### PR DESCRIPTION
## Details

- Abandoned OpenAI Responses streams no longer log an error-level `IndexError` when no terminal event arrives.
- Sync and async stream finalization now safely records no output for incomplete streams, while genuine aggregation failures retain existing error reporting.

## Change checklist

- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8138

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Ompstack workflow, Docker, pytest, pre-commit, repository tooling, independent reviewer/verifier
- Model(s): OpenAI Codex
- Scope: Root-cause investigation, SDK fix, regression tests, live compatible-provider verification
- Human verification: Required before merge

## Testing

- `docker exec --workdir /workspaces/opik/sdks/python opik-python-sdk-verify pytest tests/unit/integrations/openai/test_response_events_aggregator.py -q`
  - Passed: `4 passed`
  - Covered empty aggregation, synchronous partial-stream closure, asynchronous closure, and async task cancellation.
- `docker exec --workdir /workspaces/opik opik-precommit pre-commit run --files sdks/python/src/opik/integrations/openai/response_events_aggregator.py sdks/python/tests/unit/integrations/openai/test_response_events_aggregator.py .devcontainer/devcontainer.json`
  - Passed trailing-whitespace, end-of-file, Ruff, Ruff format, and mypy checks for the Python SDK source.
- Live DeepSeek OpenAI-compatible `/responses` stream drive:
  - Received `response.created`, closed after the first event, and observed one clean finalization with `output=None` and `error_info=None`.
  - No error-level aggregation traceback emitted.
- Environment: Docker-backed Python 3.12 devcontainer image.
- Not run: full Python SDK suite; targeted lifecycle coverage exercises the affected stream-finalization paths.
- Video evidence: N/A — no UI change.

## Documentation

N/A — bug fix does not change documented SDK usage.