### PR TITLE
[NA] [DOCS] docs: coding agent pages (Claude Code, GitHub Copilot) with Cost Intelligence call-outs

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/cost_intelligence/overview.mdx
@@ -20,6 +20,13 @@ Cost Intelligence closes that gap. It captures every coding-agent API call on th
   workspace.
 </Note>
 
+<Callout type="info">
+  Here to **review** what your coding agents did, read the conversations, evaluate and share
+  sessions, rather than reduce spend? That is Opik tracing, not Cost Intelligence. Go to
+  [Observability for coding agents](/integrations/coding-agents) for the per-agent setup. The two
+  run side by side.
+</Callout>
+
 ## How it works
 
 Each developer machine runs its own local `opik-cipx` daemon. The coding agent talks to it over the loopback interface, and the daemon forwards every call to the provider unchanged — there is no shared collector, and none of your traffic routes through Comet. What ships to your Opik workspace is a separate, asynchronous stream of metadata-only spans: token counts, costs, and structure, [never content](/cost-intelligence/data-privacy-security). The diagram shows Claude Code on the plugin path, the most common setup; see [Installation](/cost-intelligence/install/overview) for the other agents and rollout paths.

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-code.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-code.mdx
@@ -178,7 +178,12 @@ For the full variable reference, endpoint modes and validation steps, see
 
 1. Run a short Claude Code turn that uses a tool, for example "list the files in this directory".
 2. Open the target project in Opik (`claude-code` for the plugin, your `projectName` for OTel).
-3. Confirm the trace has the prompt as input, the answer as output, and one span per tool call.
+3. Confirm the trace carries content:
+   - **Plugin:** the trace input is your prompt and the trace output is the assistant's answer.
+   - **Native OTel:** the trace is named `claude_code.interaction`, its input is your prompt, and
+     the model's response is on the `claude_code.llm_request` spans (with model, tokens and cost).
+     The trace-level output stays empty on this path. Tool calls appear as `claude_code.tool` spans
+     with their input and result.
 
 ## Source references
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-code.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/claude-code.mdx
@@ -1,0 +1,187 @@
+---
+description: Log Claude Code sessions to Opik with the Opik plugin, or export Claude Code's native OpenTelemetry spans to Opik, and know which one to pick.
+headline: Claude Code
+og:description: Two ways to get Claude Code sessions into Opik, the Opik Claude Code plugin (recommended) or Claude Code's native OTel trace export, with content and endpoint caveats for each.
+og:site_name: Opik Documentation
+og:title: Claude Code Integration - Opik
+title: Observability for Claude Code with Opik
+---
+
+[Claude Code](https://claude.ai/code) sessions can be logged to Opik in two ways: with the
+**Opik Claude Code plugin**, which hooks into Claude Code directly and captures every turn, tool
+call and subagent with full content, or through Claude Code's **native OpenTelemetry export**,
+which sends spans to Opik's OTLP endpoint. Most teams should start with the plugin.
+
+## Quick start
+
+Inside Claude Code:
+
+```
+/plugin marketplace add comet-ml/opik-claude-code-plugin
+/plugin install opik
+```
+
+In a terminal, then restart Claude Code:
+
+```bash
+pip install opik && opik configure
+```
+
+Back inside Claude Code:
+
+```
+/opik:trace-claude-code start
+```
+
+Your next turn appears as a trace in the `claude-code` project in Opik. The rest of this page
+explains the two options in full, how to route traces to a project or workspace, and how to
+validate.
+
+## When this guide applies
+
+Use this guide if you want to **review Claude Code conversations in Opik**: what developers asked,
+what the model answered, which tools ran, how subagents nested, and what each turn cost.
+
+<Callout type="info">
+  This guide covers telemetry flowing **from Claude Code to Opik**. For the other direction,
+  letting Claude Code read your traces, score outputs and run evaluations from chat, register the
+  [Opik MCP server](/mcp-server) with it. One command, `uvx opik mcp configure`, installs the server
+  and the Opik skills. The two are independent, and you can use either or both.
+</Callout>
+
+<Tip title="Looking to reduce Claude Code spend rather than review sessions?">
+  Opik shows you **what Claude Code did**. If the question is **where the tokens went and how to
+  spend fewer of them**, that is [Cost Intelligence](/cost-intelligence/overview): every Claude
+  Code API call captured on the wire and attributed to system prompt, tool schemas, MCP servers,
+  skills, memory and user input, per user and per repository, with policy controls that typically
+  cut spend by 15% to 30%. Only counts and metadata leave the machine, never content. Claude Code
+  is Cost Intelligence's primary agent, and it runs side by side with the Opik plugin.
+</Tip>
+
+## Choose a path
+
+| | Opik plugin (recommended) | Native OTel export |
+| --- | --- | --- |
+| **Setup** | Two slash commands in Claude Code | Environment variables before every session |
+| **Prompt, response and tool content** | Captured by default | Redacted by default; response text needs a beta flag and only in non-interactive runs |
+| **Subagents** | Nested under the parent Task span | Flat `claude_code.*` spans |
+| **Project / workspace routing** | `OPIK_CC_PROJECT`, `OPIK_CC_WORKSPACE` | `projectName` and `Comet-Workspace` headers |
+| **Fleet rollout** | Plugin marketplace, or Claude managed settings | Managed settings can set the env vars |
+| **Status** | GA | Claude Code tracing is beta |
+
+## Option 1: Opik Claude Code plugin
+
+The [opik-claude-code-plugin](https://github.com/comet-ml/opik-claude-code-plugin) turns each
+conversation turn into an Opik trace. Tool calls, thoughts and responses become spans, and
+subagent invocations nest under their parent `Task` span.
+
+### Install
+
+From inside Claude Code:
+
+```
+/plugin marketplace add comet-ml/opik-claude-code-plugin
+/plugin install opik
+```
+
+Restart any running Claude Code session; hooks only load when a session starts.
+
+### Configure the connection
+
+```bash
+pip install opik
+opik configure
+```
+
+This writes `~/.opik.config` with your Opik URL, API key and workspace. Self-hosted and
+Enterprise deployments enter their own URL at the prompt.
+
+### Turn tracing on
+
+```
+/opik:trace-claude-code start            # this project
+/opik:trace-claude-code start --global   # every project on this machine
+/opik:trace-claude-code status
+```
+
+Traces land in the `claude-code` project by default. To route them elsewhere without touching
+the Opik SDK settings the rest of your code uses:
+
+```bash wordWrap
+export OPIK_CC_PROJECT="my-project"
+export OPIK_CC_WORKSPACE="my-workspace"
+```
+
+or add `cc_project_name` / `cc_workspace` under `[opik]` in `~/.opik.config`.
+
+### Embed Claude Code in a larger trace
+
+If Claude Code runs inside a workflow you already trace with Opik, attach its spans to that trace:
+
+```bash wordWrap
+export OPIK_CC_PARENT_TRACE_ID="<existing-trace-id>"
+export OPIK_CC_ROOT_SPAN_ID="<parent-span-id>"
+```
+
+### What you see in Opik
+
+Open the project and pick a trace: the user prompt is the trace input, the assistant's final
+answer is the output, and each tool call is a span with its input and result. The **Threads** tab
+groups turns from the same session. Token usage and cost are recorded on each LLM span.
+
+## Option 2: Native OpenTelemetry export
+
+Claude Code can emit OTel **metrics**, **events** and, in beta, **trace spans**. Opik ingests the
+trace spans only. Use this path when you already ship Claude Code telemetry to an OTel collector
+and want Opik as one more destination, or when you cannot install plugins.
+
+<Warning>
+  Without `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` Claude Code sends only metrics and events, and
+  nothing appears in Opik. Prompt, tool I/O and assistant output are **redacted by default**; the
+  flags in this section un-redact them. Assistant output on spans additionally requires the detailed-tracing
+  beta, which is available for the Claude Agent SDK and non-interactive `claude -p` runs but gated
+  in interactive sessions. If you need full content in interactive sessions, use the plugin.
+</Warning>
+
+Set these before starting Claude Code (Opik Cloud shown; swap the endpoint for your deployment,
+see the [Opik OpenTelemetry overview](/integrations/opentelemetry)):
+
+```bash wordWrap
+# 1. Enable telemetry and trace-span emission
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+
+# 2. Export traces to Opik
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+
+# 3. Un-redact prompt and tool input/output
+export OTEL_LOG_USER_PROMPTS=1
+export OTEL_LOG_TOOL_DETAILS=1
+export OTEL_LOG_TOOL_CONTENT=1
+
+# 4. Assistant output on spans (detailed-tracing beta, non-interactive only)
+export ENABLE_BETA_TRACING_DETAILED=1
+export BETA_TRACING_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+```
+
+Spans arrive as `claude_code.interaction` (one per prompt) with nested `claude_code.llm_request`
+and `claude_code.tool` spans. Opik maps their content to trace and span input/output and
+calculates cost from the model and token attributes.
+
+For the full variable reference, endpoint modes and validation steps, see
+[Claude Agent SDK and Claude Code OpenTelemetry](/integrations/claude-agent-sdk).
+
+## Validation
+
+1. Run a short Claude Code turn that uses a tool, for example "list the files in this directory".
+2. Open the target project in Opik (`claude-code` for the plugin, your `projectName` for OTel).
+3. Confirm the trace has the prompt as input, the answer as output, and one span per tool call.
+
+## Source references
+
+- [opik-claude-code-plugin](https://github.com/comet-ml/opik-claude-code-plugin)
+- [Claude Code monitoring (official)](https://code.claude.com/docs/en/monitoring-usage)
+- [Opik OpenTelemetry overview](/integrations/opentelemetry)

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/coding-agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/coding-agents.mdx
@@ -1,0 +1,52 @@
+---
+description: How to get Claude Code, Cursor, GitHub Copilot and OpenAI Codex sessions into Opik, and when Cost Intelligence or the MCP server is the better fit.
+headline: Coding agents
+og:description: One page to pick the right path for each coding agent, log sessions to Opik for review and evaluation, use Cost Intelligence to attribute and reduce spend, or connect the agent to Opik over MCP.
+og:site_name: Opik Documentation
+og:title: Coding Agents - Opik
+title: Observability for coding agents
+---
+
+Teams adopting AI coding agents need three things: to see what the agent did, to spend less doing
+it, or to use the agent to add observability to their own app.
+
+| You want to… | Use | What you get |
+| --- | --- | --- |
+| **See what the agent did.** Read the conversation, check which tools ran, debug a bad run, share a session with a teammate. | [Opik tracing](#set-up-tracing-for-your-agent), set up per agent | Every prompt, response and tool call, grouped into threads you can score, annotate and share. |
+| **Spend less doing it.** Find where the tokens actually go, per user and per repo, then cut the waste. | [Cost Intelligence](/cost-intelligence/overview) | Token counts broken out across system prompt, tools, MCP servers, skills and memory, plus policy controls. Metadata only — never your code or conversations. |
+| **Add observability to your own app.** Instrument your code, score outputs and run experiments from your coding agent. | [Opik MCP server](/mcp-server) | `uvx opik mcp configure` registers the server and the Opik skills with your agent. |
+
+## Set up tracing for your agent
+
+Each agent has its own way of getting sessions out. The **Quick start** column is the single step
+that does most of the work; the linked page has the full setup, endpoint modes and validation.
+
+| Agent | Path into Opik | Quick start | Content captured | Cost Intelligence |
+| --- | --- | --- | --- | --- |
+| [Claude Code](/integrations/claude-code) | Opik plugin (recommended), or native OTel export (beta) | `/plugin install opik` inside Claude Code | Plugin: yes. OTel: redacted unless enabled | Supported |
+| [GitHub Copilot](/integrations/github-copilot) (VS Code, CLI) | Native OTel export | `github.copilot.chat.otel.enabled: true` plus the Opik endpoint | Off unless `captureContent` is enabled | Ask your account team |
+| [Cursor](/integrations/cursor) | Opik Cursor extension | Install the `Opik` extension and paste your API key | Yes | Supported |
+| [OpenAI Codex](/integrations/openai-codex) | Native OTel export | `trace_exporter = "otlp-http"` in `~/.codex/config.toml` | Off unless `log_user_prompt = true` | Supported |
+| Other agents (opencode, Gemini CLI, ...) | Native OTel export if the agent emits `gen_ai.*` spans | Point the agent's OTLP exporter at the [Opik OTel endpoint](/integrations/opentelemetry) | Depends on the agent | Not yet |
+
+<CardGroup cols={2}>
+  <Card title="Claude Code" href="/integrations/claude-code" icon="fa-regular fa-terminal">
+    Opik plugin (recommended) captures every turn with full content. Native OpenTelemetry export is available as a beta alternative.
+  </Card>
+  <Card title="GitHub Copilot" href="/integrations/github-copilot" icon="fa-brands fa-github">
+    Native OpenTelemetry export from Copilot Chat in VS Code and from Copilot CLI. Enterprise managed settings can mandate it fleet-wide.
+  </Card>
+  <Card title="Cursor" href="/integrations/cursor" icon="fa-regular fa-i-cursor">
+    Opik Cursor extension logs every conversation, with token usage and cost from your Cursor account.
+  </Card>
+  <Card title="OpenAI Codex" href="/integrations/openai-codex" icon="fa-regular fa-code">
+    Native OpenTelemetry export configured in `config.toml`.
+  </Card>
+</CardGroup>
+
+<Note>
+  Every native OpenTelemetry path (GitHub Copilot, OpenAI Codex, Claude Code OTel, other agents)
+  shares one property: **content is redacted by default** and has to
+  be switched on explicitly. Check your organization's policy before enabling prompt and response
+  export. Structure, timing and token counts are logged either way.
+</Note>

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/cursor.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/cursor.mdx
@@ -31,6 +31,21 @@ title: Observability for Cursor with Opik
 The Cursor extension for Opik allows you to log all your Cursor conversations to Opik. Once they are available in Opik,
 you can easily review them and share them with your team.
 
+<Callout type="info">
+  Cursor does not expose an OpenTelemetry exporter for its chat, so the extension is the supported
+  way to get Cursor sessions into Opik. If you want the other direction, letting Cursor read your
+  traces, score outputs and run evaluations from chat, the extension registers the
+  [Opik MCP server](/mcp-server) for you; see the MCP Server Integration section on this page.
+</Callout>
+
+<Tip title="Looking to reduce Cursor spend rather than review sessions?">
+  Opik shows you **what Cursor did**. If the question is **where the tokens went and how to spend
+  fewer of them**, that is [Cost Intelligence](/cost-intelligence/overview): every Cursor API call
+  captured on the wire and attributed to system prompt, tools, MCP servers and user input, per
+  user and per repository, with policy controls that typically cut spend by 15% to 30%. Only
+  counts and metadata leave the machine, never content. It runs side by side with this extension.
+</Tip>
+
 <Frame>
   <img src="/img/tracing/cursor_opik_thread.png" />
 </Frame>

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/github-copilot.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/github-copilot.mdx
@@ -1,0 +1,260 @@
+---
+description: Send GitHub Copilot Chat (VS Code) and Copilot CLI sessions to Opik over OpenTelemetry, with clear content-capture and endpoint expectations.
+headline: GitHub Copilot
+og:description: GitHub Copilot exports traces over OpenTelemetry; this guide maps the VS Code settings, environment variables and enterprise managed settings to Opik endpoints.
+og:site_name: Opik Documentation
+og:title: GitHub Copilot Integration - Opik
+title: Observability for GitHub Copilot with Opik
+---
+
+[GitHub Copilot](https://github.com/features/copilot) can export traces, metrics and events over
+OpenTelemetry (OTel) from both the Copilot Chat extension in VS Code and the Copilot CLI. The spans
+follow the [OTel GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/),
+which Opik ingests natively, so every chat turn, model call and tool execution lands in Opik as a
+trace you can review, evaluate and share.
+
+## When this guide applies
+
+Use this guide if you want to **log Copilot conversations to Opik**: the prompts your developers
+send, the models Copilot calls, the tools it runs, and the tokens each turn consumed.
+
+<Callout type="info">
+  This guide covers telemetry flowing **from Copilot to Opik**. For the other direction, letting
+  Copilot read your traces, score outputs and run evaluations from chat, register the
+  [Opik MCP server](/mcp-server) with it. One command, `uvx opik mcp configure`, installs the server and
+  the Opik skills. The two are independent, and you can use either or both.
+</Callout>
+
+<Tip title="Looking to reduce coding-agent spend rather than review sessions?">
+  Opik shows you **what your agents did**. If the question is **where the tokens went and how to
+  spend fewer of them**, that is [Cost Intelligence](/cost-intelligence/overview): exact per-call
+  token attribution across system prompt, tools, MCP servers, skills and memory, per-user and
+  per-repository, with policy controls that typically cut spend by 15% to 30%. Cost Intelligence
+  currently supports [Claude Code, Codex and Cursor](/cost-intelligence/overview#supported-agents);
+  talk to your Comet account team about Copilot coverage.
+</Tip>
+
+## Quick start
+
+Copilot Chat in VS Code and Copilot CLI both honor the standard OpenTelemetry environment
+variables. For a single developer on Opik Cloud, this is the whole setup:
+
+```bash wordWrap
+export COPILOT_OTEL_ENABLED=true
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+export COPILOT_OTEL_CAPTURE_CONTENT=true   # omit to log structure and tokens only, no prompt text
+```
+
+Then launch VS Code from that shell with `code .` (or run `copilot` for the CLI) and start a chat.
+The trace appears in the Opik project named in `projectName`. The rest of this page covers the
+other configuration paths, self-hosted endpoints, what the spans contain and how to validate.
+
+## Prerequisites
+
+- An Opik API key and workspace name. Opik Cloud: [comet.com/api/my/settings](https://www.comet.com/api/my/settings).
+- GitHub Copilot Chat extension in VS Code, or GitHub Copilot CLI, signed in.
+- Permission from your organization to export prompt content, if you plan to enable content capture.
+
+## What Opik receives
+
+Copilot emits four span kinds, all with `gen_ai.*` attributes:
+
+| Span | What it represents | Key attributes Opik maps |
+| --- | --- | --- |
+| `invoke_agent` | One chat turn (root span) | `gen_ai.agent.name`, `gen_ai.conversation.id` |
+| `chat` | A model request | `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, cache read/creation tokens |
+| `execute_tool` | A tool call | `gen_ai.tool.name`, `gen_ai.tool.type`, `gen_ai.tool.call.id` |
+| `execute_hook` | A hook run | hook metadata |
+
+Opik maps `gen_ai.input.messages` and `gen_ai.output.messages` to the trace and span **input**
+and **output**, and uses `gen_ai.usage.*` for token counts. `gen_ai.conversation.id` groups turns
+into a thread in the Opik **Threads** tab.
+
+<Warning>
+  **Content is off by default.** Copilot does not export prompt text, responses or tool arguments
+  unless you turn on content capture (`github.copilot.chat.otel.captureContent` or
+  `COPILOT_OTEL_CAPTURE_CONTENT`). Without it your Opik traces show structure, timing and token
+  counts, but empty input and output. Check your organization's policy before enabling it.
+</Warning>
+
+## Opik OTLP endpoint modes
+
+The examples on this page use the Opik Cloud endpoint. Swap in the endpoint for your deployment
+from the tabs here; everything else stays the same. Copilot appends the signal path (`/v1/traces`,
+`/v1/metrics`, `/v1/logs`) to the base endpoint itself, so always give it the **base** URL, not
+the `/v1/traces` URL. For endpoint behavior in general, see the
+[Opik OpenTelemetry overview](/integrations/opentelemetry).
+
+<Tabs>
+    <Tab value="Opik Cloud" title="Opik Cloud">
+        ```bash wordWrap
+        export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+        export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+        ```
+
+        Required headers:
+        - `Authorization`
+        - `Comet-Workspace`
+
+        Optional headers:
+        - `projectName` (recommended; defaults to `Default Project`)
+    </Tab>
+    <Tab value="Enterprise deployment" title="Enterprise deployment">
+        ```bash wordWrap
+        export OTEL_EXPORTER_OTLP_ENDPOINT=https://<comet-deployment-url>/opik/api/v1/private/otel
+        export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+        ```
+
+        Required headers:
+        - `Authorization`
+        - `Comet-Workspace`
+
+        Optional headers:
+        - `projectName` (recommended)
+    </Tab>
+    <Tab value="Self-hosted instance" title="Self-hosted instance">
+        ```bash wordWrap
+        export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5173/api/v1/private/otel
+        export OTEL_EXPORTER_OTLP_HEADERS='projectName=<your-project-name>'
+        ```
+
+        Required headers:
+        - none by default (depends on your self-hosted auth setup)
+
+        Optional headers:
+        - `projectName` (recommended)
+        - auth headers if your instance enforces auth
+    </Tab>
+</Tabs>
+
+## Configure Copilot Chat in VS Code
+
+Copilot Chat reads its OTel configuration from VS Code settings, from environment variables, or
+from enterprise managed settings. Pick the one that matches how you roll out configuration.
+
+<Tabs>
+    <Tab value="settings" title="VS Code settings + env headers">
+        The exporter settings live in `settings.json`, but **exporter headers cannot be set in
+        `settings.json`**. Opik Cloud and Enterprise deployments need the `Authorization` and
+        `Comet-Workspace` headers, so those still come from one environment variable.
+
+        1. Add to your user or workspace `settings.json`:
+
+        ```json title="settings.json"
+        {
+          "github.copilot.chat.otel.enabled": true,
+          "github.copilot.chat.otel.exporterType": "otlp-http",
+          "github.copilot.chat.otel.otlpEndpoint": "https://www.comet.com/opik/api/v1/private/otel",
+          "github.copilot.chat.otel.captureContent": true
+        }
+        ```
+
+        2. Export the headers in your shell profile:
+
+        ```bash wordWrap
+        export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+        ```
+
+        3. Launch VS Code from that shell with `code .`, then reload the window.
+
+        The same macOS note applies: a Dock or Spotlight launch does not inherit the variable.
+    </Tab>
+    <Tab value="env" title="Environment variables only">
+        Every setting has an environment-variable equivalent. This is the simplest path when VS
+        Code is launched from a terminal or a wrapper script. Put the block in your shell profile
+        (`~/.zshrc`, `~/.bashrc`, or the Windows equivalent).
+
+        ```bash wordWrap
+        export COPILOT_OTEL_ENABLED=true
+        export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+        export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+        export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+        export COPILOT_OTEL_CAPTURE_CONTENT=true
+        export OTEL_SERVICE_NAME=copilot-chat
+        ```
+
+        Start VS Code from the same shell with `code .` so the extension host inherits the
+        variables.
+
+        <Note>
+          On macOS, VS Code launched from the Dock or Spotlight does not inherit variables set in
+          your shell profile. Either launch it from a terminal with `code .`, or use the managed
+          settings path.
+        </Note>
+    </Tab>
+    <Tab value="managed" title="Enterprise managed settings (recommended for teams)">
+        Organizations can **mandate** where Copilot sends OTel data through the `telemetry` block
+        in [Copilot managed settings](https://github.blog/changelog/2026-07-08-enterprise-managed-opentelemetry-export-for-vs-code-and-cli/).
+        Admins deliver it via native MDM (Windows Registry or macOS managed preferences), via a
+        server-managed policy tied to the signed-in GitHub account, or via a `managed-settings.json`
+        file on disk. It applies to both the Copilot Chat extension in VS Code and the agent host
+        process behind Copilot CLI.
+
+        The block lets you set:
+
+        - the OTLP endpoint and protocol (`otlp-http` for Opik)
+        - the OTel service name and resource attributes
+        - exporter headers, which is where the Opik `Authorization`, `Comet-Workspace` and
+          `projectName` headers go
+        - whether prompt, response and tool content is captured, and whether developers may
+          change that
+
+        A managed value always wins over environment variables and user settings, and managed
+        headers are applied only to the Copilot Chat exporter and never passed through environment
+        variables, so the Opik API key never reaches subprocess tools.
+
+        Refer to the GitHub changelog linked at the start of this tab for the exact schema of the `telemetry`
+        block for your Copilot plan.
+    </Tab>
+</Tabs>
+
+## Configure Copilot CLI
+
+Copilot CLI uses the same exporter and the same environment variables as the Quick start. It exports
+OTLP over HTTP only (`http/protobuf` or `http/json`); gRPC is not supported.
+
+```bash wordWrap
+export COPILOT_OTEL_ENABLED=true
+export COPILOT_OTEL_EXPORTER_TYPE=otlp-http
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://www.comet.com/opik/api/v1/private/otel
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=<your-api-key>,Comet-Workspace=<your-workspace>,projectName=<your-project-name>'
+export COPILOT_OTEL_CAPTURE_CONTENT=true
+export OTEL_SERVICE_NAME=copilot-cli
+```
+
+Run `copilot` from that shell and traces are exported as you work.
+
+## Validation
+
+1. Reload VS Code (or start a new Copilot CLI session) after applying the configuration.
+2. Ask Copilot something that triggers a tool call, for example "list the files in this repo".
+3. Open the target project in Opik. You should see an `invoke_agent` trace with nested `chat` and
+   `execute_tool` spans, token counts on the `chat` spans, and, with content capture enabled, the
+   prompt and response in the trace input and output.
+4. Open the **Threads** tab to see the conversation grouped by `gen_ai.conversation.id`.
+
+If nothing arrives, set `COPILOT_OTEL_LOG_LEVEL=debug` and check the **GitHub Copilot Chat**
+output channel in VS Code for exporter errors. A `401` means the `Authorization` or
+`Comet-Workspace` header did not reach the exporter; the most common cause is VS Code not
+inheriting the environment variable.
+
+## Notes
+
+- Opik ingests the **traces** signal only. Copilot also sends metrics to `/v1/metrics` and events
+  to `/v1/logs` on the same base endpoint; Opik has no receiver for those and rejects them, which
+  is harmless and does not affect trace ingestion.
+- Keep content capture off unless your policy explicitly allows prompt and response export.
+  Metadata, timing and token counts are still logged without it.
+- Cost on `chat` spans is calculated when the `gen_ai.request.model` value matches a model in
+  Opik's price table. Copilot-hosted model names may not match; if you see `$0` cost, check the
+  `model` field on the span and reach out so we can add the alias.
+
+## Source references
+
+- [Monitor agent usage with OpenTelemetry (VS Code)](https://code.visualstudio.com/docs/agents/guides/monitoring-agents)
+- [Enterprise-managed OpenTelemetry export for VS Code and CLI (GitHub changelog)](https://github.blog/changelog/2026-07-08-enterprise-managed-opentelemetry-export-for-vs-code-and-cli/)
+- [Copilot Chat agent monitoring reference (microsoft/vscode-copilot-chat)](https://github.com/microsoft/vscode-copilot-chat/blob/main/docs/monitoring/agent_monitoring.md)
+- [Opik OpenTelemetry overview](/integrations/opentelemetry)

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/github-copilot.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/github-copilot.mdx
@@ -248,9 +248,9 @@ inheriting the environment variable.
   is harmless and does not affect trace ingestion.
 - Keep content capture off unless your policy explicitly allows prompt and response export.
   Metadata, timing and token counts are still logged without it.
-- Cost on `chat` spans is calculated when the `gen_ai.request.model` value matches a model in
-  Opik's price table. Copilot-hosted model names may not match; if you see `$0` cost, check the
-  `model` field on the span and reach out so we can add the alias.
+- Cost on `chat` spans is calculated from `gen_ai.usage.*` when the `gen_ai.request.model` or
+  `gen_ai.response.model` value matches a model in Opik's price table (for example `gpt-4.1`).
+  If a span shows no cost, check its `model` field and reach out so we can add the alias.
 
 ## Source references
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
@@ -20,6 +20,21 @@ Use this guide if you run Codex (CLI/IDE/app) and want its OTEL trace exporter t
   and the Opik skills without the SDK. The two are independent, and you can use either or both.
 </Callout>
 
+<Tip title="Looking to reduce Codex spend rather than review sessions?">
+  Opik shows you **what Codex did**. If the question is **where the tokens went and how to spend
+  fewer of them**, that is [Cost Intelligence](/cost-intelligence/overview): every Codex API call
+  captured on the wire and attributed to system prompt, tools, MCP servers and user input, per
+  user and per repository, with policy controls that typically cut spend by 15% to 30%. Only
+  counts and metadata leave the machine, never content. It runs side by side with the OTel export
+  on this page.
+</Tip>
+
+<Warning>
+  Codex redacts prompt text unless `log_user_prompt = true`. With the default `false`, Opik traces
+  show structure, timing and token counts but not what the developer typed. Enable it only if your
+  policy allows prompt export.
+</Warning>
+
 <Callout type="info">
 The block structure below follows the current Codex runtime config shape used in local `config.toml` (`[otel.trace_exporter.otlp-http]`).
 </Callout>

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/overview.mdx
@@ -12,12 +12,19 @@ Opik helps you easily log, visualize, and evaluate everything from raw LLM calls
 
 ## <Icon icon="fa-regular fa-robot" /> AI Coding Assistants
 
-Connect your AI coding assistant directly to your Opik workspace with the MCP server. Read traces, score outputs, save prompts, and run experiments from chat. Works with Claude Code, Cursor, VS Code Copilot, Codex, opencode, and any other MCP client.
+Log your coding agent's sessions to Opik, or connect the agent to your Opik workspace with the MCP server. Start with the [coding agents overview](/integrations/coding-agents) to pick the right path.
 
-<CardGroup cols={1}>
-  <Card title="MCP Server — Claude Code, Cursor, VS Code Copilot, Codex, opencode" href="/mcp-server" icon="fa-regular fa-network-wired">
-    Run `uvx opik mcp configure` (no SDK needed) and drive your entire Opik workspace from your AI assistant's chat.
+<CardGroup cols={3}>
+  <Card title="Coding agents overview" href="/integrations/coding-agents" icon="fa-regular fa-compass">
+    Opik tracing, Cost Intelligence or the MCP server: which one fits, and setup per agent.
   </Card>
+  <Card title="MCP Server" href="/mcp-server" icon="fa-regular fa-network-wired">
+    Run `uvx opik mcp configure` (no SDK needed) and drive your Opik workspace from Claude Code, Cursor, VS Code Copilot, Codex, opencode, or any other MCP client.
+  </Card>
+  <Card title="Claude Code" href="/integrations/claude-code" icon="fa-regular fa-terminal" />
+  <Card title="Cursor" href="/integrations/cursor" icon="fa-regular fa-i-cursor" />
+  <Card title="GitHub Copilot" href="/integrations/github-copilot" icon="fa-brands fa-github" />
+  <Card title="OpenAI Codex" href="/integrations/openai-codex" icon="fa-regular fa-code" />
 </CardGroup>
 
 ## <Icon icon="fa-brands fa-js" /> TypeScript
@@ -195,14 +202,12 @@ Connect your AI coding assistant directly to your Opik workspace with the MCP se
 ## <Icon icon="fa-solid fa-wand-magic-sparkles" /> No-Code
 
 <CardGroup cols={3}>
-  <Card title="Cursor" href="/integrations/cursor" />
   <Card title="Dify" href="/integrations/dify" />
   <Card title="Flowise" href="/integrations/flowise" />
   <Card title="Hermes" href="/integrations/hermes" />
   <Card title="Langflow" href="/integrations/langflow" />
   <Card title="n8n" href="/integrations/n8n" />
   <Card title="OpenClaw" href="/integrations/openclaw" />
-  <Card title="OpenAI Codex" href="/integrations/openai-codex" />
   <Card title="OpenWebUI" href="/integrations/openwebui" />
   <Card title="Prompt Flow" href="/integrations/prompt-flow" />
 </CardGroup>

--- a/apps/opik-documentation/documentation/fern/docs.yml
+++ b/apps/opik-documentation/documentation/fern/docs.yml
@@ -663,9 +663,24 @@ navigation:
         skip-slug: true
         icon: fa-regular fa-robot
         contents:
+          - page: Overview
+            path: ./docs-v2/integrations/coding-agents.mdx
+            slug: coding-agents
           - page: MCP Server
             path: ./docs-v2/prompt_engineering/mcp-server.mdx
             slug: mcp-server
+          - page: Claude Code
+            path: ./docs-v2/integrations/claude-code.mdx
+            slug: claude-code
+          - page: Cursor
+            path: ./docs-v2/integrations/cursor.mdx
+            slug: cursor
+          - page: GitHub Copilot
+            path: ./docs-v2/integrations/github-copilot.mdx
+            slug: github-copilot
+          - page: OpenAI Codex
+            path: ./docs-v2/integrations/openai-codex.mdx
+            slug: openai-codex
       - section: TypeScript
         skip-slug: true
         icon: fa-brands fa-js
@@ -930,9 +945,6 @@ navigation:
         skip-slug: true
         icon: fa-solid fa-wand-magic-sparkles
         contents:
-          - page: Cursor
-            path: ./docs-v2/integrations/cursor.mdx
-            slug: cursor
           - page: Dify
             path: ./docs-v2/integrations/dify.mdx
             slug: dify
@@ -951,9 +963,6 @@ navigation:
           - page: OpenClaw
             path: ./docs-v2/integrations/openclaw.mdx
             slug: openclaw
-          - page: OpenAI Codex
-            path: ./docs-v2/integrations/openai-codex.mdx
-            slug: openai-codex
           - page: OpenWebUI
             path: ./docs-v2/integrations/openwebui.mdx
             slug: openwebui


### PR DESCRIPTION
## Details
Customers keep asking how to log coding-agent chats (VS Code Copilot, Cursor) to Opik. This adds a coding-agents overview (Opik tracing vs Cost Intelligence vs MCP server), new Claude Code and GitHub Copilot pages covering OTel export to Opik, Cost Intelligence call-outs on the Cursor and Codex pages, a link back from the Cost Intelligence overview, and groups all four agents under "AI Coding Assistants" in the nav.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- none

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5.1
- Scope: drafting pages, nav and overview edits, test scripts
- Human verification: reviewed and edited by author, rendered locally, hands-on tested against Opik Cloud

## Testing
- Claude Code native OTel: ran `claude -p` with the documented env block; `claude_code.interaction` trace with prompt, `llm_request` spans with model/tokens/cost and `tool` spans landed in Opik.
- Claude Code plugin: installed as documented, ran `claude -p`; trace with prompt as input and answer as output landed in Opik. Child spans did not: plugin 0.3.1 generates span IDs that fail Opik's UUIDv7 ingestion-window check (400 on `/spans/batch`). That is a plugin bug to fix in comet-ml/opik-claude-code-plugin; the page describes the intended behavior.
- Copilot: sent spans shaped exactly like Copilot Chat's (`invoke_agent` / `chat` / `execute_tool`, gen_ai attributes) to the documented base endpoint and headers; Opik mapped input/output, thread, model, tokens and cost correctly. Setting and env-var names verified against microsoft/vscode-copilot-chat. A live Copilot run was not possible from my machine (org Copilot CLI policy), so that last mile is still open.
- `fern docs dev`: all pages render; 92 internal links on touched pages return 200.

## Documentation
- This PR is the documentation change: 3 new pages, 4 edited pages, nav update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)