### PR TITLE
[OPIK-8328] [BE] fix: fold the demo-project exclusion into Java for trace usage queries

### DIFF
--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -4,6 +4,7 @@ import com.comet.opik.api.Project;
 import com.comet.opik.api.ProjectIdLastUpdated;
 import com.comet.opik.api.Visibility;
 import com.comet.opik.infrastructure.db.UUIDArgumentFactory;
+import lombok.NonNull;
 import org.jdbi.v3.sqlobject.config.RegisterArgumentFactory;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
@@ -97,9 +98,9 @@ interface ProjectDAO {
             @BindMethods Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 
     /**
-     * Projects with the given names across all workspaces, optionally restricted to {@code ids}. Left unrestricted
-     * the result grows with the number of projects carrying those names, so callers that already hold the ids they
-     * care about pass them and keep the query bounded.
+     * Projects with the given names across all workspaces, optionally restricted to {@code ids}. When left
+     * unrestricted, the result grows with the number of projects carrying those names, so callers that already hold
+     * the ids they care about pass them and keep the query bounded.
      *
      * <p>An empty {@code ids} reads as unrestricted rather than as "match nothing", so callers filtering a set they
      * built must handle the empty case themselves.
@@ -111,10 +112,10 @@ interface ProjectDAO {
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings
-    List<Project> findByGlobalNames(@BindList("names") List<String> names,
+    List<Project> findByGlobalNames(@NonNull @BindList("names") List<String> names,
             @Define("ids") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "ids") Set<UUID> ids);
 
-    default List<Project> findByGlobalNames(List<String> names) {
+    default List<Project> findByGlobalNames(@NonNull List<String> names) {
         return findByGlobalNames(names, null);
     }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -98,22 +98,24 @@ interface ProjectDAO {
             @BindMethods Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 
     /**
-     * Projects with the given names across all workspaces, optionally restricted to {@code ids}. When left
-     * unrestricted, the result grows with the number of projects carrying those names, so callers that already hold
-     * the ids they care about pass them and keep the query bounded.
+     * Projects with the given names, optionally restricted to {@code workspaceIds}. When left unrestricted the
+     * query spans every workspace, and neither index applies — {@code projects_workspace_id_name_uk} is keyed on
+     * {@code (workspace_id, name)}, so it needs the workspace to be known. Restricting by workspace both bounds the
+     * result and lets that index serve the lookup, which is why callers that know the workspaces they care about
+     * pass them.
      *
-     * <p>An empty {@code ids} reads as unrestricted rather than as "match nothing", so callers filtering a set they
-     * built must handle the empty case themselves.
+     * <p>An empty {@code workspaceIds} reads as unrestricted rather than as "match nothing", so callers filtering a
+     * set they built must handle the empty case themselves.
      */
     @SqlQuery("""
             SELECT * FROM projects
             WHERE name IN (<names>)
-            <if(ids)> AND id IN (<ids>) <endif>
+            <if(workspace_ids)> AND workspace_id IN (<workspace_ids>) <endif>
             """)
     @UseStringTemplateEngine
     @AllowUnusedBindings
     List<Project> findByGlobalNames(@NonNull @BindList("names") List<String> names,
-            @Define("ids") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "ids") Set<UUID> ids);
+            @Define("workspace_ids") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "workspace_ids") Set<String> workspaceIds);
 
     default List<Project> findByGlobalNames(@NonNull List<String> names) {
         return findByGlobalNames(names, null);

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectDAO.java
@@ -96,6 +96,25 @@ interface ProjectDAO {
     int[] recordLastUpdatedTrace(@Bind("workspace_id") String workspaceId,
             @BindMethods Collection<ProjectIdLastUpdated> lastUpdatedTraces);
 
-    @SqlQuery("SELECT * FROM projects WHERE name IN (<names>)")
-    List<Project> findByGlobalNames(@BindList("names") Collection<String> names);
+    /**
+     * Projects with the given names across all workspaces, optionally restricted to {@code ids}. Left unrestricted
+     * the result grows with the number of projects carrying those names, so callers that already hold the ids they
+     * care about pass them and keep the query bounded.
+     *
+     * <p>An empty {@code ids} reads as unrestricted rather than as "match nothing", so callers filtering a set they
+     * built must handle the empty case themselves.
+     */
+    @SqlQuery("""
+            SELECT * FROM projects
+            WHERE name IN (<names>)
+            <if(ids)> AND id IN (<ids>) <endif>
+            """)
+    @UseStringTemplateEngine
+    @AllowUnusedBindings
+    List<Project> findByGlobalNames(@BindList("names") List<String> names,
+            @Define("ids") @BindList(onEmpty = BindList.EmptyHandling.NULL_VALUE, value = "ids") Set<UUID> ids);
+
+    default List<Project> findByGlobalNames(List<String> names) {
+        return findByGlobalNames(names, null);
+    }
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -91,7 +91,7 @@ public interface ProjectService {
 
     Mono<Map<UUID, Instant>> getDemoProjectIdsWithTimestamps();
 
-    Mono<Set<UUID>> getDemoProjectIds(Set<UUID> candidateProjectIds);
+    Mono<Set<UUID>> getDemoProjectIdsInWorkspaces(Set<String> workspaceIds);
 
     Mono<Project> getOrCreate(String projectName);
 
@@ -142,7 +142,7 @@ class ProjectServiceImpl implements ProjectService {
     private static final Map<String, String> SORTING_FIELD_MAPPING = Map.of(
             SortableFields.LAST_UPDATED_TRACE_AT, LAST_UPDATED_TRACE_AT_SORT);
 
-    private static final int DEMO_PROJECT_ID_CHUNK_SIZE = 1_000;
+    private static final int DEMO_PROJECT_WORKSPACE_CHUNK_SIZE = 1_000;
 
     private final @NonNull TransactionTemplate template;
     private final @NonNull IdGenerator idGenerator;
@@ -487,21 +487,29 @@ class ProjectServiceImpl implements ProjectService {
     }
 
     /**
-     * Bounded demo-project lookup: which of {@code candidateProjectIds} are demo projects.
+     * Bounded demo-project lookup: the demo projects belonging to {@code workspaceIds}.
      *
      * <p>{@link #getDemoProjectIdsWithTimestamps()} is unscoped by design, so it grows with every signup and every
-     * caller pays for the whole demo population. Callers that only need to test ids they already hold use this
-     * instead, and lose nothing by it: a demo project outside the candidate set cannot change their answer. The
-     * candidates are chunked to keep each {@code IN} list bounded however many are passed.
+     * caller pays for the whole demo population. Callers that only need to classify activity in workspaces they
+     * already hold use this instead. Scoping by workspace is what lets
+     * {@code projects_workspace_id_name_uk (workspace_id, name)} serve the query, and it bounds the result to the
+     * demo projects of those workspaces — a handful each, since {@link DemoData#PROJECTS} is a fixed list.
+     *
+     * <p>Returning a demo project that saw no activity is harmless: callers test membership, so an id absent from
+     * their rows is never consulted.
+     *
+     * <p>The workspaces are chunked, which keeps the {@code IN} list within the driver's bind-parameter limit
+     * however many are passed. A day's active workspaces sit well inside one chunk, so this is a single query in
+     * practice rather than a loop.
      */
     @Override
-    public Mono<Set<UUID>> getDemoProjectIds(Set<UUID> candidateProjectIds) {
-        if (CollectionUtils.isEmpty(candidateProjectIds)) {
+    public Mono<Set<UUID>> getDemoProjectIdsInWorkspaces(Set<String> workspaceIds) {
+        if (CollectionUtils.isEmpty(workspaceIds)) {
             return Mono.just(Set.of());
         }
         return Mono.fromCallable(() -> template.inTransaction(READ_ONLY, handle -> {
             var repository = handle.attach(ProjectDAO.class);
-            return Lists.partition(List.copyOf(candidateProjectIds), DEMO_PROJECT_ID_CHUNK_SIZE)
+            return Lists.partition(List.copyOf(workspaceIds), DEMO_PROJECT_WORKSPACE_CHUNK_SIZE)
                     .stream()
                     .flatMap(chunk -> repository.findByGlobalNames(DemoData.PROJECTS, Set.copyOf(chunk)).stream())
                     .map(Project::id)

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/ProjectService.java
@@ -18,6 +18,7 @@ import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.utils.BinaryOperatorUtils;
 import com.comet.opik.utils.ErrorUtils;
+import com.google.common.collect.Lists;
 import com.google.inject.ImplementedBy;
 import jakarta.annotation.Nullable;
 import jakarta.inject.Inject;
@@ -90,6 +91,8 @@ public interface ProjectService {
 
     Mono<Map<UUID, Instant>> getDemoProjectIdsWithTimestamps();
 
+    Mono<Set<UUID>> getDemoProjectIds(Set<UUID> candidateProjectIds);
+
     Mono<Project> getOrCreate(String projectName);
 
     Project getOrCreate(String workspaceId, String projectName, String userName);
@@ -138,6 +141,8 @@ class ProjectServiceImpl implements ProjectService {
     private static final String LAST_UPDATED_TRACE_AT_SORT = "COALESCE(last_updated_trace_at, last_updated_at)";
     private static final Map<String, String> SORTING_FIELD_MAPPING = Map.of(
             SortableFields.LAST_UPDATED_TRACE_AT, LAST_UPDATED_TRACE_AT_SORT);
+
+    private static final int DEMO_PROJECT_ID_CHUNK_SIZE = 1_000;
 
     private final @NonNull TransactionTemplate template;
     private final @NonNull IdGenerator idGenerator;
@@ -479,6 +484,29 @@ class ProjectServiceImpl implements ProjectService {
                 .map(projects -> projects.stream()
                         .collect(Collectors.toMap(Project::id, Project::createdAt)))
                 .subscribeOn(reactor.core.scheduler.Schedulers.boundedElastic());
+    }
+
+    /**
+     * Bounded demo-project lookup: which of {@code candidateProjectIds} are demo projects.
+     *
+     * <p>{@link #getDemoProjectIdsWithTimestamps()} is unscoped by design, so it grows with every signup and every
+     * caller pays for the whole demo population. Callers that only need to test ids they already hold use this
+     * instead, and lose nothing by it: a demo project outside the candidate set cannot change their answer. The
+     * candidates are chunked to keep each {@code IN} list bounded however many are passed.
+     */
+    @Override
+    public Mono<Set<UUID>> getDemoProjectIds(Set<UUID> candidateProjectIds) {
+        if (CollectionUtils.isEmpty(candidateProjectIds)) {
+            return Mono.just(Set.of());
+        }
+        return Mono.fromCallable(() -> template.inTransaction(READ_ONLY, handle -> {
+            var repository = handle.attach(ProjectDAO.class);
+            return Lists.partition(List.copyOf(candidateProjectIds), DEMO_PROJECT_ID_CHUNK_SIZE)
+                    .stream()
+                    .flatMap(chunk -> repository.findByGlobalNames(DemoData.PROJECTS, Set.copyOf(chunk)).stream())
+                    .map(Project::id)
+                    .collect(Collectors.toUnmodifiableSet());
+        })).subscribeOn(Schedulers.boundedElastic());
     }
 
     private List<Project> findByGlobalNames(List<String> names) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceDAO.java
@@ -1,6 +1,5 @@
 package com.comet.opik.domain;
 
-import com.comet.opik.api.BiInformationResponse.BiInformation;
 import com.comet.opik.api.ExperimentItemReference;
 import com.comet.opik.api.Guardrail;
 import com.comet.opik.api.GuardrailType;
@@ -13,6 +12,7 @@ import com.comet.opik.api.TraceDetails;
 import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceThreadStatus;
 import com.comet.opik.api.TraceUpdate;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse.WorkspaceProjectUserCount;
 import com.comet.opik.api.VisibilityMode;
 import com.comet.opik.api.filter.Filter;
 import com.comet.opik.api.sorting.SortableFields;
@@ -24,6 +24,7 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.domain.stats.StatsMapper;
 import com.comet.opik.domain.stats.StatsMerger;
 import com.comet.opik.domain.utils.DemoDataExclusionUtils;
+import com.comet.opik.domain.utils.DemoDataExclusionUtils.WorkspaceProjectCount;
 import com.comet.opik.domain.workspaces.WorkspacesService;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -77,7 +78,6 @@ import java.util.stream.Stream;
 
 import static com.comet.opik.api.ErrorInfo.ERROR_INFO_TYPE;
 import static com.comet.opik.api.Trace.TracePage;
-import static com.comet.opik.api.TraceCountResponse.WorkspaceTraceCount;
 import static com.comet.opik.domain.AsyncContextUtils.bindUserNameAndWorkspace;
 import static com.comet.opik.domain.AsyncContextUtils.bindWorkspaceIdToMono;
 import static com.comet.opik.domain.stats.StatsMapper.mapProjectScoresStats;
@@ -128,7 +128,11 @@ public interface TraceDAO {
 
     Mono<Long> batchInsert(List<Trace> traces, Connection connection);
 
-    Flux<WorkspaceTraceCount> countTracesPerWorkspace(Map<UUID, Instant> excludedProjectIds);
+    /**
+     * Previous-day trace counts per workspace and project. Callers drop demo projects and re-aggregate via
+     * {@link DemoDataExclusionUtils}, so the exclusion never reaches the query text.
+     */
+    Flux<WorkspaceProjectCount> countTracesPerWorkspaceProject();
 
     Mono<Set<UUID>> getProjectsWithTracesInRange(Collection<Pair<String, UUID>> workspaceProjectPairs, Instant from,
             Instant to, Connection connection);
@@ -143,11 +147,10 @@ public interface TraceDAO {
 
     Mono<Map<UUID, Instant>> getStartTimesByTraceIds(Set<UUID> traceIds, String workspaceId);
 
-    Flux<BiInformation> getTraceBIInformation(Map<UUID, Instant> excludedProjectIds);
+    /** Same as {@link #countTracesPerWorkspaceProject()}, broken down by user for the BI events. */
+    Flux<WorkspaceProjectUserCount> getTraceBIInformationPerProject();
 
     Mono<ProjectStats> getStats(TraceSearchCriteria criteria);
-
-    Mono<Long> getDailyTraces(Map<UUID, Instant> excludedProjectIds);
 
     Mono<Map<UUID, ProjectStats>> getStatsByProjectIds(List<UUID> projectIds, String workspaceId,
             List<? extends Filter> filters, Instant fromTime, Instant toTime);
@@ -1529,31 +1532,43 @@ class TraceDAOImpl implements TraceDAO {
             ;
             """;
 
-    private static final String TRACE_COUNT_BY_WORKSPACE_ID = """
+    /**
+     * Previous-day trace counts per workspace, at project granularity so that
+     * {@link DemoDataExclusionUtils#foldByWorkspace} can drop demo projects and re-aggregate in Java.
+     *
+     * <p><b>The demo-project exclusion must not render into this query text.</b> It used to, as an inline
+     * {@code project_id NOT IN [...]} literal holding one UUID per demo project across all workspaces. Once
+     * {@code traces} is wrapped in a {@code Distributed} table the query text is re-parsed per shard, so that
+     * literal — unbounded, one demo project per signup — grew until the query exceeded
+     * {@code max_execution_time} and the daily usage counts silently stopped being produced. Keeping the text
+     * constant is what makes growth in the demo set unable to reintroduce that; see {@link DemoDataExclusionUtils}.
+     */
+    private static final String TRACE_DAILY_COUNT_BY_WORKSPACE_PROJECT = """
             SELECT
                  workspace_id,
+                 project_id,
                  COUNT(DISTINCT id) as trace_count
              FROM traces
              WHERE created_at BETWEEN toStartOfDay(yesterday()) AND toStartOfDay(today())
-             <if(excluded_project_ids)> AND (project_id NOT IN :excluded_project_ids
-                <if(demo_data_created_at)>OR created_at > parseDateTime64BestEffort(:demo_data_created_at, 9)<endif>)
-             <endif>
-             GROUP BY workspace_id
+             GROUP BY workspace_id, project_id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
 
-    private static final String TRACE_DAILY_BI_INFORMATION = """
+    /**
+     * Previous-day trace counts per workspace and user for the BI events, at project granularity so that
+     * {@link DemoDataExclusionUtils#foldByWorkspaceAndUser} can drop demo projects and re-aggregate in Java. Same
+     * constraint on the query text as {@link #TRACE_DAILY_COUNT_BY_WORKSPACE_PROJECT}.
+     */
+    private static final String TRACE_DAILY_BI_INFORMATION_BY_PROJECT = """
             SELECT
                  workspace_id,
                  created_by AS user,
+                 project_id,
                  COUNT(DISTINCT id) AS trace_count
             FROM traces
             WHERE created_at BETWEEN toStartOfDay(yesterday()) AND toStartOfDay(today())
-            <if(excluded_project_ids)> AND (project_id NOT IN :excluded_project_ids
-                <if(demo_data_created_at)>OR created_at > parseDateTime64BestEffort(:demo_data_created_at, 9)<endif>)
-            <endif>
-            GROUP BY workspace_id, created_by
+            GROUP BY workspace_id, created_by, project_id
             SETTINGS log_comment = '<log_comment>'
             ;
             """;
@@ -4481,75 +4496,33 @@ class TraceDAOImpl implements TraceDAO {
 
     @Override
     @WithSpan
-    public Flux<WorkspaceTraceCount> countTracesPerWorkspace(@NonNull Map<UUID, Instant> excludedProjectIds) {
-
-        Optional<Instant> demoDataCreatedAt = DemoDataExclusionUtils.calculateDemoDataCreatedAt(excludedProjectIds);
-
-        var template = getSTWithLogComment(TRACE_COUNT_BY_WORKSPACE_ID, "count_traces_per_workspace", "", "", "");
-
-        if (!excludedProjectIds.isEmpty()) {
-            template.add("excluded_project_ids", excludedProjectIds.keySet().toArray(UUID[]::new));
-        }
-
-        if (demoDataCreatedAt.isPresent()) {
-            template.add("demo_data_created_at", demoDataCreatedAt.get().toString());
-        }
+    public Flux<WorkspaceProjectCount> countTracesPerWorkspaceProject() {
+        var template = getSTWithLogComment(TRACE_DAILY_COUNT_BY_WORKSPACE_PROJECT, "count_traces_per_workspace", "",
+                "", "");
 
         return asyncTemplate
-                .nonTransaction(
-                        connection -> {
-                            Statement statement = connection.createStatement(template.render());
-
-                            if (!excludedProjectIds.isEmpty()) {
-                                statement.bind("excluded_project_ids",
-                                        excludedProjectIds.keySet().toArray(UUID[]::new));
-                            }
-
-                            if (demoDataCreatedAt.isPresent()) {
-                                statement.bind("demo_data_created_at", demoDataCreatedAt.get().toString());
-                            }
-
-                            return Mono.from(statement.execute());
-                        })
-                .flatMapMany(result -> result.map((row, rowMetadata) -> WorkspaceTraceCount.builder()
-                        .workspace(row.get("workspace_id", String.class))
-                        .traceCount(row.get("trace_count", Integer.class))
+                .nonTransaction(connection -> Mono.from(connection.createStatement(template.render()).execute()))
+                .flatMapMany(result -> result.map((row, _) -> WorkspaceProjectCount.builder()
+                        .workspaceId(row.get("workspace_id", String.class))
+                        .projectId(row.get("project_id", UUID.class))
+                        .count(row.get("trace_count", Long.class))
                         .build()));
     }
 
     @Override
     @WithSpan
-    public Flux<BiInformation> getTraceBIInformation(@NonNull Map<UUID, Instant> excludedProjectIds) {
+    public Flux<WorkspaceProjectUserCount> getTraceBIInformationPerProject() {
+        var template = getSTWithLogComment(TRACE_DAILY_BI_INFORMATION_BY_PROJECT, "get_trace_bi_information", "", "",
+                "");
 
-        Optional<Instant> demoDataCreatedAt = DemoDataExclusionUtils.calculateDemoDataCreatedAt(excludedProjectIds);
-
-        var template = getSTWithLogComment(TRACE_DAILY_BI_INFORMATION, "get_trace_bi_information", "", "", "");
-
-        if (!excludedProjectIds.isEmpty()) {
-            template.add("excluded_project_ids", excludedProjectIds.keySet().toArray(UUID[]::new));
-        }
-
-        if (demoDataCreatedAt.isPresent()) {
-            template.add("demo_data_created_at", demoDataCreatedAt.get().toString());
-        }
-
-        return asyncTemplate.nonTransaction(connection -> {
-            Statement statement = connection.createStatement(template.render());
-
-            if (!excludedProjectIds.isEmpty()) {
-                statement.bind("excluded_project_ids", excludedProjectIds.keySet().toArray(UUID[]::new));
-            }
-
-            if (demoDataCreatedAt.isPresent()) {
-                statement.bind("demo_data_created_at", demoDataCreatedAt.get().toString());
-            }
-
-            return Mono.from(statement.execute());
-        })
-                .flatMapMany(result -> result.map((row, rowMetadata) -> BiInformation.builder()
+        return asyncTemplate
+                .nonTransaction(connection -> Mono.from(connection.createStatement(template.render()).execute()))
+                .flatMapMany(result -> result.map((row, _) -> WorkspaceProjectUserCount.builder()
                         .workspaceId(row.get("workspace_id", String.class))
+                        .projectId(row.get("project_id", UUID.class))
                         .user(row.get("user", String.class))
-                        .count(row.get("trace_count", Long.class)).build()));
+                        .count(row.get("trace_count", Long.class))
+                        .build()));
     }
 
     @Override
@@ -4739,41 +4712,6 @@ class TraceDAOImpl implements TraceDAO {
                 || template.getAttribute("feedback_scores_empty_filters") != null
                 || template.getAttribute("span_feedback_scores_empty_filters") != null
                 || template.getAttribute("guardrails_filters") != null;
-    }
-
-    @Override
-    public Mono<Long> getDailyTraces(@NonNull Map<UUID, Instant> excludedProjectIds) {
-
-        Optional<Instant> demoDataCreatedAt = DemoDataExclusionUtils.calculateDemoDataCreatedAt(excludedProjectIds);
-
-        var template = getSTWithLogComment(TRACE_COUNT_BY_WORKSPACE_ID, "get_daily_traces_count", "", "", "");
-
-        if (!excludedProjectIds.isEmpty()) {
-            template.add("excluded_project_ids", excludedProjectIds.keySet().toArray(UUID[]::new));
-        }
-
-        if (demoDataCreatedAt.isPresent()) {
-            template.add("demo_data_created_at", demoDataCreatedAt.get().toString());
-        }
-
-        return asyncTemplate
-                .nonTransaction(
-                        connection -> {
-                            Statement statement = connection.createStatement(template.render());
-
-                            if (!excludedProjectIds.isEmpty()) {
-                                statement.bind("excluded_project_ids",
-                                        excludedProjectIds.keySet().toArray(UUID[]::new));
-                            }
-
-                            if (demoDataCreatedAt.isPresent()) {
-                                statement.bind("demo_data_created_at", demoDataCreatedAt.get().toString());
-                            }
-
-                            return Mono.from(statement.execute());
-                        })
-                .flatMapMany(result -> result.map((row, rowMetadata) -> row.get("trace_count", Long.class)))
-                .reduce(0L, Long::sum);
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -711,8 +711,8 @@ class TraceServiceImpl implements TraceService {
         return dao.getTraceBIInformationPerProject()
                 .collectList()
                 .flatMap(rows -> projectService
-                        .getDemoProjectIds(rows.stream()
-                                .map(WorkspaceProjectUserCount::projectId)
+                        .getDemoProjectIdsInWorkspaces(rows.stream()
+                                .map(WorkspaceProjectUserCount::workspaceId)
                                 .collect(Collectors.toSet()))
                         .map(demoProjectIds -> DemoDataExclusionUtils.foldByWorkspaceAndUser(rows, demoProjectIds)))
                 .map(biInformation -> BiInformationResponse.builder()
@@ -722,14 +722,14 @@ class TraceServiceImpl implements TraceService {
 
     /**
      * Previous-day trace counts per workspace, with demo-project activity dropped. The demo lookup is scoped to the
-     * projects that actually had traces, which is what keeps it independent of how many demo projects exist.
+     * workspaces that actually had traces, which is what keeps it independent of how many demo projects exist.
      */
     private Mono<Map<String, Long>> countsByWorkspaceExcludingDemoProjects() {
         return dao.countTracesPerWorkspaceProject()
                 .collectList()
                 .flatMap(rows -> projectService
-                        .getDemoProjectIds(rows.stream()
-                                .map(WorkspaceProjectCount::projectId)
+                        .getDemoProjectIdsInWorkspaces(rows.stream()
+                                .map(WorkspaceProjectCount::workspaceId)
                                 .collect(Collectors.toSet()))
                         .map(demoProjectIds -> DemoDataExclusionUtils.foldByWorkspace(rows, demoProjectIds)));
     }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -12,6 +12,7 @@ import com.comet.opik.api.TraceCountResponse;
 import com.comet.opik.api.TraceDetails;
 import com.comet.opik.api.TraceThread;
 import com.comet.opik.api.TraceUpdate;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse.WorkspaceProjectUserCount;
 import com.comet.opik.api.attachment.AttachmentInfo;
 import com.comet.opik.api.attachment.EntityType;
 import com.comet.opik.api.error.EntityAlreadyExistsException;
@@ -26,6 +27,8 @@ import com.comet.opik.domain.attachment.AttachmentReinjectorService;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.domain.attachment.AttachmentStripperService;
 import com.comet.opik.domain.attachment.AttachmentUtils;
+import com.comet.opik.domain.utils.DemoDataExclusionUtils;
+import com.comet.opik.domain.utils.DemoDataExclusionUtils.WorkspaceProjectCount;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -689,30 +692,46 @@ class TraceServiceImpl implements TraceService {
     @Override
     @WithSpan
     public Mono<TraceCountResponse> countTracesPerWorkspace() {
-
-        return projectService.getDemoProjectIdsWithTimestamps()
-                .switchIfEmpty(Mono.just(Map.of()))
-                .flatMapMany(dao::countTracesPerWorkspace)
-                .collectList()
-                .map(items -> TraceCountResponse.builder()
-                        .workspacesTracesCount(items)
-                        .build())
-                .switchIfEmpty(Mono.just(TraceCountResponse.empty()));
+        return countsByWorkspaceExcludingDemoProjects()
+                .map(countsByWorkspace -> TraceCountResponse.builder()
+                        .workspacesTracesCount(countsByWorkspace.entrySet()
+                                .stream()
+                                .map(entry -> TraceCountResponse.WorkspaceTraceCount.builder()
+                                        .workspace(entry.getKey())
+                                        .traceCount(Math.toIntExact(entry.getValue()))
+                                        .build())
+                                .toList())
+                        .build());
     }
 
     @Override
     @WithSpan
     public Mono<BiInformationResponse> getTraceBIInformation() {
         log.info("Getting trace BI events daily data");
-
-        return projectService.getDemoProjectIdsWithTimestamps()
-                .switchIfEmpty(Mono.just(Map.of()))
-                .flatMapMany(dao::getTraceBIInformation)
+        return dao.getTraceBIInformationPerProject()
                 .collectList()
-                .map(items -> BiInformationResponse.builder()
-                        .biInformation(items)
-                        .build())
-                .switchIfEmpty(Mono.just(BiInformationResponse.empty()));
+                .flatMap(rows -> projectService
+                        .getDemoProjectIds(rows.stream()
+                                .map(WorkspaceProjectUserCount::projectId)
+                                .collect(Collectors.toSet()))
+                        .map(demoProjectIds -> DemoDataExclusionUtils.foldByWorkspaceAndUser(rows, demoProjectIds)))
+                .map(biInformation -> BiInformationResponse.builder()
+                        .biInformation(biInformation)
+                        .build());
+    }
+
+    /**
+     * Previous-day trace counts per workspace, with demo-project activity dropped. The demo lookup is scoped to the
+     * projects that actually had traces, which is what keeps it independent of how many demo projects exist.
+     */
+    private Mono<Map<String, Long>> countsByWorkspaceExcludingDemoProjects() {
+        return dao.countTracesPerWorkspaceProject()
+                .collectList()
+                .flatMap(rows -> projectService
+                        .getDemoProjectIds(rows.stream()
+                                .map(WorkspaceProjectCount::projectId)
+                                .collect(Collectors.toSet()))
+                        .map(demoProjectIds -> DemoDataExclusionUtils.foldByWorkspace(rows, demoProjectIds)));
     }
 
     @Override
@@ -726,8 +745,11 @@ class TraceServiceImpl implements TraceService {
     @Override
     @WithSpan
     public Mono<Long> getDailyCreatedCount() {
-        return projectService.getDemoProjectIdsWithTimestamps()
-                .switchIfEmpty(Mono.just(Map.of())).flatMap(dao::getDailyTraces);
+        return countsByWorkspaceExcludingDemoProjects()
+                .map(countsByWorkspace -> countsByWorkspace.values()
+                        .stream()
+                        .mapToLong(Long::longValue)
+                        .sum());
     }
 
     @Override

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/TraceService.java
@@ -100,12 +100,18 @@ public interface TraceService {
 
     Mono<Boolean> validateTraceWorkspace(String workspaceId, Set<UUID> traceIds);
 
+    /**
+     * Previous-day trace counts per workspace, excluding activity in demo projects — including demo projects
+     * created after install, which earlier counted. {@link DemoDataExclusionUtils} carries the why.
+     */
     Mono<TraceCountResponse> countTracesPerWorkspace();
 
+    /** The same window and exclusion as {@link #countTracesPerWorkspace()}, broken down by user for the BI events. */
     Mono<BiInformationResponse> getTraceBIInformation();
 
     Mono<ProjectStats> getStats(TraceSearchCriteria searchCriteria);
 
+    /** Previous-day traces across every workspace, under the same exclusion as {@link #countTracesPerWorkspace()}. */
     Mono<Long> getDailyCreatedCount();
 
     Mono<Set<UUID>> getProjectsWithTracesInRange(@NonNull Collection<Pair<String, UUID>> workspaceProjectPairs,

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/utils/DemoDataExclusionUtils.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/utils/DemoDataExclusionUtils.java
@@ -1,28 +1,103 @@
 package com.comet.opik.domain.utils;
 
+import com.comet.opik.api.BiInformationResponse.BiInformation;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse.WorkspaceProjectUserCount;
+import lombok.Builder;
+import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
+/**
+ * Excludes demo-project usage from the daily BI and billing counts.
+ *
+ * <p>The exclusion cannot be a {@code project_id NOT IN [...]} literal in the query text. One demo project is
+ * created per signup, so the set is unbounded, and a {@code Distributed} table re-serialises and re-parses the
+ * query text for its shard — a large literal comes to dominate the query cost and eventually exceeds
+ * {@code max_execution_time}. {@code GLOBAL NOT IN} does not help, because the literal is still in the query text.
+ *
+ * <p>The usage queries therefore {@code GROUP BY project_id} and the exclusion is applied here, which keeps the
+ * query text constant however many demo projects exist.
+ *
+ * <p>Aggregating after the exclusion preserves the totals a workspace- or user-grouped query returns, because an
+ * id has exactly one project. {@code project_id} is part of the sorting key of both {@code traces} and
+ * {@code spans}, so two rows for one id under different projects would both survive deduplication and be summed
+ * twice — what stops them existing is the write path, which rejects an upsert presenting an existing id with a
+ * different project rather than moving it. The folds are insertion-ordered, so the result keeps the order the
+ * query returned its rows in.
+ */
 @UtilityClass
 public class DemoDataExclusionUtils {
+
+    /** A previous-day count for one project — the granularity the usage queries return. */
+    @Builder(toBuilder = true)
+    public record WorkspaceProjectCount(@NonNull String workspaceId, @NonNull UUID projectId, long count) {
+    }
 
     /**
      * Calculates the demo data created at timestamp by finding the maximum creation time
      * from the excluded project IDs and adding 1 minute to ensure all demo data is excluded.
      *
+     * <p>Used only by the span usage queries, which still carry the exclusion in SQL. The cutoff assumes a demo set
+     * created once at install time; where demo projects are created continuously it is effectively "now", so the
+     * {@code OR created_at > :demo_data_created_at} branch it feeds cannot match a row in the previous-day window.
+     *
      * @param excludedProjectIds map of project ID to creation timestamp
      * @return Optional containing the calculated timestamp, or empty if no projects exist
      */
-    public static Optional<Instant> calculateDemoDataCreatedAt(Map<UUID, Instant> excludedProjectIds) {
+    public Optional<Instant> calculateDemoDataCreatedAt(@NonNull Map<UUID, Instant> excludedProjectIds) {
         return excludedProjectIds.values()
                 .stream()
                 .max(Comparator.naturalOrder())
                 .map(createAt -> createAt.plus(1, ChronoUnit.MINUTES));
+    }
+
+    /**
+     * Drops demo projects and re-aggregates the per-project counts into one count per workspace.
+     *
+     * @param rows           per-project counts, in the order the query returned them
+     * @param demoProjectIds ids of the demo projects to exclude; ids absent from {@code rows} are simply unused
+     * @return workspace id to count, in the order the workspaces first appear in {@code rows}
+     */
+    public Map<String, Long> foldByWorkspace(@NonNull List<WorkspaceProjectCount> rows,
+            @NonNull Set<UUID> demoProjectIds) {
+        return rows.stream()
+                .filter(row -> !demoProjectIds.contains(row.projectId()))
+                .collect(Collectors.groupingBy(WorkspaceProjectCount::workspaceId, LinkedHashMap::new,
+                        Collectors.summingLong(WorkspaceProjectCount::count)));
+    }
+
+    /**
+     * Drops demo projects and re-aggregates the per-project counts into one count per workspace and user, the shape
+     * the BI events expect.
+     *
+     * @param rows           per-project, per-user counts, in the order the query returned them
+     * @param demoProjectIds ids of the demo projects to exclude; ids absent from {@code rows} are simply unused
+     * @return one entry per workspace and user, in the order the pairs first appear in {@code rows}
+     */
+    public List<BiInformation> foldByWorkspaceAndUser(@NonNull List<WorkspaceProjectUserCount> rows,
+            @NonNull Set<UUID> demoProjectIds) {
+        return rows.stream()
+                .filter(row -> !demoProjectIds.contains(row.projectId()))
+                .collect(Collectors.groupingBy(row -> Pair.of(row.workspaceId(), row.user()), LinkedHashMap::new,
+                        Collectors.summingLong(WorkspaceProjectUserCount::count)))
+                .entrySet()
+                .stream()
+                .map(entry -> BiInformation.builder()
+                        .workspaceId(entry.getKey().getLeft())
+                        .user(entry.getKey().getRight())
+                        .count(entry.getValue())
+                        .build())
+                .toList();
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/UsageResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/UsageResourceClient.java
@@ -1,0 +1,56 @@
+package com.comet.opik.api.resources.utils.resources;
+
+import com.comet.opik.api.BiInformationResponse;
+import com.comet.opik.api.SpansCountResponse;
+import com.comet.opik.api.TraceCountResponse;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.hc.core5.http.HttpStatus;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Client for the internal usage endpoints, which back the BI events and the usage billing pull. They take no
+ * authentication, so no api key or workspace name is threaded through.
+ */
+@RequiredArgsConstructor
+public class UsageResourceClient {
+
+    private static final String RESOURCE_PATH = "%s/v1/internal/usage";
+
+    private final ClientSupport client;
+    private final String baseURI;
+
+    public TraceCountResponse getWorkspaceTraceCounts() {
+        return get("workspace-trace-counts", TraceCountResponse.class);
+    }
+
+    public SpansCountResponse getWorkspaceSpanCounts() {
+        return get("workspace-span-counts", SpansCountResponse.class);
+    }
+
+    public UsageByWorkspaceProjectUserResponse getWorkspaceSpanCountsBreakdown() {
+        return get("workspace-span-counts-breakdown", UsageByWorkspaceProjectUserResponse.class);
+    }
+
+    /**
+     * @param entityType the entity the BI events are reported for: {@code traces}, {@code spans},
+     *                   {@code experiments} or {@code datasets}
+     */
+    public BiInformationResponse getBiInformation(@NonNull String entityType) {
+        return get("bi-%s".formatted(entityType), BiInformationResponse.class);
+    }
+
+    private <T> T get(String path, Class<T> responseType) {
+        try (var response = client.target(RESOURCE_PATH.formatted(baseURI))
+                .path(path)
+                .request()
+                .get()) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+            assertThat(response.hasEntity()).isTrue();
+            return response.readEntity(responseType);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
@@ -5,7 +5,6 @@ import com.comet.opik.api.Span;
 import com.comet.opik.api.SpansCountResponse;
 import com.comet.opik.api.Trace;
 import com.comet.opik.api.TraceCountResponse;
-import com.comet.opik.api.UsageByWorkspaceProjectUserResponse;
 import com.comet.opik.api.resources.utils.AuthTestUtils;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.ClientSupportUtils;
@@ -17,7 +16,10 @@ import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
 import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.UsageResourceClient;
 import com.comet.opik.domain.DemoData;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.comet.opik.infrastructure.db.TransactionTemplateAsync;
@@ -25,7 +27,6 @@ import com.comet.opik.podam.PodamFactoryUtils;
 import com.redis.testcontainers.RedisContainer;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
-import jakarta.ws.rs.core.Response;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -34,6 +35,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startables;
@@ -44,11 +48,13 @@ import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.infrastructure.auth.RequestContext.WORKSPACE_HEADER;
@@ -56,6 +62,8 @@ import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @DisplayName("Usage Resource Test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -63,11 +71,12 @@ import static org.awaitility.Awaitility.await;
 @ExtendWith(DropwizardAppExtensionProvider.class)
 class UsageResourceTest {
 
-    public static final String USAGE_RESOURCE_URL_TEMPLATE = "%s/v1/internal/usage";
     public static final String TRACE_RESOURCE_URL_TEMPLATE = "%s/v1/private/traces";
     public static final String SPANS_RESOURCE_URL_TEMPLATE = "%s/v1/private/spans";
     private static final String EXPERIMENT_RESOURCE_URL_TEMPLATE = "%s/v1/private/experiments";
     private static final String DATASET_RESOURCE_URL_TEMPLATE = "%s/v1/private/datasets";
+
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
 
     private final String USER = UUID.randomUUID().toString();
 
@@ -104,6 +113,7 @@ class UsageResourceTest {
     private TransactionTemplateAsync clickHouseTemplate;
     private TransactionTemplate mySqlTemplate;
     private ExperimentResourceClient experimentResourceClient;
+    private UsageResourceClient usageResourceClient;
 
     @BeforeAll
     void setUpAll(ClientSupport client, TransactionTemplateAsync clickHouseTemplate,
@@ -116,6 +126,7 @@ class UsageResourceTest {
         ClientSupportUtils.config(client);
 
         this.experimentResourceClient = new ExperimentResourceClient(client, baseURI, factory);
+        this.usageResourceClient = new UsageResourceClient(client, baseURI);
     }
 
     @AfterAll
@@ -124,7 +135,11 @@ class UsageResourceTest {
     }
 
     private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId) {
-        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, USER);
+        mockTargetWorkspace(apiKey, workspaceName, workspaceId, USER);
+    }
+
+    private void mockTargetWorkspace(String apiKey, String workspaceName, String workspaceId, String user) {
+        AuthTestUtils.mockTargetWorkspace(wireMock.server(), apiKey, workspaceName, workspaceId, user);
     }
 
     @Nested
@@ -144,38 +159,34 @@ class UsageResourceTest {
 
             // Setup mock workspace with traces
             var workspaceId = UUID.randomUUID().toString();
-            var apikey = UUID.randomUUID().toString();
-            int tracesCount = setupEntitiesForWorkspace(workspaceId, apikey, traces,
+            var apikey = "apiKey-" + UUID.randomUUID();
+            var tracesCount = setupEntitiesForWorkspace(workspaceId, apikey, traces,
                     TRACE_RESOURCE_URL_TEMPLATE);
 
-            // Change created_at to the previous day in order to capture those traces in count query, since for Stripe we need to count it daily for yesterday
+            // Change created_at to the previous day in order to capture those traces in count query, since for usage billing we need to count it daily for yesterday
             subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
 
             // Setup second workspace with traces, but leave created_at date set to today, so traces do not end up in the pool
             var workspaceIdForToday = UUID.randomUUID().toString();
-            var apikey2 = UUID.randomUUID().toString();
+            var apikey2 = "apiKey-" + UUID.randomUUID();
 
             setupEntitiesForWorkspace(workspaceIdForToday, apikey2, traces, TRACE_RESOURCE_URL_TEMPLATE);
 
-            try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                    .path("/workspace-trace-counts")
-                    .request()
-                    .get()) {
+            var expectedTraceCount = TraceCountResponse.WorkspaceTraceCount.builder()
+                    .workspace(workspaceId)
+                    .traceCount(tracesCount)
+                    .build();
 
-                var response = validateResponse(actualResponse, TraceCountResponse.class);
+            var response = usageResourceClient.getWorkspaceTraceCounts();
 
-                var workspaceTraceCount = getMatch(response.workspacesTracesCount(),
-                        wtc -> wtc.workspace().equals(workspaceId));
+            var actualTraceCount = getMatch(response.workspacesTracesCount(),
+                    wtc -> wtc.workspace().equals(workspaceId));
+            assertThat(actualTraceCount).contains(expectedTraceCount);
 
-                assertThat(workspaceTraceCount).isPresent();
-                assertThat(workspaceTraceCount.get())
-                        .isEqualTo(new TraceCountResponse.WorkspaceTraceCount(workspaceId, tracesCount));
-
-                // Check that today's workspace is not returned
-                var workspaceTraceCountToday = getMatch(response.workspacesTracesCount(),
-                        wtc -> wtc.workspace().equals(workspaceIdForToday));
-                assertThat(workspaceTraceCountToday).isEmpty();
-            }
+            // Check that today's workspace is not returned
+            var actualTraceCountToday = getMatch(response.workspacesTracesCount(),
+                    wtc -> wtc.workspace().equals(workspaceIdForToday));
+            assertThat(actualTraceCountToday).isEmpty();
         }
 
         @Test
@@ -190,82 +201,73 @@ class UsageResourceTest {
 
             // Setup mock workspace with spans
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            int spansCount = setupEntitiesForWorkspace(workspaceId, apiKey, spans, SPANS_RESOURCE_URL_TEMPLATE);
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var spansCount = setupEntitiesForWorkspace(workspaceId, apiKey, spans, SPANS_RESOURCE_URL_TEMPLATE);
 
-            // Change created_at to the previous day in order to capture those spans in count query, since for Stripe we
-            // need to count it daily for yesterday
+            // Change created_at to the previous day in order to capture those spans in count query, since for usage
+            // billing we need to count it daily for yesterday
             subtractClickHouseTableRecordsCreatedAtOneDay("spans").accept(workspaceId);
 
             // Setup second workspace with spans, but leave created_at date set to today, so spans do not end up in the
             // pool
             var workspaceIdForToday = UUID.randomUUID().toString();
-            var apiKey2 = UUID.randomUUID().toString();
+            var apiKey2 = "apiKey-" + UUID.randomUUID();
 
             setupEntitiesForWorkspace(workspaceIdForToday, apiKey2, spans, SPANS_RESOURCE_URL_TEMPLATE);
 
-            try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                    .path("/workspace-span-counts")
-                    .request()
-                    .get()) {
+            var expectedSpanCount = SpansCountResponse.WorkspaceSpansCount.builder()
+                    .workspace(workspaceId)
+                    .spanCount(spansCount)
+                    .build();
 
-                var response = validateResponse(actualResponse, SpansCountResponse.class);
+            var response = usageResourceClient.getWorkspaceSpanCounts();
 
-                var workspaceSpanCount = getMatch(response.workspacesSpansCount(),
-                        workspaceCount -> workspaceCount.workspace().equals(workspaceId));
+            var actualSpanCount = getMatch(response.workspacesSpansCount(),
+                    workspaceCount -> workspaceCount.workspace().equals(workspaceId));
+            assertThat(actualSpanCount).contains(expectedSpanCount);
 
-                assertThat(workspaceSpanCount).isPresent();
-                assertThat(workspaceSpanCount.get())
-                        .isEqualTo(new SpansCountResponse.WorkspaceSpansCount(workspaceId, spansCount));
-
-                // Check that today's workspace is not returned
-                var workspaceSpanCountToday = getMatch(response.workspacesSpansCount(),
-                        workspaceCount -> workspaceCount.workspace().equals(workspaceIdForToday));
-                assertThat(workspaceSpanCountToday).isEmpty();
-            }
+            // Check that today's workspace is not returned
+            var actualSpanCountToday = getMatch(response.workspacesSpansCount(),
+                    workspaceCount -> workspaceCount.workspace().equals(workspaceIdForToday));
+            assertThat(actualSpanCountToday).isEmpty();
         }
 
         @Test
         @DisplayName("Get span usage breakdown by workspace, project and user for previous day")
         void spanBreakdownForWorkspace() {
-            var projectName = "breakdown-%s".formatted(UUID.randomUUID());
+            var projectName = "breakdown-%s".formatted(ID_GENERATOR.generateId());
             var spans = PodamFactoryUtils.manufacturePojoList(factory, Span.class)
                     .stream()
                     .map(span -> span.toBuilder().id(null).projectName(projectName).build())
                     .toList();
 
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            int spansCount = setupEntitiesForWorkspace(workspaceId, apiKey, spans, SPANS_RESOURCE_URL_TEMPLATE);
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var spansCount = setupEntitiesForWorkspace(workspaceId, apiKey, spans, SPANS_RESOURCE_URL_TEMPLATE);
             // Backdate to the previous day so the rows land in the yesterday window of the count query
             subtractClickHouseTableRecordsCreatedAtOneDay("spans").accept(workspaceId);
 
             // Spans left at today in another workspace must be excluded
             var workspaceIdForToday = UUID.randomUUID().toString();
-            setupEntitiesForWorkspace(workspaceIdForToday, UUID.randomUUID().toString(), spans,
+            setupEntitiesForWorkspace(workspaceIdForToday, "apiKey-" + UUID.randomUUID(), spans,
                     SPANS_RESOURCE_URL_TEMPLATE);
 
-            try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                    .path("/workspace-span-counts-breakdown")
-                    .request()
-                    .get()) {
+            var response = usageResourceClient.getWorkspaceSpanCountsBreakdown();
 
-                var response = validateResponse(actualResponse, UsageByWorkspaceProjectUserResponse.class);
+            var actualRows = response.breakdown().stream()
+                    .filter(row -> row.workspaceId().equals(workspaceId))
+                    .toList();
 
-                var rows = response.breakdown().stream()
-                        .filter(row -> row.workspaceId().equals(workspaceId))
-                        .toList();
+            // All spans share one project and one user, so a single breakdown row is expected. The project id is
+            // assigned by the backend, so it is asserted as present rather than compared.
+            assertThat(actualRows).hasSize(1);
+            var actualRow = actualRows.getFirst();
+            assertThat(actualRow.user()).isEqualTo(USER);
+            assertThat(actualRow.count()).isEqualTo(spansCount);
+            assertThat(actualRow.projectId()).isNotNull();
 
-                // All spans share one project and one user, so a single breakdown row is expected
-                assertThat(rows).hasSize(1);
-                var row = rows.get(0);
-                assertThat(row.user()).isEqualTo(USER);
-                assertThat(row.count()).isEqualTo(spansCount);
-                assertThat(row.projectId()).isNotNull();
-
-                assertThat(response.breakdown())
-                        .noneMatch(r -> r.workspaceId().equals(workspaceIdForToday));
-            }
+            assertThat(response.breakdown())
+                    .noneMatch(r -> r.workspaceId().equals(workspaceIdForToday));
         }
 
         @Test
@@ -318,270 +320,265 @@ class UsageResourceTest {
                 Consumer<String> decreaseTableRecordsCreatedAt) {
             // Setup mock workspace with corresponding entities
             var workspaceId = UUID.randomUUID().toString();
-            var apikey = UUID.randomUUID().toString();
-            int entitiesCount = setupEntitiesForWorkspace(workspaceId, apikey, entities,
+            var apikey = "apiKey-" + UUID.randomUUID();
+            var entitiesCount = setupEntitiesForWorkspace(workspaceId, apikey, entities,
                     resourseUri);
 
             // Change created_at to the previous day in order to capture those entities in count query, since for BI events we need to count it daily for yesterday
             decreaseTableRecordsCreatedAt.accept(workspaceId);
 
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("bi-%s".formatted(biType))
-                        .request()
-                        .get()) {
-
-                    var response = validateResponse(actualResponse, BiInformationResponse.class);
-                    var biInformation = getMatch(response.biInformation(),
-                            biInfo -> biInfo.workspaceId().equals(workspaceId));
-
-                    return biInformation
-                            .map(biInfo -> biInfo
-                                    .equals(BiInformationResponse.BiInformation.builder()
-                                            .workspaceId(workspaceId)
-                                            .user(USER)
-                                            .count(entitiesCount)
-                                            .build()))
-                            .orElse(false);
-                }
-            });
-        }
-
-        @Test
-        @DisplayName("Get traces count excluding demo data projects")
-        void tracesCountExcludingDemoData() {
-            var regularTraces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName("Regular Project") // Non-demo project
-                            .build())
-                    .toList();
-
-            var demoTraces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName(DemoData.PROJECTS.get(0)) // Demo project name
-                            .build())
-                    .toList();
-
-            // Setup workspace with both regular and demo traces
-            var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            // Create both regular and demo traces
-            regularTraces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
-            demoTraces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
-
-            // Change created_at to the previous day to capture in usage query
-            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
-
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("workspace-trace-counts")
-                        .request()
-                        .get()) {
-
-                    var response = validateResponse(actualResponse, TraceCountResponse.class);
-                    var traceCount = getMatch(response.workspacesTracesCount(),
-                            traceInfo -> traceInfo.workspace().equals(workspaceId));
-
-                    // Should only count regular traces, not demo traces
-                    return traceCount
-                            .map(info -> info.traceCount() == regularTraces.size())
-                            .orElse(false);
-                }
-            });
+            awaitBiInformation(biType, workspaceId, entitiesCount);
         }
 
         @Test
         @DisplayName("Get spans count excluding demo data projects")
         void spansCountExcludingDemoData() {
-            var regularSpans = PodamFactoryUtils.manufacturePojoList(factory, Span.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName("Regular Project") // Non-demo project
-                            .build())
-                    .toList();
-
-            var demoSpans = PodamFactoryUtils.manufacturePojoList(factory, Span.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName(DemoData.PROJECTS.get(1)) // Demo project name
-                            .build())
-                    .toList();
+            var regularSpans = spansInProject("project-" + ID_GENERATOR.generateId());
+            var demoSpans = spansInProject(DemoData.PROJECTS.get(1));
 
             // Setup workspace with both regular and demo spans
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            // Create both regular and demo spans
-            regularSpans.forEach(span -> createEntity(span, apiKey, workspaceName, SPANS_RESOURCE_URL_TEMPLATE));
-            demoSpans.forEach(span -> createEntity(span, apiKey, workspaceName, SPANS_RESOURCE_URL_TEMPLATE));
+            createSpans(concat(regularSpans, demoSpans), apiKey, workspaceName);
 
             // Change created_at to the previous day to capture in usage query
             subtractClickHouseTableRecordsCreatedAtOneDay("spans").accept(workspaceId);
 
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("workspace-span-counts")
-                        .request()
-                        .get()) {
-
-                    var response = validateResponse(actualResponse, SpansCountResponse.class);
-                    var spanCount = getMatch(response.workspacesSpansCount(),
-                            spanInfo -> spanInfo.workspace().equals(workspaceId));
-
-                    // Should only count regular spans, not demo spans
-                    return spanCount
-                            .map(info -> info.spanCount() == regularSpans.size())
-                            .orElse(false);
-                }
-            });
+            // Should only count regular spans, not demo spans
+            awaitSpanCount(workspaceId, regularSpans.size());
         }
 
         @Test
         @DisplayName("Span count includes activity in demo projects created after the demo cutoff")
         void spansCountIncludesPostCutoffActivityInDemoProjects() {
-            var demoSpans = PodamFactoryUtils.manufacturePojoList(factory, Span.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName(DemoData.PROJECTS.get(0))
-                            .build())
-                    .toList();
+            var demoSpans = spansInProject(DemoData.PROJECTS.getFirst());
 
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            demoSpans.forEach(span -> createEntity(span, apiKey, workspaceName, SPANS_RESOURCE_URL_TEMPLATE));
+            createSpans(demoSpans, apiKey, workspaceName);
 
             // Project created today → cutoff = today + 1 min, in the future. Push the project two days back so
             // cutoff lands ~2 days ago, then move spans to yesterday — they end up post-cutoff and must be counted.
             backdateDemoProjectsCreatedAtTwoDays();
             subtractClickHouseTableRecordsCreatedAtOneDay("spans").accept(workspaceId);
 
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("workspace-span-counts")
-                        .request()
-                        .get()) {
-
-                    var response = validateResponse(actualResponse, SpansCountResponse.class);
-                    var spanCount = getMatch(response.workspacesSpansCount(),
-                            spanInfo -> spanInfo.workspace().equals(workspaceId));
-
-                    return spanCount
-                            .map(info -> info.spanCount() == demoSpans.size())
-                            .orElse(false);
-                }
-            });
+            awaitSpanCount(workspaceId, demoSpans.size());
         }
 
-        @Test
-        @DisplayName("Trace count includes activity in demo projects created after the demo cutoff")
-        void tracesCountIncludesPostCutoffActivityInDemoProjects() {
-            var demoTraces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
-                    .stream()
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName(DemoData.PROJECTS.get(0))
-                            .build())
-                    .toList();
+        /** Demo-project activity is excluded whether the workspace touched one demo project or every one of them. */
+        @ParameterizedTest
+        @MethodSource
+        void tracesCountExcludesDemoProjects(List<String> demoProjectNames) {
+            var regularTraces = tracesInProjects("project-" + ID_GENERATOR.generateId());
+            var demoTraces = tracesInProjects(demoProjectNames.toArray(String[]::new));
 
             var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceName = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
             mockTargetWorkspace(apiKey, workspaceName, workspaceId);
 
-            demoTraces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
-
-            backdateDemoProjectsCreatedAtTwoDays();
-            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
-
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("workspace-trace-counts")
-                        .request()
-                        .get()) {
-
-                    var response = validateResponse(actualResponse, TraceCountResponse.class);
-                    var traceCount = getMatch(response.workspacesTracesCount(),
-                            traceInfo -> traceInfo.workspace().equals(workspaceId));
-
-                    return traceCount
-                            .map(info -> info.traceCount() == demoTraces.size())
-                            .orElse(false);
-                }
-            });
-        }
-
-        @Test
-        @DisplayName("Mixed workspace with demo and regular data - only regular data counted")
-        void mixedWorkspaceExcludesDemoData() {
-            var regularTraces = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
-                    .stream()
-                    .limit(3)
-                    .map(e -> e.toBuilder()
-                            .id(null)
-                            .projectName("Production Project")
-                            .build())
-                    .toList();
-
-            var multiDemoTraces = DemoData.PROJECTS.stream()
-                    .flatMap(projectName -> PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
-                            .stream()
-                            .limit(2)
-                            .map(e -> e.toBuilder()
-                                    .id(null)
-                                    .projectName(projectName)
-                                    .build()))
-                    .toList();
-
-            // Setup workspace
-            var workspaceId = UUID.randomUUID().toString();
-            var apiKey = UUID.randomUUID().toString();
-            var workspaceName = UUID.randomUUID().toString();
-            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
-
-            // Create all traces (regular + demo)
-            regularTraces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
-            multiDemoTraces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
+            createTraces(concat(regularTraces, demoTraces), apiKey, workspaceName);
 
             // Change created_at to the previous day to capture in usage query
             subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
 
-            await().atMost(10, SECONDS).until(() -> {
-                try (var actualResponse = client.target(USAGE_RESOURCE_URL_TEMPLATE.formatted(baseURI))
-                        .path("workspace-trace-counts")
-                        .request()
-                        .get()) {
+            awaitTraceCount(workspaceId, regularTraces.size());
+        }
 
-                    var response = validateResponse(actualResponse, TraceCountResponse.class);
-                    var traceCount = getMatch(response.workspacesTracesCount(),
-                            traceInfo -> traceInfo.workspace().equals(workspaceId));
+        private Stream<Arguments> tracesCountExcludesDemoProjects() {
+            return Stream.of(
+                    arguments(named("a demo project", List.of(DemoData.PROJECTS.getFirst()))),
+                    arguments(named("every demo project", DemoData.PROJECTS)));
+        }
 
-                    // Should only count regular traces (3), not demo traces (10 total from 5 projects * 2 traces each)
-                    return traceCount
-                            .map(info -> info.traceCount() == regularTraces.size())
-                            .orElse(false);
-                }
+        /**
+         * The case whose behaviour changed, kept separate because the cutoff move is what it is about. The trace
+         * exclusion used to carry an {@code OR created_at > demoDataCreatedAt} branch, which counted activity in a
+         * demo project once that project predated the cutoff — what
+         * {@link #spansCountIncludesPostCutoffActivityInDemoProjects()} still pins for spans. That branch cannot
+         * match where demo projects are created continuously, since the cutoff is then effectively now, and it only
+         * existed alongside the inlined project-id literal the trace usage queries no longer carry.
+         */
+        @Test
+        void tracesCountExcludesDemoProjectsPredatingTheDemoCutoff() {
+            var regularTraces = tracesInProjects("project-" + ID_GENERATOR.generateId());
+            var demoTraces = tracesInProjects(DemoData.PROJECTS.getFirst());
+
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            createTraces(concat(regularTraces, demoTraces), apiKey, workspaceName);
+
+            // Moves demo project creation before the window, where the removed OR branch would have counted it
+            backdateDemoProjectsCreatedAtTwoDays();
+            // Change created_at to the previous day to capture in usage query. Waiting on the regular count keeps
+            // the assertion from passing on an unfinished mutation.
+            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
+
+            awaitTraceCount(workspaceId, regularTraces.size());
+        }
+
+        /**
+         * The per-workspace count is folded from per-project rows, so a workspace spanning several projects has to
+         * sum back to the total the workspace-grouped query returned.
+         */
+        @Test
+        void tracesCountSumsAWorkspacesProjectsIntoOneRow() {
+            var traces = tracesInProjects("project-" + ID_GENERATOR.generateId(),
+                    "project-" + ID_GENERATOR.generateId());
+
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            createTraces(traces, apiKey, workspaceName);
+
+            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
+
+            awaitTraceCount(workspaceId, traces.size());
+        }
+
+        /**
+         * The BI fold, which re-aggregates the per-project rows by workspace and user. One user across two regular
+         * projects plus a demo project must come back as a single row counting only the regular projects, so losing
+         * the exclusion and losing the re-aggregation are both caught.
+         */
+        @Test
+        void traceBiInfoSumsAUsersProjectsAndExcludesDemoProjects() {
+            var regularTraces = tracesInProjects("project-" + ID_GENERATOR.generateId(),
+                    "project-" + ID_GENERATOR.generateId());
+            var demoTraces = tracesInProjects(DemoData.PROJECTS.get(2));
+
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            createTraces(concat(regularTraces, demoTraces), apiKey, workspaceName);
+
+            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
+
+            awaitBiInformation("traces", workspaceId, regularTraces.size());
+        }
+
+        /**
+         * The BI fold keys on workspace and user, so two users in one workspace have to come back as two rows.
+         * Every other test here runs as a single user, and collapsing the two would misreport both.
+         */
+        @Test
+        void traceBiInfoKeepsUsersInTheSameWorkspaceApart() {
+            var workspaceId = UUID.randomUUID().toString();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var otherApiKey = "apiKey-" + UUID.randomUUID();
+            var otherUser = "user-" + UUID.randomUUID();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+            mockTargetWorkspace(otherApiKey, workspaceName, workspaceId, otherUser);
+
+            var traces = tracesInProjects("project-" + ID_GENERATOR.generateId());
+            var otherUserTraces = tracesInProjects("project-" + ID_GENERATOR.generateId());
+            createTraces(traces, apiKey, workspaceName);
+            createTraces(otherUserTraces, otherApiKey, workspaceName);
+
+            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
+
+            awaitBiInformation("traces", workspaceId,
+                    BiInformationResponse.BiInformation.builder()
+                            .workspaceId(workspaceId)
+                            .user(USER)
+                            .count(traces.size())
+                            .build(),
+                    BiInformationResponse.BiInformation.builder()
+                            .workspaceId(workspaceId)
+                            .user(otherUser)
+                            .count(otherUserTraces.size())
+                            .build());
+        }
+
+        private List<Trace> tracesInProjects(String... projectNames) {
+            return Arrays.stream(projectNames)
+                    .flatMap(projectName -> PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
+                            .stream()
+                            .map(trace -> trace.toBuilder().id(null).projectName(projectName).build()))
+                    .toList();
+        }
+
+        private List<Span> spansInProject(String projectName) {
+            return PodamFactoryUtils.manufacturePojoList(factory, Span.class)
+                    .stream()
+                    .map(span -> span.toBuilder().id(null).projectName(projectName).build())
+                    .toList();
+        }
+
+        private <T> List<T> concat(List<T> first, List<T> second) {
+            return Stream.concat(first.stream(), second.stream()).toList();
+        }
+
+        private void createTraces(List<Trace> traces, String apiKey, String workspaceName) {
+            traces.forEach(trace -> createEntity(trace, apiKey, workspaceName, TRACE_RESOURCE_URL_TEMPLATE));
+        }
+
+        private void createSpans(List<Span> spans, String apiKey, String workspaceName) {
+            spans.forEach(span -> createEntity(span, apiKey, workspaceName, SPANS_RESOURCE_URL_TEMPLATE));
+        }
+
+        private void awaitTraceCount(String workspaceId, int expectedCount) {
+            var expectedTraceCount = TraceCountResponse.WorkspaceTraceCount.builder()
+                    .workspace(workspaceId)
+                    .traceCount(expectedCount)
+                    .build();
+            await().atMost(10, SECONDS).untilAsserted(() -> {
+                var actualTraceCount = getMatch(usageResourceClient.getWorkspaceTraceCounts().workspacesTracesCount(),
+                        traceCount -> traceCount.workspace().equals(workspaceId));
+                assertThat(actualTraceCount).contains(expectedTraceCount);
+            });
+        }
+
+        private void awaitSpanCount(String workspaceId, int expectedCount) {
+            var expectedSpanCount = SpansCountResponse.WorkspaceSpansCount.builder()
+                    .workspace(workspaceId)
+                    .spanCount(expectedCount)
+                    .build();
+            await().atMost(10, SECONDS).untilAsserted(() -> {
+                var actualSpanCount = getMatch(usageResourceClient.getWorkspaceSpanCounts().workspacesSpansCount(),
+                        spanCount -> spanCount.workspace().equals(workspaceId));
+                assertThat(actualSpanCount).contains(expectedSpanCount);
+            });
+        }
+
+        private void awaitBiInformation(String entityType, String workspaceId, int expectedCount) {
+            awaitBiInformation(entityType, workspaceId, BiInformationResponse.BiInformation.builder()
+                    .workspaceId(workspaceId)
+                    .user(USER)
+                    .count(expectedCount)
+                    .build());
+        }
+
+        private void awaitBiInformation(String entityType, String workspaceId,
+                BiInformationResponse.BiInformation... expectedBiInformation) {
+            await().atMost(10, SECONDS).untilAsserted(() -> {
+                var actualBiInformation = usageResourceClient.getBiInformation(entityType)
+                        .biInformation()
+                        .stream()
+                        .filter(biInfo -> biInfo.workspaceId().equals(workspaceId))
+                        .toList();
+                assertThat(actualBiInformation).containsExactlyInAnyOrder(expectedBiInformation);
             });
         }
     }
 
     private <T> int setupEntitiesForWorkspace(String workspaceId, String okApikey, List<T> entities,
             String resourseUri) {
-        String workspaceName = UUID.randomUUID().toString();
+        var workspaceName = "test-workspace-" + UUID.randomUUID();
         mockTargetWorkspace(okApikey, workspaceName, workspaceId);
 
         entities.forEach(entity -> createEntity(entity, okApikey, workspaceName, resourseUri));
@@ -605,13 +602,6 @@ class UsageResourceTest {
         return list.stream()
                 .filter(predicate)
                 .findFirst();
-    }
-
-    private <T> T validateResponse(Response response, Class<T> entityType) {
-        assertThat(response.getStatusInfo().getStatusCode()).isEqualTo(200);
-        assertThat(response.hasEntity()).isTrue();
-
-        return response.readEntity(entityType);
     }
 
     private Consumer<String> subtractClickHouseTableRecordsCreatedAtOneDay(String table) {
@@ -645,7 +635,7 @@ class UsageResourceTest {
         // Push demo-named project creation timestamps far enough into the past that the
         // computed demoDataCreatedAt cutoff (= max(project.created_at) + 1 min) precedes
         // spans/traces backdated to yesterday — exercising the `OR created_at > cutoff`
-        // branch of the rewritten exclusion predicate. The service resolves demo projects
+        // branch of the span exclusion predicate. The service resolves demo projects
         // by global name across all workspaces, so the update must span workspaces too.
         mySqlTemplate.inTransaction(WRITE, handle -> {
             handle.createUpdate(

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
@@ -16,6 +16,7 @@ import com.comet.opik.api.resources.utils.TestUtils;
 import com.comet.opik.api.resources.utils.WireMockUtils;
 import com.comet.opik.api.resources.utils.resources.DatasetResourceClient;
 import com.comet.opik.api.resources.utils.resources.ExperimentResourceClient;
+import com.comet.opik.api.resources.utils.resources.TraceResourceClient;
 import com.comet.opik.api.resources.utils.resources.UsageResourceClient;
 import com.comet.opik.domain.DemoData;
 import com.comet.opik.domain.IdGenerator;
@@ -28,6 +29,7 @@ import com.redis.testcontainers.RedisContainer;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.HttpHeaders;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.core5.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -113,6 +115,7 @@ class UsageResourceTest {
     private TransactionTemplateAsync clickHouseTemplate;
     private TransactionTemplate mySqlTemplate;
     private ExperimentResourceClient experimentResourceClient;
+    private TraceResourceClient traceResourceClient;
     private UsageResourceClient usageResourceClient;
 
     @BeforeAll
@@ -126,6 +129,7 @@ class UsageResourceTest {
         ClientSupportUtils.config(client);
 
         this.experimentResourceClient = new ExperimentResourceClient(client, baseURI, factory);
+        this.traceResourceClient = new TraceResourceClient(client, baseURI);
         this.usageResourceClient = new UsageResourceClient(client, baseURI);
     }
 
@@ -424,6 +428,40 @@ class UsageResourceTest {
             subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
 
             awaitTraceCount(workspaceId, regularTraces.size());
+        }
+
+        /**
+         * The premise the fold rests on: summing per-project counts equals the distinct-id total the
+         * workspace-grouped query used to return, because a trace id belongs to exactly one project. The write path
+         * is what guarantees it — presenting an existing id under another project is a conflict, not a move — so no
+         * id can contribute a row under two projects for the sum to double-count. Spans already cover the
+         * equivalent rejection; this pins it for traces together with the count that depends on it.
+         */
+        @Test
+        void tracesCountCountsATraceOnceBecauseItsIdCannotMoveProjects() {
+            var workspaceId = UUID.randomUUID().toString();
+            var apiKey = "apiKey-" + UUID.randomUUID();
+            var workspaceName = "test-workspace-" + UUID.randomUUID();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var trace = PodamFactoryUtils.manufacturePojoList(factory, Trace.class)
+                    .getFirst()
+                    .toBuilder()
+                    .id(ID_GENERATOR.generateId())
+                    .projectName("project-" + ID_GENERATOR.generateId())
+                    .build();
+            createTraces(List.of(trace), apiKey, workspaceName);
+
+            var sameIdInAnotherProject = trace.toBuilder()
+                    .projectName("project-" + ID_GENERATOR.generateId())
+                    .build();
+            try (var response = traceResourceClient.callCreateTrace(sameIdInAnotherProject, apiKey, workspaceName)) {
+                assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            }
+
+            subtractClickHouseTableRecordsCreatedAtOneDay("traces").accept(workspaceId);
+
+            awaitTraceCount(workspaceId, 1);
         }
 
         /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/internal/UsageResourceTest.java
@@ -438,7 +438,7 @@ class UsageResourceTest {
          * equivalent rejection; this pins it for traces together with the count that depends on it.
          */
         @Test
-        void tracesCountCountsATraceOnceBecauseItsIdCannotMoveProjects() {
+        void tracesCountIncludesEachTraceOnceBecauseItsIdCannotMoveBetweenProjects() {
             var workspaceId = UUID.randomUUID().toString();
             var apiKey = "apiKey-" + UUID.randomUUID();
             var workspaceName = "test-workspace-" + UUID.randomUUID();

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -45,6 +45,7 @@ import com.comet.opik.api.resources.utils.traces.TraceDBUtils;
 import com.comet.opik.api.sorting.Direction;
 import com.comet.opik.api.sorting.SortableFields;
 import com.comet.opik.api.sorting.SortingField;
+import com.comet.opik.domain.DemoData;
 import com.comet.opik.domain.EntityType;
 import com.comet.opik.domain.FeedbackScoreDAO;
 import com.comet.opik.domain.GuardrailResult;
@@ -3210,6 +3211,40 @@ class ProjectsResourceTest {
             var actualEntity = projectResourceClient.findTokenUsageNames(
                     nonExistentProjectId, apiKey, workspaceName, HttpStatus.SC_NOT_FOUND);
             assertThat(actualEntity).isNull();
+        }
+    }
+
+    /**
+     * The bounded demo-project lookup behind the daily usage counts. The scope is the point of it: without one the
+     * caller loads every demo project in the installation, which is what put a query literal large enough to time
+     * the usage queries out into the ClickHouse query text. Asserted here rather than against a mocked DAO because
+     * only the real query can show that the scope filters — a lookup that ignored it would return a superset, and
+     * the folds that consume it would still produce the right counts.
+     */
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class GetDemoProjectIds {
+
+        @Test
+        void getDemoProjectIds__whenCandidatesAreGiven__thenReturnsOnlyTheDemoProjectsAmongThem() {
+            var apiKey = UUID.randomUUID().toString();
+            var workspaceId = UUID.randomUUID().toString();
+            var workspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(apiKey, workspaceName, workspaceId);
+
+            var demoProjectId = projectResourceClient.createProject(DemoData.PROJECTS.getFirst(), apiKey,
+                    workspaceName);
+            var demoProjectOutOfScopeId = projectResourceClient.createProject(DemoData.PROJECTS.get(1), apiKey,
+                    workspaceName);
+            var regularProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
+                    workspaceName);
+
+            var actualIds = projectService.getDemoProjectIds(Set.of(demoProjectId, regularProjectId)).block();
+
+            assertThat(actualIds)
+                    .as("only the demo projects among the candidates: '%s' is not a demo project, and demo project "
+                            + "'%s' was not offered as a candidate", regularProjectId, demoProjectOutOfScopeId)
+                    .containsExactly(demoProjectId);
         }
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/v1/priv/ProjectsResourceTest.java
@@ -3223,10 +3223,10 @@ class ProjectsResourceTest {
      */
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class GetDemoProjectIds {
+    class GetDemoProjectIdsInWorkspaces {
 
         @Test
-        void getDemoProjectIds__whenCandidatesAreGiven__thenReturnsOnlyTheDemoProjectsAmongThem() {
+        void getDemoProjectIdsInWorkspaces__whenWorkspacesAreGiven__thenReturnsOnlyTheirDemoProjects() {
             var apiKey = UUID.randomUUID().toString();
             var workspaceId = UUID.randomUUID().toString();
             var workspaceName = UUID.randomUUID().toString();
@@ -3234,16 +3234,22 @@ class ProjectsResourceTest {
 
             var demoProjectId = projectResourceClient.createProject(DemoData.PROJECTS.getFirst(), apiKey,
                     workspaceName);
-            var demoProjectOutOfScopeId = projectResourceClient.createProject(DemoData.PROJECTS.get(1), apiKey,
-                    workspaceName);
             var regularProjectId = projectResourceClient.createProject("project-" + UUID.randomUUID(), apiKey,
                     workspaceName);
 
-            var actualIds = projectService.getDemoProjectIds(Set.of(demoProjectId, regularProjectId)).block();
+            var otherApiKey = UUID.randomUUID().toString();
+            var otherWorkspaceId = UUID.randomUUID().toString();
+            var otherWorkspaceName = UUID.randomUUID().toString();
+            mockTargetWorkspace(otherApiKey, otherWorkspaceName, otherWorkspaceId);
+            var demoProjectOutOfScopeId = projectResourceClient.createProject(DemoData.PROJECTS.getFirst(),
+                    otherApiKey, otherWorkspaceName);
+
+            var actualIds = projectService.getDemoProjectIdsInWorkspaces(Set.of(workspaceId)).block();
 
             assertThat(actualIds)
-                    .as("only the demo projects among the candidates: '%s' is not a demo project, and demo project "
-                            + "'%s' was not offered as a candidate", regularProjectId, demoProjectOutOfScopeId)
+                    .as("only the demo projects of the given workspaces: '%s' is not a demo project, and demo "
+                            + "project '%s' belongs to a workspace that was not asked for", regularProjectId,
+                            demoProjectOutOfScopeId)
                     .containsExactly(demoProjectId);
         }
     }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
@@ -66,9 +66,9 @@ class DemoDataExclusionLiteralArchTest {
 
     /**
      * The fetch side. The unscoped fetch loads every demo project in the installation, so a new caller is a new
-     * place that can put the whole set into a query. The trace paths use {@link ProjectService#getDemoProjectIds}
-     * instead, which is scoped to the projects that actually had activity, and the span usage paths are the only
-     * remaining callers until they migrate too.
+     * place that can put the whole set into a query. The trace paths use
+     * {@link ProjectService#getDemoProjectIdsInWorkspaces} instead, which is scoped to the workspaces that
+     * actually had activity, and the span usage paths are the only remaining callers until they migrate too.
      *
      * <p><b>Deliberately no {@code allowEmptyShould}</b>: the rule selects the unscoped method itself, so an empty
      * selection means it was renamed or removed and the rule guards nothing. Failing then is the point.
@@ -82,7 +82,7 @@ class DemoDataExclusionLiteralArchTest {
             .because("""
                     fetching every demo project in the installation is unbounded — one per signup — so it must not \
                     spread beyond the span usage paths that have yet to migrate. New callers scope the lookup to the \
-                    ids they already hold, via ProjectService#getDemoProjectIds\
+                    workspaces they already hold, via ProjectService#getDemoProjectIdsInWorkspaces\
                     """);
 
     /**

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
@@ -1,0 +1,160 @@
+package com.comet.opik.domain;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static java.util.stream.Collectors.toCollection;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keeps the unbounded demo-project set out of the daily usage and BI queries.
+ *
+ * <p>Those queries used to exclude demo data with an inline {@code project_id NOT IN [...]} literal holding one
+ * UUID per demo project across all workspaces. One demo project is created per signup, so that literal grows
+ * without bound, and a {@code Distributed} table re-parses the query text for its shard — the queries eventually
+ * exceeded {@code max_execution_time} and the daily counts silently stopped being produced, because the callers
+ * consuming them cannot tell an empty result from a failed one. The exclusion now happens in Java
+ * ({@link com.comet.opik.domain.utils.DemoDataExclusionUtils}), which keeps the query text constant.
+ *
+ * <p><b>Why two rules.</b> Reintroducing the failure takes both a query template that accepts the project set and a
+ * caller that fetches the whole set to pass in. The first rule forbids the template side by name, which is precise
+ * but rename-sensitive; the second forbids the fetch side through the call graph, which is name-independent. Either
+ * alone has a hole: a template attribute called something else evades the first, and a set obtained some other way
+ * evades the second.
+ *
+ * <p><b>Spans are a known pending violation, listed explicitly.</b> {@link SpanDAO} carries the same pattern in
+ * three constants, but {@code spans} is not wrapped in a {@code Distributed} table yet, so it is not affected
+ * today and its migration is deliberately a separate change. {@link #PENDING_SPAN_USAGE_QUERIES} is asserted by
+ * exact equality rather than as a skip-list, which makes it self-cleaning in both directions: a new violation
+ * anywhere fails the build, and so does migrating spans without deleting the entries.
+ */
+@AnalyzeClasses(packages = "com.comet.opik", importOptions = ImportOption.DoNotIncludeTests.class)
+class DemoDataExclusionLiteralArchTest {
+
+    /**
+     * The template attribute and bind parameter the exclusion travelled under. Matching the SQL text rather than
+     * the call site is what makes the rule independent of how the set is assembled.
+     */
+    private static final Set<String> EXCLUSION_PLACEHOLDERS = Set.of("excluded_project_ids", "demo_data_created_at");
+
+    /**
+     * Still-inlining constants, as {@code SimpleClassName.FIELD_NAME}. Emptying this set is the spans follow-up; the
+     * assertion below fails if it is emptied without the code change, or left populated after it.
+     */
+    private static final Set<String> PENDING_SPAN_USAGE_QUERIES = Set.of(
+            "SpanDAO.SPAN_COUNT_BY_WORKSPACE_ID",
+            "SpanDAO.SPAN_DAILY_BI_INFORMATION",
+            "SpanDAO.SPAN_DAILY_COUNT_BY_WORKSPACE_PROJECT_USER");
+
+    private static final String DOMAIN_PACKAGE = "com.comet.opik.domain";
+
+    private static final String UNSCOPED_DEMO_PROJECT_FETCH = "getDemoProjectIdsWithTimestamps";
+
+    /**
+     * The fetch side. The unscoped fetch loads every demo project in the installation, so a new caller is a new
+     * place that can put the whole set into a query. The trace paths use {@link ProjectService#getDemoProjectIds}
+     * instead, which is scoped to the projects that actually had activity, and the span usage paths are the only
+     * remaining callers until they migrate too.
+     *
+     * <p><b>Deliberately no {@code allowEmptyShould}</b>: the rule selects the unscoped method itself, so an empty
+     * selection means it was renamed or removed and the rule guards nothing. Failing then is the point.
+     */
+    @ArchTest
+    static final ArchRule the_unscoped_demo_project_fetch_is_read_only_by_the_span_usage_paths = methods()
+            .that().areDeclaredIn(ProjectService.class)
+            .and().haveName(UNSCOPED_DEMO_PROJECT_FETCH)
+            .should().onlyBeCalled().byCodeUnitsThat(DescribedPredicate.describe(SpanService.class.getSimpleName(),
+                    codeUnit -> codeUnit.getOwner().isEquivalentTo(SpanService.class)))
+            .because("""
+                    fetching every demo project in the installation is unbounded — one per signup — so it must not \
+                    spread beyond the span usage paths that have yet to migrate. New callers scope the lookup to the \
+                    ids they already hold, via ProjectService#getDemoProjectIds\
+                    """);
+
+    /**
+     * Reflects over the SQL constants rather than expressing an {@link ArchRule}, for the same reason
+     * {@link TraceMutationRoutingArchTest}'s third rule uses a custom condition: ArchUnit works from bytecode and
+     * exposes call graphs, not string values. A plain test rather than an {@code ArchCondition} because the
+     * assertion is over the whole set of offenders at once — a per-class condition cannot tell "spans still
+     * pending" from "spans migrated but the exemption left behind".
+     */
+    @Test
+    void noDaoSqlConstantInlinesTheDemoProjectExclusion() {
+        var daoClasses = new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages(DOMAIN_PACKAGE)
+                .stream()
+                .filter(javaClass -> javaClass.getSimpleName().contains("DAO"))
+                .toList();
+
+        // Every string constant is inspected, not only the query-shaped ones: a placeholder can live in a predicate
+        // fragment that carries no statement keyword of its own.
+        var offenders = daoClasses.stream()
+                .flatMap(daoClass -> stringConstants(daoClass)
+                        .filter(field -> EXCLUSION_PLACEHOLDERS.stream().anyMatch(readConstant(field)::contains))
+                        .map(field -> "%s.%s".formatted(daoClass.getSimpleName(), field.getName())))
+                .collect(toCollection(TreeSet::new));
+
+        var classesDeclaringQueries = daoClasses.stream()
+                .filter(daoClass -> stringConstants(daoClass).anyMatch(field -> isQuery(readConstant(field))))
+                .map(JavaClass::getSimpleName)
+                .collect(toCollection(TreeSet::new));
+
+        // A guard that stops finding the queries it guards has stopped guarding, and would then pass for the wrong
+        // reason. SpanDAO's presence also follows from the offender assertion below, but TraceDAOImpl — the class
+        // whose queries were migrated — would otherwise be indistinguishable from not being scanned at all. If
+        // either is renamed or its SQL moves elsewhere, update this guard rather than dropping the check.
+        assertThat(classesDeclaringQueries)
+                .as("the DAO classes holding the usage queries must be in scope; searched %s for simple names "
+                        + "containing \"DAO\"", DOMAIN_PACKAGE)
+                .contains("TraceDAOImpl", "SpanDAO");
+
+        assertThat(offenders)
+                .as("""
+                        a usage query must not render the demo-project set into its text: the set is unbounded (one \
+                        project per signup) and a Distributed table re-parses the query text per shard, so the query \
+                        eventually exceeds max_execution_time and the daily usage counts silently stop. Group by \
+                        project_id and fold the exclusion in Java via DemoDataExclusionUtils instead. If this failed \
+                        because the spans queries were migrated, delete their entries from \
+                        PENDING_SPAN_USAGE_QUERIES\
+                        """)
+                .isEqualTo(new TreeSet<>(PENDING_SPAN_USAGE_QUERIES));
+    }
+
+    private Stream<Field> stringConstants(JavaClass daoClass) {
+        return Arrays.stream(daoClass.reflect().getDeclaredFields())
+                .filter(field -> Modifier.isStatic(field.getModifiers())
+                        && Modifier.isFinal(field.getModifiers())
+                        && field.getType() == String.class)
+                .filter(field -> readConstant(field) != null);
+    }
+
+    /** Query-shaped enough to prove the guard is looking at SQL, without trying to parse it. */
+    private boolean isQuery(String sql) {
+        var upperCase = sql.toUpperCase();
+        return upperCase.contains("SELECT ") || upperCase.contains("INSERT INTO");
+    }
+
+    private String readConstant(Field field) {
+        try {
+            field.setAccessible(true);
+            return (String) field.get(null);
+        } catch (IllegalAccessException e) {
+            throw new AssertionError("could not read SQL constant " + field.getName(), e);
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/DemoDataExclusionLiteralArchTest.java
@@ -74,7 +74,7 @@ class DemoDataExclusionLiteralArchTest {
      * selection means it was renamed or removed and the rule guards nothing. Failing then is the point.
      */
     @ArchTest
-    static final ArchRule the_unscoped_demo_project_fetch_is_read_only_by_the_span_usage_paths = methods()
+    static final ArchRule the_unscoped_demo_project_fetch_is_called_only_by_the_span_usage_paths = methods()
             .that().areDeclaredIn(ProjectService.class)
             .and().haveName(UNSCOPED_DEMO_PROJECT_FETCH)
             .should().onlyBeCalled().byCodeUnitsThat(DescribedPredicate.describe(SpanService.class.getSimpleName(),

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
@@ -1,0 +1,117 @@
+package com.comet.opik.domain;
+
+import com.comet.opik.api.Project;
+import com.comet.opik.api.sorting.SortingFactoryProjects;
+import com.comet.opik.domain.sorting.SortingQueryBuilder;
+import com.comet.opik.infrastructure.auth.RequestContext;
+import com.comet.opik.infrastructure.bi.AnalyticsService;
+import com.comet.opik.podam.PodamFactoryUtils;
+import com.google.common.collect.Lists;
+import jakarta.inject.Provider;
+import org.jdbi.v3.core.Handle;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+import ru.vyarus.guicey.jdbi3.tx.TxAction;
+import uk.co.jemos.podam.api.PodamFactory;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ProjectServiceImplTest {
+
+    private static final int DEMO_PROJECT_ID_CHUNK_SIZE = 1_000;
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
+
+    private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
+
+    private final TransactionTemplate template = mock(TransactionTemplate.class);
+    private final Handle handle = mock(Handle.class);
+    private final ProjectDAO projectDAO = mock(ProjectDAO.class);
+    private final Provider<RequestContext> requestContext = mock(Provider.class);
+    private final TraceDAO traceDAO = mock(TraceDAO.class);
+    private final SortingFactoryProjects sortingFactory = mock(SortingFactoryProjects.class);
+    private final SortingQueryBuilder sortingQueryBuilder = mock(SortingQueryBuilder.class);
+    private final AnalyticsService analyticsService = mock(AnalyticsService.class);
+
+    private final ProjectService projectService = new ProjectServiceImpl(template, ID_GENERATOR, requestContext,
+            traceDAO, sortingFactory, sortingQueryBuilder, analyticsService);
+
+    /**
+     * The bounded demo-project lookup, which replaced fetching every demo project in the installation for the daily
+     * usage counts. Chunking the candidates is the part with something to get wrong.
+     */
+    @Nested
+    class GetDemoProjectIds {
+
+        @Test
+        void getDemoProjectIds__whenCandidatesExceedTheChunkSize__thenUnionsWhatEveryChunkMatched() {
+            var candidateIds = Stream.generate(ID_GENERATOR::generateId)
+                    .limit(DEMO_PROJECT_ID_CHUNK_SIZE + 1)
+                    .collect(Collectors.toUnmodifiableSet());
+            var chunks = Lists.partition(List.copyOf(candidateIds), DEMO_PROJECT_ID_CHUNK_SIZE);
+            assertThat(chunks).hasSize(2);
+
+            stubTransaction();
+            // One demo project per chunk, so a lookup that dropped a chunk's result — or kept only the last —
+            // comes back with fewer ids than there were chunks.
+            var expectedIds = chunks.stream()
+                    .map(this::stubDemoProjectInChunk)
+                    .collect(Collectors.toUnmodifiableSet());
+
+            var actualIds = projectService.getDemoProjectIds(candidateIds).block();
+
+            assertThat(actualIds).isEqualTo(expectedIds);
+        }
+
+        @Test
+        void getDemoProjectIds__whenNoCandidateIsADemoProject__thenReturnsEmpty() {
+            var candidateIds = Set.of(ID_GENERATOR.generateId());
+
+            stubTransaction();
+            when(projectDAO.findByGlobalNames(DemoData.PROJECTS, candidateIds)).thenReturn(List.of());
+
+            var actualIds = projectService.getDemoProjectIds(candidateIds).block();
+
+            assertThat(actualIds).isEmpty();
+        }
+
+        @Test
+        void getDemoProjectIds__whenNoCandidates__thenReturnsEmptyWithoutTouchingTheDatabase() {
+            var actualIds = projectService.getDemoProjectIds(Set.of()).block();
+
+            assertThat(actualIds).isEmpty();
+            verifyNoInteractions(template);
+        }
+
+        private void stubTransaction() {
+            when(template.inTransaction(eq(READ_ONLY), any())).thenAnswer(invocation -> {
+                TxAction<?> callback = invocation.getArgument(1);
+                return callback.execute(handle);
+            });
+            when(handle.attach(ProjectDAO.class)).thenReturn(projectDAO);
+        }
+
+        private UUID stubDemoProjectInChunk(List<UUID> chunk) {
+            var demoProjectId = chunk.getFirst();
+            var demoProject = factory.manufacturePojo(Project.class).toBuilder()
+                    .id(demoProjectId)
+                    .name(DemoData.PROJECTS.getFirst())
+                    .build();
+            when(projectDAO.findByGlobalNames(DemoData.PROJECTS, Set.copyOf(chunk)))
+                    .thenReturn(List.of(demoProject));
+            return demoProjectId;
+        }
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.when;
 
 class ProjectServiceImplTest {
 
-    private static final int DEMO_PROJECT_ID_CHUNK_SIZE = 1_000;
+    private static final int DEMO_PROJECT_WORKSPACE_CHUNK_SIZE = 1_000;
     private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
 
     private final PodamFactory factory = PodamFactoryUtils.newPodamFactory();
@@ -50,17 +50,18 @@ class ProjectServiceImplTest {
 
     /**
      * The bounded demo-project lookup, which replaced fetching every demo project in the installation for the daily
-     * usage counts. Chunking the candidates is the part with something to get wrong.
+     * usage counts. A day's active workspaces fit in one chunk, so chunking is a bound rather than a loop — but it
+     * is still the part with something to get wrong.
      */
     @Nested
-    class GetDemoProjectIds {
+    class GetDemoProjectIdsInWorkspaces {
 
         @Test
-        void getDemoProjectIds__whenCandidatesExceedTheChunkSize__thenUnionsWhatEveryChunkMatched() {
-            var candidateIds = Stream.generate(ID_GENERATOR::generateId)
-                    .limit(DEMO_PROJECT_ID_CHUNK_SIZE + 1)
+        void getDemoProjectIdsInWorkspaces__whenWorkspacesExceedTheChunkSize__thenUnionsWhatEveryChunkMatched() {
+            var workspaceIds = Stream.generate(() -> UUID.randomUUID().toString())
+                    .limit(DEMO_PROJECT_WORKSPACE_CHUNK_SIZE + 1)
                     .collect(Collectors.toUnmodifiableSet());
-            var chunks = Lists.partition(List.copyOf(candidateIds), DEMO_PROJECT_ID_CHUNK_SIZE);
+            var chunks = Lists.partition(List.copyOf(workspaceIds), DEMO_PROJECT_WORKSPACE_CHUNK_SIZE);
             assertThat(chunks).hasSize(2);
 
             stubTransaction();
@@ -70,26 +71,26 @@ class ProjectServiceImplTest {
                     .map(this::stubDemoProjectInChunk)
                     .collect(Collectors.toUnmodifiableSet());
 
-            var actualIds = projectService.getDemoProjectIds(candidateIds).block();
+            var actualIds = projectService.getDemoProjectIdsInWorkspaces(workspaceIds).block();
 
             assertThat(actualIds).isEqualTo(expectedIds);
         }
 
         @Test
-        void getDemoProjectIds__whenNoCandidateIsADemoProject__thenReturnsEmpty() {
-            var candidateIds = Set.of(ID_GENERATOR.generateId());
+        void getDemoProjectIdsInWorkspaces__whenNoWorkspaceHasADemoProject__thenReturnsEmpty() {
+            var workspaceIds = Set.of(UUID.randomUUID().toString());
 
             stubTransaction();
-            when(projectDAO.findByGlobalNames(DemoData.PROJECTS, candidateIds)).thenReturn(List.of());
+            when(projectDAO.findByGlobalNames(DemoData.PROJECTS, workspaceIds)).thenReturn(List.of());
 
-            var actualIds = projectService.getDemoProjectIds(candidateIds).block();
+            var actualIds = projectService.getDemoProjectIdsInWorkspaces(workspaceIds).block();
 
             assertThat(actualIds).isEmpty();
         }
 
         @Test
-        void getDemoProjectIds__whenNoCandidates__thenReturnsEmptyWithoutTouchingTheDatabase() {
-            var actualIds = projectService.getDemoProjectIds(Set.of()).block();
+        void getDemoProjectIdsInWorkspaces__whenNoWorkspaces__thenReturnsEmptyWithoutTouchingTheDatabase() {
+            var actualIds = projectService.getDemoProjectIdsInWorkspaces(Set.of()).block();
 
             assertThat(actualIds).isEmpty();
             verifyNoInteractions(template);
@@ -103,15 +104,14 @@ class ProjectServiceImplTest {
             when(handle.attach(ProjectDAO.class)).thenReturn(projectDAO);
         }
 
-        private UUID stubDemoProjectInChunk(List<UUID> chunk) {
-            var demoProjectId = chunk.getFirst();
+        private UUID stubDemoProjectInChunk(List<String> chunk) {
             var demoProject = factory.manufacturePojo(Project.class).toBuilder()
-                    .id(demoProjectId)
+                    .id(ID_GENERATOR.generateId())
                     .name(DemoData.PROJECTS.getFirst())
                     .build();
             when(projectDAO.findByGlobalNames(DemoData.PROJECTS, Set.copyOf(chunk)))
                     .thenReturn(List.of(demoProject));
-            return demoProjectId;
+            return demoProject.id();
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/ProjectServiceImplTest.java
@@ -6,15 +6,17 @@ import com.comet.opik.domain.sorting.SortingQueryBuilder;
 import com.comet.opik.infrastructure.auth.RequestContext;
 import com.comet.opik.infrastructure.bi.AnalyticsService;
 import com.comet.opik.podam.PodamFactoryUtils;
-import com.google.common.collect.Lists;
 import jakarta.inject.Provider;
 import org.jdbi.v3.core.Handle;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import ru.vyarus.guicey.jdbi3.tx.TxAction;
 import uk.co.jemos.podam.api.PodamFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -24,6 +26,7 @@ import java.util.stream.Stream;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -56,24 +59,45 @@ class ProjectServiceImplTest {
     @Nested
     class GetDemoProjectIdsInWorkspaces {
 
+        /**
+         * Asserts the contract rather than the partitioning: every workspace is offered to the lookup exactly once,
+         * no single query exceeds the bound, and the union of what the queries matched comes back. Deriving the
+         * expected batches with {@code Lists.partition} would restate the implementation, so a change to how the
+         * work is split would move test and production together and prove nothing.
+         */
         @Test
-        void getDemoProjectIdsInWorkspaces__whenWorkspacesExceedTheChunkSize__thenUnionsWhatEveryChunkMatched() {
+        void getDemoProjectIdsInWorkspaces__whenWorkspacesExceedTheChunkSize__thenEachIsLookedUpOnceWithinTheBound() {
             var workspaceIds = Stream.generate(() -> UUID.randomUUID().toString())
                     .limit(DEMO_PROJECT_WORKSPACE_CHUNK_SIZE + 1)
                     .collect(Collectors.toUnmodifiableSet());
-            var chunks = Lists.partition(List.copyOf(workspaceIds), DEMO_PROJECT_WORKSPACE_CHUNK_SIZE);
-            assertThat(chunks).hasSize(2);
+            var queriedBatches = new ArrayList<Set<String>>();
+            var matchedIds = new ArrayList<UUID>();
 
             stubTransaction();
-            // One demo project per chunk, so a lookup that dropped a chunk's result — or kept only the last —
-            // comes back with fewer ids than there were chunks.
-            var expectedIds = chunks.stream()
-                    .map(this::stubDemoProjectInChunk)
-                    .collect(Collectors.toUnmodifiableSet());
+            // One demo project per batch, so a lookup that dropped a batch's result comes back short
+            when(projectDAO.findByGlobalNames(eq(DemoData.PROJECTS), anySet())).thenAnswer(invocation -> {
+                queriedBatches.add(invocation.getArgument(1));
+                var demoProject = factory.manufacturePojo(Project.class).toBuilder()
+                        .id(ID_GENERATOR.generateId())
+                        .name(DemoData.PROJECTS.getFirst())
+                        .build();
+                matchedIds.add(demoProject.id());
+                return List.of(demoProject);
+            });
 
             var actualIds = projectService.getDemoProjectIdsInWorkspaces(workspaceIds).block();
 
-            assertThat(actualIds).isEqualTo(expectedIds);
+            assertThat(queriedBatches)
+                    .as("the workspaces did not fit in one query, so the bound is exercised")
+                    .hasSizeGreaterThan(1)
+                    .allSatisfy(batch -> assertThat(batch)
+                            .hasSizeLessThanOrEqualTo(DEMO_PROJECT_WORKSPACE_CHUNK_SIZE));
+            assertThat(queriedBatches.stream().flatMap(Set::stream).toList())
+                    .as("every workspace is looked up exactly once")
+                    .containsExactlyInAnyOrderElementsOf(workspaceIds);
+            assertThat(actualIds)
+                    .as("the union of what every batch matched")
+                    .containsExactlyInAnyOrderElementsOf(matchedIds);
         }
 
         @Test
@@ -88,9 +112,12 @@ class ProjectServiceImplTest {
             assertThat(actualIds).isEmpty();
         }
 
-        @Test
-        void getDemoProjectIdsInWorkspaces__whenNoWorkspaces__thenReturnsEmptyWithoutTouchingTheDatabase() {
-            var actualIds = projectService.getDemoProjectIdsInWorkspaces(Set.of()).block();
+        /** Emptiness is handled with the null-safe {@code CollectionUtils.isEmpty}, so null takes the same path. */
+        @ParameterizedTest
+        @NullAndEmptySource
+        void getDemoProjectIdsInWorkspaces__whenNoWorkspaces__thenReturnsEmptyWithoutTouchingTheDatabase(
+                Set<String> workspaceIds) {
+            var actualIds = projectService.getDemoProjectIdsInWorkspaces(workspaceIds).block();
 
             assertThat(actualIds).isEmpty();
             verifyNoInteractions(template);
@@ -102,16 +129,6 @@ class ProjectServiceImplTest {
                 return callback.execute(handle);
             });
             when(handle.attach(ProjectDAO.class)).thenReturn(projectDAO);
-        }
-
-        private UUID stubDemoProjectInChunk(List<String> chunk) {
-            var demoProject = factory.manufacturePojo(Project.class).toBuilder()
-                    .id(ID_GENERATOR.generateId())
-                    .name(DemoData.PROJECTS.getFirst())
-                    .build();
-            when(projectDAO.findByGlobalNames(DemoData.PROJECTS, Set.copyOf(chunk)))
-                    .thenReturn(List.of(demoProject));
-            return demoProject.id();
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -434,8 +434,7 @@ class TraceServiceImplTest {
                             .projectId(DEMO_PROJECT_ID)
                             .count(randomCount())
                             .build()));
-            when(projectService.getDemoProjectIds(
-                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+            when(projectService.getDemoProjectIdsInWorkspaces(Set.of(WORKSPACE_ID)))
                     .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
 
             var expectedResponse = TraceCountResponse.builder()
@@ -481,8 +480,7 @@ class TraceServiceImplTest {
                             .user(USER)
                             .count(randomCount())
                             .build()));
-            when(projectService.getDemoProjectIds(
-                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+            when(projectService.getDemoProjectIdsInWorkspaces(Set.of(WORKSPACE_ID)))
                     .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
 
             var expectedResponse = BiInformationResponse.builder()
@@ -525,8 +523,7 @@ class TraceServiceImplTest {
                             .projectId(OTHER_REGULAR_PROJECT_ID)
                             .count(otherWorkspaceCount)
                             .build()));
-            when(projectService.getDemoProjectIds(
-                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+            when(projectService.getDemoProjectIdsInWorkspaces(Set.of(WORKSPACE_ID, OTHER_WORKSPACE_ID)))
                     .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
 
             var expectedCount = regularCount + otherWorkspaceCount;
@@ -537,12 +534,13 @@ class TraceServiceImplTest {
         }
 
         /**
-         * The bound, asserted where it is cheap to assert: the lookup only ever sees the projects that had traces.
+         * The bound, asserted where it is cheap to assert: the lookup only ever sees the workspaces that had
+         * traces.
          * {@code DemoDataExclusionLiteralArchTest} forbids the unscoped fetch from gaining callers at build time;
          * this pins that the trace path does not reach for it at runtime.
          */
         @Test
-        void countTracesPerWorkspace__whenFolding__thenTheDemoProjectLookupIsScopedToTheProjectsThatHadTraces() {
+        void countTracesPerWorkspace__whenFolding__thenTheDemoProjectLookupIsScopedToTheWorkspacesThatHadTraces() {
             when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.just(
                     WorkspaceProjectCount.builder()
                             .workspaceId(WORKSPACE_ID)
@@ -554,19 +552,19 @@ class TraceServiceImplTest {
                             .projectId(DEMO_PROJECT_ID)
                             .count(randomCount())
                             .build()));
-            when(projectService.getDemoProjectIds(Set.of(REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+            when(projectService.getDemoProjectIdsInWorkspaces(Set.of(WORKSPACE_ID)))
                     .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
 
             traceService.countTracesPerWorkspace().block();
 
-            verify(projectService).getDemoProjectIds(Set.of(REGULAR_PROJECT_ID, DEMO_PROJECT_ID));
+            verify(projectService).getDemoProjectIdsInWorkspaces(Set.of(WORKSPACE_ID));
             verify(projectService, never()).getDemoProjectIdsWithTimestamps();
         }
 
         @Test
         void countTracesPerWorkspace__whenNoTraces__thenReturnsEmptyResponse() {
             when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.empty());
-            when(projectService.getDemoProjectIds(Set.of())).thenReturn(Mono.just(Set.of()));
+            when(projectService.getDemoProjectIdsInWorkspaces(Set.of())).thenReturn(Mono.just(Set.of()));
 
             var expectedResponse = TraceCountResponse.builder().workspacesTracesCount(List.of()).build();
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/TraceServiceImplTest.java
@@ -1,12 +1,16 @@
 package com.comet.opik.domain;
 
+import com.comet.opik.api.BiInformationResponse;
 import com.comet.opik.api.Trace;
+import com.comet.opik.api.TraceCountResponse;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse.WorkspaceProjectUserCount;
 import com.comet.opik.api.error.InvalidUUIDException;
 import com.comet.opik.api.events.TracesDeleted;
 import com.comet.opik.api.sorting.TraceSortingFactory;
 import com.comet.opik.domain.attachment.AttachmentReinjectorService;
 import com.comet.opik.domain.attachment.AttachmentService;
 import com.comet.opik.domain.attachment.AttachmentStripperService;
+import com.comet.opik.domain.utils.DemoDataExclusionUtils.WorkspaceProjectCount;
 import com.comet.opik.infrastructure.DatabaseAnalyticsDataModelConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
 import com.comet.opik.infrastructure.auth.RequestContext;
@@ -16,6 +20,8 @@ import com.comet.opik.utils.ErrorUtils;
 import com.google.common.eventbus.EventBus;
 import io.r2dbc.spi.Connection;
 import jakarta.ws.rs.NotFoundException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
@@ -48,6 +55,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -56,6 +64,7 @@ import static org.mockito.Mockito.when;
 class TraceServiceImplTest {
 
     public static final LockService DUMMY_LOCK_SERVICE = new DummyLockService();
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
 
     private TraceServiceImpl traceService;
 
@@ -89,7 +98,6 @@ class TraceServiceImplTest {
 
     private final PodamFactory factory = new PodamFactoryImpl();
     private final TraceSortingFactory traceSortingFactory = new TraceSortingFactory();
-    private final IdGenerator idGenerator = TestIdGeneratorFactory.create();
 
     @BeforeEach
     void setUp() {
@@ -108,7 +116,7 @@ class TraceServiceImplTest {
                 deletionEventDAO,
                 template,
                 projectService,
-                idGenerator,
+                ID_GENERATOR,
                 DUMMY_LOCK_SERVICE,
                 eventBus,
                 traceSortingFactory,
@@ -226,8 +234,8 @@ class TraceServiceImplTest {
         @Test
         @DisplayName("when capture is disabled, then delete records no deletion events")
         void delete__whenCaptureDisabled__thenRecordsNoDeletionEvents() {
-            var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
-            var projectId = idGenerator.generateId();
+            var ids = Set.of(ID_GENERATOR.generateId(), ID_GENERATOR.generateId());
+            var projectId = ID_GENERATOR.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
             when(traceDao.delete(pairs(projectId, ids), connection)).thenReturn(Mono.empty());
@@ -247,8 +255,8 @@ class TraceServiceImplTest {
         @Test
         @DisplayName("when capture is enabled and recording fails, then the delete still succeeds")
         void delete__whenCaptureEnabledAndRecordingFails__thenDeleteSucceeds() {
-            var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
-            var projectId = idGenerator.generateId();
+            var ids = Set.of(ID_GENERATOR.generateId(), ID_GENERATOR.generateId());
+            var projectId = ID_GENERATOR.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
             when(traceDao.delete(pairs(projectId, ids), connection)).thenReturn(Mono.empty());
@@ -273,8 +281,8 @@ class TraceServiceImplTest {
         @Test
         @DisplayName("when the delete fails, then the deletion events are still recorded and the error propagates")
         void delete__whenDeleteFails__thenStillRecordsDeletionEventsAndPropagates() {
-            var ids = Set.of(idGenerator.generateId(), idGenerator.generateId());
-            var projectId = idGenerator.generateId();
+            var ids = Set.of(ID_GENERATOR.generateId(), ID_GENERATOR.generateId());
+            var projectId = ID_GENERATOR.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
             when(traceDao.delete(pairs(projectId, ids), connection))
@@ -310,12 +318,12 @@ class TraceServiceImplTest {
             // can't reach this branch (a wrapped-id_at row can't be created through the API), so it's covered here:
             // the bounded pass resolves one id, the miss set (a second id, reused across two projects) is resolved by
             // the unbounded pass, and the delete runs over the merged (project_id, id) pairs.
-            var resolvedId = idGenerator.generateId();
-            var missedId = idGenerator.generateId();
+            var resolvedId = ID_GENERATOR.generateId();
+            var missedId = ID_GENERATOR.generateId();
             var ids = Set.of(resolvedId, missedId);
-            var projectA = idGenerator.generateId();
-            var projectB = idGenerator.generateId();
-            var projectC = idGenerator.generateId();
+            var projectA = ID_GENERATOR.generateId();
+            var projectB = ID_GENERATOR.generateId();
+            var projectC = ID_GENERATOR.generateId();
             var workspaceId = UUID.randomUUID().toString();
             var connection = mockDeleteFlow();
 
@@ -386,6 +394,190 @@ class TraceServiceImplTest {
             assertThat(event.projectId()).isEqualTo(projectId);
             assertThat(event.workspaceId()).isEqualTo(workspaceId);
             assertThat(event.userName()).isEqualTo(DEFAULT_USER);
+        }
+    }
+
+    /**
+     * The demo-project exclusion is applied in this service rather than in the usage SQL, so what it does with the
+     * DAO's per-project rows is behaviour worth pinning: drop demo projects, sum the rest back into the shape the
+     * endpoints return, and resolve the demo set through the bounded lookup rather than the unscoped one.
+     */
+    @Nested
+    class DailyUsage {
+
+        private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+        private static final String OTHER_WORKSPACE_ID = UUID.randomUUID().toString();
+        private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        private static final String OTHER_USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+        private static final UUID REGULAR_PROJECT_ID = ID_GENERATOR.generateId();
+        private static final UUID OTHER_REGULAR_PROJECT_ID = ID_GENERATOR.generateId();
+        private static final UUID DEMO_PROJECT_ID = ID_GENERATOR.generateId();
+
+        @Test
+        void countTracesPerWorkspace__whenWorkspaceHasDemoAndRegularProjects__thenSumsOnlyTheRegularOnes() {
+            var regularCount = randomCount();
+            var otherRegularCount = randomCount();
+
+            when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.just(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(REGULAR_PROJECT_ID)
+                            .count(regularCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(OTHER_REGULAR_PROJECT_ID)
+                            .count(otherRegularCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(DEMO_PROJECT_ID)
+                            .count(randomCount())
+                            .build()));
+            when(projectService.getDemoProjectIds(
+                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+                    .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
+
+            var expectedResponse = TraceCountResponse.builder()
+                    .workspacesTracesCount(List.of(TraceCountResponse.WorkspaceTraceCount.builder()
+                            .workspace(WORKSPACE_ID)
+                            .traceCount(Math.toIntExact(regularCount + otherRegularCount))
+                            .build()))
+                    .build();
+
+            var actualResponse = traceService.countTracesPerWorkspace().block();
+
+            assertThat(actualResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void getTraceBIInformation__whenUserHasDemoAndRegularProjects__thenSumsOnlyTheRegularOnesPerUser() {
+            var regularCount = randomCount();
+            var otherRegularCount = randomCount();
+            var otherUserCount = randomCount();
+
+            when(traceDao.getTraceBIInformationPerProject()).thenReturn(Flux.just(
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(REGULAR_PROJECT_ID)
+                            .user(USER)
+                            .count(regularCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(OTHER_REGULAR_PROJECT_ID)
+                            .user(USER)
+                            .count(otherRegularCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(REGULAR_PROJECT_ID)
+                            .user(OTHER_USER)
+                            .count(otherUserCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(DEMO_PROJECT_ID)
+                            .user(USER)
+                            .count(randomCount())
+                            .build()));
+            when(projectService.getDemoProjectIds(
+                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+                    .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
+
+            var expectedResponse = BiInformationResponse.builder()
+                    .biInformation(List.of(
+                            BiInformationResponse.BiInformation.builder()
+                                    .workspaceId(WORKSPACE_ID)
+                                    .user(USER)
+                                    .count(regularCount + otherRegularCount)
+                                    .build(),
+                            BiInformationResponse.BiInformation.builder()
+                                    .workspaceId(WORKSPACE_ID)
+                                    .user(OTHER_USER)
+                                    .count(otherUserCount)
+                                    .build()))
+                    .build();
+
+            var actualResponse = traceService.getTraceBIInformation().block();
+
+            assertThat(actualResponse).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        void getDailyCreatedCount__whenSeveralWorkspaces__thenTotalsThemWithDemoProjectsExcluded() {
+            var regularCount = randomCount();
+            var otherWorkspaceCount = randomCount();
+
+            when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.just(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(REGULAR_PROJECT_ID)
+                            .count(regularCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(DEMO_PROJECT_ID)
+                            .count(randomCount())
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .projectId(OTHER_REGULAR_PROJECT_ID)
+                            .count(otherWorkspaceCount)
+                            .build()));
+            when(projectService.getDemoProjectIds(
+                    Set.of(REGULAR_PROJECT_ID, OTHER_REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+                    .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
+
+            var expectedCount = regularCount + otherWorkspaceCount;
+
+            var actualCount = traceService.getDailyCreatedCount().block();
+
+            assertThat(actualCount).isEqualTo(expectedCount);
+        }
+
+        /**
+         * The bound, asserted where it is cheap to assert: the lookup only ever sees the projects that had traces.
+         * {@code DemoDataExclusionLiteralArchTest} forbids the unscoped fetch from gaining callers at build time;
+         * this pins that the trace path does not reach for it at runtime.
+         */
+        @Test
+        void countTracesPerWorkspace__whenFolding__thenTheDemoProjectLookupIsScopedToTheProjectsThatHadTraces() {
+            when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.just(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(REGULAR_PROJECT_ID)
+                            .count(randomCount())
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(DEMO_PROJECT_ID)
+                            .count(randomCount())
+                            .build()));
+            when(projectService.getDemoProjectIds(Set.of(REGULAR_PROJECT_ID, DEMO_PROJECT_ID)))
+                    .thenReturn(Mono.just(Set.of(DEMO_PROJECT_ID)));
+
+            traceService.countTracesPerWorkspace().block();
+
+            verify(projectService).getDemoProjectIds(Set.of(REGULAR_PROJECT_ID, DEMO_PROJECT_ID));
+            verify(projectService, never()).getDemoProjectIdsWithTimestamps();
+        }
+
+        @Test
+        void countTracesPerWorkspace__whenNoTraces__thenReturnsEmptyResponse() {
+            when(traceDao.countTracesPerWorkspaceProject()).thenReturn(Flux.empty());
+            when(projectService.getDemoProjectIds(Set.of())).thenReturn(Mono.just(Set.of()));
+
+            var expectedResponse = TraceCountResponse.builder().workspacesTracesCount(List.of()).build();
+
+            var actualResponse = traceService.countTracesPerWorkspace().block();
+
+            assertThat(actualResponse).isEqualTo(expectedResponse);
+            verify(projectService, never()).getDemoProjectIdsWithTimestamps();
+        }
+
+        private long randomCount() {
+            return RandomUtils.secure().randomLong(1, 1_000);
         }
     }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/utils/DemoDataExclusionUtilsTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/utils/DemoDataExclusionUtilsTest.java
@@ -1,0 +1,310 @@
+package com.comet.opik.domain.utils;
+
+import com.comet.opik.api.BiInformationResponse.BiInformation;
+import com.comet.opik.api.UsageByWorkspaceProjectUserResponse.WorkspaceProjectUserCount;
+import com.comet.opik.domain.IdGenerator;
+import com.comet.opik.domain.TestIdGeneratorFactory;
+import com.comet.opik.domain.utils.DemoDataExclusionUtils.WorkspaceProjectCount;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The exclusion moved out of the usage SQL and into these folds, so what the query text used to guarantee is now
+ * their job: demo projects contribute nothing, and everything else aggregates back to exactly the per-workspace and
+ * per-workspace-user totals the previous queries returned.
+ */
+class DemoDataExclusionUtilsTest {
+
+    private static final IdGenerator ID_GENERATOR = TestIdGeneratorFactory.create();
+
+    private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String OTHER_WORKSPACE_ID = UUID.randomUUID().toString();
+    private static final String USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+    private static final String OTHER_USER = "user-" + RandomStringUtils.secure().nextAlphanumeric(32);
+
+    @Nested
+    class FoldByWorkspace {
+
+        @Test
+        void foldByWorkspace__whenAWorkspaceSpansSeveralProjects__thenSumsThemIntoOneEntry() {
+            var firstCount = randomCount();
+            var secondCount = randomCount();
+            var otherWorkspaceCount = randomCount();
+            var rows = List.of(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(firstCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(secondCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(otherWorkspaceCount)
+                            .build());
+            var expectedCounts = Map.of(
+                    WORKSPACE_ID, firstCount + secondCount,
+                    OTHER_WORKSPACE_ID, otherWorkspaceCount);
+
+            var actualCounts = DemoDataExclusionUtils.foldByWorkspace(rows, Set.of());
+
+            assertThat(actualCounts).isEqualTo(expectedCounts);
+        }
+
+        @Test
+        void foldByWorkspace__whenAWorkspaceHasDemoProjects__thenOnlyTheirCountsAreDropped() {
+            var regularCount = randomCount();
+            var demoProjectId = ID_GENERATOR.generateId();
+            var rows = List.of(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(regularCount)
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(demoProjectId)
+                            .count(randomCount())
+                            .build());
+            var expectedCounts = Map.of(WORKSPACE_ID, regularCount);
+
+            var actualCounts = DemoDataExclusionUtils.foldByWorkspace(rows, Set.of(demoProjectId));
+
+            assertThat(actualCounts).isEqualTo(expectedCounts);
+        }
+
+        @Test
+        void foldByWorkspace__whenAWorkspaceOnlyHasDemoProjects__thenItIsOmitted() {
+            var demoProjectId = ID_GENERATOR.generateId();
+            var rows = List.of(WorkspaceProjectCount.builder()
+                    .workspaceId(WORKSPACE_ID)
+                    .projectId(demoProjectId)
+                    .count(randomCount())
+                    .build());
+
+            var actualCounts = DemoDataExclusionUtils.foldByWorkspace(rows, Set.of(demoProjectId));
+
+            assertThat(actualCounts).isEmpty();
+        }
+
+        @Test
+        void foldByWorkspace__whenFolding__thenWorkspacesKeepTheOrderTheirRowsArrivedIn() {
+            var rows = List.of(
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(randomCount())
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(randomCount())
+                            .build(),
+                    WorkspaceProjectCount.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .count(randomCount())
+                            .build());
+
+            var actualWorkspaces = DemoDataExclusionUtils.foldByWorkspace(rows, Set.of()).keySet();
+
+            assertThat(actualWorkspaces).containsExactly(OTHER_WORKSPACE_ID, WORKSPACE_ID);
+        }
+
+        /**
+         * The lookup producing the demo set is scoped to the projects present in the rows, so ids for projects with
+         * no activity are expected to be absent rather than exceptional.
+         */
+        @Test
+        void foldByWorkspace__whenADemoProjectHadNoActivity__thenItsIdIsIgnored() {
+            var regularCount = randomCount();
+            var rows = List.of(WorkspaceProjectCount.builder()
+                    .workspaceId(WORKSPACE_ID)
+                    .projectId(ID_GENERATOR.generateId())
+                    .count(regularCount)
+                    .build());
+            var demoProjectIds = Set.of(ID_GENERATOR.generateId());
+            var expectedCounts = Map.of(WORKSPACE_ID, regularCount);
+
+            var actualCounts = DemoDataExclusionUtils.foldByWorkspace(rows, demoProjectIds);
+
+            assertThat(actualCounts).isEqualTo(expectedCounts);
+        }
+
+        @Test
+        void foldByWorkspace__whenNoRows__thenReturnsEmpty() {
+            var demoProjectIds = Set.of(ID_GENERATOR.generateId());
+
+            var actualCounts = DemoDataExclusionUtils.foldByWorkspace(List.of(), demoProjectIds);
+
+            assertThat(actualCounts).isEmpty();
+        }
+    }
+
+    @Nested
+    class FoldByWorkspaceAndUser {
+
+        @Test
+        void foldByWorkspaceAndUser__whenAUserSpansSeveralProjects__thenSumsThemKeepingUsersApart() {
+            var firstCount = randomCount();
+            var secondCount = randomCount();
+            var otherUserCount = randomCount();
+            var projectId = ID_GENERATOR.generateId();
+            var rows = List.of(
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(projectId)
+                            .user(USER)
+                            .count(firstCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .user(USER)
+                            .count(secondCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(projectId)
+                            .user(OTHER_USER)
+                            .count(otherUserCount)
+                            .build());
+            var expectedBiInformation = List.of(
+                    BiInformation.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .user(USER)
+                            .count(firstCount + secondCount)
+                            .build(),
+                    BiInformation.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .user(OTHER_USER)
+                            .count(otherUserCount)
+                            .build());
+
+            var actualBiInformation = DemoDataExclusionUtils.foldByWorkspaceAndUser(rows, Set.of());
+
+            assertThat(actualBiInformation).isEqualTo(expectedBiInformation);
+        }
+
+        @Test
+        void foldByWorkspaceAndUser__whenTheSameUserIsInSeveralWorkspaces__thenTheyStayApart() {
+            var count = randomCount();
+            var otherWorkspaceCount = randomCount();
+            var rows = List.of(
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .user(USER)
+                            .count(count)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .user(USER)
+                            .count(otherWorkspaceCount)
+                            .build());
+            var expectedBiInformation = List.of(
+                    BiInformation.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .user(USER)
+                            .count(count)
+                            .build(),
+                    BiInformation.builder()
+                            .workspaceId(OTHER_WORKSPACE_ID)
+                            .user(USER)
+                            .count(otherWorkspaceCount)
+                            .build());
+
+            var actualBiInformation = DemoDataExclusionUtils.foldByWorkspaceAndUser(rows, Set.of());
+
+            assertThat(actualBiInformation).isEqualTo(expectedBiInformation);
+        }
+
+        @Test
+        void foldByWorkspaceAndUser__whenAUserHasDemoProjects__thenOnlyTheirCountsAreDropped() {
+            var regularCount = randomCount();
+            var demoProjectId = ID_GENERATOR.generateId();
+            var rows = List.of(
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(ID_GENERATOR.generateId())
+                            .user(USER)
+                            .count(regularCount)
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(demoProjectId)
+                            .user(USER)
+                            .count(randomCount())
+                            .build(),
+                    WorkspaceProjectUserCount.builder()
+                            .workspaceId(WORKSPACE_ID)
+                            .projectId(demoProjectId)
+                            .user(OTHER_USER)
+                            .count(randomCount())
+                            .build());
+            var expectedBiInformation = List.of(BiInformation.builder()
+                    .workspaceId(WORKSPACE_ID)
+                    .user(USER)
+                    .count(regularCount)
+                    .build());
+
+            var actualBiInformation = DemoDataExclusionUtils.foldByWorkspaceAndUser(rows, Set.of(demoProjectId));
+
+            assertThat(actualBiInformation).isEqualTo(expectedBiInformation);
+        }
+
+        @Test
+        void foldByWorkspaceAndUser__whenNoRows__thenReturnsEmpty() {
+            var demoProjectIds = Set.of(ID_GENERATOR.generateId());
+
+            var actualBiInformation = DemoDataExclusionUtils.foldByWorkspaceAndUser(List.of(), demoProjectIds);
+
+            assertThat(actualBiInformation).isEmpty();
+        }
+    }
+
+    /** Still used by the span usage queries, which carry the exclusion in SQL. */
+    @Nested
+    class CalculateDemoDataCreatedAt {
+
+        @Test
+        void calculateDemoDataCreatedAt__whenDemoProjectsExist__thenReturnsTheLatestCreationPlusAMinute() {
+            var latest = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+            var excludedProjectIds = Map.of(
+                    ID_GENERATOR.generateId(), latest.minus(2, ChronoUnit.DAYS),
+                    ID_GENERATOR.generateId(), latest);
+            var expectedCutoff = latest.plus(1, ChronoUnit.MINUTES);
+
+            var actualCutoff = DemoDataExclusionUtils.calculateDemoDataCreatedAt(excludedProjectIds);
+
+            assertThat(actualCutoff).contains(expectedCutoff);
+        }
+
+        @Test
+        void calculateDemoDataCreatedAt__whenNoDemoProjects__thenReturnsEmpty() {
+            var actualCutoff = DemoDataExclusionUtils.calculateDemoDataCreatedAt(Map.of());
+
+            assertThat(actualCutoff).isEmpty();
+        }
+    }
+
+    private long randomCount() {
+        return RandomUtils.secure().randomLong(1, 1_000);
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/bi/DailyUsageReportJobTest.java
@@ -28,6 +28,7 @@ import io.dropwizard.jobs.GuiceJobManager;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -109,6 +110,18 @@ class DailyUsageReportJobTest {
                                 .and(matchingJsonPath("$.event_properties.daily_experiments",
                                         equalTo(dailyExperiments)))
                                 .and(matchingJsonPath("$.event_properties.daily_datasets", equalTo(dailyDatasets)))));
+    }
+
+    /**
+     * Verifies the trace count alone, for the tests whose subject is trace counting. Their dataset and experiment
+     * counts depend on what earlier tests in the class left backdated, which is incidental to what they assert.
+     */
+    private void verifyDailyTraces(WireMockServer server, String dailyTraces) {
+        server.verify(
+                postRequestedFor(urlPathEqualTo("/v1/notify/event"))
+                        .withRequestBody(matchingJsonPath("$.event_type",
+                                equalTo(DailyUsageReportJob.STATISTICS_BE))
+                                .and(matchingJsonPath("$.event_properties.daily_traces", equalTo(dailyTraces)))));
     }
 
     private void updateDatasets(String workspaceId, TransactionTemplate transactionTemplate, boolean updateUser) {
@@ -432,6 +445,34 @@ class DailyUsageReportJobTest {
             NETWORK.close();
         }
 
+        /**
+         * Each test has to run the report itself, on its own data, and verify its own event. All three were
+         * shared before:
+         *
+         * <ul>
+         * <li>the job only reports once a day — {@code shouldSendDailyReport} compares
+         * {@code metadata.daily_usage_report} against {@code CURDATE()} — so after the first test every later job
+         * run returned early and sent nothing;</li>
+         * <li>traces accumulate, because {@code updateTraces} copies the workspace's traces into the previous-day
+         * window rather than moving them, and the daily count spans every workspace;</li>
+         * <li>WireMock's journal is cumulative, so {@code verify} was satisfied by the first test's event.</li>
+         * </ul>
+         *
+         * <p>Together those let a test assert a count it never produced:
+         * {@link #dailyUsageReportMixedDataExcludesOnlyDemo()} created seven regular traces, asserted five, and
+         * passed without its job ever emitting anything. It failed as soon as it was run on its own.
+         */
+        @BeforeEach
+        void resetReportState() {
+            templateAsync.nonTransaction(
+                    connection -> Mono.from(connection.createStatement("TRUNCATE TABLE traces").execute()))
+                    .block();
+            transactionTemplate.inTransaction(TransactionTemplateAsync.WRITE,
+                    handle -> handle.createUpdate("DELETE FROM metadata WHERE `key` = 'daily_usage_report'")
+                            .execute());
+            wireMock.server().resetRequests();
+        }
+
         @Test
         void test() throws SchedulerException {
 
@@ -452,7 +493,8 @@ class DailyUsageReportJobTest {
                     .await()
                     .atMost(5, TimeUnit.SECONDS)
                     .untilAsserted(() -> {
-                        verifyResponse(wireMock.server(), "1", "1", "5", "0", "0");
+                        // setUpData backdates datasets and experiments as well as traces, so all three are counted
+                        verifyResponse(wireMock.server(), "1", "1");
                     });
 
         }
@@ -587,6 +629,8 @@ class DailyUsageReportJobTest {
             // Create demo data (which should be excluded)
             createDemoData(apiKey, workspaceName);
 
+            var expectedDailyTraces = String.valueOf(regularTraces.size());
+
             // Update created_at to yesterday to be captured in daily report
             updateTraces(ProjectService.DEFAULT_WORKSPACE_ID, templateAsync, false);
 
@@ -597,11 +641,8 @@ class DailyUsageReportJobTest {
 
             // Wait for job completion and verify
             Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
-                // Verify that demo data tracking was properly excluded from BI events
-                // The verification here would depend on how the job reports data
-                // Since this test focuses on exclusion, we verify no demo data is included
-                // in the usage statistics by checking that only regular traces are counted
-                verifyResponse(wireMock.server(), "1", "1", "5", "0", "0"); // Only regular traces counted
+                // Only the regular traces are counted; everything in a demo project is excluded
+                verifyDailyTraces(wireMock.server(), expectedDailyTraces);
             });
         }
 
@@ -638,6 +679,8 @@ class DailyUsageReportJobTest {
             // Create demo data (should be excluded from counts)
             createDemoData(apiKey, workspaceName);
 
+            var expectedDailyTraces = String.valueOf(regularTraces1.size() + regularTraces2.size());
+
             // Update created_at to yesterday to be captured in daily report
             updateTraces(ProjectService.DEFAULT_WORKSPACE_ID, templateAsync, false);
 
@@ -648,11 +691,9 @@ class DailyUsageReportJobTest {
 
             // Wait for job completion and verify
             Awaitility.await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
-                // Verify that demo data exclusion works properly with mixed data
-                // The job should process both regular and demo data, but only regular data
-                // should be included in the final usage statistics sent to the BI events
-                // Expected: Regular traces only, demo traces excluded
-                verifyResponse(wireMock.server(), "1", "1", "5", "0", "0"); // Only regular traces counted
+                // Both regular projects are summed and the demo projects dropped, so the count is the
+                // traces created here rather than either project's share of them
+                verifyDailyTraces(wireMock.server(), expectedDailyTraces);
             });
         }
 


### PR DESCRIPTION
## Details

The daily trace BI and usage-billing queries excluded demo data with an inline `project_id NOT IN [...]` literal holding one UUID per demo project across all workspaces. One demo project is created per signup, so that literal grows without bound, and once `traces` is wrapped in a `Distributed` table the query text is re-parsed per shard — the queries stopped completing inside `max_execution_time` and the daily counts silently stopped being produced, because the callers consuming them cannot tell an empty result from a failed one. `GLOBAL NOT IN` is not a fix either: the literal is still in the text.

Both queries now `GROUP BY project_id` and `TraceService` drops demo projects and re-aggregates in Java, where the demo project set already lives. The query text becomes constant, so growth in the demo set can never reintroduce the failure, and the `/v1/internal/usage/*` response shapes are unchanged, so no coordinated change is needed outside this repo. Counts are preserved: `COUNT(DISTINCT id)` at project granularity sums back to the workspace and workspace/user totals, because an id has exactly one project — the write path rejects an upsert presenting an existing id with a different project rather than moving it.

Also here:

- `ProjectDAO.findByGlobalNames` gains an optional workspace scope, and `ProjectService.getDemoProjectIdsInWorkspaces` uses it scoped to the workspaces that actually had traces in the window. Scoping by workspace is what lets `projects_workspace_id_name_uk (workspace_id, name)` serve the query; the remaining chunking is a bound on the driver's bind-parameter limit, and a day's active workspaces sit inside one chunk. The unscoped fetch remains only for the span usage paths.
- The two DAO methods that ran the same previous-day count under different log comments are now one, so `get_daily_traces_count` no longer appears in `system.query_log`.
- The `OR created_at > :demo_data_created_at` branch is dropped from the trace queries. The cutoff is `max(createdAt) + 1 minute`, so where demo projects are created continuously it is effectively now and the branch cannot match a row in the previous-day window. **On a single install it could, so demo-project activity after install is no longer counted there — including in the self-hosted daily usage report.** Spans keep the old behaviour until they migrate.
- A build-time guard, in two rules, because reintroducing the failure needs both a template that accepts the project set and a caller that fetches it: no DAO SQL constant may reference the exclusion placeholders, and the unscoped fetch may only be called by the span usage paths. `SpanDAO`'s three constants are listed as known pending violations and asserted by exact equality, so the spans migration cannot leave a stale exemption behind.

Spans are deliberately untouched: they are not wrapped in a `Distributed` table yet, so they are unaffected today, and the fold preserves counts exactly, so the two cannot disagree while they are out of step.

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-8328

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Opus 5
- Scope: full implementation
- Human verification: code review over several rounds, covering correctness, conventions and test coverage

## Testing

Targeted suites run locally; the full build runs in CI.

- `mvn surefire:test -Dtest='UsageResourceTest'` — 16 integration tests through the endpoints
- `mvn surefire:test -Dtest='ProjectsResourceTest$GetDemoProjectIds'`
- `mvn surefire:test -Dtest='DailyUsageReportJobTest'`
- `mvn surefire:test -Dtest='DemoDataExclusionUtilsTest,DemoDataExclusionLiteralArchTest,ProjectServiceImplTest,TraceServiceImplTest'`
- `mvn spotless:check`

Scenarios covered, black-box through the endpoints where possible: demo projects excluded whether the workspace touched one or all of them; excluded regardless of how old the demo project is; a workspace's projects summed into one row; BI rows summed per user and kept apart between users; spans unchanged, including the cutoff branch they still carry; and a trace counted once, because presenting its id under another project is refused — the invariant the per-project fold rests on. Unit tests cover only what integration cannot reach — chunk boundaries, a day with no traces, cross-workspace folding, and a workspace whose activity is entirely demo.

Three assertions were verified by mutation rather than assumed, each failing only for the regression it claims to cover:

- removing the scope from the query — caught only by the new `ProjectsResourceTest.GetDemoProjectIdsInWorkspaces`; every other test passed, since a lookup ignoring the scope returns a superset the folds still reduce correctly
- reintroducing the exclusion literal — caught by the guard
- making the fold stop summing across projects — caught by `DailyUsageReportJobTest.dailyUsageReportMixedDataExcludesOnlyDemo`, which could not catch it before this change

`DailyUsageReportJobTest` is made to verify its own run. Its tests shared the once-a-day report marker, the accumulated traces and WireMock's request journal, so only the first to run actually reported and the others verified its event — which let one assert a count it never produced, and masked two further expectations that did not match what the job emits.

Not run locally: the full backend suite, left to CI.

## Documentation

N/A — no user-facing documentation changes. The rationale, the constraint on the query text and the pending spans work are documented in the code: `DemoDataExclusionUtils`, the query constants in `TraceDAO`, and `DemoDataExclusionLiteralArchTest`.


