### PR TITLE
[OPIK-8351] [BE] fix: keep concurrent refresh_token requests from dropping MCP connectors

### DIFF
--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -386,10 +386,10 @@ mcpOAuth:
   # Description: Access token lifetime
   accessTokenTtl: ${MCP_OAUTH_ACCESS_TOKEN_TTL:-PT1H}
   # Default: P7D
-  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
+  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize. At most 365 days
   refreshTokenTtl: ${MCP_OAUTH_REFRESH_TOKEN_TTL:-P7D}
   # Default: P30D
-  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl; at most 365 days
   refreshTokenAbsoluteTtl: ${MCP_OAUTH_REFRESH_TOKEN_ABSOLUTE_TTL:-P30D}
   # Default: PT60S
   # Description: Authorization code lifetime

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -389,7 +389,7 @@ mcpOAuth:
   # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
   refreshTokenTtl: ${MCP_OAUTH_REFRESH_TOKEN_TTL:-P7D}
   # Default: P30D
-  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl
   refreshTokenAbsoluteTtl: ${MCP_OAUTH_REFRESH_TOKEN_ABSOLUTE_TTL:-P30D}
   # Default: PT60S
   # Description: Authorization code lifetime

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -398,7 +398,7 @@ mcpOAuth:
   # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
   refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT2M}
   # Default: 10
-  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). One more re-presentation than this is treated as reuse and revokes the whole token family
+  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). Requests beyond it are refused with invalid_grant one by one; the family and the pairs already handed out stay valid, since hitting the cap is oversubscription, not reuse
   refreshRotationMaxRetries: ${MCP_OAUTH_REFRESH_ROTATION_MAX_RETRIES:-10}
   # Default: PT10S
   # Description: Lease of the per-family Redis lock under which refresh-token rotation, in-grace retries and revocation run. Must outlast the MySQL transaction that rotates a token; if it lapses mid-rotation a concurrent refresh with the same token may be refused instead of served

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -400,6 +400,9 @@ mcpOAuth:
   # Default: 10
   # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). One more re-presentation than this is treated as reuse and revokes the whole token family
   refreshRotationMaxRetries: ${MCP_OAUTH_REFRESH_ROTATION_MAX_RETRIES:-10}
+  # Default: PT10S
+  # Description: Lease of the per-family Redis lock under which refresh-token rotation, in-grace retries and revocation run. Must outlast the MySQL transaction that rotates a token; if it lapses mid-rotation a concurrent refresh with the same token may be refused instead of served
+  refreshLockLease: ${MCP_OAUTH_REFRESH_LOCK_LEASE:-PT10S}
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: ${MCP_OAUTH_SCRUB_LOCK_TIMEOUT:-PT5M}

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -386,8 +386,11 @@ mcpOAuth:
   # Description: Access token lifetime
   accessTokenTtl: ${MCP_OAUTH_ACCESS_TOKEN_TTL:-PT1H}
   # Default: P7D
-  # Description: Refresh token absolute lifetime (not sliding)
+  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
   refreshTokenTtl: ${MCP_OAUTH_REFRESH_TOKEN_TTL:-P7D}
+  # Default: P30D
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed
+  refreshTokenAbsoluteTtl: ${MCP_OAUTH_REFRESH_TOKEN_ABSOLUTE_TTL:-P30D}
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: ${MCP_OAUTH_CODE_TTL:-PT60S}

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -391,9 +391,9 @@ mcpOAuth:
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: ${MCP_OAUTH_CODE_TTL:-PT60S}
-  # Default: PT30S
-  # Description: Grace window during which a just-rotated refresh token is still accepted
-  refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT30S}
+  # Default: PT2M
+  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
+  refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT2M}
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: ${MCP_OAUTH_SCRUB_LOCK_TIMEOUT:-PT5M}

--- a/apps/opik-backend/config.yml
+++ b/apps/opik-backend/config.yml
@@ -394,6 +394,9 @@ mcpOAuth:
   # Default: PT2M
   # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
   refreshRotationGrace: ${MCP_OAUTH_REFRESH_ROTATION_GRACE:-PT2M}
+  # Default: 10
+  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). One more re-presentation than this is treated as reuse and revokes the whole token family
+  refreshRotationMaxRetries: ${MCP_OAUTH_REFRESH_ROTATION_MAX_RETRIES:-10}
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: ${MCP_OAUTH_SCRUB_LOCK_TIMEOUT:-PT5M}

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthMapper.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthMapper.java
@@ -21,20 +21,23 @@ interface McpOAuthMapper {
     @Mapping(target = "type", source = "type")
     @Mapping(target = "familyId", source = "familyId")
     @Mapping(target = "expiresAt", source = "expiresAt")
+    @Mapping(target = "absoluteExpiresAt", source = "absoluteExpiresAt")
     @Mapping(target = "rotatedFromId", ignore = true)
     @Mapping(target = "issuedAt", ignore = true)
     @Mapping(target = "revokedAt", ignore = true)
     @Mapping(target = "revokedReason", ignore = true)
     McpOAuthToken toToken(McpOAuthCode code, String type, String id, String tokenHash, String familyId,
-            Instant expiresAt);
+            Instant expiresAt, Instant absoluteExpiresAt);
 
     @Mapping(target = "id", source = "id")
     @Mapping(target = "tokenHash", source = "tokenHash")
     @Mapping(target = "type", source = "type")
     @Mapping(target = "expiresAt", source = "expiresAt")
+    @Mapping(target = "absoluteExpiresAt", source = "absoluteExpiresAt")
     @Mapping(target = "rotatedFromId", source = "source.id")
     @Mapping(target = "issuedAt", ignore = true)
     @Mapping(target = "revokedAt", ignore = true)
     @Mapping(target = "revokedReason", ignore = true)
-    McpOAuthToken toRotatedToken(McpOAuthToken source, String type, String id, String tokenHash, Instant expiresAt);
+    McpOAuthToken toRotatedToken(McpOAuthToken source, String type, String id, String tokenHash, Instant expiresAt,
+            Instant absoluteExpiresAt);
 }

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthScrubService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthScrubService.java
@@ -22,8 +22,9 @@ public class McpOAuthScrubService {
     private final @NonNull OpikConfiguration opikConfig;
 
     /**
-     * Revoked tokens within the rotation grace window must remain queryable, so a duplicate refresh
-     * request (RFC 6749 §6 token rotation grace) returns invalid_grant instead of triggering reuse detection.
+     * Revoked tokens within the rotation grace window must remain queryable: a refresh token rotated moments ago is
+     * what a host re-presents from a parallel tool call, and {@code McpOAuthService.refresh} serves that retry a
+     * fresh pair (up to the configured cap) instead of treating it as reuse.
      */
     public Mono<Void> scrub() {
         return Mono.fromRunnable(() -> {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -126,8 +126,10 @@ public class McpOAuthService {
      * most {@code refreshRotationMaxRetries} of them, such a re-presentation is the legitimate client retrying and
      * still gets a fresh pair off the same family rather than {@code invalid_grant}: a host that sees
      * {@code invalid_grant} on refresh discards its tokens and forces the user to re-authorize (RFC 6819 §5.2.2.3
-     * flags exactly this clustered-client hazard of rotation). Outside the window, or past the cap, the
-     * re-presentation is treated as reuse and the whole family is revoked, per OAuth 2.1 §4.3.1.
+     * flags exactly this clustered-client hazard of rotation). Outside the window the re-presentation is treated
+     * as reuse and the whole family is revoked, per OAuth 2.1 §4.3.1. Inside the window but past the cap only that
+     * request is refused: hitting the cap is oversubscription, not theft, and must not cost the host the
+     * credentials it already holds.
      */
     public TokenResponse refresh(@NonNull String refreshToken, @NonNull String clientId) {
         String tokenHash = McpOAuthTokenUtils.hash(refreshToken);
@@ -192,11 +194,17 @@ public class McpOAuthService {
             if (!retry && tokenDao.revoke(current.tokenHash(), RevokedReason.ROTATED) != 1) {
                 throw new BadRequestException("refresh token could not be rotated");
             }
-            if (retry && (!isBenignRotationRetry(current, now)
-                    || countDescendantPairs(family, current) > config().getRefreshRotationMaxRetries())) {
-                // Reuse detected: kill the whole lineage
+            if (retry && !isBenignRotationRetry(current, now)) {
+                // Outside the grace window a re-presentation is the theft signal OAuth 2.1 §4.3.1 is about: the
+                // legitimate host stopped holding this token long ago. Kill the whole lineage.
                 tokenDao.revokeFamily(current.familyId(), RevokedReason.REUSE);
                 return Optional.empty();
+            }
+            if (retry && countDescendantPairs(family, current) > config().getRefreshRotationMaxRetries()) {
+                // Inside the grace window the presenter is holding the token the host legitimately still has,
+                // which is why the retries below the cap are served. The cap bounds how many pairs one token may
+                // mint; refuse this request and leave the family, and the host's other credentials, alone.
+                throw new BadRequestException("in-grace retry cap exceeded for this refresh token");
             }
 
             // Rows minted before the column existed carry no absolute expiry; their cap starts counting now.

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -19,11 +19,9 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -47,7 +45,6 @@ public class McpOAuthService {
     // the minting of a descendant pair. A row lock cannot do this without gap locks: a FOR UPDATE over the family
     // followed by an INSERT into the same range deadlocks against a second refresh doing the same.
     private static final String FAMILY_LOCK = "McpOAuthFamily";
-    private static final Duration FAMILY_LOCK_LEASE = Duration.ofSeconds(2);
 
     private final @NonNull TransactionTemplate template;
     private final @NonNull OpikConfiguration opikConfig;
@@ -99,14 +96,17 @@ public class McpOAuthService {
         String accessToken = McpOAuthTokenUtils.generateAccessToken();
         String refreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
+        // The authorization fixes the family's absolute lifetime; every rotation carries it forward.
+        Instant absoluteExpiresAt = now.plus(config().getRefreshTokenAbsoluteTtl());
+
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
             tokenDao.save(McpOAuthMapper.INSTANCE.toToken(row, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
-                    familyId, now.plus(config().getAccessTokenTtl())));
+                    familyId, now.plus(config().getAccessTokenTtl()), absoluteExpiresAt));
             tokenDao.save(McpOAuthMapper.INSTANCE.toToken(row, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(refreshToken),
-                    familyId, now.plus(config().getRefreshTokenTtl())));
+                    familyId, refreshExpiry(now, absoluteExpiresAt), absoluteExpiresAt));
 
             return buildTokenResponse(accessToken, refreshToken, row.workspaceId(), row.workspaceName());
         });
@@ -114,7 +114,8 @@ public class McpOAuthService {
 
     /**
      * Rotates a refresh token: the presented token is revoked and a new access + refresh pair is issued in the
-     * same family, with the same absolute refresh expiry.
+     * same family. The new refresh token lives {@code refreshTokenTtl} from now, capped at the family's absolute
+     * expiry, so an active connector stays connected and an idle one lapses (see {@link #refreshExpiry}).
      * <p>
      * MCP hosts run several tool calls in parallel, and when the access token expires each of them answers the
      * 401 by refreshing with the same stored refresh token. Only one of those requests can be the rotation; the
@@ -161,14 +162,24 @@ public class McpOAuthService {
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
 
-            List<McpOAuthToken> family = tokenDao.findFamily(row.familyId());
+            List<McpOAuthToken> family = tokenDao.findFamily(row.familyId(), row.workspaceId());
             McpOAuthToken current = family.stream()
                     .filter(token -> token.id().equals(row.id()))
                     .findFirst()
-                    .orElseThrow(() -> new BadRequestException("refresh token vanished during rotation"));
+                    .orElse(null);
+            if (current == null) {
+                // The presented token existed a moment ago and is gone: only the scrub job deletes rows, and it
+                // deletes expired or revoked ones. Fail closed for whatever is left of the family.
+                tokenDao.revokeFamily(row.familyId(), RevokedReason.REUSE);
+                return Optional.empty();
+            }
 
             if (isFamilyRevoked(family)) {
                 throw new BadRequestException("refresh token family already revoked");
+            }
+            // Re-checked under the lock: the pre-lock check may have waited behind another rotation.
+            if (!current.expiresAt().isAfter(Instant.now())) {
+                throw new BadRequestException("refresh token expired at '%s'".formatted(current.expiresAt()));
             }
 
             boolean retry = current.revokedAt() != null;
@@ -182,12 +193,16 @@ public class McpOAuthService {
                 return Optional.empty();
             }
 
+            // Rows minted before the column existed carry no absolute expiry; their cap starts counting now.
+            Instant absoluteExpiresAt = Optional.ofNullable(current.absoluteExpiresAt())
+                    .orElseGet(() -> now.plus(config().getRefreshTokenAbsoluteTtl()));
+
             tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
-                    now.plus(config().getAccessTokenTtl())));
+                    now.plus(config().getAccessTokenTtl()), absoluteExpiresAt));
             tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(newRefreshToken),
-                    slidingRefreshExpiry(family, now)));
+                    refreshExpiry(now, absoluteExpiresAt), absoluteExpiresAt));
 
             return Optional.of(buildTokenResponse(accessToken, newRefreshToken, current.workspaceId(),
                     current.workspaceName()));
@@ -223,7 +238,7 @@ public class McpOAuthService {
         return lockService.executeWithLockCustomExpire(
                 new LockService.Lock(familyId, FAMILY_LOCK),
                 Mono.fromSupplier(action).subscribeOn(Schedulers.boundedElastic()),
-                FAMILY_LOCK_LEASE)
+                config().getRefreshLockLease())
                 .blockOptional()
                 .orElseGet(Optional::empty);
     }
@@ -295,20 +310,13 @@ public class McpOAuthService {
     }
 
     /**
-     * The expiry of a refresh token issued by rotation: {@code refreshTokenTtl} from now, so a connector that keeps
-     * refreshing stays connected (OAuth 2.1 §4.3.3 ties refresh expiry to inactivity), capped at
-     * {@code refreshTokenAbsoluteTtl} from the authorization that created the family. The family's oldest token
-     * carries that authorization time.
+     * When a refresh token minted now expires: {@code refreshTokenTtl} from now (OAuth 2.1 §4.3.3 ties refresh
+     * expiry to inactivity, so an active connector stays connected), never past the family's absolute expiry, which
+     * the authorization fixed at {@code refreshTokenAbsoluteTtl} and every rotation carries forward.
      */
-    private Instant slidingRefreshExpiry(List<McpOAuthToken> family, Instant now) {
-        Instant familyStart = family.stream()
-                .map(McpOAuthToken::issuedAt)
-                .filter(Objects::nonNull)
-                .min(Instant::compareTo)
-                .orElse(now);
+    private Instant refreshExpiry(Instant now, Instant absoluteExpiresAt) {
         Instant sliding = now.plus(config().getRefreshTokenTtl());
-        Instant absolute = familyStart.plus(config().getRefreshTokenAbsoluteTtl());
-        return sliding.isBefore(absolute) ? sliding : absolute;
+        return sliding.isBefore(absoluteExpiresAt) ? sliding : absoluteExpiresAt;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -131,12 +132,20 @@ public class McpOAuthService {
         McpOAuthToken row = template.inTransaction(READ_ONLY,
                 handle -> handle.attach(McpOAuthTokenDAO.class).findByHash(tokenHash));
 
-        if (!isValidRefreshToken(row, clientId, now)) {
-            throw new BadRequestException(ERROR_INVALID_GRANT);
+        // The detail on these exceptions is for the log line in OAuthTokenService; the client only ever sees
+        // invalid_grant (RFC 6749 §5.2).
+        if (row == null || !TYPE_REFRESH.equals(row.type())) {
+            throw new BadRequestException("unknown refresh token");
+        }
+        if (!row.clientId().equals(clientId)) {
+            throw new BadRequestException("refresh token was issued to another client");
+        }
+        if (!row.expiresAt().isAfter(now)) {
+            throw new BadRequestException("refresh token expired at '%s'".formatted(row.expiresAt()));
         }
 
         return underFamilyLock(row.familyId(), () -> rotate(row, now))
-                .orElseThrow(() -> new BadRequestException(ERROR_INVALID_GRANT));
+                .orElseThrow(() -> new BadRequestException("refresh token reuse detected, family revoked"));
     }
 
     /**
@@ -156,30 +165,29 @@ public class McpOAuthService {
             McpOAuthToken current = family.stream()
                     .filter(token -> token.id().equals(row.id()))
                     .findFirst()
-                    .orElseThrow(() -> new BadRequestException(ERROR_INVALID_GRANT));
+                    .orElseThrow(() -> new BadRequestException("refresh token vanished during rotation"));
 
             if (isFamilyRevoked(family)) {
-                throw new BadRequestException(ERROR_INVALID_GRANT);
+                throw new BadRequestException("refresh token family already revoked");
             }
 
-            if (current.revokedAt() == null) {
-                if (tokenDao.revoke(current.tokenHash(), RevokedReason.ROTATED) != 1) {
-                    throw new BadRequestException(ERROR_INVALID_GRANT);
-                }
-            } else
-                if (!isBenignRotationRetry(current, now)
-                        || countDescendantPairs(family, current) > config().getRefreshRotationMaxRetries()) {
-                            // Reuse detected: kill the whole lineage
-                            tokenDao.revokeFamily(current.familyId(), RevokedReason.REUSE);
-                            return Optional.empty();
-                        }
+            boolean retry = current.revokedAt() != null;
+            if (!retry && tokenDao.revoke(current.tokenHash(), RevokedReason.ROTATED) != 1) {
+                throw new BadRequestException("refresh token could not be rotated");
+            }
+            if (retry && (!isBenignRotationRetry(current, now)
+                    || countDescendantPairs(family, current) > config().getRefreshRotationMaxRetries())) {
+                // Reuse detected: kill the whole lineage
+                tokenDao.revokeFamily(current.familyId(), RevokedReason.REUSE);
+                return Optional.empty();
+            }
 
             tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
                     now.plus(config().getAccessTokenTtl())));
             tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(newRefreshToken),
-                    current.expiresAt()));
+                    slidingRefreshExpiry(family, now)));
 
             return Optional.of(buildTokenResponse(accessToken, newRefreshToken, current.workspaceId(),
                     current.workspaceName()));
@@ -276,17 +284,6 @@ public class McpOAuthService {
     }
 
     /**
-     * A refresh token is usable only if it exists, is actually a refresh token (not an access token),
-     * was issued to the requesting client, and has not passed its absolute expiry.
-     */
-    private static boolean isValidRefreshToken(McpOAuthToken token, String clientId, Instant now) {
-        return token != null
-                && TYPE_REFRESH.equals(token.type())
-                && token.clientId().equals(clientId)
-                && token.expiresAt().isAfter(now);
-    }
-
-    /**
      * Distinguishes a harmless client retry from token theft. After rotation the old refresh token is
      * revoked; if the rotation response was lost in transit the client legitimately re-presents it. Such
      * a re-presentation is benign only when the token was revoked specifically for rotation and arrives
@@ -295,6 +292,23 @@ public class McpOAuthService {
     private boolean isBenignRotationRetry(McpOAuthToken token, Instant now) {
         return token.revokedReason() == RevokedReason.ROTATED
                 && !now.isAfter(token.revokedAt().plus(config().getRefreshRotationGrace()));
+    }
+
+    /**
+     * The expiry of a refresh token issued by rotation: {@code refreshTokenTtl} from now, so a connector that keeps
+     * refreshing stays connected (OAuth 2.1 §4.3.3 ties refresh expiry to inactivity), capped at
+     * {@code refreshTokenAbsoluteTtl} from the authorization that created the family. The family's oldest token
+     * carries that authorization time.
+     */
+    private Instant slidingRefreshExpiry(List<McpOAuthToken> family, Instant now) {
+        Instant familyStart = family.stream()
+                .map(McpOAuthToken::issuedAt)
+                .filter(Objects::nonNull)
+                .min(Instant::compareTo)
+                .orElse(now);
+        Instant sliding = now.plus(config().getRefreshTokenTtl());
+        Instant absolute = familyStart.plus(config().getRefreshTokenAbsoluteTtl());
+        return sliding.isBefore(absolute) ? sliding : absolute;
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -2,6 +2,7 @@ package com.comet.opik.domain.mcpoauth;
 
 import com.comet.opik.infrastructure.McpOAuthConfig;
 import com.comet.opik.infrastructure.OpikConfiguration;
+import com.comet.opik.infrastructure.lock.LockService;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.ws.rs.BadRequestException;
@@ -11,15 +12,20 @@ import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static com.comet.opik.domain.mcpoauth.McpOAuthToken.TYPE_ACCESS;
 import static com.comet.opik.domain.mcpoauth.McpOAuthToken.TYPE_REFRESH;
@@ -35,8 +41,16 @@ public class McpOAuthService {
 
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
+    // Every write that changes a token family's state (rotation, retry, revocation) runs under this lock, keyed by
+    // family_id, so concurrent refreshes with the same token serialize and a revocation can never interleave with
+    // the minting of a descendant pair. A row lock cannot do this without gap locks: a FOR UPDATE over the family
+    // followed by an INSERT into the same range deadlocks against a second refresh doing the same.
+    private static final String FAMILY_LOCK = "McpOAuthFamily";
+    private static final Duration FAMILY_LOCK_LEASE = Duration.ofSeconds(2);
+
     private final @NonNull TransactionTemplate template;
     private final @NonNull OpikConfiguration opikConfig;
+    private final @NonNull LockService lockService;
 
     private McpOAuthConfig config() {
         return opikConfig.getMcpOAuth();
@@ -97,6 +111,19 @@ public class McpOAuthService {
         });
     }
 
+    /**
+     * Rotates a refresh token: the presented token is revoked and a new access + refresh pair is issued in the
+     * same family, with the same absolute refresh expiry.
+     * <p>
+     * MCP hosts run several tool calls in parallel, and when the access token expires each of them answers the
+     * 401 by refreshing with the same stored refresh token. Only one of those requests can be the rotation; the
+     * others re-present a token that was revoked moments earlier. Within {@code refreshRotationGrace}, and for at
+     * most {@code refreshRotationMaxRetries} of them, such a re-presentation is the legitimate client retrying and
+     * still gets a fresh pair off the same family rather than {@code invalid_grant}: a host that sees
+     * {@code invalid_grant} on refresh discards its tokens and forces the user to re-authorize (RFC 6819 §5.2.2.3
+     * flags exactly this clustered-client hazard of rotation). Outside the window, or past the cap, the
+     * re-presentation is treated as reuse and the whole family is revoked, per OAuth 2.1 §4.3.1.
+     */
     public TokenResponse refresh(@NonNull String refreshToken, @NonNull String clientId) {
         String tokenHash = McpOAuthTokenUtils.hash(refreshToken);
         Instant now = Instant.now();
@@ -108,79 +135,89 @@ public class McpOAuthService {
             throw new BadRequestException(ERROR_INVALID_GRANT);
         }
 
-        if (row.revokedAt() != null) {
-            if (!isBenignRotationRetry(row, now)) { // Reuse detected: kill the whole lineage
-                template.inTransaction(WRITE, handle -> handle.attach(McpOAuthTokenDAO.class)
-                        .revokeFamily(row.familyId(), RevokedReason.REUSE));
-                throw new BadRequestException(ERROR_INVALID_GRANT);
-            }
-            // The host is re-presenting a token that was rotated moments ago: hand it its own pair (see
-            // mintRotatedPair) instead of an invalid_grant that would make it discard its credentials.
-            return mintRotatedPair(row, now, false);
-        }
-
-        return mintRotatedPair(row, now, true);
+        return underFamilyLock(row.familyId(), () -> rotate(row, now))
+                .orElseThrow(() -> new BadRequestException(ERROR_INVALID_GRANT));
     }
 
     /**
-     * Issues a new access + refresh pair descending from {@code source}, in the same family and with the same
-     * absolute refresh expiry.
-     * <p>
-     * MCP hosts run several tool calls in parallel, and when the access token expires each of them answers the
-     * 401 by refreshing with the same stored refresh token. Only one request can revoke the source token
-     * ({@code revokeSource}); the others land either after that rotation committed or inside the same race. Both
-     * are the legitimate client retrying, not a replay by a thief, as long as the rotation happened within
-     * {@code refreshRotationGrace}. Such a retry gets its own fresh pair off the same family rather than
-     * {@code invalid_grant}: a host that sees {@code invalid_grant} on refresh discards its tokens and forces the
-     * user to re-authorize (RFC 6819 §5.2.2.3 flags exactly this clustered-client hazard of rotation). After the
-     * grace window the re-presentation is treated as reuse and the family is revoked, per OAuth 2.1 §4.3.1.
+     * The locked half of {@link #refresh}: re-reads the family under the lock, decides between rotation, in-grace
+     * retry and reuse, and returns the minted pair, or empty when the presentation was reuse and the family has
+     * just been revoked. The decision and its writes share one transaction; the caller turns "empty" into
+     * {@code invalid_grant} outside it so the revocation is never rolled back by the rejection.
      */
-    private TokenResponse mintRotatedPair(McpOAuthToken source, Instant now, boolean revokeSource) {
+    private Optional<TokenResponse> rotate(McpOAuthToken row, Instant now) {
         String accessToken = McpOAuthTokenUtils.generateAccessToken();
         String newRefreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
 
-            if (revokeSource && tokenDao.revoke(source.tokenHash(), RevokedReason.ROTATED) != 1) {
-                // Lost the revoke race to a concurrent refresh with the same token. Same rule as above: a
-                // rotation that just happened means this is the host's own retry and it still gets a pair.
-                McpOAuthToken current = tokenDao.findByHash(source.tokenHash());
-                if (current == null || !isBenignRotationRetry(current, Instant.now())) {
-                    throw new BadRequestException(ERROR_INVALID_GRANT);
-                }
+            List<McpOAuthToken> family = tokenDao.findFamily(row.familyId());
+            McpOAuthToken current = family.stream()
+                    .filter(token -> token.id().equals(row.id()))
+                    .findFirst()
+                    .orElseThrow(() -> new BadRequestException(ERROR_INVALID_GRANT));
+
+            if (isFamilyRevoked(family)) {
+                throw new BadRequestException(ERROR_INVALID_GRANT);
             }
 
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_ACCESS,
+            if (current.revokedAt() == null) {
+                if (tokenDao.revoke(current.tokenHash(), RevokedReason.ROTATED) != 1) {
+                    throw new BadRequestException(ERROR_INVALID_GRANT);
+                }
+            } else
+                if (!isBenignRotationRetry(current, now)
+                        || countDescendantPairs(family, current) > config().getRefreshRotationMaxRetries()) {
+                            // Reuse detected: kill the whole lineage
+                            tokenDao.revokeFamily(current.familyId(), RevokedReason.REUSE);
+                            return Optional.empty();
+                        }
+
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
                     now.plus(config().getAccessTokenTtl())));
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_REFRESH,
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(newRefreshToken),
-                    source.expiresAt()));
+                    current.expiresAt()));
 
-            return buildTokenResponse(accessToken, newRefreshToken, source.workspaceId(), source.workspaceName());
+            return Optional.of(buildTokenResponse(accessToken, newRefreshToken, current.workspaceId(),
+                    current.workspaceName()));
         });
     }
 
     public void revoke(@NonNull String token) {
         String tokenHash = McpOAuthTokenUtils.hash(token);
 
-        template.inTransaction(WRITE, handle -> {
-            var tokenDao = handle.attach(McpOAuthTokenDAO.class);
+        McpOAuthToken row = template.inTransaction(READ_ONLY,
+                handle -> handle.attach(McpOAuthTokenDAO.class).findByHash(tokenHash));
+        if (row == null) {
+            return;
+        }
 
-            McpOAuthToken row = tokenDao.findByHash(tokenHash);
-            if (row == null) {
+        underFamilyLock(row.familyId(), () -> {
+            template.inTransaction(WRITE, handle -> {
+                var tokenDao = handle.attach(McpOAuthTokenDAO.class);
+
+                if (TYPE_REFRESH.equals(row.type())) {
+                    tokenDao.revokeFamily(row.familyId(), RevokedReason.CLIENT_REQUEST);
+                } else {
+                    tokenDao.revoke(row.tokenHash(), RevokedReason.CLIENT_REQUEST);
+                }
+
                 return null;
-            }
-
-            if (TYPE_REFRESH.equals(row.type())) {
-                tokenDao.revokeFamily(row.familyId(), RevokedReason.CLIENT_REQUEST);
-            } else {
-                tokenDao.revoke(row.tokenHash(), RevokedReason.CLIENT_REQUEST);
-            }
-
-            return null;
+            });
+            return Optional.empty();
         });
+    }
+
+    private <T> Optional<T> underFamilyLock(String familyId, Supplier<Optional<T>> action) {
+        return lockService.executeWithLockCustomExpire(
+                new LockService.Lock(familyId, FAMILY_LOCK),
+                Mono.fromSupplier(action).subscribeOn(Schedulers.boundedElastic()),
+                FAMILY_LOCK_LEASE)
+                .blockOptional()
+                .orElseGet(Optional::empty);
     }
 
     public ValidatedToken validateAccessTokenForWorkspace(@NonNull String token, String headerWorkspace) {
@@ -258,6 +295,28 @@ public class McpOAuthService {
     private boolean isBenignRotationRetry(McpOAuthToken token, Instant now) {
         return token.revokedReason() == RevokedReason.ROTATED
                 && !now.isAfter(token.revokedAt().plus(config().getRefreshRotationGrace()));
+    }
+
+    /**
+     * A family is dead once any of its refresh tokens was revoked for something other than rotation: the client
+     * asked for it ({@code /oauth/revoke}) or reuse detection fired. Rotation revocations are the normal lineage
+     * and say nothing about the family; access-token-only revocations never touch refresh rows.
+     */
+    private static boolean isFamilyRevoked(List<McpOAuthToken> family) {
+        return family.stream()
+                .filter(token -> TYPE_REFRESH.equals(token.type()))
+                .anyMatch(token -> token.revokedReason() == RevokedReason.REUSE
+                        || token.revokedReason() == RevokedReason.CLIENT_REQUEST);
+    }
+
+    /**
+     * How many token pairs already descend directly from {@code source}: one for the rotation itself, plus one
+     * per in-grace retry served so far. Counted on access rows; every pair has exactly one.
+     */
+    private static long countDescendantPairs(List<McpOAuthToken> family, McpOAuthToken source) {
+        return family.stream()
+                .filter(token -> TYPE_ACCESS.equals(token.type()) && source.id().equals(token.rotatedFromId()))
+                .count();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.core.Response;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -19,6 +20,7 @@ import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.List;
@@ -34,6 +36,7 @@ import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_TYPE_BEARER;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.READ_ONLY;
 import static com.comet.opik.infrastructure.db.TransactionTemplateAsync.WRITE;
 
+@Slf4j
 @Singleton
 @RequiredArgsConstructor(onConstructor_ = @Inject)
 public class McpOAuthService {
@@ -238,12 +241,32 @@ public class McpOAuthService {
     }
 
     private <T> Optional<T> underFamilyLock(String familyId, Supplier<Optional<T>> action) {
+        Duration lease = config().getRefreshLockLease();
         return lockService.executeWithLockCustomExpire(
                 new LockService.Lock(familyId, FAMILY_LOCK),
-                Mono.fromSupplier(action).subscribeOn(Schedulers.boundedElastic()),
-                config().getRefreshLockLease())
+                Mono.fromSupplier(() -> timed(familyId, lease, action)).subscribeOn(Schedulers.boundedElastic()),
+                lease)
                 .blockOptional()
                 .orElseGet(Optional::empty);
+    }
+
+    /**
+     * The Redis permit is a lease, not a fence: once it lapses the action keeps running while another request may
+     * enter. Correctness does not depend on it (every write re-reads the family in its own transaction and the
+     * rotation itself is a conditional UPDATE), but a lapsed lease can turn a legitimate parallel retry into
+     * {@code invalid_grant}, so make it visible when it happens.
+     */
+    private static <T> T timed(String familyId, Duration lease, Supplier<T> action) {
+        long start = System.nanoTime();
+        try {
+            return action.get();
+        } finally {
+            Duration held = Duration.ofNanos(System.nanoTime() - start);
+            if (held.compareTo(lease) > 0) {
+                log.warn("MCP OAuth family lock held for '{}' longer than its lease '{}' on family '{}'; "
+                        + "raise mcpOAuth.refreshLockLease", held, lease, familyId);
+            }
+        }
     }
 
     public ValidatedToken validateAccessTokenForWorkspace(@NonNull String token, String headerWorkspace) {

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -112,28 +112,53 @@ public class McpOAuthService {
             if (!isBenignRotationRetry(row, now)) { // Reuse detected: kill the whole lineage
                 template.inTransaction(WRITE, handle -> handle.attach(McpOAuthTokenDAO.class)
                         .revokeFamily(row.familyId(), RevokedReason.REUSE));
+                throw new BadRequestException(ERROR_INVALID_GRANT);
             }
-            throw new BadRequestException(ERROR_INVALID_GRANT);
+            // The host is re-presenting a token that was rotated moments ago: hand it its own pair (see
+            // mintRotatedPair) instead of an invalid_grant that would make it discard its credentials.
+            return mintRotatedPair(row, now, false);
         }
 
+        return mintRotatedPair(row, now, true);
+    }
+
+    /**
+     * Issues a new access + refresh pair descending from {@code source}, in the same family and with the same
+     * absolute refresh expiry.
+     * <p>
+     * MCP hosts run several tool calls in parallel, and when the access token expires each of them answers the
+     * 401 by refreshing with the same stored refresh token. Only one request can revoke the source token
+     * ({@code revokeSource}); the others land either after that rotation committed or inside the same race. Both
+     * are the legitimate client retrying, not a replay by a thief, as long as the rotation happened within
+     * {@code refreshRotationGrace}. Such a retry gets its own fresh pair off the same family rather than
+     * {@code invalid_grant}: a host that sees {@code invalid_grant} on refresh discards its tokens and forces the
+     * user to re-authorize (RFC 6819 §5.2.2.3 flags exactly this clustered-client hazard of rotation). After the
+     * grace window the re-presentation is treated as reuse and the family is revoked, per OAuth 2.1 §4.3.1.
+     */
+    private TokenResponse mintRotatedPair(McpOAuthToken source, Instant now, boolean revokeSource) {
         String accessToken = McpOAuthTokenUtils.generateAccessToken();
         String newRefreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
 
-            if (tokenDao.revoke(row.tokenHash(), RevokedReason.ROTATED) != 1) {
-                throw new BadRequestException(ERROR_INVALID_GRANT);
+            if (revokeSource && tokenDao.revoke(source.tokenHash(), RevokedReason.ROTATED) != 1) {
+                // Lost the revoke race to a concurrent refresh with the same token. Same rule as above: a
+                // rotation that just happened means this is the host's own retry and it still gets a pair.
+                McpOAuthToken current = tokenDao.findByHash(source.tokenHash());
+                if (current == null || !isBenignRotationRetry(current, Instant.now())) {
+                    throw new BadRequestException(ERROR_INVALID_GRANT);
+                }
             }
 
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(row, TYPE_ACCESS,
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
                     now.plus(config().getAccessTokenTtl())));
-            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(row, TYPE_REFRESH,
+            tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(source, TYPE_REFRESH,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(newRefreshToken),
-                    row.expiresAt()));
+                    source.expiresAt()));
 
-            return buildTokenResponse(accessToken, newRefreshToken, row.workspaceId(), row.workspaceName());
+            return buildTokenResponse(accessToken, newRefreshToken, source.workspaceId(), source.workspaceName());
         });
     }
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthService.java
@@ -97,7 +97,7 @@ public class McpOAuthService {
         String refreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
         // The authorization fixes the family's absolute lifetime; every rotation carries it forward.
-        Instant absoluteExpiresAt = now.plus(config().getRefreshTokenAbsoluteTtl());
+        Instant absoluteExpiresAt = now.plus(config().effectiveRefreshTokenAbsoluteTtl());
 
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
@@ -145,7 +145,7 @@ public class McpOAuthService {
             throw new BadRequestException("refresh token expired at '%s'".formatted(row.expiresAt()));
         }
 
-        return underFamilyLock(row.familyId(), () -> rotate(row, now))
+        return underFamilyLock(row.familyId(), () -> rotate(row))
                 .orElseThrow(() -> new BadRequestException("refresh token reuse detected, family revoked"));
     }
 
@@ -155,12 +155,15 @@ public class McpOAuthService {
      * just been revoked. The decision and its writes share one transaction; the caller turns "empty" into
      * {@code invalid_grant} outside it so the revocation is never rolled back by the rejection.
      */
-    private Optional<TokenResponse> rotate(McpOAuthToken row, Instant now) {
+    private Optional<TokenResponse> rotate(McpOAuthToken row) {
         String accessToken = McpOAuthTokenUtils.generateAccessToken();
         String newRefreshToken = McpOAuthTokenUtils.generateRefreshToken();
 
         return template.inTransaction(WRITE, handle -> {
             var tokenDao = handle.attach(McpOAuthTokenDAO.class);
+            // Taken after the lock was acquired: the grace check and every lifetime below must be measured from
+            // when this request actually gets to decide, not from when it arrived and queued behind others.
+            Instant now = Instant.now();
 
             List<McpOAuthToken> family = tokenDao.findFamily(row.familyId(), row.workspaceId());
             McpOAuthToken current = family.stream()
@@ -178,7 +181,7 @@ public class McpOAuthService {
                 throw new BadRequestException("refresh token family already revoked");
             }
             // Re-checked under the lock: the pre-lock check may have waited behind another rotation.
-            if (!current.expiresAt().isAfter(Instant.now())) {
+            if (!current.expiresAt().isAfter(now)) {
                 throw new BadRequestException("refresh token expired at '%s'".formatted(current.expiresAt()));
             }
 
@@ -195,7 +198,7 @@ public class McpOAuthService {
 
             // Rows minted before the column existed carry no absolute expiry; their cap starts counting now.
             Instant absoluteExpiresAt = Optional.ofNullable(current.absoluteExpiresAt())
-                    .orElseGet(() -> now.plus(config().getRefreshTokenAbsoluteTtl()));
+                    .orElseGet(() -> now.plus(config().effectiveRefreshTokenAbsoluteTtl()));
 
             tokenDao.save(McpOAuthMapper.INSTANCE.toRotatedToken(current, TYPE_ACCESS,
                     UUID.randomUUID().toString(), McpOAuthTokenUtils.hash(accessToken),
@@ -310,9 +313,9 @@ public class McpOAuthService {
     }
 
     /**
-     * When a refresh token minted now expires: {@code refreshTokenTtl} from now (OAuth 2.1 §4.3.3 ties refresh
-     * expiry to inactivity, so an active connector stays connected), never past the family's absolute expiry, which
-     * the authorization fixed at {@code refreshTokenAbsoluteTtl} and every rotation carries forward.
+     * The expiry of a refresh token that is minted now: {@code refreshTokenTtl} from now (OAuth 2.1 §4.3.3 ties
+     * refresh expiry to inactivity, so an active connector stays connected), but never later than the family's
+     * absolute expiry, which the authorization fixed and every rotation carries forward.
      */
     private Instant refreshExpiry(Instant now, Instant absoluteExpiresAt) {
         Instant sliding = now.plus(config().getRefreshTokenTtl());

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthToken.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthToken.java
@@ -19,6 +19,7 @@ public record McpOAuthToken(
         String rotatedFromId,
         Instant issuedAt,
         @NonNull Instant expiresAt,
+        Instant absoluteExpiresAt,
         Instant revokedAt,
         RevokedReason revokedReason) {
 

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthTokenDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthTokenDAO.java
@@ -22,17 +22,17 @@ interface McpOAuthTokenDAO {
 
     @SqlUpdate("""
             INSERT INTO mcp_oauth_tokens (id, token_hash, type, client_id, user_name, workspace_name, workspace_id,
-                resource, family_id, rotated_from_id, expires_at)
+                resource, family_id, rotated_from_id, expires_at, absolute_expires_at)
             VALUES (:bean.id, :bean.tokenHash, :bean.type, :bean.clientId, :bean.userName, :bean.workspaceName, :bean.workspaceId,
-                :bean.resource, :bean.familyId, :bean.rotatedFromId, :bean.expiresAt)
+                :bean.resource, :bean.familyId, :bean.rotatedFromId, :bean.expiresAt, :bean.absoluteExpiresAt)
             """)
     void save(@BindMethods("bean") McpOAuthToken token);
 
     @SqlQuery("SELECT * FROM mcp_oauth_tokens WHERE token_hash = :tokenHash")
     McpOAuthToken findByHash(@Bind("tokenHash") String tokenHash);
 
-    @SqlQuery("SELECT * FROM mcp_oauth_tokens WHERE family_id = :familyId")
-    List<McpOAuthToken> findFamily(@Bind("familyId") String familyId);
+    @SqlQuery("SELECT * FROM mcp_oauth_tokens WHERE family_id = :familyId AND workspace_id = :workspaceId")
+    List<McpOAuthToken> findFamily(@Bind("familyId") String familyId, @Bind("workspaceId") String workspaceId);
 
     @UseStringTemplateEngine
     @SqlUpdate("""

--- a/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthTokenDAO.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/domain/mcpoauth/McpOAuthTokenDAO.java
@@ -12,6 +12,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 @RegisterConstructorMapper(McpOAuthToken.class)
@@ -29,6 +30,9 @@ interface McpOAuthTokenDAO {
 
     @SqlQuery("SELECT * FROM mcp_oauth_tokens WHERE token_hash = :tokenHash")
     McpOAuthToken findByHash(@Bind("tokenHash") String tokenHash);
+
+    @SqlQuery("SELECT * FROM mcp_oauth_tokens WHERE family_id = :familyId")
+    List<McpOAuthToken> findFamily(@Bind("familyId") String familyId);
 
     @UseStringTemplateEngine
     @SqlUpdate("""

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -37,6 +37,9 @@ public class McpOAuthConfig {
     @NotNull private Duration refreshTokenTtl;
 
     @Valid @JsonProperty
+    @NotNull private Duration refreshTokenAbsoluteTtl;
+
+    @Valid @JsonProperty
     @NotNull private Duration codeTtl;
 
     @Valid @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -36,6 +36,10 @@ public class McpOAuthConfig {
     @Valid @JsonProperty
     @NotNull private Duration refreshTokenTtl;
 
+    // Longest a refresh-token family may be configured to live, idle or absolute. A grant that never has to be
+    // re-authorized is a standing credential; a year is already generous for a connector.
+    private static final Duration MAX_REFRESH_LIFETIME = Duration.ofDays(365);
+
     // Java-side defaults on the settings added after the first release, so an externally supplied mcpOAuth block
     // that predates them still validates.
     @Valid @JsonProperty
@@ -80,12 +84,12 @@ public class McpOAuthConfig {
         return refreshTokenAbsoluteTtl.compareTo(refreshTokenTtl) >= 0 ? refreshTokenAbsoluteTtl : refreshTokenTtl;
     }
 
-    @AssertTrue(message = "mcpOAuth.refreshTokenTtl must be positive") public boolean isRefreshTokenTtlPositive() {
-        return isPositive(refreshTokenTtl);
+    @AssertTrue(message = "mcpOAuth.refreshTokenTtl must be positive and at most 365 days") public boolean isRefreshTokenTtlPositive() {
+        return isPositive(refreshTokenTtl) && refreshTokenTtl.compareTo(MAX_REFRESH_LIFETIME) <= 0;
     }
 
-    @AssertTrue(message = "mcpOAuth.refreshTokenAbsoluteTtl must be positive") public boolean isRefreshTokenAbsoluteTtlPositive() {
-        return isPositive(refreshTokenAbsoluteTtl);
+    @AssertTrue(message = "mcpOAuth.refreshTokenAbsoluteTtl must be positive and at most 365 days") public boolean isRefreshTokenAbsoluteTtlPositive() {
+        return isPositive(refreshTokenAbsoluteTtl) && refreshTokenAbsoluteTtl.compareTo(MAX_REFRESH_LIFETIME) <= 0;
     }
 
     @AssertTrue(message = "mcpOAuth.refreshLockLease must be positive") public boolean isRefreshLockLeasePositive() {

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -71,17 +71,29 @@ public class McpOAuthConfig {
     }
 
     /**
-     * A refresh token's absolute lifetime must be at least its idle lifetime, otherwise the cap would shorten
-     * every token from the first authorization on, and both must be positive.
+     * The absolute lifetime a token family actually gets: never shorter than the idle lifetime, otherwise the cap
+     * would shorten every refresh token from the first authorization on. Derived rather than validated so that
+     * raising {@code refreshTokenTtl} alone (e.g. via {@code MCP_OAUTH_REFRESH_TOKEN_TTL}) keeps a deployment
+     * bootable instead of tripping over the default absolute value.
      */
-    @AssertTrue(message = "mcpOAuth.refreshTokenAbsoluteTtl must be positive and not shorter than mcpOAuth.refreshTokenTtl") public boolean isRefreshTokenAbsoluteTtlValid() {
-        return refreshTokenTtl != null && refreshTokenAbsoluteTtl != null
-                && !refreshTokenTtl.isNegative() && !refreshTokenTtl.isZero()
-                && refreshTokenAbsoluteTtl.compareTo(refreshTokenTtl) >= 0;
+    public Duration effectiveRefreshTokenAbsoluteTtl() {
+        return refreshTokenAbsoluteTtl.compareTo(refreshTokenTtl) >= 0 ? refreshTokenAbsoluteTtl : refreshTokenTtl;
+    }
+
+    @AssertTrue(message = "mcpOAuth.refreshTokenTtl must be positive") public boolean isRefreshTokenTtlPositive() {
+        return isPositive(refreshTokenTtl);
+    }
+
+    @AssertTrue(message = "mcpOAuth.refreshTokenAbsoluteTtl must be positive") public boolean isRefreshTokenAbsoluteTtlPositive() {
+        return isPositive(refreshTokenAbsoluteTtl);
     }
 
     @AssertTrue(message = "mcpOAuth.refreshLockLease must be positive") public boolean isRefreshLockLeasePositive() {
-        return refreshLockLease != null && !refreshLockLease.isNegative() && !refreshLockLease.isZero();
+        return isPositive(refreshLockLease);
+    }
+
+    private static boolean isPositive(Duration duration) {
+        return duration != null && !duration.isNegative() && !duration.isZero();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -36,8 +36,10 @@ public class McpOAuthConfig {
     @Valid @JsonProperty
     @NotNull private Duration refreshTokenTtl;
 
+    // Java-side defaults on the settings added after the first release, so an externally supplied mcpOAuth block
+    // that predates them still validates.
     @Valid @JsonProperty
-    @NotNull private Duration refreshTokenAbsoluteTtl;
+    @NotNull private Duration refreshTokenAbsoluteTtl = Duration.ofDays(30);
 
     @Valid @JsonProperty
     @NotNull private Duration codeTtl;
@@ -46,7 +48,10 @@ public class McpOAuthConfig {
     @NotNull private Duration refreshRotationGrace;
 
     @Valid @JsonProperty
-    @Positive private int refreshRotationMaxRetries;
+    @Positive private int refreshRotationMaxRetries = 10;
+
+    @Valid @JsonProperty
+    @NotNull private Duration refreshLockLease = Duration.ofSeconds(10);
 
     @Valid @JsonProperty
     @NotNull private Duration scrubLockTimeout;
@@ -60,6 +65,20 @@ public class McpOAuthConfig {
 
     public String getMcpResourceUri() {
         return StringUtils.isNotBlank(mcpResourceUri) ? mcpResourceUri : getIssuer() + "/api/v1/mcp";
+    }
+
+    /**
+     * A refresh token's absolute lifetime must be at least its idle lifetime, otherwise the cap would shorten
+     * every token from the first authorization on, and both must be positive.
+     */
+    @AssertTrue(message = "mcpOAuth.refreshTokenAbsoluteTtl must be positive and not shorter than mcpOAuth.refreshTokenTtl") public boolean isRefreshTokenAbsoluteTtlValid() {
+        return refreshTokenTtl != null && refreshTokenAbsoluteTtl != null
+                && !refreshTokenTtl.isNegative() && !refreshTokenTtl.isZero()
+                && refreshTokenAbsoluteTtl.compareTo(refreshTokenTtl) >= 0;
+    }
+
+    @AssertTrue(message = "mcpOAuth.refreshLockLease must be positive") public boolean isRefreshLockLeasePositive() {
+        return refreshLockLease != null && !refreshLockLease.isNegative() && !refreshLockLease.isZero();
     }
 
     /**

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -39,6 +39,7 @@ public class McpOAuthConfig {
     // Java-side defaults on the settings added after the first release, so an externally supplied mcpOAuth block
     // that predates them still validates.
     @Valid @JsonProperty
+    @Builder.Default
     @NotNull private Duration refreshTokenAbsoluteTtl = Duration.ofDays(30);
 
     @Valid @JsonProperty
@@ -48,9 +49,11 @@ public class McpOAuthConfig {
     @NotNull private Duration refreshRotationGrace;
 
     @Valid @JsonProperty
+    @Builder.Default
     @Positive private int refreshRotationMaxRetries = 10;
 
     @Valid @JsonProperty
+    @Builder.Default
     @NotNull private Duration refreshLockLease = Duration.ofSeconds(10);
 
     @Valid @JsonProperty

--- a/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
+++ b/apps/opik-backend/src/main/java/com/comet/opik/infrastructure/McpOAuthConfig.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -40,6 +41,9 @@ public class McpOAuthConfig {
 
     @Valid @JsonProperty
     @NotNull private Duration refreshRotationGrace;
+
+    @Valid @JsonProperty
+    @Positive private int refreshRotationMaxRetries;
 
     @Valid @JsonProperty
     @NotNull private Duration scrubLockTimeout;

--- a/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000096_add_absolute_expires_at_to_mcp_oauth_tokens.sql
+++ b/apps/opik-backend/src/main/resources/liquibase/db-app-state/migrations/000096_add_absolute_expires_at_to_mcp_oauth_tokens.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+--changeset yaroslavb:000096_add_absolute_expires_at_to_mcp_oauth_tokens
+--comment: Refresh-token lifetime became sliding (OPIK-8351): every rotation issues the new refresh token with a fresh idle
+--comment: lifetime, so the absolute lifetime of a token family (authorization time + refreshTokenAbsoluteTtl) has to be
+--comment: carried on the tokens themselves. It cannot be derived from the family's oldest row, which the scrub job deletes
+--comment: shortly after rotation. NULL on rows minted before this change; the next rotation starts the cap from then.
+ALTER TABLE mcp_oauth_tokens ADD COLUMN absolute_expires_at TIMESTAMP(6) NULL;
+
+--rollback ALTER TABLE mcp_oauth_tokens DROP COLUMN absolute_expires_at;

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
@@ -4,11 +4,14 @@ import com.comet.opik.api.resources.oauth.AuthorizeContext;
 import com.comet.opik.api.resources.oauth.ClientRegistrationResponse;
 import com.comet.opik.api.resources.oauth.ConsentRequest;
 import com.comet.opik.api.resources.oauth.ConsentResponse;
+import com.comet.opik.api.resources.oauth.OAuthError;
 import com.comet.opik.domain.ProjectService;
 import com.comet.opik.domain.mcpoauth.ClientRegistrationRequest;
 import com.comet.opik.domain.mcpoauth.TokenResponse;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpStatus;
@@ -25,12 +28,16 @@ import static com.comet.opik.domain.mcpoauth.OAuthConstants.AUTHORIZE_PATH;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.CODE_CHALLENGE_METHOD_S256;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.CSRF_COOKIE;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_AUTHORIZATION_CODE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CODE;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CODE_VERIFIER;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REDIRECT_URI;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_TOKEN;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.REGISTER_PATH;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.REVOKE_PATH;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -51,6 +58,47 @@ public class OAuthResourceClient {
     private final String resourceUri;
 
     public record Minted(String clientId, String code, TokenResponse tokens) {
+    }
+
+    /** What {@code POST /oauth/token} answered a {@code refresh_token} grant: the pair on 200, the error otherwise. */
+    @Builder(toBuilder = true)
+    public record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
+        public boolean isOk() {
+            return status == HttpStatus.SC_OK;
+        }
+    }
+
+    /** Runs the {@code refresh_token} grant and reports whatever the token endpoint answered, without asserting. */
+    public RefreshOutcome refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            var outcome = RefreshOutcome.builder().status(response.getStatus());
+            if (response.getStatus() == HttpStatus.SC_OK) {
+                return outcome.tokens(response.readEntity(TokenResponse.class)).build();
+            }
+            return outcome.error(response.readEntity(OAuthError.class)).build();
+        }
+    }
+
+    /** Runs the {@code refresh_token} grant and asserts it succeeded. */
+    public TokenResponse refreshOk(String clientId, String refreshToken) {
+        RefreshOutcome outcome = refresh(clientId, refreshToken);
+        assertThat(outcome.status()).isEqualTo(HttpStatus.SC_OK);
+        return outcome.tokens();
+    }
+
+    /** RFC 7009 revocation of a token; the endpoint always answers 200. */
+    public void revoke(String clientId, String token) {
+        var form = new Form()
+                .param(PARAM_TOKEN, token)
+                .param(PARAM_CLIENT_ID, clientId);
+        try (Response response = client.target(baseURI + REVOKE_PATH).request().post(Entity.form(form))) {
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        }
     }
 
     /** Registers a client, walks consent + PKCE, and exchanges the code for the raw code and the token pair. */

--- a/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/api/resources/utils/resources/OAuthResourceClient.java
@@ -50,7 +50,7 @@ public class OAuthResourceClient {
     private final String redirectUri;
     private final String resourceUri;
 
-    public record Minted(String code, TokenResponse tokens) {
+    public record Minted(String clientId, String code, TokenResponse tokens) {
     }
 
     /** Registers a client, walks consent + PKCE, and exchanges the code for the raw code and the token pair. */
@@ -58,7 +58,7 @@ public class OAuthResourceClient {
         String clientId = registerClient();
         String codeVerifier = RandomStringUtils.secure().nextAlphanumeric(64);
         String code = authorize(clientId, codeVerifier);
-        return new Minted(code, exchangeCode(clientId, code, codeVerifier));
+        return new Minted(clientId, code, exchangeCode(clientId, code, codeVerifier));
     }
 
     private String registerClient() {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
@@ -1,0 +1,137 @@
+package com.comet.opik.domain.mcpoauth;
+
+import com.comet.opik.api.resources.oauth.OAuthError;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.time.Duration;
+import java.util.List;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.ERROR_INVALID_GRANT;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The security half of rotation (OAuth 2.1 §4.3.1): once the rotation grace has passed, a rotated refresh token
+ * presented again is a replay, and the whole family, the freshly rotated token included, is revoked. Runs its own
+ * app with a one-second grace so the window can actually be crossed.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+@DisplayName("OAuth Refresh Reuse Detection Integration Test")
+class OAuthRefreshReuseDetectionIntegrationTest {
+
+    private static final String REDIRECT_URI = "http://localhost:1234/callback";
+    private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
+    private static final Duration GRACE = Duration.ofSeconds(1);
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE, MYSQL, ZOOKEEPER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("mcpOAuth.enabled", "true"),
+                                new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
+                                new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
+                                new CustomConfig("mcpOAuth.refreshRotationGrace", GRACE.toString())))
+                        .build());
+    }
+
+    private String baseURI;
+    private ClientSupport client;
+    private OAuthResourceClient oauthClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        this.oauthClient = new OAuthResourceClient(clientSupport, baseURI, REDIRECT_URI, RESOURCE_URI);
+    }
+
+    @Test
+    @DisplayName("a rotated refresh token presented after the grace window revokes the whole family")
+    void rotatedTokenPresentedAfterGrace_revokesFamily() throws InterruptedException {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String originalRefreshToken = minted.tokens().refreshToken();
+
+        RefreshOutcome rotated = refresh(clientId, originalRefreshToken);
+        assertThat(rotated.status()).isEqualTo(Response.Status.OK.getStatusCode());
+        String currentRefreshToken = rotated.tokens().refreshToken();
+
+        // Past the grace window the original token is a replay...
+        Thread.sleep(GRACE.plusMillis(500).toMillis());
+        RefreshOutcome replay = refresh(clientId, originalRefreshToken);
+        assertThat(replay.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(replay.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+
+        // ...and the token the legitimate rotation produced goes down with it.
+        RefreshOutcome afterReuse = refresh(clientId, currentRefreshToken);
+        assertThat(afterReuse.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(afterReuse.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+    }
+
+    private RefreshOutcome refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            int status = response.getStatus();
+            if (status == Response.Status.OK.getStatusCode()) {
+                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
+            }
+            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
+        }
+    }
+
+    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshReuseDetectionIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.comet.opik.domain.mcpoauth;
 
-import com.comet.opik.api.resources.oauth.OAuthError;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.MigrationUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
@@ -13,8 +12,6 @@ import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.redis.testcontainers.RedisContainer;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -33,11 +30,6 @@ import java.util.List;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.ERROR_INVALID_GRANT;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -101,37 +93,20 @@ class OAuthRefreshReuseDetectionIntegrationTest {
         String clientId = minted.clientId();
         String originalRefreshToken = minted.tokens().refreshToken();
 
-        RefreshOutcome rotated = refresh(clientId, originalRefreshToken);
+        OAuthResourceClient.RefreshOutcome rotated = oauthClient.refresh(clientId, originalRefreshToken);
         assertThat(rotated.status()).isEqualTo(Response.Status.OK.getStatusCode());
         String currentRefreshToken = rotated.tokens().refreshToken();
 
         // Past the grace window the original token is a replay...
         Thread.sleep(GRACE.plusMillis(500).toMillis());
-        RefreshOutcome replay = refresh(clientId, originalRefreshToken);
+        OAuthResourceClient.RefreshOutcome replay = oauthClient.refresh(clientId, originalRefreshToken);
         assertThat(replay.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(replay.error().error()).isEqualTo(ERROR_INVALID_GRANT);
 
         // ...and the token the legitimate rotation produced goes down with it.
-        RefreshOutcome afterReuse = refresh(clientId, currentRefreshToken);
+        OAuthResourceClient.RefreshOutcome afterReuse = oauthClient.refresh(clientId, currentRefreshToken);
         assertThat(afterReuse.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(afterReuse.error().error()).isEqualTo(ERROR_INVALID_GRANT);
     }
 
-    private RefreshOutcome refresh(String clientId, String refreshToken) {
-        var form = new Form()
-                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
-                .param(PARAM_CLIENT_ID, clientId)
-                .param(PARAM_REFRESH_TOKEN, refreshToken);
-
-        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
-            int status = response.getStatus();
-            if (status == Response.Status.OK.getStatusCode()) {
-                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
-            }
-            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
-        }
-    }
-
-    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
-    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -56,6 +56,8 @@ class OAuthRefreshRotationIntegrationTest {
     private static final int PARALLEL_REFRESHES = 5;
     // One rotation plus this many in-grace retries may be served off a single refresh token.
     private static final int MAX_RETRIES = PARALLEL_REFRESHES - 1;
+    // More parallel calls than the cap can serve: 1 rotation + MAX_RETRIES retries + 2 over the cap.
+    private static final int OVERSUBSCRIBED_REFRESHES = MAX_RETRIES + 3;
     private static final Duration BURST_TIMEOUT = Duration.ofSeconds(30);
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
@@ -109,28 +111,7 @@ class OAuthRefreshRotationIntegrationTest {
         String clientId = minted.clientId();
         String refreshToken = minted.tokens().refreshToken();
 
-        // One dedicated thread per request, all released by the same barrier, so the requests really are in
-        // flight together rather than trickling through a shared pool one at a time.
-        var barrier = new CyclicBarrier(PARALLEL_REFRESHES);
-        ExecutorService workers = Executors.newFixedThreadPool(PARALLEL_REFRESHES);
-        List<OAuthResourceClient.RefreshOutcome> outcomes;
-        try {
-            outcomes = IntStream.range(0, PARALLEL_REFRESHES)
-                    .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
-                        try {
-                            barrier.await(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
-                        } catch (Exception e) {
-                            throw new IllegalStateException("burst did not line up", e);
-                        }
-                        return oauthClient.refresh(clientId, refreshToken);
-                    }, workers))
-                    .toList()
-                    .stream()
-                    .map(future -> future.orTimeout(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS).join())
-                    .toList();
-        } finally {
-            workers.shutdownNow();
-        }
+        List<OAuthResourceClient.RefreshOutcome> outcomes = refreshBurst(PARALLEL_REFRESHES, clientId, refreshToken);
 
         assertThat(outcomes)
                 .as("every parallel refresh with the same refresh token is answered with a token pair")
@@ -154,8 +135,40 @@ class OAuthRefreshRotationIntegrationTest {
     }
 
     @Test
-    @DisplayName("one more retry than the cap is treated as reuse and revokes the whole family")
-    void retriesBeyondCap_revokeFamily() {
+    @DisplayName("a burst larger than the retry cap refuses the surplus but keeps the family alive")
+    void burstBeyondCap_refusesSurplusWithoutKillingFamily() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+
+        List<OAuthResourceClient.RefreshOutcome> outcomes = refreshBurst(OVERSUBSCRIBED_REFRESHES, clientId,
+                minted.tokens().refreshToken());
+
+        List<OAuthResourceClient.RefreshOutcome> served = outcomes.stream()
+                .filter(OAuthResourceClient.RefreshOutcome::isOk)
+                .toList();
+        assertThat(served)
+                .as("the rotation plus every in-grace retry the cap allows is served")
+                .hasSize(MAX_RETRIES + 1);
+        assertThat(outcomes)
+                .filteredOn(outcome -> !outcome.isOk())
+                .as("the surplus is refused with invalid_grant")
+                .isNotEmpty()
+                .allSatisfy(outcome -> {
+                    assertThat(outcome.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+                    assertThat(outcome.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+                });
+
+        // The point of the test: hitting the cap must not take down credentials the host already holds.
+        for (OAuthResourceClient.RefreshOutcome outcome : served) {
+            assertThat(oauthClient.refresh(clientId, outcome.tokens().refreshToken()).status())
+                    .as("a pair served before the cap was hit still rotates")
+                    .isEqualTo(Response.Status.OK.getStatusCode());
+        }
+    }
+
+    @Test
+    @DisplayName("sequential retries past the cap are refused one by one while the family stays alive")
+    void retriesBeyondCap_refusedWithoutKillingFamily() {
         var minted = oauthClient.mintArtifacts();
         String clientId = minted.clientId();
         String original = minted.tokens().refreshToken();
@@ -163,7 +176,6 @@ class OAuthRefreshRotationIntegrationTest {
         OAuthResourceClient.RefreshOutcome rotation = oauthClient.refresh(clientId, original);
         assertThat(rotation.status()).isEqualTo(Response.Status.OK.getStatusCode());
 
-        String latest = rotation.tokens().refreshToken();
         List<String> issued = new ArrayList<>(List.of(rotation.tokens().refreshToken()));
         for (int retry = 1; retry <= MAX_RETRIES; retry++) {
             OAuthResourceClient.RefreshOutcome allowed = oauthClient.refresh(clientId, original);
@@ -172,18 +184,21 @@ class OAuthRefreshRotationIntegrationTest {
             assertThat(allowed.tokens().accessToken()).isNotBlank();
             assertThat(allowed.tokens().refreshToken()).isNotBlank();
             issued.add(allowed.tokens().refreshToken());
-            latest = allowed.tokens().refreshToken();
         }
         assertThat(issued).as("every served retry carries its own refresh token").doesNotHaveDuplicates();
 
-        OAuthResourceClient.RefreshOutcome overCap = oauthClient.refresh(clientId, original);
-        assertThat(overCap.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-        assertThat(overCap.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+        for (int surplus = 1; surplus <= 2; surplus++) {
+            OAuthResourceClient.RefreshOutcome overCap = oauthClient.refresh(clientId, original);
+            assertThat(overCap.status()).as("request %d past the cap is refused", surplus)
+                    .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+            assertThat(overCap.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+        }
 
-        OAuthResourceClient.RefreshOutcome afterKill = oauthClient.refresh(clientId, latest);
-        assertThat(afterKill.status()).as("the family is gone, including the pairs handed out before the cap")
-                .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-        assertThat(afterKill.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+        for (String refreshToken : issued) {
+            assertThat(oauthClient.refresh(clientId, refreshToken).status())
+                    .as("every pair handed out before the cap still rotates")
+                    .isEqualTo(Response.Status.OK.getStatusCode());
+        }
     }
 
     @Test
@@ -203,4 +218,26 @@ class OAuthRefreshRotationIntegrationTest {
         assertThat(retry.error().error()).isEqualTo(ERROR_INVALID_GRANT);
     }
 
+    /** One dedicated thread per request, all released by the same barrier, so the burst really is concurrent. */
+    private List<OAuthResourceClient.RefreshOutcome> refreshBurst(int size, String clientId, String refreshToken) {
+        var barrier = new CyclicBarrier(size);
+        ExecutorService workers = Executors.newFixedThreadPool(size);
+        try {
+            return IntStream.range(0, size)
+                    .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                        try {
+                            barrier.await(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            throw new IllegalStateException("burst did not line up", e);
+                        }
+                        return oauthClient.refresh(clientId, refreshToken);
+                    }, workers))
+                    .toList()
+                    .stream()
+                    .map(future -> future.orTimeout(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS).join())
+                    .toList();
+        } finally {
+            workers.shutdownNow();
+        }
+    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -33,10 +33,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.ERROR_INVALID_GRANT;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.REVOKE_PATH;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,6 +58,8 @@ class OAuthRefreshRotationIntegrationTest {
     private static final String REDIRECT_URI = "http://localhost:1234/callback";
     private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
     private static final int PARALLEL_REFRESHES = 5;
+    // One rotation plus this many in-grace retries may be served off a single refresh token.
+    private static final int MAX_RETRIES = PARALLEL_REFRESHES - 1;
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -83,7 +88,9 @@ class OAuthRefreshRotationIntegrationTest {
                                 new CustomConfig("mcpOAuth.enabled", "true"),
                                 new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
                                 new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
-                                new CustomConfig("mcpOAuth.refreshRotationGrace", "PT2M")))
+                                new CustomConfig("mcpOAuth.refreshRotationGrace", "PT2M"),
+                                new CustomConfig("mcpOAuth.refreshRotationMaxRetries",
+                                        String.valueOf(MAX_RETRIES))))
                         .build());
     }
 
@@ -131,6 +138,56 @@ class OAuthRefreshRotationIntegrationTest {
                     .as("a refresh token handed out during the burst rotates normally afterwards")
                     .isEqualTo(Response.Status.OK.getStatusCode());
         }
+    }
+
+    @Test
+    @DisplayName("one more retry than the cap is treated as reuse and revokes the whole family")
+    void retriesBeyondCap_revokeFamily() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String original = minted.tokens().refreshToken();
+
+        RefreshOutcome rotation = refresh(clientId, original);
+        assertThat(rotation.status()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        String latest = rotation.tokens().refreshToken();
+        for (int retry = 1; retry <= MAX_RETRIES; retry++) {
+            RefreshOutcome allowed = refresh(clientId, original);
+            assertThat(allowed.status()).as("retry %d of %d is still served", retry, MAX_RETRIES)
+                    .isEqualTo(Response.Status.OK.getStatusCode());
+            latest = allowed.tokens().refreshToken();
+        }
+
+        RefreshOutcome overCap = refresh(clientId, original);
+        assertThat(overCap.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(overCap.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+
+        RefreshOutcome afterKill = refresh(clientId, latest);
+        assertThat(afterKill.status()).as("the family is gone, including the pairs handed out before the cap")
+                .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(afterKill.error().error()).isEqualTo(ERROR_INVALID_GRANT);
+    }
+
+    @Test
+    @DisplayName("an in-grace retry is refused once the client has revoked the family")
+    void retryAfterClientRevocation_isRejected() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String original = minted.tokens().refreshToken();
+
+        RefreshOutcome rotation = refresh(clientId, original);
+        assertThat(rotation.status()).isEqualTo(Response.Status.OK.getStatusCode());
+
+        var revoke = new Form()
+                .param(PARAM_TOKEN, rotation.tokens().refreshToken())
+                .param(PARAM_CLIENT_ID, clientId);
+        try (Response response = client.target(baseURI + REVOKE_PATH).request().post(Entity.form(revoke))) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+        }
+
+        RefreshOutcome retry = refresh(clientId, original);
+        assertThat(retry.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+        assertThat(retry.error().error()).isEqualTo(ERROR_INVALID_GRANT);
     }
 
     private RefreshOutcome refresh(String clientId, String refreshToken) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.comet.opik.domain.mcpoauth;
 
-import com.comet.opik.api.resources.oauth.OAuthError;
 import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
 import com.comet.opik.api.resources.utils.MigrationUtils;
 import com.comet.opik.api.resources.utils.MySQLContainerUtils;
@@ -13,8 +12,6 @@ import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.redis.testcontainers.RedisContainer;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -28,19 +25,13 @@ import org.testcontainers.mysql.MySQLContainer;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.IntStream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
 import static com.comet.opik.domain.mcpoauth.OAuthConstants.ERROR_INVALID_GRANT;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.REVOKE_PATH;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -112,8 +103,8 @@ class OAuthRefreshRotationIntegrationTest {
         String clientId = minted.clientId();
         String refreshToken = minted.tokens().refreshToken();
 
-        List<RefreshOutcome> outcomes = IntStream.range(0, PARALLEL_REFRESHES)
-                .mapToObj(i -> CompletableFuture.supplyAsync(() -> refresh(clientId, refreshToken)))
+        List<OAuthResourceClient.RefreshOutcome> outcomes = IntStream.range(0, PARALLEL_REFRESHES)
+                .mapToObj(i -> CompletableFuture.supplyAsync(() -> oauthClient.refresh(clientId, refreshToken)))
                 .toList()
                 .stream()
                 .map(CompletableFuture::join)
@@ -132,8 +123,8 @@ class OAuthRefreshRotationIntegrationTest {
 
         // Whichever copy of the credentials the host keeps must keep working: every refresh token handed out by
         // the burst rotates on its own.
-        for (RefreshOutcome outcome : outcomes) {
-            RefreshOutcome next = refresh(clientId, outcome.tokens().refreshToken());
+        for (OAuthResourceClient.RefreshOutcome outcome : outcomes) {
+            OAuthResourceClient.RefreshOutcome next = oauthClient.refresh(clientId, outcome.tokens().refreshToken());
             assertThat(next.status())
                     .as("a refresh token handed out during the burst rotates normally afterwards")
                     .isEqualTo(Response.Status.OK.getStatusCode());
@@ -147,22 +138,27 @@ class OAuthRefreshRotationIntegrationTest {
         String clientId = minted.clientId();
         String original = minted.tokens().refreshToken();
 
-        RefreshOutcome rotation = refresh(clientId, original);
+        OAuthResourceClient.RefreshOutcome rotation = oauthClient.refresh(clientId, original);
         assertThat(rotation.status()).isEqualTo(Response.Status.OK.getStatusCode());
 
         String latest = rotation.tokens().refreshToken();
+        List<String> issued = new ArrayList<>(List.of(rotation.tokens().refreshToken()));
         for (int retry = 1; retry <= MAX_RETRIES; retry++) {
-            RefreshOutcome allowed = refresh(clientId, original);
+            OAuthResourceClient.RefreshOutcome allowed = oauthClient.refresh(clientId, original);
             assertThat(allowed.status()).as("retry %d of %d is still served", retry, MAX_RETRIES)
                     .isEqualTo(Response.Status.OK.getStatusCode());
+            assertThat(allowed.tokens().accessToken()).isNotBlank();
+            assertThat(allowed.tokens().refreshToken()).isNotBlank();
+            issued.add(allowed.tokens().refreshToken());
             latest = allowed.tokens().refreshToken();
         }
+        assertThat(issued).as("every served retry carries its own refresh token").doesNotHaveDuplicates();
 
-        RefreshOutcome overCap = refresh(clientId, original);
+        OAuthResourceClient.RefreshOutcome overCap = oauthClient.refresh(clientId, original);
         assertThat(overCap.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(overCap.error().error()).isEqualTo(ERROR_INVALID_GRANT);
 
-        RefreshOutcome afterKill = refresh(clientId, latest);
+        OAuthResourceClient.RefreshOutcome afterKill = oauthClient.refresh(clientId, latest);
         assertThat(afterKill.status()).as("the family is gone, including the pairs handed out before the cap")
                 .isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(afterKill.error().error()).isEqualTo(ERROR_INVALID_GRANT);
@@ -175,36 +171,14 @@ class OAuthRefreshRotationIntegrationTest {
         String clientId = minted.clientId();
         String original = minted.tokens().refreshToken();
 
-        RefreshOutcome rotation = refresh(clientId, original);
+        OAuthResourceClient.RefreshOutcome rotation = oauthClient.refresh(clientId, original);
         assertThat(rotation.status()).isEqualTo(Response.Status.OK.getStatusCode());
 
-        var revoke = new Form()
-                .param(PARAM_TOKEN, rotation.tokens().refreshToken())
-                .param(PARAM_CLIENT_ID, clientId);
-        try (Response response = client.target(baseURI + REVOKE_PATH).request().post(Entity.form(revoke))) {
-            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-        }
+        oauthClient.revoke(clientId, rotation.tokens().refreshToken());
 
-        RefreshOutcome retry = refresh(clientId, original);
+        OAuthResourceClient.RefreshOutcome retry = oauthClient.refresh(clientId, original);
         assertThat(retry.status()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
         assertThat(retry.error().error()).isEqualTo(ERROR_INVALID_GRANT);
     }
 
-    private RefreshOutcome refresh(String clientId, String refreshToken) {
-        var form = new Form()
-                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
-                .param(PARAM_CLIENT_ID, clientId)
-                .param(PARAM_REFRESH_TOKEN, refreshToken);
-
-        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
-            int status = response.getStatus();
-            if (status == Response.Status.OK.getStatusCode()) {
-                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
-            }
-            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
-        }
-    }
-
-    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
-    }
 }

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -25,9 +25,14 @@ import org.testcontainers.mysql.MySQLContainer;
 import ru.vyarus.dropwizard.guice.test.ClientSupport;
 import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
@@ -51,6 +56,7 @@ class OAuthRefreshRotationIntegrationTest {
     private static final int PARALLEL_REFRESHES = 5;
     // One rotation plus this many in-grace retries may be served off a single refresh token.
     private static final int MAX_RETRIES = PARALLEL_REFRESHES - 1;
+    private static final Duration BURST_TIMEOUT = Duration.ofSeconds(30);
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -103,12 +109,28 @@ class OAuthRefreshRotationIntegrationTest {
         String clientId = minted.clientId();
         String refreshToken = minted.tokens().refreshToken();
 
-        List<OAuthResourceClient.RefreshOutcome> outcomes = IntStream.range(0, PARALLEL_REFRESHES)
-                .mapToObj(i -> CompletableFuture.supplyAsync(() -> oauthClient.refresh(clientId, refreshToken)))
-                .toList()
-                .stream()
-                .map(CompletableFuture::join)
-                .toList();
+        // One dedicated thread per request, all released by the same barrier, so the requests really are in
+        // flight together rather than trickling through a shared pool one at a time.
+        var barrier = new CyclicBarrier(PARALLEL_REFRESHES);
+        ExecutorService workers = Executors.newFixedThreadPool(PARALLEL_REFRESHES);
+        List<OAuthResourceClient.RefreshOutcome> outcomes;
+        try {
+            outcomes = IntStream.range(0, PARALLEL_REFRESHES)
+                    .mapToObj(i -> CompletableFuture.supplyAsync(() -> {
+                        try {
+                            barrier.await(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS);
+                        } catch (Exception e) {
+                            throw new IllegalStateException("burst did not line up", e);
+                        }
+                        return oauthClient.refresh(clientId, refreshToken);
+                    }, workers))
+                    .toList()
+                    .stream()
+                    .map(future -> future.orTimeout(BURST_TIMEOUT.toSeconds(), TimeUnit.SECONDS).join())
+                    .toList();
+        } finally {
+            workers.shutdownNow();
+        }
 
         assertThat(outcomes)
                 .as("every parallel refresh with the same refresh token is answered with a token pair")

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshRotationIntegrationTest.java
@@ -1,0 +1,153 @@
+package com.comet.opik.domain.mcpoauth;
+
+import com.comet.opik.api.resources.oauth.OAuthError;
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Refresh-token rotation as an MCP host actually exercises it. Hosts (Claude.ai, Codex, Claude Code) fire several
+ * tool calls in parallel; when the access token expires every one of them gets a 401 and every one of them runs the
+ * {@code refresh_token} grant with the same stored refresh token. Only one of those requests can win the rotation.
+ * The losers must still walk away with a usable token pair: a host that receives {@code invalid_grant} on refresh
+ * discards its credentials and forces the user to re-authorize.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+@DisplayName("OAuth Refresh Rotation Integration Test")
+class OAuthRefreshRotationIntegrationTest {
+
+    private static final String REDIRECT_URI = "http://localhost:1234/callback";
+    private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
+    private static final int PARALLEL_REFRESHES = 5;
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE, MYSQL, ZOOKEEPER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        // Local auth, so consent resolves to the default workspace without a session. The grace window is long
+        // enough that every request of a parallel burst lands inside it.
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("mcpOAuth.enabled", "true"),
+                                new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
+                                new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
+                                new CustomConfig("mcpOAuth.refreshRotationGrace", "PT2M")))
+                        .build());
+    }
+
+    private String baseURI;
+    private ClientSupport client;
+    private OAuthResourceClient oauthClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        this.oauthClient = new OAuthResourceClient(clientSupport, baseURI, REDIRECT_URI, RESOURCE_URI);
+    }
+
+    @Test
+    @DisplayName("parallel refreshes with the same refresh token all receive a usable token pair")
+    void parallelRefreshesWithSameToken_allReceiveUsableTokens() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        String refreshToken = minted.tokens().refreshToken();
+
+        List<RefreshOutcome> outcomes = IntStream.range(0, PARALLEL_REFRESHES)
+                .mapToObj(i -> CompletableFuture.supplyAsync(() -> refresh(clientId, refreshToken)))
+                .toList()
+                .stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        assertThat(outcomes)
+                .as("every parallel refresh with the same refresh token is answered with a token pair")
+                .allSatisfy(outcome -> {
+                    assertThat(outcome.status()).isEqualTo(Response.Status.OK.getStatusCode());
+                    assertThat(outcome.tokens().accessToken()).isNotBlank();
+                    assertThat(outcome.tokens().refreshToken()).isNotBlank();
+                });
+        assertThat(outcomes).extracting(outcome -> outcome.tokens().refreshToken())
+                .as("each answer of the burst carries its own refresh token")
+                .doesNotHaveDuplicates();
+
+        // Whichever copy of the credentials the host keeps must keep working: every refresh token handed out by
+        // the burst rotates on its own.
+        for (RefreshOutcome outcome : outcomes) {
+            RefreshOutcome next = refresh(clientId, outcome.tokens().refreshToken());
+            assertThat(next.status())
+                    .as("a refresh token handed out during the burst rotates normally afterwards")
+                    .isEqualTo(Response.Status.OK.getStatusCode());
+        }
+    }
+
+    private RefreshOutcome refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            int status = response.getStatus();
+            if (status == Response.Status.OK.getStatusCode()) {
+                return new RefreshOutcome(status, response.readEntity(TokenResponse.class), null);
+            }
+            return new RefreshOutcome(status, null, response.readEntity(OAuthError.class));
+        }
+    }
+
+    private record RefreshOutcome(int status, TokenResponse tokens, OAuthError error) {
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
@@ -1,0 +1,152 @@
+package com.comet.opik.domain.mcpoauth;
+
+import com.comet.opik.api.resources.utils.ClickHouseContainerUtils;
+import com.comet.opik.api.resources.utils.MigrationUtils;
+import com.comet.opik.api.resources.utils.MySQLContainerUtils;
+import com.comet.opik.api.resources.utils.RedisContainerUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.AppContextConfig;
+import com.comet.opik.api.resources.utils.TestDropwizardAppExtensionUtils.CustomConfig;
+import com.comet.opik.api.resources.utils.TestUtils;
+import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
+import com.comet.opik.extensions.DropwizardAppExtensionProvider;
+import com.comet.opik.extensions.RegisterApp;
+import com.redis.testcontainers.RedisContainer;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.clickhouse.ClickHouseContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.mysql.MySQLContainer;
+import ru.vyarus.dropwizard.guice.test.ClientSupport;
+import ru.vyarus.dropwizard.guice.test.jupiter.ext.TestDropwizardAppExtension;
+import ru.vyarus.guicey.jdbi3.tx.TransactionTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
+import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Refresh-token lifetime is sliding: a connector that keeps rotating stays connected, an idle one expires after
+ * {@code refreshTokenTtl}, and no family outlives {@code refreshTokenAbsoluteTtl} from its authorization. Before
+ * this, every rotation inherited the first token's expiry, so an actively used Claude.ai connector was thrown out
+ * exactly seven days after it was connected.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DropwizardAppExtensionProvider.class)
+@DisplayName("OAuth Refresh Sliding Expiry Integration Test")
+class OAuthRefreshSlidingExpiryIntegrationTest {
+
+    private static final String REDIRECT_URI = "http://localhost:1234/callback";
+    private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
+    private static final Duration IDLE_TTL = Duration.ofMinutes(2);
+    // The cap only bites once more than (ABSOLUTE - IDLE) has elapsed since authorization: 3s here, so the first
+    // rotation (after ~1s) is still sliding and the second (after ~5s) is capped, each with a ~2s margin.
+    private static final Duration ABSOLUTE_TTL = IDLE_TTL.plusSeconds(3);
+    private static final Duration FIRST_PAUSE = Duration.ofSeconds(1);
+    private static final Duration SECOND_PAUSE = Duration.ofSeconds(4);
+    private static final Duration TOLERANCE = Duration.ofSeconds(1);
+
+    private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
+    private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
+    private final ClickHouseContainer CLICKHOUSE = ClickHouseContainerUtils.newClickHouseContainer(ZOOKEEPER);
+    private final MySQLContainer MYSQL = MySQLContainerUtils.newMySQLContainer();
+
+    @RegisterApp
+    private final TestDropwizardAppExtension app;
+
+    {
+        Startables.deepStart(REDIS, CLICKHOUSE, MYSQL, ZOOKEEPER).join();
+
+        var databaseAnalyticsFactory = ClickHouseContainerUtils.newDatabaseAnalyticsFactory(CLICKHOUSE, DATABASE_NAME);
+
+        MigrationUtils.runMysqlDbMigration(MYSQL);
+        MigrationUtils.runClickhouseDbMigration(CLICKHOUSE);
+
+        app = TestDropwizardAppExtensionUtils.newTestDropwizardAppExtension(
+                AppContextConfig.builder()
+                        .jdbcUrl(MYSQL.getJdbcUrl())
+                        .databaseAnalyticsFactory(databaseAnalyticsFactory)
+                        .redisUrl(REDIS.getRedisURI())
+                        .customConfigs(List.of(
+                                new CustomConfig("mcpOAuth.enabled", "true"),
+                                new CustomConfig("mcpOAuth.baseUrl", "http://localhost:8080"),
+                                new CustomConfig("mcpOAuth.mcpResourceUri", RESOURCE_URI),
+                                new CustomConfig("mcpOAuth.refreshTokenTtl", IDLE_TTL.toString()),
+                                new CustomConfig("mcpOAuth.refreshTokenAbsoluteTtl", ABSOLUTE_TTL.toString())))
+                        .build());
+    }
+
+    private String baseURI;
+    private ClientSupport client;
+    private TransactionTemplate transactionTemplate;
+    private OAuthResourceClient oauthClient;
+
+    @BeforeAll
+    void setUpAll(ClientSupport clientSupport, TransactionTemplate transactionTemplate) {
+        this.client = clientSupport;
+        this.baseURI = TestUtils.getBaseUrl(clientSupport);
+        this.transactionTemplate = transactionTemplate;
+        this.oauthClient = new OAuthResourceClient(clientSupport, baseURI, REDIRECT_URI, RESOURCE_URI);
+    }
+
+    @Test
+    @DisplayName("each rotation renews the refresh lifetime, up to the family's absolute lifetime")
+    void rotationRenewsRefreshLifetime_untilAbsoluteCap() throws InterruptedException {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+
+        McpOAuthToken original = fetchRefreshRow(minted.tokens().refreshToken());
+        Instant familyStart = original.issuedAt();
+        assertThat(original.expiresAt()).isCloseTo(familyStart.plus(IDLE_TTL), within(TOLERANCE));
+
+        Thread.sleep(FIRST_PAUSE.toMillis());
+        TokenResponse first = refresh(clientId, minted.tokens().refreshToken());
+        McpOAuthToken afterFirst = fetchRefreshRow(first.refreshToken());
+        assertThat(afterFirst.expiresAt())
+                .as("the rotated refresh token lives a full idle TTL from the rotation, not from the authorization")
+                .isAfter(original.expiresAt())
+                .isCloseTo(afterFirst.issuedAt().plus(IDLE_TTL), within(TOLERANCE));
+
+        Thread.sleep(SECOND_PAUSE.toMillis());
+        TokenResponse second = refresh(clientId, first.refreshToken());
+        McpOAuthToken afterSecond = fetchRefreshRow(second.refreshToken());
+        assertThat(afterSecond.expiresAt())
+                .as("once idle TTL from now would pass the family's absolute lifetime, the cap wins")
+                .isCloseTo(familyStart.plus(ABSOLUTE_TTL), within(TOLERANCE))
+                .isBefore(afterSecond.issuedAt().plus(IDLE_TTL).minusSeconds(1));
+    }
+
+    private TokenResponse refresh(String clientId, String refreshToken) {
+        var form = new Form()
+                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
+                .param(PARAM_CLIENT_ID, clientId)
+                .param(PARAM_REFRESH_TOKEN, refreshToken);
+
+        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
+            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+            return response.readEntity(TokenResponse.class);
+        }
+    }
+
+    private McpOAuthToken fetchRefreshRow(String refreshToken) {
+        return transactionTemplate.inTransaction(handle -> handle.attach(McpOAuthTokenDAO.class)
+                .fetch(McpOAuthTokenUtils.hash(refreshToken))
+                .orElseThrow());
+    }
+}

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
@@ -12,9 +12,6 @@ import com.comet.opik.api.resources.utils.resources.OAuthResourceClient;
 import com.comet.opik.extensions.DropwizardAppExtensionProvider;
 import com.comet.opik.extensions.RegisterApp;
 import com.redis.testcontainers.RedisContainer;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Form;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,11 +30,6 @@ import java.time.Instant;
 import java.util.List;
 
 import static com.comet.opik.api.resources.utils.ClickHouseContainerUtils.DATABASE_NAME;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.GRANT_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_CLIENT_ID;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_GRANT_TYPE;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.PARAM_REFRESH_TOKEN;
-import static com.comet.opik.domain.mcpoauth.OAuthConstants.TOKEN_PATH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -55,12 +47,12 @@ class OAuthRefreshSlidingExpiryIntegrationTest {
     private static final String REDIRECT_URI = "http://localhost:1234/callback";
     private static final String RESOURCE_URI = "http://localhost:8080/api/v1/mcp";
     private static final Duration IDLE_TTL = Duration.ofMinutes(2);
-    // The cap only bites once more than (ABSOLUTE - IDLE) has elapsed since authorization: 3s here, so the first
-    // rotation (after ~1s) is still sliding and the second (after ~5s) is capped, each with a ~2s margin.
-    private static final Duration ABSOLUTE_TTL = IDLE_TTL.plusSeconds(3);
-    private static final Duration FIRST_PAUSE = Duration.ofSeconds(1);
-    private static final Duration SECOND_PAUSE = Duration.ofSeconds(4);
-    private static final Duration TOLERANCE = Duration.ofSeconds(1);
+    // The cap only bites once more than (ABSOLUTE - IDLE) has elapsed since authorization: 6s here, so the first
+    // rotation (after ~2s) is still sliding and the second (after ~10s) is capped, each with a ~4s margin.
+    private static final Duration ABSOLUTE_TTL = IDLE_TTL.plusSeconds(6);
+    private static final Duration FIRST_PAUSE = Duration.ofSeconds(2);
+    private static final Duration SECOND_PAUSE = Duration.ofSeconds(8);
+    private static final Duration TOLERANCE = Duration.ofSeconds(2);
 
     private final RedisContainer REDIS = RedisContainerUtils.newRedisContainer();
     private final GenericContainer<?> ZOOKEEPER = ClickHouseContainerUtils.newZookeeperContainer();
@@ -113,35 +105,29 @@ class OAuthRefreshSlidingExpiryIntegrationTest {
 
         McpOAuthToken original = fetchRefreshRow(minted.tokens().refreshToken());
         Instant familyStart = original.issuedAt();
+        Instant absoluteExpiry = original.absoluteExpiresAt();
+        assertThat(absoluteExpiry).as("the authorization fixes the family's absolute expiry")
+                .isCloseTo(familyStart.plus(ABSOLUTE_TTL), within(TOLERANCE));
         assertThat(original.expiresAt()).isCloseTo(familyStart.plus(IDLE_TTL), within(TOLERANCE));
 
         Thread.sleep(FIRST_PAUSE.toMillis());
-        TokenResponse first = refresh(clientId, minted.tokens().refreshToken());
+        TokenResponse first = oauthClient.refreshOk(clientId, minted.tokens().refreshToken());
         McpOAuthToken afterFirst = fetchRefreshRow(first.refreshToken());
+        assertThat(afterFirst.absoluteExpiresAt()).as("rotation carries the family's absolute expiry forward")
+                .isEqualTo(absoluteExpiry);
         assertThat(afterFirst.expiresAt())
                 .as("the rotated refresh token lives a full idle TTL from the rotation, not from the authorization")
                 .isAfter(original.expiresAt())
                 .isCloseTo(afterFirst.issuedAt().plus(IDLE_TTL), within(TOLERANCE));
 
         Thread.sleep(SECOND_PAUSE.toMillis());
-        TokenResponse second = refresh(clientId, first.refreshToken());
+        TokenResponse second = oauthClient.refreshOk(clientId, first.refreshToken());
         McpOAuthToken afterSecond = fetchRefreshRow(second.refreshToken());
+        assertThat(afterSecond.absoluteExpiresAt()).isEqualTo(absoluteExpiry);
         assertThat(afterSecond.expiresAt())
                 .as("once idle TTL from now would pass the family's absolute lifetime, the cap wins")
-                .isCloseTo(familyStart.plus(ABSOLUTE_TTL), within(TOLERANCE))
+                .isEqualTo(absoluteExpiry)
                 .isBefore(afterSecond.issuedAt().plus(IDLE_TTL).minusSeconds(1));
-    }
-
-    private TokenResponse refresh(String clientId, String refreshToken) {
-        var form = new Form()
-                .param(PARAM_GRANT_TYPE, GRANT_REFRESH_TOKEN)
-                .param(PARAM_CLIENT_ID, clientId)
-                .param(PARAM_REFRESH_TOKEN, refreshToken);
-
-        try (Response response = client.target(baseURI + TOKEN_PATH).request().post(Entity.form(form))) {
-            assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
-            return response.readEntity(TokenResponse.class);
-        }
     }
 
     private McpOAuthToken fetchRefreshRow(String refreshToken) {

--- a/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/domain/mcpoauth/OAuthRefreshSlidingExpiryIntegrationTest.java
@@ -130,6 +130,35 @@ class OAuthRefreshSlidingExpiryIntegrationTest {
                 .isBefore(afterSecond.issuedAt().plus(IDLE_TTL).minusSeconds(1));
     }
 
+    @Test
+    @DisplayName("a refresh token minted before the absolute expiry existed gets its cap at the next rotation")
+    void legacyTokenWithoutAbsoluteExpiry_capStartsAtNextRotation() {
+        var minted = oauthClient.mintArtifacts();
+        String clientId = minted.clientId();
+        clearAbsoluteExpiry(minted.tokens().refreshToken());
+        assertThat(fetchRefreshRow(minted.tokens().refreshToken()).absoluteExpiresAt()).isNull();
+
+        TokenResponse first = oauthClient.refreshOk(clientId, minted.tokens().refreshToken());
+        McpOAuthToken afterFirst = fetchRefreshRow(first.refreshToken());
+        assertThat(afterFirst.absoluteExpiresAt())
+                .as("the first rotation of a legacy token starts the family's absolute lifetime from that rotation")
+                .isNotNull()
+                .isCloseTo(afterFirst.issuedAt().plus(ABSOLUTE_TTL), within(TOLERANCE));
+
+        TokenResponse second = oauthClient.refreshOk(clientId, first.refreshToken());
+        assertThat(fetchRefreshRow(second.refreshToken()).absoluteExpiresAt())
+                .as("later rotations carry that cap forward unchanged")
+                .isEqualTo(afterFirst.absoluteExpiresAt());
+    }
+
+    /** Makes a token row look like one minted before {@code absolute_expires_at} existed. */
+    private void clearAbsoluteExpiry(String refreshToken) {
+        transactionTemplate.inTransaction(handle -> handle
+                .createUpdate("UPDATE mcp_oauth_tokens SET absolute_expires_at = NULL WHERE token_hash = :hash")
+                .bind("hash", McpOAuthTokenUtils.hash(refreshToken))
+                .execute());
+    }
+
     private McpOAuthToken fetchRefreshRow(String refreshToken) {
         return transactionTemplate.inTransaction(handle -> handle.attach(McpOAuthTokenDAO.class)
                 .fetch(McpOAuthTokenUtils.hash(refreshToken))

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/McpOAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/McpOAuthConfigTest.java
@@ -80,6 +80,12 @@ class McpOAuthConfigTest {
                 arguments("refreshTokenTtlPositive", "zero idle TTL",
                         (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
                                 .refreshTokenTtl(Duration.ZERO)),
+                arguments("refreshTokenAbsoluteTtlPositive", "absolute TTL above one year",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshTokenAbsoluteTtl(Duration.ofDays(366))),
+                arguments("refreshTokenTtlPositive", "idle TTL above one year",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshTokenTtl(Duration.ofDays(366))),
                 arguments("refreshLockLeasePositive", "zero lock lease",
                         (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
                                 .refreshLockLease(Duration.ZERO)),

--- a/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/McpOAuthConfigTest.java
+++ b/apps/opik-backend/src/test/java/com/comet/opik/infrastructure/McpOAuthConfigTest.java
@@ -1,0 +1,112 @@
+package com.comet.opik.infrastructure;
+
+import io.dropwizard.jersey.validation.Validators;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("MCP OAuth Config Validation Test")
+class McpOAuthConfigTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validators.newValidator();
+    }
+
+    private static McpOAuthConfig.McpOAuthConfigBuilder validConfig() {
+        return McpOAuthConfig.builder()
+                .enabled(true)
+                .baseUrl("https://www.comet.com/opik")
+                .accessTokenTtl(Duration.ofHours(1))
+                .refreshTokenTtl(Duration.ofDays(7))
+                .refreshTokenAbsoluteTtl(Duration.ofDays(30))
+                .codeTtl(Duration.ofSeconds(60))
+                .refreshRotationGrace(Duration.ofMinutes(2))
+                .refreshRotationMaxRetries(10)
+                .refreshLockLease(Duration.ofSeconds(10))
+                .scrubLockTimeout(Duration.ofMinutes(5))
+                .scrubLockWaitTime(Duration.ofMillis(100));
+    }
+
+    @Test
+    @DisplayName("the shipped defaults pass validation")
+    void validConfigHasNoViolations() {
+        assertThat(validator.validate(validConfig().build())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("a config block that predates the newer settings still validates through the Java defaults")
+    void legacyConfigBlockFallsBackToDefaults() {
+        var config = McpOAuthConfig.builder()
+                .enabled(true)
+                .baseUrl("https://www.comet.com/opik")
+                .accessTokenTtl(Duration.ofHours(1))
+                .refreshTokenTtl(Duration.ofDays(7))
+                .codeTtl(Duration.ofSeconds(60))
+                .refreshRotationGrace(Duration.ofSeconds(30))
+                .scrubLockTimeout(Duration.ofMinutes(5))
+                .scrubLockWaitTime(Duration.ofMillis(100))
+                .build();
+
+        assertThat(validator.validate(config)).isEmpty();
+        assertThat(config.getRefreshTokenAbsoluteTtl()).isEqualTo(Duration.ofDays(30));
+        assertThat(config.getRefreshRotationMaxRetries()).isEqualTo(10);
+        assertThat(config.getRefreshLockLease()).isEqualTo(Duration.ofSeconds(10));
+    }
+
+    private static Stream<Arguments> rejectedValues() {
+        return Stream.of(
+                arguments("refreshTokenAbsoluteTtlPositive", "zero absolute TTL",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshTokenAbsoluteTtl(Duration.ZERO)),
+                arguments("refreshTokenAbsoluteTtlPositive", "negative absolute TTL",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshTokenAbsoluteTtl(Duration.ofDays(-1))),
+                arguments("refreshTokenTtlPositive", "zero idle TTL",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshTokenTtl(Duration.ZERO)),
+                arguments("refreshLockLeasePositive", "zero lock lease",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshLockLease(Duration.ZERO)),
+                arguments("refreshRotationMaxRetries", "zero retry cap",
+                        (UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder>) b -> b
+                                .refreshRotationMaxRetries(0)));
+    }
+
+    @ParameterizedTest(name = "{1} is rejected")
+    @MethodSource("rejectedValues")
+    void invalidValuesAreRejected(String property, String description,
+            UnaryOperator<McpOAuthConfig.McpOAuthConfigBuilder> mutate) {
+        Set<ConstraintViolation<McpOAuthConfig>> violations = validator.validate(mutate.apply(validConfig()).build());
+
+        assertThat(violations).as(description)
+                .anyMatch(violation -> violation.getPropertyPath().toString().equals(property));
+    }
+
+    @Test
+    @DisplayName("an absolute TTL shorter than the idle TTL is not an error: the idle TTL wins as the effective cap")
+    void absoluteTtlShorterThanIdle_isRaisedToIdle() {
+        var config = validConfig()
+                .refreshTokenTtl(Duration.ofDays(60))
+                .refreshTokenAbsoluteTtl(Duration.ofDays(30))
+                .build();
+
+        assertThat(validator.validate(config)).isEmpty();
+        assertThat(config.effectiveRefreshTokenAbsoluteTtl()).isEqualTo(Duration.ofDays(60));
+    }
+}

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -298,9 +298,9 @@ mcpOAuth:
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: PT60S
-  # Default: PT30S
-  # Description: Grace window during which a just-rotated refresh token is still accepted
-  refreshRotationGrace: PT30S
+  # Default: PT2M
+  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair; after it, re-presentation is treated as reuse and revokes the whole token family
+  refreshRotationGrace: PT2M
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: PT5M

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -296,7 +296,7 @@ mcpOAuth:
   # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
   refreshTokenTtl: P7D
   # Default: P30D
-  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl
   refreshTokenAbsoluteTtl: P30D
   # Default: PT60S
   # Description: Authorization code lifetime

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -293,20 +293,23 @@ mcpOAuth:
   # Description: Access token lifetime
   accessTokenTtl: PT1H
   # Default: P7D
-  # Description: Refresh token idle lifetime; sliding, renewed on every rotation
+  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
   refreshTokenTtl: P7D
   # Default: P30D
-  # Description: Absolute lifetime of a token family from the authorization that created it; caps the sliding lifetime
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed
   refreshTokenAbsoluteTtl: P30D
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: PT60S
   # Default: PT2M
-  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair; after it, re-presentation is treated as reuse and revokes the whole token family
+  # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
   refreshRotationGrace: PT2M
   # Default: 10
-  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window; one more re-presentation is treated as reuse and revokes the family
+  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). One more re-presentation than this is treated as reuse and revokes the whole token family
   refreshRotationMaxRetries: 10
+  # Default: PT10S
+  # Description: Lease of the per-family Redis lock under which refresh-token rotation, in-grace retries and revocation run. Must outlast the MySQL transaction that rotates a token; if it lapses mid-rotation a concurrent refresh with the same token may be refused instead of served
+  refreshLockLease: PT10S
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: PT5M

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -293,8 +293,11 @@ mcpOAuth:
   # Description: Access token lifetime
   accessTokenTtl: PT1H
   # Default: P7D
-  # Description: Refresh token absolute lifetime (not sliding)
+  # Description: Refresh token idle lifetime; sliding, renewed on every rotation
   refreshTokenTtl: P7D
+  # Default: P30D
+  # Description: Absolute lifetime of a token family from the authorization that created it; caps the sliding lifetime
+  refreshTokenAbsoluteTtl: P30D
   # Default: PT60S
   # Description: Authorization code lifetime
   codeTtl: PT60S

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -301,6 +301,9 @@ mcpOAuth:
   # Default: PT2M
   # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair; after it, re-presentation is treated as reuse and revokes the whole token family
   refreshRotationGrace: PT2M
+  # Default: 10
+  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window; one more re-presentation is treated as reuse and revokes the family
+  refreshRotationMaxRetries: 10
   # Default: PT5M
   # Description: TTL of the Redis lock held by the scrub job. The lock is held until expiry (not released after the scrub), so keeping it close to the 5-minute schedule prevents staggered replicas from re-scrubbing within the same cycle.
   scrubLockTimeout: PT5M

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -293,10 +293,10 @@ mcpOAuth:
   # Description: Access token lifetime
   accessTokenTtl: PT1H
   # Default: P7D
-  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize
+  # Description: Refresh token idle lifetime. Sliding: every rotation issues the new refresh token with this much lifetime from now, so an actively used connector stays connected; one left unused for this long has to re-authorize. At most 365 days
   refreshTokenTtl: P7D
   # Default: P30D
-  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl
+  # Description: Absolute lifetime of a token family, measured from the authorization that created it. Caps the sliding refresh lifetime: no matter how actively a connector is used, it has to re-authorize once this has elapsed. Never effectively shorter than refreshTokenTtl; at most 365 days
   refreshTokenAbsoluteTtl: P30D
   # Default: PT60S
   # Description: Authorization code lifetime

--- a/apps/opik-backend/src/test/resources/config-test.yml
+++ b/apps/opik-backend/src/test/resources/config-test.yml
@@ -305,7 +305,7 @@ mcpOAuth:
   # Description: Grace window after a refresh-token rotation during which re-presenting the rotated token still mints a token pair (MCP hosts refresh from several parallel tool calls at once); after it, re-presentation is treated as reuse and revokes the whole token family
   refreshRotationGrace: PT2M
   # Default: 10
-  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). One more re-presentation than this is treated as reuse and revokes the whole token family
+  # Description: How many extra token pairs a single rotated refresh token may still mint inside the grace window (one per parallel host request that lost the rotation race). Requests beyond it are refused with invalid_grant one by one; the family and the pairs already handed out stay valid, since hitting the cap is oversubscription, not reuse
   refreshRotationMaxRetries: 10
   # Default: PT10S
   # Description: Lease of the per-family Redis lock under which refresh-token rotation, in-grace retries and revocation run. Must outlast the MySQL transaction that rotates a token; if it lapses mid-rotation a concurrent refresh with the same token may be refused instead of served


### PR DESCRIPTION
## Details
MCP hosts (Claude.ai, Codex, Claude Code) fire several tool calls in parallel; when the access token expires each of them answers the `401 invalid_token` from opik-mcp (OPIK_8252) by running the `refresh_token` grant with the same stored refresh token. Only one request won the rotation and the rest got `invalid_grant`, which hosts treat as "discard credentials, re-authorize" — this is the "hosted connector dies after ~1h, reconnect fixes it" report from BlaBlaCar. Retries landing after the 30s grace also tripped reuse detection and revoked the whole family, including the token the winner had just received.

- Within `refreshRotationGrace` a re-presented rotated refresh token now mints its own access+refresh pair off the same family, for at most `refreshRotationMaxRetries` retries (default 10, `@Positive`).
- Past the grace window nothing changes: `invalid_grant` + family revocation per OAuth 2.1 §4.3.1, committed together with the decision. Inside the window but past the cap only that request is refused; the family and the pairs already handed out stay valid (hitting the cap is oversubscription, not theft).
- Rotation, retry and `/oauth/revoke` run under a Redis lock keyed by `family_id` (`LockService`), so concurrent refreshes serialize and a revocation cannot interleave with minting.
- Default `mcpOAuth.refreshRotationGrace` raised `PT30S` → `PT2M` (prod bursts observed at 33–76s).
- Refresh lifetime is now sliding: a rotated refresh token lives `refreshTokenTtl` (7d) from the rotation, capped by the new `refreshTokenAbsoluteTtl` (default P30D). The cap is fixed at authorization and persisted on every token row (`mcp_oauth_tokens.absolute_expires_at`, migration 000096), so it survives the scrub job deleting older rows; rows minted before the column start their cap at their next rotation. Previously every rotation inherited the first token's expiry, so an actively used connector was thrown out exactly 7 days after connecting — this is what dropped the BlaBlaCar connector on Sep 11 (authorized Sep 3 20:16 UTC, rotated every 1–2h through Sep 10, expired Sep 10 20:16 UTC).
- Under the family lock the presented token's expiry is re-checked, and a token that vanished between the pre-read and the lock revokes the family. The lock lease is `refreshLockLease` (PT10S). New settings have Java-side defaults; the effective absolute TTL is floored at the idle TTL rather than validated, so raising `MCP_OAUTH_REFRESH_TOKEN_TTL` alone cannot block startup.
- `invalid_grant` refusals carry their reason in the logged exception (unknown token / other client / expired at / family revoked / reuse), since the scrub job deletes the rows that would otherwise explain them. The client still only sees `invalid_grant`.

## Change checklist
- [ ] User facing
- [ ] Documentation update
- [x] DB migration (`000096_add_absolute_expires_at_to_mcp_oauth_tokens.sql`, nullable column, no backfill)

## Issues

- OPIK-8351

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5.1
- Scope: root-cause analysis from prod logs, prod reproduction script, fix, tests, PR text
- Human verification: reproduction confirmed against prod by hand (5 parallel refreshes → 1×200 + 4×invalid_grant; replay after grace killed the fresh token); tests reviewed and run locally

## Testing
Red → green (JDK 25, testcontainers MySQL/ClickHouse/Redis):

```
cd apps/opik-backend
mvn test -Dtest=OAuthRefreshRotationIntegrationTest        # fails on main: 1×200, 4×400 invalid_grant
mvn test -Dtest=OAuthRefreshRotationIntegrationTest        # passes with fix
mvn test -Dtest=OAuthRefreshReuseDetectionIntegrationTest  # passes: replay past grace revokes family
mvn test -Dtest=OAuthRefreshSlidingExpiryIntegrationTest    # passes: rotation renews lifetime up to the absolute cap
mvn test -Dtest='OAuthValidateTokenIntegrationTest,OAuthTokenServiceTest,McpOAuthScrubServiceTest,McpOAuthScrubJobTest,OAuthTokenResourceTest'
mvn spotless:apply
```

- `OAuthRefreshRotationIntegrationTest` — register → consent → exchange over HTTP, then: 5 barrier-synchronised parallel `refresh_token` requests with the same token (every response a usable pair, each rotates afterwards); a burst larger than the cap → exactly cap+1 served, the surplus `invalid_grant`, and every served pair still rotates; sequential retries past the cap refused one by one with the family alive; a retry after the client revoked the family → `invalid_grant`.
- `OAuthRefreshReuseDetectionIntegrationTest` — own app with `refreshRotationGrace=PT1S`: replay after the window → `invalid_grant`, and the legitimately rotated token is revoked too.
- `McpOAuthConfigTest` — validator fixture: shipped defaults, a legacy config block without the new settings, rejected zero/negative durations and retry cap, the idle-TTL floor.
- `OAuthRefreshSlidingExpiryIntegrationTest` — own app with `refreshTokenTtl=PT2M`, `refreshTokenAbsoluteTtl=PT2M6S`: the persisted absolute expiry is carried through both rotations, the first rotation's refresh row expires a full idle TTL after the rotation (later than the original), the second is capped exactly at the persisted absolute expiry; a legacy row without `absolute_expires_at` gets its cap at the next rotation and keeps it.
- Existing MCP OAuth suites green (`OAuthValidateTokenIntegrationTest`, `OAuthTokenServiceTest`, `OAuthTokenResourceTest`, `OAuthClientServiceTest`, `McpOAuthScrubServiceTest`, `McpOAuthScrubJobTest`). `McpClientConnectionIntegrationTest` was not re-run locally (ClickHouse replicated-table migration clashes when several testcontainer suites share one JVM run); CI covers it.

## Documentation
`config.yml`: `refreshRotationGrace` description updated; new `refreshRotationMaxRetries`, `refreshTokenAbsoluteTtl` and `refreshLockLease` documented. No user-facing docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
