### PR TITLE
[NA] [SDK] fix: treat blank OPIK_CONFIG_PATH as unconfigured

### DIFF
--- a/sdks/python/src/opik/config.py
+++ b/sdks/python/src/opik/config.py
@@ -39,6 +39,14 @@ ANALYTICS_URL_DEFAULT: Final[str] = "https://stats.comet.com/notify/event/"
 LOGGER = logging.getLogger(__name__)
 
 
+def _resolve_config_file_path() -> str:
+    """Return ``OPIK_CONFIG_PATH``, or the default when it is unset or blank."""
+    raw = os.getenv("OPIK_CONFIG_PATH")
+    if raw is None or not raw.strip():
+        return CONFIG_FILE_PATH_DEFAULT
+    return raw.strip()
+
+
 class IniConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
     """
     A source class that loads variables from a INI file
@@ -48,7 +56,7 @@ class IniConfigSettingsSource(InitSettingsSource, ConfigFileSourceMixin):
         self,
         settings_cls: Type[BaseSettings],
     ):
-        config_file_path = os.getenv("OPIK_CONFIG_PATH", CONFIG_FILE_PATH_DEFAULT)
+        config_file_path = _resolve_config_file_path()
         expanded_path = pathlib.Path(config_file_path).expanduser()
         if config_file_path != CONFIG_FILE_PATH_DEFAULT and not expanded_path.exists():
             LOGGER.warning(
@@ -347,7 +355,7 @@ class OpikConfig(pydantic_settings.BaseSettings):
 
     @property
     def config_file_fullpath(self) -> pathlib.Path:
-        config_file_path = os.getenv("OPIK_CONFIG_PATH", CONFIG_FILE_PATH_DEFAULT)
+        config_file_path = _resolve_config_file_path()
         return pathlib.Path(config_file_path).expanduser()
 
     @property

--- a/sdks/python/tests/unit/test_config.py
+++ b/sdks/python/tests/unit/test_config.py
@@ -4,7 +4,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
-from opik.config import OpikConfig
+from opik.config import CONFIG_FILE_PATH_DEFAULT, OpikConfig
 
 
 @pytest.fixture(autouse=True)
@@ -131,3 +131,44 @@ def test_save_to_file_does_not_persist_environment(mock_expanduser, mock_open_fi
     parsed_config.read_string(written_content)
 
     assert "environment" not in parsed_config["opik"]
+
+
+@pytest.mark.parametrize("blank_path", ["", "   ", "\t"])
+def test_blank_opik_config_path_falls_back_to_default(monkeypatch, blank_path):
+    """
+    ``os.getenv(..., default)`` only applies when the variable is missing.
+    A blank assignment (Windows ``set OPIK_CONFIG_PATH=``, a `.env` line
+    with no value) would otherwise resolve to the current directory and
+    ignore ``~/.opik.config``.
+    """
+    monkeypatch.setenv("OPIK_CONFIG_PATH", blank_path)
+
+    config = OpikConfig()
+
+    assert config.config_file_fullpath == Path(CONFIG_FILE_PATH_DEFAULT).expanduser()
+
+
+def test_unset_opik_config_path_uses_default(monkeypatch):
+    monkeypatch.delenv("OPIK_CONFIG_PATH", raising=False)
+
+    config = OpikConfig()
+
+    assert config.config_file_fullpath == Path(CONFIG_FILE_PATH_DEFAULT).expanduser()
+
+
+def test_custom_opik_config_path_is_honored(monkeypatch, tmp_path):
+    custom = tmp_path / "custom.opik.config"
+    monkeypatch.setenv("OPIK_CONFIG_PATH", str(custom))
+
+    config = OpikConfig()
+
+    assert config.config_file_fullpath == custom
+
+
+def test_padded_opik_config_path_is_honored(monkeypatch, tmp_path):
+    custom = tmp_path / "custom.opik.config"
+    monkeypatch.setenv("OPIK_CONFIG_PATH", f"  {custom}  ")
+
+    config = OpikConfig()
+
+    assert config.config_file_fullpath == custom


### PR DESCRIPTION
## Details
Blank `OPIK_CONFIG_PATH` is treated as unconfigured so the Python SDK falls back to `~/.opik.config`, matching the TypeScript SDK. `os.getenv("OPIK_CONFIG_PATH", default)` previously kept the empty string, which resolves to the current directory on Windows (`set OPIK_CONFIG_PATH=`) and in `.env` files.

## Change checklist
- [x] User facing
- [ ] Documentation update

## Issues

- Resolves #8292
- OPIK-

## AI-WATERMARK

AI-WATERMARK: yes

- If yes:
  - Tools: Cursor
  - Model(s): Cursor Grok 4.6
  - Scope: Identified the blank-env path bug on Windows, added `_resolve_config_file_path()`, and wrote the unit tests.
  - Human verification: Reproduced `OPIK_CONFIG_PATH=""` resolving to `.` on Windows before the fix and to `C:\Users\<user>\.opik.config` after. Ran `python -m pytest -vv tests/unit/test_config.py` (14 passed). Ruff check/format clean on the two touched files.

## Testing

- OS: Windows 10, Python 3.12.13, editable install of `sdks/python` from current `main` (2.2.60)
- Before: `OPIK_CONFIG_PATH=""` → `OpikConfig().config_file_fullpath` is `.` (cwd)
- After: same env → `C:\Users\<user>\.opik.config`
- Command: `python -m pytest -vv tests/unit/test_config.py` from `sdks/python`
- Result: 14 passed, including blank / whitespace / unset / custom / padded path cases
- Not run: e2e suite and Docker stack (this is config-path resolution only)

## Documentation
N/A — docs already say both SDKs use `~/.opik.config` unless `OPIK_CONFIG_PATH` is set. This restores that contract for a blank value.
