### PR TITLE
[NA] [DOCS] docs: fix Codex OTel config TOML and set correct expectations for trace export

### DIFF
--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/coding-agents.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/coding-agents.mdx
@@ -26,7 +26,7 @@ that does most of the work; the linked page has the full setup, endpoint modes a
 | [Claude Code](/integrations/claude-code) | Opik plugin (recommended), or native OTel export (beta) | `/plugin install opik` inside Claude Code | Plugin: yes. OTel: redacted unless enabled | Supported |
 | [GitHub Copilot](/integrations/github-copilot) (VS Code, CLI) | Native OTel export | `github.copilot.chat.otel.enabled: true` plus the Opik endpoint | Off unless `captureContent` is enabled | Ask your account team |
 | [Cursor](/integrations/cursor) | Opik Cursor extension | Install the `Opik` extension and paste your API key | Yes | Supported |
-| [OpenAI Codex](/integrations/openai-codex) | Native OTel export | `trace_exporter = "otlp-http"` in `~/.codex/config.toml` | Off unless `log_user_prompt = true` | Supported |
+| [OpenAI Codex](/integrations/openai-codex) | Native OTel export (internal spans and `codex.*` events only) | An `[otel.trace_exporter.otlp-http]` table in `~/.codex/config.toml` | No. Prompt text and tokens go to the logs signal, which Opik does not ingest | Supported |
 | Other agents (opencode, Gemini CLI, ...) | Native OTel export if the agent emits `gen_ai.*` spans | Point the agent's OTLP exporter at the [Opik OTel endpoint](/integrations/opentelemetry) | Depends on the agent | Not yet |
 
 <CardGroup cols={2}>
@@ -40,7 +40,7 @@ that does most of the work; the linked page has the full setup, endpoint modes a
     Opik Cursor extension logs every conversation, with token usage and cost from your Cursor account.
   </Card>
   <Card title="OpenAI Codex" href="/integrations/openai-codex" icon="fa-regular fa-code">
-    Native OpenTelemetry export configured in `config.toml`.
+    Native OpenTelemetry export configured in `config.toml`. Operational spans and events only; no prompt text, tokens or cost on the trace signal.
   </Card>
 </CardGroup>
 

--- a/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
+++ b/apps/opik-documentation/documentation/fern/docs-v2/integrations/openai-codex.mdx
@@ -13,6 +13,18 @@ title: Observability for OpenAI Codex with Opik
 
 Use this guide if you run Codex (CLI/IDE/app) and want its OTEL trace exporter to send telemetry to Opik.
 
+<Warning>
+  **Know what Codex's trace exporter sends before you rely on it.** Codex exports its internal
+  tracing spans (`session_loop`, `handle_responses`, `append_items`, `auth`, ...), not LLM-call
+  spans. Conversation facts arrive as span **events** (`codex.user_prompt`, `codex.api_request`,
+  `codex.tool_result`, `codex.turn_ttft`) that Opik stores under `opentelemetry.events` in span
+  metadata, carrying the model name, tool names, durations and prompt *length*. The trace signal
+  never includes the prompt text, the response text, token counts or cost, even with
+  `log_user_prompt = true`; Codex sends those to its **logs** exporter (`otel.exporter`), which
+  Opik does not ingest. Use this integration for Codex operational telemetry. For per-user token
+  and cost attribution across Codex sessions, use [Cost Intelligence](/cost-intelligence/overview).
+</Warning>
+
 <Callout type="info">
   This guide covers telemetry flowing **from Codex to Opik**. For the other direction — letting Codex
   read your traces, score outputs and run evaluations — register the
@@ -55,8 +67,6 @@ For Opik OTEL endpoint behavior, see [Opik OpenTelemetry overview](/integrations
     <Tab value="Opik Cloud" title="Opik Cloud">
         ```toml
         [otel]
-        # Optional environment label in Codex telemetry
-        trace_exporter = "otlp-http"
         environment = "prod"
         log_user_prompt = false
 
@@ -76,7 +86,6 @@ For Opik OTEL endpoint behavior, see [Opik OpenTelemetry overview](/integrations
     <Tab value="Enterprise deployment" title="Enterprise deployment">
         ```toml
         [otel]
-        trace_exporter = "otlp-http"
         environment = "prod"
         log_user_prompt = false
 
@@ -96,7 +105,6 @@ For Opik OTEL endpoint behavior, see [Opik OpenTelemetry overview](/integrations
     <Tab value="Self-hosted instance" title="Self-hosted instance">
         ```toml
         [otel]
-        trace_exporter = "otlp-http"
         environment = "prod"
         log_user_prompt = false
 
@@ -124,8 +132,9 @@ Applies when:
 You have enabled Codex OTEL export and selected OTLP/HTTP exporter in config.
 
 Required fields:
-- `trace_exporter = "otlp-http"` under `[otel]`
-- `otel.trace_exporter` exporter block (`otlp-http`)
+- an `[otel.trace_exporter.otlp-http]` table. The table itself selects the exporter; do **not**
+  also write `trace_exporter = "otlp-http"` as a string under `[otel]`, Codex rejects the file
+  with `cannot extend value of type string with a dotted key`.
 - `endpoint`
 - `protocol` (`binary` or `json`, binary recommended)
 
@@ -138,7 +147,6 @@ Minimal valid config:
 
 ```toml
 [otel]
-trace_exporter = "otlp-http"
 log_user_prompt = false
 
 [otel.trace_exporter.otlp-http]
@@ -151,11 +159,15 @@ headers = { "Authorization" = "<your-api-key>", "Comet-Workspace" = "<your-works
 
 1. Run a Codex session after updating `config.toml`.
 2. Confirm OTLP HTTP requests are sent to `/otel/v1/traces`.
-3. Verify traces appear in the expected Opik workspace/project.
+3. Verify traces appear in the expected Opik workspace/project. Expect many short internal
+   traces per session (`auth`, `turn/start`, `codex.exec`, ...); open a `session_loop` or
+   `dispatch_tool_call_with_terminal_outcome` span and look under **Metadata →
+   opentelemetry.events** for the `codex.*` events.
 
 ## Notes
 
 - Codex telemetry export is opt-in.
+- Prompt text and token usage are only available on the logs signal (`otel.exporter`), which Opik does not receive.
 - Keep `log_user_prompt = false` unless your policy explicitly allows prompt text export.
 - If your Codex build uses a different exporter key path, align with your installed version's config reference.
 


### PR DESCRIPTION
## Details
Hands-on testing of the Codex page (codex-cli 0.154.0 → Opik Cloud) found two problems. The TOML on the page is invalid: `trace_exporter = "otlp-http"` under `[otel]` conflicts with the `[otel.trace_exporter.otlp-http]` table, and Codex rejects the file with `cannot extend value of type string with a dotted key`. And the page implied conversation traces; what actually arrives is Codex's internal tracing spans with `codex.*` events in metadata, with no prompt text, token counts or cost even with `log_user_prompt = true` (those go to the logs exporter, which Opik does not ingest). This PR keeps the table-only TOML, adds a warning that states what the integration delivers, points cost questions at Cost Intelligence, and updates the Codex row on the coding-agents overview.

## Change checklist
- [x] User facing
- [x] Documentation update

## Issues

- none

## AI-WATERMARK

AI-WATERMARK: yes

- Tools: Claude Code
- Model(s): Claude Fable 5.1
- Scope: page edits and TOML validation
- Human verification: author ran the Codex export against Opik Cloud and inspected the resulting spans

## Testing
- Ran `codex exec` with the page's original TOML as a profile: config load error. With the table-only TOML: traces arrive in Opik.
- Inspected 607 spans / 22 traces from one Codex turn in Opik: internal spans only, `codex.user_prompt` carries `prompt_length` not text, no `gen_ai.*` usage attributes anywhere.
- All four TOML blocks on the page parse with `tomllib`.

## Documentation
- This PR is the documentation change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)