### PR TITLE
[OPIK-7532] [QA] Proposed taxonomy changes from app surface

### DIFF
--- a/tests_end_to_end/coverage/taxonomy.yaml
+++ b/tests_end_to_end/coverage/taxonomy.yaml
@@ -653,8 +653,10 @@ areas:
       # (deleted-queue URL loads forever instead of showing a not-found state).
       # Fixing that bug turns the run red until the annotation is removed.
       delete-queue:            { covered: true,  tier: t2-cuj, note: "row-actions delete; sibling queue + source traces asserted to survive; deleted-queue URL known-failure OPIK-7903" }
+      queue-items-tab:         { covered: false, note: "QueueItemsTab — the detail page's default tab; branches on queue scope into TraceQueueItemsTab / ThreadQueueItemsTab, so the two scopes are separate assertions" }
       queue-configuration-tab: { covered: false }
       add-traces-to-queue:     { covered: false }
+      remove-items-from-queue: { covered: false, note: "QueueItemRowActionsCell row action + QueueItemActionsPanel bulk action, both via useAnnotationQueueDeleteItemsMutation — the inverse of add-traces-to-queue" }
       sme-flow:                { covered: false, note: "/sme route, dedicated layout" }
       export-annotated-data:   { covered: false }
 


### PR DESCRIPTION
## Proposed by nightly taxonomy discovery

Read the app's route/nav/tab surface and compared it against `taxonomy.yaml`.
Baseline before this change: **19 areas, 204 functional capabilities**.

# Taxonomy discovery — proposal (2026-09-12)

**Target:** `opik/tests_end_to_end/coverage/taxonomy.yaml`
**Variant:** Opik (single repo, `surface.py`)

## Measured against

```
opik @ 0bc06bc4f4  [NA] [DOCS] docs: coding agent pages (Claude Code, GitHub Copilot)
                   with Cost Intelligence call-outs (#8288)
git -C opik status --porcelain  ->  (empty; clean tree)
```

`surface.json` was supplied by the caller and reused rather than regenerated.
It reports 60 routes, 20 nav items, 8 tab groups, and **1** `unmatched_surfaces`
entry — the same count the skill records as the clean-`main` baseline.

---

## 1. What changed

Two capabilities added to the existing `annotation-queues` area. No new areas.
Both land as `covered: false` with no `tier:` — `reconcile.py` owns those fields.

```yaml
      queue-items-tab:         { covered: false, note: "QueueItemsTab — the detail page's default tab; branches on queue scope into TraceQueueItemsTab / ThreadQueueItemsTab, so the two scopes are separate assertions" }
      remove-items-from-queue: { covered: false, note: "QueueItemRowActionsCell row action + QueueItemActionsPanel bulk action, both via useAnnotationQueueDeleteItemsMutation — the inverse of add-traces-to-queue" }
```

Diff is exactly two inserted lines (`git -C opik diff --stat` → `2 ++`), YAML
re-parses clean.

### `annotation-queues.queue-items-tab`

| Evidence | |
|---|---|
| Tab trigger | `src/v2/pages/AnnotationQueuePage/AnnotationQueuePage.tsx:159` — `<TabsTrigger value="items">Queue items</TabsTrigger>`, and `defaultValue="items"` at :152 |
| Surface real? | `QueueItemsTab.tsx` (29 lines) dispatches on `annotationQueue.scope` into `TraceQueueItemsTab.tsx` (671 lines) and `ThreadQueueItemsTab.tsx` (588 lines), plus `NoQueueItemsPage.tsx` (88). Not a stub. |
| Product vocabulary | UI label "Queue items"; docs section *"Fetching Items from a Queue"* (`fern/docs-v2/evaluation/advanced/annotation_queues.mdx:206`, `get_items()`) |
| Why it is a gap | The area already keys the *sibling* tab as `queue-configuration-tab`. The default tab — the one that lists what is actually in the queue — has no key at all. |
| Near-miss check | `grep -niE 'queue-item\|items-tab\|list-queue' taxonomy.yaml` → only `list-queues` (the queues list page, a different surface) and `trials-table`. No duplicate. |

Naming follows the adjacent `queue-configuration-tab`, and the file's existing
tab convention (`prompts.experiments-tab`, `experiments.insights-tab`,
`experiments.configuration-tab`).

Note: `e2e/pom/annotation-queue.page.ts:102` already exposes a `queueItemsTab`
locator, and `annotation-queue-delete.spec.ts:114` asserts it is *visible* — but
that is a page-loaded check inside a delete spec, not an assertion on the tab's
contents. `covered: false` is the honest state; reconcile flips it if and when a
spec carries the tag.

### `annotation-queues.remove-items-from-queue`

| Evidence | |
|---|---|
| Row action | `QueueItemsTab/QueueItemRowActionsCell.tsx:54,75` — `title="Remove from queue"`, `confirmText="Remove item"` |
| Bulk action | `QueueItemsTab/QueueItemActionsPanel.tsx:41,46` — `title="Remove from queue"`, tooltip *"Remove selected items from queue"*, `confirmText="Remove items"` |
| API client | both call `useAnnotationQueueDeleteItemsMutation` (`src/api/annotation-queues/`) |
| Product vocabulary | docs: *"# Remove traces from the queue"* → `queue.remove_traces(...)` (`annotation_queues.mdx:327`, and the TS form at :375) |
| Why it is a gap | The taxonomy keys the inverse (`add-traces-to-queue`) but nothing for removal. `grep -niE 'remove' taxonomy.yaml` matches only `trace-tag-add-remove` and two prose comments. |

Kept as **one** key rather than splitting row-action from bulk-action: same
mutation, same confirm dialog, same user-described behaviour. Splitting would be
the `click-save-button` failure mode.

### Altitude

`annotation-queues` goes 12 → 14 capabilities, inside the 5–15 guide.

---

## 2. Coverage arithmetic

Recounted from the file before and after, per dimension, never blended.

**Functional — all capabilities (cloud view):**

> **121/204 (59.3%) → 121/206 (58.7%)**

**Functional — self-hosted view** (excludes the `cloud_only` `diagnostics` and
`ollie` areas and the three `members-*` capabilities):

> **111/180 (61.7%) → 111/182 (61.0%)**

**`annotation-queues` area, functional:**

> **5/12 (41.7%) → 5/14 (35.7%)**

**Visual:** 30/54 (55.6%) — unchanged, no visual sub-keys proposed.
**Load:** 0/9, `status: planned` — unchanged.

The drop is the point: two surfaces that were always untested are now counted.

---

## 2b. Rejected surfaces

The useful half of this run. Everything the sweep surfaced and why it was ruled
out.

### `/$workspaceName/home` — the only `unmatched_surfaces` entry. **Rejected.**

The skill records this as a "genuine borderline, left for a human on purpose."
Reading it closes the question: it is **redirect plumbing, not a surface.**

```tsx
// src/v2/pages/HomePage/HomePage.tsx — the whole component
const HomePage = () => {
  const workspaceName = useActiveWorkspaceName();
  const navigate = useNavigate();
  useEffect(() => {
    navigate({ to: "/$workspaceName/projects", params: { workspaceName }, replace: true });
  }, [workspaceName, navigate]);
  return <Loader />;
};
```

The router says so itself, at `src/v2/router.tsx:157`:

```
// ----------- home (redirects to the workspace Projects tab)
```

It is the same class of thing as `TracesTabRedirect`, which `surface.py`
correctly classifies as `kind: redirect`; this one escapes the filter only
because it is not named `*Redirect`. There is no user-visible behaviour to
assert beyond "it redirects", and its destination (`/$workspaceName/projects`)
is already `projects.list-projects`.

**`has_nav_entry: true` on this entry is a false positive.** The nav "Home" item
is `path: projectPath("/home")` (`getMenuItems.ts:68`), which resolves to
`/$workspaceName/projects/$projectId/home` — the **project** home
(`ProjectHomePage`, `router.tsx:231`), already keyed as `projects.project-home`.
The extractor matched on the `/home` suffix. The workspace-level route has no
nav entry of its own.

*Suggested follow-up for the extractor (not done here, out of scope):* classify a
component whose body is a `useEffect` → `navigate({replace: true})` as
`kind: redirect`, and anchor the `has_nav_entry` match at the full resolved path
rather than the suffix. Both would have made this run's unmatched list empty.

### Nav items — 20/20 accounted for. **Nothing new.**

Every entry in `nav_items` maps to an existing area: Ollie→`ollie`,
Logs→`traces`/`threads`, Diagnostics→`diagnostics`, Dashboards→`dashboards`,
Prompt library→`prompts`, Agent playground→`agent-playground`, Prompt
playground→`playground`, Optimization runs→`optimization-studio`, Test
suites→`test-suites`, Datasets→`datasets`, Experiments→`experiments`, Annotation
queues→`annotation-queues`, Online evaluation→`online-evaluation`,
Alerts→`alerts`, Workspace/Projects→`projects`, Configuration→`configuration`.
Home→`projects.project-home`, per above.

### Tabs — 8 groups diffed by hand. **2 proposed, 6 rejected.**

| File | Values | Verdict |
|---|---|---|
| `AgentRunnerEmptyState.tsx` | `python` / `typescript` | **Reject** — code-snippet language toggle on one panel (`:65-73`). One feature with a switch, per the skill. |
| `CreateDatasetSidebar.tsx` | `python` / `typescript` | **Reject** — same, `variant="segmented-primary"` snippet toggle at `:296-315`. |
| `AnnotationQueuePage.tsx` | `items` / `configuration` | **`items` → proposed** (above). `configuration` is already `queue-configuration-tab`. |
| `TrialSidebarContent.tsx` | `results` / `prompt` | **Reject, with doubt** — see below. |
| `PromptPage.tsx` | `experiments` / `prompt` | **Reject** — `prompts.experiments-tab` exists; the `prompt` tab is the detail default, covered by `version-history` / `list-prompts`. |
| `DatasetItemsPage.tsx` | `items` / `version-history` | **Reject** — `datasets.view-items` and `datasets.version-history-view`. |
| `ThreadDetailsPanel.tsx` | `messages` / `feedback_scores` | **Reject** — `threads.turn-order-io`, `threads.thread-feedback-score`. |
| `TraceDataViewer.tsx` | `details` / `feedback_scores` / `graph` / `messages` / `prompts` | **Reject** — `traces.messages-tab`, `agent-graph-tab`, `prompts-tab`, `manual-feedback-score`; `details` is the panel default, covered by `open-trace-panel`. |

**The one I am not certain about:** `TrialSidebarContent.tsx:75-80`
(`Results` / `Prompt`). `optimization-studio` already has `trial-detail`
(covered) and `best-trial-prompt` (uncovered). The sidebar's Prompt tab shows
*that trial's* prompt, which is not quite what `best-trial-prompt` names — the
best trial's prompt is a specific one of them. So this is either a real gap or
`best-trial-prompt` under a loose reading. **Left out of the diff**, because the
cost of guessing wrong is a duplicate key that permanently shadows an existing
one. Worth a human deciding whether `best-trial-prompt`'s scope is "the winning
trial's prompt" or "the trial sidebar's Prompt tab."

### Route-resolution cross-check — no removal candidates.

Every `routes:` entry on all 19 areas still resolves against a live route in
`surface.json` (normalising `$param`→`*`, dropping the query string, suffix
match). No area points at a deleted surface.

---

## 3. Removals

**None.** Nothing was removed, so the denominator only grows and coverage only
falls — there is no path in this proposal by which the number gets flattered.
No `@cap:` tag was orphaned; no existing key was touched.

---

## 4. Rename notes for a human

No renames performed (a rename orphans every `@cap:` tag). Three things a human
may want to act on:

1. **`optimization-studio.best-trial-prompt` is ambiguously scoped** — see the
   TrialSidebar note in §2b. Not a rename so much as a scope decision that
   should land in a `note:` either way.
2. **The file's own comment says "18 UI areas"** (`taxonomy.yaml:195`, inside
   `rules.release_surface.untracked`). The file now defines **19**
   (`workspace-roles` postdates that comment). Prose only — no counting code
   reads it — but it is wrong, and I left it alone rather than edit a comment I
   was not asked to own.
3. **The skill's Step 2 docs path is stale.** `SKILL.md` and this task both name
   `opik-documentation/documentation/fern/versions/latest.yml`; that file does
   not exist at this ref. The docs section tree now lives at
   `.../fern/docs.yml` with pages under `fern/docs-v2/`. I used `docs.yml`. The
   skill should be updated or the next run will silently skip Step 2.

---

## 5. The blind spot

> This sweep reads only what is in the opik repo.
> `PluginsStore.collectRoutes()` and `PluginsStore.sidebarSections` let the
> out-of-tree `comet` plugin inject routes and nav entries that are invisible
> here, so surfaces that exist only in the commercial build are not covered by
> this diff.

`surface.json`'s own `caveats` says the same, and `nav_gating` shows the
mechanism live: `showOlliePage` and `showDiagnostics` are both
`!!AssistantSidebar && ollieEnabled`, where `AssistantSidebar` is a
`usePluginsStore` component — the two `cloud_only: true` areas this taxonomy
already carries. Whatever *else* that plugin mounts, this sweep cannot see.

Two narrower limits worth stating:

- **`showHomePage` is gated by the `PROJECT_HOMEPAGE_ENABLED` feature toggle
  only** (`SideBarMenuItems.tsx`), not by a plugin component — so per the skill's
  rule that is *not* cloud-only. It affects `projects.project-home`, which
  already exists; no `cloud_only` was set or changed anywhere in this diff.
- Tabs were diffed from `surface.json`'s flat `{file: [values]}` map, which
  carries no route. Any tab rendered through something other than a Radix
  `<TabsTrigger>` is invisible to this sweep.

---

## Files changed

- `opik/tests_end_to_end/coverage/taxonomy.yaml` — 2 lines inserted, nothing else.

Not committed, not pushed, no PR opened.

---

### Why this is a draft

The denominator is a reviewed file — adding a capability lowers coverage
until a test exists, and removing one raises it. Both need a human.
New capabilities land `covered: false` with no `tier:`; `reconcile.py`
fills those in once a tagged spec exists.

Run: https://github.com/comet-ml/comet-automation-tests/actions/runs/34675153574
