### PR TITLE
[NA] [QA] fix: make the e2e tsc gate actually type-check the estate

### DIFF
--- a/tests_end_to_end/e2e/core/backend/client.ts
+++ b/tests_end_to_end/e2e/core/backend/client.ts
@@ -941,6 +941,11 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
       return { id, name: args.name, description: args.description };
     },
 
+    /**
+     * A dashboard does not hang off a project, so no project delete reaches
+     * it. `global-teardown` sweeps dashboards by run prefix, but only at the
+     * end of the run — a spec that builds one deletes it per-test.
+     */
     async deleteDashboard(id: string): Promise<void> {
       try {
         await opik.api.dashboards.deleteDashboard(id);
@@ -1587,26 +1592,6 @@ export function makeBackendClient(apiKey: string | null = null, workspaceName: s
         },
       );
       return { status, message, series: toMetricSeries(json) };
-    },
-
-    /**
-     * `DELETE /v1/private/dashboards/{id}`.
-     *
-     * A dashboard does not hang off a project, so no project delete reaches
-     * it. `global-teardown` does sweep dashboards by run prefix, but only at
-     * the end of the run — a spec that builds one deletes it per-test.
-     */
-    async deleteDashboard(id: string): Promise<void> {
-      const headers = workspaceHeaders();
-      const res = await fetch(`${env.apiBaseUrl}/v1/private/dashboards/${id}`, {
-        method: 'DELETE',
-        headers,
-      });
-      if (!res.ok && res.status !== 404) {
-        throw new Error(
-          `DELETE /v1/private/dashboards/${id} -> ${res.status}: ${(await res.text()).slice(0, 300)}`,
-        );
-      }
     },
 
     /**

--- a/tests_end_to_end/e2e/tsconfig.json
+++ b/tests_end_to_end/e2e/tsconfig.json
@@ -10,10 +10,10 @@
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "@e2e/*": ["./*"]
-    }
+    },
+    "types": ["node"]
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
## Details

`npx tsc --noEmit` in `tests_end_to_end/e2e` has been failing at the **config**, not the code:

```
tsconfig.json(13,5): error TS5102: Option 'baseUrl' has been removed.
```

TypeScript 7 removed `baseUrl`, so the compiler stopped before reading a single source file. The gate reported FAIL, CI reported the failure, and it went unexamined because the failure looked like a known one — which means **no file in `tests_end_to_end/e2e` has been type-checked at all** for as long as this has been broken.

### 1. `baseUrl` removed — and nothing replaces it

Removing it is sufficient on its own. Every bare import in the estate is a real package:

```
js-yaml  opik  node:child_process  node:crypto  node:fs  node:fs/promises
node:path  node:util  node:zlib
```

Nothing relied on `baseUrl`-style resolution, and `paths` resolves relative to the tsconfig's own directory when `baseUrl` is absent, so `"@e2e/*": ["./*"]` keeps working unchanged.

The replacement usually suggested for this error — `"paths": {"*": ["./*"]}` — would map **every** bare specifier and is strictly worse here. Not used.

### 2. `types: ["node"]`

Removing `baseUrl` let the compiler reach the files and surfaced 94 errors. 92 were node globals and `node:` modules failing to resolve:

```
core/backend/client.ts(1,28): error TS2591: Cannot find name 'node:zlib'.
config/env.config.ts(84,36): error TS2503: Cannot find namespace 'NodeJS'.
```

`@types/node` is in `devDependencies` (`^26.4.0`) and installed, but is not being auto-included under TS 7. Naming it explicitly fixes all 92. Six apparent `TS7006: implicitly has an 'any' type` errors in `pending-users-registry.ts` and `local-runner/connect.ts` were downstream of the missing types and disappear with them — no code change needed.

### 3. A duplicate `deleteDashboard` — the last two errors

```
core/backend/client.ts(944,11):  error TS2300: Duplicate identifier 'deleteDashboard'.
core/backend/client.ts(1599,11): error TS2300: Duplicate identifier 'deleteDashboard'.
```

Two implementations in the same object literal, added the same day by different authors:

| line | implementation | commit |
|---|---|---|
| 944 | SDK — `opik.api.dashboards.deleteDashboard` | `79b89f42` (human) |
| 1599 | raw `fetch` on `DELETE /v1/private/dashboards/{id}` | `d212bbe5` (generated) |

The later key wins in an object literal, so **the generated copy has been silently overriding the other** — and no gate could report it while `tsc` was stopping at the config.

Kept the SDK one and deleted the duplicate, because:

- it matches its neighbours — `createDashboard` (928) and `deleteDashboardsBatch` (1001) both go through the SDK; the raw `fetch` was the outlier;
- it avoids `workspaceHeaders()`, which hardcodes `env.workspace` instead of the workspace `makeBackendClient` was given.

The removed copy's docblock explained a real *why* (a dashboard hangs off no project, so no project delete reaches it), so it is carried onto the surviving method.

**This does change which implementation runs.** Both tolerate 404 — the SDK path via `isNotFoundError`, the raw path via an explicit `res.status !== 404` — and both callers (`dashboard-cleanup.fixture.ts:44`, `dashboards-list-filters.spec.ts:28`) wrap the call in `try`/`catch` and only `console.warn`, so the blast radius is contained.

`workspaceHeaders()` is still used by the attachment upload flow (1650) and is not orphaned by this.

## Change checklist

- [x] No product code changed — `tests_end_to_end/e2e` only
- [x] `tsc --noEmit` passes for the first time
- [x] `playwright --list` still collects every spec (module resolution unaffected)
- [x] `tag_lint.py` passes
- [x] No spec files added, removed or modified

## Issues

Found while reviewing #8268. Reported as a Note in that PR's generated review, deferred there because the fix is estate-wide and belongs in its own PR.

## Testing

All three estate gates, from `tests_end_to_end/e2e` on this branch:

```
npx tsc --noEmit
(clean — no output, exit 0)

npx playwright test --list
Total: 146 tests in 73 files

python3 tests_end_to_end/coverage/tag_lint.py \
  --taxonomy tests_end_to_end/coverage/taxonomy.yaml --estate tests_end_to_end
tag-lint: 76 specs checked, 1 exempt, 0 problem(s)
```

**What was not run:** the dashboards specs themselves, which is where the `deleteDashboard` change would show. It is cleanup-path only and both callers swallow failures, so a regression would surface as a leaked dashboard rather than a red test — worth a glance at `tests/dashboards/` in CI.

Expect `tsc` to start catching real errors now that it reads the source. That is the point, and the first PR to hit one is not being punished for this change.

## Documentation

No documentation change needed. Test-infrastructure configuration only; no user-facing behaviour, API or configuration changes.