### PR TITLE
[OPIK-TBD] [BE] fix: keep concurrent refresh_token requests from dropping MCP connectors

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -391,9 +391,9 @@ mcpOAuth:
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: ${MCP_OAUTH_CODE_TTL:-PT60S}
-  # Default: PT30S
-  # Description: Grace window during which a just-rotated refresh token is still accepted
-  refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT30S}
+  # Default: PT2M
+  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
+  refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT2M}
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: ${MCP_OAUTH_SCRUB_LOCK_TIMEOUT:-PT5M}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -112,28 +112,53 @@ public class McpOAuthService {
             if (!isBenignRotationRetry(row, now)) { // Reuse detected: kill the whole lineage
                 template.inTransaction(WRITE, handle -> handle.attach(McpOAuthTokenDAO.class)
                         .revokeFamily(row.familyId(), RevokedReason.REUSE));
+                throw new BadRequestException(ERROR_INVALID_GRANT);
             }
-            throw new BadRequestException(ERROR_INVALID_GRANT);
+            // The host is re-presenting a token that was rotated moments ago: hand it its own pair (see
+            // mintRotatedPair) instead of an invalid_grant that would make it discard its credentials.
+            return mintRotatedPair(row, now, false);
         }
 
+        return mintRotatedPair(row, now, true);
+    }
+
+    /**
+     * Issues a new access + refresh pair descending from {@code source}, in the same family and with the same
+     * absolute refresh expiry.
+     * <p>
+     * MCP hosts run several tool calls in parallel, and when the access token expires each of them answers the
+     * 401 by refreshing with the same stored refresh token. Only one request can revoke the source token
+     * ({@code revokeSource}); the others land either after that rotation committed or inside the same race. Both
+     * are the legitimate client retrying, not a replay by a thief, as long as the rotation happened within
+     * {@code refreshRotationGrace}. Such a retry gets its own fresh pair off the same family rather than
+     * {@code invalid_grant}: a host that sees {@code invalid_grant} on refresh discards its tokens and forces the
+     * user to re-authorize (RFC 6819 §5.2.2.3 flags exactly this clustered-client hazard of rotation). After the
+     * grace window the re-presentation is treated as reuse and the family is revoked, per OAuth 2.1 §4.3.1.
+     */
+    private TokenResponse mintRotatedPair(McpOAuthToken source, Instant now, boolean revokeSource) {
         String accessToken = McpOAuthTokenUtils.generateAccessToken();
         String newRefreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
 
-            if (tokenDao.revoke(row.tokenHash(), RevokedReason.ROTATED) != 1) {
-                throw new BadRequestException(ERROR_INVALID_GRANT);
+            if (revokeSource && tokenDao.revoke(source.tokenHash(), RevokedReason.ROTATED) != 1) {
+                // Lost the revoke race to a concurrent refresh with the same token. Same rule as above: a
+                // rotation that just happened means this is the host's own retry and it still gets a pair.
+                McpOAuthToken current = tokenDao.findByHash(source.tokenHash());
+                if (current == null || !isBenignRotationRetry(current, Instant.now())) {
+                    throw new BadRequestException(ERROR_INVALID_GRANT);
+                }
             }
 
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(row, TYPE_ACCESS,
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
                     now.plus(config().getAccessTokenTtl())));
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(row, TYPE_REFRESH,
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(newRefreshToken),
-                    row.expiresAt()));
+                    source.expiresAt()));
 
-            return buildTokenResponse(accessToken, newRefreshToken, row.workspaceId(), row.workspaceName());
+            return buildTokenResponse(accessToken, newRefreshToken, source.workspaceId(), source.workspaceName());
         });
     }
 

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
@@ -50,7 +50,7 @@ public class OAuthResourceClient {
     private final String redirectUri;
     private final String resourceUri;
 
-    public record Minted(String code, TokenResponse tokens) {
+    public record Minted(String clientId, String code, TokenResponse tokens) {
     }
 
     /** Registers a client, walks consent + PKCE, and exchanges the code for the raw code and the token pair. */
@@ -58,7 +58,7 @@ public class OAuthResourceClient {
         String clientId = registerClient();
         String codeVerifier = RandomStringUtils.secure().nextAlphanumeric(64);
         String code = authorize(clientId, codeVerifier);
-        return new Minted(code, exchangeCode(clientId, code, codeVerifier));
+        return new Minted(clientId, code, exchangeCode(clientId, code, codeVerifier));
     }
 
     private String registerClient() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
@@ -1,0 +1,137 @@
+package com.comet.opik.domain.mcpoauth;
+
+import com.comet.opik.api.resources.oauth.OAuthError;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.ERROR_INVALID_GRANT;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The security half of rotation (OAuth 2.1 §4.3.1): once the rotation grace has passed, a rotated refresh token
+ * presented again is a replay, and the whole family, the freshly rotated token included, is revoked. Runs its own
+ * app with a one-second grace so the window can actually be crossed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+@DisplayName("OAuth Refresh Reuse Detection Integration Test")
+class OAuthRefreshReuseDetectionIntegrationTest {
+
+    private static final String REDIRECT_URI = "http://localhost:1234/callback";
+    private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
+    private static final Duration GRACE = Duration.ofSeconds(1);
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE, MYSQL, ZOOKEEPER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("mcpOAuth.enabled", "true"),
+                                new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
+                                new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
+                                new CustomConfig("mcpOAuth.refreshRotationGrace", GRACE.toString())))
+                        .build());
+    }
+
+    private String baseURI;
+    private ClientSupport client;
+    private OAuthResourceClient oauthClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        this.oauthClient = new OAuthResourceClient(clientSupport, baseURI, REDIRECT_URI, RESOURCE_URI);
+    }
+
+    @Test
+    @DisplayName("a rotated refresh token presented after the grace window revokes the whole family")
+    void rotatedTokenPresentedAfterGrace_revokesFamily() throws InterruptedException {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String originalRefreshToken = minted.tokens().refreshToken();
+
+        RefreshOutcome rotated = refresh(clientId, originalRefreshToken);
+        assertThat(rotated.status()).isEqualTo(Response.Status.OK.getStatusCode());
+        String currentRefreshToken = rotated.tokens().refreshToken();
+
+        // Past the grace window the original token is a replay...
+        Thread.sleep(GRACE.plusMillis(500).toMillis());
+        RefreshOutcome replay = refresh(clientId, originalRefreshToken);
+        assertThat(replay.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(replay.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+
+        // ...and the token the legitimate rotation produced goes down with it.
+        RefreshOutcome afterReuse = refresh(clientId, currentRefreshToken);
+        assertThat(afterReuse.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(afterReuse.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+    }
+
+    private RefreshOutcome refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            int status = response.getStatus();
+            if (status == Response.Status.OK.getStatusCode()) {
+                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
+            }
+            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
+        }
+    }
+
+    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.comet.opik.domain.mcpoauth;
+
+import com.comet.opik.api.resources.oauth.OAuthError;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Refresh-token rotation as an MCP host actually exercises it. Hosts (Claude.ai, Codex, Claude Code) fire several
+ * tool calls in parallel; when the access token expires every one of them gets a 401 and every one of them runs the
+ * {@code refresh_token} grant with the same stored refresh token. Only one of those requests can win the rotation.
+ * The losers must still walk away with a usable token pair: a host that receives {@code invalid_grant} on refresh
+ * discards its credentials and forces the user to re-authorize.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+@DisplayName("OAuth Refresh Rotation Integration Test")
+class OAuthRefreshRotationIntegrationTest {
+
+    private static final String REDIRECT_URI = "http://localhost:1234/callback";
+    private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
+    private static final int PARALLEL_REFRESHES = 5;
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE, MYSQL, ZOOKEEPER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        // Local auth, so consent resolves to the default workspace without a session. The grace window is long
+        // enough that every request of a parallel burst lands inside it.
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("mcpOAuth.enabled", "true"),
+                                new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
+                                new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
+                                new CustomConfig("mcpOAuth.refreshRotationGrace", "PT2M")))
+                        .build());
+    }
+
+    private String baseURI;
+    private ClientSupport client;
+    private OAuthResourceClient oauthClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        this.oauthClient = new OAuthResourceClient(clientSupport, baseURI, REDIRECT_URI, RESOURCE_URI);
+    }
+
+    @Test
+    @DisplayName("parallel refreshes with the same refresh token all receive a usable token pair")
+    void parallelRefreshesWithSameToken_allReceiveUsableTokens() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String refreshToken = minted.tokens().refreshToken();
+
+        List<RefreshOutcome> outcomes = IntStream.range(0, PARALLEL_REFRESHES)
+                .mapToObj(i -> CompletableFuture.supplyAsync(() -> refresh(clientId, refreshToken)))
+                .toList()
+                .stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        assertThat(outcomes)
+                .as("every parallel refresh with the same refresh token is answered with a token pair")
+                .allSatisfy(outcome -> {
+                    assertThat(outcome.status()).isEqualTo(Response.Status.OK.getStatusCode());
+                    assertThat(outcome.tokens().accessToken()).isNotBlank();
+                    assertThat(outcome.tokens().refreshToken()).isNotBlank();
+                });
+        assertThat(outcomes).extracting(outcome -> outcome.tokens().refreshToken())
+                .as("each answer of the burst carries its own refresh token")
+                .doesNotHaveDuplicates();
+
+        // Whichever copy of the credentials the host keeps must keep working: every refresh token handed out by
+        // the burst rotates on its own.
+        for (RefreshOutcome outcome : outcomes) {
+            RefreshOutcome next = refresh(clientId, outcome.tokens().refreshToken());
+            assertThat(next.status())
+                    .as("a refresh token handed out during the burst rotates normally afterwards")
+                    .isEqualTo(Response.Status.OK.getStatusCode());
+        }
+    }
+
+    private RefreshOutcome refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            int status = response.getStatus();
+            if (status == Response.Status.OK.getStatusCode()) {
+                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
+            }
+            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
+        }
+    }
+
+    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -298,9 +298,9 @@ mcpOAuth:
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: PT60S
-  # Default: PT30S
-  # Description: Grace window during which a just-rotated refresh token is still accepted
-  refreshRotationGrace: PT30S
+  # Default: PT2M
+  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair; after it, re-presentation is treated as reuse and revokes the whole token family
+  refreshRotationGrace: PT2M
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: PT5M


### PR DESCRIPTION
## Details
MCP hosts (Claude.ai, Codex, Claude Code) fire several tool calls in parallel; when the access token expires each of them answers the `401 invalid_token` from opik-mcp (OPIK_8252) by running the `refresh_token` grant with the same stored refresh token. Only one request won the rotation and the rest got `invalid_grant`, which hosts treat as "discard credentials, re-authorize" — this is the "hosted connector dies after ~1h, reconnect fixes it" report from BlaBlaCar. Retries landing after the 30s grace also tripped reuse detection and revoked the whole family, including the token the winner had just received.

- Within `refreshRotationGrace` a re-presented rotated refresh token now mints its own access+refresh pair off the same family (including the request that loses the revoke race inside the transaction).
- After the grace window nothing changes: `invalid_grant` + family revocation per OAuth 2.1 §4.3.1.
- Default `mcpOAuth.refreshRotationGrace` raised `PT30S` → `PT2M` (prod bursts observed at 33–76s).

## Change checklist
- [ ] User facing
- [ ] Documentation update

## Issues

- OPIK-TBD (ticket number to be filled in; Jira MCP was unreachable when this PR was opened)

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5.1
- Scope: root-cause analysis from prod logs, prod reproduction script, fix, tests, PR text
- Human verification: reproduction confirmed against prod by hand (5 parallel refreshes → 1×200 + 4×invalid_grant; replay after grace killed the fresh token); tests reviewed and run locally

## Testing
Red → green (JDK 25, testcontainers MySQL/ClickHouse/Redis):

```
cd apps/opik-backend
mvn test -Dtest=OAuthRefreshRotationIntegrationTest        # fails on main: 1×200, 4×400 invalid_grant
mvn test -Dtest=OAuthRefreshRotationIntegrationTest        # passes with fix
mvn test -Dtest=OAuthRefreshReuseDetectionIntegrationTest  # passes: replay past grace revokes family
mvn test -Dtest='OAuthValidateTokenIntegrationTest,OAuthTokenServiceTest,McpOAuthScrubServiceTest,McpOAuthScrubJobTest,OAuthTokenResourceTest'
mvn spotless:apply
```

- `OAuthRefreshRotationIntegrationTest` — register → consent → exchange over HTTP, then 5 parallel `refresh_token` requests with the same token: every response is a usable pair, each refresh token rotates afterwards.
- `OAuthRefreshReuseDetectionIntegrationTest` — own app with `refreshRotationGrace=PT1S`: replay after the window → `invalid_grant`, and the legitimately rotated token is revoked too.
- Existing MCP OAuth suites green (35 tests). `McpClientConnectionIntegrationTest` was not re-run locally (ClickHouse replicated-table migration clashes when several testcontainer suites share one JVM run); CI covers it.

## Documentation
`config.yml` description of `refreshRotationGrace` updated. No user-facing docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
