### PR TITLE
[issue-8275] [SDK] fix: SpearmanRanking should reject rankings with duplicate items

### DIFF
--- a/sdks/python/src/opik/evaluation/metrics/heuristics/spearman.py
+++ b/sdks/python/src/opik/evaluation/metrics/heuristics/spearman.py
@@ -62,6 +62,19 @@ class SpearmanRanking(BaseMetric):
                 "Rankings cannot be empty for Spearman correlation."
             )
 
+        if len(set(output)) != len(output) or len(set(reference)) != len(reference):
+            # A rank is only well-defined when each item appears exactly
+            # once. Without this check a duplicate silently collapses in
+            # `ref_ranks` below (a dict comprehension keeps only the last
+            # occurrence's index), and the same-items check next can still
+            # pass when both sequences repeat items in a way that keeps
+            # their sets equal -- producing a numeric rho for an input that
+            # was never a valid pair of rankings, instead of raising.
+            raise MetricComputationError(
+                "Rankings must not contain duplicate items; each item's "
+                "rank must be well-defined."
+            )
+
         ref_ranks = {item: idx for idx, item in enumerate(reference)}
         if set(output) != set(reference):
             raise MetricComputationError("Rankings must contain the same items.")

--- a/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
+++ b/sdks/python/tests/unit/evaluation/metrics/test_heuristics.py
@@ -533,6 +533,23 @@ def test_spearman_ranking_metric():
     assert result.value == pytest.approx((0.5 + 1) / 2)
 
 
+@pytest.mark.parametrize(
+    "output,reference",
+    [
+        # Both cases have equal-length, equal-set output/reference despite
+        # the repeats, so before this fix they reached the correlation
+        # formula and returned a numeric score (0.625 and 0.875
+        # respectively) instead of raising.
+        (["a", "b", "a"], ["a", "a", "b"]),
+        (["a", "a", "b"], ["a", "b", "b"]),
+    ],
+)
+def test_spearman_ranking_rejects_duplicate_items(output, reference):
+    metric = SpearmanRanking(track=False)
+    with pytest.raises(MetricComputationError):
+        metric.score(output=output, reference=reference)
+
+
 def test_vader_sentiment_metric_uses_custom_analyzer():
     class StubAnalyzer:
         def polarity_scores(self, text: str) -> dict:


### PR DESCRIPTION
## Details

`SpearmanRanking.score()` checked that `output`/`reference` have the same length and the same *set* of items, but never that each is actually a permutation (each item exactly once). A duplicate that keeps both sets equal slips through, and `ref_ranks = {item: idx for idx, item in enumerate(reference)}` then silently keeps only the last occurrence's index for a repeated item — producing a numeric `rho` for an input whose per-item rank was never well-defined, instead of raising. `output=["a","b","a"], reference=["a","a","b"]` previously returned `value=0.625` (`rho=0.25`) with no error. Fix raises `MetricComputationError`, matching the existing length/empty/set-equality checks in the same function.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8275

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Sonnet 5
- Scope: found via static reading of the scoring logic against its own docstring (no dataset/model in the loop), wrote the fix and both regression tests
- Human verification: reviewed the diff and the reproduction below; ran the commands myself before pushing

## Testing

```
$ python -m pytest tests/unit/evaluation/metrics/test_heuristics.py -q
75 passed

# with spearman.py reverted:
$ python -m pytest tests/unit/evaluation/metrics/test_heuristics.py -k spearman -q
2 failed, 1 passed   # both new duplicate-item cases -> DID NOT RAISE
```

`ruff format --check` / `ruff check` / `mypy` clean on the touched source file. Environment: local venv (`pip install -e sdks/python`), Python 3.12, no Docker/backend needed (pure heuristic metric, no network).

## Documentation

None needed — behavior brought in line with the existing docstring/error contract, no public signature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUQxa2vJuTi3o67JHxKG1e