### PR TITLE
[NA] [FE] Offer Gemini 3.8 Flash thinking levels in playground and online scoring

### DIFF
--- a/apps/opik-frontend/src/lib/modelUtils.test.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.test.ts
@@ -577,6 +577,7 @@ describe("Gemini thinking level", () => {
 
   it("covers the newer Flash models on both providers", () => {
     for (const model of [
+      PROVIDER_MODEL_TYPE.GEMINI_3_8_FLASH,
       PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH,
       PROVIDER_MODEL_TYPE.GEMINI_3_6_FLASH,
       PROVIDER_MODEL_TYPE.GEMINI_3_5_FLASH,
@@ -588,6 +589,7 @@ describe("Gemini thinking level", () => {
     }
 
     for (const model of [
+      PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_8_FLASH,
       PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_7_FLASH,
       PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_6_FLASH,
       PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_5_FLASH,
@@ -605,7 +607,17 @@ describe("Gemini thinking level", () => {
     const values = (m: PROVIDER_MODEL_TYPE) =>
       getThinkingLevelOptions(m).map((o) => o.value);
 
-    // 3.7 Flash has no "minimal".
+    // 3.8 and 3.7 Flash have no "minimal".
+    expect(values(PROVIDER_MODEL_TYPE.GEMINI_3_8_FLASH)).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
+    expect(values(PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_8_FLASH)).toEqual([
+      "low",
+      "medium",
+      "high",
+    ]);
     expect(values(PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH)).toEqual([
       "low",
       "medium",
@@ -634,6 +646,12 @@ describe("Gemini thinking level", () => {
   });
 
   it("preselects each model's own documented default", () => {
+    expect(getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.GEMINI_3_8_FLASH)).toBe(
+      "medium",
+    );
+    expect(
+      getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_8_FLASH),
+    ).toBe("medium");
     expect(getDefaultThinkingLevel(PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH)).toBe(
       "medium",
     );

--- a/apps/opik-frontend/src/lib/modelUtils.ts
+++ b/apps/opik-frontend/src/lib/modelUtils.ts
@@ -101,6 +101,8 @@ const THINKING_LEVELS_BY_MODEL: ReadonlyMap<
   readonly GeminiThinkingLevel[]
 > = new Map([
   // Gemini 3.x
+  [PROVIDER_MODEL_TYPE.GEMINI_3_8_FLASH, LOW_TO_HIGH],
+  [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_8_FLASH, LOW_TO_HIGH],
   [PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH, LOW_TO_HIGH],
   [PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_7_FLASH, LOW_TO_HIGH],
   [PROVIDER_MODEL_TYPE.GEMINI_3_6_FLASH, MINIMAL_TO_HIGH],
@@ -212,7 +214,7 @@ export const getThinkingLevelOptions = (
 // Preselecting the
 // documented default keeps the control from silently changing a model's behaviour just by being
 // shown: 2.5 Flash Lite ships with thinking off, 2.5 Pro/Flash default to a dynamic budget
-// ("auto"), 3.7/3.6/3.5 Flash default to medium, and 3.5 Flash Lite to minimal — none of which is
+// ("auto"), 3.8/3.7/3.6/3.5 Flash default to medium, and 3.5 Flash Lite to minimal — none of which is
 // "high". Models absent here default to "high", which is what the Gemini 3 Pro rows document.
 const DEFAULT_THINKING_LEVEL_BY_MODEL: ReadonlyMap<
   PROVIDER_MODEL_TYPE,
@@ -230,6 +232,11 @@ const DEFAULT_THINKING_LEVEL_BY_MODEL: ReadonlyMap<
   [
     PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_2_5_FLASH,
     "auto" as GeminiThinkingLevel,
+  ],
+  [PROVIDER_MODEL_TYPE.GEMINI_3_8_FLASH, "medium" as GeminiThinkingLevel],
+  [
+    PROVIDER_MODEL_TYPE.VERTEX_AI_GEMINI_3_8_FLASH,
+    "medium" as GeminiThinkingLevel,
   ],
   [PROVIDER_MODEL_TYPE.GEMINI_3_7_FLASH, "medium" as GeminiThinkingLevel],
   [


### PR DESCRIPTION
## Details

`gemini-3.8-flash` was already synced into the model enums, provider lists, `llm-models-default.yaml` and the price tables on both the Google AI Studio and Vertex AI providers — but not into the two thinking maps in `apps/opik-frontend/src/lib/modelUtils.ts`, which is the only place that decides which thinking levels a Gemini model offers. Without a row there the level control does not render at all, so 3.8 Flash shipped with no way to set a thinking level in either surface that exposes one.

- **3.8 Flash takes low/medium/high** — the same set as 3.7 Flash, i.e. no `minimal`. Added under both provider spellings (`gemini-3.8-flash` and `vertex_ai/gemini-3.8-flash`), since level support is a property of the model rather than of the provider it is reached through.
- **Both surfaces are fixed by the one map.** Playground gates on it via `lib/playground.ts` + `PromptModelSettings/providerConfigs/{Gemini,VertexAI}ModelConfigs.tsx`; the online-scoring rule dialog gates on it via `automations/AddEditRuleDialog/schema.ts`.
- **The default entry is not redundant.** Models absent from `DEFAULT_THINKING_LEVEL_BY_MODEL` fall back to `high`, so without it 3.8 would have preselected a level no other Flash in the 3.x line uses. Set to `medium`, matching 3.7/3.6/3.5 Flash.
- **No backend change.** `GeminiThinkingParams.modelAcceptsLevel` reads the major version off the model id rather than consulting an allowlist, so 3.8 already sends a real `thinking_level` on AI Studio and a translated budget on Vertex (whose `ThinkingConfig` protobuf has no level field).

Worth noting for review: the *level set* is as specified, but the **default of `medium` is an inference** from the rest of the 3.x Flash line, not a measured value. The surrounding map comments record that these defaults were measured against the live API rather than taken from Google's docs table, so if 3.8 Flash behaves differently by default this is the line to change.

## Change checklist
- [x] User facing
- [ ] Documentation update

<!-- No docs change: nothing under apps/opik-documentation enumerates per-model thinking-level support. -->

## Issues

No Jira ticket — gap left behind by the automated `sync provider model definitions` flow, which adds models but cannot know about the per-model thinking table.

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: Both changed files authored by the agent — the two map entries in `modelUtils.ts` and the test additions in `modelUtils.test.ts`. Investigation (locating the single source of truth, confirming backend and registry parity) also agent-run.
- Human verification: Requested and reviewed by @AndreiCautisanu, who specified the supported level set (low/medium/high, as per 3.7 Flash). Gates below were run by the agent; **the `medium` default is the agent's inference and has not been verified against the live 3.8 Flash API** — flagged above for reviewer attention.

## Testing

Commands run, all from `apps/opik-frontend`:

```
npx vitest run src/lib/modelUtils.test.ts          # 87 passed
npx vitest run src/v2/pages-shared/automations     # 29 passed (3 files) — online scoring
npx tsc --project tsconfig.json --noEmit           # exit 0
npx eslint src/lib/modelUtils.ts src/lib/modelUtils.test.ts --max-warnings=0   # exit 0
npx prettier --check src/lib/modelUtils.ts src/lib/modelUtils.test.ts          # clean
```

Scenarios validated:

- 3.8 Flash is level-capable on its own provider and **not** on the other (`supportsGeminiThinkingLevel` vs `supportsVertexAIThinkingLevel`), added to the existing both-providers enumeration.
- The offered set is exactly `["low", "medium", "high"]` on both spellings — which also pins that 3.8 offers neither `auto` (a 2.5-only affordance) nor `none` (for models that do not think by default).
- The preselected default is `medium` on both spellings.
- **Mutation-checked, so the new assertions are not vacuous:** reverting only the `modelUtils.ts` change fails exactly the 3 touched tests, with `expected [] to deeply equal [ 'low', 'medium', 'high' ]` and `expected 'high' to be 'medium'` — the latter being the concrete demonstration of the `high` fallback described above.

Not run: the backend Java suite, as no backend file is touched. `GeminiThinkingParamsTest` already asserts `gemini-3.7-flash,true`, and 3.8 is the identical `gemini-3.<minor>-flash` shape through the same regex, so no case was added there.

Environment: local, Node v24.3.0, vitest 3.0.5.

No video evidence: the change is two map entries with no new UI: the level dropdown, its rendering and its wiring already exist and are unchanged.

## Documentation

None required — no user-facing doc enumerates which thinking levels each Gemini model accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
