### PR TITLE
[NA] [BE] fix: register azure_ai, vercel_ai_gateway and openrouter as canonical providers so their model prices load

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/cost/CostService.java
@@ -57,7 +57,10 @@ public class CostService {
             Map.entry("nebius", "nebius"),
             Map.entry("snowflake", "snowflake"),
             Map.entry("deepinfra", "deepinfra"),
-            Map.entry("cerebras", "cerebras"));
+            Map.entry("cerebras", "cerebras"),
+            Map.entry("azure_ai", "azure_ai"),
+            Map.entry("vercel_ai_gateway", "vercel_ai_gateway"),
+            Map.entry("openrouter", "openrouter"));
 
     // Online evaluation (and OTel ingestion) resolve models to LlmProvider serialized values whose names
     // differ from the canonical price-table vocabulary. Normalize those to the single canonical provider

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/cost/CostServiceTest.java
@@ -1151,4 +1151,32 @@ class CostServiceTest {
                                 "original_usage.prompt_tokens_details.cached_tokens", 300),
                         "0.005709"));
     }
+
+    /**
+     * Covers registering {@code azure_ai}, {@code vercel_ai_gateway} and {@code openrouter} as
+     * canonical providers so that their token-priced entries in
+     * {@code model_prices_and_context_window.json} are no longer silently dropped at load time. Each
+     * case exercises a representative token-priced model routed through
+     * {@link SpanCostCalculator#textGenerationCost}.
+     */
+    @ParameterizedTest(name = "{0}: {1}")
+    @MethodSource("provideGatewayCanonicalProviderCases")
+    void calculateCostHandlesGatewayCanonicalProviderModels(String provider, String model, String expectedCost) {
+        BigDecimal cost = CostService.calculateCost(model, provider,
+                Map.of("prompt_tokens", 1000, "completion_tokens", 200), null);
+
+        assertThat(cost).isEqualByComparingTo(expectedCost);
+    }
+
+    private static Stream<Arguments> provideGatewayCanonicalProviderCases() {
+        return Stream.of(
+                // azure_ai/gpt-oss-120b: input 1.5e-07, output 6e-07 -> 1000*1.5e-07 + 200*6e-07 = 0.00027
+                Arguments.of("azure_ai", "azure_ai/gpt-oss-120b", "0.00027"),
+                // vercel_ai_gateway/alibaba/qwen-3-14b: input 8e-08, output 2.4e-07
+                // 1000*8e-08 + 200*2.4e-07 = 0.000128
+                Arguments.of("vercel_ai_gateway", "vercel_ai_gateway/alibaba/qwen-3-14b", "0.000128"),
+                // openrouter/anthropic/claude-3.5-sonnet: input 3e-06, output 1.5e-05
+                // 1000*3e-06 + 200*1.5e-05 = 0.006
+                Arguments.of("openrouter", "openrouter/anthropic/claude-3.5-sonnet", "0.006"));
+    }
 }


### PR DESCRIPTION
## Details

`CostService.PROVIDERS_MAPPING` did not include `azure_ai`, `vercel_ai_gateway` or `openrouter`, so every priced model those providers ship in `model_prices_and_context_window.json` was dropped at load time and their spans fell back to zero cost. These are three of the largest remaining gaps (roughly 99, 101 and 97 priced entries respectively). This registers all three as canonical providers (identity mapping, same as the existing entries) so their prices load. The representative models used in the tests publish no cache rates, so they route through the default `textGenerationCost` calculator.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude
- Scope: full change (mapping entries plus the parameterized regression test)
- Human verification: cost math checked against the exact per-token rates in model_prices_and_context_window.json; provider-key resolution traced through buildRuntimeKey and findModelPrice, matching the already-merged snowflake, deepinfra and cerebras registrations

## Testing

Added a parameterized regression test in `CostServiceTest` (`calculateCostHandlesGatewayCanonicalProviderModels`) with one case per provider, asserting a real token-priced model from each now returns a non-zero cost equal to prompt and completion tokens billed at the provider's configured rates. The cases fail before the mapping entries are added (cost resolves to zero) and pass after. Run with `mvn test -Dtest=CostServiceTest` in `apps/opik-backend`.

## Documentation
